### PR TITLE
Improve "Request A Feature" pages

### DIFF
--- a/engine/Default/feature_request_comments.php
+++ b/engine/Default/feature_request_comments.php
@@ -17,6 +17,12 @@ if ($db->getNumRows() > 0) {
 	$featureModerator = $account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST);
 	$template->assign('FeatureModerator',$featureModerator);
 
+	// variables needed to set the status for this feature request
+	if ($featureModerator) {
+		$template->assign('FeatureRequestId', $var['RequestID']);
+		$template->assign('FeatureRequestStatusFormHREF', SmrSession::getNewHREF(create_container('feature_request_vote_processing.php')));
+	}
+
 	$featureRequestComments = array();
 	while ($db->nextRecord()) {
 		$commentID = $db->getField('comment_id');

--- a/engine/Default/feature_request_comments.php
+++ b/engine/Default/feature_request_comments.php
@@ -29,7 +29,7 @@ if ($db->getNumRows() > 0) {
 		if($featureModerator || !$db->getBoolean('anonymous'))
 			$featureRequestComments[$commentID]['PosterAccount'] =& SmrAccount::getAccount($db->getField('poster_id'));
 	}
-	$template->assignByRef('FeatureRequests',$featureRequestComments);
+	$template->assignByRef('Comments', $featureRequestComments);
 }
 
 $container = $var;

--- a/engine/Default/feature_request_vote_processing.php
+++ b/engine/Default/feature_request_vote_processing.php
@@ -14,6 +14,9 @@ if($_REQUEST['action']=='Vote') {
 	forward(create_container('skeleton.php', 'feature_request.php'));
 }
 else if($_REQUEST['action']=='Set Status' || $_REQUEST['status']=='Implemented' || $_REQUEST['status']=='Rejected' || $_REQUEST['status']=='Opened') {
+	if(empty($_REQUEST['status'])) {
+		create_error('You have to select a status to set');
+	}
 	$status = $_REQUEST['status'];
 	if(empty($_REQUEST['delete']))
 		create_error('You have to select a feature');

--- a/engine/Default/feature_request_vote_processing.php
+++ b/engine/Default/feature_request_vote_processing.php
@@ -18,7 +18,7 @@ else if($_REQUEST['action']=='Set Status' || $_REQUEST['status']=='Implemented' 
 		create_error('You have to select a status to set');
 	}
 	$status = $_REQUEST['status'];
-	if(empty($_REQUEST['delete']))
+	if(empty($_REQUEST['set_status_ids']))
 		create_error('You have to select a feature');
 	if(!$account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST))
 		create_error('You do not have permission to do that');
@@ -42,8 +42,8 @@ else if($_REQUEST['action']=='Set Status' || $_REQUEST['status']=='Implemented' 
 				WHERE feature_request_id=fr.feature_request_id
 					AND vote_type=' . $db->escapeString('NO') . '
 			)
