### PR TITLE
Add chat sharing

### DIFF
--- a/db/patches/V1_6_61_09__account_shares_info.sql
+++ b/db/patches/V1_6_61_09__account_shares_info.sql
@@ -1,0 +1,7 @@
+-- Allow sharing info between accounts in chat
+CREATE TABLE IF NOT EXISTS `account_shares_info` (
+  `from_account_id` int(10) unsigned NOT NULL,
+  `to_account_id` int(10) unsigned NOT NULL,
+  `game_id` int(10) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (from_account_id, to_account_id, game_id)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/engine/Default/chat_sharing.php
+++ b/engine/Default/chat_sharing.php
@@ -1,0 +1,55 @@
+<?php
+$template->assign('PageTopic', 'Chat Sharing Settings');
+
+if (isset($var['message'])) {
+	$template->assign('Message', $var['message']);
+}
+
+$shareFrom = array();
+$db->query('SELECT * FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($player->getGameID()) . ')');
+while ($db->nextRecord()) {
+	$fromAccountId = $db->getInt('from_account_id');
+	$gameId = $db->getInt('game_id');
+	try {
+		$otherPlayer = SmrPlayer::getPlayer($fromAccountId, $player->getGameID());
+	} catch (PlayerNotFoundException $e) {
+		// Player has not joined this game yet
+		$otherPlayer = null;
+	}
+	$shareFrom[$fromAccountId] = array(
+		'Player ID'   => $otherPlayer == null ? '-' : $otherPlayer->getPlayerID(),
+		'Player Name' => $otherPlayer == null ?
+		                 '<b>Account</b>: ' . SmrAccount::getAccount($fromAccountId)->getHofName() :
+		                 $otherPlayer->getPlayerName(),
+		'All Games'   => $gameId == 0 ? '<span class="green">YES</span>' : '<span class="red">NO</span>',
+		'Game ID'     => $gameId,
+	);
+}
+
+$shareTo = array();
+$db->query('SELECT * FROM account_shares_info WHERE from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($player->getGameID()) . ')');
+while ($db->nextRecord()) {
+	$gameId = $db->getInt('game_id');
+	$toAccountId = $db->getInt('to_account_id');
+	try {
+		$otherPlayer = SmrPlayer::getPlayer($toAccountId, $player->getGameID());
+	} catch (PlayerNotFoundException $e) {
+		// Player has not joined this game yet
+		$otherPlayer = null;
+	}
+	$shareTo[$toAccountId] = array(
+		'Player ID'   => $otherPlayer == null ? '-' : $otherPlayer->getPlayerID(),
+		'Player Name' => $otherPlayer == null ?
+		                 '<b>Account</b>: ' . SmrAccount::getAccount($toAccountId)->getHofName() :
+		                 $otherPlayer->getPlayerName(),
+		'All Games'   => $gameId == 0 ? '<span class="green">YES</span>' : '<span class="red">NO</span>',
+		'Game ID'     => $gameId,
+	);
+}
+
+$template->assign('ShareFrom', $shareFrom);
+$template->assign('ShareTo', $shareTo);
+
+$template->assign('ProcessingHREF', SmrSession::getNewHREF(create_container('chat_sharing_processing.php', '', array('share_to_ids' => array_keys($shareTo)))));
+
+?>

--- a/engine/Default/chat_sharing_processing.php
+++ b/engine/Default/chat_sharing_processing.php
@@ -1,0 +1,44 @@
+<?php
+
+function error_on_page($message) {
+	$message = '<span class="bold red">ERROR:</span> ' . $message;
+	forward(create_container('skeleton.php', 'chat_sharing.php', array('message' => $message)));
+}
+
+// Process adding a "share to" account
+if (isset($_POST['add'])) {
+	if (empty($_POST['add_player_id'])) {
+		error_on_page('You must specify a Player ID to share with!');
+	}
+
+	if ($_POST['add_player_id'] == $player->getPlayerID()) {
+		error_on_page('You do not need to share with yourself!');
+	}
+
+	try {
+		$accountId = SmrPlayer::getPlayerByPlayerID($_POST['add_player_id'], $player->getGameID())->getAccountID();
+	} catch (PlayerNotFoundException $e) {
+		error_on_page($e->getMessage());
+	}
+
+	if (in_array($accountId, $var['share_to_ids'])) {
+		error_on_page('You are already sharing with this player!');
+	}
+
+	$gameId = (isset($_POST['all_games'])) ? '0' : $player->getGameID();
+	$db->query('INSERT INTO account_shares_info (to_account_id, from_account_id, game_id) VALUES ('. $db->escapeNumber($accountId) .','. $db->escapeNumber($player->getAccountID()) .','. $db->escapeNumber($gameId) .')');
+}
+
+// Process removing a "share to" account
+if (isset($_POST['remove_share_to'])) {
+	$db->query('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($_POST['remove_share_to']) . ' AND from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($_POST['game_id']));
+}
+
+// Process removing a "share from" account
+if (isset($_POST['remove_share_from'])) {
+	$db->query('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND from_account_id=' . $db->escapeNumber($_POST['remove_share_from']) . ' AND game_id=' . $db->escapeNumber($_POST['game_id']));
+}
+
+forward(create_container('skeleton.php', 'chat_sharing.php'));
+
+?>

--- a/engine/Default/preferences.php
+++ b/engine/Default/preferences.php
@@ -8,6 +8,8 @@ $template->assign('PreferencesFormHREF', SmrSession::getNewHREF(create_container
 
 $template->assign('PreferencesConfirmFormHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'preferences_confirm.php')));
 
+$template->assign('ChatSharingHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'chat_sharing.php')));
+
 $transferAccounts = array();
 //if(SmrSession::$game_id>0) {
 //	$db->query('SELECT account_id,player_name,player_id FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY player_name');

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1,4 +1,8 @@
 <?php
+
+// Exception thrown when a player cannot be found in the database
+class PlayerNotFoundException extends Exception {}
+
 require_once(get_file_loc('AbstractSmrPlayer.class.inc'));
 require_once(get_file_loc('council.inc'));
 class SmrPlayer extends AbstractSmrPlayer {
@@ -144,7 +148,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$db->query('SELECT account_id FROM player WHERE game_id = '.$db->escapeNumber($gameID).' AND player_id = '.$db->escapeNumber($playerID).' LIMIT 1');
 		if($db->nextRecord())
 			return self::getPlayer($db->getInt('account_id'),$gameID,$forceUpdate);
-		throw new Exception('Player ID not found.');
+		throw new PlayerNotFoundException('Player ID not found.');
 	}
 
 	protected function __construct($gameID,&$accountIDOrResultArray) {
@@ -211,7 +215,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$this->SQL = 'account_id = ' . $this->db->escapeNumber($this->accountID) . ' AND game_id = ' . $this->db->escapeNumber($this->gameID);
 		}
 		else {
-			throw new Exception('Invalid accountID: '.$accountIDOrResultArray . ' OR gameID:'.$gameID);
+			throw new PlayerNotFoundException('Invalid accountID: '.$accountIDOrResultArray . ' OR gameID:'.$gameID);
 		}
 
 

--- a/templates/Default/engine/Default/chat_sharing.php
+++ b/templates/Default/engine/Default/chat_sharing.php
@@ -1,0 +1,70 @@
+<?php
+if (!empty($Message)) { ?>
+	<?php echo $Message; ?><?php
+} ?>
+
+<p>Chat sharing is a way to allow other players to use a query command
+in chat to display information about your trader (example: displaying
+your current turns). However, sharing will only take place if the player
+is in your alliance.</p>
+
+<p>Here you can do the following:</p>
+<ul>
+	<li>Add or remove sharing your information with others</li>
+	<li>Remove information shared by other players</li>
+	<li>Decide if you want to share for all games or just the current game</li>
+</ul>
+
+<p><h2>Players you're sharing with:</h2></p>
+<table class="standard">
+	<tr class="center">
+		<th>Player ID</th>
+		<th>Player Name</th>
+		<th>All Games</th>
+		<th>Action</th>
+	</tr><?php
+	foreach ($ShareTo as $accountId => $share) { ?>
+		<tr class="center">
+			<td><?php echo $share['Player ID']; ?></td>
+			<td><?php echo $share['Player Name']; ?></td>
+			<td><?php echo $share['All Games']; ?></td>
+			<form method="POST" action="<?php echo $ProcessingHREF; ?>">
+				<input type="hidden" name="game_id" value="<?php echo $share['Game ID']; ?>" />
+				<td><button type="submit" name="remove_share_to" value="<?php echo $accountId ?>" id="InputFields" style="width:65px">Remove</button></td>
+			</form>
+		</tr><?php
+	} ?>
+	<tr>
+		<form method="POST" action="<?php echo $ProcessingHREF; ?>">
+			<td><input class="center" type="number" name="add_player_id" id="InputFields" style="width:60px" /></td>
+			<td>&nbsp;</td>
+			<td class="center"><input type="checkbox" name="all_games"/></td>
+			<td><button type="submit" name="add" id="InputFields" style="width:65px">Add</button></td>
+		<form>
+	</tr>
+</table>
+
+<p><h2>Players sharing with you:</h2></p><?php
+if ($ShareFrom) { ?>
+	<table class="standard">
+		<tr class="center">
+			<th>Player ID</th>
+			<th>Player Name</th>
+			<th>All Games</th>
+			<th>Action</th>
+		</tr><?php
+		foreach ($ShareFrom as $accountId => $share) { ?>
+			<tr class="center">
+				<td><?php echo $share['Player ID']; ?></td>
+				<td><?php echo $share['Player Name']; ?></td>
+				<td><?php echo $share['All Games']; ?></td>
+				<form method="POST" action="<?php echo $ProcessingHREF; ?>">
+					<input type="hidden" name="game_id" value="<?php echo $share['Game ID']; ?>" />
+					<td><button type="submit" name="remove_share_from" value="<?php echo $accountId ?>" id="InputFields" style="width:65px">Remove</button></td>
+				</form>
+			</tr><?php
+		} ?>
+	</table><?php
+} else { ?>
+	<p>None</p><?php
+} ?>

--- a/templates/Default/engine/Default/preferences.php
+++ b/templates/Default/engine/Default/preferences.php
@@ -211,6 +211,19 @@ if(isset($GameID)) { ?>
 		</tr>
 
 		<tr>
+			<td>Chat Sharing:</td>
+			<td><div class="buttonA"><a href="<?php echo $ChatSharingHREF; ?>" class="buttonA">&nbsp;Manage Chat Sharing Settings&nbsp;</a></div></td>
+		</tr>
+		<tr>
+			<td>&nbsp;</td>
+			<td>These settings specify who you share your game information with in supported chat services.</td>
+		<tr>
+
+		<tr>
+			<td colspan="2">&nbsp;</td>
+		</tr>
+
+		<tr>
 			<td>Discord User ID:</td>
 			<td><input type="text" name="discord_id" value="<?php echo htmlspecialchars($ThisAccount->getDiscordId()); ?>" id="InputFields" size=50 /></td>
 		</tr>


### PR DESCRIPTION
Provides a new database table `account_shares_info` and an interface
to manage this table.

This will be used to allow users in chat to display information
about more than just the account associated with their Discord ID
(or IRC Nick). It is generic, but the primary motivation is to
allow players to display their main and multi.

![image](https://user-images.githubusercontent.com/846186/33627309-f9f8c1ea-d9b1-11e7-87a7-42a4221afcea.png)

![image](https://user-images.githubusercontent.com/846186/33627432-5b180abc-d9b2-11e7-92e5-ff4900d112ea.png)
