### PR TITLE
Rename Computer to Computers

### DIFF
--- a/db/patches/V1_6_61_11__rename_computers.sql
+++ b/db/patches/V1_6_61_11__rename_computers.sql
@@ -1,0 +1,2 @@
+-- Rename the good Computer to Computers
+UPDATE good SET good_name='Computers' WHERE good_id=10;


### PR DESCRIPTION
This was the only good named in the singular, and so it was
always grammatically incorrect.

Requires a database migration.