### PR TITLE
Simplify port leveling code

### DIFF
--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -438,15 +438,8 @@ class SmrPort {
 			
 			case 6:
 			case 7:
+			case 8:
 				$this->selectAndAddGood(3);
-			break;
-
-			case 8: // Add 1 level 3, and 50% chance of level 4
-				$this->selectAndAddGood(3);
-		
-				if (mt_rand(1,100) <= 50) { //50% chance to get tier 4 when upgrading to level 9
-					$this->selectAndAddGood(4);
-				}
 			break;
 			
 			default: // We don't want to add goods.
@@ -541,6 +534,7 @@ class SmrPort {
 			
 			case 7:
 			case 8:
+			case 9:
 				do {
 					$newGood = array_shift($GOODS);
 				} while( (!$this->hasGood($newGood['ID']) || $newGood['Class']!=3) && ($count = count($GOODS))!=0 );
@@ -549,25 +543,6 @@ class SmrPort {
 				$this->removePortGood($newGood['ID']);
 			break;
 
-			case 9: // Add 1 level 3, and 50% chance of level 4
-				do {
-					$newGood = array_shift($GOODS);;
-				} while( (!$this->hasGood($newGood['ID']) || $newGood['Class']!=3) && ($count = count($GOODS))!=0 );
-				if($count == 0)
-					break;
-				$this->removePortGood($newGood['ID']);
-		
-				$GOODS = Globals::getGoods();
-				shuffle($GOODS);
-				$count = count($GOODS);
-				do {
-					$newGood = array_shift($GOODS);;
-				} while( (!$this->hasGood($newGood['ID']) || $newGood['Class']!=4) && ($count = count($GOODS))!=0 );
-				if($count == 0)
-					break;
-				$this->removePortGood($newGood['ID']);
-			break;
-			
 			default: // We don't want to add goods.
 			break;
 		}

--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -492,13 +492,24 @@ class SmrPort {
 		return $downgrades;
 	}
 	
+	protected function selectAndRemoveGood($goodClass) {
+		// Pick good to remove from the list of goods the port currently has
+		$goods = $this->getGoodsAll();
+		shuffle($goods);
+
+		foreach ($goods as $good) {
+			if ($good['Class'] == $goodClass) {
+				$this->removePortGood($good['ID']);
+				return;
+			}
+		}
+		throw new Exception('Failed to remove a good!');
+	}
+
 	protected function doDowngrade() {
 		if($this->isCachedVersion())
 			throw new Exception('Cannot downgrade a cached port!');
-		
-		$GOODS = Globals::getGoods();
-		shuffle($GOODS);
-		$count = count($GOODS);
+
 		switch($this->level) {
 			case 1: // we don't want to downgrade a level 1 port
 //				for($i=0;$i<3;$i++) { // Add 3 goods for upgrading to level 1
@@ -512,35 +523,20 @@ class SmrPort {
 			break;
 			
 			case 2:
-				do {
-					$newGood = array_shift($GOODS);
-				} while( (!$this->hasGood($newGood['ID']) || $newGood['Class']!=1) && ($count = count($GOODS))!=0 );
-				if($count == 0)
-					break;
-				$this->removePortGood($newGood['ID']);
+				$this->selectAndRemoveGood(1);
 			break;
 			
 			case 3:
 			case 4:
 			case 5:
 			case 6:
-				do {
-					$newGood = array_shift($GOODS);
-				} while( (!$this->hasGood($newGood['ID']) || $newGood['Class']!=2) && ($count = count($GOODS))!=0 );
-				if($count == 0)
-					break;
-				$this->removePortGood($newGood['ID']);
+				$this->selectAndRemoveGood(2);
 			break;
 			
 			case 7:
 			case 8:
 			case 9:
-				do {
-					$newGood = array_shift($GOODS);
-				} while( (!$this->hasGood($newGood['ID']) || $newGood['Class']!=3) && ($count = count($GOODS))!=0 );
-				if($count == 0)
-					break;
-				$this->removePortGood($newGood['ID']);
+				$this->selectAndRemoveGood(3);
 			break;
 
 			default: // We don't want to add goods.


### PR DESCRIPTION
* Remove code for tier 4 goods (since they don't exist).
* Add `SmrPort::selectAndRemoveGood` method to refactor common code in `doDowngrade`.