### PR TITLE
alliance_leave_processing.php: fix disbanding

### DIFF
--- a/engine/Default/alliance_leave_processing.php
+++ b/engine/Default/alliance_leave_processing.php
@@ -2,27 +2,33 @@
 $action = $var['action'];
 if ($action == 'YES') {
 	$alliance =& $player->getAlliance();
-	// will this alliance be empty if we leave? (means one member right now)
+
 	if ($player->isAllianceLeader() && $alliance->getNumMembers() > 1) {
 		create_error('You are the leader! You must hand over leadership first!');
 	}
+
+	// will this alliance be empty if we leave? (means one member right now)
+	if ($alliance->getNumMembers() == 1) {
+		// Retain the alliance, but delete some auxilliary info
+		$db->query('DELETE FROM alliance_bank_transactions
+		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
+		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$db->query('DELETE FROM alliance_thread
+		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
+		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$db->query('DELETE FROM alliance_thread_topic
+		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
+		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$db->query('DELETE FROM alliance_has_roles
+		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
+		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$db->query('UPDATE alliance SET leader_id = 0, discord_channel = NULL
+		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
+		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	}
+
+	// now leave the alliance
 	$player->leaveAlliance();
-	//$db->query('DELETE FROM alliance WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db->query('DELETE FROM alliance_bank_transactions
-				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-				AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db->query('DELETE FROM alliance_thread
-				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-				AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db->query('DELETE FROM alliance_thread_topic
-				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-				AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db->query('DELETE FROM alliance_has_roles
-				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-				AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db->query('UPDATE alliance SET leader_id = 0
-				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-				AND game_id = ' . $db->escapeNumber($player->getGameID()));
 
 }
 


### PR DESCRIPTION
Previously, the player was removed from the alliance, and then
it used the alliance ID of that player to clean up the disbanded
alliance. But since the player was now in alliance 0, nothing
happened.

This fixes disbanding an alliance so that the appropriate db
entries are deleted.