### PR TITLE
Template.class.inc: do not pass vars by reference

### DIFF
--- a/admin/Default/1.6/universe_create.php
+++ b/admin/Default/1.6/universe_create.php
@@ -24,5 +24,5 @@ if ($canEditStartedGames) {
 while ($db->nextRecord()) {
 	$games[] = SmrGame::getGame($db->getInt('game_id'));
 }
-$template->assignByRef('EditGames',$games);
+$template->assign('EditGames',$games);
 ?>

--- a/admin/Default/1.6/universe_create_locations.php
+++ b/admin/Default/1.6/universe_create_locations.php
@@ -17,10 +17,10 @@ foreach ($galSectors as &$sector) {
 		$totalLocs[$sectorLocation->getTypeID()]++;
 	} unset($sectorLocation);
 } unset($sector);
-$template->assignByRef('TotalLocs', $totalLocs);
+$template->assign('TotalLocs', $totalLocs);
 
 $galaxy =& SmrGalaxy::getGalaxy($var['game_id'],$var['gal_on']);
-$template->assignByRef('Galaxy', $galaxy);
+$template->assign('Galaxy', $galaxy);
 
 // Though we expect a location to be only in one category, it is possible to
 // edit a location in the Admin Tools so that it is in two or more categories.
@@ -87,8 +87,8 @@ foreach ($locations as &$location) {
 
 	$locText[$location->getTypeID()] = $location->getName() . $extra;
 } unset($location);
-$template->assignByRef('LocText', $locText);
-$template->assignByRef('LocTypes', $categories->locTypes);
+$template->assign('LocText', $locText);
+$template->assign('LocTypes', $categories->locTypes);
 
 // Form to make location changes
 $container = create_container('1.6/universe_create_save_processing.php',

--- a/admin/Default/1.6/universe_create_planets.php
+++ b/admin/Default/1.6/universe_create_planets.php
@@ -7,7 +7,7 @@ $db->query('SELECT * FROM planet_type');
 while ($db->nextRecord()) {
 	$allowedTypes[$db->getInt('planet_type_id')] = $db->getField('planet_type_name');
 }
-$template->assignByRef('AllowedTypes', $allowedTypes);
+$template->assign('AllowedTypes', $allowedTypes);
 
 // Initialize all planet counts to zero
 $numberOfPlanets = array();
@@ -24,8 +24,8 @@ foreach ($galSectors as &$galSector) {
 	}
 }
 
-$template->assignByRef('Galaxy', $galaxy);
-$template->assignByRef('NumberOfPlanets', $numberOfPlanets);
+$template->assign('Galaxy', $galaxy);
+$template->assign('NumberOfPlanets', $numberOfPlanets);
 
 $numberOfNpcPlanets = (isset($planet_info['NPC']) ? $planet_info['NPC'] : 0);
 $template->assign('NumberOfNpcPlanets', $numberOfNpcPlanets);

--- a/admin/Default/1.6/universe_create_sectors.php
+++ b/admin/Default/1.6/universe_create_sectors.php
@@ -27,10 +27,10 @@ for ($i=0;$i<$galaxy->getHeight();$i++) {
 }
 
 
