### PR TITLE
SmrGalaxy: optimize getGalaxyContaining

### DIFF
--- a/engine/Default/beta_func_processing.php
+++ b/engine/Default/beta_func_processing.php
@@ -53,7 +53,7 @@ elseif ($var['func'] == 'Warp') {
 	if(!is_numeric($sector_to)) {
 		create_error('Sector ID has to be a number.');
 	}
-	if(!SmrGalaxy::getGalaxyContaining($player->getGameID(), $sector_to)) {
+	if (!SmrSector::sectorExists($player->getGameID(), $sector_to)) {
 		create_error('Sector ID is not in any galaxy.');
 	}
 	$player->setSectorID($sector_to);

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -30,8 +30,9 @@ if (!is_numeric($target))
 if ($player->getSectorID() == $target)
 	create_error('Hmmmm...if ' . $player->getSectorID() . '=' . $target . ' then that means...YOU\'RE ALREADY THERE! *cough*you\'re real smart*cough*');
 
-if(!SmrGalaxy::getGalaxyContaining($player->getGameID(), $target))
+if (!SmrSector::sectorExists($player->getGameID(), $target)) {
 	create_error('The target sector doesn\'t exist!');
+}
 
 // If the Calculate Turn Cost button was pressed
 if (isset($_POST['action']) && $_POST['action'] == 'Calculate Turn Cost') {

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -43,8 +43,9 @@ try {
 		if(!is_numeric($sectorID)) {
 			header('location: ' . URL . '/error.php?msg=Sector id was not a number.');
 		}
-		$galaxy = SmrGalaxy::getGalaxyContaining(SmrSession::$game_id, $sectorID);
-		if($galaxy === false) {
+		try {
+			$galaxy = SmrGalaxy::getGalaxyContaining(SmrSession::$game_id, $sectorID);
+		} catch (SectorNotFoundException $e) {
 			header('location: ' . URL . '/error.php?msg=Invalid sector id');
 			exit;
 		}

--- a/lib/Default/SmrGalaxy.class.inc
+++ b/lib/Default/SmrGalaxy.class.inc
@@ -267,14 +267,7 @@ class SmrGalaxy {
 	}
 	
 	public static function &getGalaxyContaining($gameID, $sectorID) {
-		$galaxies =& SmrGalaxy::getGameGalaxies($gameID);
-		foreach($galaxies as &$galaxy) {
-			if($galaxy->contains($sectorID)) {
-				return $galaxy;
-			}
-		}
-		$return = false;
-		return $return;
+		return SmrSector::getSector($gameID, $sectorID)->getGalaxy();
 	}
 	
 	function equals(SmrGalaxy $otherGalaxy) {

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1923,10 +1923,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	function moveDestinationButton($sectorID, $offsetTop, $offsetLeft) {
 
-		if (!is_numeric($sectorID) || $sectorID < 1 || SmrGalaxy::getGalaxyContaining($this->getGameID(), $sectorID) === false) {
-			create_error('You want to move a non-existent sector?');
-		}
-
 		if( !is_numeric($offsetLeft) || !is_numeric($offsetTop)) {
 			create_error('The position of the saved sector must be numeric!.');
 		}
@@ -1956,7 +1952,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	function addDestinationButton($sectorID, $label) {
 
-		if (!is_numeric($sectorID) || $sectorID < 1 || SmrGalaxy::getGalaxyContaining($this->getGameID(), $sectorID) === false) {
+		if (!is_numeric($sectorID) || !SmrSector::sectorExists($this->getGameID(), $sectorID)) {
 			create_error('You want to add a non-existent sector?');
 		}
 

--- a/lib/Default/SmrSector.class.inc
+++ b/lib/Default/SmrSector.class.inc
@@ -5,6 +5,9 @@ require_once(get_file_loc('SmrPlanet.class.inc'));
 require_once(get_file_loc('SmrPort.class.inc'));
 require_once(get_file_loc('SmrGalaxy.class.inc'));
 
+// Exception thrown when a sector cannot be found in the database
+class SectorNotFoundException extends Exception {}
+
 class SmrSector {
 	protected static $CACHE_SECTORS = array();
 	protected static $CACHE_GALAXY_SECTORS = array();
@@ -23,6 +26,19 @@ class SmrSector {
 
 	protected $hasChanged = false;
 	protected $isNew = false;
+
+	/**
+	 * Constructs the sector to determine if it exists.
+	 * Returns a boolean value.
+	 */
+	public static function sectorExists($gameID, $sectorID) {
+		try {
+			self::getSector($gameID, $sectorID);
+			return true;
+		} catch (SectorNotFoundException $e) {
+			return false;
+		}
+	}
 
 	public static function &getGalaxySectors($gameID,$galaxyID,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_GALAXY_SECTORS[$gameID][$galaxyID])) {
@@ -124,7 +140,7 @@ class SmrSector {
 			return;
 		}
 		else {
-			throw new Exception('No such sector: '.$gameID.'-'.$sectorID);
+			throw new SectorNotFoundException('No such sector: '.$gameID.'-'.$sectorID);
 		}
 	}
 

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -114,7 +114,7 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 				// Ugly but working, probably want a better mechanism to check if more BBCode tags get added
 				if(is_numeric($sectorID)
 					&& SmrSession::$game_id > 0
-					&& SmrGalaxy::getGalaxyContaining($overrideGameID, $sectorID) !== false
+					&& SmrSector::sectorExists($overrideGameID, $sectorID)
 					&& $disableBBLinks===false && $overrideGameID==SmrSession::$game_id) {
 					return '<a href="' . Globals::getPlotCourseHREF($player->getSectorID(), $sectorID) . '">' . $sectorTag . '</a>';
 				}


### PR DESCRIPTION
In profiling the Current Sector page, I found that a significant
fraction (roughly 10-20%) of the cost was from constructing an
`SmrGalaxy` for every galaxy in the game (see `getGameGalaxies`)
while checking to determine which galaxy the current sector is in.
This was unnecessary since the `sector` table includes the galaxy
containing each sector, which we query instead.

* Replace a few instances of `getGalaxyContaining` with a new
  function `SmrSector::sectorExists`, which more clearly indicates
  what its purpose is.

* To help with verifying sector existence, add a new exception
  `SectorNotFoundException`, which is thrown in the `SmrSector`
  constructor instead of the base Exception.