### PR TITLE
Categorize list of locations in galaxy creation

### DIFF
--- a/admin/Default/1.6/universe_create_locations.php
+++ b/admin/Default/1.6/universe_create_locations.php
@@ -2,7 +2,6 @@
 require_once(get_file_loc('SmrGalaxy.class.inc'));
 
 $locations =& SmrLocation::getAllLocations();
-$template->assignByRef('Locations', $locations);
 
 // Initialize all location counts to zero
 $totalLocs = array();
@@ -24,32 +23,50 @@ $galaxy =& SmrGalaxy::getGalaxy($var['game_id'],$var['gal_on']);
 $template->assignByRef('Galaxy', $galaxy);
 
 // Set any extra information to be displayed with each location
-$extraLocs = array();
+$locText = array();
+$locTypes = array();
 foreach ($locations as &$location) {
 	$extra = '<span class="small"><br />';
 	if ($location->isWeaponSold()) {
+		$locTypes['Weapons'][] = $location->getTypeID();
 		$weaponsSold =& $location->getWeaponsSold();
 		foreach($weaponsSold as &$weapon) {
 			$extra .= $weapon->getName() . '&nbsp;&nbsp;&nbsp;(' . $weapon->getShieldDamage() . '/' . $weapon->getArmourDamage() . '/' . $weapon->getBaseAccuracy() . ')<br />';
 		} unset($weapon);
 	}
-	if ($location->isShipSold()) {
+	elseif ($location->isShipSold()) {
+		$locTypes['Ships'][] = $location->getTypeID();
 		$shipsSold =& $location->getShipsSold();
 		foreach ($shipsSold as &$shipSold) {
 			$extra .= $shipSold['Name'] . '<br />';
 		} unset($shipSold);
 	}
-	if ($location->isHardwareSold()) {
+	elseif ($location->isHardwareSold()) {
+		$locTypes['Hardware'][] = $location->getTypeID();
 		$hardwareSold =& $location->getHardwareSold();
 		foreach ($hardwareSold as &$hardware) {
 			$extra .= $hardware['Name'] . '<br />';
 		} unset($hardware);
 	}
+	elseif ($location->isBar()) {
+		$locTypes['Bars'][] = $location->getTypeID();
+	}
+	elseif ($location->isBank()) {
+		$locTypes['Banks'][] = $location->getTypeID();
+	}
+	elseif ($location->isHQ() || $location->isUG() || $location->isFed()) {
+		$locTypes['Headquarters'][] = $location->getTypeID();
+	}
+	else {
+		// Anything that doesn't fit the other categories
+		$locTypes['Miscellaneous'][] = $location->getTypeID();
+	}
 	$extra .= '</span>';
 
-	$extraLocs[$location->getTypeID()] = $extra;
+	$locText[$location->getTypeID()] = $location->getName() . $extra;
 } unset($location);
-$template->assignByRef('ExtraLocs', $extraLocs);
+$template->assignByRef('LocText', $locText);
+$template->assignByRef('LocTypes', $locTypes);
 
 // Form to make location changes
 $container = create_container('1.6/universe_create_save_processing.php',

--- a/admin/Default/1.6/universe_create_locations.php
+++ b/admin/Default/1.6/universe_create_locations.php
@@ -71,7 +71,7 @@ $template->assignByRef('LocTypes', $locTypes);
 // Form to make location changes
 $container = create_container('1.6/universe_create_save_processing.php',
                               '1.6/universe_create_sectors.php', $var);
-$template->assign('Form', create_echo_form($container));
+$template->assign('CreateLocationsFormHREF', SmrSession::getNewHREF($container));
 
 // HREF to cancel and return to the previous page
 $container = create_container('skeleton.php', '1.6/universe_create_sectors.php', $var);

--- a/admin/Default/1.6/universe_create_locations.php
+++ b/admin/Default/1.6/universe_create_locations.php
@@ -1,17 +1,16 @@
 <?php
 require_once(get_file_loc('SmrGalaxy.class.inc'));
 
-//universe_create_locations.php
-$container = $var;
-$container['url'] = '1.6/universe_create_save_processing.php';
-$container['body'] = '1.6/universe_create_sectors.php';
-
-$PHP_OUTPUT.= create_echo_form($container);
-//get totals
-//$totalLocs[5] = 0;
-//$totalLocs[6] = 0;
 $locations =& SmrLocation::getAllLocations();
+$template->assignByRef('Locations', $locations);
 
+// Initialize all location counts to zero
+$totalLocs = array();
+foreach ($locations as &$location) {
+	$totalLocs[$location->getTypeID()] = 0;
+}
+
+// Determine the current amount of each location
 $galSectors =& SmrSector::getGalaxySectors($var['game_id'],$var['gal_on']);
 foreach ($galSectors as &$sector) {
 	$sectorLocations =& $sector->getLocations();
@@ -19,21 +18,20 @@ foreach ($galSectors as &$sector) {
 		$totalLocs[$sectorLocation->getTypeID()]++;
 	} unset($sectorLocation);
 } unset($sector);
-$galaxy =& SmrGalaxy::getGalaxy($var['game_id'],$var['gal_on']);
-$PHP_OUTPUT.= 'Working on Galaxy : ' . $galaxy->getName() . ' (' . $galaxy->getGalaxyID() . ')<br />';
-$PHP_OUTPUT.= '<table class="standard">';
+$template->assignByRef('TotalLocs', $totalLocs);
 
+$galaxy =& SmrGalaxy::getGalaxy($var['game_id'],$var['gal_on']);
+$template->assignByRef('Galaxy', $galaxy);
+
+// Set any extra information to be displayed with each location
+$extraLocs = array();
 foreach ($locations as &$location) {
-//	if (isset($loc_array['Do Not List']) && $loc_array['Do Not List']) continue;
 	$extra = '<span class="small"><br />';
 	if ($location->isWeaponSold()) {
-		//$extra = '<table class="nobord right">';
 		$weaponsSold =& $location->getWeaponsSold();
 		foreach($weaponsSold as &$weapon) {
 			$extra .= $weapon->getName() . '&nbsp;&nbsp;&nbsp;(' . $weapon->getShieldDamage() . '/' . $weapon->getArmourDamage() . '/' . $weapon->getBaseAccuracy() . ')<br />';
 		} unset($weapon);
-			//$extra .= '<tr><td class="right"><span class="small">' . $WEAPONS[$wep_id]['Weapon Name'] . '</span></td><td class="left"><span class="small">(' . $WEAPONS[$wep_id]['Shield Damage'] . '/' . $WEAPONS[$wep_id]['Armor Damage'] . '/' . $WEAPONS[$wep_id]['Accuracy'] . ')</span></td></tr>';
-		//$extra .= '</table>';
 	}
 	if ($location->isShipSold()) {
 		$shipsSold =& $location->getShipsSold();
@@ -48,19 +46,18 @@ foreach ($locations as &$location) {
 		} unset($hardware);
 	}
 	$extra .= '</span>';
-	$PHP_OUTPUT.= '<tr><td class="right">' . $location->getName() . $extra . '</td><td>';
-	$PHP_OUTPUT.= '<input type="number" value="';
-	if (isset($totalLocs[$location->getTypeID()])) $PHP_OUTPUT.= $totalLocs[$location->getTypeID()];
-	else $PHP_OUTPUT.= '0';
-	$PHP_OUTPUT.= '" size="5" name="loc' . $location->getTypeID() . '"></td></tr>';
-} unset($location);
-$PHP_OUTPUT.= '<tr><td colspan="2" class="center"><input type="submit" name="submit" value="Create Locations">';
-$container = $var;
-$container['body'] = '1.6/universe_create_sectors.php';
-$PHP_OUTPUT.= '<br /><br /><a href="'.SmrSession::getNewHREF($container).'" class="submitStyle">Cancel</a>';
-$PHP_OUTPUT.= '</td></tr></table></form>';
 
-$PHP_OUTPUT.= '<span class="small">Note: When you press "Create Locations" this will rearrange all current locations.<br />';
-$PHP_OUTPUT.= 'To add new locations without rearranging everything use the edit sector feature.</span>';
+	$extraLocs[$location->getTypeID()] = $extra;
+} unset($location);
+$template->assignByRef('ExtraLocs', $extraLocs);
+
+// Form to make location changes
+$container = create_container('1.6/universe_create_save_processing.php',
+                              '1.6/universe_create_sectors.php', $var);
+$template->assign('Form', create_echo_form($container));
+
+// HREF to cancel and return to the previous page
+$container = create_container('skeleton.php', '1.6/universe_create_sectors.php', $var);
+$template->assign('CancelHREF', SmrSession::getNewHREF($container));
 
 ?>

--- a/templates/Default/admin/Default/1.6/universe_create_locations.php
+++ b/templates/Default/admin/Default/1.6/universe_create_locations.php
@@ -1,11 +1,16 @@
-Working on Galaxy : <?php echo $Galaxy->getName(); ?> (<?php echo $Galaxy->getGalaxyID() ?>)<br />
+Working on Galaxy : <?php echo $Galaxy->getName(); ?> (<?php echo $Galaxy->getGalaxyID() ?>)<br /><br />
+
+<?php
+foreach ($LocTypes as $category => $LocIDs) { ?>
+		<a href="javascript:;" onclick="window.location.hash='<?php echo $category; ?>'">Jump to <?php echo $category; ?></a><br /><?php
+} ?>
 
 <?php echo $Form; ?>
 
 <table class="standard"><?php
 	foreach ($LocTypes as $category => $LocIDs) { ?>
 		<tr>
-			<th><?php echo $category; ?></th>
+			<th id="<?php echo $category; ?>"><?php echo $category; ?></th>
 			<th>Amount</th>
 		</tr><?php
 		foreach ($LocIDs as $LocID) { ?>

--- a/templates/Default/admin/Default/1.6/universe_create_locations.php
+++ b/templates/Default/admin/Default/1.6/universe_create_locations.php
@@ -8,34 +8,34 @@ foreach ($LocTypes as $category => $LocIDs) { ?>
 <br />
 Click a category heading to toggle its display.
 
-<?php echo $Form; ?>
+<form method="POST" action="<?php echo $CreateLocationsFormHREF; ?>">
 
-<table class="standard">
-	<!-- colgroup style ensures fixed table width as categories are toggled -->
-	<colgroup>
-		<col style="width:250px">
-		<col style="width:158px">
-	</colgroup>
-	<?php
-	foreach ($LocTypes as $category => $LocIDs) { ?>
-		<tr>
-			<th id="<?php echo $category; ?>">
-				<a href="javascript:;" onclick="$('.toggle-<?php echo $category; ?>').toggle();"><?php echo $category; ?></a>
-			</th>
-			<th>Amount</th>
-		</tr><?php
-		foreach ($LocIDs as $LocID) { ?>
-			<tr class="toggle-<?php echo $category; ?>">
-				<td class="right"><?php echo $LocText[$LocID]; ?></td>
-				<td><input type="number" value="<?php echo $TotalLocs[$LocID]; ?>" size="5" name="loc<?php echo $LocID; ?>"></td>
+	<table class="standard">
+		<!-- colgroup style ensures fixed table width as categories are toggled -->
+		<colgroup>
+			<col style="width:250px">
+			<col style="width:158px">
+		</colgroup>
+		<?php
+		foreach ($LocTypes as $category => $LocIDs) { ?>
+			<tr>
+				<th id="<?php echo $category; ?>">
+					<a href="javascript:;" onclick="$('.toggle-<?php echo $category; ?>').toggle();"><?php echo $category; ?></a>
+				</th>
+				<th>Amount</th>
 			</tr><?php
-		}
-	} ?>
+			foreach ($LocIDs as $LocID) { ?>
+				<tr class="toggle-<?php echo $category; ?>">
+					<td class="right"><?php echo $LocText[$LocID]; ?></td>
+					<td><input type="number" value="<?php echo $TotalLocs[$LocID]; ?>" size="5" name="loc<?php echo $LocID; ?>"></td>
+				</tr><?php
+			}
+		} ?>
 
-	<tr>
-		<td colspan="2" class="center"><input type="submit" name="submit" value="Create Locations"><br /><br /><a href="<?php echo $CancelHREF; ?>" class="submitStyle">Cancel</a></td>
-	</tr>
-</table>
+		<tr>
+			<td colspan="2" class="center"><input type="submit" name="submit" value="Create Locations"><br /><br /><a href="<?php echo $CancelHREF; ?>" class="submitStyle">Cancel</a></td>
+		</tr>
+	</table>
 
 </form>
 

--- a/templates/Default/admin/Default/1.6/universe_create_locations.php
+++ b/templates/Default/admin/Default/1.6/universe_create_locations.php
@@ -5,16 +5,27 @@ foreach ($LocTypes as $category => $LocIDs) { ?>
 		<a href="javascript:;" onclick="window.location.hash='<?php echo $category; ?>'">Jump to <?php echo $category; ?></a><br /><?php
 } ?>
 
+<br />
+Click a category heading to toggle its display.
+
 <?php echo $Form; ?>
 
-<table class="standard"><?php
+<table class="standard">
+	<!-- colgroup style ensures fixed table width as categories are toggled -->
+	<colgroup>
+		<col style="width:250px">
+		<col style="width:158px">
+	</colgroup>
+	<?php
 	foreach ($LocTypes as $category => $LocIDs) { ?>
 		<tr>
-			<th id="<?php echo $category; ?>"><?php echo $category; ?></th>
+			<th id="<?php echo $category; ?>">
+				<a href="javascript:;" onclick="$('.toggle-<?php echo $category; ?>').toggle();"><?php echo $category; ?></a>
+			</th>
 			<th>Amount</th>
 		</tr><?php
 		foreach ($LocIDs as $LocID) { ?>
-			<tr>
+			<tr class="toggle-<?php echo $category; ?>">
 				<td class="right"><?php echo $LocText[$LocID]; ?></td>
 				<td><input type="number" value="<?php echo $TotalLocs[$LocID]; ?>" size="5" name="loc<?php echo $LocID; ?>"></td>
 			</tr><?php

--- a/templates/Default/admin/Default/1.6/universe_create_locations.php
+++ b/templates/Default/admin/Default/1.6/universe_create_locations.php
@@ -11,6 +11,12 @@ foreach ($LocTypes as $category => $LocIDs) { ?>
 <br />
 Click a category heading to toggle its display.
 
+<style type="text/css">
+	tr.collapsible:hover {
+		cursor:pointer;
+	}
+</style>
+
 <form method="POST" action="<?php echo $CreateLocationsFormHREF; ?>">
 
 	<table class="standard">
@@ -21,10 +27,8 @@ Click a category heading to toggle its display.
 		</colgroup>
 		<?php
 		foreach ($LocTypes as $category => $LocIDs) { ?>
-			<tr>
-				<th id="<?php echo $category; ?>">
-					<a href="javascript:;" onclick="$('.toggle-<?php echo $category; ?>').toggle();"><?php echo $category; ?></a>
-				</th>
+			<tr class="collapsible" onclick="$('.toggle-<?php echo $category; ?>').toggle();">
+				<th id="<?php echo $category; ?>"><?php echo $category; ?></th>
 				<th>Amount</th>
 			</tr><?php
 			foreach ($LocIDs as $LocID) { ?>

--- a/templates/Default/admin/Default/1.6/universe_create_locations.php
+++ b/templates/Default/admin/Default/1.6/universe_create_locations.php
@@ -2,7 +2,10 @@ Working on Galaxy : <?php echo $Galaxy->getName(); ?> (<?php echo $Galaxy->getGa
 
 <?php
 foreach ($LocTypes as $category => $LocIDs) { ?>
-		<a href="javascript:;" onclick="window.location.hash='<?php echo $category; ?>'">Jump to <?php echo $category; ?></a><br /><?php
+	<!-- There is custom js that disables clicking links multiple times for any
+	link that does not have a target. Since this affects anchors as well, we
+	explicitly use the default target "_self" so the selector skips it. -->
+	<a href="#<?php echo $category; ?>" target="_self">Jump to <?php echo $category; ?></a><br /><?php
 } ?>
 
 <br />

--- a/templates/Default/admin/Default/1.6/universe_create_locations.php
+++ b/templates/Default/admin/Default/1.6/universe_create_locations.php
@@ -3,11 +3,17 @@ Working on Galaxy : <?php echo $Galaxy->getName(); ?> (<?php echo $Galaxy->getGa
 <?php echo $Form; ?>
 
 <table class="standard"><?php
-	foreach ($Locations as &$location) { ?>
+	foreach ($LocTypes as $category => $LocIDs) { ?>
 		<tr>
-			<td class="right"><?php echo $location->getName() . $ExtraLocs[$location->getTypeID()]; ?></td>
-			<td><input type="number" value="<?php echo $TotalLocs[$location->getTypeID()]; ?>" size="5" name="loc<?php echo $location->getTypeID(); ?>"></td>
+			<th><?php echo $category; ?></th>
+			<th>Amount</th>
 		</tr><?php
+		foreach ($LocIDs as $LocID) { ?>
+			<tr>
+				<td class="right"><?php echo $LocText[$LocID]; ?></td>
+				<td><input type="number" value="<?php echo $TotalLocs[$LocID]; ?>" size="5" name="loc<?php echo $LocID; ?>"></td>
+			</tr><?php
+		}
 	} ?>
 
 	<tr>

--- a/templates/Default/admin/Default/1.6/universe_create_locations.php
+++ b/templates/Default/admin/Default/1.6/universe_create_locations.php
@@ -1,0 +1,21 @@
+Working on Galaxy : <?php echo $Galaxy->getName(); ?> (<?php echo $Galaxy->getGalaxyID() ?>)<br />
+
+<?php echo $Form; ?>
+
+<table class="standard"><?php
+	foreach ($Locations as &$location) { ?>
+		<tr>
+			<td class="right"><?php echo $location->getName() . $ExtraLocs[$location->getTypeID()]; ?></td>
+			<td><input type="number" value="<?php echo $TotalLocs[$location->getTypeID()]; ?>" size="5" name="loc<?php echo $location->getTypeID(); ?>"></td>
+		</tr><?php
+	} ?>
+
+	<tr>
+		<td colspan="2" class="center"><input type="submit" name="submit" value="Create Locations"><br /><br /><a href="<?php echo $CancelHREF; ?>" class="submitStyle">Cancel</a></td>
+	</tr>
+</table>
+
+</form>
+
+<span class="small">Note: When you press "Create Locations" this will rearrange all current locations.<br />
+To add new locations without rearranging everything use the edit sector feature.</span>


### PR DESCRIPTION
When adding locations to a galaxy, the list of locations is very long, and so it is onerous to scroll through whether you're looking for a specific location or a type of location. By adding navigable categories to the list, we make the process of galaxy creation easier. 

We also convert the page to a template.

![image](https://user-images.githubusercontent.com/846186/30041326-1a85fc86-919e-11e7-9c48-71e4c33ea542.png)
