### PR TITLE
Change visibility of (Trade,Goods) to HOF_ALLIANCE

### DIFF
--- a/engine/Default/cargo_dump_processing.php
+++ b/engine/Default/cargo_dump_processing.php
@@ -76,7 +76,7 @@ else {
 $player->takeTurns(1,1);
 
 $ship->decreaseCargo($good_id,$amount);
-$player->increaseHOF($amount,array('Trade','Goods', 'Jettisoned'), HOF_PUBLIC);
+$player->increaseHOF($amount,array('Trade','Goods', 'Jettisoned'), HOF_ALLIANCE);
 
 forward($container);
 

--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -82,7 +82,7 @@ if (!empty($bargain_price) &&
 		$container['traded_transaction'] = 'bought';
 		$ship->increaseCargo($good_id,$amount);
 		$player->decreaseCredits($bargain_price);
-		$player->increaseHOF($amount,array('Trade','Goods','Bought'), HOF_PUBLIC);
+		$player->increaseHOF($amount,array('Trade','Goods','Bought'), HOF_ALLIANCE);
 		$player->increaseHOF($gained_exp,array('Trade','Experience','Buying'), HOF_PUBLIC);
 		$player->decreaseHOF($bargain_price,array('Trade','Money','Profit'), HOF_PUBLIC);
 		$player->increaseHOF($bargain_price,array('Trade','Money','Buying'), HOF_PUBLIC);
@@ -95,7 +95,7 @@ if (!empty($bargain_price) &&
 		$container['traded_transaction'] = 'sold';
 		$ship->decreaseCargo($good_id,$amount);
 		$player->increaseCredits($bargain_price);
-		$player->increaseHOF($amount,array('Trade','Goods','Sold'), HOF_PUBLIC);
+		$player->increaseHOF($amount,array('Trade','Goods','Sold'), HOF_ALLIANCE);
 		$player->increaseHOF($gained_exp,array('Trade','Experience','Selling'), HOF_PUBLIC);
 		$player->increaseHOF($bargain_price,array('Trade','Money','Profit'), HOF_PUBLIC);
 		$player->increaseHOF($bargain_price,array('Trade','Money','Selling'), HOF_PUBLIC);


### PR DESCRIPTION
Players can track what ship you're in with public visibility of
number of goods traded, which is not an intended side effect of
the Current HoF.

This HoF category was requested to be removed, but that was likely
before HOF_ALLIANCE visibility was implemented. The visibility change
should be a sufficient solution.