### PR TITLE
Fix moving stored destinations

### DIFF
--- a/templates/Default/engine/Default/course_plot.php
+++ b/templates/Default/engine/Default/course_plot.php
@@ -125,7 +125,7 @@ if(isset($XType)) { ?>
 	foreach($StoredDestinations as $SD) { ?>
 		<div class="draggableObject savedDestination"
 			style="top:<?php echo $SD['OffsetTop']; ?>px; left:<?php echo $SD['OffsetLeft']; ?>px"
-			data-sector-id="<?php echo $SD['SectorID']; ?> ">
+			data-sector-id="<?php echo $SD['SectorID']; ?>">
 			<a href="javascript:processCourse(<?php echo $SD['SectorID'];?>)"> <?php echo $SD['Label']; ?></a>
 			<a href="javascript:processRemove(<?php echo $SD['SectorID'];?>)"> <img src="images/silk/cross.png" width="16" height="16" alt="X" title="Delete Saved Sector"/></a>
 		</div><?php


### PR DESCRIPTION
The `sectorId` input element for the form used to move stored
destinations has `type=number`. Somewhere around the transition
to PHP7, it was no longer possible to set the value for this input
from a string with JavaScript. In this case, the `sectorId` input
value would be set to the empty string.

In the JavaScript, the value for `sectorId` is set using the
`data-sector-id` attribute, which is ostensibly an integer. However,
it had an extra space in the value, causing it to be interpreted
as a string. Removing the extra whitespace allowed it to be
interpreted as a number again, thus fixing the bug.

We could also have converted the `data-sector-id` attribute to
a JavaScript `Number`, but that seems to ignore the underlying
problem.