### PR TITLE
Fix changelog

### DIFF
--- a/admin/Default/changelog.php
+++ b/admin/Default/changelog.php
@@ -9,6 +9,11 @@ $link_set_live = true;
 $db->query('SELECT *
 			FROM version
 			ORDER BY version_id DESC');
+
+if ($db->getNumRows() == 0) {
+	$PHP_OUTPUT.=('Must add an initial version in the database first!');
+}
+
 while ($db->nextRecord()) {
 	$version_id = $db->getInt('version_id');
 	$version = $db->getInt('major_version') . '.' . $db->getInt('minor_version') . '.' . $db->getInt('patch_level');

--- a/engine/Default/changelog_view.php
+++ b/engine/Default/changelog_view.php
@@ -38,9 +38,10 @@ while ($db->nextRecord()) {
 	}
 
 	$PHP_OUTPUT.=('</ul><br />');
-	if(isset($var['Since'])) {
-		$PHP_OUTPUT.=create_button(create_container('logged_in.php'), 'Continue');
-	}
+}
+
+if(isset($var['Since'])) {
+	$PHP_OUTPUT.=create_button(create_container('logged_in.php'), 'Continue');
 }
 
 ?>


### PR DESCRIPTION
changelog.php: fix if version table is empty

If the `version` table is empty, then this page doesn't append to
`$PHP_OUTPUT` and therefore gives a blank page (with a PHP warning).

In this case, we simply add a line saying that an admin must
add an initial version to the database first.

--------------------

changelog_view.php: only create one continue button

If there are multiple versions since last login, then a "Continue"
button will show up for each version, which is unnecessary and
also messes up the formatting.

Move the "Continue" button out of the while loop to fix this.
