### PR TITLE
RightPanel.inc: add tooltips to cargo

### DIFF
--- a/templates/Default/engine/Default/includes/RightPanel.inc
+++ b/templates/Default/engine/Default/includes/RightPanel.inc
@@ -114,7 +114,7 @@ if(isset($GameID)) { ?>
 	if($ThisShip->hasCargo()) {
 		foreach($ThisShip->getCargo() as $GoodID => $GoodAmount) {
 			$Good =& Globals::getGood($GoodID); ?>
-			<img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" alt="<?php echo $Good['Name']; ?>"> : <?php echo $GoodAmount; ?><br /><?php
+			<img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name']; ?>" alt="<?php echo $Good['Name']; ?>"> : <?php echo $GoodAmount; ?><br /><?php
 		}
 	} ?>
 	Empty : <?php echo $ThisShip->getEmptyHolds(); ?><br /><br />


### PR DESCRIPTION
The cargo holds section no longer gives a textual indication of
the goods in the holds, only the graphical representation.

Add a tooltip to the image in case anyone (for some reason) is
not familiar with what image corresponds with what good.