### PR TITLE
Moving off course does not delete plotted course

### DIFF
--- a/engine/Default/course_plot_nearest_processing.php
+++ b/engine/Default/course_plot_nearest_processing.php
@@ -24,14 +24,7 @@ $sector =& $player->getSector();
 if($sector->hasX($realX,$player))
 	create_error('Current sector has what you\'re looking for!');
 
-$path =& Plotter::findDistanceToX($realX, $sector, true, $player, $player);
-if($path===false)
-	create_error('Unable to find what you\'re looking for, it either hasn\'t been added to this game or you haven\'t explored it yet.');
-
-if($path->getEndSectorID() < $sector->getSectorID()) { //If sector we find is a lower sector id we replot so we always use the plot from lowest to highest sector.
-	$path =& Plotter::findDistanceToX($sector, $path->getEndSector(), true);
-	$path->reversePath();
-}
+$path = Plotter::findReversiblePathToX($realX, $sector, true, $player, $player);
 
 $container['Distance'] = serialize($path);
 

--- a/engine/Default/course_plot_processing.php
+++ b/engine/Default/course_plot_processing.php
@@ -39,13 +39,7 @@ $container['url'] = 'skeleton.php';
 $container['body'] = 'course_plot_result.php';
 
 require_once(get_file_loc('Plotter.class.inc'));
-$path =& Plotter::findDistanceToX(SmrSector::getSector($player->getGameID(),max($target,$start)), SmrSector::getSector($player->getGameID(),min($target,$start)), true);
-if($path===false) {
-	create_error('Unable to plot from '.$start.' to '.$target.'.');
-}
-if($start > $target) { //We always plot lowest to highest, so reverse if need be.
-	$path->reversePath();
-}
+$path = Plotter::findReversiblePathToX(SmrSector::getSector($player->getGameID(), $target), SmrSector::getSector($player->getGameID(), $start), true);
 $container['Distance'] = serialize($path);
 
 $path->removeStart();

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -96,11 +96,17 @@ release_lock();
 // We need a lock on the new sector so that more than one person isn't hitting the same mines
 acquire_lock($player->getSectorID());
 
-// delete plotted course
-$player->deletePlottedCourse();
-
 // get new sector object
 $sector =& $player->getSector();
+
+// If we have jumped into a future of our plotted course, update!
+if ($player->hasPlottedCourse()) {
+	$path = $player->getPlottedCourse();
+	if ($path->isInPath($sector->getSectorID())) {
+		$path->skipToSector($sector->getSectorID());
+		$player->setPlottedCourse($path);
+	}
+}
 
 // make current sector visible to him
 $sector->markVisited($player);

--- a/engine/Default/sector_move_processing.php
+++ b/engine/Default/sector_move_processing.php
@@ -7,6 +7,7 @@ if($sector->getWarp() == $var['target_sector'])
 	$turns = TURNS_PER_WARP;
 else
 	$turns = TURNS_PER_SECTOR;
+
 //allow hidden players (admins that don't play) to move without pinging, hitting mines, losing turns
 if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 	//update plot
@@ -15,9 +16,11 @@ if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 		if ($path->getNextOnPath() == $var['target_sector']) {
 			$path->followPath($sector->getWarp() == $var['target_sector']);
 			$player->setPlottedCourse($path);
+		} elseif ($path->isInPath($var['target_sector'])) {
+			// Did we re-enter the course down the line?
+			$path->skipToSector($var['target_sector']);
+			$player->setPlottedCourse($path);
 		}
-		else
-			$player->deletePlottedCourse();
 	}
 	
 	//make them pop on CPL
@@ -30,6 +33,7 @@ if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 	$sector->markVisited($player);
 	forward(create_container('skeleton.php', $var['target_page']));
 }
