### PR TITLE
message_view.php: fix ordering of scout messages

### DIFF
--- a/engine/Default/message_view.php
+++ b/engine/Default/message_view.php
@@ -240,10 +240,9 @@ function displayGrouped(&$messageBox, $playerName, $player_id, $sender_id, $mess
 	$container = create_container('skeleton.php', 'trader_search_result.php');
 	$container['player_id'] = $player_id;
 	$message['SenderDisplayName'] = create_link($container, $playerName);
-	$message['FirstSendTime'] = $first;
-	$message['LastSendTime'] = $last;
+	$message['SendTime'] = date(DATE_FULL_SHORT, $first) . " - " . date(DATE_FULL_SHORT, $last);
 	$message['Text'] = $message_text;
-	$messageBox['GroupedMessages'][] = $message;
+	$messageBox['Messages'][] = $message;
 }
 function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $message_text, $send_time, $msg_read, $type, $sentMessage = false) {
 	require_once(get_file_loc('message.functions.inc'));
@@ -297,7 +296,7 @@ function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $me
 	}
 
 	$message['Unread'] = $msg_read == 'FALSE';
-	$message['SendTime'] = $send_time;
+	$message['SendTime'] = date(DATE_FULL_SHORT, $send_time);
 	$messageBox['Messages'][] = & $message;
 }
 ?>

--- a/templates/Default/engine/Default/message_view.php
+++ b/templates/Default/engine/Default/message_view.php
@@ -81,7 +81,7 @@ else {
 								?>From: <?php echo $Message['SenderDisplayName'];
 							} ?>
 						</td>
-						<td class="noWrap"<?php if(!isset($Message['Sender'])) { ?> colspan="4"<?php } ?>>Date: <?php echo date(DATE_FULL_SHORT, $Message['SendTime']); ?></td>
+						<td class="noWrap"<?php if(!isset($Message['Sender'])) { ?> colspan="4"<?php } ?>>Date: <?php echo $Message['SendTime']; ?></td>
 						<?php
 						if (isset($Message['Sender'])) { ?>
 							<td>
@@ -100,21 +100,9 @@ else {
 					</tr>
 					<?php
 				} unset($Message);
-			}
-			if(isset($MessageBox['GroupedMessages'])) {
-				foreach($MessageBox['GroupedMessages'] as &$Message) { ?>
-					<tr>
-						<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $Message['ID'] ?>" /><?php if($Message['Unread']) { ?>*<?php } ?></td>
-						<td class="noWrap" width="100%">From: <?php echo $Message['SenderDisplayName']; ?></td>
-						<td class="noWrap" colspan="4">Date: <?php echo date(DATE_FULL_SHORT, $Message['FirstSendTime']); ?> - <?php echo date(DATE_FULL_SHORT, $Message['LastSendTime']); ?></td>
-					</tr>
-					<tr>
-						<td colspan="6"><?php echo bbifyMessage($Message['Text']); ?></td>
-					</tr>
-					<?php
-				} unset($Message);
 			} ?>
 		</table>
+
 		<table class="fullwidth center">
 			<tr>
 				<td style="width: 30%" valign="middle"><?php


### PR DESCRIPTION
The template was previously set up to _always_ display individual
messages before grouped messages, which meant that if the only
new (*) messages were grouped, they would display at the end of
the list, even if it meant that old individual messages displayed
above them. This is not correct, because new messages should
always display at the top.

The engine starts to set this up correctly, by adding new messages
to the message array first, then unread messages second. However,
it then puts them into separate arrays ('Messages' and 'Grouped
Messages'). If we instead put them into the same array, then
the ordering works out correctly in a completely natural way.

As a result of this simple change, we can actually remove _all_
special casing for grouped messages in the template.