### PR TITLE
Remove ICQ from account creation

### DIFF
--- a/htdocs/login_create.php
+++ b/htdocs/login_create.php
@@ -370,19 +370,6 @@ require_once('config.inc');
 							</select>
 						</td>
 					</tr>
-					<tr>
-						<td colspan='2'>&nbsp;</td>
-					</tr>
-					<tr>
-						<th colspan='2'>Various Information (Optional)</th>
-					</tr>
-					<tr>
-						<td colspan='2'>&nbsp;</td>
-					</tr>
-					<tr>
-						<td width='27%'>ICQ:</td>
-						<td width='73%'><input type='text' name='icq' size='20' maxlength='15' id='InputFields'></td>
-					</tr>
 					</table>
 
 					<p>&nbsp;</p>

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -213,13 +213,12 @@ try {
 		}
 	}
 
-	$icq = $_REQUEST['icq'];
 	// create account
 	$timez = $_REQUEST['timez'];
 
 	// creates a new user account object
 	try {
-		$account =& SmrAccount::createAccount($login,$password,$email,$first_name,$last_name,$address,$city,$postal_code,$country_code,$icq,$timez,$referral);
+		$account =& SmrAccount::createAccount($login,$password,$email,$first_name,$last_name,$address,$city,$postal_code,$country_code,$timez,$referral);
 	}
 	catch(Exception $e) {
 		$msg = 'Invalid referral id!';

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -129,7 +129,7 @@ abstract class AbstractSmrAccount {
 		}
 	}
 
-	public static function &createAccount($login,$password,$email,$first_name,$last_name,$address,$city,$postal_code,$country_code,$icq,$timez,$referral) {
+	public static function &createAccount($login,$password,$email,$first_name,$last_name,$address,$city,$postal_code,$country_code,$timez,$referral) {
 		if($referral!=0) {
 			try {
 				SmrAccount::getAccount($referral);
@@ -139,11 +139,11 @@ abstract class AbstractSmrAccount {
 			}
 		}
 		$db = new SmrMySqlDatabase();
-		$db->query('INSERT INTO account (login, password, email, first_name, last_name, address, city, postal_code, country_code, icq, validation_code, last_login, offset,referral_id,hof_name) VALUES(' .
+		$db->query('INSERT INTO account (login, password, email, first_name, last_name, address, city, postal_code, country_code, validation_code, last_login, offset,referral_id,hof_name) VALUES(' .
 			$db->escape_string($login) . ', ' . $db->escape_string(md5($password)) . ', ' . $db->escape_string($email) . ', ' .
 			$db->escape_string($first_name) . ', ' . $db->escape_string($last_name) . ', ' .
 			$db->escape_string($address) . ', ' . $db->escape_string($city) . ', ' . $db->escape_string($postal_code) . ', ' .
-			$db->escape_string($country_code) . ', ' . $db->escape_string(trim($icq)) . ', ' . $db->escape_string(substr(SmrSession::$session_id, 0, 10)) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($timez) . ',' . $db->escapeNumber($referral).','.$db->escapeString($login).')');
+			$db->escape_string($country_code) . ', ' . $db->escape_string(substr(SmrSession::$session_id, 0, 10)) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($timez) . ',' . $db->escapeNumber($referral).','.$db->escapeString($login).')');
 		return self::getAccountByName($login);
 	}
 
@@ -704,11 +704,11 @@ abstract class AbstractSmrAccount {
 				}
 
 				$db = new SmrMySqlDatabase();
-				$db->query('INSERT INTO account (login, password, email, first_name, last_name, address, city, postal_code, country_code, icq, validation_code, veteran, last_login, logging, offset,images,fontsize,referral_id,hof_name,validated) VALUES(' .
+				$db->query('INSERT INTO account (login, password, email, first_name, last_name, address, city, postal_code, country_code, validation_code, veteran, last_login, logging, offset,images,fontsize,referral_id,hof_name,validated) VALUES(' .
 							$db->escape_string($db2->getField('login')) . ', ' . $db->escape_string(md5($db2->getField('password'))) . ', ' . $db->escape_string($db2->getField('email')) . ', ' .
 							$db->escape_string($db2->getField('first_name')) . ', ' . $db->escape_string($db2->getField('last_name')) . ', ' .
 							$db->escape_string($db2->getField('address')) . ', ' . $db->escape_string($db2->getField('city')) . ', ' . $db->escape_string($db2->getField('postal_code')) . ', ' .
-							$db->escape_string($db2->getField('country_code')) . ', ' . $db->escape_string($db2->getField('icq')) . ', ' . $db->escape_string($db2->getField('validation_code')) . ',' .
+							$db->escape_string($db2->getField('country_code')) . ', ' . $db->escape_string($db2->getField('validation_code')) . ',' .
 							$db->escape_string($db2->getField('veteran')) . ',' . $db->escapeBoolean(false) . ',' . TIME . ',' .$db->escapeNumber($db2->getInt('offset')).',' .
 							$db->escapeString($db2->getField('images')).','.$db->escapeString($db2->getField('fontsize')+20).','.$db->escapeNumber(0).','.$db->escapeString($db2->getField('login')).','.$db->escapeString($db2->getField('validated')).')');
 

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -437,7 +437,7 @@ function changeNPCLogin() {
 
 	if(SmrAccount::getAccountByName($NPC_LOGIN['Login'])==null) {
 		debug('Creating account for: '.$NPC_LOGIN['Login']);
-		$account =& SmrAccount::createAccount($NPC_LOGIN['Login'],'','NPC@smrealms.de','NPC','NPC','NPC','NPC','NPC','NPC','NPC',0,0);
+		$account =& SmrAccount::createAccount($NPC_LOGIN['Login'],'','NPC@smrealms.de','NPC','NPC','NPC','NPC','NPC','NPC',0,0);
 		$account->setValidated(true);
 	}
 	else {


### PR DESCRIPTION
* Remove the request to provide ICQ information in the registration
  page. Asking for that information makes the game look more outdated
  than it needs to and significantly lengthens the page.

* Remove the `icq` argument from SmrAccount::createAccount.
  This field isn't used anywhere else in the code.

* For simplicity, we don't bother to remove the `icq` column from
  the `account` table. It doesn't harm anything to stay there,
  since it has a null default.