### PR TITLE
Add new options to Local and Galaxy maps

### DIFF
--- a/engine/Default/map_local.php
+++ b/engine/Default/map_local.php
@@ -9,6 +9,22 @@
 if($player->isLandedOnPlanet())
 	create_error('You are on a planet!');
 
+// Create a session to store temporary display options
+session_start();
+
+// Set temporary options
+if ($player->hasAlliance()) {
+	if (isset($_POST['change_settings'])) {
+		$_SESSION['show_seedlist_sectors'] = isset($_POST['show_seedlist_sectors']);
+		$_SESSION['hide_allied_forces'] = isset($_POST['hide_allied_forces']);
+	}
+	$showSeedlistSectors = isset($_SESSION['show_seedlist_sectors']) ? $_SESSION['show_seedlist_sectors'] : false;
+	$hideAlliedForces = isset($_SESSION['hide_allied_forces']) ? $_SESSION['hide_allied_forces'] : false;
+	$template->assign('ShowSeedlistSectors', $showSeedlistSectors);
+	$template->assign('HideAlliedForces', $hideAlliedForces);
+	$template->assign('CheckboxFormHREF', ''); // Submit to same page
+}
+
 $template->assign('SpaceView',true);
 $template->assign('HeaderTemplateInclude','includes/LocalMapJS.inc');
 

--- a/engine/Default/map_local.php
+++ b/engine/Default/map_local.php
@@ -10,7 +10,10 @@ if($player->isLandedOnPlanet())
 	create_error('You are on a planet!');
 
 // Create a session to store temporary display options
