### PR TITLE
Globals::getLevelRequirements: omit redundant field

### DIFF
--- a/lib/Default/Globals.class.inc
+++ b/lib/Default/Globals.class.inc
@@ -113,7 +113,6 @@ class Globals {
 			self::$db->query('SELECT * FROM level ORDER BY level_id ASC');
 			while (self::$db->nextRecord()) {
 				self::$LEVEL_REQUIREMENTS[self::$db->getInt('level_id')] = array(
-																				'ID' => self::$db->getInt('level_id'),
 																				'Name' => self::$db->getField('level_name'),
 																				'Requirement' => self::$db->getInt('requirement')
 																				);

--- a/templates/Default/engine/Default/edit_dummys.php
+++ b/templates/Default/engine/Default/edit_dummys.php
@@ -18,8 +18,8 @@
 				<input type="text" name="dummy_name" value="<?php echo $DummyPlayer->getPlayerName() ?>" />
 				Level
 				<select name="level">
-					<?php foreach($Levels as $Level) {
-						?><option value="<?php echo $Level['Requirement']; ?>"<?php if($Level['ID']==$DummyPlayer->getLevelID()){ ?> selected="selected"<?php } ?>><?php echo $Level['ID']; ?></option><?php
+					<?php foreach($Levels as $LevelID => $Level) {
+						?><option value="<?php echo $Level['Requirement']; ?>"<?php if($LevelID==$DummyPlayer->getLevelID()){ ?> selected="selected"<?php } ?>><?php echo $LevelID; ?></option><?php
 					} ?>
 				</select>
 				Ship:


### PR DESCRIPTION
The 'ID' field is redundant with the array keys, so we omit it.