### PR TITLE
Switch to offical Flyway docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,7 @@ docker run \
 	--rm \
 	--link='smr-mysql' \
 	--volume="$(pwd)/db/patches:/flyway/sql:ro" \
-	shouldbee/flyway \
-	-url='jdbc:mysql://smr-mysql/smr_live' \
-	-user='smr' \
-	-password='smr' \
-	init
-
-docker run \
-	--rm \
-	--link='smr-mysql' \
-	--volume="$(pwd)/db/patches:/flyway/sql:ro" \
-	shouldbee/flyway \
+	boxfuse/flyway:latest-alpine \
 	-url='jdbc:mysql://smr-mysql/smr_live' \
 	-user='smr' \
 	-password='smr' \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
             - ./templates:/smr/templates
 
     flyway:
-        image: claycephas/flyway
+        image: boxfuse/flyway:latest-alpine
         command: -url=jdbc:mysql://${MYSQL_HOST}/smr_live -user=smr -password=${MYSQL_PASSWORD} migrate
         links:
             - mysql


### PR DESCRIPTION
An officially docker image for Flyway recently became available.
We will use the alpine version, since it is significantly smaller
(100MB from ~600MB).

Note that the latest version is Flyway 5, so if you used an earlier
version on an existing database, you will get a warning about the
Flyway table name change (which will be an error in Flyway 6).

While the warning recommends changing the `flyway.table` property,
it is simpler to just rename the table from `schema_version` to
`flyway_schema_history`.

Flyway 5 finally provides a command to undo migrations. Yay!