### PR TITLE
Only insert into the debug table in debug mode

### DIFF
--- a/engine/Default/smr.inc
+++ b/engine/Default/smr.inc
@@ -559,7 +559,9 @@ function do_voodoo() {
 				//Refetch var info in case it changed between grabbing lock.
 				SmrSession::fetchVarInfo();
 				if (!($var = SmrSession::retrieveVar(SmrSession::$SN))) {
-					$db->query('INSERT INTO debug VALUES (\'SPAM\',' . $db->escapeNumber(SmrSession::$account_id) . ',0,0)');
+					if (ENABLE_DEBUG) {
+						$db->query('INSERT INTO debug VALUES (\'SPAM\',' . $db->escapeNumber(SmrSession::$account_id) . ',0,0)');
+					}
 					create_error('Please do not spam click!');
 				}
 			}

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -172,7 +172,9 @@ class SmrSession {
 			//	echo 'Sleeping for: ' . $sleepTime . 'us';
 				usleep($sleepTime);
 			}
-			self::$db->query('INSERT INTO debug VALUES (' . self::$db->escapeString('Delay: ' . $currentPage) . ',' . self::$db->escapeNumber(self::$account_id) . ',' . self::$db->escapeNumber($initialTimeBetweenLoads) . ',' . self::$db->escapeNumber($timeBetweenLoads) . ')');
+			if (ENABLE_DEBUG) {
+				self::$db->query('INSERT INTO debug VALUES (' . self::$db->escapeString('Delay: ' . $currentPage) . ',' . self::$db->escapeNumber(self::$account_id) . ',' . self::$db->escapeNumber($initialTimeBetweenLoads) . ',' . self::$db->escapeNumber($timeBetweenLoads) . ')');
+			}
 		}
 
 		define('MICRO_TIME', microtime());


### PR DESCRIPTION
The `debug` table has gotten extremely large on the live server
(roughly 1GB), which is the vast majority of the size of the
database.

I think it makes sense only to use this table in debugging
environments, so make insertion dependent on ENABLE_DEBUG
being set.