### PR TITLE
docs/Dockerfile: update to PHP 7.2

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1 as builder
+FROM php:7.2-cli as builder
 
 # Install phpDox - https://github.com/theseer/phpdox
 # - dependency: XSL


### PR DESCRIPTION
* PHPDox was fixed to correctly support PHP 7.2 in the v0.11 release.
  See https://github.com/theseer/phpdox/issues/322.

* Clarify that we're using the CLI image variant (note that 7.2 is
  the same as 7.2-cli).

NOTE: We would like to use 7.2-cli-alpine for the builder image,
even though it has no effect on the final image, since it affects
the intermediate images for local building. However, PHPDox has
problems with the alpine image (likely due to the poor support
of `iconv`).