### PR TITLE
council.inc: simplify council query

### DIFF
--- a/lib/Default/council.inc
+++ b/lib/Default/council.inc
@@ -27,11 +27,9 @@ class Council {
 			$i=1;
 			self::$db->query('SELECT account_id, alignment
 								FROM player
-								JOIN account USING(account_id)
-								LEFT JOIN npc_logins ON account.login = npc_logins.login
 								WHERE game_id = ' . self::$db->escapeNumber($gameID) . '
 									AND race_id = ' . self::$db->escapeNumber($raceID) . '
-									AND npc_logins.player_name IS NULL
+									AND npc = \'FALSE\'
 								ORDER by experience DESC
 								LIMIT ' . MAX_COUNCIL_MEMBERS);
 			while(self::$db->nextRecord()) {


### PR DESCRIPTION
The `account` and `npc_login` tables were joined in the query
simply to determine if a player was an NPC. With the addition
of the `player.npc` field, we can omit them from the query.