### PR TITLE
Add credits lost message to deaths from ports/planets/forces

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1296,6 +1296,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$return['DeadExp'] = floor($this->getExperience() * $expLossPercentage);
 		$this->decreaseExperience($return['DeadExp']);
 
+		$return['LostCredits'] = $this->getCredits();
+
 		$this->db->query('SELECT * FROM alliance_vs_alliance
 						WHERE alliance_id_1 = -1 AND alliance_id_2 = ' . $this->db->escapeNumber($this->getAllianceID()) . ' AND game_id = ' . $this->db->escapeNumber($this->getGameID()));
 		if ($this->db->nextRecord()) {
@@ -1332,6 +1334,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$return['DeadExp'] = floor($this->getExperience() * $expLossPercentage);
 		$this->decreaseExperience($return['DeadExp']);
 
+		$return['LostCredits'] = $this->getCredits();
+
 		$this->killPlayer($port->getSectorID());
 		return $return;
 	}
@@ -1356,6 +1360,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$expLossPercentage = .27 - $planet->getLevel()/1000;
 		$return['DeadExp'] = floor($this->getExperience() * $expLossPercentage);
 		$this->decreaseExperience($return['DeadExp']);
+
+		$return['LostCredits'] = $this->getCredits();
 
 		$this->killPlayer($planet->getSectorID());
 		return $return;

--- a/templates/Default/engine/Default/includes/TraderCombatKillMessage.inc
+++ b/templates/Default/engine/Default/includes/TraderCombatKillMessage.inc
@@ -1,5 +1,12 @@
 <?php
 echo $TargetPlayer->getDisplayName(); ?> has been <span class="red">DESTROYED</span>, losing <span class="exp"><?php echo number_format($KillResults['DeadExp'])?></span> experience.<br /><?php
 if(isset($ShootingPlayer)) {
+	// Killed by another player
 	echo $ShootingPlayer->getDisplayName(); ?> salvages <span class="creds"><?php echo number_format($KillResults['KillerCredits']); ?></span> credits from the wreckage and gains <span class="exp"><?php echo number_format($KillResults['KillerExp']); ?></span> experience.<br /><?php
-} ?>
+} else {
+	// Killed by port, planet, forces
+	echo 'The <span class="creds"> ' . number_format($KillResults['LostCredits'])
+	     . '</span> credits that were onboard ' . $TargetPlayer->getDisplayName()
+	     . "'s ship are lost in the wreckage.<br />";
+}
+?>


### PR DESCRIPTION
This patch provides extra information about how many credits are lost when a player is destroyed by ports, planets, and forces. I don't believe this information is available to the destroyed player in any other form, which seems like an oversight.

The message reads:
"The X credits that were onboard Y's ship are lost in the wreckage."