### PR TITLE
bank_alliance.php: make reason textarea shorter

### DIFF
--- a/templates/Default/engine/Default/bank_alliance.php
+++ b/templates/Default/engine/Default/bank_alliance.php
@@ -108,7 +108,7 @@ else {
 		</tr>
 		<tr>
 			<td class="top">Reason:&nbsp;</td>
-			<td><textarea spellcheck="true" name="message"></textarea></td>
+			<td><textarea spellcheck="true" name="message" style="height: 5em"></textarea></td>
 		</tr>
 	</table>
 	<br />


### PR DESCRIPTION
Change height of "reason" textarea from 15em to 5em. This is still
probably too large, but it's quite absurd right now considering that
not many people provide a reason at all.