### PR TITLE
Do not require login to resend password

### DIFF
--- a/htdocs/resend_password.php
+++ b/htdocs/resend_password.php
@@ -26,15 +26,12 @@
 
 								<h1>FORGOT YOUR PASSWORD?</h1>
 
-								For security reasons, please enter the Username and Email that your account is registered to:
+								Please enter the e-mail address associated with your account:
+								<br /><br />
 
 								<form action="resend_password_processing.php" method="POST">
 									<div align="center">
 										<table border="0">
-											<tr>
-												<th align="right">Username:</th>
-												<td><input type="text" name="login" id="InputFields"></td>
-											</tr>
 											<tr>
 												<th align="right">Email:</th>
 												<td><input type="email" name="email" id="InputFields"></td>

--- a/htdocs/resend_password_processing.php
+++ b/htdocs/resend_password_processing.php
@@ -13,15 +13,12 @@ try {
 
 
 	// get this user from db
-	$login = $_REQUEST['login'];
-	// creates a new user account object
-	$account =& SmrAccount::getAccountByName($login);
 	$email = $_REQUEST['email'];
-	if ($account==null || $account->getEmail() != $email) {
+	$account = SmrAccount::getAccountByEmail($email);
+	if ($account==null) {
 		// unknown user
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode('User does not exist'));
+		header('Location: '.URL.'/error.php?msg=' . rawurlencode('The specified e-mail address is not registered!'));
 		exit;
-
 	}
 
 	$account->generatePasswordReset();
@@ -30,7 +27,8 @@ try {
 	// send email with password to user
 	mail($email, 'Space Merchant Realms Password',
 		 'A user from ' . getIpAddress() . ' requested to reset your password!'.EOL.EOL.
-		 '   Your password reset code is: ' . $account->getPasswordReset().EOL.
+		 '   Your game login is: ' . $account->getLogin().EOL.
+		 '   Your password reset code is: ' . $account->getPasswordReset().EOL.EOL.
 		 '   You can use this url: '.$resetURL .EOL.EOL.
 		 'The Space Merchant Realms server is on the web at '.URL.'/',
 		 'From: support@smrealms.de');

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -98,6 +98,16 @@ abstract class AbstractSmrAccount {
 		return $return;
 	}
 
+	public static function getAccountByEmail($email, $forceUpdate=false) {
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT account_id FROM account WHERE email = '.$db->escapeString($email).' LIMIT 1');
+		if ($db->nextRecord()) {
+			return self::getAccount($db->getInt('account_id'), $forceUpdate);
+		} else {
+			return null;
+		}
+	}
+
 	public static function &getAccountByHofName($hofName,$forceUpdate = false) {
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT account_id FROM account WHERE hof_name = '.$db->escapeString($hofName).' LIMIT 1');


### PR DESCRIPTION
Players might be discouraged from returning if they cannot remember
their password _or_ login name. To mitigate this concern, we allow
users to request a password reset using e-mail address only.

This change does not make password resets less secure, because you
must own the e-mail address to reset the password, and e-mails are
unique for each account.

It does mean that it is easier to spam someone with unwanted
password reset requests (all you need to know is their e-mail), but
if you want to grief someone, I can think of better ways to do it
than through SMR. Also, since we log the ip address we can take
action against the perpetrator.