### PR TITLE
SmrPlayer.class.inc: include force owner in death message

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1280,7 +1280,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$owner =& $forces->getOwner();
 		// send a message to the person who died
 		$this->sendMessage($owner->getAccountID(), MSG_PLAYER, 'Your forces <span class="red">DESTROYED </span>'.$this->getBBLink().' in sector '.$forces->getSectorID(),false);
-		$owner->sendMessage($this->getAccountID(), MSG_PLAYER, 'You were <span class="red">DESTROYED</span> by forces in sector '.$forces->getSectorID(),false);
+		$owner->sendMessage($this->getAccountID(), MSG_PLAYER, 'You were <span class="red">DESTROYED</span> by '.$owner->getBBLink().'\'s forces in sector '.$forces->getSectorID(),false);
 
 		$news_message = $this->getBBLink();
 		if ($this->hasCustomShipName()) {


### PR DESCRIPTION
Even though the force owner is displayed as the sender of the
message, we add the force owner in the text for consistency.
This is an extension of PR #69, which added the force owner to
the news entry.