### PR TITLE
Revamp the port attack page

### DIFF
--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -43,9 +43,6 @@ class SmrPort {
 	protected $experience;
 	protected $goods;
 	
-	protected $turrets = 20;
-	protected $turretDamage = 250;
-	
 	protected $cachedVersion = false;
 	protected $cachedTime = TIME;
 	
@@ -813,11 +810,16 @@ class SmrPort {
 	public function getUpgrade() {
 		return $this->upgrade;
 	}
-	
+
+	public function getNumWeapons() {
+		return self::NUMBER_OF_PORT_WEAPONS;
+	}
+
 	public function &getWeapons() {
 		$weapons = array();
-		for($i=0;$i<self::NUMBER_OF_PORT_WEAPONS;++$i)
+		for ($i=0; $i<$this->getNumWeapons(); ++$i) {
 			$weapons[$i] =& SmrWeapon::getWeapon(Globals::getGameType($this->getGameID()),WEAPON_PORT_TURRET);
+		}
 		return $weapons;
 	}
 

--- a/templates/Default/engine/Default/port_attack_warning.php
+++ b/templates/Default/engine/Default/port_attack_warning.php
@@ -28,6 +28,10 @@ if ($ThisShip->hasScanner()) {
 			<td>Armour</td>
 			<td align="center"><?php echo $Port->getArmour(); ?></td>
 		</tr>
+		<tr>
+			<td>Turrets</td>
+			<td align="center"><?php echo $Port->getNumWeapons(); ?></td>
+		</tr>
 	</table>
 </p><?php
 } ?>

--- a/templates/Default/engine/Default/port_attack_warning.php
+++ b/templates/Default/engine/Default/port_attack_warning.php
@@ -1,12 +1,38 @@
 <span class="red">WARNING WARNING</span> port assault about to commence!!<br />
-Are you sure you want to attack this port?<br /><br />
+
+<br />
+Suddenly, sirens sound and warning lights flash as your onboard sensors detect
+that the port has enough defensive firepower to reduce your ship to space debris.
+Without an armada behind you, the outcome may not be pleasant.
+<a href="<?php echo WIKI_URL; ?>/game-guide/combat#ports" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Port Combat"/></a>
+<br /><br />
+
 <?php
 if ($ThisShip->hasScanner()) {
 	$Port = $ThisSector->getPort(); ?>
-	Your scanners detect that there <?php echo $this->pluralise('is', $Port->getShields()); ?> <span id="portShields"><?php echo $Port->getShields(); ?></span> <?php echo $this->pluralise('shield', $Port->getShields()); ?>,
-	and <span id="portCDs"><?php echo $Port->getCDs(); ?></span> <?php echo $this->pluralise('combat drone', $Port->getCDs()); ?>,
-	and <span id="portArmour"><?php echo $Port->getArmour(); ?></span> <?php echo $this->pluralise('plate', $Port->getArmour()); ?> of armour.<br /><br /><?php
+<p>
+	<table class="standard">
+		<tr>
+			<th>Port</th>
+			<th>Scan Results</th>
+		<tr>
+		<tr>
+			<td>Shields</td>
+			<td align="center"><?php echo $Port->getShields(); ?></td>
+		</tr>
+		<tr>
+			<td>Combat Drones</td>
+			<td align="center"><?php echo $Port->getCDs(); ?></td>
+		</tr>
+		<tr>
+			<td>Armour</td>
+			<td align="center"><?php echo $Port->getArmour(); ?></td>
+		</tr>
+	</table>
+</p><?php
 } ?>
+
+Are you sure you want to attack this port?<br /><br />
 
 <div class="buttonA">
 	<a class="buttonA" href="<?php echo $PortAttackHREF; ?>">&nbsp;Yes&nbsp;</a>


### PR DESCRIPTION
* Replace textual scan results ("Your scanners detect...") with a
  table that looks like the sector scan results. It gives the page
  a little more substance and also makes it more consistent with
  how other pages look.

* Add a short bit of roleplaying text to help newer players realize
  that raiding a port might not be a good idea. A link to the wiki
  port combat page is provided. This was tip for newbies was
  frequently requested by players.

* Add number of turrets to the port scan.