### PR TITLE
Streamline course plot processing

### DIFF
--- a/engine/Default/course_plot_nearest_processing.php
+++ b/engine/Default/course_plot_nearest_processing.php
@@ -17,21 +17,15 @@ else {
 	$account->log(LOG_TYPE_MOVEMENT, 'Player plots to nearest '.$xType.': '.$X.'.', $player->getSectorID());
 }
 
-
-$container = create_container('skeleton.php', 'course_plot_result.php');
-
 $sector =& $player->getSector();
 if($sector->hasX($realX,$player))
 	create_error('Current sector has what you\'re looking for!');
 
 $path = Plotter::findReversiblePathToX($realX, $sector, true, $player, $player);
 
-$container['Distance'] = serialize($path);
-
-$path->removeStart();
-if ($sector->isLinked($path->getNextOnPath())&&$path->getTotalSectors()>0) {
-	$player->setPlottedCourse($path);
-}
+// Forward to do common processing of path
+$container = create_container('skeleton.php', 'course_plot_result.php');
+$container['Distance'] = $path;
 forward($container);
 
 ?>

--- a/engine/Default/course_plot_processing.php
+++ b/engine/Default/course_plot_processing.php
@@ -34,18 +34,12 @@ if($startExists===false || $targetExists===false)
 
 $account->log(LOG_TYPE_MOVEMENT, 'Player plots to '.$target.'.', $player->getSectorID());
 
-$container = array();
-$container['url'] = 'skeleton.php';
-$container['body'] = 'course_plot_result.php';
-
 require_once(get_file_loc('Plotter.class.inc'));
 $path = Plotter::findReversiblePathToX(SmrSector::getSector($player->getGameID(), $target), SmrSector::getSector($player->getGameID(), $start), true);
-$container['Distance'] = serialize($path);
 
-$path->removeStart();
-if ($sector->isLinked($path->getNextOnPath())&&$path->getTotalSectors()>0) {
-	$player->setPlottedCourse($path);
-}
+// Forward to do common processing of path
+$container = create_container('skeleton.php', 'course_plot_result.php');
+$container['Distance'] = $path;
 forward($container);
 
 ?>

--- a/engine/Default/course_plot_result.php
+++ b/engine/Default/course_plot_result.php
@@ -1,32 +1,19 @@
 <?php
-require_once(get_file_loc('Plotter.class.inc'));
-$sector =& $player->getSector();
+// Load the Distance object to do the common processing
+// for both "Conventional" and "Plot To Nearest".
+$path = $var['Distance'];
 
-$template->assign('PageTopic','Plot A Course');
-
-require_once(get_file_loc('menu.inc'));
-create_nav_menu($template, $player);
-
-$path = unserialize($var['Distance']);
-
-$PHP_OUTPUT.= '<table cellspacing="0" cellpadding="0" style="width:100%;border:none"><tr><td style="padding:0px;vertical-align:top">';
-$PHP_OUTPUT.=('The plotted course is ' . $path->getTotalSectors() . ' sectors long and '.$path->getTurns().' turns.');
-$PHP_OUTPUT.= '</td><td style="padding:0px;vertical-align:top;width:32em">';
-
-// get the array back
-
-$full = (implode(' - ', $path->getPath()));
-
-// throw start sector away
-// it's useless for the route
+// Throw start sector away (it's useless for the route),
+// but save the full path in case we end up needing to display it.
+$fullPath = implode(' - ', $path->getPath());
 $path->removeStart();
 
 // now get the sector we are going to but don't remove it (sector_move_processing does it)
 $next_sector = $path->getNextOnPath();
 
-if ($sector->isLinked($next_sector)) {
+if ($player->getSector()->isLinked($next_sector)) {
 
-	// save this to db (if we still have something
+	// save this to db (if we still have something)
 	if ($path->getTotalSectors()>0) {
 		$player->setPlottedCourse($path);
 	}
@@ -38,7 +25,11 @@ if ($sector->isLinked($next_sector)) {
 	}
 }
 
-$PHP_OUTPUT.= '</td></tr></table><br /><h2>Plotted Course</h2><br />';
-$PHP_OUTPUT.= $full;
+$template->assign('PageTopic', 'Plot A Course');
+require_once(get_file_loc('menu.inc'));
+create_nav_menu($template, $player);
+
+$template->assign('Path', $path);
+$template->assign('FullPath', $fullPath);
 
 ?>

--- a/templates/Default/engine/Default/course_plot_result.php
+++ b/templates/Default/engine/Default/course_plot_result.php
@@ -1,0 +1,5 @@
+<p>The plotted course is <?php echo $Path->getTotalSectors().' '.pluralise('sector', $Path->getTotalSectors()); ?> long and costs <?php echo $Path->getTurns().' '.pluralise('turn', $Path->getTurns()); ?> to traverse.</p>
+
+<br />
+<h2>Plotted Course</h2>
+<p><?php echo $FullPath; ?></p>


### PR DESCRIPTION
Because we deep copied the `$path` in `course_plot_processing.php`
and `course_plot_nearest_processing.php` _before_ we performed
the final path processing, we duplicated this work in
`course_plot_result.php`.

If we instead do the common processing in `course_plot_results.php`
_only_, then we avoid both the duplicated code/processing _and_
the cost of the deep copy.

Since `course_plot_results.php` is sometimes a display page, we do
the processing first so that we don't do the display work if we
end up forwarding to `current_sector.php`.

Also:
* Convert `course_plot_results.php` to a template.