### PR TITLE
jquery.hotkeys.js: add tel to text input types

### DIFF
--- a/htdocs/js/jquery.hotkeys.js
+++ b/htdocs/js/jquery.hotkeys.js
@@ -40,7 +40,7 @@
 		
 		var origHandler = handleObj.handler,
 			keys = handleObj.data.toLowerCase().split(" "),
-			textAcceptingInputTypes = ["text", "password", "number", "email", "url", "range", "date", "month", "week", "time", "datetime", "datetime-local", "search", "color"];
+			textAcceptingInputTypes = ["text", "password", "number", "email", "url", "range", "date", "month", "week", "time", "datetime", "datetime-local", "search", "color", "tel"];
 	
 		handleObj.handler = function( event ) {
 			// Don't fire in text-accepting inputs that we didn't directly bind to


### PR DESCRIPTION
The list of text-accepting input types specifies which input types
should disable hotkeys when they are selected. The "tel" type
(for phone numbers) was missing, so we add it here.

This fixes the bug where players could not enter cell phone numbers
in their player preferences.