### PR TITLE
Minor planet attack changes

### DIFF
--- a/engine/Default/planet_attack_processing.php
+++ b/engine/Default/planet_attack_processing.php
@@ -79,10 +79,9 @@ $logId = $db->getInsertID();
 // Send notification to planet owners
 $planetAttackMessage = 'Reports from the surface of '.$planet->getDisplayName().' confirm that it is under <span class="red">attack</span>! [combatlog='.$logId.']';
 if($planetOwner->hasAlliance()) {
-	$db->query('SELECT account_id FROM player WHERE game_id=' . $planetOwner->getGameID() .
-			' AND alliance_id=' . $planetOwner->getAllianceID()); //No limit in case they are over limit - ie NHA
-	while ($db->nextRecord())
-		SmrPlayer::sendMessageFromPlanet($planet->getGameID(),$db->getField('account_id'),$planetAttackMessage);
+	foreach ($planetOwner->getAlliance()->getMemberIDs() as $allyAccountID) {
+		SmrPlayer::sendMessageFromPlanet($planet->getGameID(), $allyAccountID, $planetAttackMessage);
+	}
 }
 else
 	SmrPlayer::sendMessageFromPlanet($planet->getGameID(),$planetOwner->getAccountID(),$planetAttackMessage);

--- a/engine/Default/planet_attack_processing.php
+++ b/engine/Default/planet_attack_processing.php
@@ -25,15 +25,6 @@ if($player->forceNAPAlliance($planetOwner)) {
 	create_error('You have a planet NAP, you cannot attack this planet!');
 }
 
-if ($planet->isDestroyed()) {
-	$db->query('UPDATE player SET land_on_planet = \'FALSE\' WHERE sector_id = '.$db->escapeNumber($planet->getSectorID()).' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$planet->removeClaimed();
-	$planet->removePassword();
-	$container=create_container('skeleton.php','planet_attack.php');
-	$container['sector_id'] = $planet->getSectorID();
-	forward($container);
-}
-
 // take the turns
 $player->takeTurns(3,0);
 
@@ -76,15 +67,25 @@ $db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->g
 unserialize($serializedResults); //because of references we have to undo this.
 $logId = $db->getInsertID();
 
+if ($planet->isDestroyed()) {
+	$db->query('UPDATE player SET land_on_planet = \'FALSE\' WHERE sector_id = '.$db->escapeNumber($planet->getSectorID()).' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$planet->removeClaimed();
+	$planet->removePassword();
+
+	// Prepare message for planet owners
+	$planetAttackMessage = 'The defenses of '.$planet->getDisplayName().' have been breached. The planet is lost! [combatlog='.$logId.']';
+} else {
+	$planetAttackMessage = 'Reports from the surface of '.$planet->getDisplayName().' confirm that it is under <span class="red">attack</span>! [combatlog='.$logId.']';
+}
+
 // Send notification to planet owners
-$planetAttackMessage = 'Reports from the surface of '.$planet->getDisplayName().' confirm that it is under <span class="red">attack</span>! [combatlog='.$logId.']';
 if($planetOwner->hasAlliance()) {
 	foreach ($planetOwner->getAlliance()->getMemberIDs() as $allyAccountID) {
 		SmrPlayer::sendMessageFromPlanet($planet->getGameID(), $allyAccountID, $planetAttackMessage);
 	}
-}
-else
+} else {
 	SmrPlayer::sendMessageFromPlanet($planet->getGameID(),$planetOwner->getAccountID(),$planetAttackMessage);
+}
 
 // Update sector messages for attackers
 foreach($attackers as &$attacker) {
@@ -92,9 +93,7 @@ foreach($attackers as &$attacker) {
 		$db->query('REPLACE INTO sector_message VALUES(' . $attacker->getAccountID() . ',' . $attacker->getGameID() . ',' . $db->escapeString('[ATTACK_RESULTS]'.$logId) . ')');
 } unset($attacker);
 
-$container = array();
-$container['url'] = 'skeleton.php';
-$container['body'] = 'planet_attack.php';
+$container = create_container('skeleton.php', 'planet_attack.php');
 $container['sector_id'] = $planet->getSectorID();
 
 // If they died on the shot they get to see the results

--- a/templates/Default/engine/Default/planet_attack.php
+++ b/templates/Default/engine/Default/planet_attack.php
@@ -13,10 +13,10 @@ else {
 		?><span class="red">You have been destroyed.</span><?php
 	}
 	else {
-		?><span class="yellow">You have destroyed the planet.</span><?php
+		?><span class="yellow">You have breached the planetary defenses.</span><?php
 	} ?>
-		<br />
-		<div class="buttonA"><?php
+	<br /><br />
+	<div class="buttonA"><?php
 		if($OverrideDeath) {
 			?><a href="<?php echo Globals::getPodScreenHREF() ?>" class="buttonA">Let there be pod</a><?php
 		}
@@ -24,6 +24,6 @@ else {
 			<a href="<?php echo Globals::getCurrentSectorHREF() ?>" class="buttonA">Current Sector</a>&nbsp;
 			<a href="<?php echo $Planet->getLandHREF(); ?>" class="buttonA">Land on Planet (1)</a><?php
 		} ?>
-		</div><?php
-	} ?>
+	</div><?php
+} ?>
 </div>

--- a/templates/Default/engine/Default/port_attack.php
+++ b/templates/Default/engine/Default/port_attack.php
@@ -13,8 +13,9 @@
 			?><span class="red">You have been destroyed.</span><?php
 		}
 		else { ?>
-			<span class="yellow">You have destroyed the port.</span><?php
-		} ?><br />
+			<span class="yellow">You have breached the port defenses.</span><?php
+		} ?>
+		<br /><br />
 		<div class="buttonA"><?php
 			if($OverrideDeath) { ?>
 				<a href="<?php echo Globals::getPodScreenHREF() ?>" class="buttonA">Let there be pod</a><?php


### PR DESCRIPTION
Gameplay changes:
- Busting a planet with no defenses now costs the normal planet attack turns and sends a message to the owner's alliance (previously it did not cost turns and sent no message).

Cosmetic changes:
- When a planet is busted, the final message to the owner's alliance indicates that the defenses have been breached.
- Minor spacing adjustments and wording changes to the final port/planet attack pages.