### PR TITLE
album_moderate.php: fix errors

### DIFF
--- a/admin/Default/album_moderate.php
+++ b/admin/Default/album_moderate.php
@@ -3,29 +3,24 @@
 require_once(LIB . 'Album/album_functions.php');
 $db = new SmrMySqlDatabase(); // required when referred from album
 
-if(isset($_REQUEST['account_id']))
+if (isset($_REQUEST['account_id'])) {
 	SmrSession::updateVar('account_id',$_REQUEST['account_id']);
-$account_id = $var['account_id'];
+}
 
 // echo green topic
-$PHP_OUTPUT.=create_link(create_container('skeleton.php', 'album_moderate.php'),
-		   '<h1>MODERATE PHOTO ALBUM</h1>');
+$PHP_OUTPUT.='<h1>Moderate Photo Album</h1>';
 
-// if we don't have an account id yet, ask for it (and echo error message if invalid number was entered)
-if (empty($account_id)) {
-	$PHP_OUTPUT.=('Enter the account id of the entry you wish to edit:');
-	$PHP_OUTPUT.=create_echo_form(create_container('skeleton.php', 'album_moderate.php'));
-	$PHP_OUTPUT.=('<input type="number" name="account_id" size="5" id="InputFields" class="center">&nbsp;');
-	$PHP_OUTPUT.=create_submit('Submit');
-	$PHP_OUTPUT.=('</form>');
-	$PHP_OUTPUT.=($error_msg);
-}
-else {
+// Process account_id and perform error checking
+if (isset($var['account_id'])) {
+	$account_id = $var['account_id'];
+
 	// check if input is numeric
-	if (!is_numeric($account_id))
-		create_error('Please enter an account ID, which has to be numeric!');
+	if (!is_numeric($account_id)) {
+		$account_id = 0;
+		$error_msg = '<span class="red bold">ERROR:</span> Please enter an account ID, which has to be numeric!';
+	}
 
-	// check if the givin account really has an entry
+	// check if the given account really has an entry
 	if ($account_id > 0) {
 		$db->query('SELECT * FROM album WHERE account_id = '.$db->escapeNumber($account_id).' AND Approved = \'YES\'');
 		if ($db->nextRecord()) {
@@ -40,17 +35,34 @@ else {
 		}
 		else {
 			$account_id = 0;
-			$error_msg = '<div align="center" class="red bold">This User doesn\'t have an album entry or it needs to be approved first!</div>';
+			$error_msg = '<span class="red bold">ERROR:</span> This User doesn\'t have an album entry or it needs to be approved first!';
 		}
 	}
+}
+
+// if we don't have an account id yet, ask for it (and echo error message if invalid number was entered)
+if (empty($account_id)) {
+	$PHP_OUTPUT.='<br />';
+	$PHP_OUTPUT.=('Enter the account id of the entry you wish to edit:');
+	$PHP_OUTPUT.=create_echo_form(create_container('skeleton.php', 'album_moderate.php'));
+	$PHP_OUTPUT.=('<input type="number" name="account_id" size="5" id="InputFields" class="center">&nbsp;');
+	$PHP_OUTPUT.=create_submit('Submit');
+	$PHP_OUTPUT.=('</form>');
+	if (isset($error_msg)) {
+		$PHP_OUTPUT.=('<br />' . $error_msg);
+	}
+}
+else {
 
 	$container = create_container('album_moderate_processing.php', '');
 	$container['account_id'] = $account_id;
 
+	$PHP_OUTPUT.=create_link(create_container('skeleton.php', 'album_moderate.php'), '&lt;&lt;Back');
+	$PHP_OUTPUT.='<br /><br />';
 	$PHP_OUTPUT.=('<table border="0" align="center" cellpadding="5" cellspacing="0">');
 	$PHP_OUTPUT.=('<tr>');
 	$PHP_OUTPUT.=('<td align="center" colspan="3">');
-	$PHP_OUTPUT.=('<span style="font-size:150%;">'.get_album_nick($account_id).'</span></td><td>&nbsp;</td>');
+	$PHP_OUTPUT.=('<span style="font-size:150%;"><b>Album&nbsp;Nickname:</b> '.get_album_nick($account_id).'</span></td><td>&nbsp;</td>');
 	$PHP_OUTPUT.=('</tr>');
 	$PHP_OUTPUT.=('<tr>');
 

--- a/engine/Default/album_edit_processing.php
+++ b/engine/Default/album_edit_processing.php
@@ -104,7 +104,7 @@ else {
 				VALUES(' . $db->escapeNumber(SmrSession::$account_id) . ', ' . $db->escapeString($location) . ', ' . $db->escapeString($email) . ', ' . $db->escapeString($website) . ', ' . $db->escapeNumber($day) . ', ' . $db->escapeNumber($month) . ', ' . $db->escapeNumber($year) . ', ' . $db->escapeString($other) . ', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ', \'TBC\')');
 }
 
-if ($comment) {
+if (!empty($comment)) {
 	// check if we have comments for this album already
 	$db->lockTable('album_has_comments');
 


### PR DESCRIPTION
* A major piece of error checking logic was in the wrong order,
  which resulted in displaying a broken profile for moderation.
  We now check the account_id first before trying to display
  any errors.

* Add a "<<Back" button link instead of making the `<h1>` header
  the back button.

* Prefix player name with "Album Nickname" so it's clear what
  is being displayed.

* Fix a few PHP warnings about undefined variables.
  