### PR TITLE
Dockerfile: update to php 5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.4-apache
+FROM php:5.6-apache
 RUN apt-get update \
 	&& apt-get install -y libcurl4-openssl-dev git \
 	&& rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
PHP 5.6 has been extensively tested with the current code base
(the core game, admin tools, Caretaker, and NPC's), with no
compatibility issues. We should update to PHP 5.6, because 5.5
and earlier no longer have security support (see Issue #110).