### PR TITLE
Combat log viewer cleanup

### DIFF
--- a/engine/Default/combat_log_list.php
+++ b/engine/Default/combat_log_list.php
@@ -1,0 +1,134 @@
+<?php
+
+$template->assign('PageTopic','Combat Logs');
+require_once(get_file_loc('menu.inc'));
+create_combat_log_menu();
+
+// Do we have a message from the processing page?
+if (isset($var['message'])) {
+	$template->assign('Message', $var['message']);
+}
+
+// $var['action'] is the page log type
+if(!isset($var['action'])) {
+	SmrSession::updateVar('action',0);
+}
+$action = $var['action'];
+
+switch($action) {
+	case 0:
+	case 1:
+		$query = 'type=\'PLAYER\'';
+	break;
+	case 2:
+		$query = 'type=\'PORT\'';
+	break;
+	case 3:
+		$query = 'type=\'PLANET\'';
+	break;
+	case 4:
+		$query = 'EXISTS(
+					SELECT 1
+					FROM player_saved_combat_logs
+					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
+						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+						AND log_id = c.log_id
+				)';
+	break;
+	case 6:
+		$query = 'type=\'FORCE\'';
+	break;
+	default:
+}
+if(isset($query) && $query) {
+	$query .= ' AND game_id=' . $db->escapeNumber($player->getGameID());
+	if($action != 0 //personal
+		&& $player->hasAlliance()) {
+		$query .= ' AND (attacker_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' OR defender_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ') ';
+	}
+	else {
+		$query .= ' AND (attacker_id=' . $db->escapeNumber($player->getAccountID()) . ' OR defender_id=' . $db->escapeNumber($player->getAccountID()) . ') ';
+	}
+	$page = 0;
+	if(isset($var['page'])) {
+		$page = $var['page'];
+	}
+	$db->query('SELECT count(*) as count FROM combat_logs c WHERE '.$query.' LIMIT 1');
+	if($db->nextRecord()) {
+		$totalLogs = $db->getInt('count');
+		$template->assign('TotalLogs', $totalLogs);
+	}
+	$db->query('SELECT attacker_id,defender_id,timestamp,sector_id,log_id FROM combat_logs c WHERE '.$query.' ORDER BY log_id DESC, sector_id LIMIT '.($page*COMBAT_LOGS_PER_PAGE).', '.COMBAT_LOGS_PER_PAGE);
+}
+
+function getParticipantName($accountID, $sectorID) {
+	global $player;
+	if($accountID == ACCOUNT_ID_PORT) {
+		return '<a href="' . Globals::getPlotCourseHREF($player->getSectorID(), $sectorID) . '">Port <span class="sectorColour">#' . $sectorID . '</span></a>';
+	}
+	if($accountID == ACCOUNT_ID_PLANET) {
+		return '<span class="yellow">Planetary Defenses</span>';
+	}
+
+	return SmrPlayer::getPlayer($accountID, $player->getGameID())->getLinkedDisplayName(false);
+}
+
+// For display purposes, describe the type of log
+switch($action) {
+	case 0:
+		$type = ' personal';
+	break;
+	case 1:
+		$type = ' alliance';
+	break;
+	case 2:
+		$type = ' port';
+	break;
+	case 3:
+		$type = ' planet';
+	break;
+	case 4:
+		$type = ' saved';
+	break;
+	case 6:
+		$type = ' force';
+	break;
+}
+$template->assign('LogType', $type);
+
+// Construct the list of logs of this type
+$logs = array();
+if($db->getNumRows() > 0) {
+	// 'View' and 'Save' share the same form, so we use 'old_action' as a
+	// way to return to this page when we only want to save the logs.
+	$container = create_container('combat_log_list_processing.php');
+	$container['old_action'] = $action;
+	$template->assign('LogFormHREF', SmrSession::getNewHREF($container));
+
+	// Set the links for the "view next/previous log list" buttons
+	$container = $var;
+	if($page>0) {
+		$container['page'] = $page-1;
+		$template->assign('PreviousPage', SmrSession::getNewHREF($container));
+	}
+	if(($page+1)*COMBAT_LOGS_PER_PAGE<$totalLogs) {
+		$container['page'] = $page+1;
+		$template->assign('NextPage', SmrSession::getNewHREF($container));
+	}
+	// Saved logs
+	$template->assign('CanDelete', $action == 4);
+	$template->assign('CanSave', $action != 4);
+
+	while($db->nextRecord()) {
+		$sectorID = $db->getInt('sector_id');
+		$logs[$db->getField('log_id')] = array(
+			'Attacker' => getParticipantName($db->getInt('attacker_id'), $sectorID),
+			'Defender' => getParticipantName($db->getInt('defender_id'), $sectorID),
+			'Time' => $db->getInt('timestamp'),
+			'Sector' => $sectorID
+		);
+	}
+}
+$template->assign('Logs', $logs);
+
+?>

