### PR TITLE
preferences_processing.php: fix Cell Phone regex

### DIFF
--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -149,7 +149,7 @@ elseif ($action == 'Change cell phone') {
 	} else {
 
 		// validate number
-		if (preg_match('/^\+[0-9] {3,24}$/', $cellPhone) == 0)
+		if (preg_match('/^\+[0-9]{3,24}$/', $cellPhone) == 0)
 			create_error('Cell phone numbers must be given in the international format, eg: +15551234567 (For details see this link: http://www.ehow.com/how_5547899_write-phone-number-international-format.html)');
 
 		// and save cell phone


### PR DESCRIPTION
Fix an error introduced in 84a75b15f6d4283f4b069f138173dd941914e28a.
An extra space caused the Cell Phone regex to match 3-24 spaces
instead of 3-24 numbers. This commit removes the erroneous space.
