### PR TITLE
login.inc: make standard tables look standard

### DIFF
--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -27,9 +27,15 @@
 		}
 		table.standard {
 			border:1px solid #0b8d35;
+			border-spacing: 0px;
 		}
-		.standard td,th{
+		.standard td {
 			border:1px solid #0b8d35;
+		}
+		.standard th {
+			border:1px solid #0b8d35;
+			background-color: #0A4E1D;
+			color: #80C870;
 		}
 		input.inputbox {
 			width:123px;


### PR DESCRIPTION
Apply CSS from the in-game defaults to the login page so that
the News and Announcements tables (using the `standard` class)
look like the tables in-game.

![image](https://user-images.githubusercontent.com/846186/33682823-a204c548-da7d-11e7-991b-1d422b264b80.png)
