### PR TITLE
Add functionality to manage and respond to ops in-game

### DIFF
--- a/engine/Default/alliance_mod.php
+++ b/engine/Default/alliance_mod.php
@@ -13,6 +13,36 @@ create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 
 $PHP_OUTPUT.= '<div align="center">';
 
+// Check to see if an alliance op is scheduled
+// Display it for 1 hour past start time (late arrivals, etc.)
+$db->query('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND time > ' . $db->escapeNumber(TIME - 3600) . ' LIMIT 1');
+if ($db->nextRecord()) {
+	$time = $db->getInt('time');
+	$opDate = date(DATE_FULL_SHORT, $time);
+	$opCountdown = format_time($time - TIME);
+
+	// Has player responded yet?
+	$db2 = new SmrMySqlDatabase();
+	$db2->query('SELECT response FROM alliance_has_op_response WHERE alliance_id=' . $db2->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db2->escapeNumber($player->getGameID()) . ' AND account_id=' . $db2->escapeNumber($player->getAccountID()) . ' LIMIT 1');
+
+	$response = $db2->nextRecord() ? $db2->getField('response') : null;
+	$responseHREF = SmrSession::getNewHREF(create_container('alliance_op_response_processing.php'));
+
+	$PHP_OUTPUT .= '<table class="center nobord opResponse">';
+	$PHP_OUTPUT .= '<tr><th>ENCRYPTED ALLIANCE TELEGRAM</th></tr>';
+	$PHP_OUTPUT .= '<tr><td>Your leader has scheduled an important alliance operation for ' . $opDate . '</td></tr>';
+	$PHP_OUTPUT .= '<tr><td><span id="countdown">' . $opCountdown . '</span></td></tr>';
+	$PHP_OUTPUT .= '<tr><td><b>Will you join the operation?</b></td></tr>';
+	$PHP_OUTPUT .= '<tr><td><form method="POST" action="' . $responseHREF . '">';
+	$responseInputs = array();
+	foreach (array('Yes', 'No', 'Maybe') as $option) {
+		$style = strtoupper($option) == $response ? 'style="background: green"' : '';
+		$responseInputs[] = '<input type="submit" name="op_response" ' . $style . ' value="' . $option . '" />';
+	}
+	$PHP_OUTPUT .= join('&nbsp;', $responseInputs);
+	$PHP_OUTPUT .= '</td></tr></table><br />';
+}
+
 if ($alliance->hasImageURL()) {
 	$PHP_OUTPUT.= '<img class="alliance" src="' . $alliance->getImageURL() . '" alt="' . htmlspecialchars($alliance->getAllianceName()) . ' Banner"><br /><br />';
 }

--- a/engine/Default/alliance_op_response_processing.php
+++ b/engine/Default/alliance_op_response_processing.php
@@ -1,0 +1,13 @@
+<?php
+
+if (!isset($_POST['op_response'])) {
+	create_error('No op response specified!');
+}
+
+$response = strtoupper($_POST['op_response']);
+
+$db->query('REPLACE INTO alliance_has_op_response (alliance_id, game_id, account_id, response) VALUES (' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($response) . ')');
+
+forward(create_container('skeleton.php', 'alliance_mod.php'));
+
+?>

--- a/engine/Default/alliance_option.php
+++ b/engine/Default/alliance_option.php
@@ -8,16 +8,20 @@ $template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->g
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 
-$container=create_container('skeleton.php', 'alliance_leave_confirm.php');
-$PHP_OUTPUT.= '<b><big>';
-$PHP_OUTPUT.=create_link($container,'Leave Alliance');
-$PHP_OUTPUT.= '</big></b>';
+// Create an array of links with descriptions
+$links = array();
 
-$PHP_OUTPUT.= '<br />Leave the alliance. Alliance leaders must hand over leadership before leaving.<br /><br /><b><big>';
-$container=create_container('alliance_share_maps_processing.php');
-$PHP_OUTPUT.=create_link($container,'Share Maps');
-$PHP_OUTPUT.= '</big></b>';
-$PHP_OUTPUT.= '<br />Share your knowledge of the universe with your alliance mates.';
+$container = create_container('skeleton.php', 'alliance_leave_confirm.php');
+$links[] = array(
+	'link' => create_link($container, 'Leave Alliance'),
+	'text' => 'Leave the alliance. Alliance leaders must hand over leadership before leaving.',
+);
+
+$container = create_container('alliance_share_maps_processing.php');
+$links[] = array(
+	'link' => create_link($container, 'Share Maps'),
+	'text' => 'Share your knowledge of the universe with your alliance mates.',
+);
 
 $role_id = $player->getAllianceRole($alliance->getAllianceID());
 
