### PR TITLE
SmrPlayer: fix e-mail notifications from non-player accounts

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1682,11 +1682,15 @@ class SmrPlayer extends AbstractSmrPlayer {
 			case MSG_PLAYER:
 				$receiverAccount = SmrAccount::getAccount($receiverID);
 				if($receiverAccount->isValidated() && $receiverAccount->isReceivingMessageNotifications($messageTypeID) && !$receiverAccount->isLoggedIn()) {
-					$senderPlayer = SmrPlayer::getPlayer($senderID, $gameID);
+					require_once(get_file_loc('message.functions.inc'));
+					$sender = getMessagePlayer($senderID, $gameID, $messageTypeID);
+					if ($sender instanceof SmrPlayer) {
+						$sender = $sender->getDisplayName();
+					}
 					$mail = setupMailer();
 					$mail->Subject = 'Message Notification';
 					$mail->setFrom('notifications@smrealms.de', 'SMR Notifications');
-					$bbifiedMessage = 'From: ' . $senderPlayer->getDisplayName() . ' Date: ' . date($receiverAccount->getShortDateFormat().' '.$receiverAccount->getShortTimeFormat(),TIME) . "<br/>\r\n<br/>\r\n" . bbifyMessage($message,true);
+					$bbifiedMessage = 'From: ' . $sender . ' Date: ' . date($receiverAccount->getShortDateFormat().' '.$receiverAccount->getShortTimeFormat(),TIME) . "<br/>\r\n<br/>\r\n" . bbifyMessage($message,true);
 					$mail->msgHTML($bbifiedMessage);
 					$mail->AltBody = strip_tags($bbifiedMessage);
 					$mail->addAddress($receiverAccount->getEmail(), $receiverAccount->getHofName());


### PR DESCRIPTION
The e-mail notifications for received player messages did not
correctly handle non-player senders. We would be calling
`SmrPlayer::getPlayer` for an account that doesn't exist, which
would throw a database error.

To fix this, we have to instead call `getMessagePlayer`, which
handles non-player senders correctly (this is what we do to
parse senders when viewing/sending messages in-game).