### PR TITLE
Add "Accepted" category to feature requests

### DIFF
--- a/db/patches/V1_6_61_15__request_type_accepted.sql
+++ b/db/patches/V1_6_61_15__request_type_accepted.sql
@@ -1,0 +1,2 @@
+-- Add an "Accepted" status for feature requests
+ALTER TABLE feature_request MODIFY COLUMN status enum('Opened','Implemented','Rejected','Deleted','Accepted') NOT NULL;

--- a/engine/Default/feature_request.php
+++ b/engine/Default/feature_request.php
@@ -10,6 +10,10 @@ if(!isset($var['Status'])) {
 }
 
 $container = $var;
+$container['Status'] = 'Accepted';
+$template->assign('ViewAcceptedFeaturesHref', SmrSession::getNewHREF($container));
+
+$container = $var;
 $container['Status'] = 'Implemented';
 $template->assign('ViewImplementedFeaturesHref',SmrSession::getNewHREF($container));
 
@@ -26,6 +30,9 @@ $showCurrent = (!isset($var['ShowOld']) || $var['ShowOld']!==true) && $var['Stat
 $template->assign('ShowCurrent',$showCurrent);
 $template->assign('Status',$var['Status']);
 
+if($var['Status'] != 'Accepted') {
+	$template->assign('AcceptedTotal', getFeaturesCount('Accepted'));
+}
 if($var['Status'] != 'Implemented') {
 	$template->assign('PreviousImplementedTotal', getFeaturesCount('Implemented'));
 }

--- a/engine/Default/feature_request.php
+++ b/engine/Default/feature_request.php
@@ -3,50 +3,44 @@ if (!Globals::isFeatureRequestOpen()) {
 	create_error('Feature requests are currently not being accepted.');
 }
 
-$template->assign('PageTopic','Feature Request');
-
-if(!isset($var['Status'])) {
-	SmrSession::updateVar('Status', 'Opened');
+if (!isset($var['category'])) {
+	SmrSession::updateVar('category', 'New');
 }
+$thisStatus = statusFromCategory($var['category']);
 
-$container = $var;
-$container['Status'] = 'Accepted';
-$template->assign('ViewAcceptedFeaturesHref', SmrSession::getNewHREF($container));
+$template->assign('PageTopic', 'Feature Requests - ' . $var['category']);
 
-$container = $var;
-$container['Status'] = 'Implemented';
-$template->assign('ViewImplementedFeaturesHref',SmrSession::getNewHREF($container));
+// Feature Requests show up as new for this many days
+define('NEW_REQUEST_DAYS', 30);
 
-$container = $var;
-$container['Status'] = 'Opened';
-$container['ShowOld'] = true;
-$template->assign('ShowOldFeaturesHref',SmrSession::getNewHREF($container));
+$requestCategories = array(
+	'New' => 'Open requests made within the past ' . NEW_REQUEST_DAYS . ' days',
+	'All Open' => 'All requests that remain open for voting',
+	'Accepted' => 'Features planned for future implementation',
+	'Implemented' => 'Features that have already been implemented',
+	'Rejected' => 'Features that are not planned for implementation',
+);
 
-$container = $var;
-$container['Status'] = 'Rejected';
-$template->assign('ShowRejectedFeaturesHref',SmrSession::getNewHREF($container));
-
-$showCurrent = (!isset($var['ShowOld']) || $var['ShowOld']!==true) && $var['Status']=='Opened';
-$template->assign('ShowCurrent',$showCurrent);
-$template->assign('Status',$var['Status']);
-
-if($var['Status'] != 'Accepted') {
-	$template->assign('AcceptedTotal', getFeaturesCount('Accepted'));
+$categoryTable = array();
+foreach ($requestCategories as $category => $description) {
+	$status = statusFromCategory($category);
+	
+	$container = $var;
+	$container['category'] = $category;
+	$categoryTable[$category] = array(
+		'Selected' => $category == $var['category'],
+		'HREF' => SmrSession::getNewHREF($container),
+		'Count' => getFeaturesCount($status, ($category == 'New') ? NEW_REQUEST_DAYS : false),
+		'Description' => $description
+	);
 }
-if($var['Status'] != 'Implemented') {
-	$template->assign('PreviousImplementedTotal', getFeaturesCount('Implemented'));
-}
-if($var['Status'] != 'Opened' || !$showCurrent) {
-	$template->assign('CurrentTotal', getFeaturesCount('Opened', true));
-}
-if($var['Status'] != 'Opened' || $showCurrent) {
-	$template->assign('OldTotal', getFeaturesCount('Opened'));
-}
-if($var['Status'] != 'Rejected') {
-	$template->assign('RejectedTotal', getFeaturesCount('Rejected'));
-}
+$template->assignByRef('CategoryTable', $categoryTable);
 
-if($var['Status'] == 'Opened') {
+// Can the players vote for features on the current page?
+$canVote = $thisStatus == 'Opened';
+$template->assign('CanVote', $canVote);
+
+if ($canVote) {
 	$featureVotes = array();
 	$db->query('SELECT * FROM account_votes_for_feature WHERE account_id = '.SmrSession::$account_id);
 	while($db->nextRecord())
@@ -56,8 +50,8 @@ $db->query('SELECT * ' .
 			'FROM feature_request ' .
 			'JOIN feature_request_comments super USING(feature_request_id) ' .
 			'WHERE comment_id = 1 ' .
-			'AND status = ' . $db->escapeString($var['Status']) .
-			($showCurrent?' AND EXISTS(SELECT posting_time FROM feature_request_comments WHERE feature_request_id = super.feature_request_id AND posting_time > ' . (TIME-14*86400) .')':'') .
+			'AND status = ' . $db->escapeString($thisStatus) .
+			($var['category'] == 'New' ? ' AND EXISTS(SELECT posting_time FROM feature_request_comments WHERE feature_request_id = super.feature_request_id AND posting_time > ' . (TIME - NEW_REQUEST_DAYS*86400) .')':'') .
 			' ORDER BY (SELECT MAX(posting_time) FROM feature_request_comments WHERE feature_request_id = super.feature_request_id) DESC');
 if ($db->getNumRows() > 0) {
 	$featureModerator = $account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST);
@@ -79,7 +73,7 @@ if ($db->getNumRows() > 0) {
 		if($featureModerator)
 			$featureRequests[$featureRequestID]['RequestAccount'] =& SmrAccount::getAccount($db->getInt('poster_id'));
 		
-		if($var['Status'] == 'Opened') {
+		if ($canVote) {
 			$db2->query('SELECT COUNT(*), vote_type
 						FROM account_votes_for_feature
 						WHERE feature_request_id=' . $db2->escapeNumber($featureRequestID) . '
@@ -102,7 +96,11 @@ if ($db->getNumRows() > 0) {
 
 $template->assign('FeatureRequestFormHREF',SmrSession::getNewHREF(create_container('feature_request_processing.php', '')));
 
-function getFeaturesCount($status, $onlyCurrent = false) {
+function statusFromCategory($category) {
+	return ($category == 'New' || $category == 'All Open') ? 'Opened' : $category;
+}
+
+function getFeaturesCount($status, $daysNew = false) {
 	global $db;
 	$db->query('
 		SELECT COUNT(*) AS count
@@ -110,7 +108,7 @@ function getFeaturesCount($status, $onlyCurrent = false) {
 		JOIN feature_request_comments super USING(feature_request_id)
 		WHERE comment_id = 1
 		AND status = ' . $db->escapeString($status) .
-		($onlyCurrent?' AND EXISTS(SELECT posting_time FROM feature_request_comments WHERE feature_request_id = super.feature_request_id AND posting_time > ' . (TIME-14*86400) .')':'')
+		($daysNew ? ' AND EXISTS(SELECT posting_time FROM feature_request_comments WHERE feature_request_id = super.feature_request_id AND posting_time > ' . (TIME - $daysNew*86400) .')':'')
 	);
 	$db->nextRecord();
 	return $db->getInt('count');

--- a/templates/Default/engine/Default/feature_request.php
+++ b/templates/Default/engine/Default/feature_request.php
@@ -1,23 +1,25 @@
+<table>
+	<tr>
+		<th>Action</th>
+		<th>Category</th>
+		<th>Description</th>
+		<th>Count</th>
+	</th><?php
+	foreach ($CategoryTable as $Category => $Info) { ?>
+		<tr<?php if ($Info['Selected']) { echo ' class="bold"'; } ?>>
+			<td class="center"><a href="<?php echo $Info['HREF']; ?>">View</a></td>
+			<td><?php echo $Category; ?></td>
+			<td><?php echo $Info['Description']; ?></td>
+			<td class="center"><?php echo $Info['Count']; ?></td>
+		</tr><?php
+	} ?>
+</table>
+
 <?php
-if(!$ShowCurrent) {
-	?><p><a href="<?php echo Globals::getFeatureRequestHREF(); ?>">View New Requests (<?php echo $CurrentTotal; ?>)</a></p><?php
-}
-if($Status != 'Opened' || $ShowCurrent) {
-	?><p><a href="<?php echo $ShowOldFeaturesHref; ?>">View All Open Requests (<?php echo $OldTotal; ?>)</a></p><?php
-}
-if($Status != 'Accepted') {
-	?><p><a href="<?php echo $ViewAcceptedFeaturesHref; ?>">View Accepted Requests (<?php echo $AcceptedTotal; ?>)</a></p><?php
-}
-if($Status != 'Implemented') {
-	?><p><a href="<?php echo $ViewImplementedFeaturesHref; ?>">View Implemented Requests (<?php echo $PreviousImplementedTotal; ?>)</a></p><?php
-}
-if($Status != 'Rejected') {
-	?><p><a href="<?php echo $ShowRejectedFeaturesHref; ?>">View Rejected Requests (<?php echo $RejectedTotal; ?>)</a></p><?php
-}
 if(isset($FeatureRequests)) { ?>
 	<form name="FeatureRequestVoteForm" method="POST" action="<?php echo $FeatureRequestVoteFormHREF; ?>">
 		<div align="right"><?php
-			if($Status == 'Opened') { ?>
+			if ($CanVote) { ?>
 				<input type="submit" name="action" value="Vote"><?php
 			} ?>
 		</div><br />
@@ -29,7 +31,7 @@ if(isset($FeatureRequests)) { ?>
 				<th width="30">Votes (Fav/Yes/No)</th>
 				<th>Feature</th>
 				<th>Comments</th><?php
-				if($Status == 'Opened') { ?>
+				if ($CanVote) { ?>
 					<th width="20">Favourite</th>
 					<th width="20">Yes</th>
 					<th width="20">No</th><?php
@@ -46,7 +48,7 @@ if(isset($FeatureRequests)) { ?>
 					<td><span class="bold green"><?php echo $FeatureRequest['Votes']['FAVOURITE']; ?></span> / <span class="green"><?php echo $FeatureRequest['Votes']['YES'] + $FeatureRequest['Votes']['FAVOURITE']; ?></span> / <span class="red"><?php echo $FeatureRequest['Votes']['NO']; ?></span></td>
 					<td class="left"><?php echo bbifyMessage($FeatureRequest['Message']); ?></td>
 					<td class="shrink noWrap top"><a href="<?php echo $FeatureRequest['CommentsHREF']; ?>">View (<?php echo $FeatureRequest['Comments']; ?>)</a></td><?php
-					if($Status == 'Opened') { ?>
+					if ($CanVote) { ?>
 						<td><input type="radio" name="favourite" value="<?php echo $FeatureRequest['RequestID']; ?>"<?php if($FeatureRequest['VotedFor'] == 'FAVOURITE') { ?> checked="checked"<?php } ?>></td>
 						<td><input type="radio" name="vote[<?php echo $FeatureRequest['RequestID']; ?>]" value="YES"<?php if($FeatureRequest['VotedFor'] == 'YES' || $FeatureRequest['VotedFor'] == 'FAVOURITE') { ?> checked="checked"<?php } ?>></td>
 						<td><input type="radio" name="vote[<?php echo $FeatureRequest['RequestID']; ?>]" value="NO"<?php if($FeatureRequest['VotedFor'] == 'NO') { ?> checked="checked"<?php } ?>></td><?php
@@ -68,7 +70,7 @@ if(isset($FeatureRequests)) { ?>
 					<option value="Deleted">Delete</option>
 				</select>&nbsp;<input type="submit" name="action" value="Set Status"><?php
 			}
-			if($Status == 'Opened') { ?>
+			if ($CanVote) { ?>
 				<input type="submit" name="action" value="Vote"><?php
 			} ?>
 		</div><br />
@@ -78,7 +80,7 @@ if(isset($FeatureRequests)) { ?>
 	<form name="FeatureRequestForm" method="POST" action="<?php echo $FeatureRequestFormHREF; ?>">
 		<table>
 			<tr>
-				<td align="center">Please describe the feature here:</td>
+				<td align="center">Please describe your requested feature here:</td>
 			</tr>
 			<tr>
 				<td align="center"><textarea spellcheck="true" name="feature" id="InputFields" maxlength="500"></textarea></td>

--- a/templates/Default/engine/Default/feature_request.php
+++ b/templates/Default/engine/Default/feature_request.php
@@ -5,6 +5,9 @@ if(!$ShowCurrent) {
 if($Status != 'Opened' || $ShowCurrent) {
 	?><p><a href="<?php echo $ShowOldFeaturesHref; ?>">View All Open Requests (<?php echo $OldTotal; ?>)</a></p><?php
 }
+if($Status != 'Accepted') {
+	?><p><a href="<?php echo $ViewAcceptedFeaturesHref; ?>">View Accepted Requests (<?php echo $AcceptedTotal; ?>)</a></p><?php
+}
 if($Status != 'Implemented') {
 	?><p><a href="<?php echo $ViewImplementedFeaturesHref; ?>">View Implemented Requests (<?php echo $PreviousImplementedTotal; ?>)</a></p><?php
 }
@@ -58,6 +61,7 @@ if(isset($FeatureRequests)) { ?>
 			if($FeatureModerator) { ?>&nbsp;
 				<select name="status">
 					<option disabled selected value style="display:none"> -- Select Status -- </option>
+					<option value="Accepted">Accepted</option>
 					<option value="Implemented">Implemented</option>
 					<option value="Rejected">Rejected</option>
 					<option value="Opened">Open</option>

--- a/templates/Default/engine/Default/feature_request_comments.php
+++ b/templates/Default/engine/Default/feature_request_comments.php
@@ -30,6 +30,7 @@ if ($FeatureModerator) { ?>
 		<div align="right">&nbsp;
 			<select name="status">
 				<option disabled selected value style="display:none"> -- Select Status -- </option>
+				<option value="Accepted">Accepted</option>
 				<option value="Implemented">Implemented</option>
 				<option value="Rejected">Rejected</option>
 				<option value="Opened">Open</option>


### PR DESCRIPTION
This status will help organize the (dauntingly long) list of open
feature requests. Many are good ideas that I plan to implement,
but they continue to clutter the list of open requests that still
need to be dealt with. It will also help give players some quicker
feedback about what is and isn't planned for implementation.

Also reformatted the category display:

* Include a table of categories with descriptions and counts.
* Include the currently viewed category in the table, and
  highlight it in bold.
* Display the currently viewed category in the page heading.

One of the most useful changes is the description of what a "New"
request is. Make the threshold for this category a variable,
and change it from 14 days to 30.

![image](https://user-images.githubusercontent.com/846186/35150869-ebd2a9b8-fcd0-11e7-8873-c5a652caad7d.png)
