### PR TITLE
SmrSession: allow active session for each game

### DIFF
--- a/engine/Default/game_play_processing.php
+++ b/engine/Default/game_play_processing.php
@@ -1,7 +1,7 @@
 <?php
 
 // register game_id
-SmrSession::$game_id = $var['game_id'];
+SmrSession::updateGame($var['game_id']);
 
 $player =& SmrPlayer::getPlayer(SmrSession::$account_id, $var['game_id']);
 $player->updateLastCPLAction();

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -245,12 +245,25 @@ class SmrSession {
 					' WHERE session_id=' . self::$db->escapeString(self::$session_id) . (USING_AJAX ? ' AND last_sn='.self::$db->escapeString(self::$lastSN) : '') . ' LIMIT 1');
 		}
 		else {
-			self::$db->query('DELETE FROM active_session WHERE account_id = ' . self::$db->escapeNumber(self::$account_id));
+			self::$db->query('DELETE FROM active_session WHERE account_id = ' . self::$db->escapeNumber(self::$account_id) . ' AND game_id = ' . self::$db->escapeNumber(self::$game_id));
 			self::$db->query('INSERT INTO active_session (session_id, account_id, old_account_id, game_id, last_accessed, session_var) VALUES(' . self::$db->escapeString(self::$session_id) . ',' . self::$db->escapeNumber(self::$account_id) . ',' . self::$db->escapeNumber(is_numeric(self::$old_account_id)?self::$old_account_id:0) . ',' . self::$db->escapeNumber(self::$game_id) . ',' . self::$db->escapeNumber(TIME) . ',' . self::$db->escapeBinary($compressed) . ')');
 			self::$generate = false;
 		}
 		// This takes us back to the standard database if we had to change it.
 		$db = new SmrMySqlDatabase();
+	}
+
+	/**
+	 * Updates the `game_id` attribute of the session and deletes any other
+	 * active sessions in this game for this account.
+	 */
+	public static function updateGame($gameID) {
+		if (self::$game_id == $gameID) {
+			return;
+		}
+		self::$game_id = $gameID;
+		self::$db->query('DELETE FROM active_session WHERE account_id = ' . self::$db->escapeNumber(self::$account_id) . ' AND game_id = ' . self::$game_id);
+		self::$db->query('UPDATE active_session SET game_id=' . self::$db->escapeNumber(self::$game_id) . ' WHERE session_id=' . self::$db->escapeString(self::$session_id));
 	}
 
 	public static function updateSN() {

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -245,7 +245,7 @@ class SmrSession {
 					' WHERE session_id=' . self::$db->escapeString(self::$session_id) . (USING_AJAX ? ' AND last_sn='.self::$db->escapeString(self::$lastSN) : '') . ' LIMIT 1');
 		}
 		else {
-			self::$db->query('DELETE FROM active_session WHERE account_id = ' . self::$db->escapeNumber(self::$account_id) . ' LIMIT 1');
+			self::$db->query('DELETE FROM active_session WHERE account_id = ' . self::$db->escapeNumber(self::$account_id));
 			self::$db->query('INSERT INTO active_session (session_id, account_id, old_account_id, game_id, last_accessed, session_var) VALUES(' . self::$db->escapeString(self::$session_id) . ',' . self::$db->escapeNumber(self::$account_id) . ',' . self::$db->escapeNumber(is_numeric(self::$old_account_id)?self::$old_account_id:0) . ',' . self::$db->escapeNumber(self::$game_id) . ',' . self::$db->escapeNumber(TIME) . ',' . self::$db->escapeBinary($compressed) . ')');
 			self::$generate = false;
 		}

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -525,14 +525,12 @@ function do_voodoo() {
 			$account->log(LOG_TYPE_GAME_ENTERING, 'Player left game '.SmrSession::$game_id);
 
 		// reset game id
-		SmrSession::$game_id = 0;
-		SmrSession::update();
+		SmrSession::updateGame(0);
 
 		forward(create_container('skeleton.php', 'game_play.php', $var));
 	}
 	else if($var['url'] == 'logoff_preprocessing.php') {
-		SmrSession::$game_id = 0;
-		SmrSession::update();
+		SmrSession::updateGame(0);
 
 		// log?
 		$account->log(LOG_TYPE_LOGIN, 'logged off from '.getIpAddress());

--- a/lib/Login/loginSmarty.php
+++ b/lib/Login/loginSmarty.php
@@ -10,8 +10,8 @@ while ($db->nextRecord()) {
 if(count($loginNews)>0)
 	$template->assign('LoginNews',$loginNews);
 
-
-$db->query('SELECT count(*) AS active_sessions FROM active_session WHERE account_id!=0 AND last_accessed > '.$db->escapeNumber(TIME - SmrSession::TIME_BEFORE_EXPIRY));
+// Users can have a session for each open game, so only count unique accounts
+$db->query('SELECT count(DISTINCT account_id) AS active_sessions FROM active_session WHERE account_id!=0 AND last_accessed > '.$db->escapeNumber(TIME - SmrSession::TIME_BEFORE_EXPIRY));
 $db->nextRecord();
 $template->assign('ActiveSessions',$db->getField('active_sessions'));
 


### PR DESCRIPTION
Add a new method `SmrSession::updateGame`, which changes the
`game_id`, but also ensures that active sessions are unique for
each (account_id, game_id) pair.

This allows players to have multiple games open for the same
account (though in different browsers, due to the nature of the
browser cookies).

This is also an important step towards integrating multis into
the same account as the main.

-------------------

**Prerequisite commit**
SmrSession: remove LIMIT 1 from deletion

One possible solution to (or mitigation of) the infrequent mysql error:

```
Duplicate entry '<hash>' for key 'PRIMARY'
```

is to remove the `LIMIT 1` qualifier from the deletion that directly
precedes the INSERT that is causing this error.

The reason this may help is because certain incompletely understood
race conditions might result in an account having two active sessions.
Then when this deletion comes along, it removes one but not both of
these sessions. It is unclear why the primary keys would be identical.

The `active_session` table is small (due to pruning inactive sessions),
so having to process the entire table when creating a new session is
not going to impact performance at all.
