### PR TITLE
Improved bond permissions

### DIFF
--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -456,8 +456,9 @@ function createGame($gameID) {
 	$exemptWith = TRUE;
 	$mbMessages = TRUE;
 	$sendAllMsg = TRUE;
-	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg)
-				VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ')');
+	$viewBonds = TRUE;
+	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds)
+				VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 	$withPerDay = ALLIANCE_BANK_UNLIMITED;
 	$removeMember = FALSE;
 	$changePass = FALSE;
@@ -467,8 +468,9 @@ function createGame($gameID) {
 	$exemptWith = FALSE;
 	$mbMessages = FALSE;
 	$sendAllMsg = FALSE;
-	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg) ' .
-				'VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember).', '.$db->escapeBoolean($changePass).', '.$db->escapeBoolean($changeMOD).', '.$db->escapeBoolean($changeRoles).', '.$db->escapeBoolean($planetAccess).', '.$db->escapeBoolean($exemptWith).', '.$db->escapeBoolean($mbMessages).', '.$db->escapeBoolean($sendAllMsg).')');
+	$viewBonds = FALSE;
+	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds) ' .
+				'VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember).', '.$db->escapeBoolean($changePass).', '.$db->escapeBoolean($changeMOD).', '.$db->escapeBoolean($changeRoles).', '.$db->escapeBoolean($planetAccess).', '.$db->escapeBoolean($exemptWith).', '.$db->escapeBoolean($mbMessages).', '.$db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 	$db->query('REPLACE INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', 1,' . $db->escapeNumber(NHA_ID) . ')');
 	
 	// NHA default topics

--- a/admin/Default/universe_create_end.php
+++ b/admin/Default/universe_create_end.php
@@ -21,8 +21,9 @@ $planetAccess = TRUE;
 $exemptWith = TRUE;
 $mbMessages = TRUE;
 $sendAllMsg = TRUE;
-$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg) ' .
-			'VALUES (302, '.$game_id.', 1, \'Leader\', '.$withPerDay.', '.$db->escapeString($removeMember).', '.$db->escapeString($changePass).', '.$db->escapeString($changeMOD).', '.$db->escapeString($changeRoles).', '.$db->escapeString($planetAccess).', '.$db->escapeString($exemptWith).', '.$db->escapeString($mbMessages).', '.$db->escapeString($sendAllMsg).')');
+$viewBonds = TRUE
+$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds) ' .
+			'VALUES (302, '.$game_id.', 1, \'Leader\', '.$withPerDay.', '.$db->escapeString($removeMember).', '.$db->escapeString($changePass).', '.$db->escapeString($changeMOD).', '.$db->escapeString($changeRoles).', '.$db->escapeString($planetAccess).', '.$db->escapeString($exemptWith).', '.$db->escapeString($mbMessages).', '.$db->escapeString($sendAllMsg).', '.$db->escapeString($viewBonds).')');
 $withPerDay = ALLIANCE_BANK_UNLIMITED;
 $removeMember = FALSE;
 $changePass = FALSE;
@@ -32,8 +33,9 @@ $planetAccess = TRUE;
 $exemptWith = FALSE;
 $mbMessages = FALSE;
 $sendAllMsg = FALSE;
-$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg) ' .
-			'VALUES (302, '.$game_id.', 2, \'New Member\', '.$withPerDay.', '.$db->escapeString($removeMember).', '.$db->escapeString($changePass).', '.$db->escapeString($changeMOD).', '.$db->escapeString($changeRoles).', '.$db->escapeString($planetAccess).', '.$db->escapeString($exemptWith).', '.$db->escapeString($mbMessages).', '.$db->escapeString($sendAllMsg).')');
+$viewBonds = FALSE;
+$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds) ' .
+			'VALUES (302, '.$game_id.', 2, \'New Member\', '.$withPerDay.', '.$db->escapeString($removeMember).', '.$db->escapeString($changePass).', '.$db->escapeString($changeMOD).', '.$db->escapeString($changeRoles).', '.$db->escapeString($planetAccess).', '.$db->escapeString($exemptWith).', '.$db->escapeString($mbMessages).', '.$db->escapeString($sendAllMsg).', '.$db->escapeString($viewBonds).')');
 $db->query('REPLACE INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES ('.$game_id.', '.ACCOUNT_ID_NHL.', 1,302)');
 
 // NHA default topics

--- a/db/patches/V1_6_61_01__view_bonds_option.sql
+++ b/db/patches/V1_6_61_01__view_bonds_option.sql
@@ -1,0 +1,3 @@
+-- Set permission to view bonds on the Planet List in alliance roles
+ALTER TABLE `alliance_has_roles` ADD `view_bonds` enum('TRUE','FALSE')
+  NOT NULL DEFAULT 'FALSE';

