### PR TITLE
Default.css: fix shifting page center

### DIFF
--- a/htdocs/css/Default.css
+++ b/htdocs/css/Default.css
@@ -2,7 +2,9 @@
 
 html, body {
 	height: 100%; /* fallback for older browsers */
+	width: 100%;  /* fallback for older browsers */
 	height: calc(100% - 10px); /* Account for padding to fix persistent vertical scrollbar */
+	width: calc(100vw - 34px); /* Prevent centered content shifting when scrollbar appears */
 }
 body {
 	font-family: Arial, Sans-Serif;


### PR DESCRIPTION
For pages that are too long, the browser adds a vertical scrollbar.
Because the page content is centered, the added scrollbar shifts
the content every so slightly to the left.

By making the page width only as wide as the viewport width _minus_
the scrollbar, adding the scrollbar no longer perturbs the page
content alignment.

See https://stackoverflow.com/a/25981719.