### PR TITLE
contact.php: fix page title

### DIFF
--- a/engine/Default/contact.php
+++ b/engine/Default/contact.php
@@ -1,6 +1,6 @@
 <?php
 
-$template->assign('PageTopic','Report a Bug');
+$template->assign('PageTopic','Contact Form');
 
 $PHP_OUTPUT.=('<span style="font-size:75%;">Please use this form to either send your feedback or<br />');
 $PHP_OUTPUT.=('questions to the admin team of Space Merchant Realms!</span>');


### PR DESCRIPTION
The contact form page shouldn't be titled "Report a Bug". This was
probably a copy-paste error from the bug report page.