### PR TITLE
config.php: increase starting newbie turns for newbies

### DIFF
--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -295,7 +295,7 @@ define('BOND_TIME',172800);
  * Miscellaneous definitions
  */
 
-define('STARTING_NEWBIE_TURNS_NEWBIE', 500);
+define('STARTING_NEWBIE_TURNS_NEWBIE', 750);
 define('STARTING_NEWBIE_TURNS_VET', 250);
 
 define('NEWBIE', 1);


### PR DESCRIPTION
While a more comprehensive solution to newbie deaths is needed,
a stopgap solution is to simply give some more starting newbie
turns to newbies.

I think we won't know the "correct" amount until we have more
new players, but we'll start with a conservative increase to
750 from 500.