### PR TITLE
cargo_dump.php: templatize and minor cleanup

### DIFF
--- a/engine/Default/cargo_dump.php
+++ b/engine/Default/cargo_dump.php
@@ -1,42 +1,25 @@
 <?php
 $template->assign('PageTopic','Dump Cargo');
 
-$PHP_OUTPUT.=('Enter the amount of cargo you wish to jettison.<br />');
-$PHP_OUTPUT.=('Please keep in mind that you will lose experience and one turn!<br /><br />');
-
 $db->query('SELECT * FROM ship_has_cargo JOIN good USING(good_id)
 			WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 				AND game_id = ' . $db->escapeNumber($player->getGameID()));
+
 if ($db->getNumRows()) {
-	$PHP_OUTPUT.=create_table();
-	$PHP_OUTPUT.=('<tr>');
-	$PHP_OUTPUT.=('<th>Good</th>');
-	$PHP_OUTPUT.=('<th>Amount to Drop</th>');
-	$PHP_OUTPUT.=('<th>Action</th>');
-	$PHP_OUTPUT.=('</tr>');
 
+	$goods = array();
 	while ($db->nextRecord()) {
-		$good_id	= $db->getInt('good_id');
-		$good_name	= $db->getField('good_name');
-		$amount		= $db->getInt('amount');
-
 		$container = create_container('cargo_dump_processing.php');
-		$container['good_id'] = $good_id;
+		$container['good_id'] = $db->getInt('good_id');
 
-		$PHP_OUTPUT.=create_echo_form($container);
-		$PHP_OUTPUT.=('<tr>');
-		$PHP_OUTPUT.=('<td align="center">'.$good_name.'</td>');
-		$PHP_OUTPUT.=('<td align="center"><input type="number" name="amount" value="'.$amount.'" maxlength="5" size="5" id="InputFields" class="center">');
-		$PHP_OUTPUT.=('<td align="center">');
-		$PHP_OUTPUT.=create_submit('Dump');
-		$PHP_OUTPUT.=('</td>');
-		$PHP_OUTPUT.=('</tr>');
-		$PHP_OUTPUT.=('</form>');
+		$goods[] = array(
+			'name' => $db->getField('good_name'),
+			'amount' => $db->getInt('amount'),
+			'dump_href' => SmrSession::getNewHREF($container),
+		);
 	}
-	$PHP_OUTPUT.=('</table>');
-}
-else {
-	$PHP_OUTPUT.=('You have no cargo to dump!');
+
+	$template->assign('Goods', $goods);
 }
 
 ?>

--- a/engine/Default/cargo_dump.php
+++ b/engine/Default/cargo_dump.php
@@ -13,6 +13,7 @@ if ($db->getNumRows()) {
 		$container['good_id'] = $db->getInt('good_id');
 
 		$goods[] = array(
+			'image' => Globals::getGood($db->getInt('good_id'))['ImageLink'],
 			'name' => $db->getField('good_name'),
 			'amount' => $db->getInt('amount'),
 			'dump_href' => SmrSession::getNewHREF($container),

--- a/templates/Default/engine/Default/cargo_dump.php
+++ b/templates/Default/engine/Default/cargo_dump.php
@@ -15,12 +15,12 @@ if (empty($Goods)) { ?>
 		foreach ($Goods as $good) { ?>
 			<form name="DumpForm" method="POST" action="<?php echo $good['dump_href']; ?>">
 				<tr>
-					<td align="center"><?php echo $good['name']; ?></td>
-					<td align="center">
+					<td><img src="<?php echo $good['image']; ?>" width="13" height="16" title="<?php echo $good['name']; ?>" />&nbsp;<?php echo $good['name']; ?></td>
+					<td class="center">
 						<input type="number" name="amount" value="<?php echo $good['amount']; ?>" maxlength="5" size="5" id="InputFields" class="center" />
 					</td>
-					<td align="center">
-						<input type="submit" name="action" value="Dump" id="InputFields" />
+					<td class="center">
+						<input type="submit" name="action" value="Dump (1)" id="InputFields" />
 					</td>
 				</tr>
 			</form><?php

--- a/templates/Default/engine/Default/cargo_dump.php
+++ b/templates/Default/engine/Default/cargo_dump.php
@@ -1,0 +1,31 @@
+Enter the amount of cargo you wish to jettison.<br />
+Please keep in mind that you will lose experience and one turn!<br /><br />
+
+<?php
+if (empty($Goods)) { ?>
+	You have no cargo to dump!<?php
+} else { ?>
+	<table class="standard">
+		<tr>
+			<th>Good</th>
+			<th>Amount to Drop</th>
+			<th>Action</th>
+		</tr><?php
+
+		foreach ($Goods as $good) { ?>
+			<form name="DumpForm" method="POST" action="<?php echo $good['dump_href']; ?>">
+				<tr>
+					<td align="center"><?php echo $good['name']; ?></td>
+					<td align="center">
+						<input type="number" name="amount" value="<?php echo $good['amount']; ?>" maxlength="5" size="5" id="InputFields" class="center" />
+					</td>
+					<td align="center">
+						<input type="submit" name="action" value="Dump" id="InputFields" />
+					</td>
+				</tr>
+			</form><?php
+		} ?>
+	</table><?php
+}
+
+?>


### PR DESCRIPTION
In addition to the templatization and minor cleanup, there are a small number of visual changes:

1. "Dump" now contains a "(1)" to indicate turn usage more consistently.
2. Good icons are now displayed next to the good name.

![image](https://user-images.githubusercontent.com/846186/33512557-8a5a672a-d6e7-11e7-83da-21cf38b2c527.png)
