### PR TITLE
Add some convenience methods to SmrPlayer

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -217,8 +217,36 @@ class SmrPlayer extends AbstractSmrPlayer {
 		else {
 			throw new PlayerNotFoundException('Invalid accountID: '.$accountIDOrResultArray . ' OR gameID:'.$gameID);
 		}
+	}
 
+	// Get array of players whose info can be accessed by this player.
+	// Skips players who are not in the same alliance as this player.
+	public function getSharingPlayers($forceUpdate=false) {
+		$results = array($this);
 
+		// Only return this player if not in an alliance
+		if (!$this->hasAlliance()) {
+			return $results;
+		}
+
+		// Get other players who are sharing info for this game.
+		// NOTE: game_id=0 means that player shares info for all games.
+		$this->db->query('SELECT from_account_id FROM account_shares_info WHERE to_account_id=' . $this->db->escapeNumber($this->getAccountID()) . ' AND (game_id=0 OR game_id=' . $this->db->escapeNumber($this->getGameID()) . ')');
+		while ($this->db->nextRecord()) {
+			try {
+				$otherPlayer = SmrPlayer::getPlayer($this->db->getInt('from_account_id'),
+				                                    $this->getGameID(), $forceUpdate);
+			} catch (PlayerNotFoundException $e) {
+				// Skip players that have not joined this game
+				continue;
+			}
+
+			// players must be in the same alliance
+			if ($this->sameAlliance($otherPlayer)) {
+				$results[] = $otherPlayer;
+			}
+		}
+		return $results;
 	}
 
 	public function getSQL() {

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -607,20 +607,26 @@ class SmrPlayer extends AbstractSmrPlayer {
 		return $this->originalMaintenance;
 	}
 
+	// Turns only update when player is active.
+	// Calculate turns gained between given time and the last turn update
+	public function getTurnsGained($time, $forceUpdate=false) {
+		$timeDiff = $time - $this->getLastTurnUpdate();
+		$ship = $this->getShip($forceUpdate);
+		$extraTurns = floor($timeDiff * $ship->getRealSpeed() / 3600);
+		return $extraTurns;
+	}
+
 	public function updateTurns() {
 		// is account validated?
 		if (!$this->getAccount()->isValidated()) return;
-		$ship =& $this->getShip();
-
-		// update turns?
-		$time_diff = TIME - $this->getLastTurnUpdate();
 
 		// how many turns would he get right now?
-		$extraTurns = floor($time_diff * $ship->getRealSpeed() / 3600);
+		$extraTurns = $this->getTurnsGained(TIME);
 
 		// do we have at least one turn to give?
 		if ($extraTurns > 0) {
 			// recalc the time to avoid errors
+			$ship =& $this->getShip();
 			$newLastTurnUpdate = $this->getLastTurnUpdate() + ceil($extraTurns * 3600 / $ship->getRealSpeed());
 
 			$startTurnsDate = $this->getGame()->getStartTurnsDate();
@@ -632,12 +638,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 			}
 
 			$this->setLastTurnUpdate($newLastTurnUpdate);
-
-
 			$this->giveTurns($extraTurns);
 		}
 	}
-
 
 	function isIgnoreGlobals() {
 		return $this->ignoreGlobals;

--- a/tools/discord/commands/turns.php
+++ b/tools/discord/commands/turns.php
@@ -2,14 +2,13 @@
 
 function get_turns_message($player) {
 	// turns only update when the player is active, so calculate current turns
-	$ship = $player->getShip(true);
-	$turns = $player->getTurns() + floor((time() - $player->getLastTurnUpdate()) * $ship->getRealSpeed() / 3600);
-	$turns = min($turns, $player->getMaxTurns());
-
+	$turns = min($player->getTurns() + $player->getTurnsGained(time(), true),
+	             $player->getMaxTurns());
 	$msg = $player->getPlayerName() . " has $turns/" . $player->getMaxTurns() . " turns.";
 
 	// Calculate time to max turns if under the max
 	if ($turns < $player->getMaxTurns()) {
+		$ship = $player->getShip(true);
 		$maxTime = ceil(($player->getMaxTurns() - $turns) * 3600 / $ship->getRealSpeed());
 		$msg .= " At max turns in " . format_time($maxTime, true) . ".";
 	}

--- a/tools/discord/commands/turns.php
+++ b/tools/discord/commands/turns.php
@@ -30,26 +30,7 @@ $fn_turns_all = function ($message) {
 	if (!$link->valid) return;
 	$player = $link->player;
 
-	// initialize results with current player
-	$results = array(get_turns_message($player));
-
-	// process shared players
-	$db2 = new SmrMySqlDatabase();
-	$db2->query('SELECT from_account_id FROM account_shares_info WHERE to_account_id=' . $db2->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db2->escapeNumber($player->getGameID()) . ')');
-	while ($db2->nextRecord()) {
-		try {
-			$otherPlayer = SmrPlayer::getPlayer($db2->getInt('from_account_id'), $player->getGameID(), true);
-		} catch (PlayerNotFoundException $e) {
-			// Skip players that have not joined this game
-			continue;
-		}
-
-		// players must be in the same alliance
-		if ($player->hasAlliance() && $player->getAllianceID() == $otherPlayer->getAllianceID()) {
-			$results[] = get_turns_message($otherPlayer);
-		}
-	}
-
+	$results = array_map('get_turns_message', $player->getSharingPlayers(true));
 	$message->channel->sendMessage(join("\n", $results));
 };
 


### PR DESCRIPTION
* `getSharingPlayers`: Factors out the logic that interacts with `account_shares_info`. Needed for chat functions that allow displaying info about multiple players.
* `getTurnsGained`: Computes the turns gained since last player update. Generalizes this formula for any given time with optional cache bypass. This is used by `SmrPlayer::updateTurns`, but also all of the chat functions that display info about turns.