### PR TITLE
Dockerfile: simplify apt installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN rm -rf node_modules
 
 FROM php:7.2-apache
 RUN apt-get update \
-	&& apt-get install -y libcurl4-openssl-dev git sendmail \
+	&& apt-get install -y zip unzip sendmail \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install curl json mysqli
+	&& docker-php-ext-install mysqli
 
 # Use the production php.ini unless PHP_DEBUG=1 (defaults to 0)
 ARG PHP_DEBUG=0


### PR DESCRIPTION
* Do not explicitly install curl and json php extensions. These are
  already installed in the php-apache image. As a result, we do not
  need to install the curl-dev package.

* Install zip/unzip instead of git. The former is the preferred way
  to install composer dependencies.

This also reduces image size from ~500MB to ~450MB.