### PR TITLE
Add includeAllianceID argument to SmrAlliance::getAllianceName

### DIFF
--- a/engine/Default/alliance_broadcast.php
+++ b/engine/Default/alliance_broadcast.php
@@ -1,6 +1,6 @@
 <?php
 $alliance =& SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_exempt_authorize.php
+++ b/engine/Default/alliance_exempt_authorize.php
@@ -1,6 +1,6 @@
 <?php
 $alliance =& $player->getAlliance();
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_forces.php
+++ b/engine/Default/alliance_forces.php
@@ -4,7 +4,7 @@ if (!isset($var['alliance_id'])) {
 }
 
 $alliance =& SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_leadership.php
+++ b/engine/Default/alliance_leadership.php
@@ -1,7 +1,7 @@
 <?php
 
 $alliance =& $player->getAlliance();
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($player->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_leave_confirm.php
+++ b/engine/Default/alliance_leave_confirm.php
@@ -1,7 +1,7 @@
 <?php
 
 $alliance =& $player->getAlliance();
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_message.php
+++ b/engine/Default/alliance_message.php
@@ -4,7 +4,7 @@ if (!isset($var['alliance_id'])) {
 }
 
 $alliance =& SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 $mbWrite = TRUE;

--- a/engine/Default/alliance_mod.php
+++ b/engine/Default/alliance_mod.php
@@ -7,7 +7,7 @@ $alliance =& SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID())
 
 Globals::canAccessPage('AllianceMOTD', $player, array('AllianceID' => $alliance->getAllianceID()));
 
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_option.php
+++ b/engine/Default/alliance_option.php
@@ -4,7 +4,7 @@ if (!isset($var['alliance_id'])) {
 }
 
 $alliance =& SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_planets.php
+++ b/engine/Default/alliance_planets.php
@@ -4,7 +4,7 @@ if (!isset($var['alliance_id'])) {
 }
 
 $alliance =& SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_remove_member.php
+++ b/engine/Default/alliance_remove_member.php
@@ -1,6 +1,6 @@
 <?php
 $alliance =&$player->getAlliance();
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_roles.php
+++ b/engine/Default/alliance_roles.php
@@ -4,7 +4,7 @@ if (!isset($var['alliance_id'])) {
 }
 
 $alliance =& SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_roster.php
