### PR TITLE
map_galaxy.php: significant speedup

### DIFF
--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -143,6 +143,10 @@ try {
 	$template->assignByRef('MapSectors',$mapSectors);
 	$template->assignByRef('ThisShip',$player->getShip());
 	$template->assignByRef('ThisPlayer',$player);
+
+	// AJAX updates are not set up for the galaxy map at this time
+	$template->assign('AJAX_ENABLE_REFRESH', false);
+
 	$template->display('GalaxyMap.inc');
 }
 catch(Exception $e) {


### PR DESCRIPTION
Because the Galaxy Map page uses the template system to display
the content, it will do the work to prepare the page for AJAX
updates unless it is told not to do so.

We don't even include the javascript necessary to display AJAX
updates, so this work was always being done (even if AJAX was
disabled in account preferences) for no reason.

Depending on the size of the galaxy, this extra work could take
hundreds of milliseconds (or 1/4 to 1/3 of the total runtime)!

To fix this, we simply tell the template system that AJAX is
disabled on the galaxy map.