@@ -26,42 +30,49 @@ $db->nextRecord();
 
 $container['url'] = 'skeleton.php';
 $container['alliance_id'] = $alliance->getAllianceID();
+
 if ($db->getBoolean('remove_member')) {
-	$PHP_OUTPUT.= '<br /><br />';
-	$PHP_OUTPUT.='<b><big>';
 	$container['body'] = 'alliance_remove_member.php';
-	$PHP_OUTPUT.=create_link($container,'Remove Member');
-	$PHP_OUTPUT.= '</big></b>';
-	$PHP_OUTPUT.= '<br />Remove a trader from alliance roster.';
+	$links[] = array(
+		'link' => create_link($container, 'Remove Member'),
+		'text' => 'Remove a trader from alliance roster.',
+	);
 }
 if ($player->getAccountID() == $alliance->getLeaderID()) {
-	$PHP_OUTPUT.= '<br /><br /><b><big>';
 	$container['body'] = 'alliance_leadership.php';
-	$PHP_OUTPUT.=create_link($container,'Handover Leadership');
-	$PHP_OUTPUT.= '</big></b><br />Hand over leadership of the alliance to an alliance mate.';
+	$links[] = array(
+		'link' => create_link($container, 'Handover Leadership'),
+		'text' => 'Hand over leadership of the alliance to an alliance mate.',
+	);
 }
 if ($db->getBoolean('change_pass') || $db->getBoolean('change_mod')) {
-	$PHP_OUTPUT.= '<br /><br /><b><big>';
 	$container['body'] = 'alliance_stat.php';
-	$PHP_OUTPUT.=create_link($container,'Change Alliance Stats');
-	$PHP_OUTPUT.= '</big></b><br />Change the password, description or message of the day for the alliance.';
+	$links[] = array(
+		'link' => create_link($container, 'Change Alliance Stats'),
+		'text' => 'Change the password, description or message of the day for the alliance.',
+	);
 }
 if ($db->getBoolean('change_roles')) {
-	$PHP_OUTPUT.= '<br /><br /><b><big>';
 	$container['body'] = 'alliance_roles.php';
-	$PHP_OUTPUT.=create_link($container,'Define Alliance Roles');
-	$PHP_OUTPUT.= '</big></b><br />Each member in your alliance can fit into a specific role, a task. Here you can define the roles that you can assign to them.';
+	$links[] = array(
+		'link' => create_link($container, 'Define Alliance Roles'),
+		'text' => 'Each member in your alliance can fit into a specific role, a task. Here you can define the roles that you can assign to them.',
+	);
 }
 if ($db->getBoolean('exempt_with')) {
-	$PHP_OUTPUT.= '<br /><br /><b><big>';
 	$container['body'] = 'alliance_exempt_authorize.php';
-	$PHP_OUTPUT.=create_link($container,'Exempt Bank Transactions');
-	$PHP_OUTPUT.= '</big></b><br />Here you can set certain alliance account transactions as exempt. This makes them not count against, or for, the player making the transaction in the bank report.';
+	$links[] = array(
+		'link' => create_link($container, 'Exempt Bank Transactions'),
+		'text' => 'Here you can set certain alliance account transactions as exempt. This makes them not count against, or for, the player making the transaction in the bank report.',
+	);
 }
 if ($db->getBoolean('treaty_entry')) {
-	$PHP_OUTPUT.= '<br /><br /><b><big>';
 	$container['body'] = 'alliance_treaties.php';
-	$PHP_OUTPUT.=create_link($container,'Negotiate Treaties');
-	$PHP_OUTPUT.= '</big></b><br />Negotitate treaties with other alliances.';
+	$links[] = array(
+		'link' => create_link($container, 'Negotiate Treaties'),
+		'text' => 'Negotitate treaties with other alliances.',
+	);
 }
+
+$template->assign('Links', $links);
 ?>

--- a/engine/Default/alliance_option.php
+++ b/engine/Default/alliance_option.php
@@ -38,7 +38,7 @@ if ($db->getBoolean('remove_member')) {
 		'text' => 'Remove a trader from alliance roster.',
 	);
 }
