### PR TITLE
Remove createPort methods

### DIFF
--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -234,7 +234,7 @@ elseif ($submit == 'Create Ports and Mines') {
 				if($numRacePorts[$raceID]==0)
 					unset($numRacePorts[$raceID]);
 					
-				$port =& $galSector->createPort();
+				$port =& $galSector->getPort();
 				$port->setRaceID($raceID);
 				$port->upgradeToLevel($i);
 				$port->setCreditsToDefault();
@@ -305,12 +305,7 @@ elseif ($submit == 'Edit Sector') {
 	}
 	//update port
 	if ($_POST['port_level'] > 0) {
-		if(!$sector->hasPort()) {
-			$port =& $sector->createPort();
-		}
-		else {
-			$port =& $sector->getPort();
-		}
+		$port =& $sector->getPort();
 		if ($port->getLevel()!=$_POST['port_level']) {
 			$port->upgradeToLevel($_POST['port_level']);
 			$port->setCreditsToDefault();

--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -89,14 +89,6 @@ class SmrPort {
 		unset(self::$CACHE_PORTS[$gameID][$sectorID]);
 	}
 
-	public static function &createPort($gameID,$sectorID) {
-		if(!isset(self::$CACHE_PORTS[$gameID][$sectorID])) {
-			$p = new SmrPort($gameID,$sectorID);
-			self::$CACHE_PORTS[$gameID][$sectorID] =& $p;
-		}
-		return self::$CACHE_PORTS[$gameID][$sectorID];
-	}
-	
 	public static function savePorts() {
 		foreach(self::$CACHE_PORTS as &$gamePorts) {
 			foreach($gamePorts as &$port) {

--- a/lib/Default/SmrSector.class.inc
+++ b/lib/Default/SmrSector.class.inc
@@ -592,10 +592,6 @@ class SmrSector {
 		return SmrPort::getPort($this->getGameID(),$this->getSectorID());
 	}
 
-	public function &createPort() {
-		return SmrPort::createPort($this->getGameID(),$this->getSectorID());
-	}
-
 	public function removePort() {
 		SmrPort::removePort($this->getGameID(),$this->getSectorID());
 	}


### PR DESCRIPTION
`SmrPort::createPort` is equivalent to `getPort`, so just
remove it. We can also remove the wrapper with the same name
from `SmrSector`.