### PR TITLE
Refactor information in planet_type table

### DIFF
--- a/db/patches/V1_6_61_02__remove_planet_type.sql
+++ b/db/patches/V1_6_61_02__remove_planet_type.sql
@@ -1,0 +1,2 @@
+-- Remove planet_type table in favor of php classes
+DROP TABLE planet_type;

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -1,5 +1,7 @@
 <?php
 require_once(get_file_loc('SmrPlayer.class.inc'));
+require_once(get_file_loc('SmrPlanetType.class.inc'));
+
 class SmrPlanet {
 	protected static $CACHE_PLANETS = array();
 
@@ -28,9 +30,7 @@ class SmrPlanet {
 	protected $inhabitableTime;
 	protected $currentlyBuilding;
 	protected $typeID;
-	protected $typeName;
-	protected $typeImage;
-	protected $typeDescription;
+	protected $typeInfo;
 	
 	protected $canOptions;
 	protected $hasChanged = false;
@@ -38,8 +38,6 @@ class SmrPlanet {
 	protected $hasChangedBuildings = array();
 	protected $hasStoppedBuilding = array();
 	protected $isNew = false;
-	protected $maxAttackers;
-	protected $maxLanded;
 
 	protected $delayedShieldsDelta = 0;
 	protected $delayedCDsDelta = 0;
@@ -772,52 +770,37 @@ class SmrPlanet {
 	}
 	
 	public function updateTypeInfo() {
-	
-		$this->db->query('SELECT * FROM planet_type WHERE planet_type_id = ' . $this->getTypeID());
-		if ($this->db->nextRecord()) {
-			$this->setTypeName($this->db->getField('planet_type_name'));
-			$this->setTypeImage($this->db->getField('planet_image_link'));
-			$this->setTypeDescription($this->db->getField('planet_type_description'));
-			$this->setMaxAttackers($this->db->getInt('planet_max_attackers'));
-			$this->maxLanded = $this->db->getInt('planet_max_landed');
+		if ($this->getTypeID() == 1) {
+			$this->typeInfo = new TerranPlanet();
+		} else if ($this->getTypeID() == 2) {
+			$this->typeInfo = new AridPlanet();
+		} else if ($this->getTypeID() == 3) {
+			$this->typeInfo = new DwarfPlanet();
+		} else if ($this->getTypeID() == 4) {
+			$this->typeInfo = new DefenseWorld();
 		} else {
-			$this->setTypeName("No Type Defined");
-			$this->setTypeImage("image/planet.gif");
-			$this->setTypeDescription("No description defined in database, cotnact admins!");
-			$this->setMaxAttackers(0);
-			$this->maxLanded = 0;
+			create_error('Unknown planet type ID: ' . $this->getTypeID());
 		}
 	}
-	//not public on purpose
-	function setTypeName($name) {
-		$this->typeName = $name;
-	}
-	
-	function setTypeImage($img) {
-		$this->typeImage = $img;
-	}
-	
-	function setTypeDescription($des) {
-		$this->typeDescription = $des;
-	}
-	
 	
 	public function getTypeImage() {
-		if (isset($this->typeImage))
-			return $this->typeImage;
-		return "Error";
+		return $this->typeInfo->imageLink();
 	}
 	
 	public function getTypeName() {
-		if (isset($this->typeName))
-			return $this->typeName;
-		return "Error";
+		return $this->typeInfo->name();
 	}
 	
 	public function getTypeDescription() {
-		if (isset($this->typeDescription))
-			return $this->typeDescription;
-		return "Error";
+		return $this->typeInfo->description();
+	}
+	
+	public function getMaxAttackers() {
+		return $this->typeInfo->maxAttackers();
+	}
+
+	public function getMaxLanded() {
+		return $this->typeInfo->maxLanded();
 	}
 	
 	public function getOptions($option=false) {
@@ -847,18 +830,6 @@ class SmrPlanet {
 		$this->delayedShieldsDelta = 0;
 		$this->setCDs($this->getCDs(true));
 		$this->delayedCDsDelta = 0;
-	}
-	
-	public function getMaxAttackers() {
-		return $this->maxAttackers;
-	}
-	
-	public function setMaxAttackers($value) {
-		$this->maxAttackers = $value;
-	}
-
-	public function getMaxLanded() {
-		return $this->maxLanded;
 	}
 	
 	public function update() {

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -820,15 +820,6 @@ class SmrPlanet {
 		return "Error";
 	}
 	
-	public function getPlanetID() {
-		return $this->palentID;
-	}
-	
-	public function setPlanetID($num) {
-		$this->typeID = $num;
-		$this->hasChanged = true;
-	}
-	
 	public function getOptions($option=false) {
 
 		if(!isset($this->canOptions)) {

--- a/lib/Default/SmrPlanetType.class.inc
+++ b/lib/Default/SmrPlanetType.class.inc
@@ -1,0 +1,43 @@
+<?php
+
+abstract class SmrPlanetType {
+	abstract protected function name();
+	abstract protected function imageLink();
+	abstract protected function description();
+	abstract protected function maxAttackers();
+	abstract protected function maxLanded();
+}
+
+class TerranPlanet extends SmrPlanetType {
+	public function name()         { return "Terran Planet"; }
+	public function imageLink()    { return "images/planet1.png"; }
+	public function description()  { return "A lush world, with forests, seas, sweeping meadows, and indigenous lifeforms."; }
+	public function maxAttackers() { return 10; }
+	public function maxLanded()    { return 0; }
+}
+
+class AridPlanet extends SmrPlanetType {
+	public function name()         { return "Arid Planet"; }
+	public function imageLink()    { return "images/planet2.png"; }
+	public function description()  { return "A world mostly devoid of surface water, but capable of supporting life."; }
+	public function maxAttackers() { return 5; }
+	public function maxLanded()    { return 5; }
+}
+
+class DwarfPlanet extends SmrPlanetType {
+	public function name()         { return "Dwarf Planet"; }
+	public function imageLink()    { return "images/planet3.png"; }
+	public function description()  { return "A smaller than usual planet, with no native life present."; }
+	public function maxAttackers() { return 5; }
+	public function maxLanded()    { return 0; }
+}
+
+class DefenseWorld extends SmrPlanetType {
+	public function name()         { return "Defense World"; }
+	public function imageLink()    { return "images/planet4.png"; }
+	public function description()  { return "A fully armed and operational battle station loaded with excessive firepower. Attack at your own risk."; }
+	public function maxAttackers() { return 10; }
+	public function maxLanded()    { return 0; }
+}
+
+?>


### PR DESCRIPTION
With some requested changes to Arid Planets in the pipeline, I felt it would be easier to refactor the planet_type information instead of continuing to deal with database patches for static data. The first commit simply removes two unused and redundant functions, but the second does the actual refactoring. See the commit messages for more detail.