### PR TITLE
Replace hard-coded URLs

### DIFF
--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -675,7 +675,7 @@ function createGame($gameID) {
 	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 22, \'Ships\')');
 	$text = 'Everything you do in SMR is done while you are flying some kind of ship - it can be anything from an escape pod to a huge IkThorne mothership, but you are always the pilot of something. In addition to the neutral ships, each race also has unique ships that only race members can purchase. You can find the SMR shiplist here:<br />
 	<a href="http://www.smrealms.de/ship_list.php target="_blank">http://www.smrealms.de/ship_list.php</a> <br />
-	Additional information relating to ships can be found in the <a href="http://wiki.smrealms.de/" target="_blank">SMR wiki</a><br />
+	Additional information relating to ships can be found in the <a href="' . WIKI_URL . '" target="_blank">SMR wiki</a><br />
 	<br />
 	It is important to choose ships to match your budget and your needs, and the biggest or most expensive ships are not always the best ones for all purposes.<br />
 	<br />

--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -674,7 +674,7 @@ function createGame($gameID) {
 	
 	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 22, \'Ships\')');
 	$text = 'Everything you do in SMR is done while you are flying some kind of ship - it can be anything from an escape pod to a huge IkThorne mothership, but you are always the pilot of something. In addition to the neutral ships, each race also has unique ships that only race members can purchase. You can find the SMR shiplist here:<br />
-	<a href="http://www.smrealms.de/ship_list.php target="_blank">http://www.smrealms.de/ship_list.php</a> <br />
+	<a href="' . URL . '/ship_list.php target="_blank">' . URL . '/ship_list.php</a> <br />
 	Additional information relating to ships can be found in the <a href="' . WIKI_URL . '" target="_blank">SMR wiki</a><br />
 	<br />
 	It is important to choose ships to match your budget and your needs, and the biggest or most expensive ships are not always the best ones for all purposes.<br />
@@ -703,7 +703,7 @@ function createGame($gameID) {
 	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 23, \'Weapons\')');
 	$text = 'SMR has a wide variety of weapons with which to arm your ships, and information on weapon capabilities can be found here:<br />
 	<br />
-	<a href="http://www.smrealms.de/weapon_list.php">http://www.smrealms.de/weapon_list.php</a><br />
+	<a href="' . URL . '/weapon_list.php">' . URL . '/weapon_list.php</a><br />
 	<br />
 	There are a few things to consider when choosing weapons, and the weapon combination that works for one player may not be suited to the style or the needs of another.<br />
 	<br />

--- a/admin/Default/universe_create_end.php
+++ b/admin/Default/universe_create_end.php
@@ -240,7 +240,7 @@ $db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply
 $db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES ('.$game_id.', 302, 22, \'Ships\')');
 $text = 'Everything you do in SMR is done while you are flying some kind of ship - it can be anything from an escape pod to a huge IkThorne mothership, but you are always the pilot of something. In addition to the neutral ships, each race also has unique ships that only race members can purchase. You can find the SMR shiplist here:<br />	
 <a href="http://www.smrealms.de/ship_list.php target="_blank">http://www.smrealms.de/ship_list.php</a> <br />
-Additional information relating to ships can be found in the <a href="http://wiki.smrealms.de/" target="_blank">SMR wiki</a><br />
+Additional information relating to ships can be found in the <a href="' . WIKI_URL . '" target="_blank">SMR wiki</a><br />
 <br />
 It is important to choose ships to match your budget and your needs, and the biggest or most expensive ships are not always the best ones for all purposes.<br />
 <br />

--- a/admin/Default/universe_create_end.php
+++ b/admin/Default/universe_create_end.php
@@ -239,7 +239,7 @@ $db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply
 
 $db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES ('.$game_id.', 302, 22, \'Ships\')');
 $text = 'Everything you do in SMR is done while you are flying some kind of ship - it can be anything from an escape pod to a huge IkThorne mothership, but you are always the pilot of something. In addition to the neutral ships, each race also has unique ships that only race members can purchase. You can find the SMR shiplist here:<br />	
