### PR TITLE
Dockerfile: enable Zend OPcache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM php:7.2-apache
 RUN apt-get update \
 	&& apt-get install -y zip unzip \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install mysqli
+	&& docker-php-ext-install mysqli opcache
 
 # Use the production php.ini unless PHP_DEBUG=1 (defaults to 0)
 ARG PHP_DEBUG=0


### PR DESCRIPTION
Closes #297.

At long last, the mystery is solved. The reason the live server was
~5x faster when it was using the host system's PHP (rather than Docker)
was because it had the Zend OPcache enabled. This PHP extension caches
the compiled PHP and allows it to be reused at runtime. Since we have
some fairly large libraries, loading and parsing each script was a
significant expense.

Simply installing the `opcache` PHP extension in the Dockerfile
dramatically improves performance.