### PR TITLE
SmrPlanet.class.inc: remove duplicate methods

### DIFF
--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -820,15 +820,6 @@ class SmrPlanet {
 		return "Error";
 	}
 	
-	public function getPlanetID() {
-		return $this->palentID;
-	}
-	
-	public function setPlanetID($num) {
-		$this->typeID = $num;
-		$this->hasChanged = true;
-	}
-	
 	public function getOptions($option=false) {
 
 		if(!isset($this->canOptions)) {


### PR DESCRIPTION
The methods {get,set}PlanetID were unused (and non-functional)
duplicates of the {get,set}TypeID methods, so we remove them here.

This is the non-blocking commit from PR #88.