### PR TITLE
bank_alliance.php: fix undefined variable warning

### DIFF
--- a/templates/Default/engine/Default/bank_alliance.php
+++ b/templates/Default/engine/Default/bank_alliance.php
@@ -10,7 +10,7 @@ if (count($AlliedAllianceBanks) > 0) { ?>
 } ?>
 
 Hello <?php echo $ThisPlayer->getPlayerName(); ?>,<br /><?php
-if ($UnlimitedWithdrawal === true) {
+if (isset($UnlimitedWithdrawal) && $UnlimitedWithdrawal === true) {
 	?>You can withdraw an unlimited amount from this account.<?php
 }
 else if (isset($PositiveWithdrawal)) {


### PR DESCRIPTION
For players without unlimited withdrawal permissions, the variable
`$UnlimitedWithdrawal` is undefined. So first check if it exists
before using it.