### PR TITLE
Don't let Autopilot access games that have ended

### DIFF
--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -33,7 +33,7 @@ class SmrAlliance {
 
 	public static function getAllianceByDiscordChannel($channel, $forceUpdate=false) {
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT alliance_id, game_id FROM alliance WHERE discord_channel = '.$db->escapeString($channel).' ORDER BY game_id DESC LIMIT 1');
+		$db->query('SELECT alliance_id, game_id FROM alliance JOIN game USING(game_id) WHERE discord_channel = '.$db->escapeString($channel).' AND game.end_date > '.$db->escapeNumber(time()).' ORDER BY game_id DESC LIMIT 1');
 		if ($db->nextRecord()) {
 			return self::getAlliance($db->getInt('alliance_id'), $db->getInt('game_id'), $forceUpdate);
 		} else {

--- a/tools/discord/GameLink.inc
+++ b/tools/discord/GameLink.inc
@@ -36,7 +36,7 @@ class GameLink
 		if ($channel->is_private) {
 			// Get the most recent enabled game, since there is no other way to determine the game ID
 			$db = new SmrMySqlDatabase();
-			$db->query('SELECT MAX(game_id) FROM game WHERE enabled=' . $db->escapeBoolean(true));
+			$db->query('SELECT MAX(game_id) FROM game WHERE enabled=' . $db->escapeBoolean(true) . ' AND end_date > ' . $db->escapeNumber(time()));
 			if ($db->nextRecord()) {
 				$game_id = $db->getInt('MAX(game_id)');
 			} else {


### PR DESCRIPTION
The Discord GameLink.inc will no longer return games that have
ended. We do this by checking that `end_date > time()`.