### PR TITLE
New admin tools

### DIFF
--- a/admin/Default/enable_game.php
+++ b/admin/Default/enable_game.php
@@ -15,7 +15,7 @@ while ($db->nextRecord()) {
 $template->assign('DisabledGames', $disabledGames);
 
 // Create the link to the processing file
-$link_container = create_container('enable_game_processing.php', '');
-$template->assign('EnableGameHREF', SmrSession::getNewHREF($link_container));
+$linkContainer = create_container('enable_game_processing.php', '');
+$template->assign('EnableGameHREF', SmrSession::getNewHREF($linkContainer));
 
 ?>

--- a/admin/Default/enable_game.php
+++ b/admin/Default/enable_game.php
@@ -1,0 +1,21 @@
+<?php
+
+$template->assign('PageTopic', 'Enable New Games');
+
+// If we have just forwarded from the processing file, pass its message.
+$template->assign('ProcessingMsg', $var['processing_msg']);
+
+// Get the list of disabled games
+$db->query('SELECT game_name, game_id FROM game WHERE enabled=' . $db->escapeBoolean(false));
+$disabledGames = array();
+while ($db->nextRecord()) {
+	$disabledGames[] = array('game_name' => $db->getField('game_name'),
+	                         'game_id' => $db->getInt('game_id'));
+}
+$template->assign('DisabledGames', $disabledGames);
+
+// Create the link to the processing file
+$link_container = create_container('enable_game_processing.php', '');
+$template->assign('EnableGameHREF', SmrSession::getNewHREF($link_container));
+
+?>

--- a/admin/Default/enable_game_processing.php
+++ b/admin/Default/enable_game_processing.php
@@ -1,0 +1,16 @@
+<?php
+
+if (!empty($_POST['game_id'])) {
+	// Enable the requested game
+	$game_id = $db->escapeNumber($_POST['game_id']);
+	$enabled = $db->escapeBoolean(true);
+	$db->query("UPDATE game SET enabled=$enabled WHERE game_id=$game_id");
+
+	$game = SmrGame::getGame($_POST['game_id'])->getDisplayName();
+	$msg = "<span class='green'>SUCCESS: </span>Enabled game $game.";
+}
+
+forward(create_container('skeleton.php', 'enable_game.php',
+                         array('processing_msg' => $msg)));
+
+?>

--- a/admin/Default/enable_game_processing.php
+++ b/admin/Default/enable_game_processing.php
@@ -2,9 +2,8 @@
 
 if (!empty($_POST['game_id'])) {
 	// Enable the requested game
-	$game_id = $db->escapeNumber($_POST['game_id']);
-	$enabled = $db->escapeBoolean(true);
-	$db->query("UPDATE game SET enabled=$enabled WHERE game_id=$game_id");
+	$db->query('UPDATE game SET enabled=' . $db->escapeBoolean(true) .
+	           ' WHERE game_id=' . $db->escapeNumber($_POST['game_id']));
 
 	$game = SmrGame::getGame($_POST['game_id'])->getDisplayName();
 	$msg = "<span class='green'>SUCCESS: </span>Enabled game $game.";

--- a/admin/Default/manage_post_editors.php
+++ b/admin/Default/manage_post_editors.php
@@ -4,8 +4,7 @@ $template->assign('PageTopic', 'Manage Galactic Post Editors');
 
 // Get the list of active games ordered by reverse start date
 $activeGames = array();
-$db_time = $db->escapeNumber(TIME);
-$db->query('SELECT game_id, game_name FROM game WHERE start_date < ' . $db_time . ' AND end_date > ' . $db_time . ' ORDER BY start_date DESC');
+$db->query('SELECT game_id, game_name FROM game WHERE start_date < ' . $db->escapeNumber(TIME) . ' AND end_date > ' . $db->escapeNumber(TIME) . ' ORDER BY start_date DESC');
 while ($db->nextRecord()) {
 	$activeGames[] = array('game_name' => $db->getField('game_name'),
 	                       'game_id' => $db->getInt('game_id'));
@@ -38,7 +37,7 @@ $template->assign('ProcessingMsg', $var['processing_msg']);
 
 // Create the link to the processing file
 // Pass entire $var so the processing file knows the selected game
-$link_container = create_container('manage_post_editors_processing.php', '', $var);
-$template->assign('PostEditorHREF', SmrSession::getNewHREF($link_container));
+$linkContainer = create_container('manage_post_editors_processing.php', '', $var);
+$template->assign('PostEditorHREF', SmrSession::getNewHREF($linkContainer));
 
 ?>

--- a/admin/Default/manage_post_editors.php
+++ b/admin/Default/manage_post_editors.php
@@ -1,0 +1,44 @@
+<?php
+
+$template->assign('PageTopic', 'Manage Galactic Post Editors');
+
+// Get the list of active games ordered by reverse start date
+$activeGames = array();
+$db_time = $db->escapeNumber(TIME);
+$db->query('SELECT game_id, game_name FROM game WHERE start_date < ' . $db_time . ' AND end_date > ' . $db_time . ' ORDER BY start_date DESC');
+while ($db->nextRecord()) {
+	$activeGames[] = array('game_name' => $db->getField('game_name'),
+	                       'game_id' => $db->getInt('game_id'));
+}
+$template->assign('ActiveGames', $activeGames);
+
+if ($activeGames) {
+	// Set the selected game (or the first in the list if not selected yet)
+	if (isset($_POST['game_id'])) {
+		SmrSession::updateVar('selected_game_id', $_POST['game_id']);
+		SmrSession::updateVar('processing_msg', null);
+	} else if (!isset($var['selected_game_id'])) {
+		SmrSession::updateVar('selected_game_id', $activeGames[0]['game_id']);
+	}
+	$template->assign('SelectedGame', $var['selected_game_id']);
+
+	// Get the list of current editors for the selected game
+	$currentEditors = array();
+	$db->query('SELECT account_id FROM galactic_post_writer WHERE game_id=' . $db->escapeNumber($var['selected_game_id']) . ' AND position=' . $db->escapeString('editor'));
+	while ($db->nextRecord()) {
+		$editor = SmrPlayer::getPlayer($db->getInt('account_id'),
+		                               $var['selected_game_id']);
+		$currentEditors[] = $editor->getDisplayName();
+	}
+	$template->assign('CurrentEditors', $currentEditors);
+}
+
+// If we have just forwarded from the processing file, pass its message.
+$template->assign('ProcessingMsg', $var['processing_msg']);
+
+// Create the link to the processing file
+// Pass entire $var so the processing file knows the selected game
+$link_container = create_container('manage_post_editors_processing.php', '', $var);
+$template->assign('PostEditorHREF', SmrSession::getNewHREF($link_container));
+
+?>

--- a/admin/Default/manage_post_editors_processing.php
+++ b/admin/Default/manage_post_editors_processing.php
@@ -1,0 +1,47 @@
+<?php
+
+// Get the selected game
+$game_id = $var['selected_game_id'];
+
+// Clear any messages from prior processing
+SmrSession::updateVar('processing_msg', null);
+
+// Get the POST variables
+$player_id = $_POST['player_id'];
+$action = $_POST['submit'];
+
+try {
+	$selected_player = SmrPlayer::getPlayerByPlayerID($player_id, $game_id);
+} catch (Exception $e) {
+	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
+	SmrSession::updateVar('processing_msg', $msg);
+	forward(create_container('skeleton.php', 'manage_post_editors.php', $var));
+}
+
+$name = $selected_player->getDisplayName();
+$account_id = $selected_player->getAccountID();
+$game = $selected_player->getGame()->getDisplayName();
+
+if ($action == "Assign") {
+	if ($selected_player->isGPEditor()) {
+		$msg = "<span class='red'>ERROR: </span>$name is already an editor in game $game!";
+	} else {
+		$db->query('INSERT INTO galactic_post_writer (account_id, game_id) VALUES (' . $db->escapeNumber($account_id) . ', ' . $db->escapeNumber($game_id) . ')');
+	}
+}
+else if ($action == "Remove") {
+	if (!$selected_player->isGPEditor()) {
+		$msg = "<span class='red'>ERROR: </span>$name is not an editor in game $game!";
+	} else {
+		$db->query('DELETE FROM galactic_post_writer WHERE account_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id));
+	}
+}
+else {
+	$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";
+}
+
+// Pass entire $var so that the selected game remains selected
+SmrSession::updateVar('processing_msg', $msg);
+forward(create_container('skeleton.php', 'manage_post_editors.php', $var));
+
+?>

--- a/db/patches/V1_6_61_02__admin_enable_game.sql
+++ b/db/patches/V1_6_61_02__admin_enable_game.sql
@@ -1,0 +1,3 @@
+-- Set admin permission to enable invisible games
+INSERT INTO `permission` (`permission_name`, `link_to`) VALUES
+  ('Enable Games', 'enable_game.php');

--- a/db/patches/V1_6_61_03__admin_manage_post_editors.sql
+++ b/db/patches/V1_6_61_03__admin_manage_post_editors.sql
@@ -1,0 +1,3 @@
+-- Set admin permission to manage Galactic Post editors
+INSERT INTO `permission` (`permission_name`, `link_to`) VALUES
+  ('Manage Galactic Post Editors', 'manage_post_editors.php');

--- a/lib/Default/SmrGame.class.inc
+++ b/lib/Default/SmrGame.class.inc
@@ -340,6 +340,11 @@ class SmrGame {
 	public function equals(SmrGame $otherGame) {
 		return $otherGame->getGameID()==$this->getGameID();
 	}
+
+	// Convenience function for printing the game name with id
+	public function getDisplayName() {
+		return $this->getName() . " (" . $this->getGameID() . ")";
+	}
 }
 
 ?>

--- a/templates/Default/admin/Default/enable_game.php
+++ b/templates/Default/admin/Default/enable_game.php
@@ -1,0 +1,35 @@
+<?php
+
+// This var is passed by the processing file if we enabled a game
+if (!empty($ProcessingMsg)) {
+	echo $ProcessingMsg;
+}
+
+if (empty($DisabledGames)) {
+	echo "<p>All games are already enabled!</p>";
+} else { ?>
+
+	<p>Select the game you would like to enable.<br />
+	This will make it visible to all players.</p>
+
+	<form method="POST" action="<?php echo $EnableGameHREF; ?>">
+		<table class="standard">
+			<tr>
+				<td class="center">
+					<select name="game_id"><?php
+						foreach($DisabledGames as $Game) {
+							$id = $Game['game_id'];
+							$name = $Game['game_name'];
+							echo "<option value=\"$id\">$name ($id)</option>";
+						} ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<td class="center"><input type="submit" value="Enable Game"></td>
+			</tr>
+		</table>
+	</form> <?php
+}
+
+?>

--- a/templates/Default/admin/Default/enable_game.php
+++ b/templates/Default/admin/Default/enable_game.php
@@ -5,8 +5,8 @@ if (!empty($ProcessingMsg)) {
 	echo $ProcessingMsg;
 }
 
-if (empty($DisabledGames)) {
-	echo "<p>All games are already enabled!</p>";
+if (empty($DisabledGames)) { ?>
+	<p>All games are already enabled!</p><?php
 } else { ?>
 
 	<p>Select the game you would like to enable.<br />

--- a/templates/Default/admin/Default/manage_post_editors.php
+++ b/templates/Default/admin/Default/manage_post_editors.php
@@ -1,0 +1,48 @@
+<?php
+
+if (empty($ActiveGames)) {
+	echo "<p>There are no active games at this time!</p>";
+} else { ?>
+
+	<p>Specify the Game and Player ID to assign or remove a Galactic Post editor.</p>
+
+	Select Game:&nbsp;
+	<form class="standard" id="SelectGameForm" method="POST" action="">
+		<select name="game_id" onchange="this.form.submit()"><?php
+			foreach($ActiveGames as $Game) {
+				$id = $Game['game_id'];
+				$name = $Game['game_name'];
+				$selected = ($SelectedGame == $id ? 'selected="selected"' : '');
+				echo "<option value='$id' $selected>$name ($id)</option>";
+			} ?>
+		</select>
+	</form><br />
+
+	Player ID:&nbsp;
+	<form method="POST" action="<?php echo $PostEditorHREF; ?>">
+		<input type="number" name="player_id" id="InputFields" class="center">
+		<br />
+		<input type="submit" name="submit" value="Assign">&nbsp;
+		<input type="submit" name="submit" value="Remove">
+	</form>
+	<?php
+
+	// This var is passed by the processing file if we enabled a game
+	if (!empty($ProcessingMsg)) {
+		echo "<p>$ProcessingMsg</p>";
+	}
+
+	if (empty($CurrentEditors)) {
+		echo "<p>No current editors for this game!</p>";
+	} else { ?>
+		<p>Current Editors:
+		<ul><?php
+		foreach($CurrentEditors as $Editor) {
+			echo "<li>$Editor</li>";
+		} ?>
+		</ul></p><?php
+	}
+
+}
+
+?>


### PR DESCRIPTION
Admins can now be given permission to do the following:
* Enable new games
* Assign or remove Galactic Post editors

A flyway migrate must be run for these options to take effect.