### PR TITLE
smr_file_create.php: print correct planet type

### DIFF
--- a/engine/Default/smr_file_create.php
+++ b/engine/Default/smr_file_create.php
@@ -157,7 +157,8 @@ foreach ($galaxies as &$galaxy) {
 			unset($port);
 		}
 		if($sector->hasPlanet()) {
-			$file .= 'Planet=1' . EOL;
+			$planetType = $sector->getPlanet()->getTypeID();
+			$file .= 'Planet=' . $planetType . EOL;
 		}
 		if($sector->hasLocation()) {
 			$locationsString= 'Locations=';


### PR DESCRIPTION
The current behavior of smr_file_create.php is to print "Planet=1"
for sectors that contain planets. However, this behavior was
implemented before there were different types of planets. Since the
planet types are available in the galaxy map, it seems reasonable
to include this information in the .smr file. This patch replaces
"Planet=1" with "Planet=$planetType", where $planetType is the
numerical type ID of the planet.