### PR TITLE
Make changelog more readable

### DIFF
--- a/engine/Default/changelog_view.php
+++ b/engine/Default/changelog_view.php
@@ -32,7 +32,7 @@ while ($db->nextRecord()) {
 		$went_live = 'never';
 	}
 
-	$PHP_OUTPUT.=('<b><small>'.$version.' ('.$went_live.'):</small></b>');
+	$PHP_OUTPUT.=('<b>'.$version.' ('.$went_live.'):</b>');
 
 	$PHP_OUTPUT.=('<ul>');
 
@@ -41,7 +41,7 @@ while ($db->nextRecord()) {
 				WHERE version_id = ' . $db2->escapeNumber($version_id) . '
 				ORDER BY changelog_id');
 	while ($db2->nextRecord()) {
-		$PHP_OUTPUT.=('<li>' . $db2->getField('change_title') . '<br /><small>' . $db2->getField('change_message') . '</small></li>');
+		$PHP_OUTPUT.=('<li><span style="font-size:125%;color:greenyellow;">' . $db2->getField('change_title') . '</span><br />' . $db2->getField('change_message') . '<br /><br /></li>');
 	}
 
 	$PHP_OUTPUT.=('</ul><br />');


### PR DESCRIPTION
* Increase font size
* Make headers more distinctive (yellow green color)
* Increase spacing between bullets

I realize this can (and should) be done with CSS, but since the
live server is still not dockerized, players will not see CSS
changes right now.

![image](https://user-images.githubusercontent.com/846186/36055595-708cba30-0db2-11e8-84f3-e8062049abaa.png)
