### PR TITLE
Dockerfile: remove upload volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ COPY composer.json .
 RUN composer install --no-interaction
 
 COPY . .
-VOLUME htdocs/upload
 RUN rm -rf /var/www/html/ && ln -s "$(pwd)/htdocs" /var/www/html
 
 # Provide a FQDN for sendmail (since /etc/hosts cannot be modified during the


### PR DESCRIPTION
This volume mount is incompatible with local dev testing, where
you mount the entire codebase as a volume. Instead, the volume
will have to be managed with the `-v` option (or docker-compose
volume).