### PR TITLE
Fix logging of sector movement

### DIFF
--- a/engine/Default/sector_move_processing.php
+++ b/engine/Default/sector_move_processing.php
@@ -88,7 +88,8 @@ if ($player->hasPlottedCourse()) {
 }
 
 // log action
-$player->actionTaken('WalkSector',array('Sector'=>&$sector));
+$targetSector =& SmrSector::getSector($player->getGameID(), $var['target_sector']);
+$player->actionTaken('WalkSector', array('Sector' => &$targetSector));
 
 // send scout msg
 $sector->leavingSector($player,MOVEMENT_WALK);


### PR DESCRIPTION
Sector movement was incorrectly logged because the target sector
and the current sector were set to the same value. This bug was
introduced in 30a7213e8b16, when logging for sector movement was
wrapped inside the mission actions.

Since 'EnterSector' superseded 'WalkSector' as the mission action
to detect if a player was in a sector (since 'EnterSector' accounts
for jumping into a sector, for example), there is no reason to keep
'WalkSector' as a mission action, since its only purpose was for
logging. Instead, we simply log the movement directly as we did
before the bug was introduced.