### PR TITLE
Reorganize voting for free turns

### DIFF
--- a/db/patches/V1_6_61_10__vote_link_callback.sql
+++ b/db/patches/V1_6_61_10__vote_link_callback.sql
@@ -1,0 +1,2 @@
+-- Add turns_claimed column to vote_links table
+ALTER TABLE `vote_links` ADD COLUMN `turns_claimed` enum('TRUE','FALSE') NOT NULL;

--- a/engine/Default/smr.inc
+++ b/engine/Default/smr.inc
@@ -934,48 +934,65 @@ function doSkeletionAssigns(&$template,&$player,&$ship,&$sector,&$db,&$account) 
 
 		$template->assign('WeaponReorderLink',SmrSession::getNewHREF(create_container('skeleton.php', 'weapon_reorder.php')));
 
-		$nextVoteTime = array();
-		$db->query('SELECT link_id,timeout FROM vote_links WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY link_id LIMIT 3');
-		while($db->nextRecord()) {
-			$nextVoteTime[$db->getInt('link_id')] = TIME_BETWEEN_VOTING - (TIME - $db->getField('timeout'));
-		}
 	}
 
+	// ------- VOTING --------
 	$container = create_container('vote_link.php');
+	$voteSites = array();
 
-	$voteLinks = array();
-	$voteLinks[1] = array('default_img' => 'mpogd.png', 'star_img' => 'mpogd_vote.png', 'location' => 'http://www.mpogd.com/games/game.asp?ID=1145', 'name' => 'MPOGD');
-	//OMGN no longer do voting - the link actually just redirects to archive site.
-	///$voteLinks[2] = array('default_img' => 'omgn.png', 'star_img' => 'omgn_vote.png', 'location' => 'http://www.omgn.com/topgames/vote.php?Game_ID=30', 'name' => 'OMGN');
-	// as long as TWG uses this stupid captcha which is very hard to figure out we will not support this site
-	// nor will we give free turns for NOT voting
-	//$voteLinks[3] = array('default_img' => 'twg.png', 'star_img' => 'twg_vote.png', 'location' => 'http://www.topwebgames.com/in.asp?id=136', 'name' => 'TWG');
+	// MPOGD no longer exists
+	//$voteSites[1] = array('default_img' => 'mpogd.png', 'star_img' => 'mpogd_vote.png', 'base_url' => 'http://www.mpogd.com/games/game.asp?ID=1145');
 
