### PR TITLE
SmrPlayer: remove hard-coded pod speed

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1116,18 +1116,16 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$newCredits = 100000;
 		$this->setCredits($newCredits);
 
-		// speed for pod
-		$new_speed = 7;
-
-		// adapt turns
-		$this->setTurns(round($this->turns / $old_speed * $new_speed),100);
-
 		$this->setSectorID($this->getHome());
 		$this->increaseDeaths(1);
 		$this->setLandedOnPlanet(false);
 		$this->setDead(true);
 		$this->setNewbieWarning(true);
 		$this->getShip()->getPod($this->getAccount()->isNewbie());
+
+		// Update turns due to ship change
+		$new_speed = $this->getShip()->getSpeed();
+		$this->setTurns(round($this->turns / $old_speed * $new_speed),100);
 	}
 
 	public function getHome() {


### PR DESCRIPTION
When a player is killed, their post-death ship can have a different
speed than their pre-death ship, so turns need to be modified.
Having the speed of the escape pod hard-coded in the conversion
causes two problems:

1. We can't safely change the speed of the escape pod.
2. We can't safely allow a ship other than the escape pod
   to be given upon death.

Querying the post-death ship's speed instead solves these problems.

In particular, this fixes a bug where newbie players lose extra turns
when they die, because the Newbie Merchant Vessel (the ship newbies
receive post-death instead of the Escape Pod) is speed 9 and the
Escape Pod is speed 7.