### PR TITLE
Globals: don't include processing pages with bar_main.php

### DIFF
--- a/lib/Default/Globals.class.inc
+++ b/lib/Default/Globals.class.inc
@@ -591,23 +591,19 @@ class Globals {
 	}
 
 	public static function getBarBuyDrinkHREF() {
-		$container = create_container('skeleton.php', 'bar_main.php');
-		$container['script'] = 'bar_buy_drink_processing.php';
+		$container = create_container('bar_buy_drink_processing.php');
 		$container['action'] = 'drink';
 		return SmrSession::getNewHREF($container);
 	}
 
 	public static function getBarBuyWaterHREF() {
-		$container = create_container('skeleton.php', 'bar_main.php');
-		$container['script'] = 'bar_buy_drink_processing.php';
+		$container = create_container('bar_buy_drink_processing.php');
 		$container['action'] = 'water';
 		return SmrSession::getNewHREF($container);
 	}
 
 	public static function getBarLottoClaimHREF() {
-		$container = create_container('skeleton.php', 'bar_main.php');
-		$container['script'] = 'bar_lotto_claim.php';
-		$container['action'] = 'lotto_claim';
+		$container = create_container('bar_lotto_claim.php');
 		return SmrSession::getNewHREF($container);
 	}
 


### PR DESCRIPTION
The bar processing pages (buy water, buy drink, and claim lotto)
have no display, so there is no point to including them from
within `bar_main.php`.