-			WHERE feature_request_id IN (' . $db->escapeArray($_REQUEST['delete']) . ')');
-	foreach($_REQUEST['delete'] as $featureID) {
+			WHERE feature_request_id IN (' . $db->escapeArray($_REQUEST['set_status_ids']) . ')');
+	foreach($_REQUEST['set_status_ids'] as $featureID) {
 		$db->query('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
 					VALUES(' . $db->escapeNumber($featureID) . ', ' . $db->escapeNumber(SmrSession::$account_id) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeBoolean(false) . ',' . $db->escapeString($status) . ')');
 	}

--- a/engine/Default/feature_request_vote_processing.php
+++ b/engine/Default/feature_request_vote_processing.php
@@ -13,7 +13,7 @@ if($_REQUEST['action']=='Vote') {
 
 	forward(create_container('skeleton.php', 'feature_request.php'));
 }
-else if($_REQUEST['action']=='Set Status' || $_REQUEST['status']=='Implemented' || $_REQUEST['status']=='Rejected' || $_REQUEST['status']=='Opened') {
+else if($_REQUEST['action']=='Set Status') {
 	if(empty($_REQUEST['status'])) {
 		create_error('You have to select a status to set');
 	}

--- a/templates/Default/engine/Default/feature_request.php
+++ b/templates/Default/engine/Default/feature_request.php
@@ -55,8 +55,14 @@ if(isset($FeatureRequests)) { ?>
 			} unset($FeatureRequest); ?>
 		</table>
 		<div align="right"><?php
-			if($FeatureModerator) {
-				?>&nbsp;<select name="status"><option value="Implemented">Implemented</option><option value="Rejected">Rejected</option><option value="Opened">Open</option><option value="Deleted">Delete</option></select>&nbsp;<input type="submit" name="action" value="Set Status"><?php
+			if($FeatureModerator) { ?>&nbsp;
+				<select name="status">
+					<option disabled selected value style="display:none"> -- Select Status -- </option>
+					<option value="Implemented">Implemented</option>
+					<option value="Rejected">Rejected</option>
+					<option value="Opened">Open</option>
+					<option value="Deleted">Delete</option>
+				</select>&nbsp;<input type="submit" name="action" value="Set Status"><?php
 			}
 			if($Status == 'Opened') { ?>
 				<input type="submit" name="action" value="Vote"><?php

--- a/templates/Default/engine/Default/feature_request.php
+++ b/templates/Default/engine/Default/feature_request.php
@@ -49,7 +49,7 @@ if(isset($FeatureRequests)) { ?>
 						<td><input type="radio" name="vote[<?php echo $FeatureRequest['RequestID']; ?>]" value="NO"<?php if($FeatureRequest['VotedFor'] == 'NO') { ?> checked="checked"<?php } ?>></td><?php
 					}
 					if($FeatureModerator) {
-						?><td valign="middle" align="center"><input type="checkbox" name="delete[]" value="<?php echo $FeatureRequest['RequestID']; ?>"></td><?php
+						?><td valign="middle" align="center"><input type="checkbox" name="set_status_ids[]" value="<?php echo $FeatureRequest['RequestID']; ?>"></td><?php
 					} ?>
 				</tr><?php
 			} unset($FeatureRequest); ?>

--- a/templates/Default/engine/Default/feature_request.php
+++ b/templates/Default/engine/Default/feature_request.php
@@ -40,7 +40,7 @@ if(isset($FeatureRequests)) { ?>
 					if($FeatureModerator) {
 						?><td><?php echo $FeatureRequest['RequestAccount']->getLogin(); ?>&nbsp;(<?php echo $FeatureRequest['RequestAccount']->getAccountID(); ?>)</td><?php
 					} ?>
-					<td><?php echo $FeatureRequest['Votes']['FAVOURITE']; ?> / <?php echo $FeatureRequest['Votes']['YES'] + $FeatureRequest['Votes']['FAVOURITE']; ?> / <?php echo $FeatureRequest['Votes']['NO']; ?></td>
+					<td><span class="bold green"><?php echo $FeatureRequest['Votes']['FAVOURITE']; ?></span> / <span class="green"><?php echo $FeatureRequest['Votes']['YES'] + $FeatureRequest['Votes']['FAVOURITE']; ?></span> / <span class="red"><?php echo $FeatureRequest['Votes']['NO']; ?></span></td>
 					<td class="left"><?php echo bbifyMessage($FeatureRequest['Message']); ?></td>
 					<td class="shrink noWrap top"><a href="<?php echo $FeatureRequest['CommentsHREF']; ?>">View (<?php echo $FeatureRequest['Comments']; ?>)</a></td><?php
 					if($Status == 'Opened') { ?>

--- a/templates/Default/engine/Default/feature_request_comments.php
+++ b/templates/Default/engine/Default/feature_request_comments.php
@@ -1,27 +1,27 @@
 <p><a href="<?php echo $BackHref; ?>">Back</a></p><?php
-if(isset($FeatureRequests)) { ?>
+if(isset($Comments)) { ?>
 	<table class="standard fullwidth">
 		<tr>
 			<th>Poster</th>
 			<th>Comment</th>
 			<th>Time</th>
 		</tr><?php
-		foreach($FeatureRequests as &$FeatureRequest) { ?>
+		foreach($Comments as &$Comment) { ?>
 			<tr class="center">
 				<td class="shrink noWrap top"><?php
-				if($FeatureRequest['Anonymous']) {
+				if($Comment['Anonymous']) {
 					?>Anonymous<?php
 				}
 				else {
-					echo $FeatureRequest['PosterAccount']->getHofName();
+					echo $Comment['PosterAccount']->getHofName();
 				}
 				if($FeatureModerator) {
-					?> - <?php echo $FeatureRequest['PosterAccount']->getLogin(); ?>&nbsp;(<?php echo $FeatureRequest['PosterAccount']->getAccountID(); ?>)</td><?php
+					?> - <?php echo $Comment['PosterAccount']->getLogin(); ?>&nbsp;(<?php echo $Comment['PosterAccount']->getAccountID(); ?>)</td><?php
 				} ?>
-				<td class="left"><?php echo bbifyMessage($FeatureRequest['Message']); ?></td>
-				<td class="shrink noWrap top"><?php echo $FeatureRequest['Time']; ?></td>
+				<td class="left"><?php echo bbifyMessage($Comment['Message']); ?></td>
+				<td class="shrink noWrap top"><?php echo $Comment['Time']; ?></td>
 			</tr><?php
-		} unset($FeatureRequest); ?>
+		} unset($Comment); ?>
 	</table><?php
 } ?>
 <p>

--- a/templates/Default/engine/Default/feature_request_comments.php
+++ b/templates/Default/engine/Default/feature_request_comments.php
@@ -23,7 +23,24 @@ if(isset($Comments)) { ?>
 			</tr><?php
 		} unset($Comment); ?>
 	</table><?php
+}
+
+if ($FeatureModerator) { ?>
+	<form name="FeatureRequestStatusForm" method="POST" action="<?php echo $FeatureRequestStatusFormHREF; ?>">
+		<div align="right">&nbsp;
+			<select name="status">
+				<option disabled selected value style="display:none"> -- Select Status -- </option>
+				<option value="Implemented">Implemented</option>
+				<option value="Rejected">Rejected</option>
+				<option value="Opened">Open</option>
+				<option value="Deleted">Delete</option>
+			</select>&nbsp;
+			<input type="hidden" name="set_status_ids[]" value="<?php echo $FeatureRequestId; ?>" />
+			<input type="submit" name="action" value="Set Status" />
+		</div><br />
+	</form><?php
 } ?>
+
 <p>
 	<form name="FeatureRequestCommentForm" method="POST" action="<?php echo $FeatureRequestCommentFormHREF; ?>">
 		<table>


### PR DESCRIPTION
Public improvements:
* Requests/comments no longer anonymous by default (checkbox is still there)
* Votes are color-coded

Moderator improvements:
* Option to set feature request status while viewing comments
* Disentangle "Vote" and "Set Status" buttons, so you can only do one or the other at a time
* Use a dummy "Select Status" default option for the status dropdown

Code improvements:
* Fix a couple misleading variable names