### PR TITLE
SocialLogin.class.inc: update to v2.12 Facebook API

### DIFF
--- a/lib/Login/SocialLogin.class.inc
+++ b/lib/Login/SocialLogin.class.inc
@@ -24,7 +24,7 @@ class SocialLogin {
 			self::$facebook = new Facebook\Facebook([
 				'app_id' => FACEBOOK_APP_ID,
 				'app_secret' => FACEBOOK_APP_SECRET,
-				'default_graph_version' => 'v2.7'
+				'default_graph_version' => 'v2.12'
 			]);
 		}
 


### PR DESCRIPTION
There are no API changes between 2.7 and 2.12 that affect our
usage, so we can upgrade now. Version 2.12 will reach end-of-life
some time in 2020.