### PR TITLE
SmrPlanet.class.inc: fix index error when 0 buildings

### DIFF
--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -983,7 +983,6 @@ class SmrPlanet {
 	}
 
 	function getConstructionTime($constructionID) {
-		$buildings = $this->getBuildings();
 		$baseTime = 0;
 		$this->db->query('
 			SELECT * 
@@ -993,7 +992,7 @@ class SmrPlanet {
 		if ($this->db->nextRecord()) {
 			$baseTime = $this->db->getInt('cost_time');
 		}
-		$currentBuildings = $buildings[$constructionID];
+		$currentBuildings = $this->getBuilding($constructionID);
 		$maxBuildings = $this->getMaxBuildings($constructionID);
 		// Replace this with the real equations once RCK provides some that aren't gibberish.
 		$constructionTime = TIME + ceil(3.8030328 * $baseTime * pow(($currentBuildings/$maxBuildings), 3) / Globals::getGameSpeed($this->getGameID()));


### PR DESCRIPTION
The `getBuildings` return value does not contain a key
for buildings that have not been built yet. The `getBuilding`
method accounts for this and checks for the existence of
the key.