### PR TITLE
Modify planet construction scaling formula

### DIFF
--- a/db/patches/V1_6_62_01__increase_construction_exp.sql
+++ b/db/patches/V1_6_62_01__increase_construction_exp.sql
@@ -1,0 +1,13 @@
+-- bump base construction exp due to change in scaling formula
+UPDATE planet_can_build SET exp_gain=100 WHERE planet_type_id=1 AND construction_id=1;
+UPDATE planet_can_build SET exp_gain=200 WHERE planet_type_id=1 AND construction_id=2;
+UPDATE planet_can_build SET exp_gain=600 WHERE planet_type_id=1 AND construction_id=3;
+UPDATE planet_can_build SET exp_gain=100 WHERE planet_type_id=1 AND construction_id=4;
+UPDATE planet_can_build SET exp_gain=100 WHERE planet_type_id=2 AND construction_id=1;
+UPDATE planet_can_build SET exp_gain=200 WHERE planet_type_id=2 AND construction_id=2;
+UPDATE planet_can_build SET exp_gain=200 WHERE planet_type_id=2 AND construction_id=3;
+UPDATE planet_can_build SET exp_gain=100 WHERE planet_type_id=2 AND construction_id=4;
+UPDATE planet_can_build SET exp_gain=100 WHERE planet_type_id=3 AND construction_id=1;
+UPDATE planet_can_build SET exp_gain=200 WHERE planet_type_id=3 AND construction_id=2;
+UPDATE planet_can_build SET exp_gain=600 WHERE planet_type_id=3 AND construction_id=3;
+UPDATE planet_can_build SET exp_gain=100 WHERE planet_type_id=3 AND construction_id=4;

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -676,15 +676,12 @@ class SmrPlanet {
 			$this->db->query('
 				SELECT * 
 				FROM planet_is_building 
-				JOIN planet_can_build USING(construction_id)
 				WHERE game_id = ' . $this->db->escapeNumber($this->getGameID()) . ' 
-				AND sector_id = ' . $this->db->escapeNumber($this->getSectorID()). ' 
-				AND planet_type_id = '.$this->getTypeID());
+				AND sector_id = ' . $this->db->escapeNumber($this->getSectorID()));
 			
 			while($this->db->nextRecord()) {
 				if($this->db->getInt('time_complete') <= TIME) {
-					$PLANET_BUILDINGS =& Globals::getPlanetBuildings();
-					$expGain = $this->db->getInt('exp_gain');
+					$expGain = $this->getConstructionExp($this->db->getInt('construction_id'));
 					$player =& SmrPlayer::getPlayer($this->db->getInt('constructor_id'),$this->getGameID());
 					$player->increaseHOF(1,array('Planet','Buildings','Built'), HOF_ALLIANCE);
 					$player->increaseExperience($expGain);
@@ -988,6 +985,13 @@ class SmrPlanet {
 		$currentBuildings = $this->getBuilding($constructionID);
 		$maxBuildings = $this->getMaxBuildings($constructionID);
 		return 3.8030328 * pow(($currentBuildings/$maxBuildings), 3);
+	}
+
+	// Amount of exp gained to build the next building of this type
+	function getConstructionExp($constructionID) {
+		$baseExp = Globals::getPlanetBuildings()[$constructionID]['ExpGain'][$this->getTypeID()];
+		$expGain = ceil($baseExp * $this->getCompletionModifier($constructionID));
+		return $expGain;
 	}
 
 	// Amount of time (in seconds) to build the next building of this type

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -982,20 +982,18 @@ class SmrPlanet {
 		return true;
 	}
 
-	function getConstructionTime($constructionID) {
-		$baseTime = 0;
-		$this->db->query('
-			SELECT * 
-			FROM planet_can_build 
-			WHERE planet_type_id = '.$this->getTypeID().' 
-			AND construction_id = '.$this->db->escapeNumber($constructionID));
-		if ($this->db->nextRecord()) {
-			$baseTime = $this->db->getInt('cost_time');
-		}
+	// Modifier for planet building based on the number of buildings.
+	// The average value of this modifier should roughly be 1.
+	private function getCompletionModifier($constructionID) {
 		$currentBuildings = $this->getBuilding($constructionID);
 		$maxBuildings = $this->getMaxBuildings($constructionID);
-		// Replace this with the real equations once RCK provides some that aren't gibberish.
-		$constructionTime = TIME + ceil(3.8030328 * $baseTime * pow(($currentBuildings/$maxBuildings), 3) / Globals::getGameSpeed($this->getGameID()));
+		return 3.8030328 * pow(($currentBuildings/$maxBuildings), 3);
+	}
+
+	// Amount of time (in seconds) to build the next building of this type
+	function getConstructionTime($constructionID) {
+		$baseTime = Globals::getPlanetBuildings()[$constructionID]['Build Time'][$this->getTypeID()];
+		$constructionTime = ceil($baseTime * $this->getCompletionModifier($constructionID) / Globals::getGameSpeed($this->getGameID()));
 		return $constructionTime;
 	}
 	
@@ -1011,7 +1009,7 @@ class SmrPlanet {
 		}
 	
 		// gets the time for the buildings
-		$timeComplete = $this->getConstructionTime($constructionID);
+		$timeComplete = TIME + $this->getConstructionTime($constructionID);
 		$this->db->query('INSERT INTO planet_is_building (game_id, sector_id, construction_id, constructor_id, time_complete) ' .
 						'VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getSectorID()) . ', ' . $this->db->escapeNumber($constructionID) . ', ' . $this->db->escapeNumber($constructor->getAccountID()) . ',' . $this->db->escapeNumber($timeComplete) . ')');
 

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -984,7 +984,7 @@ class SmrPlanet {
 	private function getCompletionModifier($constructionID) {
 		$currentBuildings = $this->getBuilding($constructionID);
 		$maxBuildings = $this->getMaxBuildings($constructionID);
-		return 3.8030328 * pow(($currentBuildings/$maxBuildings), 3);
+		return 0.01 + 2.97 * pow($currentBuildings/$maxBuildings, 2);
 	}
 
 	// Amount of exp gained to build the next building of this type

--- a/templates/Default/engine/Default/planet_construction.php
+++ b/templates/Default/engine/Default/planet_construction.php
@@ -45,7 +45,7 @@ You are currently building: <?php
 						 echo number_format($PlanetBuilding['Credit Cost'][$ThisPlanet->getTypeID()]); ?>-credits, <?php
 					}
 
-					echo format_time($ThisPlanet->getConstructionTime($PlanetBuilding['ConstructionID']) - TIME); ?>
+					echo format_time($ThisPlanet->getConstructionTime($PlanetBuilding['ConstructionID'])); ?>
 				</td>
 				<td><?php
 					if ($ThisPlanet->canBuild($ThisPlayer, $PlanetBuilding['ConstructionID'])===true) { ?>


### PR DESCRIPTION
* Change construction exp from a constant to being scaled with construction time
* Modify the construction time formula so that it is less backloaded

See commit messages for details.

An example of the change and its affect on construction time and exp gain for Terran planets: https://docs.google.com/spreadsheets/d/1EspLN4Zvw0UmISZBrNzKxhAQcdr0R_AP60e_ykMYMDc/edit#gid=0

A visual representation of the change in the formula:
https://www.wolframalpha.com/input/?i=plot+3.8030328+*+(x%2F100)%5E3++and+0.01+%2B2.97*(x%2F100)%5E2++and+1+for+x+from+0+to+100