### PR TITLE
Begin the crusade against references

### DIFF
--- a/lib/Default/SmrForce.class.inc
+++ b/lib/Default/SmrForce.class.inc
@@ -42,9 +42,9 @@ class SmrForce {
 	}
 
 	public static function saveForces() {
-		foreach(self::$CACHE_FORCES as &$gameForces) {
-			foreach($gameForces as &$gameSectorForces) {
-				foreach($gameSectorForces as &$forces) {
+		foreach(self::$CACHE_FORCES as $gameForces) {
+			foreach($gameForces as $gameSectorForces) {
+				foreach($gameSectorForces as $forces) {
 					$forces->update();
 				}
 			}
@@ -59,21 +59,21 @@ class SmrForce {
 			$forces = array();
 			while($db->nextRecord()) {
 				$ownerID = $db->getInt('owner_id');
-				$forces[$ownerID] =& self::getForce($db->getRow(), $sectorID, $ownerID, $forceUpdate);
+				$forces[$ownerID] = self::getForce($db->getRow(), $sectorID, $ownerID, $forceUpdate);
 			}
-			self::$CACHE_SECTOR_FORCES[$gameID][$sectorID] =& $forces;
+			self::$CACHE_SECTOR_FORCES[$gameID][$sectorID] = $forces;
 		}
 		return self::$CACHE_SECTOR_FORCES[$gameID][$sectorID];
 	}
 
-	public static function &getForce(&$gameIDOrResultArray, $sectorID, $ownerID, $forceUpdate = false) {
+	public static function &getForce($gameIDOrResultArray, $sectorID, $ownerID, $forceUpdate = false) {
 		$gameID = is_array($gameIDOrResultArray) ?
 		          $gameIDOrResultArray['game_id'] :
 		          $gameIDOrResultArray;
 		if($forceUpdate || !isset(self::$CACHE_FORCES[$gameID][$sectorID][$ownerID])) {
 			self::tidyUpForces(SmrGalaxy::getGalaxyContaining($gameID,$sectorID));
 			$p = new SmrForce($gameIDOrResultArray, $sectorID, $ownerID);
-			self::$CACHE_FORCES[$gameID][$sectorID][$ownerID] =& $p;
+			self::$CACHE_FORCES[$gameID][$sectorID][$ownerID] = $p;
 		}
 		return self::$CACHE_FORCES[$gameID][$sectorID][$ownerID];
 	}
@@ -93,10 +93,10 @@ class SmrForce {
 		}
 	}
 
-	protected function __construct(&$gameIDOrResultArray, $sectorID, $ownerID) {
+	protected function __construct($gameIDOrResultArray, $sectorID, $ownerID) {
 		$this->db = new SmrMySqlDatabase();
 		if (is_array($gameIDOrResultArray)) {
-			$result =& $gameIDOrResultArray;
+			$result = $gameIDOrResultArray;
 			$this->gameID = $result['game_id'];
 		} else {
 			$this->db->query('SELECT * FROM sector_has_forces
@@ -355,7 +355,7 @@ class SmrForce {
 		if(!$this->hasSDs() && !$skipCheck) {
 			return;
 		}
-		$owner =& $this->getOwner();
+		$owner = $this->getOwner();
 		if(!$playerPinging->sameAlliance($owner)) {
 			$playerPinging->sendMessage($owner->getAccountID(), MSG_SCOUT, $pingMessage,false);
 		}

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -65,8 +65,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public static function savePlayers() {
-		foreach(self::$CACHE_PLAYERS as &$gamePlayers) {
-			foreach($gamePlayers as &$player) {
+		foreach(self::$CACHE_PLAYERS as $gamePlayers) {
+			foreach($gamePlayers as $player) {
 				$player->save();
 			}
 		}
@@ -74,7 +74,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	public static function &getSectorPlayersByAlliances($gameID,$sectorID, array $allianceIDs, $forceUpdate = false) {
 		$players = self::getSectorPlayers($gameID,$sectorID,$forceUpdate); // Don't use & as we do an unset
-		foreach($players as $accountID => &$player) {
+		foreach($players as $accountID => $player) {
 			if(!in_array($player->getAllianceID(),$allianceIDs))
 				unset($players[$accountID]);
 		}
@@ -88,9 +88,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$players = array();
 			while($db->nextRecord()) {
 				$accountID = $db->getInt('account_id');
-				$players[$accountID] =& self::getPlayer($db->getRow(), $gameID, $forceUpdate);
+				$players[$accountID] = self::getPlayer($db->getRow(), $gameID, $forceUpdate);
 			}
-			self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] =& $players;
+			self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] = $players;
 		}
 		return self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID];
 	}
@@ -102,9 +102,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$players = array();
 			while($db->nextRecord()) {
 				$accountID = $db->getField('account_id');
-				$players[$accountID] =& self::getPlayer($db->getRow(), $gameID, $forceUpdate);
+				$players[$accountID] = self::getPlayer($db->getRow(), $gameID, $forceUpdate);
 			}
-			self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID] =& $players;
+			self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID] = $players;
 		}
 		return self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID];
 	}
@@ -116,21 +116,20 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$players = array();
 			while($db->nextRecord()) {
 				$accountID = $db->getInt('account_id');
-				$players[$accountID] =& self::getPlayer($db->getRow(), $gameID, $forceUpdate);
+				$players[$accountID] = self::getPlayer($db->getRow(), $gameID, $forceUpdate);
 			}
-			self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID] =& $players;
+			self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID] = $players;
 		}
 		return self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID];
 	}
 
