### PR TITLE
Dockerfile: make runkit known to php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ RUN apt-get update \
 
 WORKDIR /usr/share/smr/
 
-RUN pear channel-discover zenovich.github.io/pear && pecl install zenovich/runkit-1.0.4
+# runkit is needed to use NPC's
+RUN pear channel-discover zenovich.github.io/pear \
+	&& pecl install zenovich/runkit-1.0.4 \
+	&& docker-php-ext-enable runkit
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY composer.json .


### PR DESCRIPTION
Use docker-php-ext-enable to add runkit.so to the php
configuration file.