### PR TITLE
Display breaking news with regular news

### DIFF
--- a/engine/Default/news_read.php
+++ b/engine/Default/news_read.php
@@ -22,7 +22,7 @@ doLottoNewsAssign($gameID,$template);
 
 $template->assign('ViewNewsFormHref',SmrSession::getNewHREF(create_container('skeleton.php','news_read.php',array('GameID'=>$var['GameID']))));
 
-$db->query('SELECT * FROM news WHERE game_id = '.$db->escapeNumber($gameID).' AND type != \'breaking\' ORDER BY news_id DESC LIMIT ' . ($min_news - 1) . ', ' . ($max_news - $min_news + 1));
+$db->query('SELECT * FROM news WHERE game_id = '.$db->escapeNumber($gameID).' AND type != \'lotto\' ORDER BY news_id DESC LIMIT ' . ($min_news - 1) . ', ' . ($max_news - $min_news + 1));
 if ($db->getNumRows()) {
 	$NewsItems = array();
 	while ($db->nextRecord()) {

--- a/engine/Default/news_read_current.php
+++ b/engine/Default/news_read_current.php
@@ -14,7 +14,7 @@ doLottoNewsAssign($gameID,$template);
 if(!isset($var['LastNewsUpdate']))
 	SmrSession::updateVar('LastNewsUpdate',$player->getLastNewsUpdate());
 
-$db->query('SELECT * FROM news WHERE game_id = '.$db->escapeNumber($gameID).' AND time > '.$db->escapeNumber($var['LastNewsUpdate']).' AND type = \'regular\' ORDER BY news_id DESC');
+$db->query('SELECT * FROM news WHERE game_id = '.$db->escapeNumber($gameID).' AND time > '.$db->escapeNumber($var['LastNewsUpdate']).' AND type != \'lotto\' ORDER BY news_id DESC');
 $player->updateLastNewsUpdate();
 
 if ($db->getNumRows()) {

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -38,6 +38,7 @@ define('TIME_BEFORE_NEWBIE_TIME',3600); //1 hour
 define('TIME_FOR_COUNCIL_VOTE',172800); //2 days
 define('TIME_FOR_WAR_VOTE_FED_SAFETY',259200); //3 days
 define('TIME_MAP_BUY_WAIT',259200); //3 days
+define('TIME_FOR_BREAKING_NEWS', 86400); //1 day
 define('VOTE_BONUS_TURNS_TIME',1800); //30 mins
 
 define('MAX_IMAGE_SIZE',30); //in kb

--- a/lib/Default/news.functions.inc
+++ b/lib/Default/news.functions.inc
@@ -1,8 +1,7 @@
 <?php
 function doBreakingNewsAssign($gameID,&$template) {
 	$db = new SmrMySqlDatabase();
-	$db->query('DELETE FROM news WHERE time < '.$db->escapeNumber(TIME - 86400).' AND type = \'breaking\'');
-	$db->query('SELECT * FROM news WHERE game_id = '.$db->escapeNumber($gameID).' AND type = \'breaking\' ORDER BY time DESC LIMIT 1');
+	$db->query('SELECT * FROM news WHERE game_id = '.$db->escapeNumber($gameID).' AND type = \'breaking\' AND time > '.$db->escapeNumber(TIME - TIME_FOR_BREAKING_NEWS).' ORDER BY time DESC LIMIT 1');
 	if ($db->nextRecord()) {
 		$template->assign('BreakingNews',array('Time' => $db->getField('time'), 'Message' => bbifyMessage($db->getField('news_message'))));
 	}


### PR DESCRIPTION
Breaking news is often the most important news; however, since we
weren't displaying it with the regular news, we could only see one
breaking news entry at a time. This meant that if, for example, an
alliance attacked multiple planets in an evening, you would only
see the most recent event in the news the next day (and you would
only know the other attacks happened if you were actively refreshing
the news). This doesn't make sense for "important news".

Instead, we will display the news with the regular news, in addition
to displaying the most recent in the breaking news slot. To achieve
this, we also have to stop deleting breaking news entries after one
day (so that they don't disappear from regular news) and change the
query for the "most recent breaking news" to include a one day
conditional.

This should also significantly speed up the news pages, since the
deletion was not limited to the current game -- it was searching
the _entire_ `news` table!