### PR TITLE
Use separate postfix/opendkim container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 # /htdocs/
 /htdocs/upload
 
+# DKIM private keys
+/opendkim/*.private
+
 /sys$command
 
 /newsletters

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN rm -rf node_modules
 
 FROM php:7.2-apache
 RUN apt-get update \
-	&& apt-get install -y zip unzip sendmail \
+	&& apt-get install -y zip unzip \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-install mysqli
 
@@ -30,9 +30,6 @@ RUN [ "$PHP_DEBUG" = "1" ] && echo "Using development php.ini" || \
 		&& tar --file /usr/src/php.tar.xz --extract --strip-components=1 --directory /usr/src/php \
 		&& cp /usr/src/php/php.ini-production /usr/local/etc/php/php.ini; \
 	}
-
-# We need to set 'sendmail_path' since php doesn't know about sendmail when it's built
-RUN echo 'sendmail_path = "/usr/sbin/sendmail -t -i"' > /usr/local/etc/php/conf.d/mail.ini
 
 # Disable apache .htaccess files (suggested optimization)
 RUN sed -i 's/AllowOverride All/AllowOverride None/g' /etc/apache2/conf-enabled/docker-php.conf
@@ -49,7 +46,3 @@ RUN rm -rf /var/www/html/ && ln -s "$(pwd)/htdocs" /var/www/html
 
 # Make the upload directory writable by the apache user
 RUN chown www-data ./htdocs/upload
-
-# Provide a FQDN for sendmail (since /etc/hosts cannot be modified during the
-# build), then start the sendmail service before initiating apache.
-CMD ["sh", "-c", "echo \"$(hostname -i) $(hostname) $(hostname).localhost\" >> /etc/hosts && /usr/sbin/service sendmail restart && apache2-foreground"]

--- a/admin/Default/album_moderate_processing.php
+++ b/admin/Default/album_moderate_processing.php
@@ -23,7 +23,7 @@ if ($var['task'] == 'reset_image') {
 	// get his email address and send the mail
 	$receiver = SmrAccount::getAccount($account_id);
 	if (!empty($receiver->getEmail())) {
-		$mail = new \PHPMailer\PHPMailer\PHPMailer();
+		$mail = setupMailer();
 		$mail->Subject = 'SMR Photo Album Notification';
 		$mail->setFrom('album@smrealms.de', 'SMR Photo Album');
 		$mail->msgHTML(nl2br($email_txt));

--- a/admin/Default/album_moderate_processing.php
+++ b/admin/Default/album_moderate_processing.php
@@ -1,24 +1,5 @@
 <?php
 
-function send_html_mail($from_name, $from_email, $to_email, $subject, $body) {
-
-	$headers  = 'From: '.$from_name.'<'.$from_email.'>'.EOL;
-	$headers .= 'X-Sender: '.$from_email.EOL;
-	$headers .= 'X-Mailer: PHP'.EOL; //mailer
-	$headers .= 'X-Priority: 3'.EOL; //1 UrgentMessage, 3 Normal
-	$headers .= 'Return-Path: '.$from_email.EOL;
-	$headers .= 'Content-Type: text/html; charset=iso-8859-1'.EOL;
-
-	$message = '<!DOCTYPE html>'.EOL;
-	$message .= '<HTML><BODY>'.EOL;
-	$message .= wordwrap($body, 72);
-	$message .= '</BODY></HTML>';
-
-	// send the mail
-	mail($to_email, $subject, $message, $headers, '-f '.$from_email);
-
-}
-
 // get account_id from session
 $account_id = $var['account_id'];
 $email_txt = $_REQUEST['email_txt'];
@@ -40,9 +21,15 @@ if ($var['task'] == 'reset_image') {
 	$db->unlock();
 
 	// get his email address and send the mail
-	$db->query('SELECT email FROM account WHERE account_id = '.$db->escapeNumber($account_id));
-	if ($db->nextRecord())
-		send_html_mail('SMR Photo Album', 'pics@smrealms.de', $db->getField('email'), 'SMR Photo Album Notification', nl2br($email_txt));
+	$receiver = SmrAccount::getAccount($account_id);
+	if (!empty($receiver->getEmail())) {
+		$mail = new \PHPMailer\PHPMailer\PHPMailer();
+		$mail->Subject = 'SMR Photo Album Notification';
+		$mail->setFrom('album@smrealms.de', 'SMR Photo Album');
+		$mail->msgHTML(nl2br($email_txt));
+		$mail->addAddress($receiver->getEmail(), $receiver->getHofName());
+		$mail->send();
+	}
 
 } else if ($var['task'] == 'reset_location')
 	$db->query('UPDATE album SET location = \'\' WHERE account_id = '.$db->escapeNumber($account_id));

--- a/admin/Default/newsletter_send_processing.php
+++ b/admin/Default/newsletter_send_processing.php
@@ -1,7 +1,7 @@
 <?php
 
 // mailer
-$mail = new \PHPMailer\PHPMailer\PHPMailer();
+$mail = setupMailer();
 $mail->setFrom('newsletter@smrealms.de', 'SMR Team');
 
 $mail->Encoding = 'base64';

--- a/config/config.specific.sample.php
+++ b/config/config.specific.sample.php
@@ -21,6 +21,10 @@ define('TWITTER_CONSUMER_SECRET','');
 
 define('ENABLE_NPCS_CHESS', false);
 
+// Set to empty string if using a local mailserver.
+// Use the default value if using the provided docker-compose orchestration.
+define('SMTP_HOSTNAME', 'smtp');
+
 $COMPATIBILITY_DATABASES = array();
 //	array(
 //		'Game' => array(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,14 @@ services:
         # depends_on cannot be defined in extended services (i.e. smr-common)
         depends_on:
             - mysql
+            - smtp
 
     smr-dev:
         extends: smr-common
         # depends_on cannot be defined in extended services (i.e. smr-common)
         depends_on:
             - mysql
+            - smtp
         volumes:
             # Mount the source code instead of copying it.
             - ./admin:/smr/admin
@@ -36,6 +38,14 @@ services:
             - ./htdocs:/smr/htdocs
             - ./lib:/smr/lib
             - ./templates:/smr/templates
+
+    smtp:
+        image: hemberger/postfix-relay
+        environment:
+            - OPENDKIM_DOMAINS=smrealms.de
+            - OPENDKIM_SELECTOR=key1
+        volumes:
+            - ./opendkim:/etc/opendkim/keys/smrealms.de
 
     flyway:
         image: boxfuse/flyway:latest-alpine

--- a/engine/Default/contact_processing.php
+++ b/engine/Default/contact_processing.php
@@ -4,12 +4,15 @@ $receiver = $_REQUEST['receiver'];
 $subject = $_REQUEST['subject'];
 $msg = $_REQUEST['msg'];
 
-mail($receiver,
-	$subject,
+$mail = new \PHPMailer\PHPMailer\PHPMailer();
+$mail->Subject = $subject;
+$mail->setFrom($account->getEmail(), $account->getHofName());
+$mail->Body =
 	'Login:'.EOL.'------'.EOL.$account->getLogin().EOL.EOL .
 	'Account ID:'.EOL.'-----------'.EOL.$account->getAccountID().EOL.EOL .
 	'Message:'.EOL.'------------'.EOL.$msg,
-	'From: '.$account->getEmail());
+$mail->addAddress($receiver);
+$mail->send();
 
 $container = array();
 $container['url'] = 'skeleton.php';

--- a/engine/Default/contact_processing.php
+++ b/engine/Default/contact_processing.php
@@ -4,7 +4,7 @@ $receiver = $_REQUEST['receiver'];
 $subject = $_REQUEST['subject'];
 $msg = $_REQUEST['msg'];
 
-$mail = new \PHPMailer\PHPMailer\PHPMailer();
+$mail = setupMailer();
 $mail->Subject = $subject;
 $mail->setFrom($account->getEmail(), $account->getHofName());
 $mail->Body =

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -56,7 +56,7 @@ else if ($action == 'Save and resend validation code') {
 		'The Space Merchant Realms server is on the web at '.URL.'/.'.EOL.
 		'Please verify within the next 7 days or your account will be automatically deleted.';
 
-	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail = setupMailer();
 	$mail->Subject = 'Your validation code!';
 	$mail->setFrom('support@smrealms.de', 'SMR Support');
 	$mail->msgHTML(nl2br($emailMessage));

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -50,13 +50,18 @@ else if ($action == 'Save and resend validation code') {
 	$db->query('REPLACE INTO notification (notification_type, account_id, time)
 				VALUES(\'validation_code\', '.$db->escapeNumber($account->getAccountID()).', ' . $db->escapeNumber(TIME) . ')');
 
-	mail($email, 'Your validation code!',
+	$emailMessage =
 		'You changed your email address registered within SMR and need to revalidate now!'.EOL.EOL.
 		'   Your new validation code is: '.$account->getValidationCode().EOL.EOL.
 		'The Space Merchant Realms server is on the web at '.URL.'/.'.EOL.
-		'You\'ll find a quick how-to-play here <a href="' . WIKI_URL . '/game-guide">SMR Wiki: Game Guide</a>'.EOL.
-		'Please verify within the next 7 days or your account will be automatically deleted.',
-		'From: support@smrealms.de');
+		'Please verify within the next 7 days or your account will be automatically deleted.';
+
+	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail->Subject = 'Your validation code!';
+	$mail->setFrom('support@smrealms.de', 'SMR Support');
+	$mail->msgHTML(nl2br($emailMessage));
+	$mail->addAddress($account->getEmail(), $account->getHofName());
+	$mail->send();
 
 	// get rid of that email permission
 	$db->query('DELETE FROM account_is_closed

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -46,22 +46,21 @@ function logException(Exception $e) {
 		exit;
 	}
 
+	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail->Subject = 'Automatic Bug Report';
+	$mail->setFrom('bugs@smrealms.de');
+	$mail->Body = $message;
+	$mail->addAddress('bugs@smrealms.de');
 	try {
 		if(is_object($player) && method_exists($player,'sendMessageToBox'))
 			$player->sendMessageToBox(BOX_BUGS_AUTO, $message);
 		else if(is_object($account) && method_exists($account,'sendMessageToBox'))
 			$account->sendMessageToBox(BOX_BUGS_AUTO, $message);
 		else
-			mail('bugs@smrealms.de',
-			 'Automatic Bug Report',
-			 $message,
-			 'From: bugs@smrealms.de');
+			$mail->send();
 	}
 	catch(Exception $e) {
-		mail('bugs@smrealms.de',
-		 'Automatic Bug Report',
-		 $message,
-		 'From: bugs@smrealms.de');
+		$mail->send();
 	}
 	return $errorType;
 }

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -46,7 +46,7 @@ function logException(Exception $e) {
 		exit;
 	}
 
-	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail = setupMailer();
 	$mail->Subject = 'Automatic Bug Report';
 	$mail->setFrom('bugs@smrealms.de');
 	$mail->Body = $message;

--- a/htdocs/email_processing.php
+++ b/htdocs/email_processing.php
@@ -55,13 +55,18 @@ try {
 	$db->query('REPLACE INTO notification (notification_type, account_id, time)
 				VALUES(\'validation_code\', '.$db->escapeNumber($account->getAccountID()).', ' . $db->escapeNumber(TIME) . ')');
 
-	mail($email, 'Your validation code!',
+	$emailMessage =
 		'You changed your email address registered within SMR and need to revalidate now!'.EOL.EOL.
 		'   Your new validation code is: '.$account->getValidationCode().EOL.EOL.
 		'The Space Merchant Realms server is on the web at '.URL.'/.'.EOL.
-		'You\'ll find a quick how-to-play here <a href="' . WIKI_URL . '/game-guide">SMR Wiki: A look at the game</a>'.EOL.
-		'Please verify within the next 7 days or your account will be automatically deleted.',
-		'From: support@smrealms.de');
+		'Please verify within the next 7 days or your account will be automatically deleted.';
+
+	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail->Subject = 'Your validation code!';
+	$mail->setFrom('support@smrealms.de', 'SMR Support');
+	$mail->msgHTML(nl2br($emailMessage));
+	$mail->addAddress($account->getEmail(), $account->getHofName());
+	$mail->send();
 
 	// get rid of that email permission
 	$db->query('DELETE FROM account_is_closed

--- a/htdocs/email_processing.php
+++ b/htdocs/email_processing.php
@@ -61,7 +61,7 @@ try {
 		'The Space Merchant Realms server is on the web at '.URL.'/.'.EOL.
 		'Please verify within the next 7 days or your account will be automatically deleted.';
 
-	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail = setupMailer();
 	$mail->Subject = 'Your validation code!';
 	$mail->setFrom('support@smrealms.de', 'SMR Support');
 	$mail->msgHTML(nl2br($emailMessage));

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -197,7 +197,7 @@ try {
 		'The Space Merchant Realms server is on the web at '.URL.'/'.EOL .
 		'Please verify within the next 7 days or your account will be automatically deleted.';
 
-	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail = setupMailer();
 	$mail->Subject = 'New Space Merchant Realms Account';
 	$mail->setFrom('support@smrealms.de', 'SMR Support');
 	$mail->msgHTML(nl2br($emailMessage));

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -192,10 +192,17 @@ try {
 	$account->updateIP();
 
 	// send email with validation code to user
-	mail($email, 'New Space Merchant Realms User',
-				 'Your validation code is: '.$account->getValidationCode().EOL.'The Space Merchant Realms server is on the web at '.URL.'/'.EOL .
-				 'Please verify within the next 7 days or your account will be automatically deleted.',
-				 'From: support@smrealms.de');
+	$emailMessage =
+		'Your validation code is: '.$account->getValidationCode().EOL.
+		'The Space Merchant Realms server is on the web at '.URL.'/'.EOL .
+		'Please verify within the next 7 days or your account will be automatically deleted.';
+
+	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail->Subject = 'New Space Merchant Realms Account';
+	$mail->setFrom('support@smrealms.de', 'SMR Support');
+	$mail->msgHTML(nl2br($emailMessage));
+	$mail->addAddress($account->getEmail(), $account->getHofName());
+	$mail->send();
 
 	// remember when we sent validation code
 	$db->query('INSERT INTO notification (notification_type, account_id, time) ' .

--- a/htdocs/resend_password_processing.php
+++ b/htdocs/resend_password_processing.php
@@ -32,7 +32,7 @@ try {
 		 'The Space Merchant Realms server is on the web at '.URL.'/';
 
 	// send email with password to user
-	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail = setupMailer();
 	$mail->Subject = 'Space Merchant Realms Password';
 	$mail->setFrom('support@smrealms.de', 'SMR Support');
 	$mail->msgHTML(nl2br($emailMessage));

--- a/htdocs/resend_password_processing.php
+++ b/htdocs/resend_password_processing.php
@@ -24,14 +24,20 @@ try {
 	$account->generatePasswordReset();
 
 	$resetURL = URL.'/reset_password.php?login='.$account->getLogin().'&resetcode='.$account->getPasswordReset();
-	// send email with password to user
-	mail($email, 'Space Merchant Realms Password',
+	$emailMessage =
 		 'A user from ' . getIpAddress() . ' requested to reset your password!'.EOL.EOL.
 		 '   Your game login is: ' . $account->getLogin().EOL.
 		 '   Your password reset code is: ' . $account->getPasswordReset().EOL.EOL.
 		 '   You can use this url: '.$resetURL .EOL.EOL.
-		 'The Space Merchant Realms server is on the web at '.URL.'/',
-		 'From: support@smrealms.de');
+		 'The Space Merchant Realms server is on the web at '.URL.'/';
+
+	// send email with password to user
+	$mail = new \PHPMailer\PHPMailer\PHPMailer();
+	$mail->Subject = 'Space Merchant Realms Password';
+	$mail->setFrom('support@smrealms.de', 'SMR Support');
+	$mail->msgHTML(nl2br($emailMessage));
+	$mail->addAddress($account->getEmail(), $account->getHofName());
+	$mail->send();
 
 	header('Location: '.URL.'/reset_password.php');
 	exit;

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1683,7 +1683,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 				$receiverAccount = SmrAccount::getAccount($receiverID);
 				if($receiverAccount->isValidated() && $receiverAccount->isReceivingMessageNotifications($messageTypeID) && !$receiverAccount->isLoggedIn()) {
 					$senderPlayer = SmrPlayer::getPlayer($senderID, $gameID);
-					$mail = new \PHPMailer\PHPMailer\PHPMailer();
+					$mail = setupMailer();
 					$mail->Subject = 'Message Notification';
 					$mail->setFrom('notifications@smrealms.de', 'SMR Notifications');
 					$bbifiedMessage = 'From: ' . $senderPlayer->getDisplayName() . ' Date: ' . date($receiverAccount->getShortDateFormat().' '.$receiverAccount->getShortTimeFormat(),TIME) . "<br/>\r\n<br/>\r\n" . bbifyMessage($message,true);

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -7,6 +7,15 @@ require_once(get_file_loc('SmrShip.class.inc'));
 require_once(get_file_loc('SmrSector.class.inc'));
 require_once(get_file_loc('Sorter.class.inc'));
 
+function setupMailer() {
+	$mail = new \PHPMailer\PHPMailer\PHPMailer(true);
+	if (!empty(SMTP_HOSTNAME)) {
+		$mail->isSMTP();
+		$mail->Host = SMTP_HOSTNAME;
+	}
+	return $mail;
+}
+
 function htmliseMessage($message) {
 	$message = htmlentities($message,ENT_COMPAT,'utf-8');
 	$message = str_replace('&lt;br /&gt;','<br />',$message);

--- a/opendkim/README.md
+++ b/opendkim/README.md
@@ -1,0 +1,8 @@
+OpenDKIM
+========
+Place your DKIM private key here with the name `<selector>.private`,
+where `<selector>` is the DKIM selector.
+
+If you do not place a DKIM key here, one will be generated when you
+first start the `smtp` service. It will then be up to you to make
+sure that this DKIM key is accepted by the `smrealms.de` domain.


### PR DESCRIPTION
* Switch from using the php `mail` function to the PHPMailer module.

* We no longer need the sendmail package and configuration in
  the smr image. Mailing will be done with PHPMailer's SMTP
  library to connect to a postfix/opendkim container.

* When using the docker-compose orchestration, we will want
  to always use the name of the `smtp` service as the SMTP
  hostname. However, we add the `SMTP_HOSTNAME` config option to:
    a) allow specifying a non-docker SMTP host or
    b) use the local mail server (if empty or unset)
  The latter is necessary to run this patch on the current live
  (non-dockerized) server.

* We pass `true` to the PHPMailer ctor to indicate that we
  want to throw an exception if there is an error while
  sending the mail.
