### PR TITLE
Game 118 port combat changes

### DIFF
--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -8,8 +8,8 @@ class SmrPort {
 	const CHANCE_TO_DOWNGRADE = 1;
 	const TIME_FEDS_STAY = 1800;
 	const MAX_FEDS_BONUS = 4000;
-	const BASE_CDS = 500;
-	const CDS_PER_LEVEL = 125;
+	const BASE_CDS = 725;
+	const CDS_PER_LEVEL = 100;
 	const CDS_PER_TEN_MIL_CREDITS = 25;
 	const BASE_DEFENCES = 500;
 	const DEFENCES_PER_LEVEL = 700;
@@ -637,7 +637,7 @@ class SmrPort {
 	}
 
 	public function setCreditsToDefault() {
-		$this->setCredits(2100000 + $this->getLevel()*1600000 + pow($this->getLevel(), 2) * 300000);
+		$this->setCredits(2700000 + $this->getLevel()*1500000 + pow($this->getLevel(), 2) * 300000);
 	}
 
 	public function setCredits($credits) {


### PR DESCRIPTION
Proposed changes for Game 118 were too drastic. With them, a /21
felt safe taking a level 6 port solo, so we tweak the numbers to
inspire a little more fear of lower level ports (but not as much
as before).

Below are the changes from the original proposal to the final
values for Game 118.

Base drones:      500 -> 725 (previously 1000)
Drones per level: 125 -> 100 (previously 70)

Base profit:      2.1M -> 2.7M (previously 3M)
Profit per level: 1.6M -> 1.5M (previously 1.5M)

See the [spreadsheet](https://docs.google.com/spreadsheets/d/1LAt0H8G8IHeGhwIIRtpf8gU1_mo3ardzM19kPZ5-4hQ/edit?usp=sharing) for effect at all port levels. (Make sure you're on the Game 118 Proposed tab.)