### PR TITLE
SmrShip: initialize weapons as array

### DIFF
--- a/lib/Default/AbstractSmrShip.class.inc
+++ b/lib/Default/AbstractSmrShip.class.inc
@@ -16,7 +16,7 @@ abstract class AbstractSmrShip {
 
 	protected $cargo;
 
-	protected $weapons;
+	protected $weapons = array();
 
 	protected $illusionShip;
 


### PR DESCRIPTION
PHP can't correctly identify that `$this->weapons` is an array
when it isn't initialized, which causes `SmrShip::getNumWeapons`
to emit a warning in PHP 7+ that the argument to `count` must be
Countable.