### PR TITLE
Draft pick enhancements

### DIFF
--- a/admin/Default/manage_draft_leaders.php
+++ b/admin/Default/manage_draft_leaders.php
@@ -1,0 +1,45 @@
+<?php
+
+$template->assign('PageTopic', 'Manage Draft Leaders');
+
+// Get the list of active Draft games ordered by reverse start date
+$activeGames = array();
+$db->query('SELECT game_id, game_name FROM game WHERE game_type=' . $db->escapeString('Draft') . ' AND start_date < ' . $db->escapeNumber(TIME) . ' AND end_date > ' . $db->escapeNumber(TIME) . ' ORDER BY start_date DESC');
+while ($db->nextRecord()) {
+	$activeGames[] = array('game_name' => $db->getField('game_name'),
+	                       'game_id' => $db->getInt('game_id'));
+}
+$template->assign('ActiveGames', $activeGames);
+
+if ($activeGames) {
+	// Set the selected game (or the first in the list if not selected yet)
+	if (isset($_POST['game_id'])) {
+		SmrSession::updateVar('selected_game_id', $_POST['game_id']);
+		SmrSession::updateVar('processing_msg', null);
+	} else if (!isset($var['selected_game_id'])) {
+		SmrSession::updateVar('selected_game_id', $activeGames[0]['game_id']);
+	}
+	$template->assign('SelectedGame', $var['selected_game_id']);
+
+	// Get the list of current draft leaders for the selected game
+	$currentLeaders = array();
+	$db->query('SELECT account_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($var['selected_game_id']));
+	while ($db->nextRecord()) {
+		$editor = SmrPlayer::getPlayer($db->getInt('account_id'),
+		                               $var['selected_game_id']);
+		$currentLeaders[] = $editor->getDisplayName();
+	}
+	$template->assign('CurrentLeaders', $currentLeaders);
+}
+
+// If we have just forwarded from the processing file, pass its message.
+if (isset($var['processing_msg'])) {
+	$template->assign('ProcessingMsg', $var['processing_msg']);
+}
+
+// Create the link to the processing file
+// Pass entire $var so the processing file knows the selected game
+$linkContainer = create_container('manage_draft_leaders_processing.php', '', $var);
+$template->assign('ProcessingHREF', SmrSession::getNewHREF($linkContainer));
+
+?>

--- a/admin/Default/manage_draft_leaders_processing.php
+++ b/admin/Default/manage_draft_leaders_processing.php
@@ -1,0 +1,50 @@
+<?php
+
+// Get the selected game
+$gameId = $var['selected_game_id'];
+
+// Clear any messages from prior processing
+SmrSession::updateVar('processing_msg', null);
+
+// Get the POST variables
+$playerId = $_POST['player_id'];
+$action = $_POST['submit'];
+
+try {
+	$selectedPlayer = SmrPlayer::getPlayerByPlayerID($playerId, $gameId);
+} catch (Exception $e) {
+	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
+	SmrSession::updateVar('processing_msg', $msg);
+	forward(create_container('skeleton.php', 'manage_draft_leaders.php', $var));
+}
+
+$name = $selectedPlayer->getDisplayName();
+$accountId = $selectedPlayer->getAccountID();
+$game = $selectedPlayer->getGame()->getDisplayName();
+
+if ($action == "Assign") {
+	if ($selectedPlayer->isDraftLeader()) {
+		$msg = "<span class='red'>ERROR: </span>$name is already a draft leader in game $game!";
+	} else {
+		$db->query('INSERT INTO draft_leaders (account_id, game_id) VALUES (' . $db->escapeNumber($accountId) . ', ' . $db->escapeNumber($gameId) . ')');
+	}
+}
+else if ($action == "Remove") {
+	if (!$selectedPlayer->isDraftLeader()) {
+		$msg = "<span class='red'>ERROR: </span>$name is not a draft leader in game $game!";
+	} else {
+		$db->query('DELETE FROM draft_leaders WHERE account_id=' . $db->escapeNumber($accountId) . ' AND game_id=' . $db->escapeNumber($gameId));
+	}
+}
+else {
+	$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";
+}
+
+if (!empty($msg)) {
+	SmrSession::updateVar('processing_msg', $msg);
+}
+
+// Pass entire $var so that the selected game remains selected
+forward(create_container('skeleton.php', 'manage_draft_leaders.php', $var));
+
+?>

--- a/db/patches/V1_6_61_04__admin_manage_draft_leaders.sql
+++ b/db/patches/V1_6_61_04__admin_manage_draft_leaders.sql
@@ -1,0 +1,3 @@
+-- Set admin permission to manage Draft Leaders
+INSERT INTO `permission` (`permission_name`, `link_to`) VALUES
+  ('Manage Draft Leaders', 'manage_draft_leaders.php');

--- a/db/patches/V1_6_61_05__draft_history.sql
+++ b/db/patches/V1_6_61_05__draft_history.sql
@@ -1,0 +1,9 @@
+-- Keep a log of draft picks
+CREATE TABLE IF NOT EXISTS `draft_history` (
+  `draft_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `game_id` int(10) unsigned NOT NULL,
+  `leader_account_id` smallint(6) unsigned NOT NULL,
+  `picked_account_id` smallint(6) unsigned NOT NULL,
+  `time` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`draft_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;

--- a/engine/Draft/alliance_create_processing.php
+++ b/engine/Draft/alliance_create_processing.php
@@ -1,6 +1,5 @@
 <?php
-$db->query('SELECT 1 FROM draft_leaders WHERE game_id='.$db->escapeNumber($player->getGameID()).' AND account_id='.$db->escapeNumber($player->getAccountID()));
-if($db->nextRecord()) {
+if($player->isDraftLeader()) {
 	require_once(ENGINE.'Default/alliance_create_processing.php');
 }
 else {

--- a/engine/Draft/alliance_option.php
+++ b/engine/Draft/alliance_option.php
@@ -1,7 +1,7 @@
 <?php
 require(ENGINE.'Default/alliance_option.php');
 
-if($player->getAccountID()==$alliance->getLeaderID()) {
+if($player->isDraftLeader()) {
 	$PHP_OUTPUT.= '<br /><br /><b><big>';
 	$PHP_OUTPUT.=create_link(create_container('skeleton.php', 'alliance_pick.php',array('alliance_id'=>$alliance->getAllianceID())),'Pick Members');
 	$PHP_OUTPUT.= '</big></b><br />Pick alliance members.';

--- a/engine/Draft/alliance_pick.inc
+++ b/engine/Draft/alliance_pick.inc
@@ -1,21 +1,43 @@
 <?php
 
-// Returns the number of members in the smallest alliance (NHA excluded).
-// Used to determine whose turn it is to pick in the Draft.
-function min_alliance_members($gameId) {
+// Returns an array with all relevant information about draft teams,
+// including their current size and if the leader can pick teammates.
+function get_draft_teams($gameId) {
 	$db = new SmrMySqlDatabase();
-	$db->query('
-	SELECT MIN(alliance_member) min_members
-	FROM
-	(
-		SELECT COUNT(*) alliance_member
-		FROM player
-		WHERE game_id='.$db->escapeNumber($gameId).' AND alliance_id!='.$db->escapeNumber(NHA_ID).' AND alliance_id!=0
-		GROUP BY alliance_id
-	) t');
-	$db->nextRecord();
+	$db->query('SELECT account_id FROM draft_leaders WHERE game_id='.$db->escapeNumber($gameId));
 
-	return $db->getInt('min_members');
+	// Get team leader, alliance, and alliance size
+	$teams = array();
+	while ($db->nextRecord()) {
+		$leader =& SmrPlayer::getPlayer($db->getInt('account_id'), $gameId);
+		$alliance =& $leader->getAlliance();
+		if (!$leader->hasAlliance() || $alliance->getAllianceID() == NHA_ID) {
+			// Special case for leaders who haven't made their own alliance yet,
+			// or are still in the Newbie Help Alliance.
+			$teams[$leader->getAccountId()] = array('Leader'   => &$leader,
+			                                        'Size'     => 0);
+		} else {
+			$teams[$leader->getAccountId()] = array('Leader'   => &$leader,
+			                                        'Alliance' => &$alliance,
+			                                        'Size'     => $alliance->getNumMembers());
+		}
+	}
+
+	// Determine the smallest team alliance size.
+	$minSize = min(array_map(function($i) { return $i['Size']; }, $teams));
+
+	// Teams can pick only if their size is not larger than the smallest team.
+	foreach ($teams as &$team) {
+		if ($minSize == 0) {
+			// This means that at least one leader hasn't made an alliance,
+			// no one should be picking yet.
+			$team['CanPick'] = false;
+		} else {
+			$team['CanPick'] = $team['Size'] <= $minSize;
+		}
+	}
+
+  return $teams;
 }
 
 ?>

--- a/engine/Draft/alliance_pick.inc
+++ b/engine/Draft/alliance_pick.inc
@@ -1,0 +1,21 @@
+<?php
+
+// Returns the number of members in the smallest alliance (NHA excluded).
+// Used to determine whose turn it is to pick in the Draft.
+function min_alliance_members($gameId) {
+	$db = new SmrMySqlDatabase();
+	$db->query('
+	SELECT MIN(alliance_member) min_members
+	FROM
+	(
+		SELECT COUNT(*) alliance_member
+		FROM player
+		WHERE game_id='.$db->escapeNumber($gameId).' AND alliance_id!='.$db->escapeNumber(NHA_ID).' AND alliance_id!=0
+		GROUP BY alliance_id
+	) t');
+	$db->nextRecord();
+
+	return $db->getInt('min_members');
+}
+
+?>

--- a/engine/Draft/alliance_pick.php
+++ b/engine/Draft/alliance_pick.php
@@ -4,30 +4,14 @@ $template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->g
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 
-require_once('alliance_pick.inc');
-$minMembers = min_alliance_members($player->getGameID());
-
 // Get the current teams
-$teams = array();
-$db->query('SELECT account_id FROM draft_leaders WHERE game_id='.$db->escapeNumber($player->getGameID()));
-while ($db->nextRecord()) {
-	$leader =& SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID());
-	if ($leader->hasAlliance()) {
-		$draftAlliance =& $leader->getAlliance();
-		$canPick = $draftAlliance->getNumMembers() <= $minMembers;
-		$teams[] = array('Leader'   => &$leader,
-		                 'Alliance' => &$draftAlliance,
-		                 'CanPick'  => $canPick);
-	} else {
-		$teams[] = array('Leader'   => &$leader);
-	}
-}
-
+require_once('alliance_pick.inc');
+$teams = get_draft_teams($player->getGameID());
 $template->assignByRef('Teams', $teams);
 
 // Add information about current player
 $template->assign('PlayerID', $player->getPlayerID());
-$template->assign('CanPick', $alliance->getNumMembers() <= $minMembers);
+$template->assign('CanPick', $teams[$player->getAccountID()]['CanPick']);
 
 // Get a list of players still in the pick pool
 $players = array();

--- a/engine/Draft/alliance_pick.php
+++ b/engine/Draft/alliance_pick.php
@@ -39,4 +39,17 @@ while($db->nextRecord()) {
 }
 
 $template->assignByRef('PickPlayers', $players);
+
+// Get the draft history
+$history = array();
+$db->query('SELECT * FROM draft_history WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' ORDER BY draft_id');
+while ($db->nextRecord()) {
+	$leader =& SmrPlayer::getPlayer($db->getInt('leader_account_id'), $player->getGameID());
+	$pickedPlayer =& SmrPlayer::getPlayer($db->getInt('picked_account_id'), $player->getGameID());
+	$history[] = array('Leader' => &$leader,
+	                   'Player' => &$pickedPlayer,
+	                   'Time'   => $db->getInt('time'));
+}
+
+$template->assignByRef('History', $history);
 ?>

--- a/engine/Draft/alliance_pick.php
+++ b/engine/Draft/alliance_pick.php
@@ -4,6 +4,32 @@ $template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->g
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 
+require_once('alliance_pick.inc');
+$minMembers = min_alliance_members($player->getGameID());
+
+// Get the current teams
+$teams = array();
+$db->query('SELECT account_id FROM draft_leaders WHERE game_id='.$db->escapeNumber($player->getGameID()));
+while ($db->nextRecord()) {
+	$leader =& SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID());
+	if ($leader->hasAlliance()) {
+		$draftAlliance =& $leader->getAlliance();
+		$canPick = $draftAlliance->getNumMembers() <= $minMembers;
+		$teams[] = array('Leader'   => &$leader,
+		                 'Alliance' => &$draftAlliance,
+		                 'CanPick'  => $canPick);
+	} else {
+		$teams[] = array('Leader'   => &$leader);
+	}
+}
+
+$template->assignByRef('Teams', $teams);
+
+// Add information about current player
+$template->assign('PlayerID', $player->getPlayerID());
+$template->assign('CanPick', $alliance->getNumMembers() <= $minMembers);
+
+// Get a list of players still in the pick pool
 $players = array();
 $db->query('SELECT * FROM player WHERE game_id='.$db->escapeNumber($player->getGameID()).' AND (alliance_id=0 OR alliance_id='.$db->escapeNumber(NHA_ID).') AND account_id NOT IN (SELECT account_id FROM draft_leaders WHERE draft_leaders.game_id=player.game_id) AND sector_id!=1 AND account_id != '.$db->escapeNumber(ACCOUNT_ID_NHL).';');
 while($db->nextRecord()) {

--- a/engine/Draft/alliance_pick_processing.php
+++ b/engine/Draft/alliance_pick_processing.php
@@ -28,6 +28,9 @@ if($pickedPlayer->hasAlliance()) {
 $pickedPlayer->joinAlliance($player->getAllianceID());
 $pickedPlayer->update();
 
+// Update the draft history
+$db->query('INSERT INTO draft_history (game_id, leader_account_id, picked_account_id, time) VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($pickedPlayer->getAccountID()) . ', ' . $db->escapeNumber(TIME) . ')');
+
 forward(create_container('skeleton.php', 'alliance_pick.php'));
 
 ?>

--- a/engine/Draft/alliance_pick_processing.php
+++ b/engine/Draft/alliance_pick_processing.php
@@ -10,18 +10,8 @@ if($db->nextRecord()) {
 	create_error('You cannot pick another leader.');
 }
 
-$db->query('
-SELECT MIN(alliance_member) min_members
-FROM
-(
-	SELECT COUNT(*) alliance_member
-	FROM player
-	WHERE game_id='.$db->escapeNumber($player->getGameID()).' AND alliance_id!='.$db->escapeNumber(NHA_ID).' AND alliance_id!=0
-	GROUP BY alliance_id
-) t');
-$db->nextRecord();
-
-if($player->getAlliance()->getNumMembers()>$db->getInt('min_members')) {
+require_once('alliance_pick.inc');
+if($player->getAlliance()->getNumMembers() > min_alliance_members($player->getGameID())) {
 	create_error('You have to wait for others to pick first.');
 }
 $pickedPlayer =& SmrPlayer::getPlayer($var['PickedAccountID'], $player->getGameID());
@@ -38,6 +28,6 @@ if($pickedPlayer->hasAlliance()) {
 $pickedPlayer->joinAlliance($player->getAllianceID());
 $pickedPlayer->update();
 
-forward(create_container('skeleton.php', 'alliance_roster.php'));
+forward(create_container('skeleton.php', 'alliance_pick.php'));
 
 ?>

--- a/engine/Draft/alliance_pick_processing.php
+++ b/engine/Draft/alliance_pick_processing.php
@@ -11,7 +11,8 @@ if($db->nextRecord()) {
 }
 
 require_once('alliance_pick.inc');
-if($player->getAlliance()->getNumMembers() > min_alliance_members($player->getGameID())) {
+$teams = get_draft_teams($player->getGameID());
+if(!$teams[$player->getAccountID()]['CanPick']) {
 	create_error('You have to wait for others to pick first.');
 }
 $pickedPlayer =& SmrPlayer::getPlayer($var['PickedAccountID'], $player->getGameID());

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -806,8 +806,12 @@ abstract class AbstractSmrAccount {
 		$this->update();
 	}
 
-	public function getHofName() {
-		return $this->hofName;
+	public function getHofName($linked=false) {
+		if ($linked) {
+			return '<a href="' . $this->getPersonalHofHREF() . '">' . $this->hofName . '</a>';
+		} else {
+			return $this->hofName;
+		}
 	}
 
 	public function setHofName($name) {

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -52,6 +52,7 @@ abstract class AbstractSmrPlayer {
 		0 => 0
 	);
 
+	protected $draftLeader;
 	protected $gpWriter;
 	protected $HOF;
 	protected static $HOFVis;
@@ -146,6 +147,17 @@ abstract class AbstractSmrPlayer {
 
 	public function isNPC() {
 		return $this->getAccount()->isNPC();
+	}
+
+	public function isDraftLeader() {
+		if(!isset($this->draftLeader)) {
+			$this->draftLeader = false;
+			$this->db->query('SELECT 1 FROM draft_leaders WHERE game_id = ' . $this->db->escapeNumber($this->getGameID()) . ' AND account_id = ' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
+			if ($this->db->nextRecord()) {
+				$this->draftLeader = true;
+			}
+		}
+		return $this->draftLeader;
 	}
 
 	public function getGPWriter() {

--- a/templates/Default/admin/Default/manage_draft_leaders.php
+++ b/templates/Default/admin/Default/manage_draft_leaders.php
@@ -1,0 +1,48 @@
+<?php
+
+if (empty($ActiveGames)) {
+	echo "<p>There are no active Draft games at this time!</p>";
+} else { ?>
+
+	<p>Specify the Game and Player ID to assign or remove a Draft Leader.</p>
+
+	Select Game:&nbsp;
+	<form class="standard" id="SelectGameForm" method="POST" action="">
+		<select name="game_id" onchange="this.form.submit()"><?php
+			foreach($ActiveGames as $Game) {
+				$id = $Game['game_id'];
+				$name = $Game['game_name'];
+				$selected = ($SelectedGame == $id ? 'selected="selected"' : '');
+				echo "<option value='$id' $selected>$name ($id)</option>";
+			} ?>
+		</select>
+	</form><br />
+
+	Player ID:&nbsp;
+	<form method="POST" action="<?php echo $ProcessingHREF; ?>">
+		<input type="number" name="player_id" id="InputFields" class="center">
+		<br />
+		<input type="submit" name="submit" value="Assign">&nbsp;
+		<input type="submit" name="submit" value="Remove">
+	</form>
+	<?php
+
+	// This var is passed by the processing file if there was an error
+	if (!empty($ProcessingMsg)) {
+		echo "<p>$ProcessingMsg</p>";
+	}
+
+	if (empty($CurrentLeaders)) {
+		echo "<p>No current Draft Leaders for this game!</p>";
+	} else { ?>
+		<p>Current Draft Leaders:
+		<ul><?php
+		foreach($CurrentLeaders as $Leader) {
+			echo "<li>$Leader</li>";
+		} ?>
+		</ul></p><?php
+	}
+
+}
+
+?>

--- a/templates/Default/engine/Default/alliance_pick.php
+++ b/templates/Default/engine/Default/alliance_pick.php
@@ -73,3 +73,35 @@ if(count($PickPlayers)>0) { ?>
 else {
 	?>No one left to pick.<?php
 } ?>
+
+<br /><br />
+<h2>Draft History</h2>
+<?php
+if (count($History) > 0) { ?>
+	<table class="standard">
+		<tr>
+			<th>Pick</th>
+			<th>Leader</th>
+			<th>Date Picked</th>
+			<th>Player Name</th>
+			<th>Race Name</th>
+			<th>HoF Name</th>
+			<th>User Score</th>
+		</tr><?php
+		foreach(array_reverse($History, true) as $i => &$Pick) { ?>
+			<tr>
+				<td class="center"><?php echo $i+1; ?></td>
+				<td><?php echo $Pick['Leader']->getPlayerName(); ?></td>
+				<td><?php echo date(DATE_FULL_SHORT, $Pick['Time']); ?></td>
+				<td><?php echo $Pick['Player']->getPlayerName(); ?></td>
+				<td><?php echo $Pick['Player']->getRaceName(); ?></td>
+				<td><?php echo $Pick['Player']->getAccount()->getHofName(true); ?></td>
+				<td><?php echo $Pick['Player']->getAccount()->getScore(); ?></td>
+			</tr><?php
+		} ?>
+	</table><?php
+} else { ?>
+	No picks have been made yet.<?php
+}
+
+?>

--- a/templates/Default/engine/Default/alliance_pick.php
+++ b/templates/Default/engine/Default/alliance_pick.php
@@ -61,7 +61,7 @@ if(count($PickPlayers)>0) { ?>
 					<?php echo $PickPlayer['Player']->getRaceName(); ?>
 				</td>
 				<td>
-					<a href="<?php echo $PickPlayer['Player']->getAccount()->getPersonalHofHREF(); ?>"><?php echo $PickPlayer['Player']->getAccount()->getHofName(); ?></a>
+					<?php echo $PickPlayer['Player']->getAccount()->getHofName(true); ?>
 				</td>
 				<td>
 					<?php echo $PickPlayer['Player']->getAccount()->getScore(); ?>

--- a/templates/Default/engine/Default/alliance_pick.php
+++ b/templates/Default/engine/Default/alliance_pick.php
@@ -1,8 +1,43 @@
+<table class="standard">
+	<tr>
+		<th>Leader</th>
+		<th>Alliance</th>
+		<th>Members</th>
+		<th>Pick</th>
+	</tr><?php
+	foreach ($Teams as &$Team) {
+		// boldface this row if it is the current player's alliance
+		$Class = ($Team['Leader']->getPlayerID() == $PlayerID) ? "bold" : ""; ?>
+		<tr class="<?php echo $Class; ?>">
+			<td><?php echo $Team['Leader']->getLinkedDisplayName(false); ?></td><?php
+			// The leader may not have made an alliance yet
+			if (isset($Team['Alliance'])) { ?>
+				<td><?php echo $Team['Alliance']->getAllianceName(true); ?></td>
+				<td class="center"><?php echo $Team['Alliance']->getNumMembers(); ?></td>
+				<td class="center"><?php
+					if ($Team['CanPick']) { ?>
+						<span class="green">YES</span><?php
+					} else { ?>
+						<span class="red">NO</span><?php
+					} ?>
+				</td><?php
+			} ?>
+		</tr><?php
+	} ?>
+</table>
+<br />
+
 <?php 
+if ($CanPick) { ?>
+	<p>You may pick a new member now!</p><?php
+} else { ?>
+	<p>You may not pick until another team picks!<p><?php
+}
+
 if(count($PickPlayers)>0) { ?>
 	<table class="standard">
 		<tr>
-			<th></th>
+			<th>Action</th>
 			<th>Player Name</th>
 			<th>Race Name</th>
 			<th>HoF Name</th>
@@ -10,12 +45,14 @@ if(count($PickPlayers)>0) { ?>
 		</tr><?php
 		foreach($PickPlayers as &$PickPlayer) { ?>
 			<tr>
-				<td>
+				<td><?php
+				if ($CanPick) { ?>
 					<div>
 						<form id="PlayerPickForm" action="<?php echo $PickPlayer['HREF']; ?>" method="POST">
 							<input type="submit" value="Pick"/>
 						</form>
-					</div>
+					</div><?php
+				} ?>
 				</td>
 				<td>
 					<?php echo $PickPlayer['Player']->getPlayerName(); ?>

--- a/templates/Default/engine/Default/alliance_pick.php
+++ b/templates/Default/engine/Default/alliance_pick.php
@@ -45,13 +45,9 @@ if(count($PickPlayers)>0) { ?>
 		</tr><?php
 		foreach($PickPlayers as &$PickPlayer) { ?>
 			<tr>
-				<td><?php
+				<td class="center"><?php
 				if ($CanPick) { ?>
-					<div>
-						<form id="PlayerPickForm" action="<?php echo $PickPlayer['HREF']; ?>" method="POST">
-							<input type="submit" value="Pick"/>
-						</form>
-					</div><?php
+					<div class="buttonA"><a class="buttonA" href="<?php echo $PickPlayer['HREF'] ?>">&nbsp;Pick&nbsp;</a></div><?php
 				} ?>
 				</td>
 				<td>

--- a/templates/Default/engine/Default/alliance_pick.php
+++ b/templates/Default/engine/Default/alliance_pick.php
@@ -13,7 +13,7 @@
 			// The leader may not have made an alliance yet
 			if (isset($Team['Alliance'])) { ?>
 				<td><?php echo $Team['Alliance']->getAllianceName(true); ?></td>
-				<td class="center"><?php echo $Team['Alliance']->getNumMembers(); ?></td>
+				<td class="center"><?php echo $Team['Size']; ?></td>
 				<td class="center"><?php
 					if ($Team['CanPick']) { ?>
 						<span class="green">YES</span><?php


### PR DESCRIPTION
For draft leaders:
* Draft team status in the "Pick Member" page
* Draft history in the "Pick Member" page
* Make it harder to accidentally pick team members when you're not supposed to

For admins:
* New admin tool to manage draft leaders
* Two database changes (one for draft history, one for admin permission to manage draft leaders)

See the commit messages for more details.