### PR TITLE
Advertise both IRC and Discord Chat servers

### DIFF
--- a/engine/Default/chat_rules.php
+++ b/engine/Default/chat_rules.php
@@ -1,6 +1,6 @@
 <?php
 
-$template->assign('PageTopic','Space Merchant Realms Chat Room Rules');
+$template->assign('PageTopic','Space Merchant Realms Chat');
 
 $autoChannels = urlencode('#SMR');
 if($player->hasAlliance()) {

--- a/templates/Default/engine/Default/chat_rules.php
+++ b/templates/Default/engine/Default/chat_rules.php
@@ -1,69 +1,13 @@
-These rules have been created for all chatters in #SMR. The purpose of #SMR is to have a general gathering of all players, newbies and vets, and anyone else who may decide to enter the channel. The channel is meant to help anyone with any questions or problems they may have regarding the game. The following is a list of the rules we ask that everyone follow:<br /><br />
-<b>News Last Updated: <u>Sunday, 09-Feb-2003 19:45:15 EST</u></b><br />
-MrSpock setup so the applet can be administered, no longer having to ban the applet for a single abusive user ;)<br />
-<br /><br />
-<b>Rules Last Updated: <u>Sunday, 21-Dec-2003 01:47:22 EST</u></b><br />
-<br /><br />
-A. Rules <br /><br />
-
-<ol>
-	<li>No foul language is allowed. That includes swearing, explicit language, derogatory racial comments, and similar activities. </li>
-
-	<li>No advertising of sites not related to SMR is allowed. Limited advertisement of online game directories, news publications, and similar sites is accepted.</li>
-
-	<li>No promotion of illegal activities, including but not limited to illegal drug use, is allowed.</li>
-
-	<li>No cheating accusations are allowed. That includes, but is not limited to, accusations of having multiple accounts and abusing bugs. The proper action in those cases is an email to multi@smrealms.de in the former one and admin@smrealms.de (or bugs@smrealms.de) in the later.</li>
-
-	<li>No harassment of admins, ops, or regular players is allowed. That includes slandering, name-calling, and similar activites. That also includes actions that have as their sole purpose to annoy admins, ops, or other players.</li>
-
-	<li>Impersonating other players, admins, or ops, past and present, is strictly forbidden. For the purposes of this rule Space Merchant and Space Merchant Realms are considered to be the same game.</li>
-
-	<li>No flooding or spamming is allowed.</li>
-
-	<li>Since the only language that all of the ops speak is English, it is the only language allowed in #smr. If you want to speak other languages feel free to do it in other rooms or in PMs.</li>
-
-	<li>Ban hopping (logging in from another IP after you get banned and similar activities) is striclty forbidden.</li>
-
-	<li>Bots are allowed only with Spock's permission.</li>
-
-	<li>Complaints about kicks/bans are to be made in private(PM, email). Complaints in chat are not allowed.</li>
-</ol>
-
-<br /><br />
-B. Disciplinary actions.
+Chat with your fellow players as you navigate the universe! You may join via IRC or Discord. The purpose of SMR chat is to have a general gathering of all players, newbies and vets, and anyone else who may decide to join. The channel is meant to help anyone with questions or problems they may have regarding the game.
 <br /><br />
 
-<ol>
-	<li>There are 4 kinds of disciplinary action: a verbal warning, a kick, a short term ban (normally 24 hours), and a long term ban (up to life time).</li>
+<center>
+	<b>Please read the <u><a href="<?php echo WIKI_URL; ?>/rules#irc-and-discord-rules">Chat Rules</a></u> before joining!</b>
+	<br /><br /><br />
 
-	<li>Disciplinary actions should start with the lowest level and continue to the highest.</li>
+	<div class="buttonA"><a class="buttonA" href="http://widget.mibbit.com/?settings=5f6a385735f22a3138c5cc6059dab2f4&server=irc.theairlock.net&channel=<?php echo $AutoChannels; ?>&autoConnect=true&nick=<?php echo urlencode('SMR-'.str_replace(' ','_',$ThisPlayer->getPlayerName())); ?>" target="_chat">&nbsp;Connect to IRC&nbsp;</a></div>
 
-	<li>Normally, only the first 3 levels will be used with only 1 stop at each of the 2 lower levels.</li>
+	<br /><br /><br />
 
-	<li>The amount of stops at lower levels can be increased if:
-		<ol type='a'>
-			<li>the offender is a newer chat user,</li>
-			<li>the offence is very mild (for example usage of a language other than English), or</li>
-			<li>other special circumstances are at hand.</li>
-		</ol>
-	</li>
-
-	<li>The amount of stops at lower levels can be decreased if:
-		<ol type='a'>
-			<li>the offender has been punished multiple times,</li>
-			<li>the offence is especially severe (for example spamming or impersonation of an old and well known member of community (for example Speef or MrSpock)), or</li>
-			<li>other special circumstances are at hand.</li>
-		</ol>
-	</li>
-
-	<li>In extreme cases of severe and/or multiple offences long term bans will be issued.</li>
-
-	<li>In especially severe cases, including, but not limited to ban hopping in game action will be taken.</li>
-
-	<li>If you disagree with the action taken against you feel free to complain to the chat admin aka RCK in chat or through email chat@smrealms.de</li>
-</ol>
-<br />
-<br />
-<br />
-<center><a href="http://widget.mibbit.com/?settings=5f6a385735f22a3138c5cc6059dab2f4&server=irc.theairlock.net&channel=<?php echo $AutoChannels; ?>&autoConnect=true&nick=<?php echo urlencode('SMR-'.str_replace(' ','_',$ThisPlayer->getPlayerName())); ?>" target="_chat" class="submitStyle">Chat</a></center>
+	<iframe src="https://discordapp.com/widget?id=376433706916642826&theme=dark" width="320" height="370" allowtransparency="true" frameborder="0"></iframe>
+</center>

--- a/templates/Default/engine/Default/includes/LeftPanel.inc
+++ b/templates/Default/engine/Default/includes/LeftPanel.inc
@@ -72,7 +72,7 @@ if(isset($GameID) && Globals::isBetaOpen()) {
 <a href="<?php echo $ContactFormLink; ?>">Contact Form</a><br />
 <br /><?php
 if(isset($GameID)) {
-	?><a class="bold" href="<?php echo $IRCLink; ?>">IRC Chat</a><br /><?php
+	?><a class="bold" href="<?php echo $IRCLink; ?>">Join Chat</a><br /><?php
 } ?>
 <a class="bold" href="http://smrcnn.smrealms.de/viewtopic.php?f=1&amp;t=9705" target="policy">User Policy</a><br />
 <a class="bold" href="http://smrcnn.smrealms.de/" target="webboard">Webboard</a><br />


### PR DESCRIPTION
Restructure the page into summary and links. This replaces a
daunting list of rules that either a) you ignore or b) discourages
you from finding your way to the small chat link at the bottom.

* Add a prominent link to the Chat Rules on the wiki
* Add the Discord widget for the public SMR Discord server