### PR TITLE
SmrPlayer: remove changeShip method

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1419,15 +1419,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 		return $return;
 	}
 
-	function changeShip(SmrShip &$ship,$shipID) {
-		$this->db->query('DELETE FROM player_has_goods WHERE '.$this->SQL.' LIMIT 1');
-		decloak($ship);
-		$this->db->query('DELETE FROM player_has_illusion WHERE '.$this->SQL.' LIMIT 1');
-		$this->setShipID($shipID);
-		$ship = get_ship($this);
-		checkShipForExcess($ship,$this);
-	}
-
 	public function save() {
 		if($this->hasChanged === true) {
 			$this->db->query('UPDATE player SET player_name='.$this->db->escapeString($this->playerName).


### PR DESCRIPTION
This function was never used. There is a place for a function
like this (to factor out the logic for changing ships, which
does occur in a couple places), but it will need to be rewritten
anyway.