### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Files to ignore when building Docker image
+
+# Git data directory
+.git
+
+# Committed files that are not needed in the build
+docker-compose.yml
+README.md
+
+# Configuration files will be bind-mounted
+config
+
+# Products from composer install
+vendor
+composer.lock


### PR DESCRIPTION
Ignoring files that are not needed in the build has three main
advantages:

1. It reduces the size of the build.
2. It allows the build cache to be used if only the ignored
   files change.
3. Ensures that builds in development environments aren't
   contaminated by uncommitted files that may be present.