### PR TITLE
course_plot_result.php: forward to current sector

### DIFF
--- a/engine/Default/course_plot_result.php
+++ b/engine/Default/course_plot_result.php
@@ -31,28 +31,10 @@ if ($sector->isLinked($next_sector)) {
 		$player->setPlottedCourse($path);
 	}
 
-	//$PHP_OUTPUT.=create_echo_form($container);
 	if (!$player->isLandedOnPlanet()) {
-		$nextSector =& SmrSector::getSector($player->getGameID(),$path->getNextOnPath(),$player->getAccountID());
-	
-		$PHP_OUTPUT.='<table class="nobord" width="100%">
-			<tr>
-				<td class="top right">
-					<div class="buttonA">
-						<a class="buttonA" href="'.$nextSector->getCurrentSectorHREF().'">&nbsp; Follow Course ('.$path->getNextOnPath().') &nbsp;</a>
-					</div>
-				</td>
-			</tr>';
-		if($ship->hasScanner()) {
-			$PHP_OUTPUT.='<tr>
-				<td class="top right">
-					<div class="buttonA">
-						<a class="buttonA" href="'.$nextSector->getScanSectorHREF().'">&nbsp; Scan Course ('.$path->getNextOnPath().') &nbsp;</a>
-					</div>
-				</td>
-			</tr>';
-		}
-		$PHP_OUTPUT.='</table>';
+		// If the course can immediately be followed, display it on the current sector page
+		$container = create_container('skeleton.php', 'current_sector.php');
+		forward($container);
 	}
 }
 

--- a/templates/Default/engine/Default/includes/PlottedCourse.inc
+++ b/templates/Default/engine/Default/includes/PlottedCourse.inc
@@ -4,25 +4,23 @@ if($ThisPlayer->hasPlottedCourse()) {
 	$NextSector =& SmrSector::getSector($ThisPlayer->getGameID(),$PlottedCourse->getNextOnPath(),$ThisPlayer->getAccountID()); ?>
 	<table class="nobord fullwidth">
 		<tr>
-			<td<?php if($ThisShip->hasScanner()){ ?> rowspan="2"<?php }?>><?php echo implode(' - ',$PlottedCourse->getPath()); ?><br />
+			<td class="top left">
+				<h2>Plotted Course</h2><br />
+				<?php echo implode(' - ',$PlottedCourse->getPath()); ?><br />
 				(<?php echo $PlottedCourse->getTotalSectors() ?> sectors, <?php echo $PlottedCourse->getTurns(); ?> turns)
 			</td>
 			<td class="top right">
 				<div class="buttonA">
 					<a class="buttonA" href="<?php echo $NextSector->getCurrentSectorHREF(); ?>">&nbsp; Follow Course (<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
-				</div>
-			</td>
-		</tr>
-		<?php
-		if($ThisShip->hasScanner()) { ?>
-			<tr>
-				<td class="top right">
+				</div><?php
+				if($ThisShip->hasScanner()) { ?>
+					<br /><br />
 					<div class="buttonA">
 						<a class="buttonA" href="<?php echo $NextSector->getScanSectorHREF(); ?>">&nbsp; Scan Course (<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
-					</div>
-				</td>
-			</tr><?php
-		} ?>
+					</div><?php
+				} ?>
+			</td>
+		</tr>
 	</table><?php
 }
 ?>


### PR DESCRIPTION
If the start sector is not the current sector or if you are on
a planet, then the existing "Plot A Course" results page is
displayed.

Otherwise, you can immediately navigate the plotted course, so go
directly to the current sector page (which includes the plotted
course summary and action buttons) instead of displaying the
intermediate results page.

Add a "Plotted Course Results" heading to the course results
minipage on the current sector page. This will help identify
the course results to anyone who may never have seen the
intermediate course results page before.

This change helps to streamline the flow of the game.