### PR TITLE
ip_view_results.php: fix mysql error

### DIFF
--- a/admin/Default/ip_view_results.php
+++ b/admin/Default/ip_view_results.php
@@ -519,7 +519,7 @@ elseif ($type == 'list') {
 }
 elseif ($type == 'compare_log') {
 	$list = preg_split('/[,]+[\s]/', $variable);
-	$db->query('SELECT ip.* FROM account_has_ip JOIN account USING(account_id) WHERE login IN (' . $db->escapeArray($list) . ') ORDER BY ip');
+	$db->query('SELECT ip.* FROM account_has_ip ip JOIN account USING(account_id) WHERE login IN (' . $db->escapeArray($list) . ') ORDER BY ip');
 	$container = create_container('account_close.php');
 	$PHP_OUTPUT.=('<center>Listing all IPs for logins '.$variable.'<br /><br />');
 	$PHP_OUTPUT.=create_echo_form($container);


### PR DESCRIPTION
Using the "List All IPs for specified logins" option resulted in
a database error:

Unknown table 'ip'

This was because the query was missing the `ip` alias for the
`account_has_ip` table.