### PR TITLE
preferences_processing.php: allow name case change

### DIFF
--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -274,8 +274,10 @@ else if (strpos(trim($action),'Alter Player')===0) {
 		create_error('You must enter a player name!');
 
 	// Check if name is in use.
-	$db->query('SELECT 1 FROM player WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND player_name=' . $db->escape_string($player_name) . ' LIMIT 1' );
-	if($db->getNumRows()) {
+	// The player_name field has case-insensitive collation, so check against ID
+	// to allow player to change the case of their name.
+	$db->query('SELECT 1 FROM player WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND player_name=' . $db->escapeString($player_name) . ' AND player_id != ' . $db->escapeString($player->getPlayerID()) . ' LIMIT 1' );
+	if ($db->getNumRows()) {
 		create_error('Name is already being used in this game!');
 	}
 


### PR DESCRIPTION
When altering your player name, a check is done to make sure that
the new name is not already in use. Since `player_name` has a case-
insensitive collation, this prevents players from changing the case
of their name.

With this change, we allow the old and new names to be the case-
insensitively the same so long as the account ID's match.