### PR TITLE
bank_alliance*.php: initialize playerTrans array

### DIFF
--- a/engine/Default/bank_alliance.php
+++ b/engine/Default/bank_alliance.php
@@ -41,6 +41,7 @@ $template->assignByRef('AlliedAllianceBanks', $alliedAllianceBanks);
 $db->query('SELECT transaction, sum(amount) as total FROM alliance_bank_transactions
 			WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . '
 			GROUP BY transaction');
+$playerTrans = array('Deposit' => 0, 'Payment' => 0);
 while($db->nextRecord()) {
 	$playerTrans[$db->getField('transaction')] = $db->getInt('total');
 }

--- a/engine/Default/bank_alliance_processing.php
+++ b/engine/Default/bank_alliance_processing.php
@@ -63,6 +63,7 @@ else {
 		$db->query('SELECT transaction, sum(amount) as total FROM alliance_bank_transactions
 			WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . '
 			GROUP BY transaction');
+		$playerTrans = array('Deposit' => 0, 'Payment' => 0);
 		while($db->nextRecord()) {
 			$playerTrans[$db->getField('transaction')] = $db->getInt('total');
 		}


### PR DESCRIPTION
This array was accessed without being defined first, which causes
PHP warnings (but does not affect the functionality).

We initialize the array before it is accessed to prevent these
warnings.