### PR TITLE
Auto-update page to current sector when kicked from planet

### DIFF
--- a/engine/Default/planet.inc
+++ b/engine/Default/planet.inc
@@ -7,6 +7,7 @@ if (!$player->isLandedOnPlanet()) {
 		// Auto-click current sector with javascript to avoid issues with ajax
 		// updates when the display page changes.
 		$container = create_container('skeleton.php', 'current_sector.php');
+		$container['msg'] = '<span class="yellow">WARNING</span>: You have been ejected from the planet!';
 		$currentSectorHREF = SmrSession::getNewHREF($container);
 		$template->addJavascriptForAjax('EVAL', "location.href = '$currentSectorHREF'");
 		forward($container);

--- a/engine/Default/planet.inc
+++ b/engine/Default/planet.inc
@@ -1,0 +1,25 @@
+<?php
+// Common code for all the planet display pages
+
+// If not on a planet, forward to current_sector.php
+if (!$player->isLandedOnPlanet()) {
+	if (USING_AJAX) {
+		// Auto-click current sector with javascript to avoid issues with ajax
+		// updates when the display page changes.
+		$container = create_container('skeleton.php', 'current_sector.php');
+		$currentSectorHREF = SmrSession::getNewHREF($container);
+		$template->addJavascriptForAjax('EVAL', "location.href = '$currentSectorHREF'");
+		forward($container);
+	} else {
+		create_error('You are not on a planet!');
+	}
+}
+
+$planet = $player->getSectorPlanet();
+$template->assign('ThisPlanet', $planet);
+$template->assign('PageTopic', 'Planet : '.$planet->getName().' [Sector #'.$player->getSectorID().']');
+
+require_once(get_file_loc('menu.inc'));
+create_planet_menu($planet);
+
+?>

--- a/engine/Default/planet.inc
+++ b/engine/Default/planet.inc
@@ -9,7 +9,8 @@ if (!$player->isLandedOnPlanet()) {
 		$container = create_container('skeleton.php', 'current_sector.php');
 		$container['msg'] = '<span class="yellow">WARNING</span>: You have been ejected from the planet!';
 		$currentSectorHREF = SmrSession::getNewHREF($container);
-		$template->addJavascriptForAjax('EVAL', "location.href = '$currentSectorHREF'");
+		// json_encode the HREF as a safety precaution
+		$template->addJavascriptForAjax('EVAL', 'location.href = ' . json_encode($currentSectorHREF));
 		forward($container);
 	} else {
 		create_error('You are not on a planet!');

--- a/engine/Default/planet_bond_confirmation.php
+++ b/engine/Default/planet_bond_confirmation.php
@@ -1,15 +1,6 @@
 <?php
-if (!$player->isLandedOnPlanet()) {
-	create_error('You are not on a planet!');
-}
 
-// create planet object
-$planet =& $player->getSectorPlanet();
-
-$template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$player->getSectorID().']');
-
-require_once(get_file_loc('menu.inc'));
-create_planet_menu($planet);
+include('planet.inc');
 
 $template->assign('BondDuration', format_time($planet->getBondTime()));
 $template->assign('ReturnHREF', $planet->getFinancesHREF());

--- a/engine/Default/planet_construction.php
+++ b/engine/Default/planet_construction.php
@@ -1,16 +1,7 @@
 <?php
-if (!$player->isLandedOnPlanet()) {
-	create_error('You are not on a planet!');
-}
 
-$planet =& $player->getSectorPlanet();
-$template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$player->getSectorID().']');
-require_once(get_file_loc('menu.inc'));
-create_planet_menu($planet);
+include('planet.inc');
 
-$template->assign('ThisPlanet', $planet);
 $template->assign('PlanetBuildings', Globals::getPlanetBuildings());
-
-
 $template->assign('Goods', Globals::getGoods());
 ?>

--- a/engine/Default/planet_defense.php
+++ b/engine/Default/planet_defense.php
@@ -1,14 +1,6 @@
 <?php
-if (!$player->isLandedOnPlanet())
-	create_error('You are not on a planet!');
 
-// create planet object
-$planet =& $player->getSectorPlanet();
-$template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$player->getSectorID().']');
-$template->assign('ThisPlanet',$planet);
-
-require_once(get_file_loc('menu.inc'));
-create_planet_menu($planet);
+include('planet.inc');
 
 $container = create_container('planet_defense_processing.php');
 $container['type_id'] = 1;

--- a/engine/Default/planet_financial.php
+++ b/engine/Default/planet_financial.php
@@ -1,16 +1,5 @@
 <?php
-if (!$player->isLandedOnPlanet()) {
-	create_error('You are not on a planet!');
-}
 
