### PR TITLE
SmrPort: avoid fractional CDs during reinforcements

### DIFF
--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -172,7 +172,7 @@ class SmrPort {
 				$federalMod = (self::TIME_FEDS_STAY - (TIME - $this->getReinforceTime())) / self::TIME_FEDS_STAY;
 				$federalMod = max(0, round($federalMod * self::MAX_FEDS_BONUS));
 				$defences += $federalMod;
-				$cds += $federalMod / 10;
+				$cds += round($federalMod / 10);
 			}
 			$this->setShields($defences);
 			$this->setArmour($defences);


### PR DESCRIPTION
After a port has been raided, it gets a bonus to its defences.
Previously, these bonuses could result in a fractional number of
CDs. To avoid this, we simply round the number of bonus CDs.