### PR TITLE
Replace absolute paths in links

### DIFF
--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -661,8 +661,7 @@ function createGame($gameID) {
 	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 21, 1, '.$db->escapeString($text).', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(TIME) . ')');
 	
 	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 22, \'Ships\')');
-	$text = 'Everything you do in SMR is done while you are flying some kind of ship - it can be anything from an escape pod to a huge IkThorne mothership, but you are always the pilot of something. In addition to the neutral ships, each race also has unique ships that only race members can purchase. You can find the SMR shiplist here:<br />
-	<a href="' . URL . '/ship_list.php target="_blank">' . URL . '/ship_list.php</a> <br />
+	$text = 'Everything you do in SMR is done while you are flying some kind of ship - it can be anything from an escape pod to a huge IkThorne mothership, but you are always the pilot of something. In addition to the neutral ships, each race also has unique ships that only race members can purchase. You can find the SMR shiplist <a href="ship_list.php" target="_blank"><b><u>here</u></b></a>.<br />
 	Additional information relating to ships can be found in the <a href="' . WIKI_URL . '" target="_blank">SMR wiki</a><br />
 	<br />
 	It is important to choose ships to match your budget and your needs, and the biggest or most expensive ships are not always the best ones for all purposes.<br />
@@ -689,9 +688,7 @@ function createGame($gameID) {
 	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 22, 1, '.$db->escapeString($text).', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(TIME) . ')');
 	
 	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 23, \'Weapons\')');
-	$text = 'SMR has a wide variety of weapons with which to arm your ships, and information on weapon capabilities can be found here:<br />
-	<br />
-	<a href="' . URL . '/weapon_list.php">' . URL . '/weapon_list.php</a><br />
+	$text = 'SMR has a wide variety of weapons with which to arm your ships, and information on weapon capabilities can be found <a href="weapon_list.php" target="_blank"><b><u>here</b></u></a>.<br />
 	<br />
 	There are a few things to consider when choosing weapons, and the weapon combination that works for one player may not be suited to the style or the needs of another.<br />
 	<br />

