### PR TITLE
Dockerfile: Add git commit data to the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,5 @@
 # Files to ignore when building Docker image
 
-# Git data directory
-.git
-
 # Committed files that are not needed in the build
 docker-compose.yml
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,15 @@ WORKDIR /smr/
 # See https://github.com/hollandben/grunt-cache-bust/issues/236
 RUN npm i --save grunt grunt-contrib-uglify grunt-contrib-cssmin grunt-cache-bust@1.4.1
 
-# Copy the SMR source code
-COPY . .
+# Copy the SMR source code directories
+COPY admin admin
+COPY engine engine
+COPY htdocs htdocs
+COPY lib lib
+COPY templates templates
 
 # Perform CSS/JS minification and cache busting
+COPY Gruntfile.js .
 RUN npx grunt
 
 # Remove local grunt install so it is not copied to the next build stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,8 @@ RUN rm -rf /var/www/html/ && ln -s "$(pwd)/htdocs" /var/www/html
 
 # Make the upload directory writable by the apache user
 RUN chown www-data ./htdocs/upload
+
+# Store the git commit hash of the repo in the final image
+COPY .git/HEAD .git/HEAD
+COPY .git/refs .git/refs
+RUN cat .git/$(cat .git/HEAD | awk '{print $2}') > git-commit


### PR DESCRIPTION
Add enough data from the `.git` directory to be able to store
the commit hash of HEAD. This allows us to tell which version
of the code is running in a docker image.

Ideally we would want this in the image metadata, but I think
Docker prevents this sort of dynamic logic at build time.

We use this method in favor of two other alternatives:

1. Docker Cloud build arg

Docker Cloud provides a `$SOURCE_COMMIT` build arg, but it can
only be passed into the build environment with a custom build
hook. Unfortunately, this causes the Docker Cloud build to not
utilize the layer cache correctly, even though diagnostic
messages indicate that it is pulling/pushing the layer index
for the repo. I don't understand why it does this, and Docker
Cloud support is very limited. I suspect it is because the
default build hook (which is not public) has special magic that
the recommended build command override is missing.

See https://github.com/docker/hub-feedback/issues/600 for details.

2. Custom build script

If we want to forego Docker Cloud altogether, we can write our
own custom script to build images and push them to the Docker
registry. This would give us complete flexibility, but sacrifices
automation and uses personal resources instead of free commercial
services. We may have to do this anyway if Docker Cloud continues
its pattern of deactivating service components.