### PR TITLE
shop_goods.php: allow supply to ajax update

### DIFF
--- a/engine/Default/shop_goods.php
+++ b/engine/Default/shop_goods.php
@@ -129,7 +129,7 @@ if (!empty($boughtGoods)) {
 			
 		$PHP_OUTPUT.=('<tr class="center">');
 		$PHP_OUTPUT.=('<td class="left"><img src="' . $good['ImageLink'] . '" width="13" height="16" title="' . $good['Name'] . '" alt=""> ' . $good['Name'] . '</td>');
-		$PHP_OUTPUT.=('<td>' . $amount . '</td>');
+		$PHP_OUTPUT.=('<td class="ajax" id="amount'.$goodID.'">' . $amount . '</td>');
 		$PHP_OUTPUT.=('<td>' . $good['BasePrice'] . '</td>');
 		$PHP_OUTPUT.=('<td>' . $ship->getCargo($good['ID']) . '</td>');
 		$PHP_OUTPUT.=('<td><input type="number" name="amount" value="');
@@ -180,7 +180,7 @@ if (!empty($soldGoods)) {
 
 		$PHP_OUTPUT.=('<tr class="center">');
 		$PHP_OUTPUT.=('<td class="left"><img src="' . $good['ImageLink'] . '" width="13" height="16" title="' . $good['Name'] . '" alt=""> ' . $good['Name'] . '</td>');
-		$PHP_OUTPUT.=('<td>' . $amount . '</td>');
+		$PHP_OUTPUT.=('<td class="ajax" id="amount'.$goodID.'">' . $amount . '</td>');
 		$PHP_OUTPUT.=('<td>' . $good['BasePrice'] . '</td>');
 		$PHP_OUTPUT.=('<td>' . $ship->getCargo($good['ID']) . '</td>');
 		$PHP_OUTPUT.=('<td><input type="number" name="amount" value="');


### PR DESCRIPTION
The middle panel ajax is disabled on the main port page (because of
the input elements, see `Template::checkDisableAJAX`).

However, we often find ourselves refreshing the port page to see
the supply/demand incrementing, so we add the `ajax` class and a
unique id to its column to enable ajax on that specific element.

NOTE: if using this to watch for supply to increase enough to
complete a trade, the player will have to remember that the auto-fill
value for the trade will not change (since auto-updating that with
ajax would obliterate any attempt to fill in the form manually).