### PR TITLE
Add button to calculate jump drive turns

### DIFF
--- a/engine/Default/sector_jump_calculate.php
+++ b/engine/Default/sector_jump_calculate.php
@@ -1,0 +1,18 @@
+<?php
+
+$template->assign('PageTopic', 'Jump Drive');
+require_once(get_file_loc('menu.inc'));
+create_nav_menu($template, $player);
+
+$targetSector = SmrSector::getSector($player->getGameID(), $var['target']);
+$jumpInfo = $player->getJumpInfo($targetSector);
+
+$template->assign('Target', $targetSector->getSectorID());
+$template->assign('TurnCost', $jumpInfo['turn_cost']);
+
+$container = create_container('sector_jump_processing.php');
+$container['target'] = $targetSector->getSectorID();
+$container['target_page'] = 'current_sector.php';
+$template->assign('JumpProcessingHREF', SmrSession::getNewHREF($container));
+
+?>

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -44,15 +44,9 @@ if(!SmrGalaxy::getGalaxyContaining($player->getGameID(), $target))
 // create sector object for target sector
 $targetSector =& SmrSector::getSector($player->getGameID(), $target);
 
-require_once(get_file_loc('Plotter.class.inc'));
-$path =& Plotter::findDistanceToX($targetSector, $player->getSector(), true);
-if($path===false)
-	create_error('Unable to plot from '.$start.' to '.$target.'.');
-
-$distance = $path->getRelativeDistance();
-$turnsToJump = max(TURNS_JUMP_MINIMUM, round($distance * TURNS_PER_JUMP_DISTANCE));
-
-$maxMisjump = max(0,round(($distance - $turnsToJump) * MISJUMP_DISTANCE_DIFF_FACTOR / (1 + $player->getLevelID() * MISJUMP_LEVEL_FACTOR)));
+$jumpInfo = $player->getJumpInfo($targetSector);
+$turnsToJump = $jumpInfo['turn_cost'];
+$maxMisjump = $jumpInfo['max_misjump'];
 
 // check for turns
 if ($player->getTurns() < $turnsToJump)

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -1,7 +1,9 @@
 <?php
+
 $sector =& $player->getSector();
 if (isset($_REQUEST['target'])) $target = trim($_REQUEST['target']);
 else $target = $var['target'];
+
 //allow hidden players (admins that don't play) to move without pinging, hitting mines, losing turns
 if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 	$player->setSectorID($target);
@@ -12,15 +14,6 @@ if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 $action = $_REQUEST['action'];
 if ($action == 'No')
 	forward(create_container('skeleton.php', $var['target_page']));
-
-// get from and to sectors
-$from = $player->getSectorID();
-
-if (empty($target) || $target == '')
-	create_error('Where do you want to go today?');
-
-// get our rank
-$rank_id = $account->getRank();
 
 // you can't move while on planet
 if ($player->isLandedOnPlanet())
@@ -40,7 +33,7 @@ if ($sector->hasForces()) {
 	$sectorForces =& $sector->getForces();
 	foreach($sectorForces as &$forces) {
 		if($forces->hasMines() && !$player->forceNAPAlliance($forces->getOwner())) {
-			create_error('You cant jump when there are unfriendly forces in the sector!');
+			create_error('You cannot jump when there are hostile mines in the sector!');
 		}
 	} unset($forces);
 }

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -11,9 +11,10 @@ if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 	$sector->markVisited($player);
 	forward(create_container('skeleton.php', 'current_sector.php'));
 }
-$action = $_REQUEST['action'];
-if ($action == 'No')
+
+if (isset($_POST['action']) && $_POST['action'] == 'No') {
 	forward(create_container('skeleton.php', $var['target_page']));
+}
 
 // you can't move while on planet
 if ($player->isLandedOnPlanet())
@@ -29,6 +30,16 @@ if (!is_numeric($target))
 if ($player->getSectorID() == $target)
 	create_error('Hmmmm...if ' . $player->getSectorID() . '=' . $target . ' then that means...YOU\'RE ALREADY THERE! *cough*you\'re real smart*cough*');
 
+if(!SmrGalaxy::getGalaxyContaining($player->getGameID(), $target))
+	create_error('The target sector doesn\'t exist!');
+
+// If the Calculate Turn Cost button was pressed
+if (isset($_POST['action']) && $_POST['action'] == 'Calculate Turn Cost') {
+	$container = create_container('skeleton.php', 'sector_jump_calculate.php');
+	$container['target'] = $target;
+	forward($container);
+}
+
 if ($sector->hasForces()) {
 	$sectorForces =& $sector->getForces();
 	foreach($sectorForces as &$forces) {
@@ -37,9 +48,6 @@ if ($sector->hasForces()) {
 		}
 	} unset($forces);
 }
-
-if(!SmrGalaxy::getGalaxyContaining($player->getGameID(), $target))
-	create_error('The target sector doesn\'t exist!');
 
 // create sector object for target sector
 $targetSector =& SmrSector::getSector($player->getGameID(), $target);

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -49,19 +49,20 @@ $path =& Plotter::findDistanceToX($targetSector, $player->getSector(), true);
 if($path===false)
 	create_error('Unable to plot from '.$start.' to '.$target.'.');
 
