### PR TITLE
universe_create_sectors.php: add galaxy details

### DIFF
--- a/templates/Default/admin/Default/1.6/universe_create_sectors.php
+++ b/templates/Default/admin/Default/1.6/universe_create_sectors.php
@@ -2,7 +2,25 @@
 	if(isset($Message)) {
 		echo $Message; ?><br /><br /><?php
 	} ?>
-	Working on Galaxy : <?php echo $Galaxy->getName(); ?> (<?php echo $Galaxy->getGalaxyID(); ?>)<br />
+
+	Working on Galaxy <?php echo $Galaxy->getGalaxyID(); ?>/<?php echo count($Galaxies); ?><br />
+
+	<table align="center" class="standard">
+		<tr>
+			<th>Name</th>
+			<th>Type</th>
+			<th>Size</th>
+			<th>Max Force Time</th>
+		</tr>
+		<tr>
+			<td><?php echo $Galaxy->getName(); ?></td>
+			<td><?php echo $Galaxy->getGalaxyType(); ?></td>
+			<td><?php echo $Galaxy->getWidth(); ?> x <?php echo $Galaxy->getHeight(); ?></td>
+			<td><?php echo $Galaxy->getMaxForceTime() / 3600; ?> hours</td>
+		</tr>
+	</table>
+	<br />
+
 	<form method="POST" action="<?php echo $JumpGalaxyHREF; ?>">
 		<select name="jumpgal" onchange="this.form.submit()"><?php
 			foreach($Galaxies as &$CurrentGalaxy) { ?>


### PR DESCRIPTION
Once the galaxies are created, there's no way to view the galaxy
details specified at creation (e.g. Galaxy Type, Max Force Time).

We add a small table at the top of the sector creation page, which
displays the galaxy details. This should make it a little easier
to create new games.

![image](https://user-images.githubusercontent.com/846186/30026070-2f3af460-9130-11e7-830f-8f8c84809b16.png)
