### PR TITLE
forces_drop_processing.php: don't remove under attack

### DIFF
--- a/engine/Default/forces_drop_processing.php
+++ b/engine/Default/forces_drop_processing.php
@@ -207,7 +207,6 @@ $account->log(LOG_TYPE_FORCES, $change_combat_drones.' combat drones, '.$change_
 
 $forces->updateExpire();
 $forces->update(); // Needs to be in db to show up on CS instantly when querying sector forces
-$ship->removeUnderAttack();
 
 forward(create_container('skeleton.php', 'current_sector.php'));
 


### PR DESCRIPTION
I don't see any reason why the "Under Attack" warning should be
removed when you are dropping forces. In fact, the warning can be
missed altogether if you are attacked and then drop a force between
the next AJAX update (or page refresh, if AJAX is disabled).