### PR TITLE
sector_jump_calculate.php: add max misjump

### DIFF
--- a/engine/Default/sector_jump_calculate.php
+++ b/engine/Default/sector_jump_calculate.php
@@ -9,6 +9,7 @@ $jumpInfo = $player->getJumpInfo($targetSector);
 
 $template->assign('Target', $targetSector->getSectorID());
 $template->assign('TurnCost', $jumpInfo['turn_cost']);
+$template->assign('MaxMisjump', $jumpInfo['max_misjump']);
 
 $container = create_container('sector_jump_processing.php');
 $container['target'] = $targetSector->getSectorID();

--- a/templates/Default/engine/Default/sector_jump_calculate.php
+++ b/templates/Default/engine/Default/sector_jump_calculate.php
@@ -3,6 +3,13 @@ Within moments, the onboard computer dictates the report in a reassuringly confi
 
 <br /><br />
 It will cost <span class="red"><?php echo $TurnCost; ?></span> turns to jump to Sector #<?php echo $Target; ?>.
+<?php
+if ($MaxMisjump > 0) { ?>
+	There is a possibility to misjump up to <? echo $MaxMisjump . ' ' . pluralise('sector', $MaxMisjump); ?>.<?php
+} else { ?>
+	There is no possibility to misjump.<?php
+} ?>
+
 
 <br /><br />
 <div class="center">


### PR DESCRIPTION
When displaying jump calculation, also show the maximum number of
sectors that can be misjumped.

![image](https://user-images.githubusercontent.com/846186/37819397-934fdbbc-2e3a-11e8-883f-d255d808fcd7.png)
