### PR TITLE
SectorPlayers.inc: change color of protected allies

### DIFF
--- a/templates/Default/engine/Default/includes/SectorPlayers.inc
+++ b/templates/Default/engine/Default/includes/SectorPlayers.inc
@@ -1,14 +1,14 @@
 <?php
 function getPlayerOptionClass(&$player, &$other) {
 	// Returns the CSS relational class of player "other" relative to "player".
-	if (!$player->traderNAPAlliance($other)) {
-		if ($other->canFight()) {
-			return "enemy";
+	if ($other->canFight()) {
+		if ($player->traderNAPAlliance($other)) {
+			return "friendly";
 		} else {
-			return "neutral";
+			return "enemy";
 		}
 	} else {
-		return "friendly";
+		return "neutral";
 	}
 }
 ?>

--- a/templates/Default/engine/Default/includes/SectorPlayers.inc
+++ b/templates/Default/engine/Default/includes/SectorPlayers.inc
@@ -1,3 +1,18 @@
+<?php
+function getPlayerOptionClass(&$player, &$other) {
+	// Returns the CSS relational class of player "other" relative to "player".
+	if (!$player->traderNAPAlliance($other)) {
+		if ($other->canFight()) {
+			return "enemy";
+		} else {
+			return "neutral";
+		}
+	} else {
+		return "friendly";
+	}
+}
+?>
+
 <div id="players_cs" class="ajax"><?php
 	if($PlayersContainer->hasOtherTraders($ThisPlayer)) {
 		$Players =& $PlayersContainer->getOtherTraders($ThisPlayer);
@@ -58,29 +73,13 @@
 									if($PlayersContainer instanceof SmrPlanet) {
 										if($ThisPlanet->getOwnerID() == $ThisPlayer->getAccountID()) {
 											?><a href="<?php echo $Player->getPlanetKickHREF() ?>" class="<?php 
-												if(!$ThisPlayer->traderNAPAlliance($Player)){ 
-													if ($Player->canFight()) {
-														?> enemy<?php 
-													} else {
-														?> neutral<?php 
-													}
-												} else {
-													?> friendly<?php 
-												}
+												echo getPlayerOptionClass($ThisPlayer, $Player);
 												?>"> Kick </a><?php
 										}
 									}
 									else {
 										?><a href="<?php echo $Player->getExamineTraderHREF() ?>" class="<?php 
-											if(!$ThisPlayer->traderNAPAlliance($Player)){ 
-												if ($Player->canFight()) {
-													?> enemy<?php 
-												} else {
-													?> neutral<?php 
-												}	
-											} else {
-												?> friendly<?php 
-											}
+											echo getPlayerOptionClass($ThisPlayer, $Player);
 										?>"> Examine </a><?php
 									} ?>
 								</div>


### PR DESCRIPTION
Currently, players are displayed in sector with the following colors:

Enemies (newbie turns=NO):  red
Enemies (newbie turns=YES): yellow
Allies (newbie turns=NO):   green
Allies (newbie turns=YES):  green

However, this often causes confusion when an ally is in newbie turns.
It can make it difficult to count the number of allies who are able
to fight or to determine if an ally has forgotten to leave newbie
protection.

We change the colors here to make it immediately visible if an ally
is in newbie turns. Since you can already click "Examine" to inspect
if the ally has newbie turns (it will say "Your target is under newbie
protection!"), this change does not modify what information is
available to players -- only how it is displayed.

Display players with the following new colors:

Enemies (newbie turns=NO):  red
Enemies (newbie turns=YES): yellow
Allies (newbie turns=NO):   green
Allies (newbie turns=YES):  yellow  <-- changed
