### PR TITLE
games_previous.php: fix start/end dates

### DIFF
--- a/engine/Default/games_previous.php
+++ b/engine/Default/games_previous.php
@@ -57,8 +57,7 @@ else {
 	//code for the game goes in here
 
 	$db2 = new $var['HistoryDatabase']();
-	$db2->query('SELECT DATE_FORMAT(start_date, \'%c/%e/%Y\') as start_date, type, ' .
-				'DATE_FORMAT(end_date, \'%c/%e/%Y\') as end_date, game_name, speed, game_id ' .
+	$db2->query('SELECT start_date, type, end_date, game_name, speed, game_id ' .
 				'FROM game WHERE game_id = '.$db->escapeNumber($game_id));
 	$PHP_OUTPUT.=create_table();
 	$db2->nextRecord();


### PR DESCRIPTION
For compatibility games, the database query was extracting the
start/end dates in a date format rather than seconds since epoch.
We were then trying to pass those dates through the PHP `date`
function, which was not valid. It would emit a warning and then
display the date as 1/1/1970.

Now we simply select the start/end dates in seconds since epoch
and convert them to date format in PHP like we do everywhere else.