### PR TITLE
Allow using PHP 7+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN rm -rf node_modules
 
 #---------------------------
 
-FROM php:5.6-apache
+FROM php:7.2-apache
 RUN apt-get update \
 	&& apt-get install -y libcurl4-openssl-dev git sendmail \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-mysqli": "*",
         "facebook/graph-sdk": "^5.5.0",
         "google/recaptcha": "~1.1",
-        "php": "^5.4.0",
+        "php": "5.4.0 - 7.2",
         "phpmailer/phpmailer": "~6.0"
     }
 }

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -1,6 +1,9 @@
 <?php
 @date_default_timezone_set(@date_default_timezone_get());
 
+define('MICRO_TIME', microtime());
+define('TIME', (int)microtimeSec(MICRO_TIME));
+
 // Repository paths
 define('ROOT', __DIR__ . '/../');
 define('LIB', ROOT.'lib/');

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -177,9 +177,6 @@ class SmrSession {
 			}
 		}
 
-		define('MICRO_TIME', microtime());
-		define('TIME', (int)microtimeSec(MICRO_TIME));
-
 		if(class_exists('SmrMySqlDatabase',false))
 			$db = new SmrMySqlDatabase();
 	}

--- a/tools/discord/Dockerfile
+++ b/tools/discord/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-cli
+FROM php:7.2-cli
 RUN apt-get update \
 	&& apt-get install -y git \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/tools/discord/composer.json
+++ b/tools/discord/composer.json
@@ -4,8 +4,7 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "php": "5.6.0 - 7.2",
-        "illuminate/support": "5.4.36",
+        "php": "~7.2",
         "team-reflex/discord-php": "*"
     }
 }

--- a/tools/discord/composer.json
+++ b/tools/discord/composer.json
@@ -4,7 +4,7 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "php": "^5.6.0",
+        "php": "5.6.0 - 7.2",
         "illuminate/support": "5.4.36",
         "team-reflex/discord-php": "*"
     }

--- a/tools/irc/Dockerfile
+++ b/tools/irc/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-cli
+FROM php:7.2-cli
 RUN apt-get update \
 	&& apt-get install -y git \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/tools/irc/composer.json
+++ b/tools/irc/composer.json
@@ -4,6 +4,6 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "php": "^5.6.0"
+        "php": "~7.2"
     }
 }

--- a/tools/npc/Dockerfile
+++ b/tools/npc/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-cli
+FROM php:7.2-cli
 RUN apt-get update \
 	&& apt-get install -y git \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -7,10 +7,9 @@ RUN apt-get update \
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-# runkit is needed to use NPC's
-RUN pear channel-discover zenovich.github.io/pear \
-	&& pecl install zenovich/runkit-1.0.4 \
-	&& docker-php-ext-enable runkit
+# Install an extension for redefining constants
+RUN pecl install uopz-5.0.2 \
+	&& docker-php-ext-enable uopz
 
 # Install SMR-related dependencies
 WORKDIR /smr

--- a/tools/npc/composer.json
+++ b/tools/npc/composer.json
@@ -4,6 +4,6 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "php": "^5.6.0"
+        "php": "~7.2"
     }
 }

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -3,6 +3,9 @@
 // Use this exception to help override container forwarding for NPC's
 class ForwardException extends Exception {}
 
+// UOPZ overrides exit by default, which we don't want
+uopz_allow_exit(true);
+
 try {
 	echo '<pre>';
 	// global config
@@ -370,8 +373,8 @@ function processContainer($container) {
 	$previousContainer = $container;
 	debug('Executing container',$container);
  	//Redefine MICRO_TIME and TIME, the rest of the game expects them to be the single point in time that the script is executing, with it being redefined for each page load - unfortunately NPCs are one consistent script so we have to do a hack and redefine it (or change every instance of the TIME constant.
- 	runkit_constant_redefine('MICRO_TIME', microtime());
-	runkit_constant_redefine('TIME', (int)microtimeSec(MICRO_TIME));
+	uopz_redefine('MICRO_TIME', microtime());
+	uopz_redefine('TIME', (int)microtimeSec(MICRO_TIME));
 	resetContainer($container);
 	do_voodoo();
 }


### PR DESCRIPTION
Add PHP versions up to 7.2.X in the composer.json file and switch
to the latest PHP 7.2 version in Dockerfile.

Going through the list of backwards incompatible changes from 5.6
to 7.2, I don't see anything that affects the SMR codebase.

NOTE: As of PHP 7.1, the `rand()` and `array_rand()` functions use
a better random number generator, and should be considered usable.