### PR TITLE
AllianceRankings.inc: fix undefined variable warning

### DIFF
--- a/templates/Default/engine/Default/includes/AllianceRankings.inc
+++ b/templates/Default/engine/Default/includes/AllianceRankings.inc
@@ -1,7 +1,7 @@
 <div align="center">
 	<p>Here are the rankings of alliances by their <?php echo strtolower($RankingStat); ?>.</p><?php
 	if (isset($OurRank)) { ?>
-		<p>You alliance is ranked <?php echo number_format($OurRank); ?> out of <?php echo number_format($TotalRanks); ?> alliances.</p><?php
+		<p>Your alliance is ranked <?php echo number_format($OurRank); ?> out of <?php echo number_format($TotalRanks); ?> alliances.</p><?php
 	}
 	$this->includeTemplate('includes/AllianceRankingsList.inc', array('RankingStat' => $RankingStat, 'Rankings' => $Rankings)); ?>
 	<form method="POST" action="<?php echo $FilterRankingsHREF; ?>">

--- a/templates/Default/engine/Default/includes/AllianceRankings.inc
+++ b/templates/Default/engine/Default/includes/AllianceRankings.inc
@@ -1,7 +1,9 @@
 <div align="center">
-	<p>Here are the rankings of alliances by their <?php echo strtolower($RankingStat); ?>.</p>
-	<p>You alliance is ranked <?php echo number_format($OurRank); ?> out of <?php echo number_format($TotalRanks); ?> alliances.</p>
-	<?php $this->includeTemplate('includes/AllianceRankingsList.inc', array('RankingStat' => $RankingStat, 'Rankings' => $Rankings)); ?>
+	<p>Here are the rankings of alliances by their <?php echo strtolower($RankingStat); ?>.</p><?php
+	if (isset($OurRank)) { ?>
+		<p>You alliance is ranked <?php echo number_format($OurRank); ?> out of <?php echo number_format($TotalRanks); ?> alliances.</p><?php
+	}
+	$this->includeTemplate('includes/AllianceRankingsList.inc', array('RankingStat' => $RankingStat, 'Rankings' => $Rankings)); ?>
 	<form method="POST" action="<?php echo $FilterRankingsHREF; ?>">
 		<p>
 			<input type="number" name="min_rank" value="<?php echo $MinRank; ?>" size="3" id="InputFields" class="center">&nbsp;-&nbsp;<input type="number" name="max_rank" value="<?php echo $MaxRank; ?>" size="3" id="InputFields" class="center">&nbsp;


### PR DESCRIPTION
If the player is not in an alliance, don't try to tell
them what rank their alliance is!

Omit the sentence "Your alliance is ranked..." if not
in an alliance.