### PR TITLE
Fix some debug-mode warnings in admin tools

### DIFF
--- a/admin/Default/enable_game.php
+++ b/admin/Default/enable_game.php
@@ -3,7 +3,9 @@
 $template->assign('PageTopic', 'Enable New Games');
 
 // If we have just forwarded from the processing file, pass its message.
-$template->assign('ProcessingMsg', $var['processing_msg']);
+if (isset($var['processing_msg'])) {
+	$template->assign('ProcessingMsg', $var['processing_msg']);
+}
 
 // Get the list of disabled games
 $db->query('SELECT game_name, game_id FROM game WHERE enabled=' . $db->escapeBoolean(false));

--- a/admin/Default/manage_post_editors.php
+++ b/admin/Default/manage_post_editors.php
@@ -33,7 +33,9 @@ if ($activeGames) {
 }
 
 // If we have just forwarded from the processing file, pass its message.
-$template->assign('ProcessingMsg', $var['processing_msg']);
+if (isset($var['processing_msg'])) {
+	$template->assign('ProcessingMsg', $var['processing_msg']);
+}
 
 // Create the link to the processing file
 // Pass entire $var so the processing file knows the selected game

--- a/admin/Default/manage_post_editors_processing.php
+++ b/admin/Default/manage_post_editors_processing.php
@@ -40,8 +40,11 @@ else {
 	$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";
 }
 
+if (!empty($msg)) {
+	SmrSession::updateVar('processing_msg', $msg);
+}
+
 // Pass entire $var so that the selected game remains selected
-SmrSession::updateVar('processing_msg', $msg);
 forward(create_container('skeleton.php', 'manage_post_editors.php', $var));
 
 ?>

--- a/admin/Default/permission_manage.php
+++ b/admin/Default/permission_manage.php
@@ -1,8 +1,11 @@
 <?php
 
-if(isset($_REQUEST['admin_id']))
+if(isset($_REQUEST['admin_id'])) {
 	SmrSession::updateVar('admin_id',$_REQUEST['admin_id']);
-$admin_id = $var['admin_id'];
+}
+if (isset($var['admin_id'])) {
+	$admin_id = $var['admin_id'];
+}
 
 $template->assign('PageTopic','Manage Admin Permissions');
 


### PR DESCRIPTION
* Accessing an array by a key that doesn't exist produces an undefined
  index warning. Fix "Undefined index" for "processing_msg" and
  "admin_id"by checking to see if the variable is set first.
  The variables that we now conditionally set are checked by `empty`,
  which does not generate a warning if the variable doesn't exist.

* Fix "Undefined variable: msg" by checking to see if it is empty
  before using it.