### PR TITLE
Restructure port data storage to improve serialization

### DIFF
--- a/engine/Default/shop_goods.php
+++ b/engine/Default/shop_goods.php
@@ -40,14 +40,13 @@ if (!empty($var['traded_xp']) ||
 // test if we are searched. (but only if we hadn't a previous trade here
 }
 elseif ($player->getLastPort() != $player->getSectorID()) {
-	$allGoods = $port->getGoodsAll();
 
 	$base_chance = 15;
-	if(isset($allGoods[5]))
+	if ($port->hasGood(5))
 		$base_chance -= 4;
-	if(isset($allGoods[9]))
+	if ($port->hasGood(9))
 		$base_chance -= 4;
-	if(isset($allGoods[12]))
+	if ($port->hasGood(12))
 		$base_chance -= 4;
 
 	if ($ship->getShipTypeID() == 23 || $ship->getShipTypeID() == 24 || $ship->getShipTypeID() == 25)
@@ -121,26 +120,28 @@ if (!empty($boughtGoods)) {
 	$container = array();
 	$container['url'] = 'shop_goods_processing.php';
 
-	foreach ($boughtGoods as $good) {
+	foreach ($boughtGoods as $goodID) {
+		$amount = $port->getGoodAmount($goodID);
+		$good =& Globals::getGood($goodID);
 		$container['good_id'] = $good['ID'];
 		
 		$PHP_OUTPUT.=create_echo_form($container);
 			
 		$PHP_OUTPUT.=('<tr class="center">');
 		$PHP_OUTPUT.=('<td class="left"><img src="' . $good['ImageLink'] . '" width="13" height="16" title="' . $good['Name'] . '" alt=""> ' . $good['Name'] . '</td>');
-		$PHP_OUTPUT.=('<td>' . $good['Amount'] . '</td>');
+		$PHP_OUTPUT.=('<td>' . $amount . '</td>');
 		$PHP_OUTPUT.=('<td>' . $good['BasePrice'] . '</td>');
 		$PHP_OUTPUT.=('<td>' . $ship->getCargo($good['ID']) . '</td>');
 		$PHP_OUTPUT.=('<td><input type="number" name="amount" value="');
 
-		if ($good['Amount'] < $ship->getEmptyHolds())
-			$PHP_OUTPUT.=($good['Amount']);
+		if ($amount < $ship->getEmptyHolds())
+			$PHP_OUTPUT.=($amount);
 		else
 			$PHP_OUTPUT.=($ship->getEmptyHolds());
 
 		$PHP_OUTPUT.=('" size="4" id="InputFields" class="center"></td>');
 		$PHP_OUTPUT.=('<td>');
-		$PHP_OUTPUT.=create_submit($good['TransactionType']);
+		$PHP_OUTPUT.=create_submit('Buy');
 		$PHP_OUTPUT.=('</td>');
 		$PHP_OUTPUT.=('</tr>');
 		
@@ -171,25 +172,27 @@ if (!empty($soldGoods)) {
 	$container = array();
 	$container['url'] = 'shop_goods_processing.php';
 
-	foreach ($soldGoods as $good) {
+	foreach ($soldGoods as $goodID) {
+		$amount = $port->getGoodAmount($goodID);
+		$good =& Globals::getGood($goodID);
 		$container['good_id'] = $good['ID'];
 		$PHP_OUTPUT.=create_echo_form($container);
 
 		$PHP_OUTPUT.=('<tr class="center">');
 		$PHP_OUTPUT.=('<td class="left"><img src="' . $good['ImageLink'] . '" width="13" height="16" title="' . $good['Name'] . '" alt=""> ' . $good['Name'] . '</td>');
-		$PHP_OUTPUT.=('<td>' . $good['Amount'] . '</td>');
+		$PHP_OUTPUT.=('<td>' . $amount . '</td>');
 		$PHP_OUTPUT.=('<td>' . $good['BasePrice'] . '</td>');
 		$PHP_OUTPUT.=('<td>' . $ship->getCargo($good['ID']) . '</td>');
 		$PHP_OUTPUT.=('<td><input type="number" name="amount" value="');
 
-		if ($good['Amount'] < $ship->getCargo($good['ID']))
-			$PHP_OUTPUT.=($good['Amount']);
+		if ($amount < $ship->getCargo($good['ID']))
+			$PHP_OUTPUT.=($amount);
 		else
 			$PHP_OUTPUT.=$ship->getCargo($good['ID']);
 
 		$PHP_OUTPUT.=('" size="4" id="InputFields" class="center"></td>');
 		$PHP_OUTPUT.=('<td>');
-		$PHP_OUTPUT.=create_submit($good['TransactionType']);
+		$PHP_OUTPUT.=create_submit('Sell');
 		$PHP_OUTPUT.=('</td>');
 		$PHP_OUTPUT.=('</tr>');
 		$PHP_OUTPUT.=('</form>');

--- a/engine/Default/shop_goods_trade.php
+++ b/engine/Default/shop_goods_trade.php
@@ -5,15 +5,16 @@ require_once(LIB . 'Default/shop_goods.inc');
 $port =& $player->getSectorPort();
 // get values from request
 $good_id = $var['good_id'];
-$portGood = $port->getGood($good_id);
+$portGood =& $port->getGood($good_id);
+$transaction = $port->getGoodTransaction($good_id);
 
 if ($var['bargain_price'] > 0) {
 	$bargain_price = $var['bargain_price'];
 
 	$PHP_OUTPUT.=('<p>I can\'t accept your offer. It\'s still too ');
-	if ($portGood['TransactionType'] == 'Sell')
+	if ($transaction == 'Sell')
 		$PHP_OUTPUT.=('high');
-	elseif ($portGood['TransactionType'] == 'Buy')
+	elseif ($transaction == 'Buy')
 		$PHP_OUTPUT.=('low');
 	$PHP_OUTPUT.=('.</p>');
 }
@@ -21,10 +22,9 @@ else
 	$bargain_price = $var['offered_price'];
 
 $PHP_OUTPUT.=('<p>I would ');
-$portGood = $port->getGood($good_id);
-if ($portGood['TransactionType'] == 'Sell')
+if ($transaction == 'Sell')
 	$PHP_OUTPUT.=('buy ');
-elseif ($portGood['TransactionType'] == 'Buy')
+elseif ($transaction == 'Buy')
 	$PHP_OUTPUT.=('offer you ');
 $PHP_OUTPUT.=($var['amount'] . ' pcs. of ' . $portGood['Name'] . ' for ' . $var['offered_price'] . ' credits!<br />');
 $PHP_OUTPUT.=('Note: In order to maximize your experience you have to bargain with the port owner, unless you have maximum relations (1000) with that race, which gives full experience without the need to bargain.</p>');
@@ -59,7 +59,7 @@ if (isset($var['offered_price'])) {
 $PHP_OUTPUT.=('<input type="number" name="bargain_price" value="'.$bargain_price.'" id="InputFields" class="center" style="width:75;vertical-align:middle;">&nbsp;');
 $PHP_OUTPUT.=('<!-- all needed information to calculate the ideal price -->');
 $PHP_OUTPUT.=('<!-- Trade.Amount:Good.BasePrice:Good.Distance:Port.Good.Amount:Port.Good.Max:Relations:Port.Level -->');
-$PHP_OUTPUT.=('<!--('.$var['amount'].':'.$portGood['BasePrice'].':'.$port->getGoodDistance($good_id).':'.$portGood['Amount'].':'.$portGood['Max'].':'.$player->getRelation($port->getRaceID()).':'.$port->getLevel().')-->');
+$PHP_OUTPUT.=('<!--('.$var['amount'].':'.$portGood['BasePrice'].':'.$port->getGoodDistance($good_id).':'.$port->getGoodAmount($good_id).':'.$portGood['Max'].':'.$player->getRelation($port->getRaceID()).':'.$port->getLevel().')-->');
 $PHP_OUTPUT.=create_submit('Bargain (1)');
 $PHP_OUTPUT.=('</form>');
 

--- a/engine/Default/smr_file_create.php
+++ b/engine/Default/smr_file_create.php
@@ -137,23 +137,13 @@ foreach ($galaxies as &$galaxy) {
 				$port =& $sector->getCachedPort($player);
 			$file .= 'Port Level='.$port->getLevel() . EOL;
 			$file .= 'Port Race=' . $port->getRaceID() . EOL;
-			$portGoods =& $port->getGoods();
-			if(count($portGoods['Sell'])>0) {
-				$buyString = 'Buys=';
-				foreach($portGoods['Sell'] as $goodID => $amount) {
-					$buyString .= $goodID .',';
-				}
-				$file .= substr($buyString,0,-1) . EOL;
+			if (!empty($port->getSoldGoodIDs())) {
+				$file .= 'Buys=' . join(',', $port->getSoldGoodIDs()) . EOL;
 			}
 			
-			if(count($portGoods['Buy'])>0) {
-				$sellString = 'Sells=';
-				foreach($portGoods['Buy'] as $goodID => $amount) {
-					$sellString .= $goodID .',';
-				}
-				$file .= substr($sellString,0,-1) . EOL;
+			if (!empty($port->getBoughtGoodIDs())) {
+				$file .= 'Sells=' . join(',', $port->getBoughtGoodIDs()) . EOL;
 			}
-			unset($portGoods);
 			unset($port);
 		}
 		if($sector->hasPlanet()) {

--- a/lib/Default/RouteGenerator.class.inc
+++ b/lib/Default/RouteGenerator.class.inc
@@ -107,7 +107,8 @@ class RouteGenerator {
 				$gameGoods = Globals::getGoods();
 				foreach($gameGoods as $goodId => &$value) {
 					if ($goods[$goodId]===true) {
-						if ($sectors[$currentSectorId]->getPort()->getGoodStatus($goodId) === self::GOOD_SELLS && $sectors[$targetSectorId]->getPort()->getGoodStatus($goodId) === self::GOOD_BUYS) {
+						if ($sectors[$currentSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_SELLS &&
+						    $sectors[$targetSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_BUYS) {
 							$rl[] = new OneWayRoute($currentSectorId, $targetSectorId, $races[$raceID], $sectors[$targetSectorId]->getPort()->getRaceID(), $sectors[$currentSectorId]->getPort()->getGoodDistance($goodId), $sectors[$targetSectorId]->getPort()->getGoodDistance($goodId), $distance, $goodId);
 						}
 					}
@@ -133,7 +134,8 @@ class RouteGenerator {
 				$gameGoods =& Globals::getGoods();
 				foreach($gameGoods as $goodId => &$value) {
 					if ($goods[$goodId]===true) {
-						if ($sectors[$currentSectorId]->getPort()->getGoodStatus($goodId) === self::GOOD_SELLS && $sectors[$targetSectorId]->getPort()->getGoodStatus($goodId) === self::GOOD_BUYS) {
+						if ($sectors[$currentSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_SELLS &&
+						    $sectors[$targetSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_BUYS) {
 							$owr = new OneWayRoute($currentSectorId, $targetSectorId, $sectors[$currentSectorId]->getPort()->getRaceID(), $sectors[$targetSectorId]->getPort()->getRaceID(), $sectors[$currentSectorId]->getPort()->getGoodDistance($goodId), $sectors[$targetSectorId]->getPort()->getGoodDistance($goodId), $distance, $goodId);
 							$fakeReturn = new OneWayRoute($targetSectorId, $currentSectorId, $sectors[$targetSectorId]->getPort()->getRaceID(), $sectors[$currentSectorId]->getPort()->getRaceID(), 0, 0, $distance, GOOD_NOTHING);
 							$mpr = new MultiplePortRoute($owr, $fakeReturn);

--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -183,17 +183,12 @@ class SmrPort {
 	}
 	
 	private function restockGood($goodID, $secondsSinceRefresh) {
-		$good = Globals::getGood($goodID);
-		$db = new SmrMySqlDatabase();
-		$refreshPerHour = self::$BASE_REFRESH_PER_HOUR[$good['Class']] * Globals::getGameSpeed($this->getGameID());
+		$goodClass = Globals::getGood($goodID)['Class'];
+		$refreshPerHour = self::$BASE_REFRESH_PER_HOUR[$goodClass] * Globals::getGameSpeed($this->getGameID());
 		$refreshPerSec = $refreshPerHour / 3600;
 		$amountToAdd = floor($secondsSinceRefresh * $refreshPerSec);
+		$this->increaseGoodAmount($goodID, $amountToAdd);
 		
-		$amount = $this->getGoodAmount($goodID);
-		if ($amount > $good['Max'] || ($amount < $good['Max'] && $amountToAdd > 0)) {
-			$newAmount = min($good['Max'], $amount + $amountToAdd);
-			$this->setGoodAmount($goodID, $newAmount);
-		}
 		return round($amountToAdd / $refreshPerSec);
 	}
 	
@@ -317,11 +312,8 @@ class SmrPort {
 	public function setGoodAmount($goodID,$amount) {
 		if($this->isCachedVersion())
 			throw new Exception('Cannot update a cached port!');
-		if($amount < 0)
-			$amount = 0;
-		$max = $this->getGood($goodID)['Max'];
-		if($amount > $max)
-			$amount = $max;
+		// The new amount must be between 0 and the max for this good
+		$amount = max(0, min($amount, $this->getGood($goodID)['Max']));
 		if($this->getGoodAmount($goodID) == $amount)
 			return;
 		$this->goodAmounts[$goodID] = $amount;

--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -41,7 +41,11 @@ class SmrPort {
 	protected $credits;
 	protected $upgrade;
 	protected $experience;
-	protected $goods;
+
+	protected $goodIDs = array('All' => array(), 'Sell' => array(), 'Buy' => array());
+	protected $goodAmounts;
+	protected $goodDistances;
+	protected $goods;   // DEPRECATED!
 	
 	protected $cachedVersion = false;
 	protected $cachedTime = TIME;
@@ -111,7 +115,8 @@ class SmrPort {
 	
 	protected function __construct($gameID,$sectorID) {
 		$this->db = new SmrMySqlDatabase();
-		$this->db->query('SELECT * FROM port WHERE sector_id = ' . $this->db->escapeNumber($sectorID) . ' AND game_id = ' . $this->db->escapeNumber($gameID) . ' LIMIT 1');
+		$this->SQL = 'sector_id = ' . $this->db->escapeNumber($sectorID) . ' AND game_id = ' . $this->db->escapeNumber($gameID);
+		$this->db->query('SELECT * FROM port WHERE ' . $this->SQL . ' LIMIT 1');
 		if ($this->db->nextRecord()) {
 			$this->gameID = $this->db->getInt('game_id');
 			$this->sectorID = $this->db->getInt('sector_id');
@@ -126,9 +131,6 @@ class SmrPort {
 			$this->credits = $this->db->getInt('credits');
 			$this->upgrade = $this->db->getInt('upgrade');
 			$this->experience = $this->db->getInt('experience');
-			
-			$this->SQL = 'sector_id = ' . $this->db->escapeNumber($this->sectorID) . ' AND game_id = ' . $this->db->escapeNumber($this->gameID);
-			
 			
 			$this->checkDefenses();
 			$this->getGoods();
@@ -149,8 +151,6 @@ class SmrPort {
 			$this->credits = 0;
 			$this->upgrade = 0;
 			$this->experience = 0;
-			
-			$this->SQL = 'sector_id = '.$this->sectorID.' AND game_id = '.$this->gameID;
 		}
 	}
 	
@@ -181,154 +181,153 @@ class SmrPort {
 		}
 	}
 	
-	private function restockGood(&$good, $secondsSinceRefresh) {
+	private function restockGood($goodID, $secondsSinceRefresh) {
+		$good = Globals::getGood($goodID);
 		$db = new SmrMySqlDatabase();
 		$refreshPerHour = self::$BASE_REFRESH_PER_HOUR[$good['Class']] * Globals::getGameSpeed($this->getGameID());
 		$refreshPerSec = $refreshPerHour / 3600;
 		$amountToAdd = floor($secondsSinceRefresh * $refreshPerSec);
 		
-		if ($good['Amount'] > $good['Max'] || ($good['Amount'] < $good['Max'] && $amountToAdd > 0)) {
-			$good['Amount'] = min($good['Max'], $good['Amount'] + $amountToAdd);
-			$db->query('UPDATE port_has_goods SET amount = ' . $db->escapeNumber($good['Amount']) . ' WHERE ' . $this->SQL . ' AND good_id = ' . $db->escapeNumber($good['ID']) . ' LIMIT 1');
+		$amount = $this->getGoodAmount($goodID);
+		if ($amount > $good['Max'] || ($amount < $good['Max'] && $amountToAdd > 0)) {
+			$newAmount = min($good['Max'], $amount + $amountToAdd);
+			$this->setGoodAmount($goodID, $newAmount);
 		}
 		return round($amountToAdd / $refreshPerSec);
 	}
 	
-	public function &getGoods() {
-		if(!$this->isCachedVersion() && empty($this->goods)) {
-			$GOODS = Globals::getGoods();
+	// Sets the class members that identify port trade goods
+	private function getGoods() {
+		if ($this->isCachedVersion()) {
+			throw new Exception('Cannot call getGoods on cached port');
+		}
+		if (empty($this->goodIDs['All'])) {
 			$secondsSinceRefresh = max(0, TIME - $this->lastUpdate);
 				
-			$this->db->query('SELECT * FROM port_has_goods WHERE ' . $this->SQL . ' ORDER BY good_id ASC LIMIT ' . count($GOODS));
+			$this->db->query('SELECT * FROM port_has_goods WHERE ' . $this->SQL . ' ORDER BY good_id ASC');
 			
 			$timeRefreshed = $secondsSinceRefresh;
-			$this->goods['Sell'] = array();
-			$this->goods['Buy'] = array();
-			$this->goods['All Goods'] = array();
 			while ($this->db->nextRecord()) {
-				$good = $GOODS[$this->db->getInt('good_id')];
-				$good['Amount'] = $this->db->getInt('amount');
-				$good['TransactionType'] = $this->db->getField('transaction_type');
-				$timeRefreshed = min($timeRefreshed, $this->restockGood($good, $secondsSinceRefresh));
-				
-				$g = $good;
-				$this->goods['All Goods'][$g['ID']] =& $g;
-				$this->goods[$g['TransactionType']][$g['ID']] =& $g;
-				unset($g); //HACK Don't want to keep g around - it kills goods due to references.
+				$goodID = $this->db->getInt('good_id');
+				$transactionType = $this->db->getField('transaction_type');
+				$this->goodAmounts[$goodID] = $this->db->getInt('amount');
+				$this->goodIDs[$transactionType][] = $goodID;
+				$this->goodIDs['All'][] = $goodID;
+
+				$timeRefreshed = min($timeRefreshed, $this->restockGood($goodID, $secondsSinceRefresh));
 			}
 			$this->lastUpdate += $timeRefreshed;
 			$this->db->query('UPDATE port SET last_update = ' . $this->db->escapeNumber($this->lastUpdate) . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		}
-		return $this->goods;
 	}
-	public function &getVisibleGoods(AbstractSmrPlayer &$player=null) {
-		$goods = $this->getGoods();
-		$visibleGoods = array(
-			'All Goods' => array(),
-			'Sell' => array(),
-			'Buy' => array()
-		);
-		foreach($goods['All Goods'] as $key => &$good) {
-			if($player == null || $player->meetsAlignmentRestriction($good['AlignRestriction'])) {
-				$visibleGoods['All Goods'][$key] =& $good;
-				$visibleGoods[$good['TransactionType']][$key] =& $good;
-			}
+
+	private function getVisibleGoods($transaction, AbstractSmrPlayer &$player=null) {
+		$goodIDs = $this->goodIDs[$transaction];
+		if ($player == null) {
+			return $goodIDs;
+		} else {
+			return array_filter($goodIDs, function($goodID) use ($player) {
+				$good = Globals::getGood($goodID);
+				return $player->meetsAlignmentRestriction($good['AlignRestriction']);
+			});
 		}
 		return $visibleGoods;
 	}
-	public function &getVisibleGoodsAll(&$player=null) {
-		$goods = $this->getVisibleGoods($player);
-		return $goods['All Goods'];
+
+	/**
+	 * Get IDs of goods that can be sold by $player to the port
+	 */
+	public function getVisibleGoodsSold(AbstractSmrPlayer &$player=null) {
+		return $this->getVisibleGoods('Sell', $player);
 	}
-	public function &getVisibleGoodsSold(&$player=null) {
-		$goods = $this->getVisibleGoods($player);
-		return $goods['Sell'];
-	}
-	public function &getVisibleGoodsBought(AbstractSmrPlayer &$player=null) {
-		$goods = $this->getVisibleGoods($player);
-		return $goods['Buy'];
-	}
-	
-	public function &getGoodsAll() {
-		$this->getGoods();
-		return $this->goods['All Goods'];
+
+	/**
+	 * Get IDs of goods that can be bought by $player from the port
+	 */
+	public function getVisibleGoodsBought(AbstractSmrPlayer &$player=null) {
+		return $this->getVisibleGoods('Buy', $player);
 	}
 	
-	public function &getGoodsSold() {
-		$this->getGoods();
-		return $this->goods['Sell'];
+	public function &getAllGoodIDs() {
+		return $this->goodIDs['All'];
 	}
 	
-	public function &getGoodsBought() {
-		$this->getGoods();
-		return $this->goods['Buy'];
+	/**
+	 * Get IDs of goods that can be sold to the port
+	 */
+	public function &getSoldGoodIDs() {
+		return $this->goodIDs['Sell'];
+	}
+	
+	/**
+	 * Get IDs of goods that can be bought from the port
+	 */
+	public function &getBoughtGoodIDs() {
+		return $this->goodIDs['Buy'];
 	}
 	
 	public function &getGood($goodID) {
-		$goods = $this->getGoods();
-		if(isset($goods['All Goods'][$goodID]))
-			return $goods['All Goods'][$goodID];
-		else {
+		if ($this->hasGood($goodID)) {
+			return Globals::getGood($goodID);
+		} else {
 			$return = false;
 			return $return;
 		}
 	}
 	
 	public function getGoodDistance($goodID) {
-		$good =& $this->getGood($goodID);
-		if(!isset($good['Distance'])) {
-			$x = Globals::getGood($goodID);
-			switch($good['TransactionType']) {
-				case 'Buy':
-					$x['TransactionType'] = 'Sell';
-				break;
-				case 'Sell':
-					$x['TransactionType'] = 'Buy';
+		if (!isset($this->goodDistances[$goodID])) {
+			$x = $this->getGood($goodID);
+			if ($x === false) {
+				throw new Exception('This port does not have this good!');
+			}
+			if ($this->hasGood($goodID, 'Buy')) {
+				$x['TransactionType'] = 'Sell';
+			} else {
+				$x['TransactionType'] = 'Buy';
 			}
 			$di = Plotter::findDistanceToX($x, $this->getSector(), true);
 			if(is_object($di))
 				$di = $di->getRelativeDistance();
-			$good['Distance'] = max(1,$di);
+			$this->goodDistances[$goodID] = max(1, $di);
 		}
-		return $good['Distance'];
+		return $this->goodDistances[$goodID];
 	}
 	
-	public function getGoodStatus($goodID) {
-		$good =& $this->getGood($goodID);
-		return $good['TransactionType'];
+	/**
+	 * Returns the transaction type for this good (Buy or Sell).
+	 * Note: this is the player's transaction, not the port's.
+	 */
+	public function getGoodTransaction($goodID) {
+		foreach (array('Buy', 'Sell') as $transaction) {
+			if ($this->hasGood($goodID, $transaction)) {
+				return $transaction;
+			}
+		}
 	}
 	
 	public function hasGood($goodID,$type=false) {
-		$good =& $this->getGood($goodID);
-		if($good===false)
-			return false;
-		if(!$type)
-			return true;
-		return $good['TransactionType'] == $type;
+		if ($type === false) {
+			$type = 'All';
+		}
+		return in_array($goodID, $this->goodIDs[$type]);
 	}
 	
 	public function setGoodAmount($goodID,$amount) {
 		if($this->isCachedVersion())
 			throw new Exception('Cannot update a cached port!');
-		$this->getGoods();
 		if($amount < 0)
 			$amount = 0;
-		$max = $this->goods['All Goods'][$goodID]['Max'];
+		$max = $this->getGood($goodID)['Max'];
 		if($amount > $max)
 			$amount = $max;
-		if($this->goods['All Goods'][$goodID]['Amount'] == $amount)
+		if($this->getGoodAmount($goodID) == $amount)
 			return;
-		$this->goods['All Goods'][$goodID]['Amount'] = $amount;
-		if(isset($this->goods['Sell'][$goodID]))
-			$this->goods['Sell'][$goodID]['Amount'] = $amount;
-		else if(isset($this->goods['Buy'][$goodID]))
-			$this->goods['Buy'][$goodID]['Amount'] = $amount;
-		$this->db->query('UPDATE port_has_goods SET amount = ' . $this->db->escapeNumber($amount) . ' WHERE ' . $this->SQL . ' AND good_id = ' . $this->db->escapeNumber($goodID) . ' LIMIT 1');
+		$this->goodAmounts[$goodID] = $amount;
 	}
 	
 	public function getGoodAmount($goodID) {
-		$good =& $this->getGood($goodID);
-		return $good['Amount'];
+		return $this->goodAmounts[$goodID];
 	}
 	
 	public function decreaseGood(array &$good,$amount,$doRefresh) {
@@ -350,11 +349,11 @@ class SmrPort {
 	protected function refreshGoods($classTraded,$amountTraded) {
 		$refreshAmount = round($amountTraded * self::REFRESH_PER_GOOD);
 		//refresh goods that need it
-		$portGoods =& $this->getGoodsAll();
 		$refreshClass = $classTraded+1;
-		foreach ($portGoods as &$good) {
-			if($good['Class']==$refreshClass) {
-				$this->increaseGoodAmount($good['ID'], $refreshAmount);
+		foreach ($this->getAllGoodIDs() as $goodID) {
+			$goodClass = Globals::getGood($goodID)['Class'];
+			if ($goodClass == $refreshClass) {
+				$this->increaseGoodAmount($goodID, $refreshAmount);
 			}
 		}
 	}
@@ -458,21 +457,28 @@ class SmrPort {
 			throw new Exception('Cannot update a cached port!');
 		if(!is_numeric($goodID))
 			return false;
-		$newGood = Globals::getGood($goodID);
-		$newGood['Amount'] = $newGood['Max'];
-		$newGood['TransactionType'] = $type;
-		$this->goods['All Goods'][$goodID] =& $newGood;
-		$this->goods[$type][$goodID] =& $newGood;
-		$this->db->query('REPLACE INTO port_has_goods (game_id, sector_id, good_id, transaction_type, amount) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber($this->getSectorID()) . ',' . $this->db->escapeNumber($goodID) . ',' . $this->db->escapeString($type) . ',' . $this->db->escapeNumber($newGood['Amount']) . ')');
+		$this->goodIDs['All'][] = $goodID;
+		$this->goodIDs[$type][] = $goodID;
+		// sort ID arrays, since the good ID might not be the largest
+		sort($this->goodIDs['All']);
+		sort($this->goodIDs[$type]);
+		$this->goodAmounts[$goodID] = Globals::getGood($goodID)['Max'];
+		$this->db->query('REPLACE INTO port_has_goods (game_id, sector_id, good_id, transaction_type, amount) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber($this->getSectorID()) . ',' . $this->db->escapeNumber($goodID) . ',' . $this->db->escapeString($type) . ',' . $this->db->escapeNumber($this->getGoodAmount($goodID)) . ')');
 		$this->db->query('DELETE FROM route_cache WHERE game_id='.$this->db->escapeNumber($this->getGameID()));
 	}
 	
 	protected function removePortGood($goodID) {
 		if($this->isCachedVersion())
 			throw new Exception('Cannot update a cached port!');
-		unset($this->goods['All Goods'][$goodID]);
-		if(isset($this->goods['Sell'][$goodID])) unset($this->goods['Sell'][$goodID]);
-		elseif(isset($this->goods['Buy'][$goodID])) unset($this->goods['Buy'][$goodID]);
+		if (($key = array_search($goodID, $this->goodIDs['All'])) !== false) {
+			array_splice($this->goodIDs['All'], $key, 1);
+		}
+		if (($key = array_search($goodID, $this->goodIDs['Buy'])) !== false) {
+			array_splice($this->goodIDs['Buy'], $key, 1);
+		}
+		elseif (($key = array_search($goodID, $this->goodIDs['Sell'])) !== false) {
+			array_splice($this->goodIDs['Sell'], $key, 1);
+		}
 		
 		$this->db->query('DELETE FROM port_has_goods WHERE '.$this->SQL.' AND good_id=' . $this->db->escapeNumber($goodID) . ';');
 		$this->db->query('DELETE FROM route_cache WHERE game_id='.$this->db->escapeNumber($this->getGameID()));
@@ -494,10 +500,11 @@ class SmrPort {
 	
 	protected function selectAndRemoveGood($goodClass) {
 		// Pick good to remove from the list of goods the port currently has
-		$goods = $this->getGoodsAll();
-		shuffle($goods);
+		$goodIDs = $this->getAllGoodIDs();
+		shuffle($goodIDs);
 
-		foreach ($goods as $good) {
+		foreach ($goodIDs as $goodID) {
+			$good =& Globals::getGood($goodID);
 			if ($good['Class'] == $goodClass) {
 				$this->removePortGood($good['ID']);
 				return;
@@ -731,6 +738,7 @@ class SmrPort {
 			return;
 		$this->raceID = $raceID;
 		$this->hasChanged=true;
+		// route_cache tells NPC's where they can trade
 		$this->db->query('DELETE FROM route_cache WHERE game_id='.$this->db->escapeNumber($this->getGameID()));
 	}
 	
@@ -873,11 +881,10 @@ class SmrPort {
 //		echo 'Good:'.$goodID.',Dist::'.$dist.',Type:'.$transactionType.',NumGoods:'.$numGoods.',Relations:'.$relations.',';
 		if($relations>1000)
 			$relations=1000;
-		$goods = $this->getGoods();
-		$good = $goods['All Goods'][$goodID];
+		$good =& $this->getGood($goodID);
 		$base = $good['BasePrice'];
 		$maxSupply = $good['Max'];
-		$supply = $good['Amount'];
+		$supply = $this->getGoodAmount($goodID);
 		$dist = $this->getGoodDistance($goodID);
 	
 //		$relations_factor_buy = 2-(($relations + 500) / 1500);
@@ -972,9 +979,9 @@ class SmrPort {
 		return $justContainer === false ? SmrSession::getNewHREF($container) : $container;
 	}
 
-	public function getLootGoodHREF(array &$boughtGood) {
+	public function getLootGoodHREF($boughtGoodID) {
 		$container = create_container('port_loot_processing.php');
-		$container['GoodID'] = $boughtGood['ID'];
+		$container['GoodID'] = $boughtGoodID;
 		return SmrSession::getNewHREF($container);
 	}
 	public function isCachedVersion() {
@@ -999,12 +1006,6 @@ class SmrPort {
 	}
 	public function addCachePorts(array $accountIDs) {
 		if (count($accountIDs)>0 && $this->exists()) {
-			$cachedVersion = $this->cachedVersion;
-			$this->getGoods();
-			$goods = array();
-			foreach($this->goods['All Goods'] as $key => &$good) {
-				$goods[$key] = $good;
-			} unset($good);
 			$cache = $this->db->escapeBinary(gzcompress(serialize($this)));
 			$cacheHash = $this->db->escapeString(md5($cache));
 			//give them the port info
@@ -1022,11 +1023,7 @@ class SmrPort {
 						VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getSectorID()) . ', ' . $cacheHash . ', ' . $cache.')');
 
 			$this->db->query('UPDATE player_visited_port SET visited=' . $this->db->escapeNumber($this->getCachedTime()) . ', port_info_hash=' . $cacheHash . ' WHERE visited<=' . $this->db->escapeNumber($this->getCachedTime()) . ' AND account_id IN (' . $this->db->escapeArray($accountIDs) . ') AND sector_id=' . $this->db->escapeNumber($this->getSectorID()) . ' AND game_id=' . $this->db->escapeNumber($this->getGameID()) . ' LIMIT ' . count($accountIDs));
-			$this->cachedVersion = $cachedVersion; //Serializing this would have designated it as cached, this version might not be.
 
-			foreach($goods as $key => &$good) {
-				$this->goods['All Goods'][$key] =& $good;
-			} unset($good); //Serializing this would have screwed up stock counts
 			unset($cache);
 			return true;
 		}
@@ -1052,22 +1049,27 @@ class SmrPort {
 		return self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID];
 	}
 	
-	// This is a magic method used when serializing an SmrPort instance
+	// This is a magic method used when serializing an SmrPort instance.
+	// It designates which members should be included in the serialization.
 	public function __sleep() {
-		// Note: we artificially set some properties here (i.e. goods set to 1,
-		// and good distance unset) so that the hash of the serialized object
-		// is the same for all players. This greatly improves cache efficiency.
-		$this->getGoods(); //have to make sure goods have been loaded
-		foreach($this->goods['All Goods'] as &$good) {
-			$good['Amount'] = 1;
-			unset($good['Distance']);
-		} unset($good);
-		$this->cachedVersion = true;
-		return array('gameID', 'sectorID', 'raceID', 'level', 'cachedVersion', 'goods');
+		// We omit `goodAmounts` and `goodDistances` so that the hash of the
+		// serialized object is the same for all players. This greatly improves
+		// cache efficiency.
+		return array('gameID', 'sectorID', 'raceID', 'level', 'goodIDs');
 	}
 	
 	public function __wakeup() {
+		$this->cachedVersion = true;
 		$this->db = new SmrMySqlDatabase();
+
+		// DEPRECATED: this is for unserializing old SmrPort data.
+		// Remove after game 117 ends.
+		if (isset($this->goods)) {
+			$this->goodIDs = array();
+			foreach ($this->goods as $transaction => $goods) {
+				$this->goodIDs[$transaction] = array_keys($goods);
+			}
+		}
 	}
 	
 	public function update() {
@@ -1112,12 +1114,14 @@ class SmrPort {
 			}
 			$this->hasChanged=false;
 		}
-		if(isset($this->goods))
-			foreach ($this->goods['All Goods'] as $good)
-				$this->db->query('UPDATE port_has_goods SET amount = ' . $this->db->escapeNumber($good['Amount']) . '
+		if (isset($this->goodAmounts)) {
+			foreach ($this->goodAmounts as $goodID => $amount) {
+				$this->db->query('UPDATE port_has_goods SET amount = ' . $this->db->escapeNumber($amount) . '
 									WHERE game_id = ' . $this->db->escapeNumber($this->getGameID()) . '
 										AND sector_id = ' . $this->db->escapeNumber($this->getSectorID()) . '
-										AND good_id = ' . $this->db->escapeNumber($good['ID']) . ' LIMIT 1');
+										AND good_id = ' . $this->db->escapeNumber($goodID) . ' LIMIT 1');
+			}
+		}
 	}
 	
 	

--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -1264,7 +1264,12 @@ class SmrPort {
 	
 	public function &killPortByPlayer(AbstractSmrPlayer &$killer) {
 		$return = array();
-		
+
+		// Port is destroyed, so empty the port of all trade goods
+		foreach ($this->getAllGoodIDs() as $goodID) {
+			$this->setGoodAmount($goodID, 0);
+		}
+
 		$this->creditCurrentAttackersForKill();
 		
 		// News Entry

--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -1052,7 +1052,11 @@ class SmrPort {
 		return self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID];
 	}
 	
+	// This is a magic method used when serializing an SmrPort instance
 	public function __sleep() {
+		// Note: we artificially set some properties here (i.e. goods set to 1,
+		// and good distance unset) so that the hash of the serialized object
+		// is the same for all players. This greatly improves cache efficiency.
 		$this->getGoods(); //have to make sure goods have been loaded
 		foreach($this->goods['All Goods'] as &$good) {
 			$good['Amount'] = 1;
@@ -1067,6 +1071,9 @@ class SmrPort {
 	}
 	
 	public function update() {
+		if ($this->isCachedVersion()) {
+			throw new Exception('Cannot update a cached port!');
+		}
 		if(!$this->exists())
 			return;
 		if($this->hasChanged) {

--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -49,6 +49,7 @@ class SmrPort {
 	
 	protected $cachedVersion = false;
 	protected $cachedTime = TIME;
+	protected $cacheIsValid = true;
 	
 	protected $SQL;
 	
@@ -386,9 +387,6 @@ class SmrPort {
 			$this->decreaseCredits($this->getUpgradeRequirement());
 			$this->doUpgrade();
 		}
-		if($upgrades > 0) {
-			$this->updateSectorPlayersCache();
-		}
 		return $upgrades;
 	}
 	
@@ -462,7 +460,9 @@ class SmrPort {
 		// sort ID arrays, since the good ID might not be the largest
 		sort($this->goodIDs['All']);
 		sort($this->goodIDs[$type]);
+
 		$this->goodAmounts[$goodID] = Globals::getGood($goodID)['Max'];
+		$this->cacheIsValid = false;
 		$this->db->query('REPLACE INTO port_has_goods (game_id, sector_id, good_id, transaction_type, amount) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber($this->getSectorID()) . ',' . $this->db->escapeNumber($goodID) . ',' . $this->db->escapeString($type) . ',' . $this->db->escapeNumber($this->getGoodAmount($goodID)) . ')');
 		$this->db->query('DELETE FROM route_cache WHERE game_id='.$this->db->escapeNumber($this->getGameID()));
 	}
@@ -480,6 +480,7 @@ class SmrPort {
 			array_splice($this->goodIDs['Sell'], $key, 1);
 		}
 		
+		$this->cacheIsValid = false;
 		$this->db->query('DELETE FROM port_has_goods WHERE '.$this->SQL.' AND good_id=' . $this->db->escapeNumber($goodID) . ';');
 		$this->db->query('DELETE FROM route_cache WHERE game_id='.$this->db->escapeNumber($this->getGameID()));
 	}
@@ -491,9 +492,6 @@ class SmrPort {
 				++$downgrades;
 				$this->doDowngrade();
 			}
-		}
-		if($downgrades > 0) {
-			$this->updateSectorPlayersCache();
 		}
 		return $downgrades;
 	}
@@ -737,7 +735,8 @@ class SmrPort {
 		if($this->raceID == $raceID)
 			return;
 		$this->raceID = $raceID;
-		$this->hasChanged=true;
+		$this->hasChanged = true;
+		$this->cacheIsValid = false;
 		// route_cache tells NPC's where they can trade
 		$this->db->query('DELETE FROM route_cache WHERE game_id='.$this->db->escapeNumber($this->getGameID()));
 	}
@@ -1076,8 +1075,16 @@ class SmrPort {
 		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
 		}
-		if(!$this->exists())
+		if (!$this->exists()) {
 			return;
+		}
+
+		// If any cached members (see `__sleep`) changed, update the cached port
+		if (!$this->cacheIsValid) {
+			$this->updateSectorPlayersCache();
+		}
+
+		// If any fields in the `port` table have changed, update table
 		if($this->hasChanged) {
 			if($this->isNew===false) {
 				$this->db->query('UPDATE port SET experience = ' . $this->db->escapeNumber($this->getExperience()) .
@@ -1114,6 +1121,8 @@ class SmrPort {
 			}
 			$this->hasChanged=false;
 		}
+
+		// Update the port good amounts
 		if (isset($this->goodAmounts)) {
 			foreach ($this->goodAmounts as $goodID => $amount) {
 				$this->db->query('UPDATE port_has_goods SET amount = ' . $this->db->escapeNumber($amount) . '

--- a/templates/Default/engine/Default/includes/SectorMap.inc
+++ b/templates/Default/engine/Default/includes/SectorMap.inc
@@ -61,12 +61,14 @@
 									} ?>
 										<img src="images/port/buy.png" width="5" height="16" alt="Buy (<?php echo $Port->getRaceName(); ?>)" 
 											title="Buy (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-											foreach($Port->getVisibleGoodsSold($MapPlayer) as $Good) { ?>
+											foreach($Port->getVisibleGoodsSold($MapPlayer) as $GoodID) {
+												$Good =& Globals::getGood($GoodID); ?>
 												<img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name'] ?>" alt="<?php echo $Good['Name']; ?>" /><?php
 											} ?><br />
 										<img src="images/port/sell.png" width="5" height="16" alt="Sell (<?php echo $Port->getRaceName(); ?>)" 
 										title="Sell (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-											foreach($Port->getVisibleGoodsBought($MapPlayer) as $Good) { ?>
+											foreach($Port->getVisibleGoodsBought($MapPlayer) as $GoodID) {
+												$Good =& Globals::getGood($GoodID); ?>
 												<img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name'] ?>" alt="<?php echo $Good['Name']; ?>" /><?php
 											}
 									if($isCurrentSector && !$GalaxyMap){ ?></a><?php } ?>

--- a/templates/Default/engine/Default/includes/SectorPort.inc
+++ b/templates/Default/engine/Default/includes/SectorPort.inc
@@ -12,12 +12,14 @@
 						<div class="goods">
 							<img src="images/port/buy.png" width="5" height="16" alt="Buy" 
 								title="Buy" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-							foreach($Port->getVisibleGoodsSold($ThisPlayer) as $Good) {
+							foreach ($Port->getVisibleGoodsSold($ThisPlayer) as $GoodID) {
+								$Good =& Globals::getGood($GoodID);
 								?><img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name']; ?>" alt="<?php echo $Good['Name']; ?>" /><?php
 							}
 							?><br /><img src="images/port/sell.png" width="5" height="16" alt="Sell" 
 								title="Sell" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-							foreach($Port->getVisibleGoodsBought($ThisPlayer) as $Good) {
+							foreach ($Port->getVisibleGoodsBought($ThisPlayer) as $GoodID) {
+								$Good =& Globals::getGood($GoodID);
 								?><img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name']; ?>" alt="<?php echo $Good['Name']; ?>" /><?php
 							} ?>
 						</div>

--- a/templates/Default/engine/Default/port_loot.php
+++ b/templates/Default/engine/Default/port_loot.php
@@ -7,17 +7,19 @@
 		<th>Amount to Trade</th>
 		<th>Action</th>
 	</tr><?php
-	$BoughtGoods =& $ThisPort->getVisibleGoodsBought($ThisPlayer);
-	foreach($BoughtGoods as &$Good) { ?>
-		<form method="POST" action="<?php echo $ThisPort->getLootGoodHREF($Good); ?>">
+	$BoughtGoodIDs =& $ThisPort->getVisibleGoodsBought($ThisPlayer);
+	foreach ($BoughtGoodIDs as $GoodID) {
+		$Good = Globals::getGood($GoodID);
+		$Amount = $ThisPort->getGoodAmount($GoodID); ?>
+		<form method="POST" action="<?php echo $ThisPort->getLootGoodHREF($GoodID); ?>">
 			<tr>
 				<td><?php echo $Good['Name']; ?></td>
-				<td><?php echo $Good['Amount']; ?></td>
+				<td><?php echo $Amount; ?></td>
 				<td><?php echo $Good['BasePrice']; ?></td>
 				<td><?php echo $ThisShip->getCargo($Good['ID']); ?></td>
-				<td><input type="number" name="amount" value="<?php echo min($Good['Amount'], $ThisShip->getCargoHolds()); ?>" size="4" id="InputFields" class="center"></td>
+				<td><input type="number" name="amount" value="<?php echo min($Amount, $ThisShip->getCargoHolds()); ?>" size="4" id="InputFields" class="center"></td>
 				<td><input type="submit" name="action" value="Loot" id="InputFields" /></td>
 			</tr>
 		</form><?php
-	} unset($Good); ?>
+	} ?>
 </table>

--- a/tools/testDistancePlotters.php
+++ b/tools/testDistancePlotters.php
@@ -22,7 +22,7 @@ function testDistances($gameID)
 		foreach($galaxySectors as &$galaxySector)
 		{
 			if($galaxySector->hasPort())
-				$galaxySector->getPort()->getGoods();
+				$galaxySector->getPort();
 		} unset($galaxySector);
 	} unset($galaxySectors);
 	//Test plotters
@@ -34,22 +34,23 @@ function testDistances($gameID)
 		{
 			if($galaxySector->hasPort())
 			{
-				$goods =& $galaxySector->getPort()->getGoods();
-				foreach($goods as &$good)
+				$goodIDs =& $galaxySector->getPort()->getAllGoodIDs();
+				foreach($goodIDs as $goodID)
 				{
+					$transaction = $galaxySector->getPort->getGoodTransaction($goodID);
 					$time = microtime(true);
-					$newDI = getGoodDistanceNew($galaxySector,$good['ID'],$good['TransactionType']);
+					$newDI = getGoodDistanceNew($galaxySector,$goodID,$transaction);
 					$newTime += microtime(true) - $time;
 					
 					$time = microtime(true);
-					$oldDI = getGoodDistanceOld($galaxySector,$good['ID'],$good['TransactionType']);
+					$oldDI = getGoodDistanceOld($galaxySector,$goodID,$transaction);
 					$oldTime += microtime(true) - $time;
 					
 					if($newDI!=$oldDI)
 					{
-						echo 'Difference, new: '.$newDI.', old:'.$oldDI.', sector:'.$galaxySector->getSectorID().', good:'.$good['ID'].EOL;
+						echo 'Difference, new: '.$newDI.', old:'.$oldDI.', sector:'.$galaxySector->getSectorID().', good:'.$goodID.EOL;
 					}
-				} unset($good);
+				}
 			}
 		} unset($galaxySector);
 	} unset($galaxySectors);


### PR DESCRIPTION
**Serialize without modifying the port**

Break the `goods` member into three more logically distinct
members: `goodIDs`, `goodAmounts`, and `goodDistances`.
The `goodIDs` are broken up into "Buy", "Sell", and "All Goods"
arrays as before, but the latter two are simple assoc. arrays.

We will omit `good{Amounts,Distances}` in the serialization,
and only keep the `goodIDs` (which is all the cached port
users need).

We can also avoid modifying `cachedVersion` by setting this
to true in `__wakeup` instead of `__sleep`. This is because
the port we are serializing is not cached -- only the one
we get when we unserialize.

Code is included in `__wakeup` to temporarily permit unserializing
old port caches (this can be removed after any running game is
over).

(Note: below, a "good" means the lengthy data array that
`Globals::getGood{,s}` returns.)
Due to the modified internal data structure of `SmrPort`, some
of the methods have been changed as well:
* `restockGood` takes a goodID instead of a "good".
* `getLootGoodHREF` now takes a goodID instead of a "good".
* `getGoods` is now private, and is used only to populate
  the `good{IDs,Amounts}` members in the ctor.
  It also throws an exception if called on a cached port
  instead of returning false.
* `getVisibleGoods` is now private, and is just a common
  function for `getVisibleGoods{Sold,Bought}`.
* `getVisibleGoodsAll` has been removed.
* `getVisibleGoods{Bought,Sold}` now return an array of goodIDs
  instead of an array of "goods".
* `getGoods{All,Sold,Bought}` have been replaced with
  `get{All,Sold,Bought}GoodIDs`, and they return an array of goodIDs
  instead of an array of "goods".
* `getGoodStatus` has been renamed `getGoodTransaction` to more
  clearly describe what it does.
* `addCachePorts` no longer needs to store and then reset the
  `$cachedVersion` and `$goods`.
* `__sleep` no longer modifies the instance members, and replaces
  `goods` and `cachedVersion` with `goodIDs` in the serialized
  members.
* `__wakeup` now sets `cachedVersion=true` instead of `__sleep`.

Some unnecessary mysql queries have also been removed from `SmrPort`:
* updating `port_has_goods` amounts in `restockGood` (this is
  redundant with `update` called by `savePorts`?)
* updating `port_has_goods` amounts in `setGoodAmount`.

---------------

**Cache update consistency**

The cached version of the port was only updated for port
upgrades and in-combat downgrades. We now update the cache
for the following events:

* Race change (i.e. port is claimed after a raid)
* All level changes (i.e. after a port is razed)

This should now encompass all scenarios where the cached
version of the port has changed.

We use a `cacheIsValid` member now, and set that to false
in these cases; this allows us to only update the cache
once (in the `update` method).