-$template->assignByRef('Galaxy', $galaxy);
-$template->assignByRef('Galaxies', $galaxies);
-$template->assignByRef('MapSectors',$mapSectors);
-$template->assignByRef('Message',$var['message']);
+$template->assign('Galaxy', $galaxy);
+$template->assign('Galaxies', $galaxies);
+$template->assign('MapSectors',$mapSectors);
+$template->assign('Message',$var['message']);
 SmrSession::updateVar('message',null); // Only show message once
 
 if (isset($_REQUEST['connect']) && $_REQUEST['connect'] > 0) {

--- a/admin/Default/account_edit.php
+++ b/admin/Default/account_edit.php
@@ -49,7 +49,7 @@ $db->query('SELECT account_id FROM account WHERE account_id = '.$db->escapeNumbe
 									   'validation_code LIKE ' . $db->escape_string($var['val_code']));
 if ($db->nextRecord()) {
 	$curr_account =& SmrAccount::getAccount($db->getField('account_id'));
-	$template->assignByRef('EditingAccount', $curr_account);
+	$template->assign('EditingAccount', $curr_account);
 	$template->assign('EditFormHREF', SmrSession::getNewHREF(create_container('account_edit_processing.php', '', array('account_id' => $curr_account->getAccountID()))));
 }
 else {
@@ -64,7 +64,7 @@ if ($curr_account===false) {
 	while ($db->nextRecord()) {
 		$games[] = SmrGame::getGame($db->getInt('game_id'));
 	}
-	$template->assignByRef('Games', $games);
+	$template->assign('Games', $games);
 }
 else {
 	$editingPlayers = array();

--- a/admin/Default/admin_message_send.php
+++ b/admin/Default/admin_message_send.php
@@ -13,7 +13,7 @@ if (empty($gameID)) {
 	while ($db->nextRecord()) {
 		$activeGames[] = SmrGame::getGame($db->getInt('game_id'));
 	}
-	$template->assignByRef('ActiveGames', $activeGames);
+	$template->assign('ActiveGames', $activeGames);
 }
 else {
 	$container = create_container('admin_message_send_processing.php');
@@ -28,7 +28,7 @@ else {
 		while ($db->nextRecord()) {
 			$gamePlayers[]= array('AccountID' => $db->getField('account_id'), 'PlayerID' => $db->getField('player_id'), 'Name' => $db->getField('player_name'));
 		}
-		$template->assignByRef('GamePlayers',$gamePlayers);
+		$template->assign('GamePlayers',$gamePlayers);
 	}
 	if(isset($var['preview'])) {
 		$template->assign('Preview', $var['preview']);

--- a/admin/Default/box_reply.php
+++ b/admin/Default/box_reply.php
@@ -6,8 +6,8 @@ $container = create_container('box_reply_processing.php');
 transfer('game_id');
 transfer('sender_id');
 $template->assign('BoxReplyFormHref',SmrSession::getNewHREF($container));
-$template->assignByRef('Sender',SmrPlayer::getPlayer($var['sender_id'], $var['game_id']));
-$template->assignByRef('SenderAccount',SmrAccount::getAccount($var['sender_id']));
+$template->assign('Sender',SmrPlayer::getPlayer($var['sender_id'], $var['game_id']));
+$template->assign('SenderAccount',SmrAccount::getAccount($var['sender_id']));
 if(isset($var['Preview']))
 	$template->assign('Preview', $var['Preview']);
 if(isset($var['BanPoints']))

--- a/admin/Default/location_edit.php
+++ b/admin/Default/location_edit.php
@@ -31,9 +31,9 @@ if(isset($var['location_type_id'])) {
 	}
 	
 	
-	$template->assignByRef('Location',$location);
-	$template->assignByRef('Ships',AbstractSmrShip::getAllBaseShips($var['game_type_id']));
-	$template->assignByRef('Weapons',SmrWeapon::getAllWeapons($var['game_type_id']));
+	$template->assign('Location',$location);
+	$template->assign('Ships',AbstractSmrShip::getAllBaseShips($var['game_type_id']));
+	$template->assign('Weapons',SmrWeapon::getAllWeapons($var['game_type_id']));
 	
 	
 	$db->query('SELECT * FROM hardware_type');
@@ -42,9 +42,9 @@ if(isset($var['location_type_id'])) {
 		$hardware[$db->getField('hardware_type_id')] = array('ID' => $db->getField('hardware_type_id'),
 														'Name' => $db->getField('hardware_name'));
 	}
-	$template->assignByRef('AllHardware',$hardware);
+	$template->assign('AllHardware',$hardware);
 }
 else {
-	$template->assignByRef('Locations',SmrLocation::getAllLocations());
+	$template->assign('Locations',SmrLocation::getAllLocations());
 }
 ?>

--- a/admin/Default/log_console.php
+++ b/admin/Default/log_console.php
@@ -28,10 +28,10 @@ if ($db->getNumRows()) {
 	$db->query('SELECT log_type_id FROM log_type');
 	while ($db->nextRecord())
 		$logTypes[] = $db->getInt('log_type_id');
-	$template->assignByRef('LogTypes', $logTypes);
+	$template->assign('LogTypes', $logTypes);
 
 	$template->assign('LogConsoleFormHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'log_console_detail.php')));
 	$template->assign('AnonAccessHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'log_anonymous_account.php')));
 }
-$template->assignByRef('LoggedAccounts',$loggedAccounts);
+$template->assign('LoggedAccounts',$loggedAccounts);
 ?>

--- a/admin/Default/notify_reply.php
+++ b/admin/Default/notify_reply.php
@@ -11,11 +11,11 @@ $template->assign('NotifyReplyFormHref',SmrSession::getNewHREF($container));
 $offender =& getMessagePlayer($var['offender'],$var['game_id']);
 $offended =& getMessagePlayer($var['offended'],$var['game_id']);
 if(is_object($offender))
-	$template->assignByRef('OffenderAccount', SmrAccount::getAccount($var['offender']));
+	$template->assign('OffenderAccount', SmrAccount::getAccount($var['offender']));
 if(is_object($offended))
-	$template->assignByRef('OffendedAccount', SmrAccount::getAccount($var['offended']));
-$template->assignByRef('Offender', $offender);
-$template->assignByRef('Offended', $offended);
+	$template->assign('OffendedAccount', SmrAccount::getAccount($var['offended']));
+$template->assign('Offender', $offender);
+$template->assign('Offended', $offended);
 
 if(isset($var['PreviewOffender']))
 	$template->assign('PreviewOffender', $var['PreviewOffender']);

--- a/engine/Default/alliance_message.php
+++ b/engine/Default/alliance_message.php
@@ -114,7 +114,7 @@ if ($db->getNumRows() > 0) {
 		$threads[$j]['ViewHref'] = SmrSession::getNewHREF($container);
 	}
 }
-$template->assignByRef('Threads',$threads);
+$template->assign('Threads',$threads);
 
 if ($mbWrite || in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 	$container = create_container('alliance_message_add_processing.php');

--- a/engine/Default/alliance_message_view.php
+++ b/engine/Default/alliance_message_view.php
@@ -84,7 +84,7 @@ if ($mbWrite || in_array($player->getAccountID(), Globals::getHiddenPlayers())) 
 	$container['thread_index'] = $thread_index;
 	$thread['CreateThreadReplyFormHref'] = SmrSession::getNewHREF($container);
 }
-$template->assignByRef('Thread',$thread);
+$template->assign('Thread',$thread);
 if(isset($var['preview'])) {
 	$template->assign('Preview', $var['preview']);
 }

--- a/engine/Default/alliance_roles.php
+++ b/engine/Default/alliance_roles.php
@@ -48,7 +48,7 @@ while ($db->nextRecord()) {
 	$container['alliance_id'] = $alliance->getAllianceID();
 	$allianceRoles[$roleID]['HREF'] = SmrSession::getNewHREF($container);
 }
-$template->assignByRef('AllianceRoles',$allianceRoles);
+$template->assign('AllianceRoles',$allianceRoles);
 $container = create_container('alliance_roles_processing.php');
 $container['alliance_id'] = $alliance->getAllianceID();
 

--- a/engine/Default/alliance_roster.php
+++ b/engine/Default/alliance_roster.php
@@ -7,7 +7,7 @@ if (!isset($var['alliance_id'])) {
 }
 
 $alliance =& SmrAlliance::getAlliance($var['alliance_id'],$player->getGameID());
-$template->assignByRef('Alliance', $alliance);
+$template->assign('Alliance', $alliance);
 
 $template->assign('PageTopic', $alliance->getAllianceName(false, true));
 require_once(get_file_loc('menu.inc'));
@@ -30,7 +30,7 @@ if ($showRoles) {
 	while ($db->nextRecord()) {
 		$roles[$db->getInt('role_id')] = $db->getField('role');
 	}
-	$template->assignByRef('Roles', $roles);
+	$template->assign('Roles', $roles);
 
 	$container=create_container('alliance_roles_save_processing.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
@@ -65,7 +65,7 @@ $allowed = $db->nextRecord();
 $template->assign('CanChangeRoles', $allowed);
 
 $alliancePlayers =& SmrPlayer::getAlliancePlayers($player->getGameID(),$alliance->getAllianceID());
-$template->assignByRef('AlliancePlayers', $alliancePlayers);
+$template->assign('AlliancePlayers', $alliancePlayers);
 
 if ($alliance->getAllianceID() == $player->getAllianceID()) {
 	// Alliance members get to see active/inactive status of members

--- a/engine/Default/alliance_stat.php
+++ b/engine/Default/alliance_stat.php
@@ -19,8 +19,8 @@ $role_id = $player->getAllianceRole($alliance->getAllianceID());
 $db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
 $db->nextRecord();
 
-$template->assignByRef('Form', $form);
-$template->assignByRef('Alliance', $alliance);
+$template->assign('Form', $form);
+$template->assign('Alliance', $alliance);
 
 $template->assign('CanChangeDescription', $db->getBoolean('change_mod') || $account->hasPermission(PERMISSION_EDIT_ALLIANCE_DESCRIPTION));
 $template->assign('CanChangePassword', $db->getBoolean('change_pass'));

--- a/engine/Default/bank_alliance.php
+++ b/engine/Default/bank_alliance.php
@@ -36,7 +36,7 @@ if($db->getNumRows() > 0) {
 		}
 	}
 }
-$template->assignByRef('AlliedAllianceBanks', $alliedAllianceBanks);
+$template->assign('AlliedAllianceBanks', $alliedAllianceBanks);
 
 $db->query('SELECT transaction, sum(amount) as total FROM alliance_bank_transactions
 			WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . '
@@ -137,7 +137,7 @@ if ($db->getNumRows() > 0) {
 			'Exempt' => $db->getInt('exempt') == 1
 		);
 	}
-	$template->assignByRef('BankTransactions', $bankTransactions);
+	$template->assign('BankTransactions', $bankTransactions);
 
 	$template->assign('MinValue', $minValue);
 	$template->assign('MaxValue', $maxValue);
@@ -150,7 +150,7 @@ if ($db->getNumRows() > 0) {
 	$container['maxVal'] = $maxValue;
 	$template->assign('ExemptTransactionsFormHREF',SmrSession::getNewHREF($container));
 
-	$template->assignByRef('Alliance', $alliance);
+	$template->assign('Alliance', $alliance);
 }
 
 $container=create_container('skeleton.php', 'bank_report.php');

--- a/engine/Default/bounty_view.php
+++ b/engine/Default/bounty_view.php
@@ -1,5 +1,5 @@
 <?php
 $bountyPlayer =& SmrPlayer::getPlayer($var['id'], $player->getGameID());
 $template->assign('PageTopic', 'Viewing ' . $bountyPlayer->getPlayerName());
-$template->assignByRef('BountyPlayer', $bountyPlayer);
+$template->assign('BountyPlayer', $bountyPlayer);
 ?>

--- a/engine/Default/buy_message_notifications.php
+++ b/engine/Default/buy_message_notifications.php
@@ -22,6 +22,6 @@ while ($db->nextRecord()) {
 	$messageBox['BuyHref'] = SmrSession::getNewHREF($container);
 	$messageBoxes[] = $messageBox;
 }
-$template->assignByRef('MessageBoxes', $messageBoxes);
+$template->assign('MessageBoxes', $messageBoxes);
 
 ?>

--- a/engine/Default/chess.php
+++ b/engine/Default/chess.php
@@ -15,7 +15,7 @@ $db->query('SELECT player_id, player.player_name FROM player JOIN account USING(
 while ($db->nextRecord()) {
 	$players[$db->getInt('player_id')] = $db->getField('player_name');
 }
-$template->assignByRef('PlayerList',$players);
+$template->assign('PlayerList',$players);
 
 if(ENABLE_NPCS_CHESS) {
 	$npcs = array();
@@ -23,7 +23,7 @@ if(ENABLE_NPCS_CHESS) {
 	while ($db->nextRecord()) {
 		$npcs[$db->getInt('player_id')] = $db->getField('player_name');
 	}
-	$template->assignByRef('NPCList',$npcs);
+	$template->assign('NPCList',$npcs);
 }
 
 ?>

--- a/engine/Default/chess_move_processing.php
+++ b/engine/Default/chess_move_processing.php
@@ -1,7 +1,7 @@
 <?php
 require_once(get_file_loc('ChessGame.class.inc'));
 $chessGame =& ChessGame::getChessGame($var['ChessGameID']);
-$template->assignByRef('ChessGame',$chessGame);
+$template->assign('ChessGame',$chessGame);
 if(is_numeric($_REQUEST['x']) && is_numeric($_REQUEST['y']) && is_numeric($_REQUEST['toX']) && is_numeric($_REQUEST['toY'])) {
 	$x = $_REQUEST['x'];
 	$y = $_REQUEST['y'];

--- a/engine/Default/chess_play.php
+++ b/engine/Default/chess_play.php
@@ -1,5 +1,5 @@
 <?php
 require_once(get_file_loc('ChessGame.class.inc'));
-$template->assignByRef('ChessGame',ChessGame::getChessGame($var['ChessGameID']));
+$template->assign('ChessGame',ChessGame::getChessGame($var['ChessGameID']));
 $template->assign('ChessMoveHREF',SmrSession::getNewHREF(create_container('chess_move_processing.php','',array('AJAX' => true, 'ChessGameID' => $var['ChessGameID']))));
 ?>

--- a/engine/Default/combat_log_viewer.php
+++ b/engine/Default/combat_log_viewer.php
@@ -33,7 +33,7 @@ if($db->nextRecord()) {
 	$template->assign('CombatLogTimestamp',date(DATE_FULL_SHORT,$db->getField('timestamp')));
 	$results = unserialize(gzuncompress($db->getField('result')));
 	$template->assign('CombatResultsType',$db->getField('type'));
-	$template->assignByRef('CombatResults',$results);
+	$template->assign('CombatResults',$results);
 }
 else {
 	create_error('Combat log not found');

--- a/engine/Default/combat_simulator.php
+++ b/engine/Default/combat_simulator.php
@@ -28,7 +28,7 @@ if(isset($_POST['attackers']))
 
 for(;$i<=10;++$i)
 	$attackers[$i] = null;
-$template->assignByRef('Attackers',$attackers);
+$template->assign('Attackers',$attackers);
 
 $i=1;
 $realDefenders = array();
@@ -50,7 +50,7 @@ if(isset($_POST['defenders']))
 	
 for(;$i<=10;++$i)
 	$defenders[$i] = null;
-$template->assignByRef('Defenders',$defenders);
+$template->assign('Defenders',$defenders);
 
 $template->assign('Duplicates',$duplicates);
 
@@ -89,6 +89,6 @@ function runAnAttack($realAttackers,$realDefenders) {
 		$results['Defenders']['Traders'][]  =& $playerResults;
 		$results['Defenders']['TotalDamage'] += $playerResults['TotalDamage'];
 	} unset($teamPlayer);
-	$template->assignByRef('TraderCombatResults',$results);
+	$template->assign('TraderCombatResults',$results);
 }
 ?>

--- a/engine/Default/configure_hardware.php
+++ b/engine/Default/configure_hardware.php
@@ -23,7 +23,7 @@ if ($ship->hasIllusion()) {
 	while ($db->nextRecord()) {
 		$ships[$db->getField('ship_type_id')] = $db->getField('ship_name');
 	}
-	$template->assignByRef('IllusionShips',$ships);
+	$template->assign('IllusionShips',$ships);
 	$container['action'] = 'Disable Illusion';
 	$template->assign('DisableIllusionHref',SmrSession::getNewHREF($container));
 }

--- a/engine/Default/council_politics.php
+++ b/engine/Default/council_politics.php
@@ -31,8 +31,8 @@ foreach ($RACES as $otherRaceID => $raceInfo) {
 	}
 }
 
-$template->assignByRef('PeaceRaces', $peaceRaces);
-$template->assignByRef('NeutralRaces', $neutralRaces);
-$template->assignByRef('WarRaces', $warRaces);
+$template->assign('PeaceRaces', $peaceRaces);
+$template->assign('NeutralRaces', $neutralRaces);
+$template->assign('WarRaces', $warRaces);
 
 ?>

--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -7,7 +7,7 @@ if($player->isLandedOnPlanet()) {
 
 $sector =& $player->getSector();
 
-$template->assignByRef('ThisSector',$sector);
+$template->assign('ThisSector',$sector);
 $template->assign('SpaceView',true);
 
 $template->assign('PageTopic','Current Sector: ' . $player->getSectorID() . ' (' .$sector->getGalaxyName() . ')');
@@ -46,7 +46,7 @@ foreach($links as $key => $linkArray) {
 	}
 }
 
-$template->assignByRef('Sectors',$links);
+$template->assign('Sectors',$links);
 
 doTickerAssigns($template, $player, $db);
 
@@ -169,7 +169,7 @@ function checkForAttackMessage(&$msg) {
 				if($player->getSectorID()==$db->getField('sector_id')) {
 					$results = unserialize(gzuncompress($db->getField('result')));
 					$template->assign('AttackResultsType',$db->getField('type'));
-					$template->assignByRef('AttackResults',$results);
+					$template->assign('AttackResults',$results);
 				}
 			}
 		}

--- a/engine/Default/edit_dummys.php
+++ b/engine/Default/edit_dummys.php
@@ -6,8 +6,8 @@ require_once(get_file_loc('DummyShip.class.inc'));
 require_once(get_file_loc('SmrWeapon.class.inc'));
 //TODO add game type id
 $template->assign('CombatSimLink',SmrSession::getNewHREF(create_container('skeleton.php','combat_simulator.php')));
-$template->assignByRef('BaseShips',AbstractSmrShip::getAllBaseShips(0));
-$template->assignByRef('Weapons',SmrWeapon::getAllWeapons(0));
+$template->assign('BaseShips',AbstractSmrShip::getAllBaseShips(0));
+$template->assign('Weapons',SmrWeapon::getAllWeapons(0));
 
 $template->assign('EditDummysLink',SmrSession::getNewHREF(create_container('skeleton.php','edit_dummys.php')));
 
@@ -31,10 +31,10 @@ if(isset($_REQUEST['save_dummy'])) {
 }
 
 
-$template->assignByRef('DummyPlayer',$dummyPlayer);
-$template->assignByRef('DummyShip',$dummyShip);
-$template->assignByRef('ShipWeapons',$dummyShip->getWeapons());
-$template->assignByRef('Levels',Globals::getLevelRequirements());
+$template->assign('DummyPlayer',$dummyPlayer);
+$template->assign('DummyShip',$dummyShip);
+$template->assign('ShipWeapons',$dummyShip->getWeapons());
+$template->assign('Levels',Globals::getLevelRequirements());
 
 
 

--- a/engine/Default/feature_request.php
+++ b/engine/Default/feature_request.php
@@ -34,7 +34,7 @@ foreach ($requestCategories as $category => $description) {
 		'Description' => $description
 	);
 }
-$template->assignByRef('CategoryTable', $categoryTable);
+$template->assign('CategoryTable', $categoryTable);
 
 // Can the players vote for features on the current page?
 $canVote = $thisStatus == 'Opened';
@@ -91,7 +91,7 @@ if ($db->getNumRows() > 0) {
 		$commentsContainer['RequestID'] = $featureRequestID;
 		$featureRequests[$featureRequestID]['CommentsHREF'] = SmrSession::getNewHREF($commentsContainer);
 	}
-	$template->assignByRef('FeatureRequests',$featureRequests);
+	$template->assign('FeatureRequests',$featureRequests);
 }
 
 $template->assign('FeatureRequestFormHREF',SmrSession::getNewHREF(create_container('feature_request_processing.php', '')));

--- a/engine/Default/feature_request_comments.php
+++ b/engine/Default/feature_request_comments.php
@@ -35,7 +35,7 @@ if ($db->getNumRows() > 0) {
 		if($featureModerator || !$db->getBoolean('anonymous'))
 			$featureRequestComments[$commentID]['PosterAccount'] =& SmrAccount::getAccount($db->getField('poster_id'));
 	}
-	$template->assignByRef('Comments', $featureRequestComments);
+	$template->assign('Comments', $featureRequestComments);
 }
 
 $container = $var;

--- a/engine/Default/forces_attack.php
+++ b/engine/Default/forces_attack.php
@@ -1,10 +1,10 @@
 <?php
 
 $results = unserialize($var['results']);
-$template->assignByRef('FullForceCombatResults',$results);
+$template->assign('FullForceCombatResults',$results);
 
 if($var['owner_id']>0)
-	$template->assignByRef('Target',SmrForce::getForce($player->getGameID(),$player->getSectorID(),$var['owner_id']));
+	$template->assign('Target',SmrForce::getForce($player->getGameID(),$player->getSectorID(),$var['owner_id']));
 
 if(isset($var['override_death']))
 	$template->assign('OverrideDeath',true);

--- a/engine/Default/game_join.php
+++ b/engine/Default/game_join.php
@@ -2,7 +2,7 @@
 
 $game = SmrGame::getGame($var['game_id']);
 
-$template->assignByRef('Game',$game);
+$template->assign('Game',$game);
 
 // do we need credits for this game?
 if ($game->getCreditsNeeded() > 0) {

--- a/engine/Default/map_local.php
+++ b/engine/Default/map_local.php
@@ -86,6 +86,6 @@ for ($i=0;$i<$span&&$i<$galaxy->getHeight();$i++) {
 		$mapSectors[$i][$j] =& $thisSec;
 	}
 }
-$template->assignByRef('MapSectors',$mapSectors);
+$template->assign('MapSectors',$mapSectors);
 
 ?>

--- a/engine/Default/message_send.php
+++ b/engine/Default/message_send.php
@@ -10,7 +10,7 @@ transfer('receiver');
 $template->assign('MessageSendFormHref',SmrSession::getNewHREF($container));
 
 if (!empty($var['receiver']))
-	$template->assignByRef('Receiver', SmrPlayer::getPlayer($var['receiver'], $player->getGameID()));
+	$template->assign('Receiver', SmrPlayer::getPlayer($var['receiver'], $player->getGameID()));
 else
 	$template->assign('Receiver', 'All Online');
 if(isset($var['preview']))

--- a/engine/Default/message_view.php
+++ b/engine/Default/message_view.php
@@ -80,7 +80,7 @@ if (!isset ($var['folder_id'])) {
 	$messageBox['DeleteHref'] = SmrSession::getNewHREF($container);
 	$messageBoxes[] = $messageBox;
 
-	$template->assignByRef('MessageBoxes', $messageBoxes);
+	$template->assign('MessageBoxes', $messageBoxes);
 
 	$container = create_container('skeleton.php','message_blacklist.php');
 	$container['folder_id'] = $message_type_id;
@@ -185,7 +185,7 @@ else {
 		$db->query('UPDATE message SET msg_read = \'TRUE\'
 					WHERE message_type_id = ' . $db->escapeNumber($var['folder_id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id = ' . $db->escapeNumber($player->getAccountID()));
 	}
-	$template->assignByRef('MessageBox', $messageBox);
+	$template->assign('MessageBox', $messageBox);
 }
 
 function displayScouts(&$db, &$messageBox, &$player, $read, $group) {

--- a/engine/Default/planet_attack.php
+++ b/engine/Default/planet_attack.php
@@ -2,7 +2,7 @@
 require_once(get_file_loc('SmrPlanet.class.inc'));
 if(isset($var['results'])) {
 	$results = unserialize($var['results']);
-	$template->assignByRef('FullPlanetCombatResults',$results);
+	$template->assign('FullPlanetCombatResults',$results);
 	$template->assign('AlreadyDestroyed',false);
 }
 else
@@ -12,5 +12,5 @@ if(isset($var['override_death']))
 	$template->assign('OverrideDeath',true);
 else
 	$template->assign('OverrideDeath',false);
-$template->assignByRef('Planet',SmrPlanet::getPlanet($player->getGameID(),$var['sector_id']));
+$template->assign('Planet',SmrPlanet::getPlanet($player->getGameID(),$var['sector_id']));
 ?>

--- a/engine/Default/planet_construction.php
+++ b/engine/Default/planet_construction.php
@@ -8,7 +8,7 @@ $template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$playe
 require_once(get_file_loc('menu.inc'));
 create_planet_menu($planet);
 
-$template->assignByRef('ThisPlanet', $planet);
+$template->assign('ThisPlanet', $planet);
 $template->assign('PlanetBuildings', Globals::getPlanetBuildings());
 
 

--- a/engine/Default/planet_examine.php
+++ b/engine/Default/planet_examine.php
@@ -3,7 +3,7 @@
 $template->assign('PageTopic','Examine Planet');
 
 $planet =& $player->getSectorPlanet();
-$template->assignByRef('ThisPlanet', $planet);
+$template->assign('ThisPlanet', $planet);
 
 $planetLand = 
 	!$planet->hasOwner()

--- a/engine/Default/planet_financial.php
+++ b/engine/Default/planet_financial.php
@@ -11,6 +11,6 @@ $template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$playe
 require_once(get_file_loc('menu.inc'));
 create_planet_menu($planet);
 
-$template->assignByRef('ThisPlanet', $planet);
+$template->assign('ThisPlanet', $planet);
 
 ?>

--- a/engine/Default/planet_main.php
+++ b/engine/Default/planet_main.php
@@ -17,7 +17,7 @@ if (isset($var['msg'])) {
 	$template->assign('Msg', bbifyMessage($var['msg']));
 }
 
-$template->assignByRef('ThisPlanet',$planet);
+$template->assign('ThisPlanet',$planet);
 
 doTickerAssigns($template, $player, $db);
 

--- a/engine/Default/port_attack.php
+++ b/engine/Default/port_attack.php
@@ -2,7 +2,7 @@
 require_once(get_file_loc('SmrPort.class.inc'));
 if(isset($var['results'])) {
 	$results = unserialize($var['results']);
-	$template->assignByRef('FullPortCombatResults',$results);
+	$template->assign('FullPortCombatResults',$results);
 	$template->assign('AlreadyDestroyed',false);
 }
 else
@@ -13,5 +13,5 @@ if(isset($var['override_death']))
 	$template->assign('OverrideDeath',true);
 else
 	$template->assign('OverrideDeath',false);
-$template->assignByRef('Port',$sector->getPort());
+$template->assign('Port',$sector->getPort());
 ?>

--- a/engine/Default/port_loot.php
+++ b/engine/Default/port_loot.php
@@ -1,4 +1,4 @@
 <?php
 $template->assign('PageTopic','Looting The Port');
-$template->assignByRef('ThisPort',$player->getSectorPort());
+$template->assign('ThisPort',$player->getSectorPort());
 ?>

--- a/engine/Default/preferences.php
+++ b/engine/Default/preferences.php
@@ -23,5 +23,5 @@ $transferAccounts = array();
 		$transferAccounts[$db->getField('account_id')] = $db->getField('hof_name');
 	}
 //}
-$template->assignByRef('TransferAccounts',$transferAccounts);
+$template->assign('TransferAccounts',$transferAccounts);
 ?>

--- a/engine/Default/rankings_alliance_death.php
+++ b/engine/Default/rankings_alliance_death.php
@@ -28,14 +28,14 @@ if ($player->hasAlliance()) {
 
 $db->query('SELECT alliance_id, alliance_deaths amount FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, alliance_name LIMIT 10');
-$template->assignByRef('Rankings', Rankings::collectAllianceRankings($db, $player, 0));
+$template->assign('Rankings', Rankings::collectAllianceRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $numAlliances);
 
 $lowerLimit = $var['MinRank'] - 1;
 $db->query('SELECT alliance_id, alliance_deaths amount FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, alliance_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, 0));
+$template->assign('FilteredRankings', Rankings::collectAllianceRankings($db, $player, 0));
 
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_death.php')));
 ?>

--- a/engine/Default/rankings_alliance_experience.php
+++ b/engine/Default/rankings_alliance_experience.php
@@ -44,7 +44,7 @@ $db->query('SELECT alliance_id, SUM(experience) amount
 			GROUP BY alliance_id, alliance_name
 			ORDER BY amount DESC, alliance_name
 			LIMIT 10');
-$template->assignByRef('Rankings', Rankings::collectAllianceRankings($db, $player, 0));
+$template->assign('Rankings', Rankings::collectAllianceRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $numAlliances);
 
@@ -56,7 +56,7 @@ $db->query('SELECT alliance_id, SUM(experience) amount
 			GROUP BY alliance_id, alliance_name
 			ORDER BY amount DESC, alliance_name
 			LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, $lowerLimit));
+$template->assign('FilteredRankings', Rankings::collectAllianceRankings($db, $player, $lowerLimit));
 
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_experience.php')));
 ?>

--- a/engine/Default/rankings_alliance_kills.php
+++ b/engine/Default/rankings_alliance_kills.php
@@ -28,14 +28,14 @@ if ($player->hasAlliance()) {
 
 $db->query('SELECT alliance_id, alliance_kills amount FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, alliance_name LIMIT 10');
-$template->assignByRef('Rankings', Rankings::collectAllianceRankings($db, $player, 0));
+$template->assign('Rankings', Rankings::collectAllianceRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $numAlliances);
 
 $lowerLimit = $var['MinRank'] - 1;
 $db->query('SELECT alliance_id, alliance_kills amount FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, alliance_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, $lowerLimit));
+$template->assign('FilteredRankings', Rankings::collectAllianceRankings($db, $player, $lowerLimit));
 
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_kills.php')));
 ?>

--- a/engine/Default/rankings_alliance_profit.php
+++ b/engine/Default/rankings_alliance_profit.php
@@ -49,7 +49,7 @@ $db->query('SELECT alliance_id, SUM(amount) amount
 			GROUP BY alliance_id, alliance_name
 			ORDER BY amount DESC, alliance_name
 			LIMIT 10');
-$template->assignByRef('Rankings', Rankings::collectAllianceRankings($db, $player, 0));
+$template->assign('Rankings', Rankings::collectAllianceRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $numAlliances);
 
@@ -62,7 +62,7 @@ $db->query('SELECT alliance_id, SUM(amount) amount
 			GROUP BY alliance_id, alliance_name
 			ORDER BY amount DESC, alliance_name
 			LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectAllianceRankings($db, $player, $lowerLimit));
+$template->assign('FilteredRankings', Rankings::collectAllianceRankings($db, $player, $lowerLimit));
 
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_experience.php')));
 ?>

--- a/engine/Default/rankings_player_death.php
+++ b/engine/Default/rankings_player_death.php
@@ -23,7 +23,7 @@ $template->assign('OurRank', $ourRank);
 $totalPlayers = $player->getGame()->getTotalPlayers();
 
 $db->query('SELECT account_id, deaths amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY deaths DESC, player_name LIMIT 10');
-$template->assignByRef('Rankings', Rankings::collectRankings($db, $player, 0));
+$template->assign('Rankings', Rankings::collectRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 
@@ -31,5 +31,5 @@ $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container(
 
 $lowerLimit = $var['MinRank'] - 1;
 $db->query('SELECT account_id, deaths amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY deaths DESC, player_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));
+$template->assign('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));
 ?>

--- a/engine/Default/rankings_player_experience.php
+++ b/engine/Default/rankings_player_experience.php
@@ -23,7 +23,7 @@ $template->assign('OurRank', $ourRank);
 $totalPlayers = $player->getGame()->getTotalPlayers();
 
 $db->query('SELECT account_id, experience amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY experience DESC, player_name LIMIT 10');
-$template->assignByRef('Rankings', Rankings::collectRankings($db, $player, 0));
+$template->assign('Rankings', Rankings::collectRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 
@@ -31,5 +31,5 @@ $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container(
 
 $lowerLimit = $var['MinRank'] - 1;
 $db->query('SELECT account_id, experience amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY experience DESC, player_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));
+$template->assign('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));
 ?>

--- a/engine/Default/rankings_player_kills.php
+++ b/engine/Default/rankings_player_kills.php
@@ -23,7 +23,7 @@ $template->assign('OurRank', $ourRank);
 $totalPlayers = $player->getGame()->getTotalPlayers();
 
 $db->query('SELECT account_id, kills amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC, player_name LIMIT 10');
-$template->assignByRef('Rankings', Rankings::collectRankings($db, $player, 0));
+$template->assign('Rankings', Rankings::collectRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 
@@ -31,5 +31,5 @@ $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container(
 
 $lowerLimit = $var['MinRank'] - 1;
 $db->query('SELECT account_id, kills amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC, player_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));
+$template->assign('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));
 ?>

--- a/engine/Default/rankings_player_profit.php
+++ b/engine/Default/rankings_player_profit.php
@@ -28,7 +28,7 @@ $template->assign('OurRank', $ourRank);
 $totalPlayers = $player->getGame()->getTotalPlayers();
 
 $db->query('SELECT p.account_id, COALESCE(ph.amount,0) amount FROM player p LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $profitTypeEscaped . ' WHERE p.game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, player_name ASC LIMIT 10');
-$template->assignByRef('Rankings', Rankings::collectRankings($db, $player, 0));
+$template->assign('Rankings', Rankings::collectRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 
@@ -36,5 +36,5 @@ $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container(
 
 $lowerLimit = $var['MinRank'] - 1;
 $db->query('SELECT p.account_id, COALESCE(ph.amount,0) amount FROM player p LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $profitTypeEscaped . ' WHERE p.game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, player_name ASC LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
-$template->assignByRef('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));
+$template->assign('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));
 ?>

--- a/engine/Default/shop_hardware.php
+++ b/engine/Default/shop_hardware.php
@@ -15,7 +15,7 @@ if ($location->isHardwareSold()) {
 		$container['hardware_id'] = $hardwareTypeID;
 		$hardwareSold[$hardwareTypeID]['HREF'] = SmrSession::getNewHREF($container);
 	}
-	$template->assignByRef('HardwareSold', $hardwareSold);
+	$template->assign('HardwareSold', $hardwareSold);
 }
 
 ?>

--- a/engine/Default/shop_weapon.php
+++ b/engine/Default/shop_weapon.php
@@ -1,4 +1,4 @@
 <?php
 $template->assign('PageTopic','Weapon Dealer');
-$template->assignByRef('ThisLocation', SmrLocation::getLocation($var['LocationID']));
+$template->assign('ThisLocation', SmrLocation::getLocation($var['LocationID']));
 ?>

--- a/engine/Default/trader_attack.php
+++ b/engine/Default/trader_attack.php
@@ -1,8 +1,8 @@
 <?php
 $results = unserialize($var['results']);
-$template->assignByRef('TraderCombatResults',$results);
+$template->assign('TraderCombatResults',$results);
 if($var['target'])
-	$template->assignByRef('Target',SmrPlayer::getPlayer($var['target'],$player->getGameID()));
+	$template->assign('Target',SmrPlayer::getPlayer($var['target'],$player->getGameID()));
 if(isset($var['override_death']))
 	$template->assign('OverrideDeath',true);
 else

--- a/engine/Default/trader_examine.php
+++ b/engine/Default/trader_examine.php
@@ -12,5 +12,5 @@ if($targetPlayer->isDead()) {
 
 $template->assign('PageTopic','Examine Ship');
 // should we display a attack button
-$template->assignByRef('TargetPlayer',$targetPlayer);
+$template->assign('TargetPlayer',$targetPlayer);
 ?>

--- a/engine/Draft/alliance_pick.php
+++ b/engine/Draft/alliance_pick.php
@@ -7,7 +7,7 @@ create_alliance_menu($alliance->getAllianceID(),$alliance->getLeaderID());
 // Get the current teams
 require_once('alliance_pick.inc');
 $teams = get_draft_teams($player->getGameID());
-$template->assignByRef('Teams', $teams);
+$template->assign('Teams', $teams);
 
 // Add information about current player
 $template->assign('PlayerID', $player->getPlayerID());
@@ -22,7 +22,7 @@ while($db->nextRecord()) {
 						'HREF' => SmrSession::getNewHREF(create_container('alliance_pick_processing.php','',array('PickedAccountID'=>$pickPlayer->getAccountID()))));
 }
 
-$template->assignByRef('PickPlayers', $players);
+$template->assign('PickPlayers', $players);
 
 // Get the draft history
 $history = array();
@@ -35,5 +35,5 @@ while ($db->nextRecord()) {
 	                   'Time'   => $db->getInt('time'));
 }
 
-$template->assignByRef('History', $history);
+$template->assign('History', $history);
 ?>

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -57,7 +57,7 @@ try {
 				else {
 					session_start(); //Pass the data in a standard session as we don't want to initialise a normal one.
 					$_SESSION['socialLogin'] =& $socialLogin;
-					$template->assignByRef('SocialLogin',$socialLogin);
+					$template->assign('SocialLogin',$socialLogin);
 					$template->display('socialRegister.inc');
 					exit;
 				}

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -136,13 +136,13 @@ try {
 	$template->assign('CSSLink', $account->getCssUrl());
 	$template->assign('CSSColourLink', $account->getCssColourUrl());
 	$template->assign('FontSize', $account->getFontSize() - 20);
-	$template->assignByRef('ThisGalaxy',$galaxy);
-	$template->assignByRef('ThisAccount',$account);
-	$template->assignByRef('GameGalaxies',SmrGalaxy::getGameGalaxies($player->getGameID()));
-	$template->assignByRef('ThisSector',$player->getSector());
-	$template->assignByRef('MapSectors',$mapSectors);
-	$template->assignByRef('ThisShip',$player->getShip());
-	$template->assignByRef('ThisPlayer',$player);
+	$template->assign('ThisGalaxy',$galaxy);
+	$template->assign('ThisAccount',$account);
+	$template->assign('GameGalaxies',SmrGalaxy::getGameGalaxies($player->getGameID()));
+	$template->assign('ThisSector',$player->getSector());
+	$template->assign('MapSectors',$mapSectors);
+	$template->assign('ThisShip',$player->getShip());
+	$template->assign('ThisPlayer',$player);
 
 	// AJAX updates are not set up for the galaxy map at this time
 	$template->assign('AJAX_ENABLE_REFRESH', false);

--- a/lib/Default/Template.class.inc
+++ b/lib/Default/Template.class.inc
@@ -19,15 +19,11 @@ class Template {
 	}
 	
 	public function assign($var, $value) {
-		$this->data[$var] =& $value;
+		$this->data[$var] = $value;
 	}
 	
 	public function unassign($var) {
 		unset($this->data[$var]);
-	}
-	
-	public function assignByRef($var, &$value) {
-		$this->data[$var] =& $value;
 	}
 	
 	public function display($templateName,$forAjax=false, $xmlResponse=false) {
@@ -122,14 +118,12 @@ class Template {
 		if($this->nestedIncludes > 15) {
 			throw new Exception('Nested more than 15 template includes, is something wrong?');
 		}
-		foreach($this->data as $key => &$value) {
-			$$key=&$value;
-			unset($value);
+		foreach ($this->data as $key => $value) {
+			$$key = $value;
 		}
 		if($assignVars!==null) {
-			foreach($assignVars as $key => &$value) {
-				$$key=&$value;
-				unset($value);
+			foreach ($assignVars as $key => $value) {
+				$$key = $value;
 			}
 		}
 		$this->nestedIncludes++;

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -641,11 +641,11 @@ function do_voodoo() {
 
 	$template->assign('TemplateBody',$var['body']);
 	if (SmrSession::$game_id > 0) {
-		$template->assignByRef('ThisSector',$sector);
-		$template->assignByRef('ThisPlayer',$player);
-		$template->assignByRef('ThisShip',$ship);
+		$template->assign('ThisSector',$sector);
+		$template->assign('ThisPlayer',$player);
+		$template->assign('ThisShip',$ship);
 	}
-	$template->assignByRef('ThisAccount',$account);
+	$template->assign('ThisAccount',$account);
 	if($account->getCssLink()!=null) {
 		$template->assign('ExtraCSSLink',$account->getCssLink());
 	}


### PR DESCRIPTION
See #317.

We should never need to modify a variable that was assigned to
a template (because templates are for display only, not processing).
Therefore, we should only pass variables by reference to the template
to improve both performance and safety.

* `assign` and `display` no longer use references
* `assignByRef` has been removed