--- a/engine/Default/alliance_create_processing.php
+++ b/engine/Default/alliance_create_processing.php
@@ -66,8 +66,9 @@ $planetAccess = TRUE;
 $exemptWith = TRUE;
 $mbMessages = TRUE;
 $sendAllMsg = TRUE;
-$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg) ' .
-			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ')');
+$viewBonds = TRUE;
+$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds) ' .
+			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 switch ($perms) {
 	case 'full':
 		//do nothing, perms already set above.
@@ -82,6 +83,7 @@ switch ($perms) {
 		$exemptWith = FALSE;
 		$mbMessages = FALSE;
 		$sendAllMsg = FALSE;
+		$viewBonds = FALSE;
 	break;
 	case 'basic':
 		$withPerDay = ALLIANCE_BANK_UNLIMITED;
@@ -93,10 +95,11 @@ switch ($perms) {
 		$exemptWith = FALSE;
 		$mbMessages = FALSE;
 		$sendAllMsg = FALSE;
+		$viewBonds = FALSE;
 	break;
 }
-$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg) ' .
-			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ')');
+$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds) ' .
+			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 $db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id,alliance_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', 1,' . $db->escapeNumber($alliance_id) . ')');
 forward(create_container('skeleton.php', 'alliance_roster.php'));
 

--- a/engine/Default/alliance_planets.php
+++ b/engine/Default/alliance_planets.php
@@ -8,6 +8,19 @@ $template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->g
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 
+// Determine if the player can view bonds on the planet list
+$role_id = $player->getAllianceRole($player->getAllianceID());
+$db->query('
+SELECT *
+FROM alliance_has_roles
+WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
+AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+AND role_id = ' . $db->escapeNumber($role_id)
+);
+$db->nextRecord();
+$viewBonds = $db->getBoolean('view_bonds');
+$template->assignByRef('CanViewBonds', $viewBonds);
+
 // Ugly, but funtional
 $db->query('
 SELECT planet.sector_id
@@ -25,7 +38,5 @@ while ($db->nextRecord()) {
 	$alliancePlanets[$sectorID]->getCurrentlyBuilding(); //In case anything gets updated here we want to do it before template.
 }
 $template->assignByRef('AlliancePlanets',$alliancePlanets);
-$isLeader = $player->getAccountID() == $alliance->getLeaderID();
-$template->assignByRef('IsLeader',$isLeader);
 
 ?>

--- a/engine/Default/alliance_roles.php
+++ b/engine/Default/alliance_roles.php
@@ -33,6 +33,7 @@ while ($db->nextRecord()) {
 		$allianceRoles[$roleID]['ModerateMessageboard'] = $db->getBoolean('mb_messages');
 		$allianceRoles[$roleID]['ExemptWithdrawals'] = $db->getBoolean('exempt_with');
 		$allianceRoles[$roleID]['SendAllianceMessage'] = $db->getBoolean('send_alliance_msg');
+		$allianceRoles[$roleID]['ViewBondsInPlanetList'] = $db->getBoolean('view_bonds');
 	}
 	else {
 		$container = create_container('skeleton.php', 'alliance_roles.php');
@@ -63,5 +64,6 @@ $template->assign('CreateRole', array(
 	'PlanetAccess' => true,
 	'ModerateMessageboard' => false,
 	'ExemptWithdrawals' => false,
-	'SendAllianceMessage' => false));
+	'SendAllianceMessage' => false,
+	'ViewBondsInPlanetList' => false));
 ?>

--- a/engine/Default/alliance_roles_processing.php
+++ b/engine/Default/alliance_roles_processing.php
@@ -18,6 +18,7 @@ $planetAccess = (bool)$_REQUEST['planets'];
 $mbMessages = (bool)$_REQUEST['mbMessages'];
 $exemptWith = (bool)$_REQUEST['exemptWithdrawals'];
 $sendAllMsg = (bool)$_REQUEST['sendAllMsg'];
+$viewBonds = (bool)$_REQUEST['viewBonds'];
 
 // with empty role the user wants to create a new entry
 if (!isset($var['role_id'])) {
@@ -38,8 +39,8 @@ if (!isset($var['role_id'])) {
 	}
 
 	$db->query('INSERT INTO alliance_has_roles
-				(alliance_id, game_id, role_id, role, with_per_day, positive_balance, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg)
-				VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($role_id) . ', ' . $db->escapeString($_POST['role']) . ', ' . $db->escapeNumber($withPerDay) . ',' . $db->escapeBoolean($positiveBalance) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ')');
+				(alliance_id, game_id, role_id, role, with_per_day, positive_balance, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds)
+				VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($role_id) . ', ' . $db->escapeString($_POST['role']) . ', ' . $db->escapeNumber($withPerDay) . ',' . $db->escapeBoolean($positiveBalance) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 
 	$db->unlock();
 }
