### PR TITLE
Remove duplicated trade messages

### DIFF
--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -123,25 +123,9 @@ if (isset($var['errorMsg'])) $template->assign('ErrorMessage', $var['errorMsg'])
 // *
 // *******************************************
 
-//You have sold 300 units of Luxury Items for 1738500 credits. For your excellent trading skills you receive 220 experience points!
-if (!empty($var['traded_xp']) ||
-	!empty($var['traded_amount']) ||
-	!empty($var['traded_good']) ||
-	!empty($var['traded_credits'])) {
-
-	$tradeMessage = 'You have just ' . $var['traded_transaction'] . ' <span class="yellow">' .
-		$var['traded_amount'] . '</span> units of <span class="yellow">' . $var['traded_good'] .
-		'</span> for <span class="creds">' . $var['traded_credits'] . '</span> credits.<br />';
-
-	if ($var['traded_xp'] > 0) {
-		$tradeMessage .= 'Your excellent trading skills have gained you <span class="exp">' . $var['traded_xp'] . ' </span> experience points!<br />';
-	}
-
-	$tradeMessage .= '<br />';
-
-	$template->assign('TradeMessage',$tradeMessage);
+if (!empty($var['trade_msg'])) {
+	$template->assign('TradeMessage', $var['trade_msg']);
 }
-
 
 // *******************************************
 // *

--- a/engine/Default/shop_goods.php
+++ b/engine/Default/shop_goods.php
@@ -22,23 +22,13 @@ $PHP_OUTPUT.=('Your relations with them are ' . get_colored_text($relations, $re
 
 $PHP_OUTPUT.=('<p>&nbsp;</p>');
 $account->log(LOG_TYPE_TRADING, 'Player examines port', $player->getSectorID());
+
 //The player is sent here after trading and sees this if his offer is accepted.
-//You have bought/sold 300 units of Luxury Items for 1738500 credits. For your excellent trading skills you receive 220 experience points!
-if (!empty($var['traded_xp']) ||
-	!empty($var['traded_amount']) ||
-	!empty($var['traded_good']) ||
-	!empty($var['traded_credits']) ||
-	!empty($var['traded_transaction'])) {
-
-	$PHP_OUTPUT.=('<p>You have just ' . $var['traded_transaction'] . ' <span class="yellow">' . $var['traded_amount'] . '</span> units ');
-	$PHP_OUTPUT.=('of <span class="yellow">' . $var['traded_good'] . '</span> for ');
-	$PHP_OUTPUT.=('<span class="creds">' . $var['traded_credits'] . '</span> credits.<br />');
-	if ($var['traded_xp'] > 0)
-		$PHP_OUTPUT.=('<p>For your excellent trading skills you have gained <span class="exp">' . $var['traded_xp'] . '</span> experience points!</p>');
-
-// test if we are searched. (but only if we hadn't a previous trade here
+if (!empty($var['trade_msg'])) {
+	$PHP_OUTPUT .= $var['trade_msg'];
 }
 elseif ($player->getLastPort() != $player->getSectorID()) {
+	// test if we are searched, but only if we hadn't a previous trade here
 
 	$base_chance = 15;
 	if ($port->hasGood(5))

--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -77,14 +77,8 @@ if (!empty($bargain_price) &&
 	// if offered equals ideal we get a problem (division by zero)
 	$gained_exp = round($port->calculateExperiencePercent($ideal_price,$offered_price,$bargain_price,$transaction) * $base_xp);
 
-	//will use these variables in current sector and port after successful trade
-	$container['traded_xp'] = $gained_exp;
-	$container['traded_amount'] = $amount;
-	$container['traded_good'] = $good_name;
-	$container['traded_credits'] = $bargain_price;
-
 	if ($transaction == 'Buy') {
-		$container['traded_transaction'] = 'bought';
+		$msg_transaction = 'bought';
 		$ship->increaseCargo($good_id,$amount);
 		$player->decreaseCredits($bargain_price);
 		$player->increaseHOF($amount,array('Trade','Goods','Bought'), HOF_ALLIANCE);
@@ -96,8 +90,7 @@ if (!empty($bargain_price) &&
 
 	}
 	elseif ($transaction == 'Sell') {
-
-		$container['traded_transaction'] = 'sold';
+		$msg_transaction = 'sold';
 		$ship->decreaseCargo($good_id,$amount);
 		$player->increaseCredits($bargain_price);
 		$player->increaseHOF($amount,array('Trade','Goods','Sold'), HOF_ALLIANCE);
@@ -118,6 +111,19 @@ if (!empty($bargain_price) &&
 	if ($port->getRaceID() != RACE_NEUTRAL || $player->getRaceID() == RACE_ALSKANT) {
 		$player->increaseRelationsByTrade($amount,$port->getRaceID());
 	}
+
+	//will use these variables in current sector and port after successful trade
+	$tradeMessage = 'You have just '.$msg_transaction.' <span class="yellow">'.$amount.'</span> '.pluralise('unit', $amount).' of <span class="yellow">'.$good_name.'</span>';
+	if ($bargain_price > 0) {
+		$tradeMessage .= ' for <span class="creds">'.$bargain_price.'</span> '.pluralise('credit', $bargain_price);
+	}
+	$tradeMessage .= '.<br />';
+	if ($gained_exp > 0) {
+		$tradeMessage .= 'Your excellent trading skills have earned you <span class="exp">'.$gained_exp.' </span> experience '.pluralise('point', $gained_exp).'!<br />';
+	}
+	$tradeMessage .= '<br />';
+
+	$container['trade_msg'] = $tradeMessage;
 
 	if ($ship->getEmptyHolds() == 0)
 		$container['body'] = 'current_sector.php';


### PR DESCRIPTION
Only construct the trade message in `shop_goods_processing.php`
instead of both `shop_goods.php` and `current_sector.php`.
The wording of the two had also become unsynchronized at some
point.

Also correctly pluralize the nouns (points, units, credits).