### PR TITLE
Use getAllianceName(true) where possible

### DIFF
--- a/engine/Default/current_players.php
+++ b/engine/Default/current_players.php
@@ -121,13 +121,8 @@ if ($count_last_active > 0) {
 		$PHP_OUTPUT.=('<td class="center">');
 		$PHP_OUTPUT.=create_link($container, $player->getColouredRaceName($curr_player->getRaceID()));
 		$PHP_OUTPUT.=('</td>');
-		$PHP_OUTPUT.=('<td>');
-		if ($curr_player->hasAlliance()) {
-			$PHP_OUTPUT.=create_link($curr_player->getAllianceRosterHREF(), $curr_player->getAllianceName());
-		}
-		else
-			$PHP_OUTPUT.=('(none)');
-		$PHP_OUTPUT.= '</td><td class="right">'. number_format($curr_player->getExperience()) . '</td>';
+		$PHP_OUTPUT.=('<td>' . $curr_player->getAllianceName(true) . '</td>');
+		$PHP_OUTPUT.= '<td class="right">'. number_format($curr_player->getExperience()) . '</td>';
 		$PHP_OUTPUT.=('</tr>');
 	}
 	$PHP_OUTPUT.=('	</table>');

--- a/engine/Default/forces_examine.php
+++ b/engine/Default/forces_examine.php
@@ -65,7 +65,7 @@ foreach($attackers as &$attacker) {
 	$PHP_OUTPUT.=($attacker->getLinkedDisplayName(false).'<br />');
 	$PHP_OUTPUT.=('Race: '.$attacker->getRaceName().'<br />');
 	$PHP_OUTPUT.=('Level: '.$attacker->getLevelID().'<br />');
-	$PHP_OUTPUT.=('Alliance: '.create_link($attacker->getAllianceRosterHREF(), $attacker->getAllianceName()).'<br /><br />');
+	$PHP_OUTPUT.=('Alliance: '.$attacker->getAllianceName(true).'<br /><br />');
 	$PHP_OUTPUT.=('<small>');
 	$PHP_OUTPUT.=($attackerShip->getName().'<br />');
 	$PHP_OUTPUT.=('Rating : ' . $attackerShip->getAttackRating() . '/' . $attackerShip->getDefenseRating() . '<br />');

--- a/engine/Default/trader_search_result.php
+++ b/engine/Default/trader_search_result.php
@@ -60,13 +60,7 @@ if ($db->getNumRows() > 0) {
 		}
 		$PHP_OUTPUT.=('</td>');
 
-		$PHP_OUTPUT.=('<td>');
-		if ($curr_player->hasAlliance()) {
-			$PHP_OUTPUT.=create_link($curr_player->getAllianceRosterHREF(), $curr_player->getAllianceName());
-		}
-		else
-			$PHP_OUTPUT.=('(none)');
-		$PHP_OUTPUT.=('</td>');
+		$PHP_OUTPUT.=('<td>' . $curr_player->getAllianceName(true) . '</td>');
 		$container = create_container('skeleton.php', 'council_list.php');
 		$container['race_id'] = $curr_player->getRaceID();
 		$PHP_OUTPUT.=('<td align="center" valign="middle">');
@@ -161,13 +155,7 @@ if (empty($player_id)) {
 			}
 			$PHP_OUTPUT.=('</td>');
 	
-			$PHP_OUTPUT.=('<td>');
-			if ($curr_player->hasAlliance()) {
-				$PHP_OUTPUT.=create_link($curr_player->getAllianceRosterHREF(), $curr_player->getAllianceName());
-			}
-			else
-				$PHP_OUTPUT.=('(none)');
-			$PHP_OUTPUT.=('</td>');
+			$PHP_OUTPUT.=('<td>' . $curr_player->getAllianceName(true) . '</td>');
 			$container = create_container('skeleton.php', 'council_send_message.php');
 			$container['race_id'] = $curr_player->getRaceID();
 			$PHP_OUTPUT.=('<td align="center" valign="middle">');

--- a/templates/Default/engine/Default/planet_examine.php
+++ b/templates/Default/engine/Default/planet_examine.php
@@ -29,8 +29,8 @@
 	<tr>
 		<td class="bold">Alliance:</td>
 		<td><?php
-			if ($ThisPlanet->hasOwner()) { ?>
-				<a href="<?php echo $ThisPlanet->getOwner()->getAllianceRosterHREF(); ?>"><?php echo $ThisPlanet->getOwner()->getAllianceName(); ?></a><?php
+			if ($ThisPlanet->hasOwner()) {
+				echo $ThisPlanet->getOwner()->getAllianceName(true);
 			}
 			else { ?>
 				none<?php


### PR DESCRIPTION
The first argument to `Smr{Player,Alliance}::getAllianceName` is
a bool which, if true, turns the name into a link to the Roster.

Using this option simplifies a few places in the code.

NOTE: This replaces "(none)" in a few spots with "No Alliance",
in particular the Current Players and Trader Search Results pages.
The disparity was a result of not everything using the standard
methods. I somewhat prefer the former, but may wait for feedback
before I change it.