### PR TITLE
Allow header to overlay Galaxy Map

### DIFF
--- a/htdocs/css/shared.css
+++ b/htdocs/css/shared.css
@@ -303,8 +303,19 @@ a.buttonA  {
 	white-space: nowrap;
 }
 
+/* Galaxy Map */
+div.gal_map_header {
+	padding-left: 15px;
+	position: fixed;
+	top: 0;
+	z-index: 100; /*Overlay header on galaxy map*/
+	color: white; /*Ensure text can be seen in all templates*/
+}
+div.gal_map_main {
+	margin-top: 8em; /*Space for fixed-position header relative to font size*/
+}
 
-/* LM */
+/* Local Map */
 table.lmt {
 	border-collapse: separate;
 	border-spacing: 6px;

--- a/templates/Default/engine/Default/GalaxyMap.inc
+++ b/templates/Default/engine/Default/GalaxyMap.inc
@@ -13,29 +13,33 @@
 				});
 			</script><?php
 		} ?>
-    </head>
+	</head>
 	
 	<body>
-		<p>Map of the known <b><big><?php echo $ThisGalaxy->getName(); ?></big></b> galaxy.</p>
-		<form name="GalaxyMapForm" method="GET">
-			<label for="galaxy_id">Switch galaxy</label>&nbsp;
-			<select name="galaxy_id" id="galaxy_id" onchange="this.form.submit()"><?php
-				foreach($GameGalaxies as &$GameGalaxy) { 
-					$GalaxyID = $GameGalaxy->getGalaxyID(); ?>
-					<option value="<?php echo $GalaxyID; ?>"<?php if($ThisGalaxy->equals($GameGalaxy)){ ?> selected="selected"<?php } ?>>
-					<?php echo $GameGalaxy->getName(); ?>
-					</option><?php
-				} unset($GameGalaxy); ?>
-			</select>&nbsp;
-			<input type="submit" value="View"/>
-		</form>
-		<br>
-		<form name="GalaxyMapJumpTo" method="GET">
-			<label for="sector_id">Switch sector</label>&nbsp;
-			<input type="number" size="5" maxlength="5" name="sector_id" id="sector_id" />&nbsp;
-			<input type="submit" value="View" />
-		</form>
-		
-		<?php $this->includeTemplate('includes/SectorMap.inc',array('GalaxyMap'=>true)); ?>
+		<div class="gal_map_header">
+			<p>Map of the known <b><big><?php echo $ThisGalaxy->getName(); ?></big></b> galaxy.</p>
+			<form name="GalaxyMapForm" method="GET">
+				<label for="galaxy_id">Switch galaxy</label>&nbsp;
+				<select name="galaxy_id" id="galaxy_id" onchange="this.form.submit()"><?php
+					foreach($GameGalaxies as &$GameGalaxy) {
+						$GalaxyID = $GameGalaxy->getGalaxyID(); ?>
+						<option value="<?php echo $GalaxyID; ?>"<?php if($ThisGalaxy->equals($GameGalaxy)){ ?> selected="selected"<?php } ?>>
+						<?php echo $GameGalaxy->getName(); ?>
+						</option><?php
+					} unset($GameGalaxy); ?>
+				</select>&nbsp;
+				<input type="submit" value="View"/>
+			</form>
+			<br>
+			<form name="GalaxyMapJumpTo" method="GET">
+				<label for="sector_id">Switch sector</label>&nbsp;
+				<input type="number" size="5" maxlength="5" name="sector_id" id="sector_id" />&nbsp;
+				<input type="submit" value="View" />
+			</form>
+		</div>
+
+		<div class="gal_map_main">
+			<?php $this->includeTemplate('includes/SectorMap.inc',array('GalaxyMap'=>true)); ?>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
When we are scrolling around the Galaxy Map for large galaxies,
it is a pain to scroll up to the top left corner to change the
galaxy or center on a sector. By having the header in a fixed
position on the page instead, it is always available for use.

Originally, I wanted the header to have a solid background that
would overlap (and obscure) the galaxy map, and then a little
jQuery button that would minimize the header. I didn't know how
to implement this, so I settled for a transparent background,
but no ability to minimize the header. This means the galaxy
map is always slightly obscured, and the header is a bit harder
to read when it overlaps the galaxy map, but I think it is
better than obscuring a significant portion of the galaxy map.

Since I was using pure html/css, I also was unable to implement
this in such a way that the header and main body were scalable
based on the player's font size preference. I had to hard-code
the Galaxy Map font size to match the main body margin specified
in pixels. If this could be done in a more automatic way, that
would be preferable.

Also:
* Simplify header
* Fix undefined variable PHP warning