-// create planet object
-$planet =& $player->getSectorPlanet();
-
-$template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$player->getSectorID().']');
-
-require_once(get_file_loc('menu.inc'));
-create_planet_menu($planet);
-
-$template->assign('ThisPlanet', $planet);
+include('planet.inc');
 
 ?>

--- a/engine/Default/planet_main.php
+++ b/engine/Default/planet_main.php
@@ -1,13 +1,6 @@
 <?php
-if (!$player->isLandedOnPlanet())
-	create_error('You are not on a planet!');
 
-// create planet object
-$planet =& $player->getSectorPlanet();
-$template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$player->getSectorID().']');
-
-require_once(get_file_loc('menu.inc'));
-create_planet_menu($planet);
+include('planet.inc');
 
 //echo the dump cargo message or other message.
 if (isset($var['errorMsg'])) {
@@ -16,8 +9,6 @@ if (isset($var['errorMsg'])) {
 if (isset($var['msg'])) {
 	$template->assign('Msg', bbifyMessage($var['msg']));
 }
-
-$template->assign('ThisPlanet',$planet);
 
 doTickerAssigns($template, $player, $db);
 

--- a/engine/Default/planet_ownership.php
+++ b/engine/Default/planet_ownership.php
@@ -1,13 +1,6 @@
 <?php
-if (!$player->isLandedOnPlanet())
-	create_error('You are not on a planet!');
 
-// create planet object
-$planet = $player->getSectorPlanet();
-$template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$player->getSectorID().']');
-
-require_once(get_file_loc('menu.inc'));
-create_planet_menu($planet);
+include('planet.inc');
 
 $container = create_container('planet_ownership_processing.php');
 $template->assign('ProcessingHREF', SmrSession::getNewHREF($container));

--- a/engine/Default/planet_stockpile.php
+++ b/engine/Default/planet_stockpile.php
@@ -1,14 +1,6 @@
 <?php
-if (!$player->isLandedOnPlanet())
-	create_error('You are not on a planet!');
 
-// create planet object
-$planet =& $player->getSectorPlanet();
-
-$template->assign('PageTopic','Planet : '.$planet->getName().' [Sector #'.$planet->getSectorID().']');
-
-require_once(get_file_loc('menu.inc'));
-create_planet_menu($planet);
+include('planet.inc');
 
 $goodInfo = array();
 foreach (Globals::getGoods() as $goodID => $good) {

--- a/lib/Default/Template.class.inc
+++ b/lib/Default/Template.class.inc
@@ -255,7 +255,7 @@ class Template {
 	/*
 	 * EVAL is special (well, will be when needed and implemented in the javascript).
 	 */
-	protected function addJavascriptForAjax($varName, $obj) {
+	public function addJavascriptForAjax($varName, $obj) {
 		if($varName == 'EVAL') {
 			if(!isset($this->ajaxJS['EVAL'])) {
 				return $this->ajaxJS['EVAL'] = $obj;


### PR DESCRIPTION
In `create_error`, an exception is thrown if `USING_AJAX=true`.
This is because the ajax page refreshes don't really know how
to handle when a different page needs to be displayed without
the user clicking a button.

The most important place where this occurs is when a player is
kicked from a planet (by the owner or in a bust). In the past,
this would cause ajax to stop updating due to the exception.
We could instead forward to the current sector page, but this
would display a disjointed page because a) the left panel links
don't have span id's for updating and so you'd still see the
"Planet Main" link, and b) the middle panel won't update
correctly because we already have ajax-enabled child elements,
which disables the full middle panel update.

Instead what we will do is use `Template::addJavascriptForAjax`
(which needs to be made public so it can be used in the `engine`
files as well as the `template` files) to force the page to
load the current sector, circumventing all the ajax issues.

However, we still need to display _some_ page, since the javascript
won't trigger until after the page loads. Our options are:
1) Display the planet page for maximum continuity, but then if
   the player isn't using javascript, they will be able to
   effectively stay on the planet even when kicked off.
2) Return immediately after adding the javascript (which would
   need to be done both in the `engine` and `template` pages),
   but then a blank middle panel will display (which also isn't
   a great thing to display for non-javascript users).
3) Forward to `current_sector.php` after adding the javascript.
   This only requires us to modify the `engine` files, and
   displays only a marginally broken ajax-updated page.

We also continue to call `create_error` as before whenever
`USING_AJAX=false`, since that will correctly forward to the
current sector and display the error message.

Since this logic is somewhat fragile and is needed for all planet
display pages (not processing pages, since those require an
explicit click by the user), this is a good opportunity to refactor
all the common code out of these pages into `planet.inc`.