### PR TITLE
bar_lotto_claim.php: fix claim error

### DIFF
--- a/engine/Default/bar_lotto_claim.php
+++ b/engine/Default/bar_lotto_claim.php
@@ -4,7 +4,7 @@ $message = '';
 //check if we really are a winner
 $db->query('SELECT * FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 			AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND time = 0');
-while ($db->nextRecord()) {
+if ($db->nextRecord()) {
 	$prize = $db->getInt('prize');
 	$NHLAmount = ($prize - 1000000) / 9;
 	$db->query('UPDATE player SET bank = bank + ' . $db->escapeNumber($NHLAmount) . ' WHERE account_id = ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));


### PR DESCRIPTION
People have been getting the "Multiple actions" error when
claiming a lotto prize.

In a debug environment, claiming a lotto prize resulted in
trying to call `fetch_assoc` on a boolean within `$db->nextRecord()`.
I believe this is because it was a `while`-condition, but within
the `while`-loop, `$db` was modified by additional queries.

Since we know there is only one entry we will be getting, we can
use `if` instead of `while`, which fixes the issue in debug.

What is very strange about the live environment is that the ticket
is deleted, but they don't get the money. The only way this makes
sense to me is if `$player->update()` is not called if a
"Multiple actions" error is encountered. I suppose it must be...