### PR TITLE
SmrPlanet.class.inc: change inhabitableTime

### DIFF
--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -75,7 +75,9 @@ class SmrPlanet {
 	public static function &createPlanet($gameID,$sectorID,$type=1) {
 		if(!self::getPlanet($gameID,$sectorID)->exists()) {
 			require_once(get_file_loc('SmrGame.class.inc'));
-			$inhabitableTime = SmrGame::getGame($gameID)->getStartDate() + pow(mt_rand(45, 85), 3);
+			$minTime = max(SmrGame::getGame($gameID)->getStartDate(),
+			               SmrGame::getGame($gameID)->getStartTurnsDate());
+			$inhabitableTime = $minTime + pow(mt_rand(45, 85), 3);
 
 			// insert planet into db
 			$db = new SmrMySqlDatabase();


### PR DESCRIPTION
We don't want planets to start becoming habitable before players start
moving, so we have modified the `inhabitableTime` to be at a random
time after players start accumulating turns, rather than after the
game starts. This is because games often start before turns start
accumulating to give players time to create their traders.

NOTE: we use `max(StartDate, StartTurnsDate)` in case `StartTurnsDate`
can be set to before `StartDate`. This likely is an unnecessary
precaution, but it doesn't hurt anything to be careful here.