### PR TITLE
announcement_create_processing.php: fix PHP warning

### DIFF
--- a/admin/Default/announcement_create_processing.php
+++ b/admin/Default/announcement_create_processing.php
@@ -6,8 +6,9 @@ if($_REQUEST['action'] == 'Preview announcement') {
 	forward($container);
 }
 
-if (sizeof($message) > 255)
+if (strlen($message) > 255) {
 	create_error('No more than 255 characters per announcement!');
+}
 
 // put the msg into the database
 $db->query('INSERT INTO announcement (time, admin_id, msg) VALUES('.$db->escapeNumber(TIME).', '.$db->escapeNumber(SmrSession::$account_id).', '.$db->escapeString($message).')');


### PR DESCRIPTION
The `sizeof` function (an alias of `count`) only works on objects
implementing `Countable`. Strings do not do that, and should use
`strlen` instead.