### PR TITLE
Refactor Smr*MySqlDatabase.class.inc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,7 @@
 /htdocs/upload
 
 # /lib/Default/
-/lib/Default/SmrMySqlDatabase.class.inc
-/lib/Default/SmrHistoryMySqlDatabase.class.inc
-/lib/Default/SmrSessionMySqlDatabase.class.inc
+/lib/Default/SmrMySqlSecrets.inc
 /lib/Default/Smr12MySqlDatabase.class.inc
 /lib/Default/SmrClassicMySqlDatabase.class.inc
 /lib/Default/SmrClassicHistoryMySqlDatabase.class.inc

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ docker run \
 	--link='smr-mysql' \
 	--publish='80:80' \
 	--volume="/path/to/config.specific.php:/usr/share/smr/htdocs/config.specific.php:ro" \
-	--volume="/path/to/SmrSessionMySqlDatabase.class.sample.inc:/usr/share/smr/lib/Default/SmrSessionMySqlDatabase.class.inc:ro" \
-	--volume="/path/to/SmrMySqlDatabase.class.sample.inc:/usr/share/smr/lib/Default/SmrMySqlDatabase.class.inc:ro" \
+	--volume="/path/to/SmrMySqlSecrets.sample.inc:/usr/share/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
 	--detach \
 	smrealms/smr
 ```
@@ -65,8 +64,7 @@ docker run \
 	--publish='80:80' \
 	--volume="$(pwd):/usr/share/smr" \
 	--volume="$(pwd)/htdocs/config.specific.sample.php:/usr/share/smr/htdocs/config.specific.php:ro" \
-	--volume="$(pwd)/lib/Default/SmrSessionMySqlDatabase.class.sample.inc:/usr/share/smr/lib/Default/SmrSessionMySqlDatabase.class.inc:ro" \
-	--volume="$(pwd)/lib/Default/SmrMySqlDatabase.class.sample.inc:/usr/share/smr/lib/Default/SmrMySqlDatabase.class.inc:ro" \
+	--volume="$(pwd)/lib/Default/SmrMySqlSecrets.sample.inc:/usr/share/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
 	--detach \
 	smrealms/smr
 ```
@@ -83,7 +81,7 @@ docker logs -f smr
 These list the known dependencies, there may be more - please update if you find any!
 
 ### Core
-* PHP 5.3+
+* PHP 5.4+
 * MySQL 5.5
 
 ### PHP Extensions
@@ -97,8 +95,7 @@ These list the known dependencies, there may be more - please update if you find
 Currently it is required to create installation specific copies of the following files:
 
 * htdocs/config.specific.sample.php -> htdocs/config.specific.php
-* lib/Default/SmrSessionMySqlDatabase.class.sample.inc -> lib/Default/SmrSessionMySqlDatabase.class.inc
-* lib/Default/SmrMySqlDatabase.class.sample.inc -> lib/Default/SmrMySqlDatabase.class.inc
+* lib/Default/SmrMySqlSecrets.sample.inc -> lib/Default/SmrMySqlSecrets.inc
 
 For "Caretaker" functionality:
 * tools/irc/config.specific.sample.php -> tools/irc/config.specific.php

--- a/lib/Default/SmrMySqlDatabase.class.inc
+++ b/lib/Default/SmrMySqlDatabase.class.inc
@@ -1,10 +1,10 @@
 <?php
 require_once('MySqlDatabase.class.inc');
+require_once('SmrMySqlSecrets.inc');
+
 class SmrMySqlDatabase extends MySqlDatabase {
-	private static $host = 'smr-mysql';
-	private static $databaseName = 'smr_live';
-	private static $user = 'smr';
-	private static $password = 'smr';
+	// add host, user, password, and databaseName static members via traits
+	use SmrMySqlSecrets;
 	public function SmrMySqlDatabase() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$databaseName);
 	}

--- a/lib/Default/SmrMySqlSecrets.sample.inc
+++ b/lib/Default/SmrMySqlSecrets.sample.inc
@@ -1,0 +1,8 @@
+<?php
+trait SmrMySqlSecrets {
+	private static $host = 'smr-mysql';
+	private static $databaseName = 'smr_live';
+	private static $user = 'smr';
+	private static $password = 'smr';
+}
+?>

--- a/lib/Default/SmrSessionMySqlDatabase.class.inc
+++ b/lib/Default/SmrSessionMySqlDatabase.class.inc
@@ -1,10 +1,10 @@
 <?php
 require_once('MySqlDatabase.class.inc');
+require_once('SmrMySqlSecrets.inc');
+
 class SmrSessionMySqlDatabase extends MySqlDatabase {
-	private static $host = 'smr-mysql';
-	private static $databaseName = 'smr_live';
-	private static $user = 'smr';
-	private static $password = 'smr';
+	// add host, user, password, and databaseName static members via traits
+	use SmrMySqlSecrets;
 	public function SmrSessionMySqlDatabase() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$databaseName);
 	}


### PR DESCRIPTION
This change simplifies server configuration.

Move the static MySQL database configuration into a separate trait
called SmrMySqlSecrets, which is contained in a separate file from
the rest of the database code. This has several benefits:

* The database configuration only needs to be specified in a single
  file, and thus reduces configuration/code duplication and also
  reduces the number of files that need to be managed by Docker.

* The rest of the database code now resides in a version-controlled
  file, whereas previously it was specified in two user-created
  configuration files.

PHP traits require php 5.4+.