### PR TITLE
combat_log_viewer.php: include type of logs in message

### DIFF
--- a/engine/Default/combat_log_viewer.php
+++ b/engine/Default/combat_log_viewer.php
@@ -168,29 +168,32 @@ if($action != 5) {
 		return SmrPlayer::getPlayer($accountID, $player->getGameID())->getLinkedDisplayName(false);
 	}
 
+	// For display purposes, describe the type of log
+	switch($action) {
+		case 0:
+			$type = ' personal';
+		break;
+		case 1:
+			$type = ' alliance';
+		break;
+		case 2:
+			$type = ' port';
+		break;
+		case 3:
+			$type = ' planet';
+		break;
+		case 4:
+			$type = ' saved';
+		break;
+		case 6:
+			$type = ' force';
+		break;
+	}
+	$template->assign('LogType', $type);
+
+	// Construct the list of logs of this type
 	$logs = array();
 	if($db->getNumRows() > 0) {
-		switch($action) {
-			case 0:
-				$type = ' personal';
-			break;
-			case 1:
-				$type = ' alliance';
-			break;
-			case 2:
-				$type = ' port';
-			break;
-			case 3:
-				$type = ' planet';
-			break;
-			case 4:
-				$type = ' saved';
-			break;
-			case 6:
-				$type = ' force';
-			break;
-		}
-		$template->assign('LogType', $type);
 		$container = create_container('skeleton.php', 'combat_log_viewer.php');
 		$container['action'] = 5;
 		$container['old_action'] = $action;

--- a/templates/Default/engine/Default/combat_log_viewer.php
+++ b/templates/Default/engine/Default/combat_log_viewer.php
@@ -35,7 +35,7 @@ else {
 	<div align="center"><?php
 		$NumLogs = count($Logs);
 		if($NumLogs > 0) { ?>
-		There <span id="total-logs"><?php echo $this->pluralise('is', $TotalLogs), ' ', $TotalLogs, $this->pluralise(' log', $NumLogs); ?></span> available for viewing of which <?php echo $NumLogs, ' ', $this->pluralise('is', $NumLogs); ?> being shown.<br /><br />
+			There <span id="total-logs"><?php echo $this->pluralise('is', $TotalLogs), ' ', $TotalLogs, ' ', $LogType, $this->pluralise(' log', $NumLogs); ?></span> available for viewing of which <?php echo $NumLogs, ' ', $this->pluralise('is', $NumLogs); ?> being shown.<br /><br />
 			<form class="standard" method="POST" action="<?php echo $LogFormHREF; ?>">
 				<table class="fullwidth center">
 					<tr>
@@ -97,7 +97,7 @@ else {
 			</script><?php
 		}
 		else { ?>
-			No combat logs found<?php
+			No <?php echo $LogType; ?> combat logs found<?php
 		} ?>
 	</div><?php
 } ?>


### PR DESCRIPTION
Before this file was converted to a template, the combat log viewer
would identify the type of logs in the message (e.g. "There are 4
alliance logs available..."). In the template conversion, the `LogType`
template variable was set, but appears to have been mistakenly unused.
We could have simply removed this variable, but the extra descriptive
message is helpful (even if only to identify what page we're on),
so we add the LogType back in.