### PR TITLE
SectorMap.inc: remove superfluous logic

### DIFF
--- a/templates/Default/engine/Default/includes/SectorMap.inc
+++ b/templates/Default/engine/Default/includes/SectorMap.inc
@@ -94,7 +94,7 @@
 						$CanScanSector = $UniGen || ($ThisShip->hasScanner() && $isLinkedSector) || $isCurrentSector;
 						if( ($CanScanSector && ($Sector->hasForces() || $Sector->hasPlayers()) ) || $Sector->hasFriendlyForces($MapPlayer) || $Sector->hasFriendlyTraders($MapPlayer)) { ?>
 							<div class="lmtf"><?php
-								if(!$UniGen && (($isCurrentSector && $Sector->hasOtherTraders($MapPlayer)) || ($ThisShip->hasScanner() && $isLinkedSector && $Sector->hasPlayers()) || $Sector->hasFriendlyTraders($MapPlayer))) {
+								if(!$UniGen) {
 									if($CanScanSector && $Sector->hasEnemyTraders($MapPlayer)) {
 										?><img class="enemyBack" title="Enemy Trader" alt="Enemy Trader" src="images/trader.png" width="13" height="16"/><?php
 									}


### PR DESCRIPTION
This if-statement duplicated the checks performed inside it without
scoping any additional html. Therefore it can be safely removed.