### PR TITLE
Silence ircbot ping message by default

### DIFF
--- a/config/irc/config.specific.sample.php
+++ b/config/irc/config.specific.sample.php
@@ -5,5 +5,6 @@ define('IRC_BOT_SERVER_PORT', 6667);
 define('IRC_BOT_NICK', 'Caretaker');
 define('IRC_BOT_PASS', 'secret_key');
 define('IRC_BOT_USER', strtolower(IRC_BOT_NICK) . ' oberon smrealms.de :Official SMR bot');
+define('IRC_BOT_VERBOSE_PING', false);
 
 ?>

--- a/tools/irc/server.php
+++ b/tools/irc/server.php
@@ -9,7 +9,10 @@ function server_ping($fp, $rdata)
 
 		$server = $msg[1];
 
-		echo_r('[PING] from ' . $server);
+		// This message is very spammy
+		if (defined('IRC_BOT_VERBOSE_PING') && IRC_BOT_VERBOSE_PING) {
+			echo_r('[PING] from ' . $server);
+		}
 
 		fputs($fp, 'PONG ' . $server . EOL);
 		return true;


### PR DESCRIPTION
The server ping (which occurs roughly every minute) prints a message
that becomes extremely verbose when the ircbot has been running for
a long time. To avoid overloading the logs, we silence this message
by default. An optional config variable `IRC_BOT_VERBOSE_PING` can
be sent to `true` to recover this diagnostic message.