### PR TITLE
SmrPort: remove unused methods

### DIFF
--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -862,20 +862,6 @@ class SmrPort {
 		return $this->isNew===false||$this->hasChanged===true;
 	}
 	
-	public function addCredits($credits,$portIsSelling=false) {
-		if($portIsSelling===true)
-			$this->addUpgrade($credits);
-		$this->setCredits($this->credits + $credits);
-	}
-	
-	public function addUpgrade($upgrade) {
-		$this->setUpgrade($this->upgrade + $upgrade);
-	}
-	
-	public function addExperience($exp) {
-		$this->setExperience($this->experience + $exp);
-	}
-	
 	public function decreaseShields($number) {
 		$this->setShields($this->getShields() - $number);
 	}


### PR DESCRIPTION
The `increase{Credits,Upgrade,Experience}` are used in favor of
the `add{Credits,Upgrade,Experience}` methods.