### PR TITLE
Fix broken HoF links for pre-1.6 games

### DIFF
--- a/engine/Default/game_play.php
+++ b/engine/Default/game_play.php
@@ -233,7 +233,7 @@ if(USE_COMPATIBILITY) {
 				$container['body'] = 'games_previous.php';
 
 				$games['Previous'][$index]['PreviousGameLink'] = SmrSession::getNewHREF($container);
-				$container['body'] = 'hall_of_fame_new.php';
+				$container['body'] = 'games_previous_hof.php';
 				$games['Previous'][$index]['PreviousGameHOFLink'] = SmrSession::getNewHREF($container);
 				$container['body'] = 'games_previous_news.php';
 				$games['Previous'][$index]['PreviousGameNewsLink'] = SmrSession::getNewHREF($container);

--- a/engine/Default/games_previous_hof.php
+++ b/engine/Default/games_previous_hof.php
@@ -1,0 +1,68 @@
+<?php
+
+// NOTE: this is only for compatibility database games
+
+// Get old account ID's
+$db = new SmrMySqlDatabase();
+$oldDbName = str_replace('History', '', $var['HistoryDatabase']);
+$oldAccountId = $account->getOldAccountID($oldDbName);
+
+require_once(get_file_loc($var['HistoryDatabase'].'.class.inc'));
+$db = new $var['HistoryDatabase']();
+
+$gameId = $var['game_id'];
+$gameName = $var['game_name'];
+
+$template->assign('PageTopic', 'Hall of Fame : ' . $gameName);
+
+$PHP_OUTPUT .= '<div align="center">';
+
+if (!isset($var['stat'])) {
+	// Display a list of stats available to view
+	$db->query('SHOW COLUMNS FROM player_has_stats');
+	$PHP_OUTPUT .= create_table();
+	while ($db->nextRecord()) {
+		$stat = $db->getField('Field');
+		if ($stat == 'account_id' || $stat == 'game_id') {
+			continue;
+		}
+		$statDisplay = ucwords(str_replace('_', ' ', $stat));
+		$container = $var;
+		$container['stat'] = $stat;
+		$container['stat_display'] = $statDisplay;
+		$PHP_OUTPUT .= '<tr><td class="center">' . create_link($container, $statDisplay) . '</td></tr>';
+	}
+	$PHP_OUTPUT .= '</table>';
+}
+else {
+	// Link back to overview page
+	$container = $var;
+	unset($container['stat']);
+	unset($container['stat_display']);
+	$PHP_OUTPUT .= create_link($container, '&lt;&lt;Back');
+
+	// Rankings display
+	$PHP_OUTPUT .= '<br /><br /><h2>Rankings: ' . $var['stat_display'] . '</h2>';
+	$db->query('SELECT * FROM player_has_stats s INNER JOIN player p ON (p.account_id = s.account_id AND p.game_id = s.game_id) WHERE s.game_id=' . $db->escapeNumber($gameId) . ' ORDER BY s.' . $var['stat'] . ' DESC LIMIT 25');
+	if ($db->getNumRows() > 0) {
+		$PHP_OUTPUT .= create_table();
+		$rank = 1;
+		while ($db->nextRecord()) {
+			$boldClass = $db->getInt('account_id') == $oldAccountId ? 'class="bold"' : '';
+			$PHP_OUTPUT .= '<tr ' . $boldClass . '>';
+			$PHP_OUTPUT .= '<td class="center">' . $rank++ . '</td>';
+			$PHP_OUTPUT .= '<td>' . stripslashes($db->getField('player_name')) . '</td>';
+			$PHP_OUTPUT .= '<td class="center">' . $db->getInt($var['stat']) . '</td>';
+			$PHP_OUTPUT .= '</tr>';
+		}
+		$PHP_OUTPUT .= '</table>';
+	} else {
+		$PHP_OUTPUT .= 'We apologize, but this stat does not exist for this game!';
+	}
+}
+
+$PHP_OUTPUT .= '</div>';
+
+$db = new SmrMySqlDatabase();
+
+?>


### PR DESCRIPTION
The `hall_of_fame_new.php` script only works for 1.6 games. For
the old history databases (pre-1.6 games), this script causes a
database error.

We don't do anything special with this new script, just present the
stats in the simplest way possible.

Current account's stats are highlighted.

----------

NOTE: the "Rankings" db query inserts `$var['stat']`, which is a user-specified column name. This is currently not escaped in any way, so presumably is susceptible to injection. I'm not sure if there is a standard way to escape column names in this code.