### PR TITLE
SmrShip: remove table lock from updateHardware

### DIFF
--- a/lib/Default/SmrShip.class.inc
+++ b/lib/Default/SmrShip.class.inc
@@ -120,25 +120,20 @@ class SmrShip extends AbstractSmrShip {
 	}
 	
 	function updateHardware() {
-		if (!empty($this->hasChangedHardware)) {
-			$this->db->lockTable('ship_has_hardware');
-			
-			// write hardware info only for hardware that has changed
-			foreach ($this->hasChangedHardware as $hardwareTypeID => $hasChanged) {
-				if (!$hasChanged) {
-					continue;
-				}
-				$amount = $this->getHardware($hardwareTypeID);
-				if ($amount > 0) {
-					$this->db->query('REPLACE INTO ship_has_hardware (account_id, game_id, hardware_type_id, amount, old_amount) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($hardwareTypeID) . ', ' . $this->db->escapeNumber($amount) . ', ' . $this->db->escapeNumber($this->getOldHardware($hardwareTypeID)) . ')');
-				}
-				else {
-					$this->db->query('DELETE FROM ship_has_hardware WHERE account_id = ' . $this->db->escapeNumber($this->getAccountID()) . ' AND game_id = ' . $this->db->escapeNumber($this->getGameID()) . ' AND hardware_type_id = ' . $this->db->escapeNumber($hardwareTypeID));
-				}
+		// write hardware info only for hardware that has changed
+		foreach ($this->hasChangedHardware as $hardwareTypeID => $hasChanged) {
+			if (!$hasChanged) {
+				continue;
 			}
-			$this->db->unlock();
-			$this->hasChangedHardware = array();
+			$amount = $this->getHardware($hardwareTypeID);
+			if ($amount > 0) {
+				$this->db->query('REPLACE INTO ship_has_hardware (account_id, game_id, hardware_type_id, amount, old_amount) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($hardwareTypeID) . ', ' . $this->db->escapeNumber($amount) . ', ' . $this->db->escapeNumber($this->getOldHardware($hardwareTypeID)) . ')');
+			}
+			else {
+				$this->db->query('DELETE FROM ship_has_hardware WHERE account_id = ' . $this->db->escapeNumber($this->getAccountID()) . ' AND game_id = ' . $this->db->escapeNumber($this->getGameID()) . ' AND hardware_type_id = ' . $this->db->escapeNumber($hardwareTypeID));
+			}
 		}
+		$this->hasChangedHardware = array();
 	}
 	
 	function updateWeapon() {


### PR DESCRIPTION
As Page pointed out in #305, this lock probably doesn't provide
any useful security.

* Race conditions on hardware would likely only occur in the same
  sector (and would be protected by the sector lock).

* The hardware amount could still change between when it is
  queried and when it is updated in the database, and we don't
  re-query, so it wouldn't protect against race conditions.

* Since it doesn't lock on the sector level, someone laying mines
  in one galaxy could block someone from unoing in another galaxy.

So we remove the lock!