### PR TITLE
Remove explicit mysql API calls outside of the database class

### DIFF
--- a/engine/1.2/alliance_treaties_processing.php
+++ b/engine/1.2/alliance_treaties_processing.php
@@ -148,8 +148,7 @@ if (isset($_REQUEST['proposedAlliance'])) {
 	$db->next_record();
 	$leader_2 = $db->f("leader_id");
 	$message = 'An ambassador from <span class="yellow">' . $alliance_name . '</span> has arrived.';
-	$message = mysql_real_escape_string($message);
-	$msg = '(' . SmrSession::$game_id . ',' . $leader_2 . ',6,"' . $message . '",0,' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
+	$msg = '(' . SmrSession::$game_id . ',' . $leader_2 . ',6,"' . $db->escape_string($message) . '",0,' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
 	$db->query("INSERT INTO message (game_id, account_id, message_type_id, message_text, sender_id, send_time, msg_read, expire_time) VALUES $msg");
 	$db->query("INSERT INTO player_has_unread_messages (account_id, game_id, message_type_id) VALUES ($leader_2, ".SmrSession::$game_id.", 6)");
 	$container=array();

--- a/engine/1.2/combat_log_viewer.php
+++ b/engine/1.2/combat_log_viewer.php
@@ -22,7 +22,7 @@ if (isset($_REQUEST['action'])) {
 		if (sizeof($savedLogs)) {
 			foreach ($savedLogs as $a) {
 				if (!empty($query)) $query .= ",";
-				$query .= "($a[0],'$a[1]',$a[2],$a[3],$a[4],$a[5],$a[6],$a[7],'" . mysql_real_escape_string($a[8]) . "'," . $player->account_id . ")";
+				$query .= "($a[0],'$a[1]',$a[2],$a[3],$a[4],$a[5],$a[6],$a[7],'" . $db->escape_string($a[8]) . "'," . $player->account_id . ")";
 			}
 			$db->query('INSERT INTO combat_logs 
 						(game_id,type,sector_id,timestamp,attacker_id,attacker_alliance_id,defender_id,defender_alliance_id,result,saved)

--- a/engine/1.2/message_blacklist_add.php
+++ b/engine/1.2/message_blacklist_add.php
@@ -10,11 +10,9 @@ if(!isset($_REQUEST['PlayerName'])) {
 	exit;
 }
 
-$player_name = mysql_real_escape_string($_REQUEST['PlayerName']);
-
 $db = new SmrMySqlDatabase();
 
-$db->query('SELECT account_id FROM player WHERE player_name=\'' . $player_name . '\' AND game_id=' . SmrSession::$game_id . ' LIMIT 1');
+$db->query('SELECT account_id FROM player WHERE player_name=\'' . $db->escape_string($_REQUEST['PlayerName']) . '\' AND game_id=' . SmrSession::$game_id . ' LIMIT 1');
 
 if(!$db->next_record()) {
 	$container['error'] = 1;	

--- a/engine/1.2/planet_attack_processing.php
+++ b/engine/1.2/planet_attack_processing.php
@@ -767,8 +767,7 @@ function processNews($fleet, $planet) {
 				$text .= ", a member of " . stripslashes($db->f("alliance_name"));
 			}
 			$text .= ".";
-			$text = mysql_real_escape_string($text);
-			$db->query("INSERT INTO news (game_id, time, news_message, type) VALUES ($player->game_id, " . TIME . ", '$text', 'breaking')");
+			$db->query("INSERT INTO news (game_id, time, news_message, type) VALUES ($player->game_id, " . TIME . ", '" . $db->escape_string($text) . "', 'breaking')");
 		}
 	}
 	
@@ -967,17 +966,16 @@ function podPlayers($IDArray, $ships, $hqs, $planet, $players) {
 		$msg .= ' was destroyed by ';
 		$msg .= "<span style=\"color:yellow;font-variant:small-caps\">" . $planet[PLANET_NAME] . "</span>'s planetary defenses";
 	 	$msg .= ' in Sector&nbsp#' . $player->sector_id;
-		$msg = mysql_real_escape_string($msg);
-		$db->query("INSERT INTO news (game_id, time, news_message) VALUES ($player->game_id, " . TIME . ", '$msg')");
+		$db->query("INSERT INTO news (game_id, time, news_message) VALUES ($player->game_id, " . TIME . ", '" . $db->escape_string($msg) . "')");
 		
 		$killer_id = $planet[OWNER];
 		
-		$temp = mysql_real_escape_string('You were <span class="red">DESTROYED</span> by <span style="color:yellow;font-variant:small-caps">' . $planet[PLANET_NAME] . '</span>\'s planetary defenses in sector <span class="blue">#' . $player->sector_id . '</span>');
-		$msg = '(' . SmrSession::$game_id . ',' . $accId . ',2,"' . $temp . '",' . $killer_id . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
+		$temp = 'You were <span class="red">DESTROYED</span> by <span style="color:yellow;font-variant:small-caps">' . $planet[PLANET_NAME] . '</span>\'s planetary defenses in sector <span class="blue">#' . $player->sector_id . '</span>';
+		$msg = '(' . SmrSession::$game_id . ',' . $accId . ',2,"' . $db->escape_string($temp) . '",' . $killer_id . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
 		$db->query("INSERT INTO message (game_id, account_id, message_type_id, message_text, sender_id, send_time, msg_read, expire_time) VALUES $msg");
 		$db->query("INSERT INTO player_has_unread_messages (account_id, game_id, message_type_id) VALUES ($accId, ".SmrSession::$game_id.", 2)");
-		$temp = mysql_real_escape_string('Your planet <span class="red">DESTROYED</span> ' . $players[$accId][PLAYER_NAME] . ' in sector <span class="blue">#' . $player->sector_id . '</span>');
-		$msg = '(' . SmrSession::$game_id . ',' . $killer_id . ',2,"' . $temp . '",' . $accId . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
+		$temp = 'Your planet <span class="red">DESTROYED</span> ' . $players[$accId][PLAYER_NAME] . ' in sector <span class="blue">#' . $player->sector_id . '</span>';
+		$msg = '(' . SmrSession::$game_id . ',' . $killer_id . ',2,"' . $db->escape_string($temp) . '",' . $accId . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
 		$db->query("INSERT INTO message (game_id, account_id, message_type_id, message_text, sender_id, send_time, msg_read, expire_time) VALUES $msg");
 		$db->query("INSERT INTO player_has_unread_messages (account_id, game_id, message_type_id) VALUES ($killer_id, ".SmrSession::$game_id.", 2)");
 		unset($temp);
@@ -1010,7 +1008,6 @@ function sendReport($results, $planet) {
 		$topic = "Planet Attack Report Sector $player->sector_id";
 		$text = "Reports from the surface of $planetName confirm that it is under <span class=\"red\">attack</span>!<br />";
 		$text .= $mainText;
-		$text = mysql_real_escape_string($text);
 		$thread_id = 0;
 		$db->query("SELECT * FROM alliance_thread_topic WHERE game_id = $player->game_id AND alliance_id = $ownerAlliance AND topic = '$topic' LIMIT 1");
 		if ($db->next_record()) $thread_id = $db->f("thread_id");
@@ -1028,7 +1025,7 @@ function sendReport($results, $planet) {
 		if ($db->next_record()) $reply_id = $db->f("reply_id") + 1;
 		else $reply_id = 1;
 		$db->query("INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES " .
-				"($player->game_id, $ownerAlliance, $thread_id, $reply_id, '$text', 0, " . TIME . ")");
+				"($player->game_id, $ownerAlliance, $thread_id, $reply_id, '" . $db->escape_string($text) . "', 0, " . TIME . ")");
 		$db->query("SELECT * FROM player WHERE alliance_id = $ownerAlliance AND game_id = $player->game_id");
 		while ($db->next_record())
 			$temp[] = $db->f("account_id");
@@ -1039,16 +1036,14 @@ function sendReport($results, $planet) {
 	} else {
 		$text = "Reports from the surface of $planetName confirm that it is under <span class=\"red\">attack</span>!<br />";
 		$text .= $mainText;
-		$text = mysql_real_escape_string($text);
 		$db->query("INSERT INTO message (game_id, account_id, message_type_id, message_text, sender_id, send_time) VALUES " .
-					"($player->game_id, " . $planet[OWNER] . ", 3, '$text', 0, " . TIME . ")");
+					"($player->game_id, " . $planet[OWNER] . ", 3, '" . $db->escape_string($text) . "', 0, " . TIME . ")");
 		$db->query("INSERT INTO player_has_unread_messages (account_id, game_id, message_type_id) VALUES " .
 						"(" . $planet[OWNER] . ", $player->game_id, 3)");
 	} if ($player->alliance_id > 0) {
 		$topic = "Planet Siege Report Sector $player->sector_id";
 		$text = "Reports have come in from the space above $planetName and have confirmed our <span class=\"red\">siege</span>!<br />";
 		$text .= $mainText;
-		$text = mysql_real_escape_string($text);
 		$thread_id = 0;
 		$db->query("SELECT * FROM alliance_thread_topic WHERE game_id = $player->game_id AND alliance_id = $player->alliance_id AND topic = '$topic' LIMIT 1");
 		if ($db->next_record()) $thread_id = $db->f("thread_id");
@@ -1066,7 +1061,7 @@ function sendReport($results, $planet) {
 		if ($db->next_record()) $reply_id = $db->f("reply_id") + 1;
 		else $reply_id = 1;
 		$db->query("INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES " .
-				"($player->game_id, $player->alliance_id, $thread_id, $reply_id, '$text', 0, " . TIME . ")");
+				"($player->game_id, $player->alliance_id, $thread_id, $reply_id, '" . $db->escape_string($text) . "', 0, " . TIME . ")");
 	}
 }
 function planetDowngrade(&$results, &$planet) {
@@ -1177,7 +1172,7 @@ $db->query("SELECT alliance_id FROM player WHERE account_id = " . $planet[OWNER]
 $db->next_record();
 $ownerAlliance = $db->f("alliance_id");
 $finalResults = $results[0] . '<br /><img src="images/planetAttack.jpg" alt="Planet Attack" title="Planet Attack"><br />' . $results[1];
-$db->query('INSERT INTO combat_logs VALUES("",' . SmrSession::$game_id . ',"PLANET",' . $player->sector_id . ',' . time() . ',' . SmrSession::$old_account_id . ',' . $player->alliance_id . ',' . $planet[OWNER] . ',' . $ownerAlliance . ',"' . mysql_real_escape_string(gzcompress($finalResults)) . '", "FALSE")');
+$db->query('INSERT INTO combat_logs VALUES("",' . SmrSession::$game_id . ',"PLANET",' . $player->sector_id . ',' . time() . ',' . SmrSession::$old_account_id . ',' . $player->alliance_id . ',' . $planet[OWNER] . ',' . $ownerAlliance . ',"' . $db->escape_string(gzcompress($finalResults)) . '", "FALSE")');
 if (DEBUG) print("Pre Forward/Display<br>");
 $container=array();
 $container["url"] = "skeleton.php";

--- a/engine/1.2/port_attack_processing_new.php
+++ b/engine/1.2/port_attack_processing_new.php
@@ -761,8 +761,7 @@ function processNews() {
 		$text .= " The Federal Government is offering a bounty of " . round($player->level_id * .4) . " million credits for the death of <span class=\"yellow\">$player->player_name</span>";
 	}
 	$text .= " prior to the destruction of the port, or until federal forces arrive to defend the port.";
-	$text = mysql_real_escape_string($text);
-	$db->query("INSERT INTO news (game_id, time, news_message, type) VALUES ($player->game_id, " . TIME . ", '$text', 'regular')");
+	$db->query("INSERT INTO news (game_id, time, news_message, type) VALUES ($player->game_id, " . TIME . ", '" . $db->escape_string($text) . "', 'regular')");
 }
 function hofTracker($players, $port) {
 	if (DEBUG) print("Tracking HoF<br>");
@@ -895,8 +894,7 @@ function processResults(&$players, &$port, $fleet, $weapons) {
 				$news = '<span class="yellow smallCaps">Port ' . $player->sector_id . '</span> has been successfully raided by ';
 				if ($player->alliance_id) $news .= 'the members of <span class="yellow">' . $player->alliance_name . '</span>';
 				else $news .= '<span class="yellow">' . $player->player_name . '</span>';
-				$news = mysql_real_escape_string($news);
-				$db->query("INSERT INTO news (game_id, time, news_message, type) VALUES ($player->game_id, " . TIME . ", '$news', 'regular')");
+				$db->query("INSERT INTO news (game_id, time, news_message, type) VALUES ($player->game_id, " . TIME . ", '" . $db->escape_string($news) . "', 'regular')");
 				// Trigger gets an alignment change and a bounty if port is taken
 				$db->query("SELECT * FROM bounty WHERE game_id = $player->game_id AND account_id = $player->account_id " .
 					"AND claimer_id = 0 AND type = 'HQ'");
@@ -998,13 +996,12 @@ function podPlayers($IDArray, $ships, $hqs, $port, $players) {
 		
 		$msg .= ' was destroyed while invading ';
 		$msg .= "<span style=\"color:yellow;font-variant:small-caps\">Port " . $player->sector_id . "</span>.";
-		$msg = mysql_real_escape_string($msg);
-		$db->query("INSERT INTO news (game_id, time, news_message) VALUES ($player->game_id, " . TIME . ", '$msg')");
+		$db->query("INSERT INTO news (game_id, time, news_message) VALUES ($player->game_id, " . TIME . ", '" . $db->escape_string($msg) . "')");
 		
 		$killer_id = 0;
 		
-		$temp = mysql_real_escape_string('You were <span class="red">DESTROYED</span> by <span style="color:yellow;font-variant:small-caps">Port ' . $player->sector_id . '</span>\'s defenses.');
-		$msg = '(' . SmrSession::$game_id . ',' . $accId . ',2,"' . $temp . '",' . $killer_id . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
+		$temp = 'You were <span class="red">DESTROYED</span> by <span style="color:yellow;font-variant:small-caps">Port ' . $player->sector_id . '</span>\'s defenses.';
+		$msg = '(' . SmrSession::$game_id . ',' . $accId . ',2,"' . $db->escape_string($temp) . '",' . $killer_id . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
 		$db->query("INSERT INTO message (game_id, account_id, message_type_id, message_text, sender_id, send_time, msg_read, expire_time) VALUES $msg");
 		$db->query("INSERT INTO player_has_unread_messages (account_id, game_id, message_type_id) VALUES ($accId, ".SmrSession::$game_id.", 2)");
 		unset($temp);
@@ -1031,7 +1028,6 @@ function sendReport($results, $port) {
 		$topic = "Port Siege Report Sector $player->sector_id";
 		$text = "Reports have come in from the space above <span class=\"yellow\">Port " . $player->sector_id . "</span> and have confirmed our <span class=\"red\">siege</span>!<br />";
 		$text .= $mainText;
-		$text = mysql_real_escape_string($text);
 		$thread_id = 0;
 		$db->query("SELECT * FROM alliance_thread_topic WHERE game_id = $player->game_id AND alliance_id = $player->alliance_id AND topic = '$topic' LIMIT 1");
 		if ($db->next_record()) $thread_id = $db->f("thread_id");
@@ -1049,7 +1045,7 @@ function sendReport($results, $port) {
 		if ($db->next_record()) $reply_id = $db->f("reply_id") + 1;
 		else $reply_id = 1;
 		$db->query("INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES " .
-				"($player->game_id, $player->alliance_id, $thread_id, $reply_id, '$text', 0, " . TIME . ")");
+				"($player->game_id, $player->alliance_id, $thread_id, $reply_id, '" . $db->escape_string($text) . "', 0, " . TIME . ")");
 	}
 }
 function portDowngrade(&$results, &$port) {
@@ -1129,7 +1125,7 @@ sendReport($results, $port);
 doLog($results);
 //insert into combat logs
 $finalResults = $results[0] . '<br /><img src="images/portAttack.jpg" width="480px" height="330px" alt="Port Attack" title="Port Attack"><br />' . $results[1];
-$db->query('INSERT INTO combat_logs VALUES("",' . SmrSession::$game_id . ',"PORT",' . $player->sector_id . ',' . time() . ',' . SmrSession::$old_account_id . ',' . $player->alliance_id . ',0,0,"' . mysql_real_escape_string(gzcompress($finalResults)) . '", "FALSE")');
+$db->query('INSERT INTO combat_logs VALUES("",' . SmrSession::$game_id . ',"PORT",' . $player->sector_id . ',' . time() . ',' . SmrSession::$old_account_id . ',' . $player->alliance_id . ',0,0,"' . $db->escape_string(gzcompress($finalResults)) . '", "FALSE")');
 if (DEBUG) print("Pre Forward/Display<br>");
 $container=array();
 $container["url"] = "skeleton.php";

--- a/engine/1.2/trader_attack.php
+++ b/engine/1.2/trader_attack.php
@@ -36,7 +36,7 @@ if($db->next_record()) {
 list($usec, $sec) = explode(" ", microtime());
 $usec = (int)($usec * 1000);
 
-$db->query('INSERT INTO combat_logs VALUES("",' . SmrSession::$game_id . ',"PLAYER",' . $player->sector_id . ',' . $sec . ',' . SmrSession::$old_account_id . ',' . $player->alliance_id . ',' . $var['target'] . ',' . $defender_alliance_id . ',"' . mysql_real_escape_string(gzcompress($results)) . '")');
+$db->query('INSERT INTO combat_logs VALUES("",' . SmrSession::$game_id . ',"PLAYER",' . $player->sector_id . ',' . $sec . ',' . SmrSession::$old_account_id . ',' . $player->alliance_id . ',' . $var['target'] . ',' . $defender_alliance_id . ',"' . $db->escape_string(gzcompress($results)) . '")');
 
 echo $results;
 

--- a/engine/1.2/trader_attack_processing_new.php
+++ b/engine/1.2/trader_attack_processing_new.php
@@ -865,7 +865,7 @@ function build_results(&$players,&$fleets,&$weapons,&$killed_ids,&$killer_ids) {
 
 function process_news(&$players,&$killed_id,&$ship_names) {
 
-	global $session,$player;
+	global $session,$player,$db;
 	
 	$killer_id = $players[$killed_id][KILLER];
 	$msg = $players[$killed_id][PLAYER_NAME];
@@ -906,19 +906,19 @@ function process_news(&$players,&$killed_id,&$ship_names) {
 	*/
  	$msg .= ' in Sector&nbsp#' . $player->sector_id;
 
-	return '(' . SmrSession::$game_id . ',' . TIME . ',"' . mysql_real_escape_string($msg) . '","regular")';
+	return '(' . SmrSession::$game_id . ',' . TIME . ',"' . $db->escape_string($msg) . '","regular")';
 }
 
 function process_messages(&$players,$killed_id) {
 
-	global $session,$player;
+	global $session,$player,$db;
 	
 	$killer_id = $players[$killed_id][KILLER];
 	
-	$temp = mysql_real_escape_string('You were <span class="red">DESTROYED</span> by ' . $players[$killer_id][PLAYER_NAME] . ' in sector <span class="blue">#' . $player->sector_id . '</span>');
-	$msg .= '(' . SmrSession::$game_id . ',' . $killed_id . ',2,"' . $temp . '",' . $killer_id . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
-	$temp = mysql_real_escape_string('You <span class="red">DESTROYED</span> ' . $players[$killed_id][PLAYER_NAME] . ' in sector <span class="blue">#' . $player->sector_id . '</span>');
-	$msg .= ',(' . SmrSession::$game_id . ',' . $killer_id . ',2,"' . $temp . '",' . $killed_id . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
+	$temp = 'You were <span class="red">DESTROYED</span> by ' . $players[$killer_id][PLAYER_NAME] . ' in sector <span class="blue">#' . $player->sector_id . '</span>';
+	$msg .= '(' . SmrSession::$game_id . ',' . $killed_id . ',2,"' . $db->escape_string($temp) . '",' . $killer_id . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
+	$temp = 'You <span class="red">DESTROYED</span> ' . $players[$killed_id][PLAYER_NAME] . ' in sector <span class="blue">#' . $player->sector_id . '</span>';
+	$msg .= ',(' . SmrSession::$game_id . ',' . $killer_id . ',2,"' . $db->escape_string($temp) . '",' . $killed_id . ',' . TIME . ',"FALSE",' . MESSAGE_EXPIRES . ')';
 
 	return $msg;	
 }
@@ -1291,7 +1291,7 @@ foreach($account_ids as $account_id) {
 
 $db->query('UPDATE sector SET battles=battles+1 WHERE sector_id=' . $player->sector_id . ' AND game_id=' . SmrSession::$game_id . ' LIMIT 1');
 
-$db->query('INSERT INTO combat_logs VALUES("",' . SmrSession::$game_id . ',"PLAYER",' . $player->sector_id . ',' . time() . ',' . SmrSession::$old_account_id . ',' . $player->alliance_id . ',' . $var['target'] . ',' . $players[$var['target']][ALLIANCE_ID] . ',"' . mysql_real_escape_string(gzcompress($results)) . '", "FALSE")');
+$db->query('INSERT INTO combat_logs VALUES("",' . SmrSession::$game_id . ',"PLAYER",' . $player->sector_id . ',' . time() . ',' . SmrSession::$old_account_id . ',' . $player->alliance_id . ',' . $var['target'] . ',' . $players[$var['target']][ALLIANCE_ID] . ',"' . $db->escape_string(gzcompress($results)) . '", "FALSE")');
 
 $container = array();
 $container["url"] = "skeleton.php";

--- a/engine/Classic 1.6/planet_attack_processing.php
+++ b/engine/Classic 1.6/planet_attack_processing.php
@@ -710,7 +710,6 @@ function processNews($fleet, $planet) {
 				$text .= ', a member of ' . stripslashes($db->f('alliance_name'));
 			}
 			$text .= '.';
-			$text = mysql_real_escape_string($text);
 			$db->query('INSERT INTO news (game_id, time, news_message, type,killer_id,killer_alliance,dead_id,dead_alliance) VALUES ('.$player->getGameID().', ' . TIME . ', '.$db->escapeString($text).', \'breaking\','.$player->getAccountID().','.$player->getAllianceID().','.$planet[OWNER].','.$allianceID.')');
 		}
 	}
@@ -909,16 +908,15 @@ function podPlayers($IDArray, $ships, $hqs, $planet, $players) {
 		$msg .= ' was destroyed by ';
 		$msg .= '<span style="color:yellow;font-variant:small-caps">' . $planet[PLANET_NAME] . '</span>\'s planetary defenses';
 	 	$msg .= ' in Sector&nbsp#' . $player->getSectorID();
-		$msg = mysql_real_escape_string($msg);
 		$db->query('INSERT INTO news (game_id, time, news_message,killer_id,killer_alliance) VALUES ('.$player->getGameID().', ' . TIME . ', '.$db->escapeString($msg).','.$currPlayer->getAccountID().','.$currPlayer->getAllianceID().')');
 		
 		$killer_id = $planet[OWNER];
 		
-		$temp = mysql_real_escape_string('You were <span class="red">DESTROYED</span> by <span style="color:yellow;font-variant:small-caps">' . $planet[PLANET_NAME] . '</span>\'s planetary defenses in sector <span class="blue">#' . $player->getSectorID() . '</span>');
+		$temp = 'You were <span class="red">DESTROYED</span> by <span style="color:yellow;font-variant:small-caps">' . $planet[PLANET_NAME] . '</span>\'s planetary defenses in sector <span class="blue">#' . $player->getSectorID() . '</span>';
 		$msg = '(' . SmrSession::$game_id . ',' . $accId . ',2,' . $db->escape_string($temp) . ',' . $killer_id . ',' . TIME . ',\'FALSE\',' . MESSAGE_EXPIRES . ')';
 		$db->query('INSERT INTO message (game_id, account_id, message_type_id, message_text, sender_id, send_time, msg_read, expire_time) VALUES '.$msg);
 		$db->query('INSERT INTO player_has_unread_messages (account_id, game_id, message_type_id) VALUES ('.$accId.', '.SmrSession::$game_id.', 2)');
-		$temp = mysql_real_escape_string('Your planet <span class="red">DESTROYED</span> ' . $players[$accId][PLAYER_NAME] . ' in sector <span class="blue">#' . $player->getSectorID() . '</span>');
+		$temp = 'Your planet <span class="red">DESTROYED</span> ' . $players[$accId][PLAYER_NAME] . ' in sector <span class="blue">#' . $player->getSectorID() . '</span>';
 		$msg = '(' . SmrSession::$game_id . ',' . $killer_id . ',2,' . $db->escape_string($temp) . ',' . $accId . ',' . TIME . ',\'FALSE\',' . MESSAGE_EXPIRES . ')';
 		$db->query('INSERT INTO message (game_id, account_id, message_type_id, message_text, sender_id, send_time, msg_read, expire_time) VALUES '.$msg);
 		$db->query('INSERT INTO player_has_unread_messages (account_id, game_id, message_type_id) VALUES ('.$killer_id.', '.SmrSession::$game_id.', 2)');
@@ -952,7 +950,6 @@ function sendReport($results, $planet) {
 		$topic = 'Planet Attack Report Sector $player->getSectorID()';
 		$text = 'Reports from the surface of $planetName confirm that it is under <span class="red">attack</span>!<br />';
 		$text .= $mainText;
-		$text = mysql_real_escape_string($text);
 		$thread_id = 0;
 		$db->query('SELECT * FROM alliance_thread_topic WHERE game_id = '.$player->getGameID().' AND alliance_id = '.$ownerAlliance.' AND topic = '.$db->escapeString($topic).' LIMIT 1');
 		if ($db->next_record()) $thread_id = $db->f('thread_id');
@@ -980,7 +977,6 @@ function sendReport($results, $planet) {
 	} else {
 		$text = 'Reports from the surface of '.$planetName.' confirm that it is under <span class="red">attack</span>!<br />';
 		$text .= $mainText;
-		$text = mysql_real_escape_string($text);
 		$db->query('INSERT INTO message (game_id, account_id, message_type_id, message_text, sender_id, send_time) VALUES ' .
 					'('.$player->getGameID().', ' . $planet[OWNER] . ', 3, '.$db->escapeString($text).', 0, ' . TIME . ')');
 		$db->query('INSERT INTO player_has_unread_messages (account_id, game_id, message_type_id) VALUES ' .
@@ -989,7 +985,6 @@ function sendReport($results, $planet) {
 		$topic = 'Planet Siege Report Sector '.$player->getSectorID();
 		$text = 'Reports have come in from the space above $planetName and have confirmed our <span class="red">siege</span>!<br />';
 		$text .= $mainText;
-		$text = mysql_real_escape_string($text);
 		$thread_id = 0;
 		$db->query('SELECT * FROM alliance_thread_topic WHERE game_id = '.$player->getGameID().' AND alliance_id = '.$player->getAllianceID().' AND topic = '.$db->escapeString($topic).' LIMIT 1');
 		if ($db->next_record()) $thread_id = $db->f('thread_id');

--- a/engine/Classic 1.6/port_attack_processing.php
+++ b/engine/Classic 1.6/port_attack_processing.php
@@ -705,7 +705,6 @@ function processNews() {
 		$text .= ' The Federal Government is offering a bounty of ' . round($player->getLevelID() * .4) . ' million credits for the death of <span class="yellow">'.$player->getPlayerName().'</span>';
 	}
 	$text .= ' prior to the destruction of the port, or until federal forces arrive to defend the port.';
-	$text = mysql_real_escape_string($text);
 	$db->query('INSERT INTO news (game_id, time, news_message, type,killer_id,killer_alliance,dead_id) VALUES ('.$player->getGameID().', ' . TIME . ', '.$db->escapeString($text).', \'regular\','.$player->getAccountID().','.$player->getAllianceID().','.ACCOUNT_ID_PORT.')');
 }
 function hofTracker($players, $port) {
@@ -835,7 +834,6 @@ function processResults(&$players, &$port, $fleet, $weapons) {
 				$news = '<span class="yellow smallCaps">Port ' . $player->getSectorID() . '</span> has been successfully raided by ';
 				if ($player->getAllianceID()) $news .= 'the members of <span class="yellow">' . $player->getAllianceName() . '</span>';
 				else $news .= '<span class="yellow">' . $player->getPlayerName() . '</span>';
-				$news = mysql_real_escape_string($news);
 				$db->query('INSERT INTO news (game_id, time, news_message, type,killer_id,killer_alliance,dead_id) VALUES ('.$player->getGameID().', ' . TIME . ', '.$db->escapeString($news).', \'regular\','.$player->getAccountID().','.$player->getAllianceID().','.ACCOUNT_ID_PORT.')');
 				// Trigger gets an alignment change and a bounty if port is taken
 				$db->query('SELECT * FROM bounty WHERE game_id = '.$player->getGameID().' AND account_id = '.$player->getAccountID().' ' .
@@ -940,7 +938,6 @@ function podPlayers($IDArray, $ships, $hqs, $port, $players) {
 		
 		$msg .= ' was destroyed while invading ';
 		$msg .= '<span style="color:yellow;font-variant:small-caps">Port ' . $player->getSectorID() . '</span>.';
-		$msg = mysql_real_escape_string($msg);
 		$db->query('INSERT INTO news (game_id, time, news_message,killer_id,dead_id,dead_alliance) VALUES ('.$player->getGameID().', ' . TIME . ', '.$db->escapeString($msg).','.ACCOUNT_ID_PORT.','.$currPlayer->getAccountID().','.$currPlayer->getAllianceID().')');
 		
 		$killer_id = 0;
@@ -973,7 +970,6 @@ function sendReport($results, $port) {
 		$topic = 'Port Siege Report Sector '.$player->getSectorID();
 		$text = 'Reports have come in from the space above <span class="yellow">Port ' . $player->getSectorID() . '</span> and have confirmed our <span class="red">siege</span>!<br />';
 		$text .= $mainText;
-		$text = mysql_real_escape_string($text);
 		$thread_id = 0;
 		$db->query('SELECT * FROM alliance_thread_topic WHERE game_id = '.$player->getGameID().' AND alliance_id = '.$player->getAllianceID().' AND topic = '.$db->escapeString($topic).' LIMIT 1');
 		if ($db->next_record()) $thread_id = $db->f('thread_id');

--- a/engine/Default/message_blacklist_add.php
+++ b/engine/Default/message_blacklist_add.php
@@ -14,11 +14,9 @@ if(isset($var['account_id'])) {
 	$blacklisted_id = $var['account_id'];
 }
 else {
-	$player_name = mysql_real_escape_string($_REQUEST['PlayerName']);
-
 	$db = new SmrMySqlDatabase();
 
-	$db->query('SELECT account_id FROM player WHERE player_name=' . $db->escapeString($player_name) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' LIMIT 1');
+	$db->query('SELECT account_id FROM player WHERE player_name=' . $db->escapeString($_REQUEST['PlayerName']) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' LIMIT 1');
 
 	if(!$db->nextRecord()) {
 		$container['error'] = 1;

--- a/engine/Default/port_attack_processing.php
+++ b/engine/Default/port_attack_processing.php
@@ -88,7 +88,6 @@ forward($container);
 //		$topic = 'Port Siege Report Sector '.$player->getSectorID();
 //		$text = 'Reports have come in from the space above <span class="yellow">Port ' . $player->getSectorID() . '</span> and have confirmed our <span class="red">siege</span>!<br />';
 //		$text .= $mainText;
-//		$text = mysql_real_escape_string($text);
 //		$thread_id = 0;
 //		$db->query('SELECT * FROM alliance_thread_topic WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND topic = '.$db->escapeString($topic).' LIMIT 1');
 //		if ($db->nextRecord()) $thread_id = $db->getField('thread_id');


### PR DESCRIPTION
  Avoid unnecessary explicit mysql API calls

We remove the explicit calls to `mysql_real_escape_string`
outside of MySqlDatabase.class.inc, because the database
queries already use `$db->escapeString`.


  Remove explicit mysql API calls in 1.2 engine

Use the escape_string database method instead of the explicit
API call, and put the escaping inline in the database query.