### PR TITLE
 ajax.js: fix refresh ignoring disable

### DIFF
--- a/htdocs/js/ajax.js
+++ b/htdocs/js/ajax.js
@@ -4,7 +4,7 @@ var exec = function(s) {
 };
 (function() {
 	"use strict";
-	var bindOne, updateRefreshTimeout, refreshSpeed, ajaxRunning = true, refreshReady = true, disableStartAJAX=false, xmlHttpRefresh, sn, updateRefresh, updateRefreshRequest, stopAJAX, getURLParameter;
+	var bindOne, updateRefreshTimeout, refreshSpeed, ajaxRunning = true, refreshReady = true, disableStartAJAX=true, xmlHttpRefresh, sn, updateRefresh, updateRefreshRequest, stopAJAX, getURLParameter;
 
 	bindOne = function(func, arg) {
 		return function() {
@@ -14,7 +14,7 @@ var exec = function(s) {
 
 	// startAJAX
 	window.onfocus = function() {
-		// Start the Ajax updates
+		// Start the Ajax updates if startRefresh has been called
 		if(!disableStartAJAX) {
 			ajaxRunning = true;
 			clearTimeout(updateRefreshTimeout);
@@ -143,6 +143,10 @@ var exec = function(s) {
 
 	//Globals
 	window.startRefresh = function(_refreshSpeed) {
+		// If auto-refresh is disabled in preferences, then this function is not called,
+		// so make sure the refresh is enabled ONLY if this function is called.
+		disableStartAJAX = false;
+
 		if(!_refreshSpeed) {
 			return;
 		}


### PR DESCRIPTION
The issue
=========
When "Auto Refresh" is disabled in preferences, then the
`startRefresh` function will not be called. However, when the
browser regains focus, it will begin to refresh with NO delay.
This is a result of the way the `onfocus` and `startRefresh`
functions interact in ajax.js.

The solution
============
One way to solve this problem is to disable the refresh by
default in ajax.js, and ONLY enable it if `startRefresh` is
called. This ensures that ajax updates will only occur if the
"Auto Refresh" preference is enabled.

--------------

This depends on PR #239. To review, please just look at the diff for the top commit in this PR.