### PR TITLE
Replace deprecated constructors

### DIFF
--- a/lib/Default/Smr12HistoryMySqlDatabase.class.inc
+++ b/lib/Default/Smr12HistoryMySqlDatabase.class.inc
@@ -5,7 +5,7 @@ require_once(CONFIG . 'SmrMySqlSecrets.inc');
 
 class Smr12HistoryMySqlDatabase extends MySqlDatabase {
 	use SmrMySqlSecrets;
-	public function Smr12HistoryMySqlDatabase() {
+	public function __construct() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$dbName_Smr12History,
 		                    self::$port, self::$socket);
 	}

--- a/lib/Default/Smr12MySqlDatabase.class.inc
+++ b/lib/Default/Smr12MySqlDatabase.class.inc
@@ -5,7 +5,7 @@ require_once(CONFIG . 'SmrMySqlSecrets.inc');
 
 class Smr12MySqlDatabase extends MySqlDatabase {
 	use SmrMySqlSecrets;
-	public function Smr12MySqlDatabase() {
+	public function __construct() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$dbName_Smr12,
 		                    self::$port, self::$socket);
 	}

--- a/lib/Default/SmrClassicHistoryMySqlDatabase.class.inc
+++ b/lib/Default/SmrClassicHistoryMySqlDatabase.class.inc
@@ -5,7 +5,7 @@ require_once(CONFIG . 'SmrMySqlSecrets.inc');
 
 class SmrClassicHistoryMySqlDatabase extends MySqlDatabase {
 	use SmrMySqlSecrets;
-	public function SmrClassicHistoryMySqlDatabase() {
+	public function __construct() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$dbName_SmrClassicHistory,
 		                    self::$port, self::$socket);
 	}

--- a/lib/Default/SmrClassicMySqlDatabase.class.inc
+++ b/lib/Default/SmrClassicMySqlDatabase.class.inc
@@ -5,7 +5,7 @@ require_once(CONFIG . 'SmrMySqlSecrets.inc');
 
 class SmrClassicMySqlDatabase extends MySqlDatabase {
 	use SmrMySqlSecrets;
-	public function SmrClassicMySqlDatabase() {
+	public function __construct() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$dbName_SmrClassic,
 		                    self::$port, self::$socket);
 	}

--- a/lib/Default/SmrMySqlDatabase.class.inc
+++ b/lib/Default/SmrMySqlDatabase.class.inc
@@ -5,7 +5,7 @@ require_once(CONFIG . 'SmrMySqlSecrets.inc');
 class SmrMySqlDatabase extends MySqlDatabase {
 	// add static members via traits
 	use SmrMySqlSecrets;
-	public function SmrMySqlDatabase() {
+	public function __construct() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$databaseName,
 		                    self::$port, self::$socket);
 	}

--- a/lib/Default/SmrSessionMySqlDatabase.class.inc
+++ b/lib/Default/SmrSessionMySqlDatabase.class.inc
@@ -5,7 +5,7 @@ require_once(CONFIG . 'SmrMySqlSecrets.inc');
 class SmrSessionMySqlDatabase extends MySqlDatabase {
 	// add static members via traits
 	use SmrMySqlSecrets;
-	public function SmrSessionMySqlDatabase() {
+	public function __construct() {
 		parent::__construct(self::$host, self::$user, self::$password, self::$databaseName,
 		                    self::$port, self::$socket);
 	}


### PR DESCRIPTION
The `Smr*MySqlDatabase` classes used constructors with the same name
as the class. This emits a warning in PHP 7:

> Methods with the same name as their class will not be constructors
in a future version of PHP.

We use the magic method `__construct` instead.