### PR TITLE
Move warp into sector table

### DIFF
--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -170,6 +170,7 @@ elseif ($submit == 'Create Warps') {
 			}
 		}
 	} unset($eachGalaxy);
+	SmrSector::saveSectors();
 	$var['message'] = '<span class="green">Success</span> : Succesfully added warps.';
 }
 elseif ($submit == 'Create Planets') {
@@ -347,13 +348,17 @@ elseif ($submit == 'Edit Sector') {
 	foreach($locationsToAdd as &$locationToAdd) {
 		addLocationToSector($locationToAdd,$sector);
 	}
-	if($sector->hasWarp() && $sector->getWarp()!=$_POST['warp']) {
-		$sector->getWarpSector()->removeWarp();
-		$sector->removeWarp();
-	}
 	if ($_POST['warp'] > 0) {
-		//add warp to other side
-		$sector->setWarp(SmrSector::getSector($var['game_id'],$_POST['warp']));
+		$warp = SmrSector::getSector($var['game_id'], $_POST['warp']);
+		if ($sector->equals($warp)) {
+			create_error('We do not allow any sector to warp to itself!');
+		}
+		// Removing warps first may do extra work, but is logically simpler
+		$warp->removeWarp();
+		$sector->removeWarp();
+		$sector->setWarp($warp);
+	} else {
+		$sector->removeWarp();
 	}
 	$var['message'] = '<span class="green">Success</span> : Succesfully edited sector.';
 	SmrSector::saveSectors();

--- a/admin/Default/1.6/universe_create_warps.php
+++ b/admin/Default/1.6/universe_create_warps.php
@@ -28,6 +28,10 @@ while ($db->nextRecord()) {
 	$warp1 = SmrSector::getSector($var['game_id'], $db->getInt('sector_id'));
 	$warp2 = SmrSector::getSector($var['game_id'], $db->getInt('warp'));
 	if ($warp1->getGalaxyID() == $warp2->getGalaxyID()) {
+		// For warps within the same galaxy, even though there will be two
+		// sectors with warps, we still consider this as "one warp" (pair).
+		// Since we're looping over all sectors, we'll hit this twice for each
+		// same-galaxy warp pair, so only add 0.5 to avoid double counting.
 		$warps[$warp1->getGalaxyID()][$warp2->getGalaxyID()] += 0.5;
 	} else {
 		$warps[$warp1->getGalaxyID()][$warp2->getGalaxyID()]++;

--- a/admin/Default/1.6/universe_create_warps.php
+++ b/admin/Default/1.6/universe_create_warps.php
@@ -23,15 +23,14 @@ foreach ($galaxies as $gal1) {
 }
 
 //get totals
-$db->query('SELECT * FROM warp WHERE game_id='.$db->escapeNumber($var['game_id']));
+$db->query('SELECT sector_id, warp FROM sector WHERE warp != 0 AND game_id='.$db->escapeNumber($var['game_id']));
 while ($db->nextRecord()) {
-	$warp1 = SmrSector::getSector($db->getInt('game_id'), $db->getInt('sector_id_1'));
-	$warp2 = SmrSector::getSector($db->getInt('game_id'), $db->getInt('sector_id_2'));
+	$warp1 = SmrSector::getSector($var['game_id'], $db->getInt('sector_id'));
+	$warp2 = SmrSector::getSector($var['game_id'], $db->getInt('warp'));
 	if ($warp1->getGalaxyID() == $warp2->getGalaxyID()) {
-		$warps[$warp1->getGalaxyID()][$warp2->getGalaxyID()]++;
+		$warps[$warp1->getGalaxyID()][$warp2->getGalaxyID()] += 0.5;
 	} else {
 		$warps[$warp1->getGalaxyID()][$warp2->getGalaxyID()]++;
-		$warps[$warp2->getGalaxyID()][$warp1->getGalaxyID()]++;
 	}
 }
 

--- a/admin/Default/game_delete_processing.php
+++ b/admin/Default/game_delete_processing.php
@@ -343,7 +343,6 @@ if ($action == 'Yes') {
 	$smr_db_sql[] = 'DELETE FROM ship_has_illusion WHERE game_id = '.$game_id;
 	$smr_db_sql[] = 'DELETE FROM ship_has_weapon WHERE game_id = '.$game_id;
 	$smr_db_sql[] = 'DELETE FROM ship_is_cloaked WHERE game_id = '.$game_id;
-	$smr_db_sql[] = 'DELETE FROM warp WHERE game_id = '.$game_id;
 	$smr_db_sql[] = 'UPDATE game SET end_date='.TIME.' WHERE game_id = '.$game_id.' AND end_date > '.TIME; // Do not delete game placeholder, just make sure game is finished
 	$smr_db_sql[] = 'UPDATE active_session SET game_id = 0 WHERE game_id = '.$game_id;
 

--- a/admin/Default/smc_new.php
+++ b/admin/Default/smc_new.php
@@ -241,14 +241,9 @@ while ($db->nextRecord()) {
 	if ($db->getField('link_left') > 0)
 		echo ('W');
 	echo (',');
-	$db2->query('SELECT * FROM warp WHERE game_id = '.$game_id.' AND sector_id_1 = '.$id);
+	$db2->query('SELECT warp FROM sector WHERE warp != 0 AND game_id = '.$game_id.' AND sector_id = '.$id);
 	if ($db2->nextRecord()) {
-		$warp = $db2->getField('sector_id_2');
-		echo ($warp);
-	}
-	$db2->query('SELECT * FROM warp WHERE game_id = '.$game_id.' AND sector_id_2 = '.$id);
-	if ($db2->nextRecord()) {
-		$warp = $db2->getField('sector_id_1');
+		$warp = $db2->getField('warp');
 		echo ($warp);
 	}
 	echo (',');

--- a/db/patches/V1_6_62_04__add_sector_warp.sql
+++ b/db/patches/V1_6_62_04__add_sector_warp.sql
@@ -1,0 +1,7 @@
+-- Add a `warp` field to the `sector` table
+ALTER TABLE sector ADD COLUMN warp int(10) unsigned NOT NULL DEFAULT '0' AFTER link_right;
+
+-- Move the warp data into the `sector` table
+UPDATE sector JOIN warp USING (game_id) SET warp = sector_id_2 WHERE sector_id = sector_id_1;
+UPDATE sector JOIN warp USING (game_id) SET warp = sector_id_1 WHERE sector_id = sector_id_2;
+DROP TABLE warp;

--- a/lib/Default/SmrSector.class.inc
+++ b/lib/Default/SmrSector.class.inc
@@ -120,22 +120,14 @@ class SmrSector {
 			if($this->db->getField('link_right'))
 				$this->links['Right'] = $this->db->getInt('link_right');
 
-
-			$this->db->query('SELECT * FROM warp
-								WHERE game_id = ' . $this->db->escapeNumber($this->gameID) . '
-								AND (
-									sector_id_1 = ' . $this->db->escapeNumber($this->sectorID) . '
-									OR sector_id_2 = ' . $this->db->escapeNumber($this->sectorID) . ')');
-			if ($this->db->nextRecord())
-				$this->warp = ($this->db->getInt('sector_id_1') == $this->sectorID) ? $this->db->getInt('sector_id_2') : $this->db->getInt('sector_id_1');
-			else
-				$this->warp = 0;
+			$this->warp = $this->db->getInt('warp');
 		}
 		else if($create) {
 			$this->gameID		= (int)$gameID;
 			$this->sectorID		= (int)$sectorID;
 			$this->battles		= 0;
 			$this->links = array();
+			$this->warp = 0;
 			$this->isNew		= true;
 			return;
 		}
@@ -153,10 +145,11 @@ class SmrSector {
 									', link_right=' . $this->db->escapeNumber($this->getLinkRight()) .
 									', link_down=' . $this->db->escapeNumber($this->getLinkDown()) .
 									', link_left=' . $this->db->escapeNumber($this->getLinkLeft()) .
+									', warp=' . $this->db->escapeNumber($this->getWarp()) .
 								' WHERE ' . $this->SQL . ' LIMIT 1');
 			}
 			else {
-				$this->db->query('INSERT INTO sector(sector_id,game_id,galaxy_id,link_up,link_down,link_left,link_right)
+				$this->db->query('INSERT INTO sector(sector_id,game_id,galaxy_id,link_up,link_down,link_left,link_right,warp)
 								values
 								(' . $this->db->escapeNumber($this->getSectorID()) .
 								',' . $this->db->escapeNumber($this->getGameID()) .
@@ -165,6 +158,7 @@ class SmrSector {
 								',' . $this->db->escapeNumber($this->getLinkDown()) .
 								',' . $this->db->escapeNumber($this->getLinkLeft()) .
 								',' . $this->db->escapeNumber($this->getLinkRight()) .
+								',' . $this->db->escapeNumber($this->getWarp()) .
 								')');
 				$this->isNew=false;
 			}
@@ -540,6 +534,9 @@ class SmrSector {
 		$this->setLink('Right',$linkID);
 	}
 
+	/**
+	 * Returns the warp sector if the sector has a warp; returns 0 otherwise.
+	 */
 	public function getWarp() {
 		return $this->warp;
 	}
@@ -552,41 +549,54 @@ class SmrSector {
 		return $this->getWarp()!=0;
 	}
 
-	public function setWarp(SmrSector $warp,$justThisObjectData=false) {
-		if($justThisObjectData===false) {
-			if($this->hasWarp()) {
-				//Update both possible combinations for the warp
-				$this->db->query('UPDATE warp SET sector_id_1 = ' . $this->db->escapeNumber($warp->getSectorID()) . '
-									WHERE game_id=' . $this->db->escapeNumber($this->getGameID()) . '
-										AND sector_id_1 = ' . $this->db->escapeNumber($this->getWarp()) . '
-										AND sector_id_2 = ' . $this->db->escapeNumber($this->getSectorID()) . ' LIMIT 1');
-				$this->db->query('UPDATE warp SET sector_id_2 = ' . $this->db->escapeNumber($warp->getSectorID()) . '
-									WHERE game_id=' . $this->db->escapeNumber($this->getGameID()) . '
-										AND sector_id_1 = ' . $this->db->escapeNumber($this->getSectorID()) . '
-										AND sector_id_2 = ' . $this->db->escapeNumber($this->getWarp()) . ' LIMIT 1');
-			}
-			else {
-				//Only need to enter once
-				$this->db->query('INSERT INTO warp (game_id,sector_id_1,sector_id_2)values(' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber($this->getSectorID()) . ',' . $this->db->escapeNumber($warp->getSectorID()) . ')');
-			}
-			$warp->setWarp($this,true);
+	/**
+	 * Set the warp sector for both $this and $warp to ensure
+	 * a consistent 2-way warp.
+	 */
+	public function setWarp(SmrSector $warp) {
+		if ($this->getWarp() == $warp->getSectorID() &&
+		    $warp->getWarp() == $this->getSectorID()) {
+			// Warps are already set correctly!
+			return;
 		}
+
+		if ($this->equals($warp)) {
+			throw new Exception('Sector must not warp to itself!');
+		}
+
+		if (($warp->hasWarp() && $warp->getWarp() != $this->getSectorID()) ||
+		    ($this->hasWarp() && $this->getWarp() != $warp->getSectorID())) {
+			throw new Exception('One of the sectors already has a warp!');
+		}
+
 		$this->warp = $warp->getSectorID();
+		$this->hasChanged = true;
+
+		if ($warp->getWarp() != $this->getSectorID()) {
+			// Set the other side if needed
+			$warp->setWarp($this);
+		}
 	}
 
+	/**
+	 * Remove the warp sector for both sides of the warp.
+	 */
 	public function removeWarp() {
-		if($this->hasWarp()) {
-			//Update both possible combinations for the warp
-			$this->db->query('DELETE FROM warp
-								WHERE (
-									sector_id_1 = ' . $this->db->escapeNumber($this->getWarp()) . '
-									AND sector_id_2 = ' . $this->db->escapeNumber($this->getSectorID()) . '
-								) OR (
-									sector_id_1 = ' . $this->db->escapeNumber($this->getSectorID()) . '
-									AND sector_id_2 = ' . $this->db->escapeNumber($this->getWarp()) . '
-								) LIMIT 1');
+		if (!$this->hasWarp()) {
+			return;
 		}
+
+		$warp = $this->getWarpSector();
+		if ($warp->hasWarp() && $warp->getWarp() != $this->getSectorID()) {
+			throw new Exception('Warp sectors do not match');
+		}
+
 		$this->warp = 0;
+		$this->hasChanged = true;
+
+		if ($warp->hasWarp()) {
+			$warp->removeWarp();
+		}
 	}
 
 	public function hasMine() {


### PR DESCRIPTION
Due to the way we construct `SmrSector`, we end up querying the
`warp` table for every single sector. This essentially doubles the
cost of the `SmrSector` ctor.

On the other hand, adding an extra `warp` field to the `sector`
table adds a negligible cost to the `sector` database query, so we
do this instead.