### PR TITLE
Security layer for combat log BBCode links

### DIFF
--- a/engine/Default/combat_log_viewer_verify.php
+++ b/engine/Default/combat_log_viewer_verify.php
@@ -1,0 +1,25 @@
+<?php
+// Verify that the player is permitted to view the requested combat log
+// Qualifications:
+//  * Log must be from the current game
+//  * Attacker or defender is the player OR in the player's alliance
+
+$query = 'SELECT log_id FROM combat_logs WHERE log_id=' . $db->escapeNumber($var['log_id']) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND ';
+if ($player->hasAlliance()) {
+	$query .= '(attacker_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' OR defender_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ')';
+} else {
+	$query .= '(attacker_id=' . $db->escapeNumber($player->getAccountID()) . ' OR defender_id=' . $db->escapeNumber($player->getAccountID()) . ')';
+}
+$db->query($query . ' LIMIT 1');
+
+// Error if qualifications are not met
+if (!$db->nextRecord()) {
+	create_error('You do not have permission to view this combat log!');
+}
+
+// Player has permission, so go to the display page!
+$container = create_container('skeleton.php', 'combat_log_viewer.php');
+$container['log_ids'] = array($var['log_id']);
+$container['current_log'] = 0;
+forward($container);
+?>

--- a/engine/Default/smr.inc
+++ b/engine/Default/smr.inc
@@ -28,9 +28,8 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 				if ($action == BBCODE_CHECK) {
 					return true;
 				}
-				$container = create_container('skeleton.php', 'combat_log_viewer.php');
-				$container['log_ids'] = array($logID);
-				$container['current_log'] = 0;
+				$container = create_container('combat_log_viewer_verify.php');
+				$container['log_id'] = $logID;
 				return '<a href="' . SmrSession::getNewHREF($container) . '"><img src="images/notify.gif" width="14" height="11" border="0" title="View the combat log" /></a>';
 			break;
 			case 'player':


### PR DESCRIPTION
Now that we have a BB-tag that links to sensitive information (in this
case combat logs), since player messages are bbify'd, you could send
a message to another player with "[combatlog=X]", where X is some valid
combat log ID, and the recipient would then have a link to that combat
log -- even if they would otherwise be unable to see it in the combat
log viewer.

This exploit is unlikely to be discovered (and even harder to abuse),
but since it is theoretically possible, it needs to be prevented.

To do this, we create a security layer between the BBLink and the
displayed combat log page. This layer verifies that the player should
be allowed to access it. Currently, restrictions include:

* Log is from the current game
* Attacker/Defender is the player or in the player's alliance