### PR TITLE
tools/*/Dockerfile: only copy needed libs

### DIFF
--- a/tools/discord/Dockerfile
+++ b/tools/discord/Dockerfile
@@ -13,7 +13,9 @@ COPY tools/discord/composer.json .
 RUN composer install --no-interaction
 
 # Get the SMR source code
-COPY . .
+COPY ./htdocs ./htdocs
+COPY ./lib ./lib
+COPY ./tools ./tools
 
 # Set up the DiscordPHP bot
 WORKDIR /smr/tools/discord

--- a/tools/irc/Dockerfile
+++ b/tools/irc/Dockerfile
@@ -13,7 +13,9 @@ COPY tools/irc/composer.json .
 RUN composer install --no-interaction
 
 # Get the SMR source code
-COPY . .
+COPY ./htdocs ./htdocs
+COPY ./lib ./lib
+COPY ./tools ./tools
 
 WORKDIR /smr/tools/irc
 

--- a/tools/npc/Dockerfile
+++ b/tools/npc/Dockerfile
@@ -18,7 +18,9 @@ COPY tools/npc/composer.json .
 RUN composer install --no-interaction
 
 # Get the SMR source code
-COPY . .
+COPY ./htdocs ./htdocs
+COPY ./lib ./lib
+COPY ./tools ./tools
 
 WORKDIR /smr/tools/npc
 


### PR DESCRIPTION
Avoid unnecessarily invalidating the layer cache by only copying
required subdirectories of the source code.