-<a href="http://www.smrealms.de/ship_list.php target="_blank">http://www.smrealms.de/ship_list.php</a> <br />
+<a href="' . URL . '/ship_list.php target="_blank">' . URL . '/ship_list.php</a> <br />
 Additional information relating to ships can be found in the <a href="' . WIKI_URL . '" target="_blank">SMR wiki</a><br />
 <br />
 It is important to choose ships to match your budget and your needs, and the biggest or most expensive ships are not always the best ones for all purposes.<br />
@@ -268,7 +268,7 @@ $db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply
 $db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES ('.$game_id.', 302, 23, \'Weapons\')');
 $text = 'SMR has a wide variety of weapons with which to arm your ships, and information on weapon capabilities can be found here:<br />
 <br />
-<a href="http://www.smrealms.de/weapon_list.php">http://www.smrealms.de/weapon_list.php</a><br />>
+<a href="' . URL . '/weapon_list.php">' . URL . '/weapon_list.php</a><br />>
 <br />
 There are a few things to consider when choosing weapons, and the weapon combination that works for one player may not be suited to the style or the needs of another.<br />
 <br />

--- a/engine/Default/alliance_forces.php
+++ b/engine/Default/alliance_forces.php
@@ -52,7 +52,7 @@ AND player.alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
 AND expire_time >= ' . $db->escapeNumber(TIME) . '
 ORDER BY ' . $categorySQL . ', ' . $subcategory);
 
