### PR TITLE
Change the way planetary bond confirmation works

### DIFF
--- a/engine/Default/planet_bond_confirmation.php
+++ b/engine/Default/planet_bond_confirmation.php
@@ -1,0 +1,36 @@
+<?php
+if (!$player->isLandedOnPlanet()) {
+	create_error('You are not on a planet!');
+}
+
+// create planet object
+$planet =& $player->getSectorPlanet();
+
+$template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$player->getSectorID().']');
+
+require_once(get_file_loc('menu.inc'));
+create_planet_menu($planet);
+
+$bondDuration = format_time($planet->getBondTime());
+$returnHREF = $planet->getFinancesHREF();
+
+$PHP_OUTPUT = <<<HTML
+<h2>Planetary Bond Confirmation</h2>
+<p>All credits on the planet at the time of confirmation, along with any
+credits currently bonded (and any partial interest they may have accrued),
+will be added to a new bond. You will not be able to access these funds until
+the bond matures in $bondDuration.</p>
+
+<p>Please confirm to proceed.</p>
+
+<form id="BondConfirmForm" method="POST" action="$returnHREF">
+	<table>
+		<tr>
+			<td><input type="submit" name="action" value="Confirm" id="confirmBond" /></td>
+			<td><input type="submit" name="action" value="Cancel" id="cancelBond" /></td>
+		</tr>
+	</table>
+</form>
+HTML
+
+?>

--- a/engine/Default/planet_financial_processing.php
+++ b/engine/Default/planet_financial_processing.php
@@ -4,6 +4,8 @@ if (!$player->isLandedOnPlanet())
 $planet =& $player->getSectorPlanet();
 $action = $_REQUEST['action'];
 $amount = $_REQUEST['amount'];
+
+// Player has requested a planetary fund transaction
 if ($action == 'Deposit' || $action == 'Withdraw') {
 	if (!is_numeric($amount))
 		create_error('Numbers only please!');
@@ -32,15 +34,13 @@ if ($action == 'Deposit' || $action == 'Withdraw') {
 		$account->log(LOG_TYPE_BANK, 'Player takes '.$amount.' credits from planet', $player->getSectorID());
 	}
 }
-elseif ($action == 'Bond It!') {
-	if(!$planet->isClaimed()) {
-		create_error('Cannot bond on an unclaimed planet.');
-	}
 
+// Player has confirmed the request to bond
+elseif ($action == 'Confirm') {
 	$planet->bond();
 
 	// save to db
-	$account->log(LOG_TYPE_BANK, 'Player bonds '.$planet->getCredits().' credits at planet.', $player->getSectorID());
+	$account->log(LOG_TYPE_BANK, 'Player bonds '.$planet->getBonds().' credits at planet.', $player->getSectorID());
 }
 
 forward(create_container('skeleton.php', 'planet_financial.php'));

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -1105,6 +1105,10 @@ class SmrPlanet {
 		return SmrSession::getNewHREF(create_container('planet_financial_processing.php'));
 	}
 
+	public function getBondConfirmationHREF() {
+		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_bond_confirmation.php'));
+	}
+
 	public function attackedBy(AbstractSmrPlayer $trigger, array $attackers) {
 		$trigger->increaseHOF(1,array('Combat','Planet','Number Of Triggers'), HOF_PUBLIC);
 		foreach ($attackers as $attacker) {

--- a/templates/Default/engine/Default/planet_financial.php
+++ b/templates/Default/engine/Default/planet_financial.php
@@ -10,54 +10,30 @@
 			<td><input type="submit" name="action" value="Withdraw" id="InputFields" /></td>
 		</tr>
 	</table>
-
-	<p>&nbsp;</p>
-
-	<p>You are able to transfer this money into a saving bond.<br />
-	It remains there for <?php echo format_time($ThisPlanet->getBondTime()); ?> and will gain <?php echo $ThisPlanet->getInterestRate() * 100; ?>% interest.<br /><br /><?php
-
-	if ($ThisPlanet->getBonds() > 0) { ?>
-		Right now there are <?php echo number_format($ThisPlanet->getBonds()); ?> credits bonded<?php
-		if ($ThisPlanet->getMaturity() > 0) { ?>
-			and will come to maturity in <?php echo format_time($ThisPlanet->getMaturity() - TIME);
-		}
-	} ?>
-
-	</p>
-
-	<input class="BondFormSubmit" type="submit" name="action" value="Bond It!" id="InputFields" />
 </form>
-<div id="BondDialog" title="Confirmation required">You will be unable to access these funds until the bond matures.<br><br>Please confirm you wish to proceed.</div>
-<script>
-$(function(){
-	$("#BondDialog").dialog({
-		autoOpen: false,
-		modal: true,
-		height: 200,
-		resizable: false,
-		buttons:
-			[{
-				text: "Confirm",
-				click: function() {
-					$(this).dialog('close');
-					$(".BondFormSubmit").off("click");
-					$(".BondFormSubmit").click();
-				}
-			},
-			{
-				text: "Cancel",
-				click: function() {
-				$(this).dialog('close');
-			}
-			}],
-		close: function() {
-			$(this).dialog('close');
-		}
-	});
-        
-	$(".BondFormSubmit").on("click", function() {
-		$("#BondDialog").dialog('open');
-		return false;
-	});
-});
-</script>
+
+	<p>&nbsp;</p> <?php
+
+// Print bond properties if the planet is claimed
+if (!$ThisPlanet->isClaimed()) {
+	echo "This planet must be claimed before you can bond funds here.<br /><br />";
+} else { ?>
+	You are able to transfer these credits into a planetary bond.<br />
+	The credits will remain bonded for <?php echo format_time($ThisPlanet->getBondTime()); ?> and will gain <?php echo $ThisPlanet->getInterestRate() * 100; ?>% interest.<br /><br /><?php
+}
+
+// Always display the bond status if there is a bond
+if ($ThisPlanet->getBonds() > 0) { ?>
+	Right now there are <?php echo number_format($ThisPlanet->getBonds()); ?> credits bonded<?php
+	if ($ThisPlanet->getMaturity() > 0) { ?>
+		and will come to maturity in <?php echo format_time($ThisPlanet->getMaturity() - TIME); ?>.
+		<br /><br /> <?php
+	}
+}
+
+// Allow the player to bond if the planet is claimed
+if ($ThisPlanet->isClaimed()) { ?>
+	<div class="buttonA">
+		<a id="bondFunds" class="buttonA" href="<?php echo $ThisPlanet->getBondConfirmationHREF(); ?>">&nbsp;Bond Funds&nbsp;</a>
+	</div>&nbsp; <?php
+} ?>


### PR DESCRIPTION
* Replace the modal dialog with a new planet page that asks for
  confirmation of the bond request. This fixes two issues:
    1. The modal dialog was very much out of the style and
       aesthetic of SMR.
    2. The modal dialog text erroneously flashes on the Planet
       Financial page before 'Bond It!' is even clicked.

* When a planet is unclaimed, the 'Bond It!' button was displayed,
  only to trigger an error if you press it. With this patch, the
  button is replaced with text informing the player that the planet
  must be claimed to start a bond.

* Slightly modify the description of the bonding mechanics for
  clarity (e.g. "money" -> "credits" and "saving bond" ->
  "planetary bond").

* Fix logging of bonding amounts. Previously it was logging
  $planet->getCredits(), which is zero by definition after bonding.
  Instead it should log $planet->getBonds().