### PR TITLE
Use list.js to sort personal and alliance force lists

### DIFF
--- a/engine/Default/alliance_forces.php
+++ b/engine/Default/alliance_forces.php
@@ -8,25 +8,6 @@ $template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->g
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 
-//get the sequence
-if (!isset($var['seq'])) {
-	SmrSession::updateVar('seq', 'ASC');
-}
-$order = $var['seq'];
-
-//get the ordering info
-if (!isset($var['category'])) {
-	SmrSession::updateVar('category', 'player_name');
-}
-$category = $var['category'];
-
-$categorySQL = $category.' '.$order;
-
-if (!isset($var['subcategory'])) {
-	SmrSession::updateVar('subcategory', 'expire_time ASC');
-}
-$subcategory = $var['subcategory'];
-
 $db->query('
 SELECT
 sum(mines) as tot_mines,
@@ -37,11 +18,22 @@ WHERE player.game_id=' . $db->escapeNumber($alliance->getGameID()) . '
 AND player.alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
 AND expire_time >= ' . $db->escapeNumber(TIME));
 
+$hardwareTypes =& Globals::getHardwareTypes();
+
+$total = array();
+$totalCost = array();
 if ($db->nextRecord()) {
+	// Get total number of forces
 	$total['Mines'] = $db->getInt('tot_mines');
 	$total['CDs'] = $db->getInt('tot_cds');
 	$total['SDs'] = $db->getInt('tot_sds');
+	// Get total cost of forces
+	$totalCost['Mines'] = $total['Mines'] * $hardwareTypes[HARDWARE_MINE]['Cost'];
+	$totalCost['CDs'] = $total['CDs'] * $hardwareTypes[HARDWARE_COMBAT]['Cost'];
+	$totalCost['SDs'] = $total['SDs'] * $hardwareTypes[HARDWARE_SCOUT]['Cost'];
 }
+$template->assign('Total', $total);
+$template->assign('TotalCost', $totalCost);
 
 $db->query('
 SELECT sector_has_forces.sector_id, sector_has_forces.owner_id
@@ -50,84 +42,15 @@ JOIN sector_has_forces ON player.game_id = sector_has_forces.game_id AND player.
 WHERE player.game_id=' . $db->escapeNumber($alliance->getGameID()) . '
 AND player.alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
 AND expire_time >= ' . $db->escapeNumber(TIME) . '
-ORDER BY ' . $categorySQL . ', ' . $subcategory);
+ORDER BY sector_id ASC');
 
 $PHP_OUTPUT.= '<div align="center"><a href="' . WIKI_URL . '/game-guide/forces" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a>';
 
-if ($db->getNumRows() > 0) {
-	$PHP_OUTPUT.= 'Your alliance currently has ';
-	$PHP_OUTPUT.= $db->getNumRows();
-	$PHP_OUTPUT.= ' stacks of forces in the universe!<br />';
-
-	$hardwareTypes =& Globals::getHardwareTypes();
-
-	$PHP_OUTPUT.=create_table();
-	$PHP_OUTPUT.=('<th>Number of Force</th><th>Value</th></tr>');
-	$PHP_OUTPUT.=('<tr><td><span class="yellow">' . number_format($total['Mines']) . '</span> mines</td><td><span class="creds">' . number_format($total['Mines'] * $hardwareTypes[HARDWARE_MINE]['Cost']) . '</span> credits</td></tr>');
-	$PHP_OUTPUT.=('<tr><td><span class="yellow">' . number_format($total['CDs']) . '</span> combat drones</td><td><span class="creds">' . number_format($total['CDs'] * $hardwareTypes[HARDWARE_COMBAT]['Cost']) . '</span> credits</td></tr>');
-	$PHP_OUTPUT.=('<tr><td><span class="yellow">' . number_format($total['SDs']) . '</span> scout drones</td><td><span class="creds">' . number_format($total['SDs'] * $hardwareTypes[HARDWARE_SCOUT]['Cost']) . '</span> credits</td></tr>');
-	$PHP_OUTPUT.=('<tr><td><span class="yellow bold">' . number_format(array_sum($total)) . '</span> forces</td><td><span class="creds bold">' . number_format($total['Mines'] * $hardwareTypes[HARDWARE_MINE]['Cost'] + $total['CDs'] * $hardwareTypes[HARDWARE_COMBAT]['Cost'] + $total['SDs'] * $hardwareTypes[HARDWARE_SCOUT]['Cost']) . '</span> credits</td></tr>');
-	$PHP_OUTPUT.=('</table><br />');
-
-	$PHP_OUTPUT.= '<table class="standard inset"><tr>';
-
-	$container = create_container('skeleton.php','alliance_forces.php');
-
-	$container['seq'] = $order == 'ASC' ? 'DESC' : 'ASC';
-
-	setCategories($container,'player_name',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.= '<th>';
-	$PHP_OUTPUT.=create_header_link($container, 'Player Name');
-	$PHP_OUTPUT.= '</th>';
-	setCategories($container,'sector_has_forces.sector_id',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.= '<th>';
-	$PHP_OUTPUT.=create_header_link($container, 'Sector ID');
-	$PHP_OUTPUT.= '</th>';
-	setCategories($container,'combat_drones',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.= '<th>';
-	$PHP_OUTPUT.=create_header_link($container, 'Combat Drones');
-	$PHP_OUTPUT.= '</th>';
-	setCategories($container,'scout_drones',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.= '<th>';
-	$PHP_OUTPUT.=create_header_link($container, 'Scout Drones');
-	$PHP_OUTPUT.= '</th>';
-	setCategories($container,'mines',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.= '<th>';
-	$PHP_OUTPUT.=create_header_link($container, 'Mines');
-	$PHP_OUTPUT.= '</th>';
-	setCategories($container,'expire_time',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.= '<th>';
-	$PHP_OUTPUT.=create_header_link($container, 'Expire time');
-	$PHP_OUTPUT.= '</th>';
-	$PHP_OUTPUT.= '</tr>';
-
-	while ($db->nextRecord()) {
-		$forces =& SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'));
-
-		$PHP_OUTPUT .= '<tr>';
-		$PHP_OUTPUT .= '<td>'.$forces->getOwner()->getLinkedDisplayName(false) . '</td>';
-		$PHP_OUTPUT .= '<td class="shrink noWrap">' . $forces->getSectorID() . ' (' . $forces->getGalaxy()->getName() . ')</td>';
-		$PHP_OUTPUT .= '<td class="shrink center">' . $forces->getCDs() . '</td>';
-		$PHP_OUTPUT .= '<td class="shrink center">' . $forces->getSDs() . '</td>';
-		$PHP_OUTPUT .= '<td class="shrink center">' . $forces->getMines() . '</td>';
-		$PHP_OUTPUT .= '<td class="shrink noWrap">' . date(DATE_FULL_SHORT, $forces->getExpire()) . '</td>';
-		$PHP_OUTPUT .= '</tr>';
-	}
-	$PHP_OUTPUT.= '</table>';
+$forces = array();
+while ($db->nextRecord()) {
+	$forces[] = SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'));
 }
-else {
-	$PHP_OUTPUT.= 'Your alliance has no deployed forces';
-}
+$template->assign('Forces', $forces);
 
-$PHP_OUTPUT.= '</div>';
 
-function setCategories(&$container,$newCategory,$oldCategory,$oldCategorySQL,$subcategory) {
-	$container['category'] = $newCategory;
-	if($oldCategory==$container['category']) {
-		$container['subcategory'] = $subcategory;
-	}
-	else {
-		$container['subcategory'] = $oldCategorySQL;
-	}
-}
 ?>

--- a/engine/Default/forces_list.php
+++ b/engine/Default/forces_list.php
@@ -2,89 +2,17 @@
 
 $template->assign('PageTopic','View Forces');
 
-//allow for ordering of forces
-if (!isset($var['seq']))
-	$order = 'ASC';
-else
-	$order = $var['seq'];
-
-if (!isset($var['category']))
-	$category = 'sector_id';
-else
-	$category = $var['category'];
-$categorySQL = $category.' '.$order;
-
-if (!isset($var['subcategory']))
-	$subcategory = 'expire_time ASC';
-else
-	$subcategory = $var['subcategory'];
-
 $db->query('SELECT sector_id, owner_id
 			FROM sector_has_forces
 			WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . '
 			AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 			AND expire_time >= '.$db->escapeNumber(TIME).'
-			ORDER BY '.$categorySQL.', '.$subcategory);
-if ($db->getNumRows() > 0) {
+			ORDER BY sector_id ASC');
 
-	$container = array();
-	$container['url'] = 'skeleton.php';
-	$container['body'] = 'forces_list.php';
-	if ($order == 'ASC')
-		$container['seq'] = 'DESC';
-	else
-		$container['seq'] = 'ASC';
-	$container['subcategory'] = $category;
-
-	$PHP_OUTPUT.=create_table();
-	$PHP_OUTPUT.=('<a href="' . WIKI_URL . '/game-guide/forces" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a><br />');
-	$PHP_OUTPUT.=('<tr>');
-	setCategories($container,'sector_id',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.=('<th align="center">');
-	$PHP_OUTPUT.=create_link($container, '<span class="lgreen">Sector ID</span>');
-	$PHP_OUTPUT.=('</th>');
-	setCategories($container,'combat_drones',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.=('<th align="center">');
-	$PHP_OUTPUT.=create_link($container, '<span class="lgreen">Combat Drones</span>');
-	$PHP_OUTPUT.=('</th>');
-	setCategories($container,'scout_drones',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.=('<th align="center">');
-	$PHP_OUTPUT.=create_link($container, '<span class="lgreen">Scout Drones</span>');
-	$PHP_OUTPUT.=('</th>');
-	setCategories($container,'mines',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.=('<th align="center">');
-	$PHP_OUTPUT.=create_link($container, '<span class="lgreen">Mines</span>');
-	$PHP_OUTPUT.=('</th>');
-	setCategories($container,'expire_time',$category,$categorySQL,$subcategory);
-	$PHP_OUTPUT.=('<th align="center">');
-	$PHP_OUTPUT.=create_link($container, '<span class="lgreen">Expire time</span>');
-	$PHP_OUTPUT.=('</th>');
-	$PHP_OUTPUT.=('</tr>');
-
-	while ($db->nextRecord()) {
-		$forces =& SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'));
-
-		$PHP_OUTPUT .= '<tr>';
-		$PHP_OUTPUT .= '<td class="shrink noWrap">'.$forces->getSectorID().' ('.$forces->getGalaxy()->getName().')</td>';
-		$PHP_OUTPUT .= '<td class="shrink center">'.$forces->getCDs().'</td>';
-		$PHP_OUTPUT .= '<td class="shrink center">'.$forces->getSDs().'</td>';
-		$PHP_OUTPUT .= '<td class="shrink center">'.$forces->getMines().'</td>';
-		$PHP_OUTPUT .= '<td class="shrink noWrap">' . date(DATE_FULL_SHORT, $forces->getExpire()) . '</td>';
-		$PHP_OUTPUT .= '</tr>';
-	}
-
-	$PHP_OUTPUT.=('</table>');
+$forces = array();
+while ($db->nextRecord()) {
+	$forces[] = SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'));
 }
+$template->assign('Forces', $forces);
 
-else
-	$PHP_OUTPUT.=('You have no deployed forces <a href="' . WIKI_URL . '/game-guide/forces" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a>');
-
-
-function setCategories(&$container,$newCategory,$oldCategory,$oldCategorySQL,$subcategory) {
-	$container['category'] = $newCategory;
-	if($oldCategory==$container['category'])
-		$container['subcategory'] = $subcategory;
-	else
-		$container['subcategory'] = $oldCategorySQL;
-}
 ?>

--- a/templates/Default/engine/Default/alliance_forces.php
+++ b/templates/Default/engine/Default/alliance_forces.php
@@ -1,0 +1,74 @@
+<?php
+if (empty($Forces)) { ?>
+	Your alliance has no deployed forces.
+	<a href="<?php echo WIKI_URL; ?>/game-guide/forces" target="_blank">
+		<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/>
+	</a><?php
+} else { ?>
+	<div align="center">
+		Your alliance currently has <?php echo count($Forces); ?> stacks of forces in the universe.
+		<a href="<?php echo WIKI_URL; ?>/game-guide/forces" target="_blank">
+			<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/>
+		</a>
+		<br /><br />
+
+		<table class="standard">
+			<tr>
+				<th>Number of Force</th>
+				<th>Value</th>
+			</tr>
+			<tr>
+				<td><span class="yellow"><?php echo number_format($Total['Mines']); ?></span> mines</td>
+				<td><span class="creds"><?php echo number_format($TotalCost['Mines']); ?></span> credits</td>
+			</tr>
+			<tr>
+				<td><span class="yellow"><?php echo number_format($Total['CDs']); ?></span> combat drones</td>
+				<td><span class="creds"><?php echo number_format($TotalCost['CDs']); ?></span> credits</td>
+			</tr>
+			<tr>
+				<td><span class="yellow"><?php echo number_format($Total['SDs']); ?></span> scout drones</td>
+				<td><span class="creds"><?php echo number_format($TotalCost['SDs']); ?></span> credits</td>
+			</tr>
+			<tr>
+				<td><span class="yellow bold"><?php echo number_format(array_sum($Total)); ?></span> forces</td>
+				<td><span class="creds bold"><?php echo number_format(array_sum($TotalCost)); ?></span> credits</td>
+			</tr>
+		</table>
+		<br />
+
+		<table id="forces-list" class="standard inset">
+		<thead>
+		<tr>
+			<th class="sort" data-sort="sort_name">Player Name</th>
+			<th class="sort shrink" data-sort="sort_sector">Sector ID</th>
+			<th class="sort shrink" data-sort="sort_cds">Combat Drones</th>
+			<th class="sort shrink" data-sort="sort_sds">Scout Drones</th>
+			<th class="sort shrink" data-sort="sort_mines">Mines</th>
+			<th class="sort shrink" data-sort="sort_expire">Expire Time</th>
+		</tr>
+		</thead>
+
+		<tbody class="list"><?php
+		foreach ($Forces as $Force) { ?>
+			<tr>
+				<td class="sort_name"><?php echo $Force->getOwner()->getLinkedDisplayName(false); ?></td>
+				<td class="sort_sector noWrap"><?php echo $Force->getSectorID(); ?> (<?php echo $Force->getGalaxy()->getName(); ?>)</td>
+				<td class="sort_cds center"><?php echo $Force->getCDs(); ?></td>
+				<td class="sort_sds center"><?php echo $Force->getSDs(); ?></td>
+				<td class="sort_mines center"><?php echo $Force->getMines(); ?></td>
+				<td class="sort_expire noWrap" data-expire="<?php echo $Force->getExpire(); ?>"><?php echo date(DATE_FULL_SHORT, $Force->getExpire()); ?></td>
+			</tr><?php
+		} ?>
+		</table>
+	</div>
+
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
+	<script>
+	var list = new List('forces-list', {
+		valueNames: ['sort_name', 'sort_sector', 'sort_cds', 'sort_sds', 'sort_mines', {name: 'sort_expire', attr: 'data-expire'}],
+		sortFunction: function(a, b, options) {
+			return list.utils.naturalSort(a.values()[options.valueName].replace(/<.*?>|,/g,''), b.values()[options.valueName].replace(/<.*?>|,/g,''), options);
+		}
+	});
+	</script><?php
+} ?>

--- a/templates/Default/engine/Default/forces_list.php
+++ b/templates/Default/engine/Default/forces_list.php
@@ -1,0 +1,45 @@
+<?php
+if (empty($Forces)) { ?>
+	You have no deployed forces.
+	<a href="<?php echo WIKI_URL; ?>/game-guide/forces" target="_blank">
+		<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/>
+	</a><?php
+} else { ?>
+	<table id="forces-list" class="standard inset">
+		<a href="<?php echo WIKI_URL; ?>/game-guide/forces" target="_blank">
+			<img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/>
+		</a><br />
+
+		<thead>
+		<tr>
+			<th class="sort shrink" data-sort="sort_sector">Sector ID</th>
+			<th class="sort shrink" data-sort="sort_cds">Combat Drones</th>
+			<th class="sort shrink" data-sort="sort_sds">Scout Drones</th>
+			<th class="sort shrink" data-sort="sort_mines">Mines</th>
+			<th class="sort shrink" data-sort="sort_expire">Expire Time</th>
+		</tr>
+		</thead>
+
+		<tbody class="list"><?php
+		foreach ($Forces as $Force) { ?>
+			<tr>
+				<td class="sort_sector noWrap"><?php echo $Force->getSectorID(); ?> (<?php echo $Force->getGalaxy()->getName(); ?>)</td>
+				<td class="sort_cds center"><?php echo $Force->getCDs(); ?></td>
+				<td class="sort_sds center"><?php echo $Force->getSDs(); ?></td>
+				<td class="sort_mines center"><?php echo $Force->getMines(); ?></td>
+				<td class="sort_expire noWrap" data-expire="<?php echo $Force->getExpire(); ?>"><?php echo date(DATE_FULL_SHORT, $Force->getExpire()); ?></td>
+			</tr><?php
+		} ?>
+		</tbody>
+	</table>
+
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
+	<script>
+	var list = new List('forces-list', {
+		valueNames: ['sort_sector', 'sort_cds', 'sort_sds', 'sort_mines', {name: 'sort_expire', attr: 'data-expire'}],
+		sortFunction: function(a, b, options) {
+			return list.utils.naturalSort(a.values()[options.valueName].replace(/<.*?>|,/g,''), b.values()[options.valueName].replace(/<.*?>|,/g,''), options);
+		}
+	});
+	</script><?php
+}


### PR DESCRIPTION
This dramatically improves performance of sorting the force lists,
which gets quite slow once the list is large (as it always is).

We also convert forces_list.php and alliance_forces.php to templates
in the process.

NOTE: in doing this, I believe we lose the ability to secondary sort.
While this was useful, the page loading is so slow that it loses its
convenience (you need to load the page 4 times just to sort by
desc mines with asc expire time, which is typically the only case
where secondary sorting is used). However, secondary sorting can
be re-implemented by adjusting the list.js sort function, if it is
requested.