### PR TITLE
Template.class.inc: call ob_clean conditionally

### DIFF
--- a/lib/Default/Template.class.inc
+++ b/lib/Default/Template.class.inc
@@ -27,7 +27,15 @@ class Template {
 	}
 	
 	public function display($templateName,$forAjax=false, $xmlResponse=false) {
-		@ob_clean();
+		// If we already started output buffering before calling `display`,
+		// we may have unwanted content in the buffer that we need to remove
+		// before we send the Content-Type headers below.
+		// Skip this for debug builds to help discover offending output.
+		if (!ENABLE_DEBUG) {
+			if (ob_get_length() > 0) {
+				ob_clean();
+			}
+		}
 		ob_start();
 		$this->includeTemplate($templateName);
 		$this->captures[$this->currentCaptureID].=ob_get_clean();


### PR DESCRIPTION
If we already started output buffering before calling
`Template::display`, we may have unwanted content in the buffer
that we need to remove before we send the Content-Type headers.

Ultimately, we want to remove all instances of pre-header output,
so we disable the `ob_clean` when `ENABLE_DEBUG=true`.