### PR TITLE
Use docker-compose to manage services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Dockerfile for smr service
 FROM php:5.6-apache
 RUN apt-get update \
 	&& apt-get install -y libcurl4-openssl-dev git sendmail \
@@ -19,8 +20,13 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 COPY composer.json .
 RUN composer install --no-interaction
 
+# Copy the smr source tree
 COPY . .
-VOLUME htdocs/upload
+
+# Replace placeholders in local files
+ARG MYSQL_PASSWORD
+RUN sed "s/__MYSQL_PASSWORD__/${MYSQL_PASSWORD}/" lib/Default/SmrMySqlSecrets.sample.inc > lib/Default/SmrMySqlSecrets.inc
+
 RUN rm -rf /var/www/html/ && ln -s "$(pwd)/htdocs" /var/www/html
 
 # Provide a FQDN for sendmail (since /etc/hosts cannot be modified during the

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ COPY . .
 
 # Replace placeholders in local files
 ARG MYSQL_PASSWORD
+ARG MYSQL_HOST
 RUN sed "s/__MYSQL_PASSWORD__/${MYSQL_PASSWORD}/" lib/Default/SmrMySqlSecrets.sample.inc > lib/Default/SmrMySqlSecrets.inc
+RUN sed -i "s/__MYSQL_HOST__/${MYSQL_HOST}/" lib/Default/SmrMySqlSecrets.inc
 
 RUN rm -rf /var/www/html/ && ln -s "$(pwd)/htdocs" /var/www/html
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ First, you must write a `.env` file with the following format:
 SMR_CONFIG_FILE=/path/to/config.specific.php
 MYSQL_ROOT_PASSWORD=chooseapassword
 MYSQL_PASSWORD=chooseapassword
+MYSQL_HOST=chooseahost  # must be unique on each network
 ```
 
 Then you can start up the persistent services

--- a/README.md
+++ b/README.md
@@ -1,78 +1,36 @@
 # Installation with docker
 
-## Building an SMR docker image
-```
-docker build --tag smrealms/smr .
-```
-
-## Running a mysql server via docker (optional)
-
-### Start the mysql server
-```
-docker run \
-	--name='smr-mysql' \
-	--env='MYSQL_RANDOM_ROOT_PASSWORD=yes' \
-	--env='MYSQL_USER=smr' \
-	--env='MYSQL_PASSWORD=smr' \
-	--env='MYSQL_DATABASE=smr_live' \
-	--detach \
-	mysql:5.5
-```
-### Populate the mysql server
-```
-docker run \
-	--rm \
-	--link='smr-mysql' \
-	--volume="$(pwd)/db/patches:/flyway/sql:ro" \
-	shouldbee/flyway \
-	-url='jdbc:mysql://smr-mysql/smr_live' \
-	-user='smr' \
-	-password='smr' \
-	init
-
-docker run \
-	--rm \
-	--link='smr-mysql' \
-	--volume="$(pwd)/db/patches:/flyway/sql:ro" \
-	shouldbee/flyway \
-	-url='jdbc:mysql://smr-mysql/smr_live' \
-	-user='smr' \
-	-password='smr' \
-	migrate
+## Start up the services
+First, you must write a `.env` file with the following format:
+```bash
+# Variables needed by docker-compose.yml
+SMR_CONFIG_FILE=/path/to/config.specific.php
+MYSQL_ROOT_PASSWORD=chooseapassword
+MYSQL_PASSWORD=chooseapassword
 ```
 
-## Running SMR via docker
-
-You must change the paths to filled in config files, see the config section below for more info
-
-For production
+Then you can start up the persistent services
 ```
-docker run \
-	--name="smr" \
-	--link='smr-mysql' \
-	--publish='80:80' \
-	--volume="/path/to/config.specific.php:/usr/share/smr/htdocs/config.specific.php:ro" \
-	--volume="/path/to/SmrMySqlSecrets.sample.inc:/usr/share/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
-	--detach \
-	smrealms/smr
-```
-For development (will automatically pick up source changes, but you will need to make sure you have run `composer install`)
-```
-docker run \
-	--name="smr" \
-	--link='smr-mysql' \
-	--publish='80:80' \
-	--volume="$(pwd):/usr/share/smr" \
-	--volume="$(pwd)/htdocs/config.specific.sample.php:/usr/share/smr/htdocs/config.specific.php:ro" \
-	--volume="$(pwd)/lib/Default/SmrMySqlSecrets.sample.inc:/usr/share/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
-	--detach \
-	smrealms/smr
+docker-compose up --build -d smr mysql phpmyadmin
 ```
 
