### PR TITLE
SmrSession: add some ALWAYS_AVAILABLE pages

### DIFF
--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -2,9 +2,14 @@
 require_once('SmrSessionMySqlDatabase.class.inc');
 if(!defined('USING_AJAX'))
 	define('USING_AJAX',false);
+
 class SmrSession {
 	const ALWAYS_AVAILABLE = 999999;
 	const TIME_BEFORE_EXPIRY = 3600;
+
+	// Defines the number of pages that can be loaded after
+	// this page before the links on this page become invalid
+	// (i.e. before you get a back button error).
 	private static $URL_DEFAULT_REMAINING_PAGE_LOADS = array(
 			'alliance_broadcast.php' => self::ALWAYS_AVAILABLE,
 			'alliance_forces.php' => self::ALWAYS_AVAILABLE,
@@ -90,6 +95,7 @@ class SmrSession {
 			'alliance_message_delete_processing.php' => self::ALWAYS_AVAILABLE,
 			'alliance_pick_processing.php' => self::ALWAYS_AVAILABLE,
 			'chess_move_processing.php' => self::ALWAYS_AVAILABLE,
+			'combat_log_viewer_verify.php' => self::ALWAYS_AVAILABLE,
 			'toggle_processing.php' => self::ALWAYS_AVAILABLE,
 			//Admin pages
 			'account_edit.php' => self::ALWAYS_AVAILABLE,
@@ -101,6 +107,8 @@ class SmrSession {
 			'form_open.php' => self::ALWAYS_AVAILABLE,
 			'ip_view_results.php' => self::ALWAYS_AVAILABLE,
 			'ip_view.php' => self::ALWAYS_AVAILABLE,
+			'info.php' => self::ALWAYS_AVAILABLE,
+			'info_proc.php' => self::ALWAYS_AVAILABLE,
 			'password_check.php' => self::ALWAYS_AVAILABLE,
 			'permission_manage.php' => self::ALWAYS_AVAILABLE,
 			'word_filter.php' => self::ALWAYS_AVAILABLE,


### PR DESCRIPTION
* info.php: Whenever I try to use this page, I enter the number
  of players to check, click "Next Page", then enter the name
  and click "Check" and I get a back button error. When I make
  this page ALWAYS_AVAILABLE, the error disappears.

* combat_log_viewer_verify.php: On the live server, when someone
  clicks on a [combatlog=X] BBLink in a _new_ scout message
  (i.e. if their forces are attacked), they get a back button error.

  I am not sure if this will fix the problem for a few reasons:
  1. I cannot reproduce this on my test server.
  2. I have been told (but not seen myself) that this also
     occurs when clicking on the Player BBLink in the same
     scout message, but that page (`message_view.php`) is
     already set as ALWAYS_AVAILABLE.
  3. I don't fully understand how RemainingPageLoads works for
     processing files (which `combat_log_viewer_verify.php` is).