### PR TITLE
port_attack_warning.php: fix shifting elements

### DIFF
--- a/templates/Default/engine/Default/port_attack_warning.php
+++ b/templates/Default/engine/Default/port_attack_warning.php
@@ -10,7 +10,6 @@ Without an armada behind you, the outcome may not be pleasant.
 <?php
 if ($ThisShip->hasScanner()) {
 	$Port = $ThisSector->getPort(); ?>
-<p>
 	<table class="standard">
 		<tr>
 			<th>Port</th>
@@ -33,7 +32,7 @@ if ($ThisShip->hasScanner()) {
 			<td align="center"><?php echo $Port->getNumWeapons(); ?></td>
 		</tr>
 	</table>
-</p><?php
+	<br /><?php
 } ?>
 
 Are you sure you want to attack this port?<br /><br />


### PR DESCRIPTION
This page contained a `<table>` element inside a `<p>`, which is
invalid HTML. There is no standard way to parse this, and the
DOMDocument parses it differently than the browser. This
results in the `<p>` element shifting after the auto-refresh.

We replace the `<p>` with `<br />` to avoid this problem.