### PR TITLE
message.functions.inc: add Government to race name

### DIFF
--- a/lib/Default/message.functions.inc
+++ b/lib/Default/message.functions.inc
@@ -15,7 +15,7 @@ function &getMessagePlayer($accountID, $gameID, $messageType = false) {
 		$RACES =& Globals::getRaces();
 		foreach($RACES as $raceID => &$raceInfo) {
 			if($accountID==ACCOUNT_ID_GROUP_RACES+$raceID) {
-				$return = '<span class="yellow">'.$raceInfo['Race Name'].'</span>';
+				$return = '<span class="yellow">'.$raceInfo['Race Name'].' Government</span>';
 				return $return;
 			}
 		}


### PR DESCRIPTION
In `getMessagePlayer`, messages sent by a non-player race account
will have a sender `<RACE> Government` instead of just `<RACE>`.

![image](https://user-images.githubusercontent.com/846186/32606107-d9caf04a-c508-11e7-851b-db33cf986553.png)
