### PR TITLE
account_edit.php: fix searching with no account ID

### DIFF
--- a/admin/Default/account_edit.php
+++ b/admin/Default/account_edit.php
@@ -2,7 +2,7 @@
 
 $template->assign('PageTopic','Edit Account');
 
-$account_id = SmrSession::getRequestVar('account_id', 0);
+$account_id = SmrSession::getRequestVar('account_id', '');
 $player_name = SmrSession::getRequestVar('player_name', '');
 SmrSession::getRequestVar('login', '');
 SmrSession::getRequestVar('val_code', '');
@@ -15,7 +15,9 @@ elseif(!isset($var['SearchGameID'])) {
 	SmrSession::updateVar('SearchGameID', 0);
 }
 
-if(!empty($account_id) && !is_numeric($account_id)) {
+if (empty($account_id)) {
+	$account_id = 0;
+} elseif (!is_numeric($account_id)) {
 	create_error('Account ID must be a number.');
 }
 


### PR DESCRIPTION
Fix a bug introduced in cd34fdd0625, which resulted because
`$_REQUEST['account_id']` is _always_ specified due to the way
that the form is set up. I thought the default value would be 0,
but it will always be the empty string if not specified. Then
this empty string caused a `$db->escapeNumber` to fail.

We now explciitly set `$account_id = 0` if it is not specified.