### PR TITLE
Alliance option to add Discord widget

### DIFF
--- a/db/patches/V1_6_61_13__alliance_discord_server.sql
+++ b/db/patches/V1_6_61_13__alliance_discord_server.sql
@@ -1,0 +1,2 @@
+-- Add `discord_server` field to `alliance` table
+ALTER TABLE `alliance` ADD COLUMN `discord_server` VARCHAR(32) DEFAULT NULL;

--- a/engine/Default/alliance_mod.php
+++ b/engine/Default/alliance_mod.php
@@ -60,6 +60,12 @@ if ($db->getBoolean('change_mod') || $db->getBoolean('change_pass')) {
 	$container['alliance_id'] = $alliance->getAllianceID();
 	$PHP_OUTPUT.=create_button($container,'Edit');
 }
+
+$discordServer = $alliance->getDiscordServer();
+if (!empty($discordServer)) {
+	$PHP_OUTPUT .= '<br /><br /><br /><iframe src="https://discordapp.com/widget?id=' . $discordServer . '&theme=dark" width="350" height="375" allowtransparency="true" frameborder="0"></iframe>';
+}
+
 $PHP_OUTPUT.= '</div>';
 
 ?>

--- a/engine/Default/alliance_stat_processing.php
+++ b/engine/Default/alliance_stat_processing.php
@@ -10,8 +10,11 @@ if (isset($_REQUEST['password'])) {
 if (isset($_REQUEST['description'])) {
 	$description = trim($_REQUEST['description']);
 }
-if (isset($_REQUEST['discord'])) {
-	$discordChannel = trim($_REQUEST['discord']);
+if (isset($_REQUEST['discord_server'])) {
+	$discordServer = trim($_REQUEST['discord_server']);
+}
+if (isset($_REQUEST['discord_channel'])) {
+	$discordChannel = trim($_REQUEST['discord_channel']);
 }
 if (isset($_REQUEST['irc'])) {
 	$irc = trim($_REQUEST['irc']);
@@ -37,6 +40,9 @@ if (isset($password)) {
 }
 if (isset($description)) {
 	$alliance->setAllianceDescription($description);
+}
+if (isset($discordServer)) {
+	$alliance->setDiscordServer($discordServer);
 }
 if (isset($discordChannel)) {
 	if (empty($discordChannel)) {

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -18,6 +18,7 @@ class SmrAlliance {
 	protected $deaths;
 	protected $motd;
 	protected $imgSrc;
+	protected $discordServer;
 	protected $discordChannel;
 	protected $ircChannel;
 
@@ -70,6 +71,7 @@ class SmrAlliance {
 			$this->deaths			= $this->db->getInt('alliance_deaths');
 			$this->motd				= strip_tags(stripslashes($this->db->getField('mod')));
 			$this->imgSrc			= $this->db->getField('img_src');
+			$this->discordServer	= $this->db->getField('discord_server');
 			$this->discordChannel	= $this->db->getField('discord_channel');
 
 			if (empty($this->kills)) {
@@ -114,6 +116,14 @@ class SmrAlliance {
 
 	public function &getLeader() {
 		return SmrPlayer::getPlayer($this->getLeaderID(),$this->getGameID());
+	}
+
+	public function getDiscordServer() {
+		return $this->discordServer;
+	}
+
+	public function setDiscordServer($serverId) {
+		$this->discordServer = $serverId;
 	}
 
 	public function getDiscordChannel() {
@@ -283,6 +293,7 @@ class SmrAlliance {
 								img_src = ' . $this->db->escapeString($this->imgSrc) . ',
 								alliance_kills = '.$this->db->escapeNumber($this->kills).',
 								alliance_deaths = '.$this->db->escapeNumber($this->deaths).',
+								discord_server = '.$this->db->escapeString($this->discordServer).',
 								discord_channel = '.$this->db->escapeString($this->discordChannel).',
 								leader_id = '.$this->db->escapeNumber($this->leaderID).'
 							WHERE alliance_id = '.$this->db->escapeNumber($this->allianceID).'

--- a/templates/Default/engine/Default/alliance_stat.php
+++ b/templates/Default/engine/Default/alliance_stat.php
@@ -16,9 +16,18 @@ if ($CanChangeDescription) { ?>
 
 if ($CanChangeChatChannel) { ?>
 	<tr>
+		<td class="top">Discord Server ID:&nbsp;</td>
+		<td>
+			<input type="text" name="discord_server" size="30" value="<?php echo htmlspecialchars($Alliance->getDiscordServer()); ?>" />&nbsp;
+			<a href="<?php echo WIKI_URL; ?>/chat#alliance-discord-widget" target="_blank">
+				<img src="images/silk/help.png" width="16" height="16" alt="" title="Goto SMR Wiki: Discord Widget"/>
+			</a>
+			<br />Adds the Discord join server widget to the Message of the Day page.
+		</td>
+	<tr>
 		<td class="top noWrap">Discord Channel ID:&nbsp;</td>
 		<td>
-			<input type="text" name="discord" size="30" value="<?php echo htmlspecialchars($Alliance->getDiscordChannel()); ?>" />&nbsp;
+			<input type="text" name="discord_channel" size="30" value="<?php echo htmlspecialchars($Alliance->getDiscordChannel()); ?>" />&nbsp;
 			<a href="<?php echo WIKI_URL; ?>/chat#autopilot-for-alliance-channels" target="_blank">
 				<img src="images/silk/help.png" width="16" height="16" alt="" title="Goto SMR Wiki: Autopilot"/>
 			</a>


### PR DESCRIPTION
Adds a "Discord Server" option to the Alliance Stats page, which when set will enable the Discord widget to display on the Message of the Day page.

Also improved descriptions and links for the chat-related Alliance options.

On Alliance Stats page:
![image](https://user-images.githubusercontent.com/846186/34647326-13dd63b2-f335-11e7-8a08-3810985af08b.png)

On Message of the Day page:
![image](https://user-images.githubusercontent.com/846186/34647333-2ced4fde-f335-11e7-93a3-e2076c604ab0.png)

