### PR TITLE
newsletter_send_processing.php: minor cleanup

### DIFF
--- a/admin/Default/newsletter_send_processing.php
+++ b/admin/Default/newsletter_send_processing.php
@@ -6,12 +6,9 @@ require(LIB . 'External/phpMailer/class.phpmailer.php');
 $mail = new PHPMailer();
 $mail->From				= 'newsletter@smrealms.de';
 $mail->FromName			= 'SMR Team';
-$mail->Maile			= 'smtp';
-$mail->SMTPKeepAlive	= true;
 
 //$mail->ConfirmReadingTo       = 'newsletter-read@smrealms.de';
 
-$mail->AddReplyTo('support@smrealms.de', 'SMR Support');
 $mail->Encoding = 'base64';
 $mail->WordWrap = 72;
 
@@ -72,7 +69,6 @@ if($_REQUEST['to_email']=='*') {
 
 		if(!$mail->Send()) {
 			echo 'error.'.EOL . $mail->ErrorInfo;
-			$mail->SmtpClose();
 			ob_flush();
 			exit;
 		}
@@ -86,18 +82,16 @@ if($_REQUEST['to_email']=='*') {
 
 	}
 
-	$mail->SmtpClose();
-
 	echo 'Total '.$total.' mails sent.'.EOL;
 	release_lock();
 	exit();
 }
 else {
 
+	$mail->AddReplyTo('support@smrealms.de', 'SMR Support');
 	$mail->AddAddress($_REQUEST['to_email'], $_REQUEST['to_email']);
 
 	$mail->Send();
-	$mail->SmtpClose();
 }
 
 forward(create_container('skeleton.php', 'newsletter_send.php'))


### PR DESCRIPTION
* Move initial AddReplyTo so that we are only ever setting it
  once in each of the two logical branches (1. sending to a single
  address, 2. sending to all players).

* Remove incorrectly set PHPMailer attribute. `Maile` was a typo
  for `Mailer`, so we just remove it (we weren't using smtp anyway).