### PR TITLE
Fix alliance rankings

### DIFF
--- a/engine/Default/rankings_alliance_experience.php
+++ b/engine/Default/rankings_alliance_experience.php
@@ -56,7 +56,7 @@ $db->query('SELECT alliance_id, SUM(experience) amount
 			GROUP BY alliance_id, alliance_name
 			ORDER BY amount DESC, alliance_name
 			LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, 0));
+$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, $lowerLimit));
 
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_experience.php')));
 ?>

--- a/engine/Default/rankings_alliance_kills.php
+++ b/engine/Default/rankings_alliance_kills.php
@@ -35,7 +35,7 @@ Rankings::calculateMinMaxRanks($ourRank, $numAlliances);
 $lowerLimit = $var['MinRank'] - 1;
 $db->query('SELECT alliance_id, alliance_kills amount FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, alliance_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, 0));
+$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, $lowerLimit));
 
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_kills.php')));
 ?>

--- a/engine/Default/rankings_alliance_profit.php
+++ b/engine/Default/rankings_alliance_profit.php
@@ -32,7 +32,7 @@ if ($player->hasAlliance()) {
 				WHERE (
 					t.amount > us.amount
 					OR (
-						t.amount = us.amount
+						COALESCE(t.amount,0) = COALESCE(us.amount,0)
 						AND alliance_name <= ' . $db->escapeString($player->getAllianceName()) . '
 					)
 				)');

--- a/engine/Default/rankings_alliance_profit.php
+++ b/engine/Default/rankings_alliance_profit.php
@@ -62,7 +62,7 @@ $db->query('SELECT alliance_id, SUM(amount) amount
 			GROUP BY alliance_id, alliance_name
 			ORDER BY amount DESC, alliance_name
 			LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, 0));
+$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, $lowerLimit));
 
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_experience.php')));
 ?>


### PR DESCRIPTION
Fix filtered alliance rankings

Reported by Bouncer in 2013:

Under Alliance rankings, the top 10 are fine. If your alliance is
out of the top 10 though and is shown in the lower section (say 10-20),
the ranking on the left-hand side still says 1-10.

----------------

rankings_alliance_profit.php: fix rankings if 0 profit

For alliances with no profit, they would show up as rank 0 because
the `amount` field in the query would be null. We fix this in the
same way as in `rankings_player_profit.php` by using COALESCE to
return the amount (if it exists) or 0 (if it doesn't).