### PR TITLE
SmrPort: swap one good when razing Level 1 port

### DIFF
--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -523,15 +523,13 @@ class SmrPort {
 			throw new Exception('Cannot downgrade a cached port!');
 
 		switch($this->level) {
-			case 1: // we don't want to downgrade a level 1 port
-//				for($i=0;$i<3;$i++) { // Add 3 goods for upgrading to level 1
-//					do {
-//						$newGood = array_shift($GOODS);
-//					} while( (!$this->hasGood($newGood['ID']) || $newGood['Class']!=1) && ($count = count($GOODS))!=0 );
-//					if($count == 0)
-//						break;
-//					$this->removePortGood($newGood['ID'],);
-//				}
+			case 1:
+				// Replace one class 1 good with another
+				$this->selectAndRemoveGood(1);
+				$newGood = $this->selectAndAddGood(1);
+				// Set new good to 0 supply
+				// (since other goods are set to 0 when port is destroyed)
+				$this->setGoodAmount($newGood['ID'], 0);
 			break;
 			
 			case 2:
@@ -554,7 +552,11 @@ class SmrPort {
 			default: // We don't want to add goods.
 			break;
 		}
-		$this->decreaseLevel(1);
+
+		// Don't make the port level 0
+		if ($this->level > 1) {
+			$this->decreaseLevel(1);
+		}
 		$this->setUpgrade(0);
 	}
 	

--- a/templates/Default/engine/Default/port_attack.php
+++ b/templates/Default/engine/Default/port_attack.php
@@ -23,10 +23,8 @@
 				<a href="<?php echo Globals::getCurrentSectorHREF() ?>" class="buttonA">Current Sector</a>&nbsp;
 				<a href="<?php echo $Port->getClaimHREF(); ?>" class="buttonA">Claim this port for your race</a><?php
 				if($Port->getCredits() > 0) { ?>&nbsp;
-					<a href="<?php echo $Port->getLootHREF(); ?>" class="buttonA">Loot the port<?php if($Port->getCredits() > 0) { ?>(100% money)<?php } ?></a><?php
-					if($Port->getLevel() > 1) { ?>&nbsp;
-						<a href="<?php echo $Port->getRazeHREF(); ?>" class="buttonA">Raze the port (<?php echo SmrPort::RAZE_MONEY_PERCENT; ?>% money, 1 downgrade)</a><?php
-					}
+					<a href="<?php echo $Port->getLootHREF(); ?>" class="buttonA">Loot the port<?php if($Port->getCredits() > 0) { ?>(100% money)<?php } ?></a>&nbsp;
+					<a href="<?php echo $Port->getRazeHREF(); ?>" class="buttonA">Raze the port (<?php echo SmrPort::RAZE_MONEY_PERCENT; ?>% money, 1 downgrade)</a><?php
 				}
 			} ?>
 		</div><?php


### PR DESCRIPTION
Previously, you were unable to raze a level 1 port.
Now, it will remove one of the existing T1 goods and
replace it with another.

At some point in the distant past, all level 1 goods
were rearranged when a level was busted. This seems like
a nice compromise between the two.

Note that this only affects razing. Levels still cannot
be busted at level 1 by shot damage.