### PR TITLE
alliance_stat_processing.php: don't require description

### DIFF
--- a/engine/Default/alliance_stat_processing.php
+++ b/engine/Default/alliance_stat_processing.php
@@ -31,10 +31,6 @@ if (isset($password) && $password == '') {
 	create_error('You cannot set an empty password!');
 }
 
-if (isset($description) && $description == '') {
-	create_error('Please enter a description for your alliance.');
-}
-
 $alliance =& SmrAlliance::getAlliance($alliance_id, $player->getGameID());
 if (isset($password)) {
 	$alliance->setPassword($password);


### PR DESCRIPTION
Allow alliances to be created and edited without entering an
alliance description.

Two motivations:
* Proliferation of alliances with a description that is just "."
* Omitting a description sends you back to the current sector
  screen, and then you have to re-enter all the other information.