### PR TITLE
htdocs/config.inc: fix autoload.php require_once

### DIFF
--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -116,7 +116,7 @@ function explodeElement($delimiter, $string, $index) {
 	return $arr[$index];
 }
 
-require_once('../vendor/autoload.php');
+require_once(__DIR__ . '/../vendor/autoload.php');
 require_once('config.php');
 
 //	//num races


### PR DESCRIPTION
When running php scripts outside of this directory (i.e. the `irc`
or `npc` scripts), the relative path given in the `require_once`
will fail. We use `__DIR__` to make the path absolute, as suggested
in https://stackoverflow.com/a/5371875.