### PR TITLE
Use named constants for sendMessage types

### DIFF
--- a/engine/Default/planet_kick_processing.php
+++ b/engine/Default/planet_kick_processing.php
@@ -8,7 +8,7 @@ $owner =& $planet->getOwner();
 if ($owner->getAllianceID() != $player->getAllianceID())
 	create_error('You can not kick someone off a planet your alliance does not own!');
 $message = 'You have been kicked from ' . $planet->getName() . ' in ' . Globals::getSectorBBLink($player->getSectorID());
-$player->sendMessage($planetPlayer->getAccountID(), 2, $message, false);
+$player->sendMessage($planetPlayer->getAccountID(), MSG_PLAYER, $message, false);
 
 $planetPlayer->setLandedOnPlanet(false);
 $planetPlayer->setKicked(true);

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -421,7 +421,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$allianceID = $this->getAllianceID();
 		$alliance = $this->getAlliance();
 		if($kickedBy != null) {
-			$kickedBy->sendMessage($this->getAccountID(), 2, 'You were kicked out of the alliance!', false);
+			$kickedBy->sendMessage($this->getAccountID(), MSG_PLAYER, 'You were kicked out of the alliance!', false);
 			$this->actionTaken('PlayerKicked', array('Alliance' => &$alliance, 'Player' => &$kickedBy));
 			$kickedBy->actionTaken('KickPlayer', array('Alliance' => &$alliance, 'Player' => &$this));
 		}
@@ -431,7 +431,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 		else {
 			$this->actionTaken('LeaveAlliance', array('Alliance' => &$alliance));
 			if ($alliance->getLeaderID() != 0 && $alliance->getLeaderID() != ACCOUNT_ID_NHL) {
-				$this->sendMessage($alliance->getLeaderID(), 2, 'I left your alliance!', false);
+				$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I left your alliance!', false);
 			}
 		}
 
@@ -450,7 +450,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->setAllianceID($allianceID);
 		$alliance = $this->getAlliance();
 		if (!$this->isAllianceLeader())
-			$this->sendMessage($alliance->getLeaderID(), 2, 'I joined your alliance!', false);
+			$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I joined your alliance!', false);
 		$this->db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getAccountID()) . ', 2,' . $this->db->escapeNumber($alliance->getAllianceID()) . ')');
 		$this->actionTaken('JoinAlliance', array('Alliance' => &$alliance));
 	}


### PR DESCRIPTION
A few calls to `sendMessage` still used integers instead of
named constants.