### PR TITLE
Add PHP documentation generator

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# phpdox output directory
+/api

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:7
+
+# Install phpDox - https://github.com/theseer/phpdox
+# - dependency: XSL
+# - dependency: git (for composer and git enricher)
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN apt-get update && apt-get install -y \
+    libxslt-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker-php-ext-install xsl
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+RUN composer global require --no-plugins --no-scripts --dev theseer/phpdox
+ENV PATH /root/.composer/vendor/bin:$PATH
+
+WORKDIR "/api"
+ENTRYPOINT ["phpdox"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+Documentation Instructions
+--------------------------
+We use `phpdox` to generate rich API documentation of the SMR source code.
+
+To generate the documentation, run:
+
+```
+docker-compose run --rm phpdox
+```
+
+This will build the docker image and run phpdox. On subsequent calls, it
+will pick up any changes except to `Dockerfile`. If you ever need to modify
+`Dockerfile`, make sure to run `docker-compose build` afterwards.
+
+To view the documentation locally, run:
+
+```
+some-browser ./api/html/index.xhtml
+```
+
+Where `some-browser` is your browser of choice.

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+
+services:
+    phpdox:
+        build:
+            context: .
+        volumes:
+            # phpdox configuration file
+            - ./phpdox.xml:/api/phpdox.xml:ro
+            # Mount entire src code for git enricher
+            - ../:/api/smr:ro
+            # Mount phpdox output dir for access to html
+            - ./api:/api:rw

--- a/docs/phpdox.xml
+++ b/docs/phpdox.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpdox xmlns="http://xml.phpdox.net/config">
+  <project name="SMR" source="${basedir}/smr/lib/Default" workdir="${basedir}/xml">
+    <collector backend="parser" publiconly="false">
+      <include mask="*.inc" />
+    </collector>
+    <generator output="${basedir}">
+      <enrich base="${basedir}">
+        <source type="git">
+          <git binary="git" />
+        </source>
+      </enrich>
+      <build engine="html" output="html" />
+    </generator>
+  </project>
+</phpdox>


### PR DESCRIPTION
Use phpdox to generate html documentation for all objects
defined in lib/Default. We use docker and docker-compose
to manage dependencies and run the program.

See docs/README.md for usage instructions.

I have temporarily hosted the documentation generated from
this branch [here](http://54.88.80.238:8081/index.xhtml).