### PR TITLE
Dockerfile: fix upload directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN composer install --no-interaction
 COPY . .
 RUN rm -rf /var/www/html/ && ln -s "$(pwd)/htdocs" /var/www/html
 
+# Make the upload directory writable by the apache user
+RUN chown www-data ./htdocs/upload
+
 # Provide a FQDN for sendmail (since /etc/hosts cannot be modified during the
 # build), then start the sendmail service before initiating apache.
 CMD ["sh", "-c", "echo \"$(hostname -i) $(hostname) $(hostname).localhost\" >> /etc/hosts && /usr/sbin/service sendmail restart && apache2-foreground"]


### PR DESCRIPTION
In the php-apache image, the web user is `www-data`, so our
`htdocs/upload` directory needs to be writable by this user.

When mounting a named volume (e.g. the dev docker-compose.yml),
if we set the permissions in the image first, they should carry
over to the named volume.