### PR TITLE
SmrPlayer: add npc field

### DIFF
--- a/db/patches/V1_6_61_16__player_npc_field.sql
+++ b/db/patches/V1_6_61_16__player_npc_field.sql
@@ -1,0 +1,7 @@
+-- Add an `npc` field to the `player` table
+ALTER TABLE player ADD COLUMN npc enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE';
+
+-- Set `npc` to true for any existing NPC players
+UPDATE player, account SET player.npc = 'TRUE'
+  WHERE account.login IN (SELECT login FROM npc_logins)
+    AND player.account_id = account.account_id;

--- a/engine/Default/game_join_processing.php
+++ b/engine/Default/game_join_processing.php
@@ -135,8 +135,8 @@ else {
 }
 
 // insert into player table.
-$db->query('INSERT INTO player (account_id, game_id, player_id, player_name, race_id, ship_type_id, credits, alliance_id, sector_id, last_turn_update, last_cpl_action, last_active, newbie_turns)
-			VALUES(' . $db->escapeNumber(SmrSession::$account_id) . ', ' . $db->escapeNumber($gameID) . ', '.$db->escapeNumber($player_id).', ' . $db->escape_string($player_name, true) . ', '.$db->escapeNumber($race_id).', '.$db->escapeNumber($ship_id).', '.$db->escapeNumber(Globals::getStartingCredits($gameID)).', '.$db->escapeNumber($alliance_id).', '.$db->escapeNumber($home_sector_id).', '.$db->escapeNumber($last_turn_update).', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($startingNewbieTurns) . ')');
+$db->query('INSERT INTO player (account_id, game_id, player_id, player_name, race_id, ship_type_id, credits, alliance_id, sector_id, last_turn_update, last_cpl_action, last_active, newbie_turns, npc)
+			VALUES(' . $db->escapeNumber(SmrSession::$account_id) . ', ' . $db->escapeNumber($gameID) . ', '.$db->escapeNumber($player_id).', ' . $db->escape_string($player_name, true) . ', '.$db->escapeNumber($race_id).', '.$db->escapeNumber($ship_id).', '.$db->escapeNumber(Globals::getStartingCredits($gameID)).', '.$db->escapeNumber($alliance_id).', '.$db->escapeNumber($home_sector_id).', '.$db->escapeNumber($last_turn_update).', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($startingNewbieTurns) . ',' . $db->escapeBoolean(defined('NPCScript')) . ')');
 
 $db->unlock();
 

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -20,6 +20,7 @@ abstract class AbstractSmrPlayer {
 	protected $lastSectorID;
 	protected $newbieTurns;
 	protected $dead;
+	protected $npc;
 	protected $startDead;
 	protected $landedOnPlanet;
 	protected $lastShieldUpdate;
@@ -159,7 +160,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function isNPC() {
-		return $this->getAccount()->isNPC();
+		return $this->npc;
 	}
 
 	public function isDraftLeader() {

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -171,6 +171,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$this->fleed						= $result['fleed']=='TRUE';
 			$this->attackColour					= (string) $result['attack_warning'];
 			$this->dead							= $result['dead']=='TRUE';
+			$this->npc							= $result['npc']=='TRUE';
 			$this->startDead					= $this->dead;
 			$this->landedOnPlanet				= $result['land_on_planet']=='TRUE';
 			$this->kicked						= $result['kicked']=='TRUE';


### PR DESCRIPTION
We often have to get the display name for a list of players.
Since we append "[NPC]" to the display name for NPC players,
we have to check if each player is an NPC, which entails:

1) querying the associated account to get the account login
2) cross-checking the login with the `npc_logins` table

These two queries triple the already large expense of displaying
lists of players.

By adding a boolean `npc` field to the `player` table, we
can entirely avoid this additional cost. (This could also be
achieved with a compound query, but the boolean is the simplest
and most efficient solution.)