### PR TITLE
bar_buy_drink_processing.php: fix PHP warning

### DIFF
--- a/engine/Default/bar_buy_drink_processing.php
+++ b/engine/Default/bar_buy_drink_processing.php
@@ -80,7 +80,7 @@ $player->actionTaken('BuyDrink', array(
 ));
 
 //see if the player blacksout or not
-if ($num_drinks > 15) {
+if (isset($num_drinks) && $num_drinks > 15) {
 	$percent = mt_rand(1,25);
 	$lostCredits = round($player->getCredits() * $percent / 100);
 


### PR DESCRIPTION
The `$num_drinks` variable is only defined when we have purchased
a drink. So check for its existence before using it.