### PR TITLE
Add Discord ID fields to the database

### DIFF
--- a/db/patches/V1_6_61_06__discord_id.sql
+++ b/db/patches/V1_6_61_06__discord_id.sql
@@ -1,0 +1,2 @@
+-- Add `discord_id` field to `account` table
+ALTER TABLE `account` ADD COLUMN `discord_id` VARCHAR(32) DEFAULT NULL AFTER `hof_name`;

--- a/db/patches/V1_6_61_07__alliance_discord_channel.sql
+++ b/db/patches/V1_6_61_07__alliance_discord_channel.sql
@@ -1,0 +1,2 @@
+-- Add `discord_channel` field to `alliance` table
+ALTER TABLE `alliance` ADD COLUMN `discord_channel` VARCHAR(32) DEFAULT NULL;

--- a/engine/Default/alliance_stat_processing.php
+++ b/engine/Default/alliance_stat_processing.php
@@ -10,6 +10,9 @@ if (isset($_REQUEST['password'])) {
 if (isset($_REQUEST['description'])) {
 	$description = trim($_REQUEST['description']);
 }
+if (isset($_REQUEST['discord'])) {
+	$discordChannel = trim($_REQUEST['discord']);
+}
 if (isset($_REQUEST['irc'])) {
 	$irc = trim($_REQUEST['irc']);
 }
@@ -38,6 +41,17 @@ if (isset($password)) {
 }
 if (isset($description)) {
 	$alliance->setAllianceDescription($description);
+}
+if (isset($discordChannel)) {
+	if (empty($discordChannel)) {
+		$alliance->setDiscordChannel(null);
+	} else {
+		// no duplicates in a given game
+		$db->query('SELECT * FROM alliance WHERE discord_channel =' .$db->escapeString($discordChannel) .' AND game_id = '.$db->escapeNumber($alliance->getGameID()).' AND alliance_id != '.$db->escapeNumber($alliance->getAllianceID()).' LIMIT 1');
+		if ($db->nextRecord()) create_error('Another alliance is already using that Discord Channel ID!');
+
+		$alliance->setDiscordChannel($discordChannel);
+	}
 }
 if (isset($irc)) {
 	$alliance->setIrcChannel($irc);

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -19,6 +19,7 @@ $new_password = $_REQUEST['new_password'];
 $old_password = $_REQUEST['old_password'];
 $retype_password = $_REQUEST['retype_password'];
 $HoF_name = trim($_REQUEST['HoF_name']);
+$discordId = trim($_REQUEST['discord_id']);
 $ircNick = trim($_REQUEST['irc_nick']);
 $cellPhone = trim($_REQUEST['cell_phone']);
 $friendlyColour = $_REQUEST['friendly_color'];
@@ -119,7 +120,23 @@ elseif ($action == 'Change Name') {
 	$account->setHofName($HoF_name);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your hall of fame name.';
 }
-elseif ($action == 'Change Nick') {
+
+elseif ($action == 'Change Discord ID') {
+	if (empty($discordId)) {
+		$account->setDiscordId(null);
+		$container['msg'] = '<span class="green">SUCCESS: </span>You have deleted your Discord User ID.';
+
+	} else {
+		// no duplicates
+		$db->query('SELECT * FROM account WHERE discord_id =' . $db->escapeString($discordId) . ' AND account_id != '.$db->escapeNumber($account->getAccountID()).' LIMIT 1');
+		if ($db->nextRecord()) create_error('Someone is already using that Discord User ID!');
+
+		$account->setDiscordId($discordId);
+		$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your Discord User ID.';
+	}
+}
+
+elseif ($action == 'Change IRC Nick') {
 	for ($i = 0; $i < strlen($ircNick); $i++) {
 		// disallow certain ascii chars (and whitespace!)
 		if (ord($ircNick[$i]) < 33 || ord($ircNick[$i]) > 127)

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -44,6 +44,7 @@ abstract class AbstractSmrAccount {
 	protected $validation_code;
 	protected $last_login;
 	protected $hofName;
+	protected $discordId;
 	protected $ircNick;
 	protected $veteran;
 	protected $logging;
@@ -212,6 +213,7 @@ abstract class AbstractSmrAccount {
 			$this->maxRankAchieved	= $row['max_rank_achieved'];
 
 			$this->hofName			= $row['hof_name'];
+			$this->discordId		= $row['discord_id'];
 			$this->ircNick			= $row['irc_nick'];
 
 			$this->dateShort		= $row['date_short'];
@@ -277,6 +279,7 @@ abstract class AbstractSmrAccount {
 			', logging = '.$this->db->escapeBoolean($this->logging).
 			', time_short = ' . $this->db->escapeString($this->timeShort).
 			', date_short = ' . $this->db->escapeString($this->dateShort).
+			', discord_id = ' . $this->db->escapeString($this->discordId, true, true).
 			', irc_nick = ' . $this->db->escapeString($this->ircNick, true, true).
 			', hof_name = ' . $this->db->escapeString($this->hofName).
 			', colour_scheme = ' . $this->db->escapeString($this->colourScheme).
@@ -830,6 +833,19 @@ abstract class AbstractSmrAccount {
 		if($this->ircNick==$nick)
 			return;
 		$this->ircNick = $nick;
+		$this->hasChanged = true;
+		$this->update();
+	}
+
+	public function getDiscordId() {
+		return $this->discordId;
+	}
+
+	public function setDiscordId($id) {
+		if ($this->discordId == $id) {
+			return;
+		}
+		$this->discordId = $id;
 		$this->hasChanged = true;
 		$this->update();
 	}

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -18,6 +18,7 @@ class SmrAlliance {
 	protected $deaths;
 	protected $motd;
 	protected $imgSrc;
+	protected $discordChannel;
 	protected $ircChannel;
 
 	protected $memberList;
@@ -59,6 +60,7 @@ class SmrAlliance {
 			$this->deaths			= $this->db->getInt('alliance_deaths');
 			$this->motd				= strip_tags(stripslashes($this->db->getField('mod')));
 			$this->imgSrc			= $this->db->getField('img_src');
+			$this->discordChannel	= $this->db->getField('discord_channel');
 
 			if (empty($this->kills)) {
 				$this->kills = 0;
@@ -98,6 +100,14 @@ class SmrAlliance {
 
 	public function &getLeader() {
 		return SmrPlayer::getPlayer($this->getLeaderID(),$this->getGameID());
+	}
+
+	public function getDiscordChannel() {
+		return $this->discordChannel;
+	}
+
+	public function setDiscordChannel($channelId) {
+		$this->discordChannel = $channelId;
 	}
 
 	public function getIrcChannel() {
@@ -259,6 +269,7 @@ class SmrAlliance {
 								img_src = ' . $this->db->escapeString($this->imgSrc) . ',
 								alliance_kills = '.$this->db->escapeNumber($this->kills).',
 								alliance_deaths = '.$this->db->escapeNumber($this->deaths).',
+								discord_channel = '.$this->db->escapeString($this->discordChannel).',
 								leader_id = '.$this->db->escapeNumber($this->leaderID).'
 							WHERE alliance_id = '.$this->db->escapeNumber($this->allianceID).'
 								AND game_id = '.$this->db->escapeNumber($this->gameID));

--- a/templates/Default/engine/Default/alliance_stat.php
+++ b/templates/Default/engine/Default/alliance_stat.php
@@ -16,6 +16,10 @@ if ($CanChangeDescription) { ?>
 
 if ($CanChangeChatChannel) { ?>
 	<tr>
+		<td class="top">Discord Channel ID:&nbsp;</td>
+		<td><input type="text" name="discord" size="30" value="<?php echo htmlspecialchars($Alliance->getDiscordChannel()); ?>" /></td>
+	</tr>
+	<tr>
 		<td class="top">IRC Channel:&nbsp;</td>
 		<td><input type="text" name="irc" size="30" value="<?php echo htmlspecialchars($Alliance->getIrcChannel()); ?>">(For Caretaker and autojoining via chat link - works best if you join the channel using the chat link and type "/autoconnect on" as an op)</td>
 	</tr><?php

--- a/templates/Default/engine/Default/preferences.php
+++ b/templates/Default/engine/Default/preferences.php
@@ -209,7 +209,17 @@ if(isset($GameID)) { ?>
 		<tr>
 			<td colspan="2">&nbsp;</td>
 		</tr>
-	
+
+		<tr>
+			<td>Discord User ID:</td>
+			<td><input type="text" name="discord_id" value="<?php echo htmlspecialchars($ThisAccount->getDiscordId()); ?>" id="InputFields" size=50 /></td>
+		</tr>
+
+		<tr>
+			<td>&nbsp;</td>
+			<td><input type="submit" name="action" value="Change Discord ID" id="InputFields" /></td>
+		</tr>
+
 		<tr>
 			<td>IRC Nick:</td>
 			<td><input type="text" name="irc_nick" value="<?php echo htmlspecialchars($ThisAccount->getIrcNick()); ?>" id="InputFields" size="50" /></td>
@@ -217,7 +227,7 @@ if(isset($GameID)) { ?>
 
 		<tr>
 			<td>&nbsp;</td>
-			<td><input type="submit" name="action" value="Change Nick" id="InputFields" /></td>
+			<td><input type="submit" name="action" value="Change IRC Nick" id="InputFields" /></td>
 		</tr>
 
 		<tr>


### PR DESCRIPTION
Store a Discord Channel in SmrAlliance

For now, we restrict to a 1-to-1 mapping between accounts and
Discord Channel ID's for any given game. We allow duplicates
across games since alliances may use the same channel for
multiple games.

* SmrAlliance: add `{get,set}DiscordChannel` methods
* MySQL database: add `discord_channel` field to `alliance` table
* Alliance Stats: add field to change/delete Discord Channel ID

----------------------

  Store a Discord User ID in SmrAccount

For now, we restrict to a 1-to-1 mapping between accounts and
Discord ID's. We will handle the case of multi support later.

* SmrAccount: add `{get,set}DiscordId` methods
* MySQL database: add `discord_id` field to `account` table
* Preferences: add field to change/delete Discord ID

-------------------------

These changes require a flyway migration.

We add the Discord User and Channel ID's to the database now in preparation
for forthcoming Discord integration. Having the database updated now will make
it easier to test the new infrastructure.

The Discord integration is completed and tested locally, but needs some careful
testing with the software stack on the server since it is not using Docker yet.


