### PR TITLE
SmrAccount: make is{Newbie,Veteran} less expensive

### DIFF
--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -358,7 +358,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function isVeteran() {
-		return $this->isVeteranBumped() || $this->getRank() >= FLEDGLING;
+		// Use maxRankAchieved to avoid a database call to get user stats.
+		// This saves a lot of time on the CPL, Rankings, Rosters, etc.
+		return $this->isVeteranBumped() || $this->maxRankAchieved >= FLEDGLING;
 	}
 
 	public function isNewbie() {


### PR DESCRIPTION
The previous implementation of these methods used `getRank`,
which has to query the user stats in the database. This gets
especially expensive when you're doing it for a list of players:

* Current Players list
* Rankings
* Alliance rosters
* Current Sector Players list

By switching to `maxRankAchieved` for these methods, we can
use data that we already have for the `SmrAccount` (no extra
database calls), which significantly speeds up these pages.

This does mean, however, that there may be a time when a player
has technically reached Fledgeling (the first veteran rank) but
is still reported in italics (Newbie/Beginner). I do not think we
need to be rigorous about this, because it is never reported
inconsistently and the player's `maxRankAchieved` will be updated
next time they log in (or view Rankings page, or Trader Status page).