-	public static function &getPlayer(&$accountIDOrResultArray, $gameID, $forceUpdate = false) {
+	public static function &getPlayer($accountIDOrResultArray, $gameID, $forceUpdate = false) {
 		$accountID = is_array($accountIDOrResultArray) ?
 		             $accountIDOrResultArray['account_id'] :
 		             $accountIDOrResultArray;
 		if ($forceUpdate || !isset(self::$CACHE_PLAYERS[$gameID][$accountID])) {
 			$p = new SmrPlayer($gameID,$accountIDOrResultArray);
-			self::$CACHE_PLAYERS[$gameID][$p->getAccountID()] =& $p;
-			return self::$CACHE_PLAYERS[$gameID][$p->getAccountID()];
+			self::$CACHE_PLAYERS[$gameID][$p->getAccountID()] = $p;
 		}
 		return self::$CACHE_PLAYERS[$gameID][$accountID];
 	}
@@ -143,12 +142,12 @@ class SmrPlayer extends AbstractSmrPlayer {
 		throw new PlayerNotFoundException('Player ID not found.');
 	}
 
-	protected function __construct($gameID,&$accountIDOrResultArray) {
+	protected function __construct($gameID, $accountIDOrResultArray) {
 		parent::__construct();
 		$this->db = new SmrMySqlDatabase();
 		$result=false;
 		if (is_array($accountIDOrResultArray))
-			$result =& $accountIDOrResultArray;
+			$result = $accountIDOrResultArray;
 		else {
 			$this->db->query('SELECT * FROM player WHERE account_id = ' . $this->db->escapeNumber($accountIDOrResultArray) . ' AND game_id = ' . $this->db->escapeNumber($gameID) . ' LIMIT 1');
 			$this->db->nextRecord();
@@ -425,12 +424,12 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	public function setSectorID($sectorID) {
 		require_once('SmrPort.class.inc');
-		$port =& SmrPort::getPort($this->getGameID(),$this->getSectorID());
+		$port = SmrPort::getPort($this->getGameID(),$this->getSectorID());
 		$port->addCachePort($this->getAccountID()); //Add port of sector we were just in, to make sure it is left totally up to date.
 
 		parent::setSectorID($sectorID);
 
-		$port =& SmrPort::getPort($this->getGameID(),$sectorID);
+		$port = SmrPort::getPort($this->getGameID(),$sectorID);
 		$port->addCachePort($this->getAccountID()); //Add the port of sector we are now in.
 	}
 
@@ -630,7 +629,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 		// do we have at least one turn to give?
 		if ($extraTurns > 0) {
 			// recalc the time to avoid errors
-			$ship =& $this->getShip();
+			$ship = $this->getShip();
 			$newLastTurnUpdate = $this->getLastTurnUpdate() + ceil($extraTurns * 3600 / $ship->getRealSpeed());
 
 			$startTurnsDate = $this->getGame()->getStartTurnsDate();
@@ -1089,7 +1088,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function killPlayer($sectorID) {
-		$sector =& SmrSector::getSector($this->getGameID(),$sectorID);
+		$sector = SmrSector::getSector($this->getGameID(),$sectorID);
 		//msg taken care of in trader_att_proc.php
 		// forget plotted course
 		$this->deletePlottedCourse();
@@ -1306,7 +1305,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	public function &killPlayerByForces(SmrForce &$forces) {
 		$return = array();
-		$owner =& $forces->getOwner();
+		$owner = $forces->getOwner();
 		// send a message to the person who died
 		self::sendMessageFromFedClerk($this->getGameID(), $owner->getAccountID(), 'Your forces <span class="red">DESTROYED </span>'.$this->getBBLink().' in sector '.Globals::getSectorBBLink($forces->getSectorID()));
 		self::sendMessageFromFedClerk($this->getGameID(), $this->getAccountID(), 'You were <span class="red">DESTROYED</span> by '.$owner->getBBLink().'\'s forces in sector '.Globals::getSectorBBLink($this->getSectorID()));
@@ -1386,7 +1385,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 	public function &killPlayerByPlanet(SmrPlanet &$planet) {
 		$return = array();
 		// send a message to the person who died
-		$planetOwner =& $planet->getOwner();
+		$planetOwner = $planet->getOwner();
 		self::sendMessageFromFedClerk($this->getGameID(), $planetOwner->getAccountID(), 'Your planet <span class="red">DESTROYED</span>&nbsp;'.$this->getBBLink().' in sector '.Globals::getSectorBBLink($planet->getSectorID()));
 		self::sendMessageFromFedClerk($this->getGameID(), $this->getAccountID(), 'You were <span class="red">DESTROYED</span> by the planetary defenses of '.$planet->getDisplayName());
 
@@ -1596,7 +1595,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function isPresident() {
-		$president =& Council::getPresident($this->getGameID(),$this->getRaceID());
+		$president = Council::getPresident($this->getGameID(),$this->getRaceID());
 		return is_object($president)&&$this->equals($president);
 	}
 
@@ -1681,9 +1680,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 		switch ($messageTypeID) {
 			case MSG_PLAYER:
-				$receiverAccount =& SmrAccount::getAccount($receiverID);
+				$receiverAccount = SmrAccount::getAccount($receiverID);
 				if($receiverAccount->isValidated() && $receiverAccount->isReceivingMessageNotifications($messageTypeID) && !$receiverAccount->isLoggedIn()) {
-					$senderPlayer =& SmrPlayer::getPlayer($senderID, $gameID);
+					$senderPlayer = SmrPlayer::getPlayer($senderID, $gameID);
 					$mail = new \PHPMailer\PHPMailer\PHPMailer();
 					$mail->Subject = 'Message Notification';
 					$mail->setFrom('notifications@smrealms.de', 'SMR Notifications');

--- a/templates/Default/engine/Default/includes/Missions.inc
+++ b/templates/Default/engine/Default/includes/Missions.inc
@@ -4,9 +4,9 @@ if(isset($MissionMessage)) { ?>
 	echo $MissionMessage;
 }
 
-$AvailableMissions =& $ThisPlayer->getAvailableMissions();
+$AvailableMissions = $ThisPlayer->getAvailableMissions();
 if(count($AvailableMissions) > 0) {
-	foreach($AvailableMissions as $MissionID => &$AvailableMission) { ?>
+	foreach($AvailableMissions as $MissionID => $AvailableMission) { ?>
 		<span class="green">New Mission: </span><?php
 		echo bbifyMessage($AvailableMission['Steps'][0]['Text']); ?><br/><br/>
 		<div class="buttonA"><a href="<?php echo Globals::getAcceptMissionHREF($MissionID); ?>" class="buttonA">&nbsp;Accept&nbsp;</a></div><br/><?php
@@ -14,9 +14,9 @@ if(count($AvailableMissions) > 0) {
 }
 
 
-$Missions =& $ThisPlayer->getActiveMissions();
+$Missions = $ThisPlayer->getActiveMissions();
 if(count($Missions) > 0) {
-	foreach($Missions as $MissionID => &$Mission) {
+	foreach($Missions as $MissionID => $Mission) {
 		if(in_array($MissionID, $UnreadMissions)) { ?>
 			<span class="green">Task Complete: </span><?php
 			echo bbifyMessage($Mission['Task']['Text']); ?><br/><?php


### PR DESCRIPTION
See #317.

In strict PHP, you can only assign variables by reference. Things
that are not variables include function calls and constants.

So we begin the herculean task of removing all unneeded references.
Here are some important details about references:

* Objects are always passed/copied by reference (in the c++ sense).
  We can pass an object without the `&` and still access/modify
  its internal data.

* Arrays are passed/copied by value, but not really because of
  copy-on-write, which means that it will only make a copy of
  the array if you try to modify it.

* References disable copy-on-write. If you have an array that was
  copied by value, and then you take a reference to it, you will
  immediately make a copy of it, even if the reference doesn't
  modify that array.

### Moral of the story

Do not use references in an attempt to improve performance. PHP
does all the right performance things behind the scenes _if_
you are using the language in the intended way.

References are only intended for when you truly want to pass
something to another function and have that function modify it.

For more details, see
http://schlueters.de/blog/archives/125-Do-not-use-PHP-references.html