### PR TITLE
 Allow Underground ships to steal goods

### DIFF
--- a/engine/Default/shop_goods.php
+++ b/engine/Default/shop_goods.php
@@ -132,6 +132,9 @@ if (!empty($boughtGoods)) {
 		$PHP_OUTPUT.=('" size="4" id="InputFields" class="center"></td>');
 		$PHP_OUTPUT.=('<td>');
 		$PHP_OUTPUT.=create_submit('Buy');
+		if ($ship->isUnderground()) {
+			$PHP_OUTPUT.=create_submit('Steal');
+		}
 		$PHP_OUTPUT.=('</td>');
 		$PHP_OUTPUT.=('</tr>');
 		

--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -65,6 +65,21 @@ if ($_REQUEST['action'] == 'Steal') {
 		create_error('You are not allowed to steal goods!');
 	}
 	$transaction = $_REQUEST['action'];
+
+	// Small chance to get caught stealing
+	$catchChancePercent = $port->getMaxLevel() - $port->getLevel() + 1;
+	if (rand(1, 100) <= $catchChancePercent) {
+		$fine = $ideal_price * ($port->getLevel() + 1);
+		// Don't take the trader all the way to 0 credits
+		$newCredits = max(5000, $player->getCredits() - $fine);
+		$player->setCredits($newCredits);
+		$player->decreaseAlignment(5);
+
+		$fineMessage = '<span class="red">A Federation patrol caught you loading stolen goods onto your ship!<br />The stolen goods have been confiscated and you have been fined '.number_format($fine).' credits.</span><br /><br />';
+		$container = create_container('skeleton.php', 'shop_goods.php');
+		$container['trade_msg'] = $fineMessage;
+		forward($container);
+	}
 }
 
 // can we accept the current price?


### PR DESCRIPTION
Underground ships (Thief / Assassin / DC) can steal goods instead of buying them:
* Stolen goods cost 0 credits
* Maximum exp is earned

Add small chance to get caught stealing goods:
* 1-9% chance to get caught (from Port Level 9 to 1 respectively)
* Fine is `(Port Level + 1) * Ideal Price`
* Lose 5 alignment when caught