### PR TITLE
Make script runtime more accurate

### DIFF
--- a/htdocs/css/Freon22-layout.css
+++ b/htdocs/css/Freon22-layout.css
@@ -130,6 +130,16 @@ tr.topRow {
 	padding: 5px;
 	margin: 0px 0px 10px 0px;
 }
+.footer_right {
+	text-align: right;
+	font-size: xx-small;
+}
+.footer_left {
+	text-align: left;
+	font-size: xx-small;
+	width: 60%;
+	float: left;
+}
 
 /* ****************************************************
  This starts the borders for the right info area
@@ -158,11 +168,6 @@ div.rightInfoShip a {
 }
 .wep1 {
 	white-space:normal;
-}
-.copyright {
-	text-align: right;
-	font-size: xx-small;
-	padding: 10px;
 }
 .messages {
 	font-size: .6em;

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -650,8 +650,6 @@ function do_voodoo() {
 		$template->assign('ExtraCSSLink',$account->getCssLink());
 	}
 	doSkeletionAssigns($template,$player,$ship,$sector,$db,$account);
-	$time_elapsed = microtimeDiff(microtime(),MICRO_TIME);
-	$template->assign('ScriptRuntime', number_format($time_elapsed,3));
 
 	if(isset($var['DisableAjax']) && $var['DisableAjax']===true) {
 		$template->assign('AJAX_ENABLE_REFRESH',false);

--- a/templates/Default/engine/Default/includes/copyright.inc
+++ b/templates/Default/engine/Default/includes/copyright.inc
@@ -1,6 +1,6 @@
 <div align="right">
 	SMR <?php echo $Version; ?>&copy;2007-<?php echo $CurrentYear; ?> Page and SMR<br />
 	Kindly Hosted by <a href="http://www.fem.tu-ilmenau.de/" target="fem">FeM</a><br />
-	Script runtime: <span id="rt"><?php echo $ScriptRuntime; ?></span> seconds<br />
+	Script runtime: <span id="rt"><?php echo number_format(microtimeDiff(microtime(), MICRO_TIME), 3); ?></span> seconds<br />
 	<a href="imprint.html">[Imprint]</a>
 </div>

--- a/templates/Freon22/engine/Default/skeleton.php
+++ b/templates/Freon22/engine/Default/skeleton.php
@@ -124,17 +124,11 @@
 							}
 							$this->includeTemplate($TemplateBody); ?>
 						</div>
-						<div style="width:60%; float: left;" class="left">
+						<div class="footer_left">
 							<?php $this->includeTemplate('includes/VoteLinks.inc'); ?>
 						</div>
-						<div class="copyright">
-							SMR <?php echo $Version; ?>&copy;2007-<?php echo $CurrentYear; ?> Page and SMR
-							<br />
-							Kindly Hosted by FeM
-							<br />
-							Script runtime: <span id="rt"><?php echo $ScriptRuntime; ?></span> seconds
-							<br />
-							<a href="imprint.html">[Imprint]</a>
+						<div class="footer_right">
+							<?php $this->includeTemplate('includes/copyright.inc'); ?>
 						</div>
 					</td>
 				</tr>


### PR DESCRIPTION
The script runtime was computed at the end of `do_voodoo`, but before
`$template->display`. As a result, the displayed runtime only included
the cost of processing the `engine` files. However, this entirely
excludes the cost of processing the `template` files, which is the
majority of the cost for some files (e.g. Local and Galaxy maps).

Ideally we would compute the script runtime at the end of `do_voodoo`
just before `exit` is called, but unfortunately there is no way to
then display this number since the html document tags are closed at
the end of `$template->display`.

Since `copyright.inc` is processed (nearly) last on the page, it is a
significant improvement to compute the script runtime inline, so we
do that now . This is still not ideal, but it only excludes a few
milliseconds of processing that occurs afterwards.

Also:
* Synchronize right footer of Freon22 template with Default template.