-## Viewing logs via docker
+For development, it may be desirable to automatically pick up source code changes without rebuilding the docker image. You will need to make sure you have run `composer install`, then you can replace the `smr` service with `smr-dev`, i.e.:
+```
+docker-compose up --build -d smr-dev mysql phpmyadmin
+```
+
+## Populate the mysql database
+To initialize the database or update it with new patches, run:
+```
+docker-compose run --rm flyway
+```
+If you are starting from an empty database, this must be run after
+starting up the `mysql` service for the first time.
+
+## Viewing logs via docker-compose
 
 ```
-docker logs -f smr
+docker-compose logs
 ```
 
 # Installation natively

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ docker run \
 	--link='smr-mysql' \
 	--publish='80:80' \
 	--volume="/path/to/config.specific.php:/usr/share/smr/htdocs/config.specific.php:ro" \
-	--volume="/path/to/SmrSessionMySqlDatabase.class.sample.inc:/usr/share/smr/lib/Default/SmrSessionMySqlDatabase.class.inc:ro" \
-	--volume="/path/to/SmrMySqlDatabase.class.sample.inc:/usr/share/smr/lib/Default/SmrMySqlDatabase.class.inc:ro" \
+	--volume="/path/to/SmrMySqlSecrets.sample.inc:/usr/share/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
 	--detach \
 	smrealms/smr
 ```
@@ -65,8 +64,7 @@ docker run \
 	--publish='80:80' \
 	--volume="$(pwd):/usr/share/smr" \
 	--volume="$(pwd)/htdocs/config.specific.sample.php:/usr/share/smr/htdocs/config.specific.php:ro" \
-	--volume="$(pwd)/lib/Default/SmrSessionMySqlDatabase.class.sample.inc:/usr/share/smr/lib/Default/SmrSessionMySqlDatabase.class.inc:ro" \
-	--volume="$(pwd)/lib/Default/SmrMySqlDatabase.class.sample.inc:/usr/share/smr/lib/Default/SmrMySqlDatabase.class.inc:ro" \
+	--volume="$(pwd)/lib/Default/SmrMySqlSecrets.sample.inc:/usr/share/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
 	--detach \
 	smrealms/smr
 ```
@@ -83,7 +81,7 @@ docker logs -f smr
 These list the known dependencies, there may be more - please update if you find any!
 
 ### Core
-* PHP 5.3+
+* PHP 5.4+
 * MySQL 5.5
 
 ### PHP Extensions
@@ -97,8 +95,7 @@ These list the known dependencies, there may be more - please update if you find
 Currently it is required to create installation specific copies of the following files:
 
 * htdocs/config.specific.sample.php -> htdocs/config.specific.php
-* lib/Default/SmrSessionMySqlDatabase.class.sample.inc -> lib/Default/SmrSessionMySqlDatabase.class.inc
-* lib/Default/SmrMySqlDatabase.class.sample.inc -> lib/Default/SmrMySqlDatabase.class.inc
+* lib/Default/SmrMySqlSecrets.sample.inc -> lib/Default/SmrMySqlSecrets.inc
 
 For "Caretaker" functionality:
 * tools/irc/config.specific.sample.php -> tools/irc/config.specific.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '2'
+services:
+    smr-common:
+        # Base configuration for `smr` (production) and `smr-dev` (testing).
+        build:
+            context: .
+            args:
+                MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+        ports:
+            - "80:80"
+        volumes:
+            - smr_upload:/usr/share/smr/htdocs/upload
+            - ${SMR_CONFIG_FILE}:/usr/share/smr/htdocs/config.specific.php:ro
+
+    smr:
+        extends: smr-common
+        # Links cannot be defined in extended services (i.e. smr-common)
+        links:
+            - mysql
+
+    smr-dev:
+        extends: smr-common
+        # Links cannot be defined in extended services (i.e. smr-common)
+        links:
+            - mysql
+        volumes:
+            # Mount the source code instead of copying it.
+            # You must have run `composer install` to do this.
+            - .:/usr/share/smr:ro
+
+    flyway:
+        image: claycephas/flyway
+        command: -url=jdbc:mysql://smr-mysql/smr_live -user=smr -password=${MYSQL_PASSWORD} migrate
+        links:
+            - mysql
+        volumes:
+            - ./db/patches:/flyway/sql:ro
+
+    mysql:
+        image: mysql:5.5
+        container_name: smr-mysql
+        # By using the default image, we must expose the secrets in
+        # the runtime environment (because we can't specify build args).
+        environment:
+            MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+            MYSQL_USER:          smr
+            MYSQL_PASSWORD:      ${MYSQL_PASSWORD}
+            MYSQL_DATABASE:      smr_live
+        volumes:
+            - smr_mysql_data:/var/lib/mysql
+
+    phpmyadmin:
+        image: phpmyadmin/phpmyadmin
+        # Publish to port 8080
+        ports:
+            - 8080:80
+        links:
+            - mysql:db
+
+# We want persistent, anonymous data volumes
+volumes:
+    smr_upload:
+    smr_mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
             context: .
             args:
                 MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+                MYSQL_HOST: ${MYSQL_HOST}
         ports:
             - "80:80"
         volumes:
