### PR TITLE
menu.inc: fix PHP warning on Arid planets

### DIFF
--- a/engine/Default/menu.inc
+++ b/engine/Default/menu.inc
@@ -133,20 +133,19 @@ function create_planet_menu($planet) {
 	
 	$menu_array = array();
 	$menu_array[] = array('Link'=>Globals::getPlanetMainHREF(),'Text'=>'Planet Main');
-	$planetOptions = $planet->getOptions();
-	if ($planetOptions['CONSTRUCTION']) {
+	if ($planet->getOptions('CONSTRUCTION')) {
 		$menu_array[] = array('Link'=>Globals::getPlanetConstructionHREF(),'Text'=>'Construction');
 	}
-	if ($planetOptions['DEFENSE']) {
+	if ($planet->getOptions('DEFENSE')) {
 		$menu_array[] = array('Link'=>Globals::getPlanetDefensesHREF(),'Text'=>'Defense');
 	}
-	if ($planetOptions['OWNERSHIP']) {
+	if ($planet->getOptions('OWNERSHIP')) {
 		$menu_array[] = array('Link'=>Globals::getPlanetOwnershipHREF(),'Text'=>'Ownership');
 	}
-	if ($planetOptions['STOCKPILE']) {
+	if ($planet->getOptions('STOCKPILE')) {
 		$menu_array[] = array('Link'=>Globals::getPlanetStockpileHREF(),'Text'=>'Stockpile');
 	}
-	if ($planetOptions['FINANCE']) {
+	if ($planet->getOptions('FINANCE')) {
 		$menu_array[] = array('Link'=>Globals::getPlanetFinancesHREF(),'Text'=>'Financial');
 	}
 	


### PR DESCRIPTION
Since Arid planets lack a "Financial" page, we were getting
an undefined index when we queried the `$planetOptions`.

However, `$planet->getOptions(...)` takes care of the check
for existence of the index (and it is cached), so it is an
obvious drop-in replacement that fixes the PHP warning.