### PR TITLE
Minor cleanup in a couple admin pages

### DIFF
--- a/admin/Default/account_edit.php
+++ b/admin/Default/account_edit.php
@@ -2,42 +2,12 @@
 
 $template->assign('PageTopic','Edit Account');
 
-if(isset($_REQUEST['account_id']) && is_numeric($_REQUEST['account_id'])) {
-	SmrSession::updateVar('account_id',$_REQUEST['account_id']);
-}
-elseif(!isset($var['account_id'])) {
-	SmrSession::updateVar('account_id', 0);
-}
-if(isset($_REQUEST['login'])) {
-	SmrSession::updateVar('login',$_REQUEST['login']);
-}
-elseif(!isset($var['login'])) {
-	SmrSession::updateVar('login', '');
-}
-if(isset($_REQUEST['val_code'])) {
-	SmrSession::updateVar('val_code',$_REQUEST['val_code']);
-}
-elseif(!isset($var['val_code'])) {
-	SmrSession::updateVar('val_code', '');
-}
-if(isset($_REQUEST['email'])) {
-	SmrSession::updateVar('email',$_REQUEST['email']);
-}
-elseif(!isset($var['email'])) {
-	SmrSession::updateVar('email', '');
-}
-if(isset($_REQUEST['hofname'])) {
-	SmrSession::updateVar('hofname',$_REQUEST['hofname']);
-}
-elseif(!isset($var['hofname'])) {
-	SmrSession::updateVar('hofname', '');
-}
-if(isset($_REQUEST['player_name'])) {
-	SmrSession::updateVar('player_name',$_REQUEST['player_name']);
-}
-elseif(!isset($var['player_name'])) {
-	SmrSession::updateVar('player_name', '');
-}
+$account_id = SmrSession::getRequestVar('account_id', 0);
+$player_name = SmrSession::getRequestVar('player_name', '');
+SmrSession::getRequestVar('login', '');
+SmrSession::getRequestVar('val_code', '');
+SmrSession::getRequestVar('email', '');
+SmrSession::getRequestVar('hofname', '');
 if(isset($_REQUEST['game_id'])) {
 	SmrSession::updateVar('SearchGameID',$_REQUEST['game_id']);
 }
@@ -45,12 +15,9 @@ elseif(!isset($var['SearchGameID'])) {
 	SmrSession::updateVar('SearchGameID', 0);
 }
 
-if(!empty($var['account_id']) && !is_numeric($var['account_id'])) {
+if(!empty($account_id) && !is_numeric($account_id)) {
 	create_error('Account ID must be a number.');
 }
-
-$account_id = $var['account_id'];
-$player_name = $var['player_name'];
 
 // create account object
 $curr_account = false;
@@ -144,7 +111,11 @@ if ($curr_account!==false) {
 }
 
 
-$template->assign('ErrorMessage', $var['errorMsg']);
-$template->assign('Message', $var['msg']);
+if (isset($var['errorMsg'])) {
+	$template->assign('ErrorMessage', $var['errorMsg']);
+}
+if (isset($var['msg'])) {
+	$template->assign('Message', $var['msg']);
+}
 
 ?>

--- a/admin/Default/admin_message_send.php
+++ b/admin/Default/admin_message_send.php
@@ -1,10 +1,8 @@
 <?php
 
-$template->assign('PageTopic','Send Message');
-if(isset($_REQUEST['game_id'])) {
-	SmrSession::updateVar('SendGameID',$_REQUEST['game_id']);
-}
-$gameID = $var['SendGameID'];
+$template->assign('PageTopic', 'Send Admin Message');
+
+$gameID = SmrSession::getRequestVar('SendGameID');
 // check if we know the game yet
 if (empty($gameID)) {
 	$template->assign('AdminMessageChooseGameFormHref',SmrSession::getNewHREF(create_container('skeleton.php', 'admin_message_send.php')));

--- a/admin/Default/admin_message_send_processing.php
+++ b/admin/Default/admin_message_send_processing.php
@@ -24,9 +24,13 @@ if (!empty($account_id) || $game_id == 20000) {
 			SmrPlayer::sendMessageFromAdmin($db->getField('game_id'), $db->getField('account_id'), $message,$expire);
 		}
 	}
+	$msg = '<span class="green">SUCCESS: </span>Your message has been sent.';
+} else {
+	$msg = '<span class="bold red">ERROR: </span>You must specify a player to message!';
 }
+
 $container = create_container('skeleton.php', 'admin_tools.php');
-$container['msg'] = '<span class="green">SUCCESS: </span>Your message has been sent.';
+$container['msg'] = $msg;
 forward($container)
 
 ?>

--- a/templates/Default/admin/Default/account_edit.php
+++ b/templates/Default/admin/Default/account_edit.php
@@ -312,6 +312,6 @@
 if(isset($ErrorMessage)) { ?>
 	<div align="center"><?php echo $ErrorMessage; ?></div><?php
 }
-
-?>
-<div align="center"><?php echo $Message; ?></div>
+if(isset($Message)) { ?>
+	<div align="center"><?php echo $Message; ?></div><?php
+} ?>

--- a/templates/Default/admin/Default/admin_message_send.php
+++ b/templates/Default/admin/Default/admin_message_send.php
@@ -2,7 +2,7 @@
 if (!isset($MessageGameID)) { ?>
 	<form name="AdminMessageChooseGameForm" method="POST" action="<?php echo $AdminMessageChooseGameFormHref; ?>">
 		<p>Please select a game:</p>
-		<select name="game_id" size="1" id="InputFields">
+		<select name="SendGameID" size="1" id="InputFields">
 			<option value="20000">Send to All Players</option><?php
 			foreach($Games as &$Game) {
 				?><option value="<?php echo $Game['ID']; ?>"><?php echo $Game['GameName']; ?></option><?php


### PR DESCRIPTION
admin_send_message.php:

* Fix an undefined variable PHP warning using
  `SmrSession::getRequestVar`.

* Provide an error message if no account is selected.
  Previously it would still report success even if the message
  was not sent to anyone.

account_edit.php:

* Use `SmrSession::getRequestVar` to vastly simplify the boilerplate.

* Fix undefined index PHP warnings for `$var['msg']` and
  `$var['errorMsg']`.