+
 $action = '';
 if(isset($_REQUEST['action'])) {
 	$action = $_REQUEST['action'];
@@ -83,9 +87,11 @@ if ($player->hasPlottedCourse()) {
 	if ($path->getNextOnPath() == $var['target_sector']) {
 		$path->followPath($sector->getWarp() == $var['target_sector']);
 		$player->setPlottedCourse($path);
+	} elseif ($path->isInPath($var['target_sector'])) {
+		// Did we re-enter the course down the line?
+		$path->skipToSector($var['target_sector']);
+		$player->setPlottedCourse($path);
 	}
-	else
-		$player->deletePlottedCourse();
 }
 
 // log action

--- a/lib/Default/Plotter.class.inc
+++ b/lib/Default/Plotter.class.inc
@@ -107,7 +107,7 @@ class Plotter {
 		//Warps first as a slight optimisation due to how visitedSectors is set.
 		if($checkSector->hasWarp()===true) {
 			$d = new Distance($gameID,$checkSector->getSectorID());
-			$d->addWarpToPath($checkSector->getWarp());
+			$d->addWarpToPath($checkSector->getWarp(), $checkSector->getSectorID());
 			$distanceQ[$warpAddIndex][] = $d;
 		}
 		foreach ($checkSector->getLinks() as $nextSector) {
@@ -151,7 +151,7 @@ class Plotter {
 					if($checkSector->hasWarp()===true) {
 						if (!isset($visitedSectors[$checkSector->getWarp()])) {
 							$cloneDistance = clone($distance);
-							$cloneDistance->addWarpToPath($checkSector->getWarp());
+							$cloneDistance->addWarpToPath($checkSector->getWarp(), $checkSector->getSectorID());
 							$distanceQ[$warpAddIndex][] = $cloneDistance;
 						}
 					}
@@ -198,6 +198,7 @@ class Distance {
 	private $distance = -1; //First sector added will be the start and a distance of 0
 	private $numWarps = 0;
 	private $path = array();
+	private $warpMap = array();
 
 	public function __construct($gameID,$_startSectorId) {
 		$this->gameID = $gameID;
@@ -209,14 +210,6 @@ class Distance {
 //		$this->numWarps = $_numWarps;
 //		$this->path = $_path;
 //	}
-
-	public function setDistance($_distance) {
-		$this->distance = $_distance;
-	}
-
-	public function setNumWarps($_numWarps) {
-		$this->numWarps = $_numWarps;
-	}
 
 	protected function incrementDistance() {
 		$this->distance++;
@@ -237,10 +230,6 @@ class Distance {
 	public function getNumWarps() {
 		return $this->numWarps;
 	}
-
-//	public function clone() {
-//		return new Distance($this->distance, $this->numWarps, clone($this->path));
-//	}
 
 	public function getTurns() {
 		return $this->distance * TURNS_PER_SECTOR + $this->numWarps * TURNS_PER_WARP;
@@ -283,8 +272,10 @@ class Distance {
 		return $this->path;
 	}
 	
+	// NOTE: this assumes 2-way warps
 	public function reversePath() {
 		$this->path = array_reverse($this->path);
+		$this->warpMap = array_flip($this->warpMap);
 	}
 
 	/**
@@ -296,9 +287,10 @@ class Distance {
 		$this->path[] = $nextSector;
 	}
 	
-	public function addWarpToPath($nextSector) {
+	public function addWarpToPath($sectorAfterWarp, $sectorBeforeWarp) {
 		$this->incrementNumWarps();
-		$this->path[] = $nextSector;
+		$this->path[] = $sectorAfterWarp;
+		$this->warpMap[$sectorBeforeWarp] = $sectorAfterWarp;
 	}
 	
 	public function getNextOnPath() {
@@ -320,20 +312,23 @@ class Distance {
 	public function isInPath($sectorID) {
 		return in_array($sectorID,$this->getPath());
 	}
+
+	/**
+	 * If the given sector is in the path, then return the segment
+	 * of the path that comes after the given sector.
+	 */
+	public function skipToSector($sectorID) {
+		$position = array_search($sectorID, $this->path);
+		if ($position !== false) {
+			// The resulting path does not include sectorID, i.e. (sectorID,end]
+			$this->path = array_slice($this->path, $position + 1);
+			$this->numWarps = count(array_intersect($this->path, array_values($this->warpMap)));
+			$this->distance = count($this->path) - $this->numWarps;
+			return $this;
+		} else {
+			throw new Exception('Cannot skip to sector not in path!');
+		}
+	}
 }
-//$d = new Distance(1);
-//$d->addToPath(3);
-//$d2 = clone($d);
-//$d2->addWarpToPath(6);
-//var_dump($d);
-//var_dump($d2);
 
-//$x = 1;
-
-//$x = Globals::getGood(1);
-//$x['TransactionType'] = 'Sell';
-
-//$x =& SmrSector::getSector(1,2);
-//var_dump($x);
-//var_dump(Plotter::findDistanceToX($x, SmrSector::getSector(1,1), 0, 2000, 500,true));
 ?>

--- a/lib/Default/Plotter.class.inc
+++ b/lib/Default/Plotter.class.inc
@@ -34,6 +34,61 @@ class Plotter {
 		}
 	}
 
+	/**
+	 * Returns the shortest path from $sector to $x as a Distance object.
+	 * The path is guaranteed reversible ($x -> $sector == $sector -> $x), which
+	 * is not true for findDistanceToX. If $x is not a SmrSector, then this
+	 * function does 2x the work.
+	 */
+	public static function findReversiblePathToX($x, SmrSector $sector, $useFirst, AbstractSmrPlayer $needsToHaveBeenExplored=null, AbstractSmrPlayer $player=null) {
+		if ($x instanceof SmrSector) {
+
+			// To ensure reversibility, always plot lowest to highest.
+			$reverse = $sector->getSectorID() > $x->getSectorID();
+			if ($reverse) {
+				$start = $x;
+				$end = $sector;
+			} else {
+				$start = $sector;
+				$end = $x;
+			}
+			$path = Plotter::findDistanceToX($end, $start, $useFirst,
+			                                 isset($needsToHaveBeenExploredBy) ? $needsToHavebeenExploredBy : null,
+			                                 isset($player) ? $player : null);
+			if ($path===false) {
+				create_error('Unable to plot from '.$sector->getSectorID().' to '.$x->getSectorID().'.');
+			}
+			// Reverse if we plotted $x -> $sector (since we want $sector -> $x)
+			if ($reverse) {
+				$path->reversePath();
+			}
+
+		} else {
+
+			// At this point we don't know what sector $x will be at
+			$path = Plotter::findDistanceToX($x, $sector, $useFirst,
+			                                 isset($needsToHaveBeenExploredBy) ? $needsToHavebeenExploredBy : null,
+			                                 isset($player) ? $player : null);
+			if ($path===false) {
+				create_error('Unable to find what you\'re looking for, it either hasn\'t been added to this game or you haven\'t explored it yet.');
+			}
+			// Now that we know where $x is, make sure path is reversible
+			// (i.e. start sector < end sector)
+			if ($path->getEndSectorID() < $sector->getSectorID()) {
+				$path =& Plotter::findDistanceToX($sector, $path->getEndSector(), true);
+				$path->reversePath();
+			}
+
+		}
+		return $path;
+	}
+
+	/**
+	 * Returns the shortest path from $sector to $x as a Distance object.
+	 * $x can be any type implemented by SmrSector::hasX or the string 'Distance'.
+	 * The resulting path prefers neighbors in their order in SmrSector->links,
+	 * (i.e. up, down, left, right).
+	 */
 	public static function &findDistanceToX($x, SmrSector &$sector, $useFirst, AbstractSmrPlayer $needsToHaveBeenExploredBy=null, AbstractSmrPlayer $player=null, $distanceLimit=10000, $lowLimit=0, $highLimit=100000) {
 		$warpAddIndex = TURNS_WARP_SECTOR_EQUIVALENCE-1;
 

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1848,7 +1848,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 				// get the course back
 				$this->plottedCourse = unserialize($this->db->getField('course'));
 				$endSectorID = $this->plottedCourse->getEndSectorID();
-				if($endSectorID != $this->getSectorID() && $this->plottedCourse->isInPath($this->getSectorID())) {
+				if ($endSectorID != $this->getSectorID() && $this->isPartOfCourse($this->getSector())) {
 					// Current sector is in the path, we have jumped along it somehow
 					$this->setPlottedCourse($this->plottedCourse->skipToSector($this->getSectorID()));
 				}

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1867,8 +1867,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 				(account_id, game_id, course)
 				VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeBinary(serialize($this->plottedCourse)) . ')');
 		else if($hadPlottedCourse) {
-			$this->plottedCourse = false;
-			$this->db->query('DELETE FROM player_plotted_course WHERE account_id = ' . $this->db->escapeNumber($this->getAccountID()) . ' AND game_id = ' . $this->db->escapeNumber($this->getGameID()));
+			$this->deletePlottedCourse();
 		}
 	}
 

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1848,8 +1848,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 				// get the course back
 				$this->plottedCourse = unserialize($this->db->getField('course'));
 				$endSectorID = $this->plottedCourse->getEndSectorID();
-				if($endSectorID != $this->getSectorID() && $this->plottedCourse->isInPath($this->getSectorID())) { //Current sector is in the path, we have jumped along it somehow so lets replot from our cur
-					$this->plottedCourse =& Plotter::findDistanceToX(SmrSector::getSector($this->getGameID(),$endSectorID), $this->getSector(), true);
+				if($endSectorID != $this->getSectorID() && $this->plottedCourse->isInPath($this->getSectorID())) {
+					// Current sector is in the path, we have jumped along it somehow so lets replot
+					$this->plottedCourse =& Plotter::findReversiblePathToX($this->plottedCourse->getEndSector(), $this->getSector(), true);
 					if($this->plottedCourse === false) {
 						throw new Exception('For some reason we could not replot from "'.$this->getSectorID().'" to "'.$endSectorID);
 					}

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1849,13 +1849,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 				$this->plottedCourse = unserialize($this->db->getField('course'));
 				$endSectorID = $this->plottedCourse->getEndSectorID();
 				if($endSectorID != $this->getSectorID() && $this->plottedCourse->isInPath($this->getSectorID())) {
-					// Current sector is in the path, we have jumped along it somehow so lets replot
-					$this->plottedCourse =& Plotter::findReversiblePathToX($this->plottedCourse->getEndSector(), $this->getSector(), true);
-					if($this->plottedCourse === false) {
-						throw new Exception('For some reason we could not replot from "'.$this->getSectorID().'" to "'.$endSectorID);
-					}
-					$this->plottedCourse->removeStart();
-					$this->setPlottedCourse($this->plottedCourse);
+					// Current sector is in the path, we have jumped along it somehow
+					$this->setPlottedCourse($this->plottedCourse->skipToSector($this->getSectorID()));
 				}
 			}
 			else

--- a/templates/Default/engine/Default/includes/PlottedCourse.inc
+++ b/templates/Default/engine/Default/includes/PlottedCourse.inc
@@ -1,7 +1,8 @@
 <?php
 if($ThisPlayer->hasPlottedCourse()) {
-	$CancelCourseHREF = SmrSession::getNewHREF(create_container('course_plot_cancel_processing.php'));
 	$PlottedCourse =& $ThisPlayer->getPlottedCourse();
+	$CancelCourseHREF = SmrSession::getNewHREF(create_container('course_plot_cancel_processing.php'));
+	$ReplotCourseHREF = SmrSession::getNewHREF(create_container('course_plot_processing.php', '', array('to' => $PlottedCourse->getEndSectorID(), 'from' => $ThisSector->getSectorID())));
 	$NextSector =& SmrSector::getSector($ThisPlayer->getGameID(),$PlottedCourse->getNextOnPath(),$ThisPlayer->getAccountID()); ?>
 	<table class="nobord fullwidth">
 		<tr>
@@ -10,14 +11,20 @@ if($ThisPlayer->hasPlottedCourse()) {
 				<?php echo implode(' - ',$PlottedCourse->getPath()); ?><br />
 				(<?php echo $PlottedCourse->getTotalSectors() ?> sectors, <?php echo $PlottedCourse->getTurns(); ?> turns)
 			</td>
-			<td class="top right">
-				<div class="buttonA">
-					<a class="buttonA" href="<?php echo $NextSector->getCurrentSectorHREF(); ?>">&nbsp; Follow Course (#<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
-				</div><?php
-				if($ThisShip->hasScanner()) { ?>
-					<br /><br />
+			<td class="top right"><?php
+				if ($ThisSector->isLinked($NextSector->getSectorID())) { ?>
 					<div class="buttonA">
-						<a class="buttonA" href="<?php echo $NextSector->getScanSectorHREF(); ?>">&nbsp; Scan Course (#<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
+						<a class="buttonA" href="<?php echo $NextSector->getCurrentSectorHREF(); ?>">&nbsp; Follow Course (#<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
+					</div><?php
+					if($ThisShip->hasScanner()) { ?>
+						<br /><br />
+						<div class="buttonA">
+							<a class="buttonA" href="<?php echo $NextSector->getScanSectorHREF(); ?>">&nbsp; Scan Course (#<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
+						</div><?php
+					}
+				} else { ?>
+					<div class="buttonA">
+						<a class="buttonA" href="<?php echo $ReplotCourseHREF; ?>">&nbsp; Replot Course to #<?php echo $PlottedCourse->getEndSectorID(); ?> &nbsp;</a>
 					</div><?php
 				} ?>
 				<br /><br />


### PR DESCRIPTION
The progress you have made will remain until you cancel or reach
your destination (or trigger some other condition that cancels
the plotted course). Jumping will not cancel your course, either.

* If you move to a sector that is not linked to the next sector in
  the course, you will lose the "Follow/Scan Course" links on the
  Current Sector page. When you move back to a sector that is linked
  to the next sector, you will regain those links.

* When off the course, you will have a "Replot Course" button,
  which will replot to the original destination sector, but
  starting from your current sector.

* If you re-enter the course at some later point in the chain, the
  course will be updated to remove all the sectors you skipped.

This is implemented with a simple modification to Plotter.class.inc.
By keeping track of the warp sectors, we now retain enough data to
be able to skip to any point in the plotted path **without**
calculating another expensive `Plotter::findDistanceToX`. See
`Plotter::skipToSector` for the details.

--------------

Also add `Plotter::findReversiblePathToX` to factor out the work of
calling `Plotter::findDistanceToX` so that the resulting path is
reversible.