### PR TITLE
smr.inc: show only 3 decimals of script runtime

### DIFF
--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -651,7 +651,7 @@ function do_voodoo() {
 	}
 	doSkeletionAssigns($template,$player,$ship,$sector,$db,$account);
 	$time_elapsed = microtimeDiff(microtime(),MICRO_TIME);
-	$template->assign('ScriptRuntime',number_format($time_elapsed,4));
+	$template->assign('ScriptRuntime', number_format($time_elapsed,3));
 
 	if(isset($var['DisableAjax']) && $var['DisableAjax']===true) {
 		$template->assign('AJAX_ENABLE_REFRESH',false);


### PR DESCRIPTION
Showing 3 decimals instead of 4 allows us to associate the decimal
number with the number of milliseconds, which is a more natural unit
than tenths of a millisecond.