-session_start();
+// Do not garbage collect here for best performance (see map_galaxy.php).
+if (!session_start(['gc_probability' => 0, 'gc_maxlifetime' => 86400])) {
+	throw new Exception('Failed to start session');
+}
 
 // Set temporary options
 if ($player->hasAlliance()) {

--- a/htdocs/css/shared.css
+++ b/htdocs/css/shared.css
@@ -316,6 +316,27 @@ div.gal_map_main {
 }
 
 /* Local Map */
+div.lm_seedlist {
+	background-image:
+		repeating-linear-gradient(
+			45deg,
+			transparent,
+			transparent 8%,
+			#00f 10%,
+			#00f 13%
+		);
+}
+div.currentSeclm_seedlist {
+	background-image:
+		url('../../images/currentsector.png'),
+		repeating-linear-gradient(
+			45deg,
+			transparent,
+			transparent 8%,
+			#00f 10%,
+			#00f 13%
+		);
+}
 table.lmt {
 	border-collapse: separate;
 	border-spacing: 6px;

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -69,6 +69,22 @@ try {
 	// create account object
 	$account =& $player->getAccount();
 	
+	// Create a session to store temporary display options
+	session_start();
+
+	// Set temporary options
+	if ($player->hasAlliance()) {
+		if (isset($_POST['change_settings'])) {
+			$_SESSION['show_seedlist_sectors'] = isset($_POST['show_seedlist_sectors']);
+			$_SESSION['hide_allied_forces'] = isset($_POST['hide_allied_forces']);
+		}
+		$showSeedlistSectors = isset($_SESSION['show_seedlist_sectors']) ? $_SESSION['show_seedlist_sectors'] : false;
+		$hideAlliedForces = isset($_SESSION['hide_allied_forces']) ? $_SESSION['hide_allied_forces'] : false;
+		$template->assign('ShowSeedlistSectors', $showSeedlistSectors);
+		$template->assign('HideAlliedForces', $hideAlliedForces);
+		$template->assign('CheckboxFormHREF', ''); // Submit to same page
+	}
+
 	if (!isset($galaxyID) && !isset($sectorID)) {
 		$galaxy =& SmrGalaxy::getGalaxyContaining(SmrSession::$game_id,$player->getSectorID());
 	}

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -70,7 +70,10 @@ try {
 	$account =& $player->getAccount();
 	
 	// Create a session to store temporary display options
-	session_start();
+	// Garbage collect here often, since the page is slow anyways (see map_local.php)
+	if (!session_start(['gc_probability' => 10, 'gc_maxlifetime' => 86400])) {
+		throw new Exception('Failed to start session');
+	}
 
 	// Set temporary options
 	if ($player->hasAlliance()) {

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -24,6 +24,7 @@ class SmrAlliance {
 	protected $ircChannel;
 
 	protected $memberList;
+	protected $seedlist;
 
 	public static function &getAlliance($allianceID,$gameID,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_ALLIANCES[$gameID][$allianceID])) {
@@ -344,6 +345,27 @@ class SmrAlliance {
 			$planets[] = $planet;
 		}
 		return $planets;
+	}
+
+	/**
+	 * Return array of sector_id for sectors in the alliance seedlist.
+	 */
+	public function getSeedlist() {
+		if (!isset($this->seedlist)) {
+			$this->db->query('SELECT sector_id FROM alliance_has_seedlist WHERE ' . $this->SQL);
+			$this->seedlist = array();
+			while ($this->db->nextRecord()) {
+				$this->seedlist[] = $this->db->getInt('sector_id');
+			}
+		}
+		return $this->seedlist;
+	}
+
+	/**
+	 * Is the given sector in the alliance seedlist?
+	 */
+	public function isInSeedlist(SmrSector $sector) {
+		return in_array($sector->getSectorID(), $this->getSeedlist());
 	}
 
 }

--- a/lib/Default/SmrSector.class.inc
+++ b/lib/Default/SmrSector.class.inc
@@ -703,6 +703,18 @@ class SmrSector {
 		return $enemyForces;
 	}
 
+	/**
+	 * Returns true if any forces in this sector belong to $player.
+	 */
+	public function hasPlayerForces(AbstractSmrPlayer $player) {
+		foreach ($this->getForces() as $force) {
+			if ($player->getAccountID() == $force->getOwnerID()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public function hasFriendlyForces(AbstractSmrPlayer &$player=null) {
 		if($player == null || !$this->hasForces())
 			return false;

--- a/templates/Default/engine/Default/GalaxyMap.inc
+++ b/templates/Default/engine/Default/GalaxyMap.inc
@@ -18,24 +18,33 @@
 	<body>
 		<div class="gal_map_header">
 			<p>Map of the known <b><big><?php echo $ThisGalaxy->getName(); ?></big></b> galaxy.</p>
-			<form name="GalaxyMapForm" method="GET">
-				<label for="galaxy_id">Switch galaxy</label>&nbsp;
-				<select name="galaxy_id" id="galaxy_id" onchange="this.form.submit()"><?php
-					foreach($GameGalaxies as &$GameGalaxy) {
-						$GalaxyID = $GameGalaxy->getGalaxyID(); ?>
-						<option value="<?php echo $GalaxyID; ?>"<?php if($ThisGalaxy->equals($GameGalaxy)){ ?> selected="selected"<?php } ?>>
-						<?php echo $GameGalaxy->getName(); ?>
-						</option><?php
-					} unset($GameGalaxy); ?>
-				</select>&nbsp;
-				<input type="submit" value="View"/>
-			</form>
-			<br>
-			<form name="GalaxyMapJumpTo" method="GET">
-				<label for="sector_id">Switch sector</label>&nbsp;
-				<input type="number" size="5" maxlength="5" name="sector_id" id="sector_id" />&nbsp;
-				<input type="submit" value="View" />
-			</form>
+			<table cellspacing="0" cellpadding="0">
+				<tr>
+					<td class="nopad" style="vertical-align:top">
+						<form name="GalaxyMapForm" method="GET">
+							<label for="galaxy_id">Switch galaxy</label>&nbsp;
+							<select name="galaxy_id" id="galaxy_id" onchange="this.form.submit()"><?php
+								foreach($GameGalaxies as &$GameGalaxy) {
+									$GalaxyID = $GameGalaxy->getGalaxyID(); ?>
+									<option value="<?php echo $GalaxyID; ?>"<?php if($ThisGalaxy->equals($GameGalaxy)){ ?> selected="selected"<?php } ?>>
+									<?php echo $GameGalaxy->getName(); ?>
+									</option><?php
+								} unset($GameGalaxy); ?>
+							</select>&nbsp;
+							<input type="submit" value="View"/>
+						</form>
+						<br />
+						<form name="GalaxyMapJumpTo" method="GET">
+							<label for="sector_id">Switch sector</label>&nbsp;
+							<input type="number" size="5" maxlength="5" name="sector_id" id="sector_id" />&nbsp;
+							<input type="submit" value="View" />
+						</form>
+					</td>
+					<td style="vertical-align:bottom">
+						<?php $this->includeTemplate('includes/SectorMapOptions.inc'); ?>
+					</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="gal_map_main">

--- a/templates/Default/engine/Default/includes/SectorMap.inc
+++ b/templates/Default/engine/Default/includes/SectorMap.inc
@@ -8,10 +8,18 @@
 			foreach($MapSector as &$Sector) {
 				$isCurrentSector = !$UniGen && $ThisSector->equals($Sector);
 				$isLinkedSector = !$UniGen && $ThisSector->isLinkedSector($Sector);
+				$isSeedlistSector = !$UniGen && isset($ShowSeedlistSectors) && $ShowSeedlistSectors && $MapPlayer->getAlliance()->isInSeedlist($Sector);
 				$isVisited = $Sector->isVisited($MapPlayer); ?>
 				<td id="sector<?php echo $Sector->getSectorID(); ?>" class="ajax">
 					<div class="lm_sector galaxy<?php echo $Sector->getGalaxyID();
-						if($isCurrentSector){ ?> currentSeclm<?php }else if($isLinkedSector){ ?> connectSeclm<?php }else if($isVisited){ ?> normalSeclm<?php }else{ ?> normalSeclmu<?php } ?>"><?php
+						if ($isSeedlistSector){
+							if ($isCurrentSector){ ?> currentSeclm_seedlist<?php } else { ?> lm_seedlist<?php }
+						}
+						if ($isCurrentSector){ ?> currentSeclm<?php
+						} else if($isLinkedSector){ ?> connectSeclm<?php
+						} else if($isVisited){ ?> normalSeclm<?php
+						} else{ ?> normalSeclmu<?php } ?>"><?php
+
 						if($isVisited) {
 							if(isset($ToggleLink)) {
 								$ToggleLink['sector_id'] = $Sector->getSectorID();
@@ -94,7 +102,10 @@
 							</div><?php
 						}
 						$CanScanSector = $UniGen || ($ThisShip->hasScanner() && $isLinkedSector) || $isCurrentSector;
-						if( ($CanScanSector && ($Sector->hasForces() || $Sector->hasPlayers()) ) || $Sector->hasFriendlyForces($MapPlayer) || $Sector->hasFriendlyTraders($MapPlayer)) { ?>
+						$ShowFriendlyForces = !$UniGen && isset($HideAlliedForces) && $HideAlliedForces ?
+						                      $Sector->hasPlayerForces($MapPlayer) :
+						                      $Sector->hasFriendlyForces($MapPlayer);
+						if( ($CanScanSector && ($Sector->hasForces() || $Sector->hasPlayers()) ) || $ShowFriendlyForces || $Sector->hasFriendlyTraders($MapPlayer)) { ?>
 							<div class="lmtf"><?php
 								if(!$UniGen) {
 									if($CanScanSector && $Sector->hasEnemyTraders($MapPlayer)) {
@@ -111,7 +122,7 @@
 									if($CanScanSector && $Sector->hasEnemyForces($MapPlayer)) {
 										?><img class="enemyBack" title="Enemy Forces" alt="Enemy Forces" src="images/forces.png" width="13" height="16"/><?php
 									}
-									if($Sector->hasFriendlyForces($MapPlayer)) {
+									if ($ShowFriendlyForces) {
 										?><img class="friendlyBack" title="Friendly Forces" alt="Friendly Forces" src="images/forces.png" width="13" height="16"/><?php
 									}
 									/*?><img title="Forces" alt="Forces" src="images/forces.jpg"/><?php*/

--- a/templates/Default/engine/Default/includes/SectorMapOptions.inc
+++ b/templates/Default/engine/Default/includes/SectorMapOptions.inc
@@ -1,0 +1,17 @@
+<?php
+if (isset($CheckboxFormHREF)) { ?>
+	<form method="POST" action="<?php echo $CheckboxFormHREF; ?>">
+		<table>
+			<tr>
+				<td><input name="hide_allied_forces" onchange="this.form.submit()" type="checkbox" <?php if ($HideAlliedForces) { ?>checked<?php }; ?> /></td>
+				<td>Hide allied forces</td>
+			</tr>
+			<tr>
+				<td><input name="show_seedlist_sectors" onchange="this.form.submit()" type="checkbox" <?php if ($ShowSeedlistSectors) { ?>checked<?php }; ?> /></td>
+				<td>Show seedlist sectors</td>
+			</tr>
+			<input type=hidden name="change_settings" />
+		</table>
+	</form><?php
+}
+?>

--- a/templates/Default/engine/Default/map_local.php
+++ b/templates/Default/engine/Default/map_local.php
@@ -7,4 +7,7 @@
 	<a id="status" onClick="toggleM();">Mouse Zoom is <?php if($isZoomOn){ ?>On<?php }else{ ?>Off<?php } ?>.  Click to toggle.</a>
 </div><br />
 
-<?php $this->includeTemplate('includes/SectorMap.inc'); ?>
+<?php
+$this->includeTemplate('includes/SectorMap.inc');
+$this->includeTemplate('includes/SectorMapOptions.inc');
+?>


### PR DESCRIPTION
* Hide Allied Forces: toggles on and off displaying alliance forces.
  If off, only your own forces will display on the map.

* Show Seedlist Sectors: toggles on and off display of sectors that
  are in the alliance seedlist.

We implement these options as part of a PHP session, for simplicity,
to avoid unnecessarily modifying the `account` or `player` database
tables. This is because these options are typically not needed to
persist indefinitely. We will need to monitor community reaction to
this behavior, as well as possible performance impact of PHP sessions
to see if we need to migrate these options to the database at a
later time.

Add a few class methods:

* SmrSector::hasPlayerForces
  This is needed to replace `hasFriendlyForces` when using the
  "Hide Allied Forces" option. We could have added a bool option
  to the existing method, but I think a separate method is clearer.

* SmrAlliance:isInSeedlist
  Specifies whether a sector is in the alliance seedlist. This is
  needed for the "Show Seedlist Sectors" option.

* SmrAlliance::getSeedlist
  Returns an array of sector IDs from the alliance seedlist.
  Seedlist is cached so that it can be called without extra expense
  from `isInSeedlist`.

Note about CSS:

We add the `div.currentSeclm_seedlist` CSS class in addition to the
`div.lm_seedlist` because there are (unavoidable?) issues with
overlaying two background images when they are part of two separate
classes in the same element. (i.e. you can't do `<div class="a b">`
and display background images in both). However, you can use a child
`div` (i.e. `<div class="a"><div class="b">...</div></div>`) or use
a list of items in the CSS background image attribute. We chose the
latter for simplicity.