### PR TITLE
Do not require a composer install for dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,17 @@ docker run \
 	--detach \
 	smrealms/smr
 ```
-For development (will automatically pick up source changes, but you will need to make sure you have run `composer install`)
+For development (will automatically pick up source changes)
 ```
 docker run \
 	--name="smr" \
 	--link='smr-mysql' \
 	--publish='80:80' \
-	--volume="$(pwd):/smr" \
+	--volume="$(pwd)/admin:/smr/admin" \
+	--volume="$(pwd)/engine:/smr/engine" \
+	--volume="$(pwd)/htdocs:/smr/htdocs" \
+	--volume="$(pwd)/lib:/smr/lib" \
+	--volume="$(pwd)/templates:/smr/templates" \
 	--volume="$(pwd)/config:/smr/config:ro" \
 	--detach \
 	smrealms/smr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,11 @@ services:
             - mysql
         volumes:
             # Mount the source code instead of copying it.
-            # You must have run `composer install` to do this.
-            - .:/smr:rw
+            - ./admin:/smr/admin
+            - ./engine:/smr/engine
+            - ./htdocs:/smr/htdocs
+            - ./lib:/smr/lib
+            - ./templates:/smr/templates
 
     flyway:
         image: claycephas/flyway


### PR DESCRIPTION
In the dev environment (where the local source code is mounted in
the container), we previously mounted the repository root.

This had the unpleasant side effect that you had to run `composer
install` in your host environment, which requires you to download
and correctly configure all the PHP dependencies, defeating the
purpose of using docker in the first place.

However, if we mount only the relevant source code directories,
then you retain the `vendor` directory that is created by the
`composer install` in the image, and then you no longer need to
install _any_ dependencies on the host. This is well worth the
slightly enlarged list of mounts.