@@ -70,7 +71,8 @@ else {
 					planet_access = ' . $db->escapeBoolean($planetAccess) . ',
 					exempt_with = ' . $db->escapeBoolean($exemptWith) . ',
 					mb_messages = ' . $db->escapeBoolean($mbMessages) . ',
-					send_alliance_msg = ' . $db->escapeBoolean($sendAllMsg) . '
+					send_alliance_msg = ' . $db->escapeBoolean($sendAllMsg) . ',
+					view_bonds = ' . $db->escapeBoolean($viewBonds) . '
 					WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 						AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 						AND role_id = ' . $db->escapeNumber($var['role_id']));

--- a/templates/Default/engine/Default/includes/AllianceRole.inc
+++ b/templates/Default/engine/Default/includes/AllianceRole.inc
@@ -47,6 +47,10 @@
 				<tr>
 					<td align="left">Send Alliance Message</td>
 					<td align="left"><input type="checkbox" name="sendAllMsg"<?php if ($Role['SendAllianceMessage']){ ?> checked="checked"<?php } ?>></td>
+				</tr>
+				<tr>
+					<td align="left">View Bonds In Planet List</td>
+					<td align="left"><input type="checkbox" name="viewBonds"<?php if ($Role['ViewBondsInPlanetList']){ ?> checked="checked"<?php } ?>></td>
 				</tr><?php
 			}
 		} ?>

--- a/templates/Default/engine/Default/includes/AllianceRole.inc
+++ b/templates/Default/engine/Default/includes/AllianceRole.inc
@@ -6,7 +6,7 @@
 		</tr><?php
 		if ($Role['EditingRole']) { ?>
 			<tr>
-				<td align="left" rowspan="3">Withdrawal limit per 24 hours (Or max negative balance for "positive balance")</td>
+				<td align="left" rowspan="3">Withdrawal limit per 24 hours<br>(Or max negative balance for "positive balance")</td>
 				<td align="left"><input type="number" name="maxWith" value="<?php echo max($Role['WithdrawalLimit'],0); ?>"></td>
 			</tr>
 			<tr>
@@ -25,7 +25,7 @@
 					<td align="left"><input type="checkbox" name="changePW"<?php if ($Role['ChangePass']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Change MoD</td>
+					<td align="left">Change Message Of The Day</td>
 					<td align="left"><input type="checkbox" name="changeMoD"<?php if ($Role['ChangeMod']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
@@ -37,11 +37,11 @@
 					<td align="left"><input type="checkbox" name="planets"<?php if ($Role['PlanetAccess']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Moderate messageboard</td>
+					<td align="left">Moderate Message Board</td>
 					<td align="left"><input type="checkbox" name="mbMessages"<?php if ($Role['ModerateMessageboard']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Exempt withdrawals</td>
+					<td align="left">Exempt Withdrawals</td>
 					<td align="left"><input type="checkbox" name="exemptWithdrawals" alt="This user can mark withdrawals from the alliance account as 'for the alliance' instead of 'for the individual'"<?php if ($Role['ExemptWithdrawals']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>

--- a/templates/Default/engine/Default/includes/PlanetList.inc
+++ b/templates/Default/engine/Default/includes/PlanetList.inc
@@ -23,7 +23,7 @@ if (count($Planets) > 0) { ?>
 				<th class="sort shrink" data-sort="pArmour">Armour</th>
 				<th class="shrink">Supplies</th>
 				<th class="sort shrink" data-sort="build">Build</th><?php
-				if(isset($IsLeader) && $IsLeader) { ?>
+				if($CanViewBonds) { ?>
 					<th class="bonds shrink">Bonds</th><?php
 				} ?>
 			</tr>
@@ -69,7 +69,7 @@ if (count($Planets) > 0) { ?>
 							?>Nothing<?php
 						} ?>
 					</td><?php
-					if(isset($IsLeader) && $IsLeader) { ?>
+					if($CanViewBonds) { ?>
 						<td class="bonds"><?php
 							if($Planet->getBonds() > 0) { ?>
 								Credits:<br/><?php


### PR DESCRIPTION
It would be useful to be able to customize who can see the bond information in the planet list. Rather than only giving the leader *player* this ability, we can give the leader *role* this ability (and we can make it customizable for each role).

This pull request adds a new permission to the "alliance roles" that specifies whether or not they can see the bond information in the planet list. It also adds a commit with very minor cosmetic changes to the alliance roles page.