### PR TITLE
Don't pass strings by reference for speed

### DIFF
--- a/engine/Default/smr.inc
+++ b/engine/Default/smr.inc
@@ -132,12 +132,12 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 	return htmlspecialchars($params['_tag']) . $tagContent . htmlspecialchars($params['_endtag']);
 }
 
-function &xmlify(&$str) {
+function xmlify($str) {
 	$xml = htmlspecialchars($str, ENT_XML1, 'utf-8');
 	return $xml;
 }
 
-function &bbifyMessage($message,$noLinks=false) {
+function bbifyMessage($message, $noLinks=false) {
 	static $bbParser;
 	if(!isset($bbParser)) {
 		require_once(LIB.'External/BBCode/nbbc.php');

--- a/lib/Default/Template.class.inc
+++ b/lib/Default/Template.class.inc
@@ -178,7 +178,7 @@ class Template {
 //		}
 //	}
 	
-	protected function checkDisableAJAX(&$html) {
+	protected function checkDisableAJAX($html) {
 		return preg_match('/<input'.'[^>]*'.'[^(submit)(hidden)(image)]'.'[^>]*'.'>/i', $html)!=0;
 	}
 	


### PR DESCRIPTION
Only pass them by reference if you need to modify them. Passing
a string by value does not create a copy of the string, rather
it increases the refcount of that string object.

![image](https://user-images.githubusercontent.com/846186/33810887-001b06b6-ddc0-11e7-807d-5edd5ca7e94b.png)
Ref: https://derickrethans.nl/talks/phparch-php-variables-article.pdf (among others)