### PR TITLE
trader_relations.php: display all Races

### DIFF
--- a/engine/Default/trader_relations.php
+++ b/engine/Default/trader_relations.php
@@ -16,7 +16,6 @@ $PHP_OUTPUT.=('<td valign="top" width="50%">');
 $PHP_OUTPUT.=('<p>');
 $RACES =& Globals::getRaces();
 foreach($RACES as $raceID => $race) {
-	if ($raceID == 1) continue;
 	$otherRaceRelations = Globals::getRaceRelations($player->getGameID(),$raceID);
 	$PHP_OUTPUT.=($race['Race Name'].' : ' . get_colored_text($otherRaceRelations[$player->getRaceID()], $otherRaceRelations[$player->getRaceID()]) . '<br />');
 
@@ -28,7 +27,6 @@ $PHP_OUTPUT.=('<td valign="top">');
 
 $PHP_OUTPUT.=('<p>');
 foreach($RACES as $raceID => $race) {
-	if ($raceID == 1) continue;
 	$PHP_OUTPUT.=($race['Race Name'].' : ' . get_colored_text($player->getPureRelation($raceID), $player->getPureRelation($raceID)) . '<br />');
 
 }


### PR DESCRIPTION
On the "Trader Relations" page, include relations with Neutral, as is
done in the "Relations (Personal)" section of the "Trader Status" page.
There is no reason to make this exception, because relations with
Neutral can be improved (for Alskant) by trading at Neutral ports.
Including this information for non-Alskant traders doesn't hurt
anything, it will just always be zero.