### PR TITLE
Bilateral Relations

### DIFF
--- a/engine/Default/council_vote.php
+++ b/engine/Default/council_vote.php
@@ -23,19 +23,17 @@ if ($db->nextRecord()) {
 }
 
 $voteRelations = array();
-$playerRaceGlobalRelations = Globals::getRaceRelations($player->getGameID(),$player->getRaceID());
+$globalRelations = Globals::getRaceRelations($player->getGameID(), $player->getRaceID());
 $races =& Globals::getRaces();
 foreach($races as $raceID => $raceInfo) {
 	if($raceID == RACE_NEUTRAL || $raceID == $player->getRaceID())
 		continue;
 	$container = create_container('council_vote_processing.php', '', array('race_id' => $raceID));
-	$otherRaceGlobalRelations = Globals::getRaceRelations($player->getGameID(),$raceID);
 	$voteRelations[$raceID] = array(
 		'HREF' => SmrSession::getNewHREF($container),
 		'Increased' => $votedForRace == $raceID && $votedFor == 'INC',
 		'Decreased' => $votedForRace == $raceID && $votedFor == 'DEC',
-		'RelationToThem' => $playerRaceGlobalRelations[$raceID],
-		'RelationToUs' => $otherRaceGlobalRelations[$player->getRaceID()]
+		'Relations' => $globalRelations[$raceID],
 	);
 }
 $template->assign('VoteRelations', $voteRelations);

--- a/engine/Default/shop_goods.php
+++ b/engine/Default/shop_goods.php
@@ -9,7 +9,6 @@ $tradeable = checkPortTradeable($port,$player);
 if($tradeable!==true)
 	create_error($tradeable);
 
-$portRelations = Globals::getRaceRelations($player->getGameID(),$port->getRaceID());
 $relations = $player->getRelation($port->getRaceID());
 
 // topic

--- a/engine/Default/trader_relations.php
+++ b/engine/Default/trader_relations.php
@@ -8,9 +8,9 @@ $politicalRelations = array();
 $personalRelations = array();
 
 $RACES =& Globals::getRaces();
+$globalRelations = Globals::getRaceRelations($player->getGameID(), $player->getRaceID());
 foreach($RACES as $raceID => $race) {
-	$otherRaceRelations = Globals::getRaceRelations($player->getGameID(),$raceID);
-	$politicalRelations[$race['Race Name']] = $otherRaceRelations[$player->getRaceID()];
+	$politicalRelations[$race['Race Name']] = $globalRelations[$raceID];
 	$personalRelations[$race['Race Name']] = $player->getPureRelation($raceID);
 }
 $template->assign('PoliticalRelations', $politicalRelations);

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -621,6 +621,9 @@ abstract class AbstractSmrPlayer {
 		return $this->pureRelations;
 	}
 
+	/**
+	 * Get personal relations with a race
+	 */
 	public function getPureRelation($raceID) {
 		$rels = $this->getPureRelations();
 		return $rels[$raceID];
@@ -632,16 +635,17 @@ abstract class AbstractSmrPlayer {
 			$RACES = Globals::getRaces();
 			$raceRelations =& Globals::getRaceRelations($this->getGameID(),$this->getRaceID());
 			$pureRels = $this->getPureRelations(); // make sure they're initialised.
-//			$stats = $this->getStats(); // make sure they're initialised.
 			$this->relations = array();
 			foreach ($RACES as $raceID => $raceName) {
-				$raceRelations =& Globals::getRaceRelations($this->getGameID(), $raceID);
-				$this->relations[$raceID] = round($pureRels[$raceID] + $raceRelations[$this->getRaceID()]);// + $stats['Relations'] / 2);
+				$this->relations[$raceID] = $pureRels[$raceID] + $raceRelations[$raceID];
 			}
 		}
 		return $this->relations;
 	}
 
