### PR TITLE
Disable AJAX Refresh no longer disables hotkeys

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -39,7 +39,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 //	protected $chatPosition;
 	protected $displayMissions;
 	protected $displayWeapons;
-	protected $useAJAX;
 	protected $ignoreGlobals;
 //	protected $changedStats;
 	protected $mining;

--- a/templates/Default/engine/Default/includes/EndingJavascript.inc
+++ b/templates/Default/engine/Default/includes/EndingJavascript.inc
@@ -6,15 +6,16 @@ if(!empty($js)) {
 foreach($this->jsAlerts as $string) {
 	?>alert(<?php echo json_encode($string); ?>);<?php
 }
-if($AJAX_ENABLE_REFRESH) {
-	$AvailableLinks = Globals::getAvailableLinks();
-	?><script type="text/javascript">$(function(){
+
+$AvailableLinks = Globals::getAvailableLinks(); ?>
+<script type="text/javascript">$(function(){<?php
+	if ($AJAX_ENABLE_REFRESH) { ?>
 		startRefresh('<?php echo $AJAX_ENABLE_REFRESH; ?>');<?php
-		foreach($AvailableLinks as $LinkName => $AvailableLink) {
-			$Hotkeys = $ThisAccount->getHotkeys($LinkName);
-			foreach($Hotkeys as $Hotkey) {
-				?>$(document).bind('keydown', '<?php echo addslashes($Hotkey); ?>', followLink('<?php echo $AvailableLink; ?>'));<?php
-			}
-		} ?>
-	})</script><?php
-} ?>
+	}
+	foreach($AvailableLinks as $LinkName => $AvailableLink) {
+		$Hotkeys = $ThisAccount->getHotkeys($LinkName);
+		foreach($Hotkeys as $Hotkey) {
+			?>$(document).bind('keydown', '<?php echo addslashes($Hotkey); ?>', followLink('<?php echo $AvailableLink; ?>'));<?php
+		}
+	} ?>
+})</script>


### PR DESCRIPTION
The option in User Preferences indicates that it controls the AJAX
Refresh. However, it also controls the hotkeys.

We reduce the scope of the if-statement so that the option now
only controls the AJAX Refresh and not the hotkeys.