--- a/admin/Default/album_approve.php
+++ b/admin/Default/album_approve.php
@@ -51,9 +51,9 @@ if ($db->nextRecord()) {
 	$PHP_OUTPUT.=('<td colspan="2" align="center" valign="middle">');
 
 	if ($disabled == 'FALSE')
-		$PHP_OUTPUT.=('<img src="'.URL.'/upload/'.$album_id.'">');
+		$PHP_OUTPUT.=('<img src="upload/'.$album_id.'">');
 	else
-		$PHP_OUTPUT.=('<img src="'.URL.'/upload/0">');
+		$PHP_OUTPUT.=('<img src="upload/0">');
 
 	$PHP_OUTPUT.=('</td>');
 	$PHP_OUTPUT.=('</tr>');

--- a/admin/Default/album_moderate.php
+++ b/admin/Default/album_moderate.php
@@ -71,7 +71,7 @@ else {
 					 'Thanks,'.EOL.EOL .
 					 'Admin Team';
 
-	$PHP_OUTPUT.=('<td colspan="2"><img src="'.URL.'/upload/'.$account_id.'"></td>');
+	$PHP_OUTPUT.=('<td colspan="2"><img src="upload/'.$account_id.'"></td>');
 	$PHP_OUTPUT.=('<td style="font-size:75%;">You can edit the text that will be sent<br />to that user as an email if you reset his picture!<br /><br />');
 	$PHP_OUTPUT.=('<textarea spellcheck="true" name="email_txt" id="InputFields" style="width:300;height:200;">'.$default_email.'</textarea></td>');
 	$PHP_OUTPUT.=('</form>');

--- a/engine/Default/album_edit.php
+++ b/engine/Default/album_edit.php
@@ -22,7 +22,7 @@ if ($db->nextRecord()) {
 		$albumEntry['Status']=('<span class="red">Disabled</span>');
 	}
 	elseif ($approved == 'YES') {
-		$albumEntry['Status']=('<a href="'.URL.'/album/?'.$account->getHofName().'" class="dgreen">Online</a>');
+		$albumEntry['Status']=('<a href="album/?'.$account->getHofName().'" class="dgreen">Online</a>');
 	}
 		
 	if(is_readable(UPLOAD . SmrSession::$account_id)) {

--- a/engine/Default/bar_gambling_processing.php
+++ b/engine/Default/bar_gambling_processing.php
@@ -154,8 +154,6 @@ elseif ($action == 'blackjack') {
 	}
 
 	function create_card($card, $show) {
-		//picture directory
-		$dir = URL . '/images';
 		//only display what the card really is if they want to
 		$card_height = 100;
 		$card_width = 125;
@@ -164,14 +162,14 @@ elseif ($action == 'blackjack') {
 		//lets try and echo cards
 		$return.=('<table style="border:1px solid green"><tr><td><table><tr><td valign=top align=left height='.$card_height.' width='.$card_width.'>');
 		if ($show) {
-			$return.=('<h1>'.$first.'<img src="'.$dir.'/'.$second.'.gif"></h1></td></tr>');
+			$return.=('<h1>'.$first.'<img src="images/'.$second.'.gif"></h1></td></tr>');
 		}
 		else {
 			$return.=('</td></tr>');
 		}
 		$return.=('<tr><td valign=bottom align=right height='.$card_height.' width='.$card_width.'>');
 		if ($show) {
-			$return.=('<h1><img src="'.$dir.'/'.$second.'.gif">'.$first.'</h1></td></tr></table>');
+			$return.=('<h1><img src="images/'.$second.'.gif">'.$first.'</h1></td></tr></table>');
 		}
 		else {
 			$return.=('</td></tr></table>');

--- a/engine/Default/buy_ship_name_processing.php
+++ b/engine/Default/buy_ship_name_processing.php
@@ -48,7 +48,7 @@ if(!isset($var['ShipName'])) {
 			}
 
 			$filename = $player->getAccountID() . 'logo' . $player->getGameID();
-			$name = '<img style="padding:3px;" src="'.URL.'/upload/' . $filename . '"><br />';
+			$name = '<img style="padding:3px;" src="upload/' . $filename . '"><br />';
 			move_uploaded_file($_FILES['photo']['tmp_name'], UPLOAD . $filename);
 			$db->query('REPLACE INTO ship_has_name (game_id, account_id, ship_name)
 						VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($name) . ')');

--- a/engine/Default/trader_status.php
+++ b/engine/Default/trader_status.php
@@ -83,7 +83,7 @@ if ($player->hasCurrentBounty('UG')) {
 }
 
 // Ship
-$PHP_OUTPUT.= '<br /><br /><span class="yellow bold">Ship</span><a href="' . URL . '/ship_list.php" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Ship List"/></a><br />Name: ';
+$PHP_OUTPUT.= '<br /><br /><span class="yellow bold">Ship</span><a href="ship_list.php" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Ship List"/></a><br />Name: ';
 
 $PHP_OUTPUT.= $ship->getName();
 $PHP_OUTPUT.= '<br />Speed: ';
@@ -109,7 +109,7 @@ else {
 	if ($ship->canHaveDCS()) $PHP_OUTPUT.= 'Drone Scrambler<br />';
 }
 
-$PHP_OUTPUT.= '<br /><a href="'.URL.'/level_requirements.php" target="levelRequirements"><span class="yellow bold">Next Level</span></a><a href="' . WIKI_URL . '/game-guide/experience-levels" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Experience Levels"/></a><br />';
+$PHP_OUTPUT.= '<br /><a href="level_requirements.php" target="levelRequirements"><span class="yellow bold">Next Level</span></a><a href="' . WIKI_URL . '/game-guide/experience-levels" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Experience Levels"/></a><br />';
 $db->query('SELECT level_name,requirement FROM level WHERE requirement>' . $db->escapeNumber($player->getExperience()) . ' ORDER BY requirement ASC LIMIT 1');
 if(!$db->nextRecord()) {
 	$db->query('SELECT level_name,requirement FROM level ORDER BY requirement DESC LIMIT 1');

--- a/htdocs/album/index.php
+++ b/htdocs/album/index.php
@@ -117,7 +117,7 @@ catch(Exception $e) {
 <table width="100%" height="100%" border="0" cellspacing="5" cellpadding="5">
 <tr>
 <td valign="top" align="center">
-<form action="<?php echo URL; ?>/album/search_processing.php">
+<form action="search_processing.php">
 Quick Search:<br />
 <input type="text" name="nick" size="10" id="InputFields"><br />
 <input type="submit" value="Search" id="InputFields">

--- a/htdocs/graph.php
+++ b/htdocs/graph.php
@@ -10,7 +10,7 @@ if ($val == 3) {
 	$hunt = 8;
 	
 }
-echo ('<body background="'.URL.'/images/graph'.$val.'.gif">');
+echo ('<body background="images/graph'.$val.'.gif">');
 /*
 echo ('<font color=white size=4><div align=center valign=top><font size=1>&nbsp;&nbsp;&nbsp;</font>'.$trade.'</div>');
 echo ('<br /><br /><br /><br /><br /><br /><br /><font size=1><br /><br /><br /></font><div align=justify>'.$combat.'&nbsp;');

--- a/lib/Album/album_functions.php
+++ b/lib/Album/album_functions.php
@@ -37,7 +37,7 @@ function main_page() {
 			$page_views = $db->getField('page_views');
 			$nick = get_album_nick($db->getField('account_id'));
 
-			echo('<a href="'.URL.'/album/?' . urlencode($nick) . '">'.$nick.'</a> ('.$page_views.')<br />');
+			echo('<a href="?' . urlencode($nick) . '">'.$nick.'</a> ('.$page_views.')<br />');
 		}
 	}
 
@@ -53,7 +53,7 @@ function main_page() {
 			$created = $db->getField('created');
 			$nick = get_album_nick($db->getField('account_id'));
 
-			echo('<span style="font-size:85%;"><b>[' . date(defined('DATE_FULL_SHORT')?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $created) . ']</b> Picture of <a href="'.URL.'/album/?' . urlencode($nick) . '">'.$nick.'</a> added</span><br />');
+			echo('<span style="font-size:85%;"><b>[' . date(defined('DATE_FULL_SHORT')?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $created) . ']</b> Picture of <a href="?' . urlencode($nick) . '">'.$nick.'</a> added</span><br />');
 		}
 	}
 	else
@@ -114,7 +114,7 @@ function album_entry($album_id) {
 	echo '<td style="text-align: center; width: 30%" valign="middle">';
 	if ($db->nextRecord()) {
 		$priv_nick = $db->getField('hof_name');
-		echo '<a href="'.URL.'/album/?' . urlencode($priv_nick) . '"><img src="'.URL.'/images/album/rew.jpg" alt="'.$priv_nick.'" border="0"></a>&nbsp;&nbsp;&nbsp;';
+		echo '<a href="?' . urlencode($priv_nick) . '"><img src="/images/album/rew.jpg" alt="'.$priv_nick.'" border="0"></a>&nbsp;&nbsp;&nbsp;';
 	}
 	echo '</td>';
 	echo('<td style="text-align: center;" valign="middle"><span style="font-size:150%;">'.$nick.'</span><br /><span style="font-size:75%;">Views: '.$page_views.'</span></td>');
@@ -128,7 +128,7 @@ function album_entry($album_id) {
 	echo '<td style="text-align: center; width: 30%" valign="middle">';
 	if ($db->nextRecord()) {
 		$next_nick = $db->getField('hof_name');
-		echo '&nbsp;&nbsp;&nbsp;<a href="'.URL.'/album/?' . urlencode($next_nick) . '"><img src="'.URL.'/images/album/fwd.jpg" alt="'.$next_nick.'" border="0"></a>';
+		echo '&nbsp;&nbsp;&nbsp;<a href="?' . urlencode($next_nick) . '"><img src="/images/album/fwd.jpg" alt="'.$next_nick.'" border="0"></a>';
 	}
 	echo '</td>';
 
@@ -141,9 +141,9 @@ function album_entry($album_id) {
 	echo('<td colspan="2" align="center" valign="middle">');
 
 	if ($disabled == false)
-		echo('<img src="'.URL.'/upload/'.$album_id.'">');
+		echo('<img src="../upload/'.$album_id.'">');
 	else
-		echo('<img src="'.URL.'/images/album/disabled.jpg">');
+		echo('<img src="../images/album/disabled.jpg">');
 
 	echo('</td>');
 	echo('</tr>');
@@ -200,7 +200,7 @@ function album_entry($album_id) {
 	}
 
 	if (SmrSession::$account_id > 0) {
-		echo('<form action="'.URL.'/album/album_comment.php">');
+		echo('<form action="album_comment.php">');
 		echo('<input type="hidden" name="album_id" value="'.$album_id.'">');
 		echo('<table>');
 		echo('<tr>');
@@ -219,7 +219,7 @@ function album_entry($album_id) {
 		echo('</form>');
 	}
 	else
-		echo('<p>Please <a href="'.URL.'/login.php?return_page='.URL.'/album/?' . urlencode($nick) . '"><u>login</u></a> if you want comment on this picture!</p>');
+		echo('<p>Please <a href="/login.php?return_page='.URL.'/album/?' . urlencode($nick) . '"><u>login</u></a> if you want comment on this picture!</p>');
 
 	echo('</td>');
 	echo('</tr>');
@@ -244,7 +244,7 @@ function search_result($album_ids) {
 
 		$nick = get_album_nick($album_id);
 
-		echo('<a href="'.URL.'/album/?' . urlencode($nick) . '" style="font-size:80%;">'.$nick.'</a><br />');
+		echo('<a href="?' . urlencode($nick) . '" style="font-size:80%;">'.$nick.'</a><br />');
 
 		if (floor(sizeof($album_ids) / 4) > 0 && $count % floor(sizeof($album_ids) / 4) == 0)
 			echo('</td><td width="25%" valign="top">');
@@ -255,33 +255,33 @@ function search_result($album_ids) {
 
 function create_link_list() {
 	echo('<div align="center" style="font-size:80%;">[ ');
-	echo('<a href="'.URL.'/album/?%">All</a> | ');
-	echo('<a href="'.URL.'/album/?A">A</a> | ');
-	echo('<a href="'.URL.'/album/?B">B</a> | ');
-	echo('<a href="'.URL.'/album/?C">C</a> | ');
-	echo('<a href="'.URL.'/album/?D">D</a> | ');
-	echo('<a href="'.URL.'/album/?E">E</a> | ');
-	echo('<a href="'.URL.'/album/?F">F</a> | ');
-	echo('<a href="'.URL.'/album/?G">G</a> | ');
-	echo('<a href="'.URL.'/album/?H">H</a> | ');
-	echo('<a href="'.URL.'/album/?I">I</a> | ');
-	echo('<a href="'.URL.'/album/?J">J</a> | ');
-	echo('<a href="'.URL.'/album/?K">K</a> | ');
-	echo('<a href="'.URL.'/album/?L">L</a> | ');
-	echo('<a href="'.URL.'/album/?M">M</a> | ');
-	echo('<a href="'.URL.'/album/?N">N</a> | ');
-	echo('<a href="'.URL.'/album/?O">O</a> | ');
-	echo('<a href="'.URL.'/album/?P">P</a> | ');
-	echo('<a href="'.URL.'/album/?Q">Q</a> | ');
-	echo('<a href="'.URL.'/album/?R">R</a> | ');
-	echo('<a href="'.URL.'/album/?S">S</a> | ');
-	echo('<a href="'.URL.'/album/?T">T</a> | ');
-	echo('<a href="'.URL.'/album/?U">U</a> | ');
-	echo('<a href="'.URL.'/album/?V">V</a> | ');
-	echo('<a href="'.URL.'/album/?W">W</a> | ');
-	echo('<a href="'.URL.'/album/?X">X</a> | ');
-	echo('<a href="'.URL.'/album/?Y">Y</a> | ');
-	echo('<a href="'.URL.'/album/?Z">Z</a> ]</div>');
+	echo('<a href="?%">All</a> | ');
+	echo('<a href="?A">A</a> | ');
+	echo('<a href="?B">B</a> | ');
+	echo('<a href="?C">C</a> | ');
+	echo('<a href="?D">D</a> | ');
+	echo('<a href="?E">E</a> | ');
+	echo('<a href="?F">F</a> | ');
+	echo('<a href="?G">G</a> | ');
+	echo('<a href="?H">H</a> | ');
+	echo('<a href="?I">I</a> | ');
+	echo('<a href="?J">J</a> | ');
+	echo('<a href="?K">K</a> | ');
+	echo('<a href="?L">L</a> | ');
+	echo('<a href="?M">M</a> | ');
+	echo('<a href="?N">N</a> | ');
+	echo('<a href="?O">O</a> | ');
+	echo('<a href="?P">P</a> | ');
+	echo('<a href="?Q">Q</a> | ');
+	echo('<a href="?R">R</a> | ');
+	echo('<a href="?S">S</a> | ');
+	echo('<a href="?T">T</a> | ');
+	echo('<a href="?U">U</a> | ');
+	echo('<a href="?V">V</a> | ');
+	echo('<a href="?W">W</a> | ');
+	echo('<a href="?X">X</a> | ');
+	echo('<a href="?Y">Y</a> | ');
+	echo('<a href="?Z">Z</a> ]</div>');
 	echo('<hr align="center">');
 }
 

--- a/templates/Default/engine/Default/includes/RightPanelShip.inc
+++ b/templates/Default/engine/Default/includes/RightPanelShip.inc
@@ -69,7 +69,7 @@ if(isset($GameID)) { ?>
 		}
 	} ?>
 	Empty : <?php echo $ThisShip->getEmptyHolds(); ?><br /><br />
-	<a href="<?php echo $WeaponReorderLink; ?>"><span class="bold">Weapons</span></a>&nbsp;<a href="<?php echo URL; ?>/weapon_list.php" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Weapon List" title="Weapon List"/></a><br /><?php
+	<a href="<?php echo $WeaponReorderLink; ?>"><span class="bold">Weapons</span></a>&nbsp;<a href="weapon_list.php" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Weapon List" title="Weapon List"/></a><br /><?php
 	if($ThisShip->hasWeapons()) { ?>
 		<div class="wep_drop1" id="hide-show" onclick="toggleWepD('<?php echo $ThisPlayer->getToggleWeaponHidingHREF(); ?>');">
 			<noscript><a href="<?php echo $ThisPlayer->getToggleWeaponHidingHREF(); ?>"></noscript>

--- a/templates/Default/engine/Default/message_view.php
+++ b/templates/Default/engine/Default/message_view.php
@@ -47,7 +47,7 @@ else {
 			<tr>
 				<td style="width: 30%" valign="middle"><?php
 					if(isset($PreviousPageHREF)) {
-						?><a href="<?php echo $PreviousPageHREF; ?>"><img src="<?php echo URL; ?>/images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
+						?><a href="<?php echo $PreviousPageHREF; ?>"><img src="images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
 					} ?>
 				</td>
 				<td>
@@ -59,7 +59,7 @@ else {
 				</td>
 				<td style="width: 30%" valign="middle"><?php
 					if(isset($NextPageHREF)) {
-						?><a href="<?php echo $NextPageHREF; ?>"><img src="<?php echo URL; ?>/images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
+						?><a href="<?php echo $NextPageHREF; ?>"><img src="images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
 					} ?>
 				</td>
 			</tr>
@@ -107,14 +107,14 @@ else {
 			<tr>
 				<td style="width: 30%" valign="middle"><?php
 					if(isset($PreviousPageHREF)) {
-						?><a href="<?php echo $PreviousPageHREF; ?>"><img src="<?php echo URL; ?>/images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
+						?><a href="<?php echo $PreviousPageHREF; ?>"><img src="images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
 					} ?>
 				</td>
 				<td>
 				</td>
 				<td style="width: 30%" valign="middle"><?php
 					if(isset($NextPageHREF)) {
-						?><a href="<?php echo $NextPageHREF; ?>"><img src="<?php echo URL; ?>/images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
+						?><a href="<?php echo $NextPageHREF; ?>"><img src="images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
 					} ?>
 				</td>
 			</tr>

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -109,7 +109,7 @@
 				<img src="images/login/bottom_left.gif" width="7" height="11" alt="">
 
 				<!-- small header menu -->
-				<a href="<?php echo URL ?>"><img src="images/login/home.png" width="55" height="11" alt="Home"></a>
+				<a href=""><img src="images/login/home.png" width="55" height="11" alt="Home"></a>
 				<img src="images/login/site_map.png" width="87" height="11" alt="Site Map">
 				<a href="mailto:support@smrealms.de" target="_blank"><img src="images/login/contact.png" width="80" height="11" alt="Contact"></a>
 
@@ -120,7 +120,7 @@
 				<a href="<?php echo WIKI_URL; ?>" target="manu"><img src="images/login/manual2.png" width="129" height="29" alt="Wiki"></a>
 				<a href="http://smrcnn.smrealms.de" target="board"><img src="images/login/webboard2.png" width="128" height="29" alt="Web Board"></a>
 				<a href="album" target="ml"><img src="images/login/sml.png" width="166" height="29" alt="Merchant Library"></a>
-				<a href="<?php echo URL; ?>/cgi-bin/awstats.pl" target="stat"><img src="images/login/stats2.png" width="180" height="29" alt="Site Statistics"></a>
+				<a href="cgi-bin/awstats.pl" target="stat"><img src="images/login/stats2.png" width="180" height="29" alt="Site Statistics"></a>
 				<br />
 			</p>
 			<?php


### PR DESCRIPTION
References to internal content do not need to specify the
webserver URL. So we remove it in favor of relative paths.
Less text means less data to serve!

Also fixes a broken link in the NHA message board threads.