### PR TITLE
SmrPlayer.class.inc: fix planet message whitespace

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1344,7 +1344,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$return = array();
 		// send a message to the person who died
 		$planetOwner =& $planet->getOwner();
-		$this->sendMessage($planetOwner->getAccountID(), MSG_PLAYER, 'Your planet <span class="red">DESTROYED</span> '.$this->getBBLink().' in sector '.$planet->getSectorID(),false);
+		$this->sendMessage($planetOwner->getAccountID(), MSG_PLAYER, 'Your planet <span class="red">DESTROYED</span>&nbsp;'.$this->getBBLink().' in sector '.$planet->getSectorID(),false);
 		$planetOwner->sendMessage($this->getAccountID(), MSG_PLAYER, 'You were <span class="red">DESTROYED</span> by '.$planet->getDisplayName().'\'s defenses.',false);
 
 		$news_message = $this->getBBLink();


### PR DESCRIPTION
In the message sent to planet owners when a planet kills an attacker,
it used a regular space between two HTML tags, which gets removed,
which results in two words being merged into one. We add a `&nbsp;`
to ensure that a space is added between the tags.