### PR TITLE
Improved php debugging

### DIFF
--- a/engine/Default/planet_stockpile.php
+++ b/engine/Default/planet_stockpile.php
@@ -12,7 +12,7 @@ create_planet_menu($planet);
 
 $PHP_OUTPUT.=('<p>There are no goods present on your ship or the planet!</p>');
 $present = false;
-$table.=('<p>');
+$table=('<p>');
 $table.=('<table class="standard">');
 
 $table.=('<tr>');

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -2,6 +2,11 @@
 @date_default_timezone_set(@date_default_timezone_get());
 require_once(dirname(__FILE__) . '/config.specific.php');
 
+if (ENABLE_DEBUG) {
+	// Warn about everything when in debug mode
+	error_reporting(E_ERROR | E_WARNING | E_PARSE | E_NOTICE);
+}
+
 define('ACCOUNT_ID_PORT',65535);
 define('ACCOUNT_ID_ADMIN',65534);
 define('ACCOUNT_ID_PLANET',65533);

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -741,8 +741,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setEmail($email) {
-		if($this->$email==$email)
+		if($this->email==$email) {
 			return;
+		}
 		$this->email = $email;
 		$this->hasChanged = true;
 		$this->update();

--- a/lib/Default/SmrForce.class.inc
+++ b/lib/Default/SmrForce.class.inc
@@ -60,7 +60,7 @@ class SmrForce {
 			while($db->nextRecord()) {
 				$forces[$db->getField('owner_id')] =& self::getForce($gameID,$sectorID,$db->getInt('owner_id'));
 			}
-			return self::$CACHE_SECTOR_FORCES[$gameID][$sectorID] =& $forces;
+			self::$CACHE_SECTOR_FORCES[$gameID][$sectorID] =& $forces;
 		}
 		return self::$CACHE_SECTOR_FORCES[$gameID][$sectorID];
 	}
@@ -69,7 +69,7 @@ class SmrForce {
 		if($forceUpdate || !isset(self::$CACHE_FORCES[$gameID][$sectorID][$ownerID])) {
 			self::tidyUpForces(SmrGalaxy::getGalaxyContaining($gameID,$sectorID));
 			$p = new SmrForce($gameID,$sectorID,$ownerID);
-			return self::$CACHE_FORCES[$gameID][$sectorID][$ownerID] =& $p;
+			self::$CACHE_FORCES[$gameID][$sectorID][$ownerID] =& $p;
 		}
 		return self::$CACHE_FORCES[$gameID][$sectorID][$ownerID];
 	}

--- a/lib/Default/SmrGalaxy.class.inc
+++ b/lib/Default/SmrGalaxy.class.inc
@@ -27,7 +27,7 @@ class SmrGalaxy {
 				$galaxyID = $db->getField('galaxy_id');
 				$galaxies[$galaxyID] =& self::getGalaxy($gameID,$galaxyID,$forceUpdate);
 			}
-			return self::$CACHE_GAME_GALAXIES[$gameID] =& $galaxies;
+			self::$CACHE_GAME_GALAXIES[$gameID] =& $galaxies;
 		}
 		return self::$CACHE_GAME_GALAXIES[$gameID];
 	}

--- a/lib/Default/SmrLocation.class.inc
+++ b/lib/Default/SmrLocation.class.inc
@@ -44,7 +44,7 @@ class SmrLocation {
 				$locations[$i] =& self::getLocation($db->getField('location_type_id'));
 				$i++;
 			}
-			return self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] =& $locations;
+			self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] =& $locations;
 		}
 		return self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID];
 	}
