### PR TITLE
planet_ownership.php: add message about losing ownership

### DIFF
--- a/engine/Default/planet_ownership.php
+++ b/engine/Default/planet_ownership.php
@@ -15,4 +15,10 @@ $template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
 $template->assign('Planet', $planet);
 $template->assign('Player', $player);
 
+// Check if this player already owns a planet
+$db->query('SELECT sector_id FROM planet WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND owner_id=' . $db->escapeNumber($player->getAccountID()));
+if ($db->nextRecord()) {
+	$template->assign('PlayerPlanet', $db->getInt('sector_id'));
+}
+
 ?>

--- a/engine/Default/planet_ownership.php
+++ b/engine/Default/planet_ownership.php
@@ -3,43 +3,16 @@ if (!$player->isLandedOnPlanet())
 	create_error('You are not on a planet!');
 
 // create planet object
-$planet =& $player->getSectorPlanet();
+$planet = $player->getSectorPlanet();
 $template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$player->getSectorID().']');
 
 require_once(get_file_loc('menu.inc'));
 create_planet_menu($planet);
 
-$PHP_OUTPUT.=('<p>');
+$container = create_container('planet_ownership_processing.php');
+$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
 
-if (!$planet->hasOwner()) {
-	$PHP_OUTPUT.=('The planet is unclaimed.');
-	$PHP_OUTPUT.=create_echo_form(create_container('planet_ownership_processing.php', ''));
-	$PHP_OUTPUT.=create_submit('Take Ownership');
-	$PHP_OUTPUT.=('</form>');
-}
-else {
-	if ($planet->getOwnerID() != $player->getAccountID()) {
-		$PHP_OUTPUT.=('You can claim the planet when you enter the correct password.');
-		$PHP_OUTPUT.=create_echo_form(create_container('planet_ownership_processing.php', ''));
-		$PHP_OUTPUT.=('<input type="text" name="password" id="InputFields">&nbsp;&nbsp;&nbsp;');
-		$PHP_OUTPUT.=create_submit('Take Ownership');
-		$PHP_OUTPUT.=('</form>');
-	}
-	else {
-		$PHP_OUTPUT.=('You can set a password for that planet.');
-		$PHP_OUTPUT.=create_echo_form(create_container('planet_ownership_processing.php', ''));
-		$PHP_OUTPUT.=('<input type="text" name="password" value="'.htmlspecialchars($planet->getPassword()).'" id="InputFields">&nbsp;&nbsp;&nbsp;');
-		$PHP_OUTPUT.=create_submit('Set Password');
-		$PHP_OUTPUT.=('</form>');
-
-		$PHP_OUTPUT.=('You can rename the planet.');
-		$PHP_OUTPUT.=create_echo_form(create_container('planet_ownership_processing.php', ''));
-		$PHP_OUTPUT.=('<input type="text" name="name" value="'.htmlspecialchars($planet->getName()).'" id="InputFields">&nbsp;&nbsp;&nbsp;');
-		$PHP_OUTPUT.=create_submit('Rename');
-		$PHP_OUTPUT.=('</form>');
-	}
-}
-
-$PHP_OUTPUT.=('</p>');
+$template->assign('Planet', $planet);
+$template->assign('Player', $player);
 
 ?>

--- a/templates/Default/engine/Default/planet_ownership.php
+++ b/templates/Default/engine/Default/planet_ownership.php
@@ -1,0 +1,33 @@
+<?php
+
+if (!$Planet->hasOwner()) { ?>
+	<p>The planet is unclaimed.</p>
+	<form method="POST" action="<?php echo $ProcessingHREF; ?>">
+		<input type="submit" name="action" value="Take Ownership" id="InputFields" />
+	</form><?php
+}
+else {
+	if ($Planet->getOwnerID() != $Player->getAccountID()) { ?>
+		<p>You can claim the planet when you enter the correct password.</p>
+		<form method="POST" action="<?php echo $ProcessingHREF; ?>">
+			<input type="text" name="password" id="InputFields">&nbsp;&nbsp;&nbsp;
+			<input type="submit" name="action" value="Take Ownership" id="InputFields" />
+		</form><?php
+	}
+	else { ?>
+		<p>You can set a password for the planet.</p>
+		<form method="POST" action="<?php echo $ProcessingHREF; ?>">
+			<input type="text" name="password" value="<?php echo htmlspecialchars($Planet->getPassword()); ?>" id="InputFields" />&nbsp;&nbsp;&nbsp;
+			<input type="submit" name="action" value="Set Password" id="InputFields" />
+		</form>
+		<br />
+
+		<p>You can rename the planet.</p>
+		<form method="POST" action="<?php echo $ProcessingHREF; ?>">
+			<input type="text" name="name" value="<?php echo htmlspecialchars($Planet->getName()); ?>" id="InputFields" />&nbsp;&nbsp;&nbsp;
+			<input type="submit" name="action" value="Rename" id="InputFields" />
+		</form><?php
+	}
+}
+
+?>

