### PR TITLE
Dumping cargo at 0 exp damages armour

### DIFF
--- a/engine/Default/cargo_dump_processing.php
+++ b/engine/Default/cargo_dump_processing.php
@@ -10,7 +10,7 @@ if (!is_numeric($amount)) {
 }
 
 if ($amount <= 0) {
-	create_error('You must actually enter an ammount > 0!');
+	create_error('You must actually enter an amount > 0!');
 }
 
 if ($player->isLandedOnPlanet()) {
@@ -31,38 +31,52 @@ if ($sector->offersFederalProtection()) {
 	create_error('You can\'t dump cargo in a Federal Sector!');
 }
 
-require_once('shop_goods.inc');
+$container = create_container('skeleton.php', 'current_sector.php');
 
-// get the distance
-$x = Globals::getGood($good_id);
-$x['TransactionType'] = 'Sell';
-$good_distance = Plotter::findDistanceToX($x, $sector, true);
-if(is_object($good_distance)) {
-	$good_distance = $good_distance->getRelativeDistance();
+if ($player->getExperience() > 0) {
+	// If they have any experience left, lose exp
+
+	// get the distance
+	$x = Globals::getGood($good_id);
+	$x['TransactionType'] = 'Sell';
+	$good_distance = Plotter::findDistanceToX($x, $sector, true);
+	if(is_object($good_distance)) {
+		$good_distance = $good_distance->getRelativeDistance();
+	}
+	$good_distance = max(1,$good_distance);
+
+	// Don't lose more exp than you have
+	$lost_xp = min($player->getExperience(),
+	               round(SmrPort::getBaseExperience($amount, $good_distance)));
+	$player->decreaseExperience($lost_xp);
+	$player->increaseHOF($lost_xp, array('Trade','Experience', 'Jettisoned'), HOF_PUBLIC);
+
+	$container['msg'] = 'You have jettisoned <span class="yellow">'.$amount.'</span> ' . pluralise('unit', $amount) . ' of '.$good_name.' and have lost <span class="exp">'.$lost_xp.'</span> experience.';
+	// log action
+	$account->log(LOG_TYPE_TRADING, 'Dumps '.$amount.' of '.$good_name.' and loses '.$lost_xp.' experience', $player->getSectorID());
 }
-$good_distance = max(1,$good_distance);
+else {
+	// No experience to lose, so damage the ship
+	$damage = ceil($amount/5);
 
-$lost_xp = round(SmrPort::getBaseExperience($amount, $good_distance));
-$player->decreaseExperience($lost_xp);
-$player->increaseHOF($lost_xp,array('Trade','Experience', 'Jettisoned'), HOF_PUBLIC);
+	// Don't allow ship to be destroyed dumping cargo
+	if ($ship->getArmour() <= $damage) {
+		create_error('Your ship is too damaged to risk dumping cargo!');
+	}
+
+	$ship->decreaseArmour($damage);
+	$ship->removeUnderAttack(); // don't trigger attack warning
+
+	$container['msg'] = 'You have jettisoned <span class="yellow">'.$amount.'</span> ' . pluralise('unit', $amount) . ' of '.$good_name.'. Due to your lack of piloting experience, the cargo pierces the hull of your ship as you clumsily try to jettison the goods through the bay doors, destroying <span class="red">'.$damage.'</span> ' . pluralise('plate', $damage) . ' of armour!';
+	// log action
+	$account->log(LOG_TYPE_TRADING, 'Dumps '.$amount.' of '.$good_name.' and takes '.$damage.' armour damage', $player->getSectorID());
+}
 
 // take turn
 $player->takeTurns(1,1);
 
 $ship->decreaseCargo($good_id,$amount);
 $player->increaseHOF($amount,array('Trade','Goods', 'Jettisoned'), HOF_PUBLIC);
-
-// log action
-$account->log(LOG_TYPE_TRADING, 'Dumps '.$amount.' of '.$good_name.' and looses '.$lost_xp.' experience', $player->getSectorID());
-
-$container = create_container('skeleton.php', 'current_sector.php');
-
-if ($amount > 1) {
-	$container['msg'] = 'You have jettisoned <span class="yellow">'.$amount.'</span> units of '.$good_name.' and have lost <span class="exp">'.$lost_xp.'</span> experience.';
-}
-else {
-	$container['msg'] = 'You have jettisoned <span class="yellow">'.$amount.'</span> unit of '.$good_name.' and have lost <span class="exp">'.$lost_xp.'</span> experience.';
-}
 
 forward($container);
 


### PR DESCRIPTION
* When at 0 experience, dumping goods does armour damage, but
  will not let you dump if it would take you below 1 armour
  (i.e. you can't destroy your ship dumping cargo).

* Armour damage will be holds/5 (e.g. you can dump 4x 300 holds
  in an IST before you need to UNO). This number may need to be
  adjusted based on feedback.

* There is no rollover. You either lose exp (down to 0) or armour.

* When losing experience, don't show that you lost more experience
  than you have.

The official motivation for this change is to ensure that there
is a tradeoff when slaving. When the slave has exp, it can be lost;
but when you slave at 0 exp, there is no longer any tradeoff.
You basically get slaving for free, which was not intended.
Incurring a ship damage penalty seems like a fitting solution.

More importantly, this idea (suggested by Page) has too perfect of
a role-playing payoff to pass up.


-------------

Depends on PRs #217 and #198.