### PR TITLE
current_sector.php: fix mini combat display warnings

### DIFF
--- a/templates/Default/engine/Default/current_sector.php
+++ b/templates/Default/engine/Default/current_sector.php
@@ -31,10 +31,10 @@
 						$this->includeTemplate('includes/ForceFullCombatResults.inc',array('FullForceCombatResults'=>$AttackResults,'MinimalDisplay'=>true));
 					}
 					else if($AttackResultsType=='PORT') {
-						$this->includeTemplate('includes/PortFullCombatResults.inc',array('FullPortCombatResults'=>$AttackResults,'MinimalDisplay'=>true));
+						$this->includeTemplate('includes/PortFullCombatResults.inc',array('FullPortCombatResults'=>$AttackResults,'MinimalDisplay'=>true,'AlreadyDestroyed'=>false));
 					}
 					else if($AttackResultsType=='PLANET') {
-						$this->includeTemplate('includes/PlanetFullCombatResults.inc',array('FullPlanetCombatResults'=>$AttackResults,'MinimalDisplay'=>true));
+						$this->includeTemplate('includes/PlanetFullCombatResults.inc',array('FullPlanetCombatResults'=>$AttackResults,'MinimalDisplay'=>true,'AlreadyDestroyed'=>false));
 					} ?><br /><?php
 				}
 				if(isset($VarMessage)) {


### PR DESCRIPTION
Pass `AlreadyDestroyed => false` to the included templates for
minimal combat display. Since `AlreadyDestroyed` is only true
for the trader doing the attacking when there is no combat, we
don't get a combat log and so we know that the minimal display
will not be triggered.

This logic is perhaps a bit convoluted, but would probably need
a refactor to make the logic more automatic.