@@ -52,7 +52,7 @@ class SmrLocation {
 	public static function &getLocation($locationTypeID,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_LOCATIONS[$locationTypeID])) {
 			$p = new SmrLocation($locationTypeID);
-			return self::$CACHE_LOCATIONS[$locationTypeID] =& $p;
+			self::$CACHE_LOCATIONS[$locationTypeID] =& $p;
 		}
 		return self::$CACHE_LOCATIONS[$locationTypeID];
 	}

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -43,6 +43,7 @@ class SmrPlanet {
 
 	protected $delayedShieldsDelta = 0;
 	protected $delayedCDsDelta = 0;
+	protected $delayedArmourDelta = 0;
 
 	public static function refreshCache() {
 		foreach(self::$CACHE_PLANETS as $gameID => &$gamePlanets) {
@@ -847,6 +848,8 @@ class SmrPlanet {
 		$this->delayedShieldsDelta = 0;
 		$this->setCDs($this->getCDs(true));
 		$this->delayedCDsDelta = 0;
+		$this->setArmour($this->getArmour(true));
+		$this->delayedArmourDelta = 0;
 	}
 	
 	public function getMaxAttackers() {

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -67,7 +67,7 @@ class SmrPlanet {
 	public static function &getPlanet($gameID,$sectorID,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_PLANETS[$gameID][$sectorID])) {
 			$p = new SmrPlanet($gameID,$sectorID);
-			return self::$CACHE_PLANETS[$gameID][$sectorID] =& $p;
+			self::$CACHE_PLANETS[$gameID][$sectorID] =& $p;
 		}
 		return self::$CACHE_PLANETS[$gameID][$sectorID];
 	}

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -97,7 +97,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 				$accountID = $db->getInt('account_id');
 				$players[$accountID] =& self::getPlayer($accountID,$gameID,$forceUpdate);
 			}
-			return self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] =& $players;
+			self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] =& $players;
 		}
 		return self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID];
 	}
@@ -111,7 +111,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 				$accountID = $db->getField('account_id');
 				$players[$accountID] =& self::getPlayer($accountID,$gameID,$forceUpdate);
 			}
-			return self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID] =& $players;
+			self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID] =& $players;
 		}
 		return self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID];
 	}
@@ -125,7 +125,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 				$accountID = $db->getInt('account_id');
 				$players[$accountID] =& self::getPlayer($accountID,$gameID);
 			}
-			return self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID] =& $players;
+			self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID] =& $players;
 		}
 		return self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID];
 	}
@@ -133,7 +133,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 	public static function &getPlayer($accountIDOrResultArray,$gameID,$forceUpdate = false) {
 		if($forceUpdate || is_array($accountIDOrResultArray) || !isset(self::$CACHE_PLAYERS[$gameID][$accountIDOrResultArray])) {
 			$p = new SmrPlayer($gameID,$accountIDOrResultArray);
-			return self::$CACHE_PLAYERS[$gameID][$p->getAccountID()] =& $p;
+			self::$CACHE_PLAYERS[$gameID][$p->getAccountID()] =& $p;
+			return self::$CACHE_PLAYERS[$gameID][$p->getAccountID()];
 		}
 		return self::$CACHE_PLAYERS[$gameID][$accountIDOrResultArray];
 	}

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -300,7 +300,9 @@ class SmrSession {
 			$container['RemainingPageLoads'] = 1; // Allow refreshing
 		}
 		if(!isset($container['PreviousRequestTime'])) {
-			$container['PreviousRequestTime'] = self::$var[$sn]['PreviousRequestTime']; // Copy across the previous request time if not explicitly set.
+			if(isset(self::$var[$sn]['PreviousRequestTime'])) {
+				$container['PreviousRequestTime'] = self::$var[$sn]['PreviousRequestTime']; // Copy across the previous request time if not explicitly set.
+			}
 		}
 
 		self::$var[$sn] = $container;

--- a/lib/Default/SmrShip.class.inc
+++ b/lib/Default/SmrShip.class.inc
@@ -35,7 +35,7 @@ class SmrShip extends AbstractSmrShip {
 	public static function &getShip(AbstractSmrPlayer &$player,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_SHIPS[$player->getGameID()][$player->getAccountID()])) {
 			$s = new SmrShip($player);
-			return self::$CACHE_SHIPS[$player->getGameID()][$s->getAccountID()] =& $s;
+			self::$CACHE_SHIPS[$player->getGameID()][$player->getAccountID()] =& $s;
 		}
 		return self::$CACHE_SHIPS[$player->getGameID()][$player->getAccountID()];
 	}


### PR DESCRIPTION
When in debug mode (as defined by `ENABLE_DEBUG` in `config.specific.php`), all php notices will be printed to help catch bugs. A quick pass through the code with these notices turned on revealed a few issues, which are fixed in this PR.

See commit messages for more details.