-$PHP_OUTPUT.= '<div align="center"><a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Forces" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a>';
+$PHP_OUTPUT.= '<div align="center"><a href="' . WIKI_URL . '/index.php?title=Game_Guide:_Forces" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a>';
 
 if ($db->getNumRows() > 0) {
 	$PHP_OUTPUT.= 'Your alliance currently has ';

--- a/engine/Default/forces_list.php
+++ b/engine/Default/forces_list.php
@@ -37,7 +37,7 @@ if ($db->getNumRows() > 0) {
 	$container['subcategory'] = $category;
 
 	$PHP_OUTPUT.=create_table();
-	$PHP_OUTPUT.=('<a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Forces" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a><br />');
+	$PHP_OUTPUT.=('<a href="' . WIKI_URL . '/index.php?title=Game_Guide:_Forces" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a><br />');
 	$PHP_OUTPUT.=('<tr>');
 	setCategories($container,'sector_id',$category,$categorySQL,$subcategory);
 	$PHP_OUTPUT.=('<th align="center">');
@@ -77,7 +77,7 @@ if ($db->getNumRows() > 0) {
 }
 
 else
-	$PHP_OUTPUT.=('You have no deployed forces <a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Forces" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a>');
+	$PHP_OUTPUT.=('You have no deployed forces <a href="' . WIKI_URL . '/index.php?title=Game_Guide:_Forces" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a>');
 
 
 function setCategories(&$container,$newCategory,$oldCategory,$oldCategorySQL,$subcategory) {

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -59,7 +59,7 @@ else if ($action == 'Save and resend validation code') {
 		'You changed your email address registered within SMR and need to revalidate now!'.EOL.EOL.
 		'   Your new validation code is: '.$account->getValidationCode().EOL.EOL.
 		'The Space Merchant Realms server is on the web at '.URL.'/.'.EOL.
-		'You\'ll find a quick how-to-play here <a href="http://wiki.smrealms.de/index.php?title=Video_Tutorials#A_Look_At_The_Game">SMR Wiki: A look at the game</a>'.EOL.
+		'You\'ll find a quick how-to-play here <a href="' . WIKI_URL . '/index.php?title=Video_Tutorials#A_Look_At_The_Game">SMR Wiki: A look at the game</a>'.EOL.
 		'Please verify within the next 7 days or your account will be automatically deleted.',
 		'From: support@smrealms.de');
 

--- a/engine/Default/trader_status.php
+++ b/engine/Default/trader_status.php
@@ -82,7 +82,7 @@ if($bounty['Amount']>0||$bounty['SmrCredits']>0)
 else
 	$PHP_OUTPUT.= 'None';
 
-$PHP_OUTPUT.= '<br /><br /><span class="yellow bold">Ship</span><a href="http://www.smrealms.de/ship_list.php" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Ship List"/></a><br />Name: ';
+$PHP_OUTPUT.= '<br /><br /><span class="yellow bold">Ship</span><a href="' . URL . '/ship_list.php" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Ship List"/></a><br />Name: ';
 
 $PHP_OUTPUT.= $ship->getName();
 $PHP_OUTPUT.= '<br />Speed: ';

--- a/engine/Default/trader_status.php
+++ b/engine/Default/trader_status.php
@@ -9,7 +9,7 @@ $container['url'] = 'skeleton.php';
 
 $PHP_OUTPUT.= '<table class="standard fullwidth"><tr><td style="width:50%" class="top">';
 
-$PHP_OUTPUT.= '<span class="yellow bold">Protection</span><a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Federal_Protection" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Protection"/></a><br />';
+$PHP_OUTPUT.= '<span class="yellow bold">Protection</span><a href="' . WIKI_URL . '/index.php?title=Game_Guide:_Federal_Protection" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Protection"/></a><br />';
 if($player->getNewbieTurns()) {
 	$PHP_OUTPUT.= 'You are under <span class="green">NEWBIE</span> protection.<br /><br />';
 
@@ -38,7 +38,7 @@ foreach($RACES as $raceID => $raceInfo) {
 $PHP_OUTPUT.= '<br />';
 
 $container['body'] = 'council_list.php';
-$PHP_OUTPUT.=create_link($container, '<span class="yellow bold">Politics</span><a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>');
+$PHP_OUTPUT.=create_link($container, '<span class="yellow bold">Politics</span><a href="' . WIKI_URL . '/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>');
 $PHP_OUTPUT.= '<br />';
 
 require_once(get_file_loc('council.inc'));
@@ -58,7 +58,7 @@ else {
 $PHP_OUTPUT.= '<br /><br />';
 
 $container['body'] = 'trader_savings.php';
-$PHP_OUTPUT.=create_link($container, '<span class="yellow bold">Savings</span><a href="http://wiki.smrealms.de/index.php?title=Banks" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Banks"/></a>');
+$PHP_OUTPUT.=create_link($container, '<span class="yellow bold">Savings</span><a href="' . WIKI_URL . '/index.php?title=Banks" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Banks"/></a>');
 $PHP_OUTPUT.= '<br />You have <span class="yellow">';
 
 $PHP_OUTPUT.= number_format($player->getBank());
@@ -67,7 +67,7 @@ $PHP_OUTPUT.= '</span> credits in your personal account.';
 $PHP_OUTPUT.= '</td><td class="top" style="width:50%">';
 
 $container['body'] = 'trader_bounties.php';
-$PHP_OUTPUT.=create_link($container, '<span class="yellow bold">Bounties</span><a href="http://wiki.smrealms.de/index.php?title=Headquarters" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Bounties"/></a>');
+$PHP_OUTPUT.=create_link($container, '<span class="yellow bold">Bounties</span><a href="' . WIKI_URL . '/index.php?title=Headquarters" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Bounties"/></a>');
 
 $PHP_OUTPUT.= '<br /><span class="green">Federal: </span>';
 $bounty = $player->getCurrentBounty('HQ');
@@ -89,7 +89,7 @@ $PHP_OUTPUT.= '<br />Speed: ';
 $PHP_OUTPUT.= $ship->getRealSpeed();
 $PHP_OUTPUT.= ' turns/hour<br />Max: ';
 $PHP_OUTPUT.= $player->getMaxTurns();
-$PHP_OUTPUT.= ' turns<br /><br /><span class="yellow bold">Supported Hardware</span><a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Technologies" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Technologies"/></a><br />';
+$PHP_OUTPUT.= ' turns<br /><br /><span class="yellow bold">Supported Hardware</span><a href="' . WIKI_URL . '/index.php?title=Game_Guide:_Technologies" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Technologies"/></a><br />';
 
 if (!$ship->canHaveScanner() &&
 	!$ship->canHaveIllusion() &&
@@ -104,7 +104,7 @@ else {
 	if ($ship->canHaveDCS()) $PHP_OUTPUT.= 'Drone Scrambler<br />';
 }
 
-$PHP_OUTPUT.= '<br /><a href="'.URL.'/level_requirements.php" target="levelRequirements"><span class="yellow bold">Next Level</span></a><a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Experience_Levels" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Experience Levels"/></a><br />';
+$PHP_OUTPUT.= '<br /><a href="'.URL.'/level_requirements.php" target="levelRequirements"><span class="yellow bold">Next Level</span></a><a href="' . WIKI_URL . '/index.php?title=Game_Guide:_Experience_Levels" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Experience Levels"/></a><br />';
 $db->query('SELECT level_name,requirement FROM level WHERE requirement>' . $db->escapeNumber($player->getExperience()) . ' ORDER BY requirement ASC LIMIT 1');
 if(!$db->nextRecord()) {
 	$db->query('SELECT level_name,requirement FROM level ORDER BY requirement DESC LIMIT 1');

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -25,6 +25,8 @@ define('MAX_IMAGE_HEIGHT',30);
 define('IRC_BOT_SOCKET', '/tmp/ircbot.sock');
 define('MULTI_CHECKING_COOKIE_VERSION','v3');
 
+define('WIKI_URL', 'http://wiki.smrealms.de');
+
 /*
  * Localisations
  */

--- a/htdocs/email_processing.php
+++ b/htdocs/email_processing.php
@@ -59,7 +59,7 @@ try {
 		'You changed your email address registered within SMR and need to revalidate now!'.EOL.EOL.
 		'   Your new validation code is: '.$account->getValidationCode().EOL.EOL.
 		'The Space Merchant Realms server is on the web at '.URL.'/.'.EOL.
-		'You\'ll find a quick how-to-play here <a href="http://wiki.smrealms.de/index.php?title=Video_Tutorials#A_Look_At_The_Game">SMR Wiki: A look at the game</a>'.EOL.
+		'You\'ll find a quick how-to-play here <a href="' . WIKI_URL . '/index.php?title=Video_Tutorials#A_Look_At_The_Game">SMR Wiki: A look at the game</a>'.EOL.
 		'Please verify within the next 7 days or your account will be automatically deleted.',
 		'From: support@smrealms.de');
 

--- a/templates/Default/engine/Default/alliance_planets.php
+++ b/templates/Default/engine/Default/alliance_planets.php
@@ -6,7 +6,7 @@
 	}
 	else { ?>
 		Your alliance has no claimed planets.
-		<a href="http://wiki.smrealms.de/index.php?title=Planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
+		<a href="<?php echo WIKI_URL; ?>/index.php?title=Planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
 		<?php
 	} ?>
 </div>

--- a/templates/Default/engine/Default/council_embassy.php
+++ b/templates/Default/engine/Default/council_embassy.php
@@ -1,4 +1,4 @@
-<a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
+<a href="<?php echo WIKI_URL; ?>/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
 <div class="center bold">Diplomatic Treaties</div><br />
 <div class="center standard">
 	Welcome President <?php echo $ThisPlayer->getDisplayName(); ?>,<br /><br />

--- a/templates/Default/engine/Default/council_list.php
+++ b/templates/Default/engine/Default/council_list.php
@@ -1,5 +1,5 @@
 <div align="center">
-	<a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
+	<a href="<?php echo WIKI_URL; ?>/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
 	<h3>President</h3><br/><?php
 	$President =& Council::getPresident($ThisPlayer->getGameID(),$RaceID);
 	if ($President !== false) { ?>

--- a/templates/Default/engine/Default/council_politics.php
+++ b/templates/Default/engine/Default/council_politics.php
@@ -1,4 +1,4 @@
-<a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
+<a href="<?php echo WIKI_URL; ?>/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
 <div class="center">
 	<p>We currently have the following diplomatic relationships:</p>
 	<table class="center">

--- a/templates/Default/engine/Default/council_vote.php
+++ b/templates/Default/engine/Default/council_vote.php
@@ -1,4 +1,4 @@
-<a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
+<a href="<?php echo WIKI_URL; ?>/index.php?title=Game_Guide:_Politics_and_the_Ruling_Council" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
 
 <div class="center bold">Diplomatic Treaties</div><br />
 <div class="center standard">

--- a/templates/Default/engine/Default/course_plot.php
+++ b/templates/Default/engine/Default/course_plot.php
@@ -1,4 +1,4 @@
-<a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_How_your_ship_works" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: How Your Ship Works"/></a>
+<a href="<?php echo WIKI_URL; ?>/index.php?title=Game_Guide:_How_your_ship_works" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: How Your Ship Works"/></a>
 <form class="standard" id="PlotCourseForm" method="POST" action="<?php echo $PlotCourseFormLink; ?>">
 	<h2>Conventional</h2>
 	<div class="standard">Enter a destination sector.</div>

--- a/templates/Default/engine/Default/game_join.php
+++ b/templates/Default/engine/Default/game_join.php
@@ -62,7 +62,7 @@ if($Game['GameDescription']) { ?>
 						<li>Names that violate these rules will be changed by the admins and require you to change your name, in extreme cases, abuse of the naming process will result in your account being banned.</li>
 					</ul>
 					If you disregard these rules, your player will be deleted, so choose your name wisely.<br /><br />
-					All Space Merchant Realms Rules can be viewed on the Space Merchant Realms Wiki under <a href="http://wiki.smrealms.de/index.php?title=Space_Merchant_Realms_v1.6_Rules" target="_blank">Rules<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Rules"/></a>
+					All Space Merchant Realms Rules can be viewed on the Space Merchant Realms Wiki under <a href="<?php echo WIKI_URL; ?>/index.php?title=Space_Merchant_Realms_v1.6_Rules" target="_blank">Rules<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Rules"/></a>
 					<br />
 				</p>	
 				<h2>Choosing Your Race</h2>
@@ -78,7 +78,7 @@ if($Game['GameDescription']) { ?>
 					<br />
 					Each race has unique characteristics that cannot be represented by the graphs to be shown here. Races that appear strongest may have certain disadvantages while races that appear weakest have special benefits. Listed below are some of the basic characteristics of each race.<br />
 					<br />
-					A full description including benefits and disadvantages as well as ship lists of each race can be seen by accessing SMR Wiki <a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Races" target="_blank">Races<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Races"/></a> page.<br /><br />
+					A full description including benefits and disadvantages as well as ship lists of each race can be seen by accessing SMR Wiki <a href="<?php echo WIKI_URL; ?>/index.php?title=Game_Guide:_Races" target="_blank">Races<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Races"/></a> page.<br /><br />
 				<ul>
 					<li>Alskant - Large variety of hardware but no dedicated warship. Trade bonus with Neutral ports.</li>
 					<li>Creonti - Cute and cuddly with lots of firepower. Ships' defences consist predominantly of armour.</li>

--- a/templates/Default/engine/Default/includes/LeftPanel.inc
+++ b/templates/Default/engine/Default/includes/LeftPanel.inc
@@ -56,7 +56,7 @@ else {
 }
 //<a href="http://www.azool.us/baalz/" target="manual">Help Pages</a><br />
 ?>
-<a href="http://wiki.smrealms.de" target="_blank">SMR Wiki</a><br /><?php
+<a href="<?php echo WIKI_URL; ?>" target="_blank">SMR Wiki</a><br /><?php
 if(isset($GameID)) {
 	?><a href="<?php echo Globals::getSmrFileCreateHREF(); ?>" target="_self">DL Sectors File</a><br /><?php
 } ?>

--- a/templates/Default/engine/Default/includes/PlanetList.inc
+++ b/templates/Default/engine/Default/includes/PlanetList.inc
@@ -5,7 +5,7 @@ if (count($Planets) > 0) { ?>
 		<thead>
 			<tr>
 				<th class="sort shrink" data-sort="image">
-					<a href="http://wiki.smrealms.de/index.php?title=Planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a></th>
+					<a href="<?php echo WIKI_URL; ?>/index.php?title=Planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a></th>
 				<th class="sort shrink" data-sort="name">Name</th>
 				<th class="sort shrink" data-sort="lvl">Level</th>
 				<th class="sort shrink" data-sort="owner">Owner</th>

--- a/templates/Default/engine/Default/includes/RightPanel.inc
+++ b/templates/Default/engine/Default/includes/RightPanel.inc
@@ -35,7 +35,7 @@ if(isset($GameID)) { ?>
 	Credits : <span id="creds"><?php echo number_format($ThisPlayer->getCredits()); ?></span><br />
 	Experience : <span id="exp"><?php echo number_format($ThisPlayer->getExperience()); ?></span><br />
 	<a href="<?php echo URL; ?>/level_requirements.php" target="levelRequirements">Level : <span id="lvl"><?php echo $ThisPlayer->getLevelID(); ?></span></a><br />
-	<a href="<?php echo URL; ?>/level_requirements.php" target="levelRequirements">Next Level: </a><a href="http://wiki.smrealms.de/index.php?title=Game_Guide:_Experience_Levels" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Experience Levels"/></a><br /><?php
+	<a href="<?php echo URL; ?>/level_requirements.php" target="levelRequirements">Next Level: </a><a href="<?php echo WIKI_URL; ?>/index.php?title=Game_Guide:_Experience_Levels" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Experience Levels"/></a><br /><?php
 	$NextLevelExperience = number_format($ThisPlayer->getNextLevelExperience());
 	$Experience = number_format($ThisPlayer->getExperience()); ?>
 	<a href="<?php echo URL; ?>/level_requirements.php" target="levelRequirements">

--- a/templates/Default/engine/Default/newbie_warning.php
+++ b/templates/Default/engine/Default/newbie_warning.php
@@ -20,4 +20,4 @@
 
 <p>Plan for your safety now. Remember to use federal protection (Must have an acceptable attack rating, this increases/decreases with your align so it is safest to have an attack rating of 0 if unsure, also make sure to stick to the federal space of friendly races), know where your alliances strongest planets are, and watch out for the people looking for you.</p>
 
-<p>For more information visit the <a href="http://wiki.smrealms.de">SMR Wiki</a></p>
+<p>For more information visit the <a href="<?php echo WIKI_URL; ?>">SMR Wiki</a></p>

--- a/templates/Default/engine/Default/planet_main.php
+++ b/templates/Default/engine/Default/planet_main.php
@@ -19,7 +19,7 @@ if (isset($Msg)) {
 		</td>
 	<tr>
 		<td style="width:50%">
-			<a href="http://wiki.smrealms.de/index.php?title=Planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
+			<a href="<?php echo WIKI_URL; ?>/index.php?title=Planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
 			<table class="standard">
 				<tr>
 					<th width="145">&nbsp;</th>

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -111,8 +111,8 @@
 
                 <!-- header menu -->
                 <a href="http://video.smrealms.de/" target="vid"><img src="images/login/video.png" width="166" height="29" alt="Video Tutorials"></a>
-                <a href="http://wiki.smrealms.de" target="ml"><img src="images/login/sml.png" width="166" height="29" alt="Merchant Library"></a>
-                <a href="http://wiki.smrealms.de" target="manu"><img src="images/login/manual2.png" width="129" height="29" alt="Wiki"></a>
+                <a href="<?php echo WIKI_URL; ?>" target="ml"><img src="images/login/sml.png" width="166" height="29" alt="Merchant Library"></a>
+                <a href="<?php echo WIKI_URL; ?>" target="manu"><img src="images/login/manual2.png" width="129" height="29" alt="Wiki"></a>
                 <a href="http://smrcnn.smrealms.de" target="board"><img src="images/login/webboard2.png" width="128" height="29" alt="Web Board"></a>
                 <a href="http://www.smrealms.de/cgi-bin/awstats.pl" target="stat"><img src="images/login/stats2.png" width="180" height="29" alt="Site Statistics"></a><br />
 			</p>

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -114,7 +114,7 @@
                 <a href="<?php echo WIKI_URL; ?>" target="ml"><img src="images/login/sml.png" width="166" height="29" alt="Merchant Library"></a>
                 <a href="<?php echo WIKI_URL; ?>" target="manu"><img src="images/login/manual2.png" width="129" height="29" alt="Wiki"></a>
                 <a href="http://smrcnn.smrealms.de" target="board"><img src="images/login/webboard2.png" width="128" height="29" alt="Web Board"></a>
-                <a href="http://www.smrealms.de/cgi-bin/awstats.pl" target="stat"><img src="images/login/stats2.png" width="180" height="29" alt="Site Statistics"></a><br />
+                <a href="<?php echo URL; ?>/cgi-bin/awstats.pl" target="stat"><img src="images/login/stats2.png" width="180" height="29" alt="Site Statistics"></a><br />
 			</p>
 			<?php
 


### PR DESCRIPTION
These two commits replace the following hard-coded URLs with global defines:
* www.smrealms.de (already existed as `URL`)
* wiki.smrealms.de (created new global define `WIKI_URL`)