### PR TITLE
Login cleanup

### DIFF
--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -102,19 +102,20 @@
 				<img src="images/login/smr_banner_16.png" width="769" height="132" alt=""><br />
 				<img src="images/login/bottom_left.gif" width="7" height="11" alt="">
 
-                <!-- small header menu -->
-                <a href="<?php echo URL ?>"><img src="images/login/home.png" width="55" height="11" alt="Home"></a>
-                <img src="images/login/site_map.png" width="87" height="11" alt="Site Map">
-                <img src="images/login/contact.png" width="80" height="11" alt="Contact">
+				<!-- small header menu -->
+				<a href="<?php echo URL ?>"><img src="images/login/home.png" width="55" height="11" alt="Home"></a>
+				<img src="images/login/site_map.png" width="87" height="11" alt="Site Map">
+				<a href="mailto:support@smrealms.de" target="_blank"><img src="images/login/contact.png" width="80" height="11" alt="Contact"></a>
 
-                <img src="images/login/bottom_right.png" width="540" height="11" alt=""><br />
+				<img src="images/login/bottom_right.png" width="540" height="11" alt=""><br />
 
-                <!-- header menu -->
-                <a href="http://video.smrealms.de/" target="vid"><img src="images/login/video.png" width="166" height="29" alt="Video Tutorials"></a>
-                <a href="<?php echo WIKI_URL; ?>" target="ml"><img src="images/login/sml.png" width="166" height="29" alt="Merchant Library"></a>
-                <a href="<?php echo WIKI_URL; ?>" target="manu"><img src="images/login/manual2.png" width="129" height="29" alt="Wiki"></a>
-                <a href="http://smrcnn.smrealms.de" target="board"><img src="images/login/webboard2.png" width="128" height="29" alt="Web Board"></a>
-                <a href="<?php echo URL; ?>/cgi-bin/awstats.pl" target="stat"><img src="images/login/stats2.png" width="180" height="29" alt="Site Statistics"></a><br />
+				<!-- header menu -->
+				<a href="<?php echo WIKI_URL; ?>/tutorials#video-tutorials" target="vid"><img src="images/login/video.png" width="166" height="29" alt="Video Tutorials"></a>
+				<a href="<?php echo WIKI_URL; ?>" target="ml"><img src="images/login/sml.png" width="166" height="29" alt="Merchant Library"></a>
+				<a href="<?php echo WIKI_URL; ?>" target="manu"><img src="images/login/manual2.png" width="129" height="29" alt="Wiki"></a>
+				<a href="http://smrcnn.smrealms.de" target="board"><img src="images/login/webboard2.png" width="128" height="29" alt="Web Board"></a>
+				<a href="<?php echo URL; ?>/cgi-bin/awstats.pl" target="stat"><img src="images/login/stats2.png" width="180" height="29" alt="Site Statistics"></a>
+				<br />
 			</p>
 			<?php
 

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -196,7 +196,7 @@
 					<td style="width:470px"><?php
 						if(isset($LoginNews)) { ?>
 							<table class="standard">
-							<tr><th>Date</th><th>News</th></tr><?php
+							<tr><th>Date</th><th>Announcements</th></tr><?php
 							foreach($LoginNews as $News) { ?>
 								<tr>
 									<td>
@@ -223,8 +223,7 @@
 					<td class="center" colspan="3">
 						Players Online Now: <?php echo $ActiveSessions; ?><br /><br /><?php
 						if(isset($GameNews)) { ?>
-							Recent News<br />
-							<table class="standard" style="width:100%"><tr><th class="center">Time</th><th class="center">News</th></tr><?php
+							<table class="standard" style="width:100%"><tr><th class="center">Time</th><th class="center">Recent News</th></tr><?php
 								foreach($GameNews as $News) { ?>
 									<tr>
 										<td><?php


### PR DESCRIPTION
login.inc: remove duplicate news headers

* Remove "Recent News" header just above game news and rename
  "News" in the table to "Recent News". No sense in having two
  here when one does the job.

* Rename "News" in admin announcements to "Announcements".

-------------------

login.inc: fix missing links

* Link to "Video Tutorials" on the wiki
* Add support@smrealms.de "Contact" link

Remaining issues:
* Duplicate link to wiki ("Merchant Library" and "Game Manual")
* No "Site Map" link
* Pointless "Home" link

---------------------

Supersedes and closes #161 