+	/**
+	 * Get total relations with a race (personal + political)
+	 */
 	public function getRelation($raceID) {
 		$rels = $this->getRelations();
 		return $rels[$raceID];

--- a/lib/Default/DummyPlayer.class.inc
+++ b/lib/Default/DummyPlayer.class.inc
@@ -174,8 +174,8 @@ class DummyPlayer extends AbstractSmrPlayer {
 //		$killer->increaseHOF($this->getShip()->getCost(),'killing','ships_killed_cost');
 
 		// The killer may change alignment
-		$relations = Globals::getRaceRelations($this->getGameID(),$killer->getRaceID());
-		$relation = $relations[$this->getRaceID()];
+		$relations = Globals::getRaceRelations($this->getGameID(), $this->getRaceID());
+		$relation = $relations[$killer->getRaceID()];
 
 		$alignChangePerRelation = 0.1;
 		if($relation >= RELATIONS_PEACE || $relation <= RELATIONS_WAR)

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1175,8 +1175,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$killer->increaseCredits($return['KillerCredits']);
 
 		// The killer may change alignment
-		$relations = Globals::getRaceRelations($this->getGameID(),$killer->getRaceID());
-		$relation = $relations[$this->getRaceID()];
+		$relations = Globals::getRaceRelations($this->getGameID(), $this->getRaceID());
+		$relation = $relations[$killer->getRaceID()];
 
 		$alignChangePerRelation = 0.1;
 		if($relation >= RELATIONS_PEACE || $relation <= RELATIONS_WAR)

--- a/lib/Default/council.inc
+++ b/lib/Default/council.inc
@@ -94,9 +94,14 @@ function modifyRelations($race_id_1) {
 
 		$db2->query('UPDATE race_has_relation
 					SET relation = ' . $db2->escapeNumber($relation) . '
-					WHERE race_id_1 = ' . $db2->escapeNumber($race_id_1) . '
-						AND race_id_2 = '.$db2->escapeNumber($race_id_2) . '
-						AND game_id = '.$db2->escapeNumber($player->getGameID()));
+					WHERE game_id = '.$db2->escapeNumber($player->getGameID()).'
+						AND (
+								race_id_1 = '.$db2->escapeNumber($race_id_1).'
+								AND race_id_2 = '.$db2->escapeNumber($race_id_2).'
+							OR
+								race_id_1 = '.$db2->escapeNumber($race_id_2).'
+								AND race_id_2 = '.$db2->escapeNumber($race_id_1).'
+						)');
 
 		$db2->query('DELETE FROM player_votes_relation
 					WHERE account_id = ' . $db2->escapeNumber($account_id) . '

--- a/templates/Default/engine/Default/council_vote.php
+++ b/templates/Default/engine/Default/council_vote.php
@@ -57,8 +57,7 @@ if (!$VoteTreaties) { ?>
 	<tr>
 		<th>Race</th>
 		<th>Vote</th>
-		<th>Our Relation<br />with them</th>
-		<th>Their Relation<br />with us</th>
+		<th>Relations</th>
 	</tr><?php
 
 	foreach($VoteRelations as $RaceID => $VoteInfo) { ?>
@@ -76,8 +75,7 @@ if (!$VoteTreaties) { ?>
 					<input type="submit" name="action" value="Decrease" id="InputFields"<?php if($VoteInfo['Decreased']){ ?> style="background-color:green"<?php } ?> />
 				</form>
 			</td>
-			<td align="center"><?php echo get_colored_text($VoteInfo['RelationToThem']); ?></td>
-			<td align="center"><?php echo get_colored_text($VoteInfo['RelationToUs']); ?></td>
+			<td align="center"><?php echo get_colored_text($VoteInfo['Relations']); ?></td>
 		</tr><?php
 	} ?>
 </table>

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -527,8 +527,7 @@ function doUNO($hardwareID,$amount) {
 function tradeGoods($goodID,AbstractSmrPlayer &$player,SmrPort &$port) {
 	sleepNPC(); //We have an extra sleep at port to make the NPC more vulnerable.
 	$ship =& $player->getShip();
-	$portRelations = Globals::getRaceRelations($player->getGameID(),$port->getRaceID());
-	$relations = $player->getRelation($port->getRaceID()) + $portRelations[$player->getRaceID()];
+	$relations = $player->getRelation($port->getRaceID());
 
 	$portGood = $port->getGood($goodID);
 	


### PR DESCRIPTION
Remove the "our relation with them / their relation with us"
paradigm in favor of a single global relation between two races.

This feature was requested in 2015.

Effect on game dynamics
=======================

Due to the reduced number of players, sometimes races don't have
any active players. This makes it impossible for other races to
ever interact with that race. For the benefit of those still
playing, this change gives them the ability to make slow progress
towards peace with a defunct race.

Since there are 7 other races, which could all in theory be
choosing to change relations with your race, you are no longer
in direct control over your relations. You can still counter some
of them with your votes, and you still have the trump card: a
war vote, which will allow any active council to prevent peace
with another race if they so choose.

I also consider this to satisfy point 2 in issue #53, since a
bilateral relation means that relations can increase twice as
fast. As such, we will keep the relation change at +/-10.

Effect on code performance
==========================

The relations were actually stored (or at least queried) backwards
from the standpoint of performance. Previously, to get your relations
with a race, you would query that race's relations with _all other_
races (see `Globals::getRaceRelations`). So if you needed to get
your relations with all races, you needed to query 8*8=64 relations!

With bilateral relations, all you will ever need to query are the 8
numbers that represent your race's relations with the other races
(and, equivalently, their relations with your race).

The database structure hasn't changed, so we just need to be aware
that querying `Globals::getRaceRelations` with the current player's
race ID is the preferred usage in all normal scenarios.