+++ b/engine/Default/alliance_roster.php
@@ -9,7 +9,7 @@ if (!isset($var['alliance_id'])) {
 $alliance =& SmrAlliance::getAlliance($var['alliance_id'],$player->getGameID());
 $template->assignByRef('Alliance', $alliance);
 
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 

--- a/engine/Default/alliance_set_op.php
+++ b/engine/Default/alliance_set_op.php
@@ -1,7 +1,7 @@
 <?php
 
 $alliance =& $player->getAlliance();
-$template->assign('PageTopic', $alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance->getAllianceID(), $alliance->getLeaderID());
 

--- a/engine/Default/alliance_stat.php
+++ b/engine/Default/alliance_stat.php
@@ -5,7 +5,7 @@ if (!isset($var['alliance_id'])) {
 $alliance_id = $var['alliance_id'];
 
 $alliance =& SmrAlliance::getAlliance($alliance_id,$player->getGameID());
-$template->assign('PageTopic',$alliance->getAllianceName() . ' (' . $alliance->getAllianceID() . ')');
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
 create_alliance_menu($alliance_id,$alliance->getLeaderID());
 

--- a/engine/Default/alliance_treaties_processing.php
+++ b/engine/Default/alliance_treaties_processing.php
@@ -66,7 +66,7 @@ if (isset($_REQUEST['proposedAlliance'])) {
 	$mbRead = $mbWrite || isset($_REQUEST['mbRead']);
 	$modRead = isset($_REQUEST['modRead']);
 	//get confirmation
-	$template->assign('PageTopic',$alliance1->getAllianceName() . ' (' . $alliance1->getAllianceID() . ')');
+	$template->assign('PageTopic', $alliance1->getAllianceName(false, true));
 	require_once(get_file_loc('menu.inc'));
 	create_alliance_menu($alliance1->getAllianceID(),$alliance1->getLeaderID());
 	$PHP_OUTPUT.=('<br /><br /');

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -510,9 +510,9 @@ abstract class AbstractSmrPlayer {
 		return $this->hasAlliance()?'[alliance='.$this->getAllianceID().']':$this->getAllianceName();
 	}
 
-	public function getAllianceName($linked = false) {
+	public function getAllianceName($linked=false, $includeAllianceID=false) {
 		if($this->hasAlliance()) {
-			return $this->getAlliance()->getAllianceName($linked);
+			return $this->getAlliance()->getAllianceName($linked, $includeAllianceID);
 		}
 		else {
 			return 'No Alliance';

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -85,11 +85,15 @@ class SmrAlliance {
 		return $this->allianceID;
 	}
 
-	public function getAllianceName($linked = false) {
-		if($linked === true && !$this->hasDisbanded()) {
-			return create_link(Globals::getAllianceRosterHREF($this->getAllianceID()), $this->allianceName);
+	public function getAllianceName($linked=false, $includeAllianceID=false) {
+		$name = $this->allianceName;
+		if ($includeAllianceID) {
+			$name .= ' (' . $this->allianceID . ')';
 		}
-		return $this->allianceName;
+		if($linked === true && !$this->hasDisbanded()) {
+			return create_link(Globals::getAllianceRosterHREF($this->getAllianceID()), $name);
+		}
+		return $name;
 	}
 
 	public function getGameID() {
@@ -210,7 +214,7 @@ class SmrAlliance {
 			return;
 		}
 		global $player,$account;
-		$boxDescription = 'Alliance '.$this->getAllianceName().'('.$this->getAllianceID().') had their description changed to:'.EOL.EOL.$description;
+		$boxDescription = 'Alliance '.$this->getAllianceName(false, true).' had their description changed to:'.EOL.EOL.$description;
 		if(is_object($player)) {
 			$player->sendMessageToBox(BOX_ALLIANCE_DESCRIPTIONS,$boxDescription);
 		}

--- a/templates/Default/engine/Default/includes/RightPanelPlayer.inc
+++ b/templates/Default/engine/Default/includes/RightPanelPlayer.inc
@@ -47,11 +47,7 @@ if(isset($GameID)) { ?>
 		</span>
 	</a>
 	Alignment : <span id="align"><?php echo get_colored_text($ThisPlayer->getAlignment(),number_format($ThisPlayer->getAlignment())); ?></span><br />
-	Alliance : <span id="alliance"><a href="<?php echo Globals::getAllianceHREF($ThisPlayer->getAllianceID()); ?>"><?php
-		echo $ThisPlayer->getAllianceName();
-		if($ThisPlayer->hasAlliance()) {
-			echo '('.number_format($ThisPlayer->getAllianceID()).')';
-		} ?></a></span><br />
+	Alliance : <span id="alliance"><a href="<?php echo Globals::getAllianceHREF($ThisPlayer->getAllianceID()); ?>"><?php echo $ThisPlayer->getAllianceName(false, true); ?></a></span><br />
 	<br />
 	<?php
 }

--- a/templates/Freon22/engine/Default/skeleton.php
+++ b/templates/Freon22/engine/Default/skeleton.php
@@ -75,10 +75,7 @@
 												Alignment: <span id="align"><?php echo get_colored_text($ThisPlayer->getAlignment(),number_format($ThisPlayer->getAlignment())); ?></span><br />
 												
 												Alliance: <span id="alliance"><a href="<?php echo Globals::getAllianceHREF($ThisPlayer->getAllianceID()); ?>"><?php
-													echo $ThisPlayer->getAllianceName();
-													if($ThisPlayer->hasAlliance()) {
-														echo '('.number_format($ThisPlayer->getAllianceID()).')';
-													} ?></a></span>
+													echo $ThisPlayer->getAllianceName(false, true); ?></a></span>
 											</div>
 										</td>
 									</tr>


### PR DESCRIPTION
This is the second argument, after `$linked`.

If true, will append `' (' . $this->allianceID . ')'` to the
alliance name. This happens to fix a missing space problem
between the alliance name and ID in the right panel.

Also add this argument to `SmrPlayer::getAllianceName`, which
forwards to the `SmrAlliance` method.