### PR TITLE
SmrShip: update cargo display immediately

### DIFF
--- a/lib/Default/AbstractSmrShip.class.inc
+++ b/lib/Default/AbstractSmrShip.class.inc
@@ -753,6 +753,9 @@ abstract class AbstractSmrShip {
 			return;
 		$this->cargo[$goodID] = $amount;
 		$this->hasChangedCargo = true;
+		// Sort cargo by goodID to make sure it shows up in the correct order
+		// before the next page is loaded.
+		ksort($this->cargo);
 	}
 
 	public function decreaseCargo($goodID,$amount) {

--- a/lib/Default/SmrShip.class.inc
+++ b/lib/Default/SmrShip.class.inc
@@ -110,10 +110,14 @@ class SmrShip extends AbstractSmrShip {
 		if($this->hasChangedCargo === true) {
 			// write cargo info
 			foreach ($this->getCargo() as $id => $amount) {
-				if ($amount > 0)
+				if ($amount > 0) {
 					$this->db->query('REPLACE INTO ship_has_cargo (account_id, game_id, good_id, amount) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($id) . ', ' . $this->db->escapeNumber($amount) . ')');
-				else
+				} else {
 					$this->db->query('DELETE FROM ship_has_cargo WHERE account_id = ' . $this->db->escapeNumber($this->getAccountID()) . ' AND game_id = ' . $this->db->escapeNumber($this->getGameID()) . ' AND good_id = ' . $this->db->escapeNumber($id) . ' LIMIT 1');
+					// Unset now to omit displaying this good with 0 amount
+					// before the next page is loaded.
+					unset($this->cargo[$id]);
+				}
 			}
 			$this->hasChangedCargo = false;
 		}


### PR DESCRIPTION
When ship cargo changes, the data in memory is not consistent with
the data when it is loaded from the database. This means that the
cargo will be displayed one way when it first changes, and then on
the next page it will be displayed differently.

I found at least two scenarios where this occurs:

1. When you have more than one good and then sell or dump one of
   the goods, it will then display with zero amount (e.g. "Ore: 0").
   To fix this, we remove the field from the cargo property when
   we delete it from the database so that it never shows up at all.

2. When you already have one good in your cargo and you buy a
   second kind of good, if the second good has a lower ID than the
   first, it will display after the first good, and then switch
   on the next page. If we sort the cargo property when we first
   add the new good, then it will always display in numerical ID
   order.