### PR TITLE
Add button to cancel plotted course

### DIFF
--- a/engine/Default/course_plot_cancel_processing.php
+++ b/engine/Default/course_plot_cancel_processing.php
@@ -1,0 +1,7 @@
+<?php
+
+$player->deletePlottedCourse();
+
+forward(create_container('skeleton.php', 'current_sector.php'));
+
+?>

--- a/templates/Default/engine/Default/includes/PlottedCourse.inc
+++ b/templates/Default/engine/Default/includes/PlottedCourse.inc
@@ -11,12 +11,12 @@ if($ThisPlayer->hasPlottedCourse()) {
 			</td>
 			<td class="top right">
 				<div class="buttonA">
-					<a class="buttonA" href="<?php echo $NextSector->getCurrentSectorHREF(); ?>">&nbsp; Follow Course (<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
+					<a class="buttonA" href="<?php echo $NextSector->getCurrentSectorHREF(); ?>">&nbsp; Follow Course (#<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
 				</div><?php
 				if($ThisShip->hasScanner()) { ?>
 					<br /><br />
 					<div class="buttonA">
-						<a class="buttonA" href="<?php echo $NextSector->getScanSectorHREF(); ?>">&nbsp; Scan Course (<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
+						<a class="buttonA" href="<?php echo $NextSector->getScanSectorHREF(); ?>">&nbsp; Scan Course (#<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
 					</div><?php
 				} ?>
 			</td>

--- a/templates/Default/engine/Default/includes/PlottedCourse.inc
+++ b/templates/Default/engine/Default/includes/PlottedCourse.inc
@@ -1,5 +1,6 @@
 <?php
 if($ThisPlayer->hasPlottedCourse()) {
+	$CancelCourseHREF = SmrSession::getNewHREF(create_container('course_plot_cancel_processing.php'));
 	$PlottedCourse =& $ThisPlayer->getPlottedCourse();
 	$NextSector =& SmrSector::getSector($ThisPlayer->getGameID(),$PlottedCourse->getNextOnPath(),$ThisPlayer->getAccountID()); ?>
 	<table class="nobord fullwidth">
@@ -19,6 +20,10 @@ if($ThisPlayer->hasPlottedCourse()) {
 						<a class="buttonA" href="<?php echo $NextSector->getScanSectorHREF(); ?>">&nbsp; Scan Course (#<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
 					</div><?php
 				} ?>
+				<br /><br />
+				<div class="buttonA">
+					<a class="buttonA" href="<?php echo $CancelCourseHREF; ?>">&nbsp; Cancel Course &nbsp;</a>
+				</div>
 			</td>
 		</tr>
 	</table><?php


### PR DESCRIPTION
Two commits:
* Cancels the currently plotted course. This was a frequently requested feature.
* To avoid confusion between sector numbers and turn cost, add a '#' to the sector number in the plotted course action buttons.

With scanner:
![image](https://user-images.githubusercontent.com/846186/33811579-03b4be84-ddca-11e7-8c5c-065cd120915b.png)

Without scanner:
![image](https://user-images.githubusercontent.com/846186/33811588-32a36a42-ddca-11e7-951a-b160e8b18ff4.png)