--- a/engine/Default/combat_log_list.php
+++ b/engine/Default/combat_log_list.php
@@ -11,22 +11,22 @@ if (isset($var['message'])) {
 
 // $var['action'] is the page log type
 if(!isset($var['action'])) {
-	SmrSession::updateVar('action',0);
+	SmrSession::updateVar('action', COMBAT_LOG_PERSONAL);
 }
 $action = $var['action'];
 
 switch($action) {
-	case 0:
-	case 1:
+	case COMBAT_LOG_PERSONAL:
+	case COMBAT_LOG_ALLIANCE:
 		$query = 'type=\'PLAYER\'';
 	break;
-	case 2:
+	case COMBAT_LOG_PORT:
 		$query = 'type=\'PORT\'';
 	break;
-	case 3:
+	case COMBAT_LOG_PLANET:
 		$query = 'type=\'PLANET\'';
 	break;
-	case 4:
+	case COMBAT_LOG_SAVED:
 		$query = 'EXISTS(
 					SELECT 1
 					FROM player_saved_combat_logs
@@ -35,14 +35,14 @@ switch($action) {
 						AND log_id = c.log_id
 				)';
 	break;
-	case 6:
+	case COMBAT_LOG_FORCE:
 		$query = 'type=\'FORCE\'';
 	break;
 	default:
 }
 if(isset($query) && $query) {
 	$query .= ' AND game_id=' . $db->escapeNumber($player->getGameID());
-	if($action != 0 //personal
+	if($action != COMBAT_LOG_PERSONAL
 		&& $player->hasAlliance()) {
 		$query .= ' AND (attacker_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' OR defender_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ') ';
 	}
@@ -75,22 +75,22 @@ function getParticipantName($accountID, $sectorID) {
 
 // For display purposes, describe the type of log
 switch($action) {
-	case 0:
+	case COMBAT_LOG_PERSONAL:
 		$type = ' personal';
 	break;
-	case 1:
+	case COMBAT_LOG_ALLIANCE:
 		$type = ' alliance';
 	break;
-	case 2:
+	case COMBAT_LOG_PORT:
 		$type = ' port';
 	break;
-	case 3:
+	case COMBAT_LOG_PLANET:
 		$type = ' planet';
 	break;
-	case 4:
+	case COMBAT_LOG_SAVED:
 		$type = ' saved';
 	break;
-	case 6:
+	case COMBAT_LOG_FORCE:
 		$type = ' force';
 	break;
 }
@@ -116,8 +116,8 @@ if($db->getNumRows() > 0) {
 		$template->assign('NextPage', SmrSession::getNewHREF($container));
 	}
 	// Saved logs
-	$template->assign('CanDelete', $action == 4);
-	$template->assign('CanSave', $action != 4);
+	$template->assign('CanDelete', $action == COMBAT_LOG_SAVED);
+	$template->assign('CanSave', $action != COMBAT_LOG_SAVED);
 
 	while($db->nextRecord()) {
 		$sectorID = $db->getInt('sector_id');

--- a/engine/Default/combat_log_list_processing.php
+++ b/engine/Default/combat_log_list_processing.php
@@ -1,0 +1,57 @@
+<?php
+
+// If here, we have hit either the 'Save', 'Delete', or 'View' form buttons.
+// Immediately return to the log list if we haven't selected any logs.
+if (!isset($_REQUEST['id'])) {
+	$container = create_container('skeleton.php', 'combat_log_list.php');
+	$container['message'] = 'You must select at least one combat log!';
+	$container['action'] = $var['old_action'];
+	forward($container);
+}
+
+$submitAction = $_REQUEST['action'];
+$logIDs = array_keys($_REQUEST['id']);
+
+// Do we need to save any logs (or delete any saved logs)?
+if ($submitAction == 'Save' || $submitAction == 'Delete') {
+	if($submitAction == 'Save') {
+		//save the logs we checked
+		// Query means people can only save logs that they are allowd to view.
+		$db->query('INSERT IGNORE INTO player_saved_combat_logs (account_id, game_id, log_id)
+					SELECT ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', log_id
+					FROM combat_logs
+					WHERE log_id IN (' . $db->escapeArray($logIDs) . ')
+						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+						AND (
+							attacker_id = ' . $db->escapeNumber($player->getAccountID()) . '
+							OR defender_id = ' . $db->escapeNumber($player->getAccountID()) .
+							($player->hasAlliance() ? '
+								OR attacker_alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
+								OR defender_alliance_id = ' . $db->escapeNumber($player->getAllianceID())
+							: '') . '
+						)
+					LIMIT ' . count($logIDs));
+	}
+	else if($submitAction == 'Delete') {
+		$db->query('DELETE FROM player_saved_combat_logs
+					WHERE log_id IN (' . $db->escapeArray($logIDs) . ')
+						AND account_id = ' . $db->escapeNumber($player->getAccountID()) . '
+						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+					LIMIT ' . count($logIDs));
+	}
+
+	// Now that the logs have been saved/deleted, go back to the log list
+	$container = create_container('skeleton.php', 'combat_log_list.php');
+	$container['message'] = $submitAction . 'd ' . $db->getChangedRows() . ' new logs.';
+	$container['action'] = $var['old_action'];
+	forward($container);
+}
+else if ($submitAction == 'View') {
+	$container = create_container('skeleton.php', 'combat_log_viewer.php');
+	$container['log_ids'] = $logIDs;
+	sort($container['log_ids']);
+	$container['current_log'] = 0;
+	forward($container);
+}
+
+?>

--- a/engine/Default/combat_log_viewer.php
+++ b/engine/Default/combat_log_viewer.php
@@ -3,227 +3,40 @@
 $template->assign('PageTopic','Combat Logs');
 require_once(get_file_loc('menu.inc'));
 create_combat_log_menu();
-if (isset($_REQUEST['action'])) {
-	$submitAction = $_REQUEST['action'];
-	if (isset($_REQUEST['id'])) {
-		$logIDs = array_keys($_REQUEST['id']);
-		if($submitAction == 'Save') {
-			//save the logs we checked
-			// Query means people can only save logs that they are allowd to view.
-			$db->query('INSERT IGNORE INTO player_saved_combat_logs (account_id, game_id, log_id)
-						SELECT ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', log_id
-						FROM combat_logs
-						WHERE log_id IN (' . $db->escapeArray($logIDs) . ')
-							AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND (
-								attacker_id = ' . $db->escapeNumber($player->getAccountID()) . '
-								OR defender_id = ' . $db->escapeNumber($player->getAccountID()) .
-								($player->hasAlliance() ? '
-									OR attacker_alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-									OR defender_alliance_id = ' . $db->escapeNumber($player->getAllianceID())
-								: '') . '
-							)
-						LIMIT ' . count($logIDs));
-			$template->assign('Message', $db->getChangedRows() . ' new logs have been saved.');
-			//back to viewing
-			$var['action'] = $var['old_action'];
-		}
-		else if($submitAction == 'Delete') {
-			$db->query('DELETE FROM player_saved_combat_logs
-						WHERE log_id IN (' . $db->escapeArray($logIDs) . ')
-							AND account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-							AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						LIMIT ' . count($logIDs));
-			$template->assign('Message', $db->getChangedRows() . ' new logs have been deleted.');
-			//back to viewing
-			$var['action'] = $var['old_action'];
-		}
-	}
-	else {
-		$var['action'] = $var['old_action'];
-	}
-}
-if(!isset($var['action'])) {
-	SmrSession::updateVar('action',0);
-}
-$action = $var['action'];
 
-if($action == 5) {
-	if(!isset($_REQUEST['id']) && !isset($var['log_ids'])) {
-		$action = $var['old_action'];
-	}
-	else {
-		$container = array();
-		$container['url'] = 'skeleton.php';
-		$container['body'] = 'combat_log_viewer.php';
-		if(!isset($var['log_ids'])) {
-			$container['log_ids'] = array_keys($_REQUEST['id']);
-			sort($container['log_ids']);
-			$container['current_log'] = 0;
-			SmrSession::updateVar('log_ids',$container['log_ids']);
-			SmrSession::updateVar('current_log',0);
-		}
-		else {
-			$container['log_ids'] = $var['log_ids'];
-			$container['current_log'] = $var['current_log'];
-		}
-		$container['action'] = 5;
-		
-		if($var['direction']) {
-			if($var['direction'] == 1) {
-				--$container['current_log'];
-			}
-			else {
-				++$container['current_log'];
-			}
-		}
-		$display_id = $container['log_ids'][$container['current_log']];
-		if(count($container['log_ids']) > 1) {
-			if($container['current_log'] > 0) {
-				$container['direction'] = 1;
-				$template->assign('PreviousLogHREF',SmrSession::getNewHREF($container));
-			}
-			if($container['current_log'] < count($container['log_ids']) - 1) {
-				$container['direction'] = 2;
-				$template->assign('NextLogHREF',SmrSession::getNewHREF($container));
-			}
-		}
-	}
+if(!isset($var['log_ids']) && !isset($var['current_log'])) {
+	create_error('You must select a combat log to view');
 }
 
-if(isset($display_id)) {
-	//These are required in case we unzip these classes.
-	require_once(get_file_loc('SmrPort.class.inc'));
-	require_once(get_file_loc('SmrPlanet.class.inc'));
-	$db->query('SELECT timestamp,sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($display_id) . ' LIMIT 1');
-
-	if($db->nextRecord()) {
-		$template->assign('CombatLogSector',$db->getField('sector_id'));
-		$template->assign('CombatLogTimestamp',date(DATE_FULL_SHORT,$db->getField('timestamp')));
-		$results = unserialize(gzuncompress($db->getField('result')));
-		$template->assign('CombatResultsType',$db->getField('type'));
-		$template->assignByRef('CombatResults',$results);
-	}
-	else {
-		create_error('Combat log not found');
-	}
+// Create a container for the next/previous log.
+// We initialize it with the current $var, then modify it to set
+// which log to view when we press the next/previous log buttons.
+$container = create_container('skeleton.php', 'combat_log_viewer.php', $var);
+if($var['current_log'] > 0) {
+	$container['current_log'] = $var['current_log'] - 1;
+	$template->assign('PreviousLogHREF',SmrSession::getNewHREF($container));
+}
+if($var['current_log'] < count($container['log_ids']) - 1) {
+	$container['current_log'] = $var['current_log'] + 1;
+	$template->assign('NextLogHREF',SmrSession::getNewHREF($container));
 }
 
-switch($action) {
-	case 0:
-	case 1:
-		$query = 'type=\'PLAYER\'';
-	break;
-	case 2:
-		$query = 'type=\'PORT\'';
-	break;
-	case 3:
-		$query = 'type=\'PLANET\'';
-	break;
-	case 4:
-		$query = 'EXISTS(
-					SELECT 1
-					FROM player_saved_combat_logs
-					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND log_id = c.log_id
-				)';
-	break;
-	case 6:
-		$query = 'type=\'FORCE\'';
-	break;
-	default:
+// Set properties for the current display page
+$display_id = $var['log_ids'][$var['current_log']];
+//These are required in case we unzip these classes.
+require_once(get_file_loc('SmrPort.class.inc'));
+require_once(get_file_loc('SmrPlanet.class.inc'));
+$db->query('SELECT timestamp,sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($display_id) . ' LIMIT 1');
+
+if($db->nextRecord()) {
+	$template->assign('CombatLogSector',$db->getField('sector_id'));
+	$template->assign('CombatLogTimestamp',date(DATE_FULL_SHORT,$db->getField('timestamp')));
+	$results = unserialize(gzuncompress($db->getField('result')));
+	$template->assign('CombatResultsType',$db->getField('type'));
+	$template->assignByRef('CombatResults',$results);
 }
-if(isset($query) && $query) {
-	$query .= ' AND game_id=' . $db->escapeNumber($player->getGameID());
-	if($action != 0 //personal
-		&& $player->hasAlliance()) {
-		$query .= ' AND (attacker_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' OR defender_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ') ';
-	}
-	else {
-		$query .= ' AND (attacker_id=' . $db->escapeNumber($player->getAccountID()) . ' OR defender_id=' . $db->escapeNumber($player->getAccountID()) . ') ';
-	}
-	$page = 0;
-	if(isset($var['page'])) {
-		$page = $var['page'];
-	}
-	$db->query('SELECT count(*) as count FROM combat_logs c WHERE '.$query.' LIMIT 1');
-	if($db->nextRecord()) {
-		$totalLogs = $db->getInt('count');
-		$template->assign('TotalLogs', $totalLogs);
-	}
-	$db->query('SELECT attacker_id,defender_id,timestamp,sector_id,log_id FROM combat_logs c WHERE '.$query.' ORDER BY log_id DESC, sector_id LIMIT '.($page*COMBAT_LOGS_PER_PAGE).', '.COMBAT_LOGS_PER_PAGE);
-}
-
-if($action != 5) {
-	function getParticipantName($accountID, $sectorID) {
-		global $player;
-		if($accountID == ACCOUNT_ID_PORT) {
-			return '<a href="' . Globals::getPlotCourseHREF($player->getSectorID(), $sectorID) . '">Port <span class="sectorColour">#' . $sectorID . '</span></a>';
-		}
-		if($accountID == ACCOUNT_ID_PLANET) {
-			return '<span class="yellow">Planetary Defenses</span>';
-		}
-
-		return SmrPlayer::getPlayer($accountID, $player->getGameID())->getLinkedDisplayName(false);
-	}
-
-	// For display purposes, describe the type of log
-	switch($action) {
-		case 0:
-			$type = ' personal';
-		break;
-		case 1:
-			$type = ' alliance';
-		break;
-		case 2:
-			$type = ' port';
-		break;
-		case 3:
-			$type = ' planet';
-		break;
-		case 4:
-			$type = ' saved';
-		break;
-		case 6:
-			$type = ' force';
-		break;
-	}
-	$template->assign('LogType', $type);
-
-	// Construct the list of logs of this type
-	$logs = array();
-	if($db->getNumRows() > 0) {
-		$container = create_container('skeleton.php', 'combat_log_viewer.php');
-		$container['action'] = 5;
-		$container['old_action'] = $action;
-		$container['direction'] = 0;
-		$template->assign('LogFormHREF', SmrSession::getNewHREF($container));
-
-		$container = $var;
-		if($page>0) {
-			$container['page'] = $page-1;
-			$template->assign('PreviousPage', SmrSession::getNewHREF($container));
-		}
-		if(($page+1)*COMBAT_LOGS_PER_PAGE<$totalLogs) {
-			$container['page'] = $page+1;
-			$template->assign('NextPage', SmrSession::getNewHREF($container));
-		}
-		// Saved logs
-		$template->assign('CanDelete', $action == 4);
-		$template->assign('CanSave', $action != 4);
-
-		while($db->nextRecord()) {
-			$sectorID = $db->getInt('sector_id');
-			$logs[$db->getField('log_id')] = array(
-				'Attacker' => getParticipantName($db->getInt('attacker_id'), $sectorID),
-				'Defender' => getParticipantName($db->getInt('defender_id'), $sectorID),
-				'Time' => $db->getInt('timestamp'),
-				'Sector' => $sectorID
-			);
-		}
-	}
-	$template->assign('Logs', $logs);
+else {
+	create_error('Combat log not found');
 }
 
 ?>

--- a/engine/Default/menu.inc
+++ b/engine/Default/menu.inc
@@ -98,7 +98,7 @@ function create_message_menu() {
 function create_combat_log_menu() {
 	global $template;
 
-	$container = create_container('skeleton.php','combat_log_viewer.php');
+	$container = create_container('skeleton.php', 'combat_log_list.php');
 	$menuItems = array();
 
 	$container['action'] = 0;

--- a/engine/Default/menu.inc
+++ b/engine/Default/menu.inc
@@ -101,17 +101,17 @@ function create_combat_log_menu() {
 	$container = create_container('skeleton.php', 'combat_log_list.php');
 	$menuItems = array();
 
-	$container['action'] = 0;
+	$container['action'] = COMBAT_LOG_PERSONAL;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Personal');
-	$container['action'] = 1;
+	$container['action'] = COMBAT_LOG_ALLIANCE;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Alliance');
-	$container['action'] = 6;
+	$container['action'] = COMBAT_LOG_FORCE;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Force');
-	$container['action'] = 2;
+	$container['action'] = COMBAT_LOG_PORT;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Port');
-	$container['action'] = 3;
+	$container['action'] = COMBAT_LOG_PLANET;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Planet');
-	$container['action'] = 4;
+	$container['action'] = COMBAT_LOG_SAVED;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Saved');
 
 	$template->assign('MenuItems',$menuItems);

--- a/engine/Default/smr.inc
+++ b/engine/Default/smr.inc
@@ -29,7 +29,6 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 					return true;
 				}
 				$container = create_container('skeleton.php', 'combat_log_viewer.php');
-				$container['action'] = 5;
 				$container['log_ids'] = array($logID);
 				$container['current_log'] = 0;
 				return '<a href="' . SmrSession::getNewHREF($container) . '"><img src="images/notify.gif" width="14" height="11" border="0" title="View the combat log" /></a>';
@@ -770,7 +769,7 @@ function doSkeletionAssigns(&$template,&$player,&$ship,&$sector,&$db,&$account) 
 
 		$template->assign('PoliticsLink',Globals::getPoliticsHREF());
 
-		$container['body'] = 'combat_log_viewer.php';
+		$container['body'] = 'combat_log_list.php';
 		$template->assign('CombatLogsLink',SmrSession::getNewHREF($container));
 
 		$template->assign('PlanetLink',Globals::getTraderPlanetHREF());

--- a/engine/Semi Wars/menu.inc
+++ b/engine/Semi Wars/menu.inc
@@ -98,7 +98,7 @@ function create_message_menu() {
 function create_combat_log_menu() {
 	global $template;
 
-	$container = create_container('skeleton.php','combat_log_viewer.php');
+	$container = create_container('skeleton.php', 'combat_log_list.php');
 	$menuItems = array();
 
 	$container['action'] = 0;

--- a/engine/Semi Wars/menu.inc
+++ b/engine/Semi Wars/menu.inc
@@ -101,17 +101,17 @@ function create_combat_log_menu() {
 	$container = create_container('skeleton.php', 'combat_log_list.php');
 	$menuItems = array();
 
-	$container['action'] = 0;
+	$container['action'] = COMBAT_LOG_PERSONAL;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Personal');
-	$container['action'] = 1;
+	$container['action'] = COMBAT_LOG_ALLIANCE;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Alliance');
-	$container['action'] = 6;
+	$container['action'] = COMBAT_LOG_FORCE;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Force');
-	$container['action'] = 2;
+	$container['action'] = COMBAT_LOG_PORT;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Port');
-	$container['action'] = 3;
+	$container['action'] = COMBAT_LOG_PLANET;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Planet');
-	$container['action'] = 4;
+	$container['action'] = COMBAT_LOG_SAVED;
 	$menuItems[] = array('Link'=>SmrSession::getNewHREF($container),'Text'=>'Saved');
 
 	$template->assign('MenuItems',$menuItems);

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -109,6 +109,16 @@ define('SHIP_TYPE_VENGEANCE',72);
 define('SHIP_TYPE_FURY',75);
 
 /*
+ * Combat log pages
+ */
+define('COMBAT_LOG_PERSONAL', 0);
+define('COMBAT_LOG_ALLIANCE', 1);
+define('COMBAT_LOG_FORCE',    2);
+define('COMBAT_LOG_PORT',     3);
+define('COMBAT_LOG_PLANET',   4);
+define('COMBAT_LOG_SAVED',    5);
+
+/*
  * Combat system
  */
 define('MAX_ATTACK_RATING_NEWBIE',4);

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -25,6 +25,7 @@ class SmrSession {
 			'changelog_view.php' => self::ALWAYS_AVAILABLE,
 			'chat_rules.php' => self::ALWAYS_AVAILABLE,
 			'chess_play.php' => self::ALWAYS_AVAILABLE,
+			'combat_log_list.php' => self::ALWAYS_AVAILABLE,
 			'combat_log_viewer.php' => self::ALWAYS_AVAILABLE,
 			'current_sector.php' => self::ALWAYS_AVAILABLE,
 			'configure_hardware.php' => self::ALWAYS_AVAILABLE,

--- a/templates/Default/engine/Default/combat_log_list.php
+++ b/templates/Default/engine/Default/combat_log_list.php
@@ -1,0 +1,73 @@
+<?php
+if(isset($Message)) {?>
+	<div class="center"><?php echo $Message; ?></div><br /><?php
+} ?>
+
+<div align="center"><?php
+	$NumLogs = count($Logs);
+	if($NumLogs > 0) { ?>
+		There <span id="total-logs"><?php echo $this->pluralise('is', $TotalLogs), ' ', $TotalLogs, ' ', $LogType, $this->pluralise(' log', $NumLogs); ?></span> available for viewing of which <?php echo $NumLogs, ' ', $this->pluralise('is', $NumLogs); ?> being shown.<br /><br />
+		<form class="standard" method="POST" action="<?php echo $LogFormHREF; ?>">
+			<table class="fullwidth center">
+				<tr>
+					<td id="prev" class="ajax" style="width: 30%" valign="middle"><?php
+						if(isset($PreviousPage)) { ?>
+							<a href="<?php echo $PreviousPage; ?>"><img src="images/album/rew.jpg" width="25" height="25" alt="Previous Page" border="0"></a><?php
+						} ?>
+					</td>
+					<td>
+						<input class="submit" type="submit" name="action" value="View"><?php
+						if($CanDelete) {
+							?>&nbsp;<input class="submit" type="submit" name="action" value="Delete"><?php
+						}
+						if($CanSave) {
+							?>&nbsp;<input class="submit" type="submit" name="action" value="Save"><?php
+						} ?>
+					</td>
+					<td id="next" class="ajax" style="width: 30%" valign="middle"><?php
+						if(isset($NextPage)) { ?>
+							<a href="<?php echo $NextPage; ?>"><img src="images/album/fwd.jpg" width="25" height="25" alt="Next Page" border="0"></a><?php
+						} ?>
+					</td>
+				</tr>
+			</table>
+			<br /><br />
+			<table id="logs-list" class="standard fullwidth">
+				<thead>
+					<tr>
+						<th class="shrink">View</th>
+						<th class="sort shrink" data-sort="date">Date</th>
+						<th class="sort shrink" data-sort="sectorid">Sector</th>
+						<th class="sort" data-sort="attacker">Attacker</th>
+						<th class="sort" data-sort="defender">Defender</th>
+					</tr>
+				</thead>
+				<tbody class="list"><?php
+					foreach ($Logs as $LogID => $Log) { ?>
+						<tr id="log-<?php echo $LogID; ?>" class="ajax">
+							<td class="center">
+								<input type="checkbox" value="on" name="id[<?php echo $LogID; ?>]">
+							</td>
+							<td class="date noWrap"><?php echo date(DATE_FULL_SHORT, $Log['Time']); ?></td>
+							<td class="sectorid center"><?php echo $Log['Sector']; ?></td>
+							<td class="attacker"><?php echo $Log['Attacker']; ?></td>
+							<td class="defender"><?php echo $Log['Defender']; ?></td>
+						</tr><?php
+					} ?>
+				</tbody>
+			</table>
+		</form>
+		<script type="text/javascript" src="js/list.1.0.0.custom.min.js"></script>
+		<script>
+		var list = new List('logs-list', {
+			valueNames: ['date', 'sectorid', 'attacker', 'defender'],
+			sortFunction: function(a, b) {
+				return list.sort.naturalSort(a.values()[this.valueName].replace(/<.*?>|,/g,''), b.values()[this.valueName].replace(/<.*?>|,/g,''), this);
+			}
+		});
+		</script><?php
+	}
+	else { ?>
+		No <?php echo $LogType; ?> combat logs found<?php
+	} ?>
+</div>

--- a/templates/Default/engine/Default/combat_log_viewer.php
+++ b/templates/Default/engine/Default/combat_log_viewer.php
@@ -1,103 +1,29 @@
 <?php
-if(isset($CombatResultsType)&&$CombatResultsType) {
-	if(isset($PreviousLogHREF) || isset($NextLogHREF)) { ?>
-		<div class="center"><?php
-		if(isset($PreviousLogHREF)) {
-			?><a href="<?php echo $PreviousLogHREF ?>"><img title="Previous" alt="Previous" src="images/album/rew.jpg" /></a><?php
-		}
-		if(isset($NextLogHREF)) {
-			?><a href="<?php echo $NextLogHREF ?>"><img title="Next" alt="Next" src="images/album/fwd.jpg" /></a><?php
-		} ?>
-		</div><?php
+if(isset($PreviousLogHREF) || isset($NextLogHREF)) { ?>
+	<div class="center"><?php
+	if(isset($PreviousLogHREF)) {
+		?><a href="<?php echo $PreviousLogHREF ?>"><img title="Previous" alt="Previous" src="images/album/rew.jpg" /></a><?php
+	}
+	if(isset($NextLogHREF)) {
+		?><a href="<?php echo $NextLogHREF ?>"><img title="Next" alt="Next" src="images/album/fwd.jpg" /></a><?php
 	} ?>
-	Sector <?php echo $CombatLogSector ?><br />
-	<?php echo $CombatLogTimestamp ?><br />
-	<br />
-
-	<?php
-	if($CombatResultsType=='PLAYER') {
-		$this->includeTemplate('includes/TraderFullCombatResults.inc',array('TraderCombatResults'=>$CombatResults));
-	}
-	else if($CombatResultsType=='FORCE') {
-		$this->includeTemplate('includes/ForceFullCombatResults.inc',array('FullForceCombatResults'=>$CombatResults));
-	}
-	else if($CombatResultsType=='PORT') {
-		$this->includeTemplate('includes/PortFullCombatResults.inc',array('FullPortCombatResults'=>$CombatResults));
-	}
-	else if($CombatResultsType=='PLANET') {
-		$this->includeTemplate('includes/PlanetFullCombatResults.inc',array('FullPlanetCombatResults'=>$CombatResults));
-	}
-}
-else {
-	if(isset($Message)) {?>
-		<div class="center"><?php echo $Message; ?></div><br /><?php
-	} ?>
-	<div align="center"><?php
-		$NumLogs = count($Logs);
-		if($NumLogs > 0) { ?>
-			There <span id="total-logs"><?php echo $this->pluralise('is', $TotalLogs), ' ', $TotalLogs, ' ', $LogType, $this->pluralise(' log', $NumLogs); ?></span> available for viewing of which <?php echo $NumLogs, ' ', $this->pluralise('is', $NumLogs); ?> being shown.<br /><br />
-			<form class="standard" method="POST" action="<?php echo $LogFormHREF; ?>">
-				<table class="fullwidth center">
-					<tr>
-						<td id="prev" class="ajax" style="width: 30%" valign="middle"><?php
-							if(isset($PreviousPage)) { ?>
-								<a href="<?php echo $PreviousPage; ?>"><img src="images/album/rew.jpg" width="25" height="25" alt="Previous Page" border="0"></a><?php
-							} ?>
-						</td>
-						<td>
-							<input class="submit" type="submit" name="action" value="View"><?php
-							if($CanDelete) {
-								?>&nbsp;<input class="submit" type="submit" name="action" value="Delete"><?php
-							}
-							if($CanSave) {
-								?>&nbsp;<input class="submit" type="submit" name="action" value="Save"><?php
-							} ?>
-						</td>
-						<td id="next" class="ajax" style="width: 30%" valign="middle"><?php
-							if(isset($NextPage)) { ?>
-								<a href="<?php echo $NextPage; ?>"><img src="images/album/fwd.jpg" width="25" height="25" alt="Next Page" border="0"></a><?php
-							} ?>
-						</td>
-					</tr>
-				</table>
-				<br /><br />
-				<table id="logs-list" class="standard fullwidth">
-					<thead>
-						<tr>
-							<th class="shrink">View</th>
-							<th class="sort shrink" data-sort="date">Date</th>
-							<th class="sort shrink" data-sort="sectorid">Sector</th>
-							<th class="sort" data-sort="attacker">Attacker</th>
-							<th class="sort" data-sort="defender">Defender</th>
-						</tr>
-					</thead>
-					<tbody class="list"><?php
-						foreach ($Logs as $LogID => $Log) { ?>
-							<tr id="log-<?php echo $LogID; ?>" class="ajax">
-								<td class="center">
-									<input type="checkbox" value="on" name="id[<?php echo $LogID; ?>]">
-								</td>
-								<td class="date noWrap"><?php echo date(DATE_FULL_SHORT, $Log['Time']); ?></td>
-								<td class="sectorid center"><?php echo $Log['Sector']; ?></td>
-								<td class="attacker"><?php echo $Log['Attacker']; ?></td>
-								<td class="defender"><?php echo $Log['Defender']; ?></td>
-							</tr><?php
-						} ?>
-					</tbody>
-				</table>
-			</form>
-			<script type="text/javascript" src="js/list.1.0.0.custom.min.js"></script>
-			<script>
-			var list = new List('logs-list', {
-				valueNames: ['date', 'sectorid', 'attacker', 'defender'],
-				sortFunction: function(a, b) {
-					return list.sort.naturalSort(a.values()[this.valueName].replace(/<.*?>|,/g,''), b.values()[this.valueName].replace(/<.*?>|,/g,''), this);
-				}
-			});
-			</script><?php
-		}
-		else { ?>
-			No <?php echo $LogType; ?> combat logs found<?php
-		} ?>
 	</div><?php
 } ?>
+Sector <?php echo $CombatLogSector ?><br />
+<?php echo $CombatLogTimestamp ?><br />
+<br />
+
+<?php
+if($CombatResultsType=='PLAYER') {
+	$this->includeTemplate('includes/TraderFullCombatResults.inc',array('TraderCombatResults'=>$CombatResults));
+}
+else if($CombatResultsType=='FORCE') {
+	$this->includeTemplate('includes/ForceFullCombatResults.inc',array('FullForceCombatResults'=>$CombatResults));
+}
+else if($CombatResultsType=='PORT') {
+	$this->includeTemplate('includes/PortFullCombatResults.inc',array('FullPortCombatResults'=>$CombatResults));
+}
+else if($CombatResultsType=='PLANET') {
+	$this->includeTemplate('includes/PlanetFullCombatResults.inc',array('FullPlanetCombatResults'=>$CombatResults));
+}
+?>


### PR DESCRIPTION
Two commits affecting `combat_log_viewer.php`:
1. Major refactor (breaking up into 3 files) to simplify and comment the code. This makes the diff look very large, but most of the difference is code being moved to new files.
2. Switch to named constants to avoid fragile references to the combat log pages.

See the commit messages for more details.