### PR TITLE
Do not install mysql PHP extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM php:5.6-apache
 RUN apt-get update \
 	&& apt-get install -y libcurl4-openssl-dev git sendmail \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install curl json mysql mysqli
+	&& docker-php-ext-install curl json mysqli
 
 # We need to set 'sendmail_path' since php doesn't know about sendmail when it's built
 RUN echo 'sendmail_path = "/usr/sbin/sendmail -t -i"' > /usr/local/etc/php/conf.d/mail.ini

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "electrolinux/phpquery": "0.9.6",
         "ext-curl": "*",
         "ext-json": "^1.0.0",
-        "ext-mysql": "^1.0.0",
         "ext-mysqli": "*",
         "facebook/graph-sdk": "^5.5.0",
         "google/recaptcha": "~1.1",

--- a/tools/discord/Dockerfile
+++ b/tools/discord/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.6-cli
 RUN apt-get update \
 	&& apt-get install -y git \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install mysqli mysql
+	&& docker-php-ext-install mysqli
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/tools/discord/composer.json
+++ b/tools/discord/composer.json
@@ -4,7 +4,6 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "ext-mysql": "*",
         "php": "^5.6.0",
         "illuminate/support": "5.4.36",
         "team-reflex/discord-php": "*"

--- a/tools/irc/Dockerfile
+++ b/tools/irc/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.6-cli
 RUN apt-get update \
 	&& apt-get install -y git \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install mysqli mysql
+	&& docker-php-ext-install mysqli
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/tools/irc/composer.json
+++ b/tools/irc/composer.json
@@ -4,7 +4,6 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "ext-mysql": "*",
         "php": "^5.6.0"
     }
 }

--- a/tools/npc/Dockerfile
+++ b/tools/npc/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.6-cli
 RUN apt-get update \
 	&& apt-get install -y git \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install mysqli mysql
+	&& docker-php-ext-install mysqli
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/tools/npc/composer.json
+++ b/tools/npc/composer.json
@@ -4,7 +4,6 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "ext-mysql": "*",
         "php": "^5.6.0"
     }
 }


### PR DESCRIPTION
The mysqli database connector has been working without issue
for a while now, so we can safely remove the deprecated mysql
connector.

This is the next step on our transition to PHP 7.