### PR TITLE
log_console_detail.php: add 2 more colors

### DIFF
--- a/admin/Default/log_console_detail.php
+++ b/admin/Default/log_console_detail.php
@@ -37,7 +37,8 @@ else {
 	$db2 = new SmrMySqlDatabase();
 
 	// predefine a color array
-	$avail_colors = array('#FFFFFF', '#FF0000', '#00FF00', '#0000FF');
+	$avail_colors = array('#FFFFFF', '#00FF00', '#FF3377', '#0099FF',
+	                      '#FF0000', '#0000FF');
 
 	// now assign each account id a color
 	for ($i = 0; $i < count($account_ids); $i++) {


### PR DESCRIPTION
Logs from different accounts are color-coded, but the color cycle
only has 4 colors. To avoid repeated colors if viewing more than
4 accounts, 2 additional colors (light blue and pink) were added.

The colors that are hardest to read on the dark green background
(red and blue) were moved to the end of the color cycle.

NOTE: Another option would be to include a column for the account
name instead of, or in addition to, the colors.