### PR TITLE
SmrShip: only update hardware that has changed

### DIFF
--- a/lib/Default/AbstractSmrShip.class.inc
+++ b/lib/Default/AbstractSmrShip.class.inc
@@ -22,7 +22,7 @@ abstract class AbstractSmrShip {
 
 	protected $hasChangedWeapons = false;
 	protected $hasChangedCargo = false;
-	protected $hasChangedHardware = false;
+	protected $hasChangedHardware = array();
 
 	public static function &getBaseShip($gameTypeID,$shipTypeID,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_BASE_SHIPS[$gameTypeID][$shipTypeID])) {
@@ -334,12 +334,11 @@ abstract class AbstractSmrShip {
 	}
 
 	public function removeAllHardware() {
-		foreach($this->hardware as &$hardware) {
-			$hardware = 0;
+		foreach (array_keys($this->hardware) as $hardwareTypeID) {
+			$this->setHardware($hardwareTypeID, 0);
 		}
 		$this->decloak();
 		$this->disableIllusion();
-		$this->hasChangedHardware = true;
 	}
 
 	public function getPod($isNewbie = false) {
@@ -507,7 +506,7 @@ abstract class AbstractSmrShip {
 		if($this->getHardware($hardwareTypeID) == $amount)
 			return;
 		$this->hardware[$hardwareTypeID] = $amount;
-		$this->hasChangedHardware = true;
+		$this->hasChangedHardware[$hardwareTypeID] = true;
 	}
 
 	public function increaseHardware($hardwareTypeID,$amount) {
@@ -524,7 +523,7 @@ abstract class AbstractSmrShip {
 		if($this->getOldHardware($hardwareTypeID) == $amount)
 			return;
 		$this->oldHardware[$hardwareTypeID] = $amount;
-		$this->hasChangedHardware = true;
+		$this->hasChangedHardware[$hardwareTypeID] = true;
 	}
 
 	public function hasMaxHardware($hardwareTypeID) {

--- a/lib/Default/SmrShip.class.inc
+++ b/lib/Default/SmrShip.class.inc
@@ -120,11 +120,15 @@ class SmrShip extends AbstractSmrShip {
 	}
 	
 	function updateHardware() {
-		if($this->hasChangedHardware === true) {
+		if (!empty($this->hasChangedHardware)) {
 			$this->db->lockTable('ship_has_hardware');
 			
-			// write hardware info
-			foreach ($this->hardware as $hardwareTypeID => $amount) {
+			// write hardware info only for hardware that has changed
+			foreach ($this->hasChangedHardware as $hardwareTypeID => $hasChanged) {
+				if (!$hasChanged) {
+					continue;
+				}
+				$amount = $this->getHardware($hardwareTypeID);
 				if ($amount > 0) {
 					$this->db->query('REPLACE INTO ship_has_hardware (account_id, game_id, hardware_type_id, amount, old_amount) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($hardwareTypeID) . ', ' . $this->db->escapeNumber($amount) . ', ' . $this->db->escapeNumber($this->getOldHardware($hardwareTypeID)) . ')');
 				}
@@ -133,7 +137,7 @@ class SmrShip extends AbstractSmrShip {
 				}
 			}
 			$this->db->unlock();
-			$this->hasChangedHardware = false;
+			$this->hasChangedHardware = array();
 		}
 	}
 	


### PR DESCRIPTION
There are up to 11 pieces of hardware at the moment, but often
only one of them is changing at a time (e.g. shields/forces).
However, we previously would update every value if any single
hardware amount changed, resulting in up to 10 unnecessary db
queries.

Because of `set{Old}Hardware`, it is easy to keep track of
which hardware has changed, and only perform the db query to
update those that have changed.