--- a/templates/Default/engine/Default/planet_ownership.php
+++ b/templates/Default/engine/Default/planet_ownership.php
@@ -1,28 +1,38 @@
 <?php
 
 if (!$Planet->hasOwner()) { ?>
-	<p>The planet is unclaimed.</p>
+	<p>
+		This planet is unclaimed.<?php
+		if (isset($PlayerPlanet)) { ?>
+			<br />If you claim it, you will lose ownership of the planet in Sector #<?php echo $PlayerPlanet; ?>!<?php
+		} ?>
+	</p>
 	<form method="POST" action="<?php echo $ProcessingHREF; ?>">
 		<input type="submit" name="action" value="Take Ownership" id="InputFields" />
 	</form><?php
 }
 else {
 	if ($Planet->getOwnerID() != $Player->getAccountID()) { ?>
-		<p>You can claim the planet when you enter the correct password.</p>
+		<p><?php echo SmrPlayer::getPlayer($Planet->getOwnerID(), $Planet->getGameID())->getLinkedDisplayName(false); ?> owns this planet.</p>
+		<p>
+			You can claim the planet when you enter the correct password.<?php
+			if (isset($PlayerPlanet)) { ?>
+				<br />If you do, you will lose ownership of the planet in Sector #<?php echo $PlayerPlanet; ?>!<?php
+			} ?>
+		</p>
 		<form method="POST" action="<?php echo $ProcessingHREF; ?>">
 			<input type="text" name="password" id="InputFields">&nbsp;&nbsp;&nbsp;
 			<input type="submit" name="action" value="Take Ownership" id="InputFields" />
 		</form><?php
 	}
 	else { ?>
-		<p>You can set a password for the planet.</p>
+		<p>You own this planet!</p>
 		<form method="POST" action="<?php echo $ProcessingHREF; ?>">
 			<input type="text" name="password" value="<?php echo htmlspecialchars($Planet->getPassword()); ?>" id="InputFields" />&nbsp;&nbsp;&nbsp;
 			<input type="submit" name="action" value="Set Password" id="InputFields" />
 		</form>
 		<br />
 
-		<p>You can rename the planet.</p>
 		<form method="POST" action="<?php echo $ProcessingHREF; ?>">
 			<input type="text" name="name" value="<?php echo htmlspecialchars($Planet->getName()); ?>" id="InputFields" />&nbsp;&nbsp;&nbsp;
 			<input type="submit" name="action" value="Rename" id="InputFields" />


### PR DESCRIPTION
When you go to claim a planet, it is often annoying to check to
see if you already own a planet (especially now that we have multis).

With this change, a message will be displayed letting you know that
if you take ownership when you already have a planet, you will lose
ownership of that other planet. This implicitly declares the
"one planet per person" rule, which was otherwise not stated anywhere.

Also minor rewording to make the new text fit better in context.

![image](https://user-images.githubusercontent.com/846186/34647947-3654b250-f345-11e7-95e9-352c360838ff.png)

![image](https://user-images.githubusercontent.com/846186/34647964-78fe5cdc-f345-11e7-91bb-dd85282bde67.png)

![image](https://user-images.githubusercontent.com/846186/34647953-45619704-f345-11e7-9019-285df5f72353.png)

![image](https://user-images.githubusercontent.com/846186/34647969-9015eb38-f345-11e7-8a4d-2d7c57882394.png)

![image](https://user-images.githubusercontent.com/846186/34647956-522b2fae-f345-11e7-84de-c75d71361d7c.png)
