### PR TITLE
Changes to Refresh All

### DIFF
--- a/engine/Default/forces_mass_refresh.php
+++ b/engine/Default/forces_mass_refresh.php
@@ -1,37 +1,16 @@
 <?php
 
-//variables
-if($player->hasAlliance()) {
-	//get treaties
-	$db->query('SELECT * FROM alliance_treaties WHERE (alliance_id_1 = ' . $db->escapeNumber($player->getAllianceID()) . ' OR alliance_id_2 = ' . $db->escapeNumber($player->getAllianceID()) . ')
-				AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-				AND forces_nap = 1 AND official = \'TRUE\'');
-	$allied[] = $player->getAllianceID();
-	while ($db->nextRecord()) {
-		if ($db->getField('alliance_id_1') == $player->getAllianceID()) $allied[] = $db->getField('alliance_id_2');
-		else $allied[] = $db->getField('alliance_id_1');
-	}
-	//populate alliance list
-	$db->query('SELECT account_id FROM player
-			JOIN sector_has_forces
-				ON sector_has_forces.game_id = player.game_id AND sector_has_forces.owner_id = player.account_id
-			WHERE sector_has_forces.sector_id = ' . $db->escapeNumber($player->getSectorID()) . '
-			AND alliance_id IN (' . $db->escapeArray($allied) . ')
-			AND player.game_id = ' . $db->escapeNumber($player->getGameID()));
-	$time = TIME;
-	$db2 = new SmrMySqlDatabase();
-	while ($db->nextRecord()) {
+// Note: getSectorForces is cached and also called for sector display,
+// so it saves time to call it here instead of a new query.
+$sectorForces = SmrForce::getSectorForces($player->getGameID(), $player->getSectorID());
+$time = TIME;
+foreach ($sectorForces as $sectorForce) {
+	if ($player->sharedForceAlliance($sectorForce->getOwner())) {
 		$time += SmrForce::REFRESH_ALL_TIME_PER_STACK;
-		$db2->query('UPDATE sector_has_forces SET refresh_at=' . $db2->escapeNumber($time) . ', refresher=' . $db2->escapeNumber($player->getAccountID()) . '
-					WHERE game_id = ' . $db2->escapeNumber($player->getGameID()) . '
-						AND sector_id = ' . $db2->escapeNumber($player->getSectorID()) . ' AND owner_id=' . $db2->escapeNumber($db->getInt('account_id')) . ' LIMIT 1');
+		$sectorForce->updateRefreshAll($player, $time);
 	}
 }
-else {
-	$db->query('UPDATE sector_has_forces SET refresh_at=' . $db->escapeNumber(TIME + SmrForce::REFRESH_ALL_TIME_PER_STACK).', refresher=' . $db->escapeNumber($player->getAccountID()) . '
-				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND sector_id = ' . $db->escapeNumber($player->getSectorID()) . ' AND owner_id=' . $db->escapeNumber($db->getInt('account_id')) . ' LIMIT 1');
-}
+
 $message = '[Force Check]'; //this notifies the CS to look for info.
 $container = create_container('skeleton.php', 'current_sector.php');
 $container['msg'] = $message;

--- a/engine/Default/forces_mass_refresh.php
+++ b/engine/Default/forces_mass_refresh.php
@@ -21,14 +21,14 @@ if($player->hasAlliance()) {
 	$time = TIME;
 	$db2 = new SmrMySqlDatabase();
 	while ($db->nextRecord()) {
-		$time += 2;
+		$time += SmrForce::REFRESH_ALL_TIME_PER_STACK;
 		$db2->query('UPDATE sector_has_forces SET refresh_at=' . $db2->escapeNumber($time) . ', refresher=' . $db2->escapeNumber($player->getAccountID()) . '
 					WHERE game_id = ' . $db2->escapeNumber($player->getGameID()) . '
 						AND sector_id = ' . $db2->escapeNumber($player->getSectorID()) . ' AND owner_id=' . $db2->escapeNumber($db->getInt('account_id')) . ' LIMIT 1');
 	}
 }
 else {
-	$db->query('UPDATE sector_has_forces SET refresh_at=' . $db->escapeNumber(TIME+2).', refresher=' . $db->escapeNumber($player->getAccountID()) . '
+	$db->query('UPDATE sector_has_forces SET refresh_at=' . $db->escapeNumber(TIME + SmrForce::REFRESH_ALL_TIME_PER_STACK).', refresher=' . $db->escapeNumber($player->getAccountID()) . '
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND sector_id = ' . $db->escapeNumber($player->getSectorID()) . ' AND owner_id=' . $db->escapeNumber($db->getInt('account_id')) . ' LIMIT 1');
 }

--- a/lib/Default/SmrForce.class.inc
+++ b/lib/Default/SmrForce.class.inc
@@ -393,6 +393,13 @@ class SmrForce {
 		$this->hasChanged = false;
 	}
 
+	/**
+	 * Update the table fields associated with using Refresh All
+	 */
+	public function updateRefreshAll(SmrPlayer $player, $refreshTime) {
+		$this->db->query('UPDATE sector_has_forces SET refresh_at=' . $this->db->escapeNumber($refreshTime) . ', refresher=' . $this->db->escapeNumber($player->getAccountID()) . ' WHERE game_id = ' . $this->db->escapeNumber($this->getGameID()) . ' AND sector_id = ' . $this->db->escapeNumber($this->getSectorID()) . ' AND owner_id=' . $this->db->escapeNumber($this->getOwnerID()) . ' LIMIT 1');
+	}
+
 	public function getExamineDropForcesHREF() {
 		$container = create_container('skeleton.php', 'forces_drop.php');
 		$container['owner_id']	= $this->getOwnerID();

--- a/lib/Default/SmrForce.class.inc
+++ b/lib/Default/SmrForce.class.inc
@@ -10,7 +10,7 @@ class SmrForce {
 	const TIME_PERCENT_PER_SCOUT = 0.02; // 1/50th
 	const TIME_PERCENT_PER_COMBAT = 0.02; // 1/50th
 	const TIME_PERCENT_PER_MINE = 0.02; // 1/50th
-	const REFRESH_ALL_TIME_PER_STACK = 2; // 2 seconds
+	const REFRESH_ALL_TIME_PER_STACK = 1; // 1 second
 
 	protected static $refreshAllHREF;
 

--- a/lib/Default/SmrForce.class.inc
+++ b/lib/Default/SmrForce.class.inc
@@ -10,6 +10,7 @@ class SmrForce {
 	const TIME_PERCENT_PER_SCOUT = 0.02; // 1/50th
 	const TIME_PERCENT_PER_COMBAT = 0.02; // 1/50th
 	const TIME_PERCENT_PER_MINE = 0.02; // 1/50th
+	const REFRESH_ALL_TIME_PER_STACK = 2; // 2 seconds
 
 	protected static $refreshAllHREF;
 


### PR DESCRIPTION
Gameplay
-----------

SmrForce: halve the Refresh All interval  

Due to faster connections to the server over time, people have
stopped using "Refresh All" because it is simply far too much
slower than refreshing each stack individually. While we still
want there to be a tradeoff between speed and convenience, dropping
the wait time per stack from 2 seconds to 1 second should make
it more competitive.

Non-Gameplay
---------

Refresh All costs a fixed number of seconds per stack, and so we
use a named constant instead of hard-coding the number.

Add a method `SmrForce::updateRefreshAll` to set the `refresh_at`
and `refresher` fields of the `sector_has_force` table when the
"Refresh All" button is pressed.

We also refactor completely `forces_mass_refresh.php` to use
class methods instead of its own queries. This makes the code much
easier to maintain at no extra cost, since the class methods
cache most of their queries.