### PR TITLE
Fix AJAX clearing military payment message prematurely

### DIFF
--- a/engine/Default/military_payment_claim.php
+++ b/engine/Default/military_payment_claim.php
@@ -9,17 +9,26 @@ if ($sector->hasHQ())
 else
 	create_ug_menu();
 
-if ($player->hasMilitaryPayment()) {
-	$PHP_OUTPUT.=('For your military help you have been paid <span class="creds">'.number_format($player->getMilitaryPayment()).'</span> credits');
+// We can only claim the payment once, so to prevent clobbering the message
+// upon AJAX refresh, we store it as a session variable when we first get it.
+if(!isset($var['ClaimText'])) {
+	if ($player->hasMilitaryPayment()) {
+		$payment = $player->getMilitaryPayment();
+		$player->increaseHOF($payment, array('Military Payment','Money','Claimed'), HOF_PUBLIC);
 
-	$player->increaseHOF($player->getMilitaryPayment(),array('Military Payment','Money','Claimed'), HOF_PUBLIC);
+		// add to our cash
+		$player->increaseCredits($payment);
+		$player->setMilitaryPayment(0);
+		$player->update();
 
-	// add to our cash
-	$player->increaseCredits($player->getMilitaryPayment());
-	$player->setMilitaryPayment(0);
-	$player->update();
+		$claimText = ('For your military activity you have been paid <span class="creds">'.number_format($payment).'</span> credits.');
+	} else {
+		$claimText = ('You have done nothing worthy of military payment.');
+	}
 
-} else
-	$PHP_OUTPUT.=('You have done nothing worthy of military payment');
+	SmrSession::updateVar('ClaimText', $claimText);
+}
+
+$PHP_OUTPUT .= $var['ClaimText'];
 
 ?>


### PR DESCRIPTION
Follow the protocol in bounty_claim.php for storing a message from
a one-time transaction (in this case, claiming military payment)
so that it can correctly remain on the screen when AJAX refreshes.

Without this fix, the message about claimed military payment is
immediately replaced with the message that there is no military
payment to claim.