### PR TITLE
trader_status.php: add countdown to max turns

### DIFF
--- a/engine/Default/trader_status.php
+++ b/engine/Default/trader_status.php
@@ -90,7 +90,11 @@ $PHP_OUTPUT.= '<br />Speed: ';
 $PHP_OUTPUT.= $ship->getRealSpeed();
 $PHP_OUTPUT.= ' turns/hour<br />Max: ';
 $PHP_OUTPUT.= $player->getMaxTurns();
-$PHP_OUTPUT.= ' turns<br /><br />';
+$PHP_OUTPUT.= ' turns<br />';
+
+// Max turns countdown clock
+$timeToMax = $player->getTimeUntilMaxTurns(TIME);
+$PHP_OUTPUT .= 'At max turns in <span id="max_turns">' . format_time($timeToMax, true) . '</span>.<br /><br />';
 
 $container['body'] = 'configure_hardware.php';
 $PHP_OUTPUT.= create_link($container, '<span class="yellow bold">Supported Hardware</span>');

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -598,6 +598,19 @@ class SmrPlayer extends AbstractSmrPlayer {
 		return $this->originalMaintenance;
 	}
 
+	/**
+	 * Calculate the time in seconds between the given time and when the
+	 * player will be at max turns.
+	 */
+	public function getTimeUntilMaxTurns($time, $forceUpdate=false) {
+		$timeDiff = $time - $this->getLastTurnUpdate();
+		$turnsDiff = $this->getMaxTurns() - $this->getTurns();
+		$ship = $this->getShip($forceUpdate);
+		$maxTurnsTime = ceil(($turnsDiff * 3600 / $ship->getRealSpeed())) - $timeDiff;
+		// If already at max turns, return 0
+		return max(0, $maxTurnsTime);
+	}
+
 	// Turns only update when player is active.
 	// Calculate turns gained between given time and the last turn update
 	public function getTurnsGained($time, $forceUpdate=false) {

--- a/tools/discord/commands/turns.php
+++ b/tools/discord/commands/turns.php
@@ -7,10 +7,9 @@ function get_turns_message($player) {
 	$msg = $player->getPlayerName() . " has $turns/" . $player->getMaxTurns() . " turns.";
 
 	// Calculate time to max turns if under the max
-	if ($turns < $player->getMaxTurns()) {
-		$ship = $player->getShip(true);
-		$maxTime = ceil(($player->getMaxTurns() - $turns) * 3600 / $ship->getRealSpeed());
-		$msg .= " At max turns in " . format_time($maxTime, true) . ".";
+	$timeToMax = $player->getTimeUntilMaxTurns(time(), true);
+	if ($timeToMax > 0) {
+		$msg .= " At max turns in " . format_time($timeToMax, true) . ".";
 	}
 
 	return $msg;


### PR DESCRIPTION
Add a countdown in the Trader Status page until max turns will be
reached. This feature was requested by players.

Since this is already calculated in the `turns` Discord command,
we factor the calculation into the `SmrPlayer::getTimeUntilMaxTurns`
function.

![image](https://user-images.githubusercontent.com/846186/35797687-538e04ca-0a15-11e8-816a-005d58b994ea.png)
