### PR TITLE
Fix a Facebook Login exception when no App ID is provided

### DIFF
--- a/lib/Login/SocialLogin.class.inc
+++ b/lib/Login/SocialLogin.class.inc
@@ -55,6 +55,10 @@ class SocialLogin {
 	}
 
 	public static function getFacebookLoginUrl() {
+		if (empty(FACEBOOK_APP_ID)) {
+			// No facebook app specified. Continuing would throw an exception.
+			return;
+		}
 		$helper = self::getFacebookObj()->getRedirectLoginHelper();
 		$permissions = ['email'];
 		$loginUrl = $helper->GetLoginUrl(URL . '/login_processing.php?loginType=Facebook', $permissions);

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -117,20 +117,6 @@
                 <a href="http://www.smrealms.de/cgi-bin/awstats.pl" target="stat"><img src="images/login/stats2.png" width="180" height="29" alt="Site Statistics"></a><br />
 			</p>
 			<?php
-			/*
-			if(!$isFirefox) { ?>
-				<br />
-				<a class="button" href="http://www.spreadfirefox.com/node&amp;id=216853&amp;t=210">
-				<img alt="Get Firefox!" title="Get Firefox!" src="images/firefox.png"></a><br />
-				SMR is primarly coded and tested with Firefox.<br />Firefox is recommended for the best gameplay.
-				<a href="http://www.spreadfirefox.com/node&amp;id=216853&amp;t=215">Download Firefox</a> now, it's free.
-				<br /><?php
-			}
-
-			/*if($isAprilFools) { ?>
-				<a href="http://www.smrealms.de/merge.php"><span class="red bold">Important Announcement</span></a> : SMR and TDZK are set to merge.
-				Please <a href="http://www.smrealms.de/merge.php">click here</a> for more details.<?php
-			} */
 
 			if(isset($Message)) { ?>
 				<h4 style="margin-bottom: 0px;"><?php echo $Message ?></h4><?php


### PR DESCRIPTION
SocialLogin.class.inc: prevent Facebook exception

If not specifying a Facebook App ID, return an empty Facebook login link. We do this to prevent an exception in the Facebook authorization code if we were to continue.

Ideally we would perhaps omit the Facebook login object altogether if there is no App ID, but that would require more extensive changes to the login page code. For this minimal change, a non-interactive button is preferable to an Exception.