### PR TITLE
Dockerfile: place smr in filesystem root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 # We need to set 'sendmail_path' since php doesn't know about sendmail when it's built
 RUN echo 'sendmail_path = "/usr/sbin/sendmail -t -i"' > /usr/local/etc/php/conf.d/mail.ini
 
-WORKDIR /usr/share/smr/
+WORKDIR /smr/
 
 # runkit is needed to use NPC's
 RUN pear channel-discover zenovich.github.io/pear \

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ docker run \
 	--name="smr" \
 	--link='smr-mysql' \
 	--publish='80:80' \
-	--volume="/path/to/config.specific.php:/usr/share/smr/htdocs/config.specific.php:ro" \
-	--volume="/path/to/SmrMySqlSecrets.sample.inc:/usr/share/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
+	--volume="/path/to/config.specific.php:/smr/htdocs/config.specific.php:ro" \
+	--volume="/path/to/SmrMySqlSecrets.sample.inc:/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
 	--detach \
 	smrealms/smr
 ```
@@ -62,9 +62,9 @@ docker run \
 	--name="smr" \
 	--link='smr-mysql' \
 	--publish='80:80' \
-	--volume="$(pwd):/usr/share/smr" \
-	--volume="$(pwd)/htdocs/config.specific.sample.php:/usr/share/smr/htdocs/config.specific.php:ro" \
-	--volume="$(pwd)/lib/Default/SmrMySqlSecrets.sample.inc:/usr/share/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
+	--volume="$(pwd):/smr" \
+	--volume="$(pwd)/htdocs/config.specific.sample.php:/smr/htdocs/config.specific.php:ro" \
+	--volume="$(pwd)/lib/Default/SmrMySqlSecrets.sample.inc:/smr/lib/Default/SmrMySqlSecrets.inc:ro" \
 	--detach \
 	smrealms/smr
 ```

--- a/htdocs/config.specific.sample.php
+++ b/htdocs/config.specific.sample.php
@@ -2,7 +2,7 @@
 define('USE_COMPATIBILITY',false);
 
 define('URL','http://localhost');
-define('ROOT','/usr/share/smr/');
+define('ROOT','/smr/');
 define('LIB',ROOT.'lib/');
 define('ENGINE',ROOT.'engine/');
 define('WWW',ROOT.'htdocs/');


### PR DESCRIPTION
There's no need to keep the smr code in `/usr/share/`.
We can put it in `/`, which shortens many of the paths we
need to specify (e.g. for volume mounts).