### PR TITLE
Add a way to close accounts but let users reopen

### DIFF
--- a/admin/Default/account_edit_processing.php
+++ b/admin/Default/account_edit_processing.php
@@ -6,6 +6,7 @@ $curr_account =& SmrAccount::getAccount($account_id);
 // request
 $donation = $_REQUEST['donation'];
 $smr_credit = $_REQUEST['smr_credit'];
+$closeByRequest = $_REQUEST['close_by_request'];
 $reopenType = $_REQUEST['reopen_type'];
 $choise = $_REQUEST['choise'];
 $reason_pre_select = $_REQUEST['reason_pre_select'];
@@ -38,6 +39,26 @@ if(!empty($_REQUEST['grant_credits'])&&is_numeric($_REQUEST['grant_credits'])) {
 		$msg .= 'and ';
 	$msg .= 'added ' . $_REQUEST['grant_credits'] . ' reward credits';
 }
+
+if ($closeByRequest) {
+	// Make sure the special closing reason exists
+	$db->query('SELECT reason_id FROM closing_reason WHERE reason='.$db->escapeString(CLOSE_ACCOUNT_BY_REQUEST_REASON));
+	if ($db->nextRecord()) {
+		$reasonID = $db->getInt('reason_id');
+	} else {
+		$db->query('INSERT INTO closing_reason (reason) VALUES(' . $db->escapeString(CLOSE_ACCOUNT_BY_REQUEST_REASON).')');
+		$reasonID = $db->getInsertID();
+	}
+
+	$closeByRequestNote = $_REQUEST['close_by_request_note'];
+	if (empty($closeByRequestNote)) {
+		$closeByRequestNote = CLOSE_ACCOUNT_BY_REQUEST_REASON;
+	}
+
+	$curr_account->banAccount(0, $account, $reasonID, $closeByRequestNote);
+	$msg .= 'added ' . CLOSE_ACCOUNT_BY_REQUEST_REASON . ' ban ';
+}
+
 if ($choise == 'reopen') {
 	if($reopenType=='account') {
 		//do we have points

--- a/engine/Default/reopen_account.php
+++ b/engine/Default/reopen_account.php
@@ -1,0 +1,23 @@
+<?php
+
+$template->assign('PageTopic','Re-Open Account?');
+
+// This page should only be accessed by players whose accounts
+// have been closed at their own request.
+$disabled = $account->isDisabled();
+
+if ($disabled === false) {
+	create_error('Your account is not disabled!');
+}
+if ($disabled['Reason'] != CLOSE_ACCOUNT_BY_REQUEST_REASON) {
+	create_error('You are not allowed to re-open your account!');
+}
+
+// It doesn't really matter what page we link to -- the closing
+// conditional will be triggered in the loader since the account
+// is still banned, so we do the unbanning there.
+$container = create_container('skeleton.php', 'game_play.php');
+$container['do_reopen_account'] = true;
+$template->assign('ReopenLink', SmrSession::getNewHREF($container));
+
+?>

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -348,6 +348,8 @@ define('NUM_RACES', 8);
 
 define('TIME_BEFORE_INACTIVE', 259200); // 3 days.
 
+define('CLOSE_ACCOUNT_BY_REQUEST_REASON', 'User Request');
+
 define('ACCURACY_STAT_FACTOR', 0.04);
 define('INCREASED_ACC_GADGET_FACTOR', 0.15);
 define('INCREASED_MAN_GADGET_FACTOR', 0.15);

--- a/htdocs/loader.php
+++ b/htdocs/loader.php
@@ -41,6 +41,7 @@ try {
 	// overwrite database class to use our db
 	require_once(LIB . 'Default/SmrMySqlDatabase.class.inc');
 	require_once(LIB . 'Default/Globals.class.inc');
+	require_once(get_file_loc('smr.inc'));
 
 	
 	// new db object
@@ -105,13 +106,21 @@ try {
 			header('Location: '.URL.'/email.php');
 			exit;
 		}
+		else if ($disabled['Reason'] == CLOSE_ACCOUNT_BY_REQUEST_REASON) {
+			if (isset($var['do_reopen_account'])) {
+				// The user has requested to reopen their account
+				$account->unbanAccount($account);
+			} else {
+				$container = create_container('skeleton.php', 'reopen_account.php');
+				forward($container);
+			}
+		}
 		else {
 			header('Location: '.URL.'/disabled.php');
 			exit;
 		}
 	}
 	
-	require_once(get_file_loc('smr.inc'));
 	do_voodoo();
 }
 catch(Exception $e) {

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -143,7 +143,7 @@ try {
 			header('Location: '.URL.'/email.php');
 			exit;
 		}
-		else {
+		else if ($disabled['Reason'] != CLOSE_ACCOUNT_BY_REQUEST_REASON) {
 			header('Location: '.URL.'/disabled.php');
 			exit;
 		}

--- a/templates/Default/admin/Default/account_edit.php
+++ b/templates/Default/admin/Default/account_edit.php
@@ -130,6 +130,22 @@
 					<td><hr noshade style="height:1px; border:1px solid white;"></td>
 				</tr>
 
+				<tr>
+					<td align="right" valign="top" class="bold">Close by User Request:</td>
+					<td>
+						Users will be able to re-open their account by themselves if this
+						account<br />closing method is used. It is useful if, e.g., they do not
+						want to receive<br />any more newsletters.<br />
+						<p><input type="checkbox" name="close_by_request" />Close account</p>
+						<p>Note (optional): <input type="text" name="close_by_request_note" id="InputFields" /></p>
+					</td>
+				</tr>
+
+				<tr>
+					<td>&nbsp;</td>
+					<td><hr noshade style="height:1px; border:1px solid white;"></td>
+				</tr>
+
 				<script type="text/javascript">
 					function go() {
 						var val = window.document.form_acc.reason_pre_select.value;

--- a/templates/Default/engine/Default/reopen_account.php
+++ b/templates/Default/engine/Default/reopen_account.php
@@ -1,0 +1,8 @@
+Welcome back to <b>Space Merchant Realms</b>!
+
+<p>Your account was closed at your own request.
+To re-open it, simply click the button below.</p>
+
+<div class="buttonA">
+	<a class="buttonA" href="<?php echo $ReopenLink; ?>">&nbsp;Yes, re-open it!&nbsp;</a>
+</div>


### PR DESCRIPTION
Sometimes users will request that their account be closed (usually
to not receive newsletters anymore). However, it would be nice to
allow these players to reopen their accounts on their own should
they choose to return (since the energy barrier for getting an admin
to reopen is probably too high).

We add a new option to `account_edit.php` that allows admins to
close accounts with the "User Request" reason. This is a special
reason that will trigger the `reopen_account.php` page upon login,
where they can simply press a button to re-open their account.