### PR TITLE
config.php: set date.timezone

### DIFF
--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -1,5 +1,5 @@
 <?php
-@date_default_timezone_set(@date_default_timezone_get());
+ini_set('date.timezone', 'CET');
 
 define('MICRO_TIME', microtime());
 define('TIME', (int)microtimeSec(MICRO_TIME));


### PR DESCRIPTION
Calling `date_default_timezone_get` before setting the timezone
raises a warning in xdebug and can impact performance (since it
has to determine which timezone to use).

Just set it to "CET", since that's what the server currently
uses. If we really want, we can make it a `config.specific.php`
option in the future.

We also may want to consider switching to UTC as well, but that
may require us to change how player time offsets are stored
(currently they're just integers, which is problematic when it
comes to daylight savings).