### PR TITLE
Add tests/phplint.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: php
+php:
+  - '5.6'
+git:
+  depth: false
+script:
+  - tests/phplint.sh

--- a/admin/Default/universe_create_end.php
+++ b/admin/Default/universe_create_end.php
@@ -21,7 +21,7 @@ $planetAccess = TRUE;
 $exemptWith = TRUE;
 $mbMessages = TRUE;
 $sendAllMsg = TRUE;
-$viewBonds = TRUE
+$viewBonds = TRUE;
 $db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds) ' .
 			'VALUES (302, '.$game_id.', 1, \'Leader\', '.$withPerDay.', '.$db->escapeString($removeMember).', '.$db->escapeString($changePass).', '.$db->escapeString($changeMOD).', '.$db->escapeString($changeRoles).', '.$db->escapeString($planetAccess).', '.$db->escapeString($exemptWith).', '.$db->escapeString($mbMessages).', '.$db->escapeString($sendAllMsg).', '.$db->escapeString($viewBonds).')');
 $withPerDay = ALLIANCE_BANK_UNLIMITED;

--- a/admin/Default/universe_create_ports_processing.php
+++ b/admin/Default/universe_create_ports_processing.php
@@ -25,10 +25,8 @@ function draw_rand_array($array, $draws) {
 
 }
 
-
 $action = $_REQUEST['action'];
 if ($action == 'Skip >>') {
-
 	$container = array();
 	$container['url']		= 'skeleton.php';
 	$container['body']		= 'universe_create_planets.php';
@@ -135,7 +133,7 @@ foreach($ports as $galaxy_id => $amount) {
 		$curr_goods = $goods;
 
 		// add 4 from good_class one
-		$good_ids = draw_rand_array(& $curr_goods[1], 4);
+		$good_ids = draw_rand_array($curr_goods[1], 4);
 
 		// now go through each lvl. and add one good from it's class each time
 		for ($level_count = 2; $level_count <= $level; $level_count++) {
@@ -148,7 +146,7 @@ foreach($ports as $galaxy_id => $amount) {
 				$good_class = 3;
 
 			// get one good
-			$good_ids[] = draw_rand_array(& $curr_goods[$good_class], 1);
+			$good_ids[] = draw_rand_array($curr_goods[$good_class], 1);
 
 		}
 

--- a/engine/1.2/album_edit_processing.php
+++ b/engine/1.2/album_edit_processing.php
@@ -178,7 +178,7 @@ function php_link_check($url, $r = FALSE) {
 	if (!checkdnsrr($url["host"], "A"))
 		return FALSE;
 
-	$fp = fsockopen($url["host"], $url["port"], &$errno, &$errstr, 30);
+	$fp = fsockopen($url["host"], $url["port"], $errno, $errstr, 30);
 
 	if (!$fp) return FALSE;
 	else

--- a/engine/1.2/smr.inc
+++ b/engine/1.2/smr.inc
@@ -259,13 +259,6 @@ function different_level($rank1, $rank2, $forced_vet1, $forced_vet2) {
 
 }
 
-function hex2bin( $data ) {
-
-	$len = strlen( $data );
-	return pack( "H" . $len, $data );
-
-}
-
 function word_filter($string) {
 	
 	static $words;

--- a/lib/Default/DummyShip.class.inc
+++ b/lib/Default/DummyShip.class.inc
@@ -55,12 +55,12 @@ class DummyShip extends AbstractSmrShip {
 	}
 	
 	public function cacheDummyShip() {
-		$cache = serialize(&$this);
+		$cache = serialize($this);
 		$db = new SmrMySqlDatabase();
 		$db->query('REPLACE INTO cached_dummys ' .
 					'(type, id, info) ' .
 					'VALUES (\'DummyShip\', '.$db->escapeString($this->getPlayer()->getPlayerName()).', '.$db->escapeString($cache).')');
-		unserialize(&$cache);
+		unserialize($cache);
 	}
 	
 	public static function &getCachedDummyShip(AbstractSmrPlayer &$player) {

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -448,12 +448,6 @@ function makeBold($value) {
 //	return false;
 //
 //}
-if(!function_exists('hex2bin')) {
-	function hex2bin( $data ) {
-		$len = strlen( $data );
-		return pack( 'H' . $len, $data );
-	}
-}
 
 function word_filter($string) {
 	static $words;

--- a/tests/phplint.sh
+++ b/tests/phplint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Runs `php -l` on each *.php and *.inc file in the repository.
+# This performs basic linting checks.
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+error=false
+find $ROOT -type f -name "*.php" -o -name "*.inc" | while read FILE;
+do
+    RESULTS=`php -l "$FILE" 2>&1`
+
+    if [ "$RESULTS" != "No syntax errors detected in $FILE" ] ; then
+        echo "====> $FILE"
+        echo "$RESULTS"
+        error=true
+    fi
+done
+
+if [ "$error" = true ] ; then
+    exit 1
+else
+    echo "Success! No linting errors."
+    exit 0
+fi


### PR DESCRIPTION
Script to perform basic linting checks on the entire source code.
These checks are by no means sufficient, but they are a necessary
check with complete coverage.

Fixes the following fatal errors:

* As of PHP 5.4, call-time pass by reference was removed.
  Function calls no longer require specifying the `&`.

* hex2bin was added in PHP 5.4. Since we require PHP 5.4+,
  remove the redeclarations of this function.

* universe_create_end.php: fix missing semi-colon