### PR TITLE
SmrSession: add helper function to get $_REQUEST data

### DIFF
--- a/admin/Default/info.php
+++ b/admin/Default/info.php
@@ -1,15 +1,16 @@
 <?php
 
 $template->assign('PageTopic','Checking Info');
-$container = array();
-$container['url'] = 'skeleton.php';
-$container['body'] = 'info.php';
-if (isset($_REQUEST['number'])) $number = $_REQUEST['number'];
-$login = $_REQUEST['login'];
-if (isset($number))
+$container = create_container('skeleton.php', 'info.php');
+
+$login = SmrSession::getRequestVar('login');
+$number = SmrSession::getRequestVar('number');
+if (isset($number)) {
 	$container['number'] = $number;
+}
+
 $u = 3;
-if (!isset($number) && !isset($var['number'])) {
+if (!isset($number)) {
 
 	$PHP_OUTPUT.=create_echo_form($container);
 	$PHP_OUTPUT.=('How many player\'s info do you need to check?<br />');
@@ -35,7 +36,6 @@ if (!isset($number) && !isset($var['number'])) {
 
 } else {
 
-	if (isset($var['number'])) $number = $var['number'];
 	$db2 = new SmrMySqlDatabase();
 	$db3 = new SmrMySqlDatabase();
 	$container = array();

--- a/admin/Default/universe_create_galaxies.php
+++ b/admin/Default/universe_create_galaxies.php
@@ -2,15 +2,15 @@
 
 $template->assign('PageTopic','Create Universe - Adding Galaxies (2/10)');
 
+$galaxy_count = SmrSession::getRequestVar('galaxy_count');
+
 $db->query('SELECT * FROM game WHERE game_id = ' . $db->escapeNumber($var['game_id']));
 if ($db->nextRecord())
 	$template->assign('GameName',$db->getField('game_name'));
-$galaxy_count = isset($_REQUEST['galaxy_count']) ? $_REQUEST['galaxy_count'] : 0;
 if (empty($galaxy_count)) {
 	// do we already have galaxies?
 	$db->query('SELECT * FROM sector WHERE game_id = ' . $db->escapeNumber($var['game_id']) . ' GROUP BY galaxy_id');
 	$galaxy_count = $db->getNumRows();
-
 }
 
 if (empty($galaxy_count)) {

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -290,6 +290,25 @@ class SmrSession {
 		return self::$var[$sn];
 	}
 
+	/**
+	 * Gets a var from $_REQUEST (or $default) and then stores it in the
+	 * session so that it can still be retrieved when the page auto-refreshes.
+	 * This is the recommended way to get $_REQUEST data.
+	 */
+	public static function getRequestVar($varName, $default=null) {
+		global $var;
+		// Set the session var, if in $_REQUESTS or if a default is given
+		if (isset($_REQUEST[$varName])) {
+			self::updateVar($varName, $_REQUEST[$varName]);
+		} elseif (isset($default) && !isset($var[$varName])) {
+			self::updateVar($varName, $default);
+		}
+		// Return the possibly updated session var
+		if (isset($var[$varName])) {
+			return $var[$varName];
+		}
+	}
+
 	public static function resetLink($container, $sn) { //Do not allow sharing SN, useful for forwarding.
 		global $lock;
 		if(isset(self::$var[$sn]['CommonID'])) {


### PR DESCRIPTION
The function `getRequestVar` gets a variable preferentially from
* `$_REQUEST`
* The session $var
* A default value (if specified)
* null

This greatly reduces the boilerplate in each file, and reduces
the likelihood of making a mistake setting the var (which is
a common source of back-button errors).

The two extra commits utilize this function to fix back-button errors.