-if ($player->getAccountID() == $alliance->getLeaderID()) {
+if ($player->isAllianceLeader()) {
 	$container['body'] = 'alliance_leadership.php';
 	$links[] = array(
 		'link' => create_link($container, 'Handover Leadership'),
@@ -71,6 +71,13 @@ if ($db->getBoolean('treaty_entry')) {
 	$links[] = array(
 		'link' => create_link($container, 'Negotiate Treaties'),
 		'text' => 'Negotitate treaties with other alliances.',
+	);
+}
+if ($player->isAllianceLeader()) {
+	$container['body'] = 'alliance_set_op.php';
+	$links[] = array(
+		'link' => create_link($container, 'Schedule Operation'),
+		'text' => 'Schedule and manage the next alliance operation.',
 	);
 }
 

--- a/engine/Default/alliance_set_op.php
+++ b/engine/Default/alliance_set_op.php
@@ -1,0 +1,30 @@
+<?php
+
+$alliance =& $player->getAlliance();
+$template->assign('PageTopic', $alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+require_once(get_file_loc('menu.inc'));
+create_alliance_menu($alliance->getAllianceID(), $alliance->getLeaderID());
+
+$container = create_container('alliance_set_op_processing.php');
+
+// Print any error messages that may have been created
+if (!empty($var['message'])) {
+	$template->assign('Message', $var['message']);
+}
+
+// get the op from db
+$db->query('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND  game_id=' . $db->escapeNumber($player->getGameID()));
+
+if ($db->nextRecord()) {
+	// An op is already scheduled, so get the time
+	$time = $db->getInt('time');
+	$template->assign('OpDate', date(DATE_FULL_SHORT, $time));
+	$template->assign('OpCountdown', format_time($time - TIME));
+
+	// Add a cancel button
+	$container['cancel'] = true;
+}
+
+$template->assign('OpProcessingHREF', SmrSession::getNewHREF($container));
+
+?>

--- a/engine/Default/alliance_set_op_processing.php
+++ b/engine/Default/alliance_set_op_processing.php
@@ -1,0 +1,30 @@
+<?php
+
+function error_on_page($error) {
+	$message = '<span class="bold red">ERROR:</span> ' . $error;
+	forward(create_container('skeleton.php', 'alliance_set_op.php', array('message' => $message)));
+}
+
+if (!empty($var['cancel'])) {
+	// just get rid of op
+	$db->query('DELETE FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
+	$db->query('DELETE FROM alliance_has_op_response WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
+}
+else {
+	// schedule an op
+	if (empty($_POST['date'])) {
+		error_on_page('You must specify a date for the operation!');
+	}
+
+	$time = strtotime($_POST['date']);
+	if ($time === false) {
+		error_on_page('The specified date is not in a valid format.');
+	}
+
+	// add op to db
+	$db->query('INSERT INTO alliance_has_op (alliance_id, game_id, time) VALUES (' . $db->escapeNumber($player->getAllianceID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($time) . ')');
+}
+
+forward(create_container('skeleton.php', 'alliance_set_op.php'));
+
+?>

--- a/htdocs/css/Default/Default.css
+++ b/htdocs/css/Default/Default.css
@@ -270,3 +270,14 @@ table.csForces th.header {
 .neutralBack, .neutralBack:hover {
 	background-color: #FFD800;
 }
+
+/* Op response table */
+table.opResponse {
+	border: 2px solid #BB0808;
+	background-color: #500;
+	border-spacing: 0px;
+}
+.opResponse th {
+	background-color: #BB0808;
+	color: #DEDE00;
+}

--- a/templates/Default/engine/Default/alliance_option.php
+++ b/templates/Default/engine/Default/alliance_option.php
@@ -1,0 +1,8 @@
+<?php
+foreach ($Links as $Link) { ?>
+	<b><big><?php echo $Link['link']; ?></big></b>
+	<br />
+	<?php echo $Link['text']; ?>
+	<br /><br /><?php
+}
+?>

--- a/templates/Default/engine/Default/alliance_set_op.php
+++ b/templates/Default/engine/Default/alliance_set_op.php
@@ -1,0 +1,28 @@
+<h2>Alliance Operation Schedule</h2>
+<?php
+if (!empty($Message)) {
+	echo "<p>$Message</p>";
+}
+if (!empty($OpDate)) { ?>
+	<p>The next alliance operation is scheduled for:</p>
+	<table class="nobord">
+		<tr>
+			<td><b>Date:</b></td>
+			<td><?php echo $OpDate; ?></td>
+		</tr>
+		<tr>
+			<td><b>Countdown:</b></td>
+			<td><span id="countdown"><?php echo $OpCountdown; ?></span></td>
+		</tr>
+	</table>
+	<br />
+	<div class="buttonA"><a class="buttonA" href="<?php echo $OpProcessingHREF; ?>">&nbsp;Cancel&nbsp;</a></div>
+	<?php
+} else { ?>
+	<p>Schedule the next alliance operation:<br><small>Enter the date in server time (example: Dec 12 18:30)</small></p>
+	<form method="POST" action="<?php echo $OpProcessingHREF; ?>">
+		<input type="text" name="date" />
+		<input type="submit" value="Confirm" />
+	</form><?
+}
+?>


### PR DESCRIPTION
* Allow alliance leaders to manage ops in-game in additon to chat.
* When an op is scheduled, a new block of text will be displayed on the alliance MOD page with an option to respond to the op.