-	$minVoteTime = 86400;
-	$voteSite = array();
-	for($i=1;$i<2;$i++) {
-		if(!isset($nextVoteTime[$i])) {
-			$nextVoteTime[$i] = 0;
-		}
-		$minVoteTime = min($minVoteTime,$nextVoteTime[$i]);
-		$voteSite[$i] = '<a href=';
-		if(SmrSession::$game_id != 0 && $nextVoteTime[$i] <= 0) {
-			$container['link_id'] = $i;
-			$voteSite[$i] .= '\'javascript:voteSite("' . $voteLinks[$i]['location'] . '",';
-			$voteSite[$i] .= '"' . SmrSession::getNewHREF($container,true) . '")\'';
-			$img = $voteLinks[$i]['star_img'];
-		}
-		else {
-			$voteSite[$i] .= '"' . $voteLinks[$i]['location'] . '" target="_blank"';
-			$img = $voteLinks[$i]['default_img'];
-		}
+	// OMGN no longer do voting - the link actually just redirects to archive site.
+	//$voteSites[2] = array('default_img' => 'omgn.png', 'star_img' => 'omgn_vote.png', 'base_url' => 'http://www.omgn.com/topgames/vote.php?Game_ID=30');
 
-		$voteSite[$i] .= '><img class="vote_site" src="'.URL.'/images/game_sites/' . $img . '" alt="' . $voteLinks[$i]['name'] . '" width="98" height="41"></a>';
+	$voteSites[3] = array('default_img' => 'twg.png',
+	                      'star_img' => 'twg_vote.png',
+	                      'base_url' => 'http://topwebgames.com/in.aspx?ID=136&alwaysreward=1');
+
+	// Determine the time left until the account can vote again at each site
+	// We ignore rows with links that are no longer active
+	// (note: try not to change the $voteSites keys)
+	$voteWait = array();
+	$activeLinks = array_keys($voteSites);
+	$db->query('SELECT link_id, timeout FROM vote_links WHERE account_id=' . $db->escapeNumber(SmrSession::$account_id) . ' AND link_id IN (' . join(',', $activeLinks) . ') LIMIT ' . $db->escapeNumber(count($activeLinks)));
+	while($db->nextRecord()) {
+		// 'timeout' is the last time the player clicked this vote site link
+		$voteWait[$db->getInt('link_id')] = ($db->getField('timeout') + TIME_BETWEEN_VOTING) - TIME;
 	}
-	$template->assign('VoteSites',$voteSite);
-	$template->assign('TimeToNextVote',$minVoteTime);
 
+	$modVoteSites = array();
+	foreach ($voteSites as $linkId => $voteSite) {
+		// If not in the vote_link database, we can vote for turns at this site now
+		if (!isset($voteWait[$linkId])) {
+			$voteWait[$linkId] = 0;
+		}
 
+		// update attributes if we can vote for free turns here
+		if (SmrSession::$game_id != 0 && $voteWait[$linkId] <= 0) {
+			$container['link_id'] = $linkId;
+			$container['can_get_turns'] = true;
+			$internalUrl = SmrSession::getNewHREF($container, true);
+			$query = array('account' => $player->getAccountID(), 'game' => $player->getGameID(), 'link' => $linkId);
+			$externalUrl = $voteSite['base_url'] . '&' . http_build_query($query);
+			$modVoteSites[] = array('url' => 'javascript:voteSite("' . $externalUrl . '","' . $internalUrl . '")',
+			                        'img' => $voteSite['star_img']);
+		} else {
+			$modVoteSites[] = array('url' => $voteSite['base_url'],
+			                        'img' => $voteSite['default_img']);
+		}
+	}
+	$template->assign('VoteSites', $modVoteSites);
+
+	// Determine the minimum time until the next vote across all sites
+	$minVoteWait = min($voteWait);
+	if ($minVoteWait <= 0) {
+		$template->assign('TimeToNextVote', 'now');
+	} else {
+		$template->assign('TimeToNextVote', 'in ' . format_time($minVoteWait, true));
+	}
+
+	// ------- VERSION --------
 	$db->query('SELECT * FROM version ORDER BY went_live DESC LIMIT 1');
 	$version = '';
 	if ($db->nextRecord()) {

--- a/htdocs/vote_link_callback.php
+++ b/htdocs/vote_link_callback.php
@@ -1,0 +1,27 @@
+<?php
+// Callback script for player voting on external sites
+
+if (!isset($_POST['account']) || !isset($_POST['game']) || !isset($_POST['link'])) {
+	exit;
+}
+
+require_once('config.inc');
+require_once(ENGINE . 'Default/smr.inc');
+
+// Is the player allowed to get free turns from this link right now?
+// If player clicked a valid free turns link, they have `can_get_turns=true`
+$db = new SmrMySqlDatabase();
+$db->query('SELECT timeout FROM vote_links WHERE account_id=' . $db->escapeNumber($_POST['account']) . ' AND link_id=' . $db->escapeNumber($_POST['link']) . ' AND turns_claimed=' . $db->escapeBoolean(false) . ' LIMIT 1');
+
+if ($db->nextRecord()) {
+	// Eligibility was checked when `turns_claimed` was set to false.
+	// So give free turns now!
+	$player = SmrPlayer::getPlayer($_POST['account'], $_POST['game']);
+	$player->setLastTurnUpdate($player->getLastTurnUpdate()-VOTE_BONUS_TURNS_TIME); //Give turns via added time, no rounding errors.
+	$player->save();
+
+	// Prevent getting additional turns until a valid free turns link is clicked again
+	$db->query('UPDATE vote_links SET turns_claimed=' . $db->escapeBoolean(true) . ' WHERE account_id=' . $db->escapeNumber($_POST['account']) . ' AND link_id=' . $db->escapeNumber($_POST['link']));
+}
+
+?>

--- a/templates/Default/engine/Default/skeleton.php
+++ b/templates/Default/engine/Default/skeleton.php
@@ -43,9 +43,11 @@
 			</tr>
 			<tr>
 				<td class="footer_left">
-					<div style="width:294px;" class="center">Get <b><u>FREE TURNS</u></b> for voting if you see the star, next available <span id="v"><?php if($TimeToNextVote <= 0){ ?>now<?php }else{ ?>in <?php echo format_time($TimeToNextVote,true); } ?></span>.</div><?php
-						foreach($VoteSites as $VoteSite) {
-							echo $VoteSite;
+					<div>Get <b><u>FREE TURNS</u></b> for voting if you see the star, available <span id="v"><?php echo $TimeToNextVote ?></span>.</div><?php
+						foreach ($VoteSites as $VoteSite) { ?>
+							<a href='<? echo $VoteSite['url']; ?>' target="_blank">
+								<img class="vote_site" src="images/game_sites/<?php echo $VoteSite['img']; ?>" alt="" width="98" height="41" />
+							</a><?php
 						} ?>
 				</td>
 				<td class="footer_right">


### PR DESCRIPTION
Changes to voting sites:

* Remove MPOGD, because it no longer exists.

* Re-add TWD, which seems to be up and running just fine.
  I have updated the info for SMR on this site.

Change to code organization:

* Fix a bug where when you weren't in a game, it would always
  display that free turns were available. Now it gives you the
  correct time when not in a game, but still doesn't give you
  the free turns link (since it wouldn't have a game to attribute
  them to).

* Implement a callback for the TWD voting. Free turns are no
  longer awarded automatically. Instead, TWD is set up to callback
  to `vote_link_callback.php` when the player actually votes, and
  turns are awarded there.

  The callback is implemented by passing the game and account ID
  to the vote link in the query string, and TWD will return this
  to us in a POST. Because TWD's vote counting rules are somewhat
  arbitrary, we also pass "alwaysreward" so that free turns are
  consistently awarded for voting.

This patch requires database migration.

-----------------------

Depends on PR #198 to avoid a rebase conflict.