### PR TITLE
Minor fixes on the Versus alliance rankings page

### DIFF
--- a/engine/Default/rankings_alliance_vs_alliance.php
+++ b/engine/Default/rankings_alliance_vs_alliance.php
@@ -3,7 +3,7 @@ require_once(get_file_loc('SmrAlliance.class.inc'));
 $template->assign('PageTopic','Alliance VS Alliance Rankings');
 
 require_once(get_file_loc('menu.inc'));
-create_ranking_menu(1, 3);
+create_ranking_menu(1, 4);
 $db2 = new SmrMySqlDatabase();
 $container = array();
 $container['url'] = 'skeleton.php';

--- a/engine/Default/rankings_alliance_vs_alliance.php
+++ b/engine/Default/rankings_alliance_vs_alliance.php
@@ -11,9 +11,10 @@ $container['body'] = 'rankings_alliance_vs_alliance.php';
 
 $PHP_OUTPUT.=create_echo_form($container);
 
-if (isset($_REQUEST['alliancer']))
+if (isset($_REQUEST['alliancer'])) {
 	SmrSession::updateVar('alliancer',$_REQUEST['alliancer']);
-$alliancer = $var['alliancer'];
+	$alliancer = $var['alliancer'];
+}
 
 $PHP_OUTPUT.=('<div align="center">');
 $PHP_OUTPUT.=('<p>Here are the rankings of alliances vs other alliances<br />');


### PR DESCRIPTION
* Highlight the "Versus" subheading of "Alliance Rankings" when it is clicked on. It was previously highlighting the "Death" subheading.
* Fix an "Undefined index: alliancer" warning.
