### PR TITLE
login_check_processing.php: simplify checks

### DIFF
--- a/engine/Default/login_check_processing.php
+++ b/engine/Default/login_check_processing.php
@@ -8,10 +8,12 @@ if(!isset($var['CheckType']) || $var['CheckType'] == 'Validate') {
 		$var['CheckType'] = 'Announcements';
 	}
 }
+
+$lastLogin = $account->getLastLogin();
+
 $db = new SmrMySqlDatabase();
 if($var['CheckType'] == 'Announcements') {
-	$db->query('SELECT 1 FROM account JOIN announcement ON last_login < time
-				WHERE account_id = ' . $db->escapeNumber(SmrSession::$account_id) . ' LIMIT 1');
+	$db->query('SELECT 1 FROM announcement WHERE time >= '.$db->escapeNumber($lastLogin).' LIMIT 1');
 	// do we have announcements?
 	if ($db->nextRecord()) {
 		forward(create_container('skeleton.php', 'announcements.php'));
@@ -22,11 +24,10 @@ if($var['CheckType'] == 'Announcements') {
 }
 
 if($var['CheckType'] == 'Updates') {
-	$db->query('SELECT last_login FROM account JOIN version ON last_login < went_live
-				WHERE account_id = ' . $db->escapeNumber(SmrSession::$account_id) . ' LIMIT 1');
+	$db->query('SELECT 1 FROM version WHERE went_live >= '.$db->escapeNumber($lastLogin).' LIMIT 1');
 	// do we have updates?
 	if ($db->nextRecord()) {
-		forward(create_container('skeleton.php', 'changelog_view.php', array('Since' => $db->getInt('last_login'))));
+		forward(create_container('skeleton.php', 'changelog_view.php', array('Since' => $lastLogin)));
 	}
 }
 


### PR DESCRIPTION
We can avoid extra database work by using the `last_login`
information that we already loaded into the `SmrAccount`.

This also makes the checks independent of the structure of
the `account` table.