### PR TITLE
Add .gitkeep in htdocs/upload/

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For these files the sample version should provide good hints on what info is req
 
 
 ## Filesystem permissions
-SMR requires write access to htdocs/upload, you will need to create this folder.
+SMR requires write access to htdocs/upload.
 
 ## Database
 SMR is using [Flyway](http://flywaydb.org) to deploy database patches.


### PR DESCRIPTION
This directory needs to be created for a successful game build,
so we use .gitkeep to ensure that the directory exists.