### PR TITLE
HOF: make categories link to the subcategory

### DIFF
--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -46,7 +46,15 @@ if(!isset($var['view'])) {
 
 	foreach($hofTypes as $type => $value) {
 		$PHP_OUTPUT.=('<tr>');
-		$PHP_OUTPUT.=('<td>'.$type.'</td>');
+		// Make each category a link to view the subcategory page
+		$container = $var;
+		$container['view'] = $type;
+		if (!isset($var['type'])) {
+			$container['type'] = array();
+		}
+		$PHP_OUTPUT.=('<td>'.create_link($container, $type).'</td>');
+
+		// Make the subcategory buttons
 		$container = $var;
 		if (!isset($var['type']))
 			$container['type'] = array();


### PR DESCRIPTION
Currently, if you want to see the "HoF -> Planets" page, you have
to click on the "Buildings" button in the "Planets" subcategory,
and then click "Planets" in the breadcrumb you get on that page.

This Category link allows you to go directly to the subcategory
page.