### PR TITLE
Clarify lotto news message

### DIFF
--- a/engine/Default/bar_lotto_claim.php
+++ b/engine/Default/bar_lotto_claim.php
@@ -14,8 +14,7 @@ while ($db->nextRecord()) {
 	$message .= '<div align="center">You have claimed <span class="red">$' . number_format($prize) . '</span>!<br /></div><br />';
 	$db->query('DELETE FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND prize = ' . $db->escapeNumber($prize) . ' AND time = 0 LIMIT 1');
-	$news_message = '<span class="yellow">'.$player->getPlayerName().'</span> has won the lotto!  The jackpot was ' . number_format($prize) . '.  <span class="yellow">'.$player->getPlayerName().'</span> can report to any bar to claim his prize!';
-	$db->query('DELETE FROM news WHERE news_message = ' . $db->escapeString($news_message) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->query('DELETE FROM news WHERE type = \'lotto\' AND game_id = '.$db->escapeNumber($player->getGameID()));
 }
 //offer another drink and such
 $container=create_container('skeleton.php','bar_main.php');

--- a/lib/Default/bar.functions.inc
+++ b/lib/Default/bar.functions.inc
@@ -34,7 +34,7 @@ function checkForLottoWinner($gameID) {
 		$winner =& SmrPlayer::getPlayer($winner_id, $gameID);
 		$winner->increaseHOF($lottoInfo['Prize'],array('Bar','Lotto','Money','Winnings'), HOF_PUBLIC);
 		$winner->increaseHOF(1,array('Bar','Lotto','Results','Wins'), HOF_PUBLIC);
-		$news_message = '<span class="yellow">'.$winner->getPlayerName().'</span> has won the lotto! The jackpot was ' . number_format($lottoInfo['Prize']) . '. <span class="yellow">'.$winner->getPlayerName().'</span> can report to any bar to claim their prize!';
+		$news_message = '<span class="yellow">'.$winner->getPlayerName().'</span> has won the lotto! The jackpot was ' . number_format($lottoInfo['Prize']) . '. <span class="yellow">'.$winner->getPlayerName().'</span> can report to any bar to claim their prize before the next drawing!';
 		// insert the news entry
 		$db->query('DELETE FROM news WHERE type = \'lotto\' AND game_id = '.$db->escapeNumber($gameID));
 		$db->query('INSERT INTO news


### PR DESCRIPTION
* Make it clearer that the prize must be claimed before the
  next drawing. (We can probably be more explicit, but this
  message will at least help a little.)

* Change the old lotto news deletion so that it doesn't depend
  on the specific message. Presumably this was written before
  the "lotto" news type was added.