### PR TITLE
 SmrPlayer: change exp loss/gain on death

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1149,19 +1149,14 @@ class SmrPlayer extends AbstractSmrPlayer {
 		self::sendMessageFromFedClerk($this->getGameID(), $this->getAccountID(), 'You were <span class="red">DESTROYED</span> by ' . $killer->getBBLink() . ' in sector ' . Globals::getSectorBBLink($this->getSectorID()));
 		self::sendMessageFromFedClerk($this->getGameID(), $killer->getAccountID(), 'You <span class="red">DESTROYED</span>&nbsp;' . $this->getBBLink() . ' in sector ' . Globals::getSectorBBLink($this->getSectorID()));
 
-		// The person who got the kill gains experience
-		$expGainPercent = 0.04875 + 0.03 * ($this->getLevelID() - $killer->getLevelID()) / max($this->getLevelID(), $killer->getLevelID());
-		$return['KillerExp'] = ceil($expGainPercent * $this->getExperience());
+		// Dead player loses between 5% and 25% experience
+		$expLossPercentage = 0.15 + 0.10 * ($this->getLevelID() - $killer->getLevelID()) / $this->getMaxLevel();
+		$return['DeadExp'] = max(0, floor($this->getExperience() * $expLossPercentage));
+		$this->decreaseExperience($return['DeadExp']);
 
+		// Killer gains 50% of the lost exp
+		$return['KillerExp'] = max(0, ceil(0.5 * $return['DeadExp']));
 		$killer->increaseExperience($return['KillerExp']);
-
-		// Dead player loses experience
-		$expLossPercentage = 0.12 + (($this->getLevelID() - $killer->getLevelID()) * 0.0025);
-		$return['DeadExp'] = 0;
-		if($expLossPercentage > 0) {
-			$return['DeadExp'] = floor($this->getExperience() * $expLossPercentage);
-			$this->decreaseExperience($return['DeadExp']);
-		}
 
 		$return['KillerCredits'] = $this->getCredits();
 		$killer->increaseCredits($return['KillerCredits']);
@@ -1315,7 +1310,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->db->query('INSERT INTO news (game_id, time, news_message,killer_id,killer_alliance,dead_id,dead_alliance)
 						VALUES(' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(TIME) . ', ' . $this->db->escapeString($news_message) . ',' . $this->db->escapeNumber($owner->getAccountID()) . ',' . $this->db->escapeNumber($owner->getAllianceID()) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
-		$expLossPercentage = .30;
+		// Player loses 25% experience
+		$expLossPercentage = .25;
 		$return['DeadExp'] = floor($this->getExperience() * $expLossPercentage);
 		$this->decreaseExperience($return['DeadExp']);
 
@@ -1359,8 +1355,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->db->query('INSERT INTO news (game_id, time, news_message,killer_id,dead_id,dead_alliance)
 						VALUES(' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(TIME) . ', ' . $this->db->escapeString($news_message) . ',' . $this->db->escapeNumber(ACCOUNT_ID_PORT) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
-		$expLossPercentage = .31 - $port->getLevel()/100;
-		$return['DeadExp'] = floor($this->getExperience() * $expLossPercentage);
+		// Player loses between 20% and 28% experience
+		$expLossPercentage = .29 - .09 * $port->getLevel()/$port->getMaxLevel();
+		$return['DeadExp'] = max(0, floor($this->getExperience() * $expLossPercentage));
 		$this->decreaseExperience($return['DeadExp']);
 
 		$return['LostCredits'] = $this->getCredits();
@@ -1392,8 +1389,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->db->query('INSERT INTO news (game_id, time, news_message,killer_id,killer_alliance,dead_id,dead_alliance)
 						VALUES(' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(TIME) . ', ' . $this->db->escapeString($news_message) . ',' . $this->db->escapeNumber($planetOwner->getAccountID()) . ',' . $this->db->escapeNumber($planetOwner->getAllianceID()) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
-		$expLossPercentage = .27 - $planet->getLevel()/1000;
-		$return['DeadExp'] = floor($this->getExperience() * $expLossPercentage);
+		// Player loses between 20% and 27% experience
+		$expLossPercentage = .27 - .07 * $planet->getLevel()/$planet->getMaxLevel();
+		$return['DeadExp'] = max(0, floor($this->getExperience() * $expLossPercentage));
 		$this->decreaseExperience($return['DeadExp']);
 
 		$return['LostCredits'] = $this->getCredits();


### PR DESCRIPTION
* Fix the formulas so that they cannot trigger a DB error:

  - Scale the loss/gain by the max level so that the bounds
    are independent of the absolute magnitude of the level.
    (This was still an issue for Defense World planets, which
    had a much higher max level than other planet types.)

  - As an extra precaution, to ensure that the death is fully
    processed, take the `max(0, $expLoss)`.

* Retool the exp loss/gain percentages:

  - Death to forces: 30% -> 25% (this could be much lower still)
  - Death to ports: [22, 30]% -> [20, 28]%
  - Death to planets: unchanged (as calibrated for level 70)
  - Death to players: [-0.5, 24.5]% -> [5, 25]%
  - Gain on kill: [2, 8]% -> [2.5, 12.5]% (half the loss)

The rationale for the changes are:

1) Force deaths were way too punishing and many people have
   complained about them.
2) Ports and planets are roughly the same, with lower max level
   planets dropping a bit to facilitate the formula based on
   max level. This will allow us to change planet buildings
   without worrying about its impact on this code.
3) A slightly higher average player loss (up to 15% from 12.5%)
   to account for the fact that the average PvP loss is roughly
   half of what it is for any other type of death.
4) Gains are increased slightly due to the much rarer occurrence
   of PvP kills.