### PR TITLE
SectorLocations.inc: add a space between image and text

### DIFF
--- a/templates/Default/engine/Default/includes/SectorLocations.inc
+++ b/templates/Default/engine/Default/includes/SectorLocations.inc
@@ -12,7 +12,7 @@ if($ThisSector->hasLocation()) {
 		foreach($Locations as $Location) { ?>
 			<tr>
 				<td<?php if(!$Location->hasAction() && $ThisSector->hasAnyLocationsWithAction()){ ?> colspan="2"<?php } ?>>
-					<img align="left"src="<?php echo $Location->getImage(); ?>" width="16" height="16" alt="<?php echo $Location->getName(); ?>" title="<?php echo $Location->getName(); ?>" /> <?php echo $Location->getName(); ?>
+					<img align="left"src="<?php echo $Location->getImage(); ?>" width="16" height="16" alt="<?php echo $Location->getName(); ?>" title="<?php echo $Location->getName(); ?>" />&nbsp;<?php echo $Location->getName(); ?>
 				</td><?php
 				if($Location->hasAction()) { ?>
 					<td class="shrink noWrap">


### PR DESCRIPTION
In the "Location" table, there was previously no space between the
location image and text. The added (non-breaking) space gives them
a little room to breathe and doesn't look as crowded.

Before:
![image](https://user-images.githubusercontent.com/846186/29490522-df88d420-84f3-11e7-9e8c-a1163c55bf6a.png)
![image](https://user-images.githubusercontent.com/846186/29490546-7d124ce4-84f4-11e7-9c4e-d3efc4dc3d66.png)

After:
![image](https://user-images.githubusercontent.com/846186/29490520-cd429d5a-84f3-11e7-807f-dc81c12aa1e1.png)
![image](https://user-images.githubusercontent.com/846186/29490540-582624c8-84f4-11e7-9a04-8ff052cb0fb6.png)

