### PR TITLE
Remove some instances of get_file_loc

### DIFF
--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -4,7 +4,7 @@ require_once('SmrForce.class.inc');
 require_once('SmrGame.class.inc');
 require_once('SmrAlliance.class.inc');
 require_once('missions.inc');
-require_once(get_file_loc('Plotter.class.inc'));
+require_once('Plotter.class.inc');
 
 abstract class AbstractSmrPlayer {
 	protected $db;

--- a/lib/Default/Plotter.class.inc
+++ b/lib/Default/Plotter.class.inc
@@ -1,5 +1,5 @@
 <?php
-require_once(get_file_loc('SmrSector.class.inc'));
+require_once('SmrSector.class.inc');
 class Plotter {
 	public function __construct() {
 	}

--- a/lib/Default/SmrAccount.class.inc
+++ b/lib/Default/SmrAccount.class.inc
@@ -1,5 +1,5 @@
 <?php
-require_once(get_file_loc('AbstractSmrAccount.class.inc'));
+require_once('AbstractSmrAccount.class.inc');
 class SmrAccount extends AbstractSmrAccount {
 }
 

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -1,6 +1,6 @@
 <?php
-require_once(get_file_loc('SmrAccount.class.inc'));
-require_once(get_file_loc('SmrPlayer.class.inc'));
+require_once('SmrAccount.class.inc');
+require_once('SmrPlayer.class.inc');
 
 class SmrAlliance {
 	protected static $CACHE_ALLIANCES = array();

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -3,8 +3,9 @@
 // Exception thrown when a player cannot be found in the database
 class PlayerNotFoundException extends Exception {}
 
-require_once(get_file_loc('AbstractSmrPlayer.class.inc'));
-require_once(get_file_loc('council.inc'));
+require_once('AbstractSmrPlayer.class.inc');
+require_once('council.inc');
+
 class SmrPlayer extends AbstractSmrPlayer {
 	const TIME_FOR_FEDERAL_BOUNTY_ON_PR = 10800;
 	const TIME_FOR_ALLIANCE_SWITCH = 0;
@@ -359,7 +360,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function &getAccount() {
-		require_once(get_file_loc('SmrAccount.class.inc'));
+		require_once('SmrAccount.class.inc');
 		return SmrAccount::getAccount($this->getAccountID());
 	}
 
@@ -1836,7 +1837,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	public function &getPlottedCourse() {
 		if(!isset($this->plottedCourse)) {
-			require_once(get_file_loc('Plotter.class.inc'));
+			require_once('Plotter.class.inc');
 			// check if we have a course plotted
 			$this->db->query('SELECT course FROM player_plotted_course
 			WHERE account_id=' . $this->db->escapeNumber($this->getAccountID()) . '
@@ -1897,7 +1898,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	// Computes the turn cost and max misjump between current and target sector
 	public function getJumpInfo(SmrSector $targetSector) {
-		require_once(get_file_loc('Plotter.class.inc'));
+		require_once('Plotter.class.inc');
 		$path = Plotter::findDistanceToX($targetSector, $this->getSector(), true);
 		if ($path===false) {
 			create_error('Unable to plot from '.$this->getSectorID().' to '.$targetSector->getSectorID().'.');

--- a/lib/Default/SmrSector.class.inc
+++ b/lib/Default/SmrSector.class.inc
@@ -1,9 +1,9 @@
 <?php
-require_once(get_file_loc('SmrPlayer.class.inc'));
-require_once(get_file_loc('SmrLocation.class.inc'));
-require_once(get_file_loc('SmrPlanet.class.inc'));
-require_once(get_file_loc('SmrPort.class.inc'));
-require_once(get_file_loc('SmrGalaxy.class.inc'));
+require_once('SmrPlayer.class.inc');
+require_once('SmrLocation.class.inc');
+require_once('SmrPlanet.class.inc');
+require_once('SmrPort.class.inc');
+require_once('SmrGalaxy.class.inc');
 
 class SmrSector {
 	protected static $CACHE_SECTORS = array();

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -1,11 +1,11 @@
 <?php
 
-require_once(LIB . '/Default/Globals.class.inc');
-require_once(get_file_loc('SmrPlayer.class.inc'));
-require_once(get_file_loc('SmrAccount.class.inc'));
-require_once(get_file_loc('SmrShip.class.inc'));
-require_once(get_file_loc('SmrSector.class.inc'));
-require_once(get_file_loc('Sorter.class.inc'));
+require_once('Globals.class.inc');
+require_once('SmrPlayer.class.inc');
+require_once('SmrAccount.class.inc');
+require_once('SmrShip.class.inc');
+require_once('SmrSector.class.inc');
+require_once('Sorter.class.inc');
 
 function htmliseMessage($message) {
 	$message = htmlentities($message,ENT_COMPAT,'utf-8');


### PR DESCRIPTION
For all the class files, we do not need to look for them,
because they are in the same directory. While `get_file_loc`
accounts for a small percent of the runtime, it is an easy
change to make.

Profiling showed `get_file_loc` using 1-2% in an empty sector.