### PR TITLE
chat_rules.php: clicking Rules link opens new window

### DIFF
--- a/templates/Default/engine/Default/chat_rules.php
+++ b/templates/Default/engine/Default/chat_rules.php
@@ -2,7 +2,7 @@ Chat with your fellow players as you navigate the universe! You may join via IRC
 <br /><br />
 
 <center>
-	<b>Please read the <u><a href="<?php echo WIKI_URL; ?>/rules#irc-and-discord-rules">Chat Rules</a></u> before joining!</b>
+	<b>Please read the <u><a href="<?php echo WIKI_URL; ?>/rules#irc-and-discord-rules" target="_blank">Chat Rules</a></u> before joining!</b>
 	<br /><br /><br />
 
 	<div class="buttonA"><a class="buttonA" href="http://widget.mibbit.com/?settings=5f6a385735f22a3138c5cc6059dab2f4&server=irc.theairlock.net&channel=<?php echo $AutoChannels; ?>&autoConnect=true&nick=<?php echo urlencode('SMR-'.str_replace(' ','_',$ThisPlayer->getPlayerName())); ?>" target="_chat">&nbsp;Connect to IRC&nbsp;</a></div>


### PR DESCRIPTION
The Rules link leads to the wiki, so we probably want to
open the link in a new window so that we're not redirecting
people out of the game.

Thanks JJ for the suggestion!