-// send scout msg
-$sector->leavingSector($player,MOVEMENT_JUMP);
-
-// Move the user around
-// TODO: (Must be done while holding both sector locks)
 $distance = $path->getRelativeDistance();
 $turnsToJump = max(TURNS_JUMP_MINIMUM, round($distance * TURNS_PER_JUMP_DISTANCE));
+
+$maxMisjump = max(0,round(($distance - $turnsToJump) * MISJUMP_DISTANCE_DIFF_FACTOR / (1 + $player->getLevelID() * MISJUMP_LEVEL_FACTOR)));
 
 // check for turns
 if ($player->getTurns() < $turnsToJump)
 	create_error('You don\'t have enough turns for that jump!');
 
-$maxMisjump = max(0,round(($distance - $turnsToJump) * MISJUMP_DISTANCE_DIFF_FACTOR / (1 + $player->getLevelID() * MISJUMP_LEVEL_FACTOR)));
+// send scout msg
+$sector->leavingSector($player,MOVEMENT_JUMP);
+
+// Move the user around
+// TODO: (Must be done while holding both sector locks)
 $misjump = mt_rand(0,$maxMisjump);
 if ($misjump > 0) { // we missed the sector
 	$distances = Plotter::findDistanceToX('Distance', $targetSector, false, null, null, $misjump);

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1836,6 +1836,20 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->db->query('DELETE FROM player_plotted_course WHERE '.$this->SQL.' LIMIT 1');
 	}
 
+	// Computes the turn cost and max misjump between current and target sector
+	public function getJumpInfo(SmrSector $targetSector) {
+		require_once(get_file_loc('Plotter.class.inc'));
+		$path = Plotter::findDistanceToX($targetSector, $this->getSector(), true);
+		if ($path===false) {
+			create_error('Unable to plot from '.$this->getSectorID().' to '.$targetSector->getSectorID().'.');
+		}
+		$distance = $path->getRelativeDistance();
+
+		$turnCost = max(TURNS_JUMP_MINIMUM, round($distance * TURNS_PER_JUMP_DISTANCE));
+		$maxMisjump = max(0, round(($distance - $turnCost) * MISJUMP_DISTANCE_DIFF_FACTOR / (1 + $this->getLevelID() * MISJUMP_LEVEL_FACTOR)));
+		return array('turn_cost' => $turnCost, 'max_misjump' => $maxMisjump);
+	}
+
 	public function __sleep() {
 		return array('accountID', 'gameID', 'sectorID', 'alignment', 'playerID', 'playerName');
 	}

--- a/templates/Default/engine/Default/includes/JumpDrive.inc
+++ b/templates/Default/engine/Default/includes/JumpDrive.inc
@@ -2,12 +2,13 @@
 if ($ThisShip->hasJump()) { ?>
 	<br />
 	<form class="standard" id="JumpDriveForm" method="POST" action="<?php echo $JumpDriveFormLink; ?>">
-		<h2>Jumpdrive</h2><br />
+		<h2>Jump Drive</h2><br />
 		<table cellspacing="0" cellpadding="0" class="nobord nohpad">
 			<tr>
 				<td>Jump To:&nbsp;</td>
 				<td><input type="number" size="5" name="target" maxlength="5" class="center"></td>
 				<td>&nbsp;&nbsp;&nbsp;&nbsp;<input class="submit" type="submit" name="action" value="Engage Jump (<?php echo TURNS_JUMP_MINIMUM; ?>+)"></td>
+				<td>&nbsp;&nbsp;<input type="submit" name="action" value="Calculate Turn Cost" /></td>
 			</tr>
 		</table>
 	</form><?php

--- a/templates/Default/engine/Default/sector_jump_calculate.php
+++ b/templates/Default/engine/Default/sector_jump_calculate.php
@@ -1,0 +1,15 @@
+You punch the destination sector into your Jump Drive console.
+Within moments, the onboard computer dictates the report in a reassuringly confident voice.
+
+<br /><br />
+It will cost <span class="red"><?php echo $TurnCost; ?></span> turns to jump to Sector #<?php echo $Target; ?>.
+
+<br /><br />
+<div class="center">
+	<a href="<?php echo $JumpProcessingHREF; ?>">
+		<button id="InputFields">Engage Jump (<?php echo $TurnCost; ?>)</button>
+	</a>
+</div>
+
+<br />
+<p class="center"><img src="images/logoff.jpg" width="324" height="216" alt=""></p>


### PR DESCRIPTION
A new option for jump drives is "Calculate Turn Cost". When clicked
it will take you to a new page that says how many turns will be
spent when jumping to the target sector.

I think this is a reasonable addition because previously jump drives
had a fixed turn cost (15), so we could report the cost exactly.
Now the cost is just listed as (10+), which is a little misleading
since the turn cost has no upper bound.

Some additional changes needed for this feature:
* Cleanup in `sector_jump_processing.php`
* Fix an order of operations bug where scout messages could be sent for jumping out of sector when you don't actually jump because you're out of turns
* Refactor jump drive calculations in `SmrPlayer::getJumpInfo`

![image](https://user-images.githubusercontent.com/846186/33923844-32314060-df88-11e7-9470-680314d12f4b.png)

![image](https://user-images.githubusercontent.com/846186/33923905-7fc011bc-df88-11e7-9f90-595412e8e96d.png)
