### PR TITLE
Fix bug in saving MICRO_TIME to the database

### DIFF
--- a/admin/Default/log_console_detail.php
+++ b/admin/Default/log_console_detail.php
@@ -169,7 +169,7 @@ else {
 	$db->query('SELECT * FROM account_has_logs WHERE account_id IN ('.$account_list.') AND log_type_id IN ('.$db->escapeArray($log_type_id_list).') ORDER BY ' . $var['item'] . ' ' . $var['order']);
 	while ($db->nextRecord()) {
 		$account_id		= $db->getInt('account_id');
-		$microtime		= $db->getMicrotime('microtime');
+		$microtime		= $db->getMicrotime('microtime', true); //fix value length errors
 		$message		= stripslashes($db->getField('message'));
 		$log_type_id	= $db->getInt('log_type_id');
 		$sector_id		= $db->getInt('sector_id');

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -104,11 +104,20 @@ function microtimeDiff($m1,$m2) {
 }
 
 function microtimeSec($microtime) {
-	return (int)substr($microtime,11);
+	if (strlen($microtime) == 21) {
+		return substr($microtime,11);
+	} else {
+		throw new Exception('Not a microtime! ('.$microtime.')');
+	}
 }
 
 function microtimeMSec($microtime) {
-	return (int)substr($microtime,2,6);
+	if (strlen($microtime) == 21) {
+		// Do not cast to int, because the substring can begin with '0'
+		return substr($microtime,2,6);
+	} else {
+		throw new Exception('Not a microtime! ('.$microtime.')');
+	}
 }
 
 function explodeElement($delimiter, $string, $index) {

--- a/lib/Default/MySqlDatabase.class.inc
+++ b/lib/Default/MySqlDatabase.class.inc
@@ -182,10 +182,7 @@ abstract class MySqlDatabase implements Database {
 	}
 	
 	public function escapeMicrotime($microtime,$quotes=false) {
-		if(strlen($microtime)==21)
-			return $this->escapeString(microtimeSec($microtime).microtimeMSec($microtime),$quotes);
-		else
-			throw new Exception('Not a microtime! ('.$microtime.')');
+		return $this->escapeString(microtimeSec($microtime).microtimeMSec($microtime),$quotes);
 	}
 	
 	public function escapeBoolean($bool,$quotes=true) {

--- a/lib/Default/MySqlDatabase.class.inc
+++ b/lib/Default/MySqlDatabase.class.inc
@@ -61,8 +61,22 @@ abstract class MySqlDatabase implements Database {
 		return (float)$this->dbRecord[$name];
 	}
 	
-	public function getMicrotime($name) {
-		return '0.'.substr($this->dbRecord[$name],-6).'00 '.substr($this->dbRecord[$name],0,-6);
+	// WARNING: In the past, Microtime was stored in the database incorrectly.
+	// For backwards compatibility, set $pad_msec=true to try to guess at the
+	// intended value. This is not safe if the Microtime length is wrong for an
+	// unrelated reason!
+	public function getMicrotime($name, $pad_msec=false) {
+		$data = $this->dbRecord[$name];
+		$sec  = substr($data, 0, 10);
+		$msec = substr($data, 10);
+		if (strlen($msec) != 6) {
+			if ($pad_msec) {
+				$msec = str_pad($msec, 6, '0', STR_PAD_LEFT);
+			} else {
+				throw new Exception('Field is not an escaped microtime ('.$data.')');
+			}
+		}
+		return '0.'.$msec.'00 '.$sec;
 	}
 	
 	public function getObject($name,$compressed=false) {


### PR DESCRIPTION
The `microtime` built-in function outputs a string that looks like:

0.39324900 1504296581

The first word is the number of microseconds in seconds.
The function `microtimeMSec` took the 6 digits after the decimal
from the first word and converted that to an int.

However, if the number of microseconds was small enough to start
with a `0` after the decimal (e.g. `0.09324900`), then casting
the substring to an int would give `93249` instead of `093249`.
Therefore, when reconstructing the time from this value, we would
be one digit off, and you'd get a timestamp from 1974 or so.
[Thanks to Curufir for identifying this issue.]

By having `microtimeMSec` (and `microtimeSec`) return strings instead
of ints, we avoid the casting problem altogether.

We also move the sanity check on the microtime argument format
(i.e. that it has a length of 21 characters) out of `escapeMicrotime`,
which is agnostic to the format, and into `microtime{M,}Sec`, which
extract substrings that depend on the precise string format.

Due to the limited use of `escapeMicrotime`, this bug only affected
saving MICRO_TIME into the `account_has_logs` table. With this fix,
the Log Console now properly displays the event times.

-----------

**NOTE**: I have also added a backwards compatibility fix for the incorrectly stored `microtime`'s in the database. However, if you don't mind throwing out all the old logs, a cleaner fix to this bug is to simply avoid parsing `microtime()` output in the first place. Instead, we could use `microtime(true)`, which returns the microtime as a float instead of two strings (and then we would store it as a float in the database).