### PR TITLE
Improve bounties display

### DIFF
--- a/engine/Default/trader_bounties.php
+++ b/engine/Default/trader_bounties.php
@@ -5,6 +5,16 @@ $template->assign('PageTopic','Bounties');
 require_once(get_file_loc('menu.inc'));
 create_trader_menu();
 
+foreach (array('HQ', 'UG') as $type) {
+	if ($player->hasCurrentBounty($type)) {
+		$bounty = $player->getCurrentBounty($type);
+		$msg = number_format($bounty['Amount']).' credits and '.number_format($bounty['SmrCredits']).' SMR credits';
+	} else {
+		$msg = 'None';
+	}
+	$template->assign('Bounty'.$type, $msg);
+}
+
 $template->assign('AllClaims', array($player->getClaimableBounties('HQ'),
                                      $player->getClaimableBounties('UG')));
 

--- a/engine/Default/trader_bounties.php
+++ b/engine/Default/trader_bounties.php
@@ -5,28 +5,21 @@ $template->assign('PageTopic','Bounties');
 require_once(get_file_loc('menu.inc'));
 create_trader_menu();
 
-$PHP_OUTPUT.= 'Bounties awaiting collection.<br /><br />';
-
-$PHP_OUTPUT.= '<table class="standard fullwidth"><tr><th>Federal</th><th>Underground</th></tr><tr>';
-
-$db->query('SELECT * FROM bounty WHERE claimer_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND type=\'HQ\'');
-doBountyList($PHP_OUTPUT,$db,$player);
-$db->query('SELECT * FROM bounty WHERE claimer_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND type=\'UG\'');
-doBountyList($PHP_OUTPUT,$db,$player);
-$PHP_OUTPUT.= '</tr></table>';
-
-function doBountyList(&$PHP_OUTPUT,&$db,&$player) {
-	$PHP_OUTPUT.='<td style="width:50%" class="top">';
-	$any=false;
-	while($db->nextRecord()) {
-		$any=true;
+function getBountyList($player, $type) {
+	$results = array();
+	$db = new SmrMySqlDatabase();
+	$db->query('SELECT * FROM bounty WHERE claimer_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND type=' . $db->escapeString($type));
+	while ($db->nextRecord()) {
 		$bountyPlayer =& SmrPlayer::getPlayer($db->getInt('account_id'),$player->getGameID());
-		$PHP_OUTPUT.= $bountyPlayer->getLinkedDisplayName()
-						.' : <span class="creds">'.number_format($db->getInt('amount')).'</span> credits and'
-						. ' <span class="yellow">'.number_format($db->getInt('smr_credits')). '</span> SMR credits<br />';
+		$results[] = array(
+			'name' => $bountyPlayer->getLinkedDisplayName(),
+			'credits' => number_format($db->getInt('amount')),
+			'smr_credits' => number_format($db->getInt('smr_credits')),
+		);
 	}
-	if(!$any)
-		$PHP_OUTPUT.='None';
-	$PHP_OUTPUT.='</td>';
+	return $results;
 }
+
+$template->assign('AllClaims', array(getBountyList($player, 'HQ'), getBountyList($player, 'UG')));
+
 ?>

--- a/engine/Default/trader_bounties.php
+++ b/engine/Default/trader_bounties.php
@@ -5,21 +5,7 @@ $template->assign('PageTopic','Bounties');
 require_once(get_file_loc('menu.inc'));
 create_trader_menu();
 
-function getBountyList($player, $type) {
-	$results = array();
-	$db = new SmrMySqlDatabase();
-	$db->query('SELECT * FROM bounty WHERE claimer_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND type=' . $db->escapeString($type));
-	while ($db->nextRecord()) {
-		$bountyPlayer =& SmrPlayer::getPlayer($db->getInt('account_id'),$player->getGameID());
-		$results[] = array(
-			'name' => $bountyPlayer->getLinkedDisplayName(),
-			'credits' => number_format($db->getInt('amount')),
-			'smr_credits' => number_format($db->getInt('smr_credits')),
-		);
-	}
-	return $results;
-}
-
-$template->assign('AllClaims', array(getBountyList($player, 'HQ'), getBountyList($player, 'UG')));
+$template->assign('AllClaims', array($player->getClaimableBounties('HQ'),
+                                     $player->getClaimableBounties('UG')));
 
 ?>

--- a/engine/Default/trader_status.php
+++ b/engine/Default/trader_status.php
@@ -66,22 +66,23 @@ $PHP_OUTPUT.= '</span> credits in your personal account.';
 
 $PHP_OUTPUT.= '</td><td class="top" style="width:50%">';
 
+// Bounties
 $container['body'] = 'trader_bounties.php';
 $PHP_OUTPUT.=create_link($container, '<span class="yellow bold">Bounties</span><a href="' . WIKI_URL . '/game-guide/locations#headquarters" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Bounties"/></a>');
 
-$PHP_OUTPUT.= '<br /><span class="green">Federal: </span>';
-$bounty = $player->getCurrentBounty('HQ');
-if($bounty['Amount']>0||$bounty['SmrCredits']>0)
-	$PHP_OUTPUT.= number_format($bounty['Amount']).' credits and '.number_format($bounty['SmrCredits']).' SMR credits';
-else
-	$PHP_OUTPUT.= 'None';
-$PHP_OUTPUT.= '<br /><span class="red">Underground: </span>';
-$bounty = $player->getCurrentBounty('UG');
-if($bounty['Amount']>0||$bounty['SmrCredits']>0)
-	$PHP_OUTPUT.= number_format($bounty['Amount']).' credits and '.number_format($bounty['SmrCredits']).' SMR credits';
-else
-	$PHP_OUTPUT.= 'None';
+$db->query('SELECT count(*) FROM bounty WHERE claimer_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
+$db->nextRecord();
+$claims = $db->getInt('count(*)');
+$PHP_OUTPUT.= '<br />You can claim <span class="yellow">'.$claims.'</span> bounties.';
 
+if ($player->hasCurrentBounty('HQ')) {
+	$PHP_OUTPUT.= '<br />You are <span class="red">wanted</span> by the <span class="green">Federal Government</span>!';
+}
+if ($player->hasCurrentBounty('UG')) {
+	$PHP_OUTPUT.= '<br />You are <span class="red">wanted</span> by the <span class="red">Underground</span>!';
+}
+
+// Ship
 $PHP_OUTPUT.= '<br /><br /><span class="yellow bold">Ship</span><a href="' . URL . '/ship_list.php" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Ship List"/></a><br />Name: ';
 
 $PHP_OUTPUT.= $ship->getName();

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1543,6 +1543,22 @@ class SmrPlayer extends AbstractSmrPlayer {
 		}
 	}
 
+	// Get bounties that can be claimed by this player
+	// Type must be 'HQ' or 'UG'
+	public function getClaimableBounties($type) {
+		$bounties = array();
+		$this->db->query('SELECT * FROM bounty WHERE claimer_id=' . $this->db->escapeNumber($this->getAccountID()) . ' AND game_id=' . $this->db->escapeNumber($this->getGameID()) . ' AND type=' . $this->db->escapeString($type));
+		while ($this->db->nextRecord()) {
+			$bounties[] = array(
+				'player' => SmrPlayer::getPlayer($this->db->getInt('account_id'), $this->getGameID()),
+				'bounty_id' => $this->db->getInt('bounty_id'),
+				'credits' => $this->db->getInt('amount'),
+				'smr_credits' => $this->db->getInt('smr_credits'),
+			);
+		}
+		return $bounties;
+	}
+
 	public function isPresident() {
 		$president =& Council::getPresident($this->getGameID(),$this->getRaceID());
 		return is_object($president)&&$this->equals($president);

--- a/templates/Default/engine/Default/trader_bounties.php
+++ b/templates/Default/engine/Default/trader_bounties.php
@@ -15,7 +15,7 @@ Bounties awaiting collection:<br /><br />
 					echo "None";
 				}
 				foreach ($Claims as $Claim) {
-					echo $Claim['name']; ?> : <span class="creds"><? echo $Claim['credits']; ?></span> credits and <span class="yellow"><?php echo $Claim['smr_credits']; ?></span> SMR credits<br />
+					echo $Claim['player']->getLinkedDisplayName(); ?> : <span class="creds"><? echo number_format($Claim['credits']); ?></span> credits and <span class="yellow"><?php echo number_format($Claim['smr_credits']); ?></span> SMR credits<br />
 					<?php
 				} ?>
 			</td><?php

--- a/templates/Default/engine/Default/trader_bounties.php
+++ b/templates/Default/engine/Default/trader_bounties.php
@@ -1,0 +1,24 @@
+
+Bounties awaiting collection:<br /><br />
+
+<table class="standard fullwidth">
+	<tr>
+		<th>Federal</th>
+		<th>Underground</th>
+	</tr>
+
+	<tr><?php
+		// AllClaims is array(ClaimsHQ, ClaimsUG)
+		foreach ($AllClaims as $Claims) { ?>
+			<td style="width:50%" class="top"><?php
+				if (empty($Claims)) {
+					echo "None";
+				}
+				foreach ($Claims as $Claim) {
+					echo $Claim['name']; ?> : <span class="creds"><? echo $Claim['credits']; ?></span> credits and <span class="yellow"><?php echo $Claim['smr_credits']; ?></span> SMR credits<br />
+					<?php
+				} ?>
+			</td><?php
+		} ?>
+	</tr>
+</table>

--- a/templates/Default/engine/Default/trader_bounties.php
+++ b/templates/Default/engine/Default/trader_bounties.php
@@ -1,5 +1,17 @@
+You have the following bounties on your head:<br /><br />
+<table>
+	<tr>
+		<td><span class="green">Federal</span> :</td>
+		<td><?php echo $BountyHQ; ?></td>
+	</tr>
+	<tr>
+		<td><span class="red">Underground</span> :</td>
+		<td><?php echo $BountyUG; ?></td>
+	</tr>
+</table>
+<br />
 
-Bounties awaiting collection:<br /><br />
+<p>Bounties awaiting your collection:</p>
 
 <table class="standard fullwidth">
 	<tr>


### PR DESCRIPTION
* Convert `trader_bounties.php` to a template
* Refactor claimable bounties into the `SmrPlayer::getClaimableBounties` method
* Reorganize bounties display in the "Trader Status" and "View Bounties" pages

Trader Status page now displays (less detailed) information about both bounties on your head _and_ bounties you can claim.
![image](https://user-images.githubusercontent.com/846186/33826534-2c57654e-de1a-11e7-9dc8-5ed66b2464e9.png)

View Bounties page now displays fully detailed information about both bounties you can claim _and_ bounties on your head.
![image](https://user-images.githubusercontent.com/846186/33826639-8068f21a-de1a-11e7-8c3e-6ca9352fc8b3.png)
