### PR TITLE
Move path defines to config.php

### DIFF
--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -1,11 +1,22 @@
 <?php
 @date_default_timezone_set(@date_default_timezone_get());
-require_once(dirname(__FILE__) . '/config.specific.php');
 
 if (ENABLE_DEBUG) {
 	// Warn about everything when in debug mode
 	error_reporting(E_ERROR | E_WARNING | E_PARSE | E_NOTICE);
 }
+
+// Repository paths
+define('ROOT', __DIR__ . '/../');
+define('LIB', ROOT.'lib/');
+define('ENGINE', ROOT.'engine/');
+define('WWW', ROOT.'htdocs/');
+define('UPLOAD', WWW.'upload/');
+define('ADMIN', ROOT.'admin/');
+define('TOOLS', ROOT.'tools/');
+
+// Define server-specific constants
+require_once(WWW . '/config.specific.php');
 
 define('ACCOUNT_ID_PORT',65535);
 define('ACCOUNT_ID_ADMIN',65534);

--- a/htdocs/config.specific.sample.php
+++ b/htdocs/config.specific.sample.php
@@ -2,13 +2,6 @@
 define('USE_COMPATIBILITY',false);
 
 define('URL','http://localhost');
-define('ROOT','/smr/');
-define('LIB',ROOT.'lib/');
-define('ENGINE',ROOT.'engine/');
-define('WWW',ROOT.'htdocs/');
-define('UPLOAD',WWW.'upload/');
-define('ADMIN',ROOT.'admin/');
-define('TOOLS',ROOT.'tools/');
 
 define('ENABLE_DEBUG', true); // This is useful for debugging on dev machines.
 define('ENABLE_BETA', false);


### PR DESCRIPTION
There is no benefit to specifying the repository path defines
in config.specific.php. These paths cannot be changed, so we
hard-code them into config.php instead of relying on the user
to correctly define them.

Furthermore, having to manually specify `ROOT` can only ever
cause problems. The correct value for `ROOT` can be determined
programmatically using `__DIR__`.