@@ -30,7 +31,7 @@ services:
 
     flyway:
         image: claycephas/flyway
-        command: -url=jdbc:mysql://smr-mysql/smr_live -user=smr -password=${MYSQL_PASSWORD} migrate
+        command: -url=jdbc:mysql://${MYSQL_HOST}/smr_live -user=smr -password=${MYSQL_PASSWORD} migrate
         links:
             - mysql
         volumes:
@@ -38,7 +39,7 @@ services:
 
     mysql:
         image: mysql:5.5
-        container_name: smr-mysql
+        container_name: ${MYSQL_HOST}
         # By using the default image, we must expose the secrets in
         # the runtime environment (because we can't specify build args).
         environment:

--- a/lib/Default/SmrMySqlDatabase.class.inc
+++ b/lib/Default/SmrMySqlDatabase.class.inc
@@ -1,10 +1,10 @@
 <?php
 require_once('MySqlDatabase.class.inc');
+require_once('SmrMySqlSecrets.inc');
+
 class SmrMySqlDatabase extends MySqlDatabase {
-	private static $host = 'smr-mysql';
-	private static $databaseName = 'smr_live';
-	private static $user = 'smr';
-	private static $password = 'smr';
+	// add host, user, password, and databaseName static members via traits
+	use SmrMySqlSecrets;
 	public function SmrMySqlDatabase() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$databaseName);
 	}

--- a/lib/Default/SmrMySqlSecrets.sample.inc
+++ b/lib/Default/SmrMySqlSecrets.sample.inc
@@ -1,6 +1,6 @@
 <?php
 trait SmrMySqlSecrets {
-	private static $host = 'smr-mysql';
+	private static $host = '__MYSQL_HOST__';
 	private static $databaseName = 'smr_live';
 	private static $user = 'smr';
 	private static $password = '__MYSQL_PASSWORD__';

--- a/lib/Default/SmrMySqlSecrets.sample.inc
+++ b/lib/Default/SmrMySqlSecrets.sample.inc
@@ -3,6 +3,6 @@ trait SmrMySqlSecrets {
 	private static $host = 'smr-mysql';
 	private static $databaseName = 'smr_live';
 	private static $user = 'smr';
-	private static $password = 'smr';
+	private static $password = '__MYSQL_PASSWORD__';
 }
 ?>

--- a/lib/Default/SmrMySqlSecrets.sample.inc
+++ b/lib/Default/SmrMySqlSecrets.sample.inc
@@ -1,0 +1,8 @@
+<?php
+trait SmrMySqlSecrets {
+	private static $host = 'smr-mysql';
+	private static $databaseName = 'smr_live';
+	private static $user = 'smr';
+	private static $password = 'smr';
+}
+?>

--- a/lib/Default/SmrSessionMySqlDatabase.class.inc
+++ b/lib/Default/SmrSessionMySqlDatabase.class.inc
@@ -1,10 +1,10 @@
 <?php
 require_once('MySqlDatabase.class.inc');
+require_once('SmrMySqlSecrets.inc');
+
 class SmrSessionMySqlDatabase extends MySqlDatabase {
-	private static $host = 'smr-mysql';
-	private static $databaseName = 'smr_live';
-	private static $user = 'smr';
-	private static $password = 'smr';
+	// add host, user, password, and databaseName static members via traits
+	use SmrMySqlSecrets;
 	public function SmrSessionMySqlDatabase() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$databaseName);
 	}


### PR DESCRIPTION
This patch simplifies the service management by using `docker-compose`. All services (smr, smr-dev, mysql, phpmyadmin, and flyway) are maintained in the `docker-compose.yml` file. The updated management commands are reflected in the changes to `README.md`, which are much shorter and require less information to manually specified.

A refactor of `Smr{,Session}MySqlDatabase.class.inc` followed by the inclusion of specifying mysql passwords in an uncommitted `.env` file allow us to avoid needing to link any of these files. The `.env` file also specifies the path to the `config.specific.php` file.

See the commit messages for details about each change.