### PR TITLE
SectorNavigation.inc: fix duplicate class attribute

### DIFF
--- a/templates/Default/engine/Default/includes/SectorNavigation.inc
+++ b/templates/Default/engine/Default/includes/SectorNavigation.inc
@@ -3,7 +3,7 @@
 		<div class="<?php if($ThisShip->hasScanner()){ ?>scan<?php }else{ ?>no_scan<?php } ?>">
 			<?php
 			if($Sectors['Up']['ID'] != 0) { ?>
-				<div class="move_up move_text move_hover" id="moveUp" class="ajax">
+				<div class="move_up move_text move_hover" id="moveUp">
 					<a href="<?php echo Globals::getCurrentSectorMoveHREF($Sectors['Up']['ID']); ?>" class="<?php echo $Sectors['Up']['Class']; ?>">
 						<?php echo $Sectors['Up']['ID']; ?>
 					</a>
@@ -25,7 +25,7 @@
 			
 			
 			if($Sectors['Left']['ID'] != 0) { ?>
-				<div class="move_left move_text move_hover" id="moveLeft" class="ajax">
+				<div class="move_left move_text move_hover" id="moveLeft">
 					<a href="<?php echo Globals::getCurrentSectorMoveHREF($Sectors['Left']['ID']); ?>" class="<?php echo $Sectors['Left']['Class']; ?>">
 						<?php echo $Sectors['Left']['ID']; ?>
 					</a>
@@ -58,7 +58,7 @@
 			
 			<?php
 			if($Sectors['Right']['ID'] != 0) { ?>
-				<div class="move_right move_text move_hover" id="moveRight" class="ajax">
+				<div class="move_right move_text move_hover" id="moveRight">
 					<a href="<?php echo Globals::getCurrentSectorMoveHREF($Sectors['Right']['ID']); ?>" class="<?php echo $Sectors['Right']['Class']; ?>">
 						<?php echo $Sectors['Right']['ID']; ?>
 					</a>
@@ -80,7 +80,7 @@
 			
 
 			if($Sectors['Down']['ID'] != 0) { ?>
-				<div class="move_down move_text move_hover" id="moveDown" class="ajax">
+				<div class="move_down move_text move_hover" id="moveDown">
 					<a href="<?php echo Globals::getCurrentSectorMoveHREF($Sectors['Down']['ID']); ?>" class="<?php echo $Sectors['Down']['Class']; ?>">
 						<?php echo $Sectors['Down']['ID']; ?>
 					</a>
@@ -102,7 +102,7 @@
 			
 
 			if($Sectors['Warp']['ID'] != 0) { ?>
-				<div class="move_warp move_text move_hover" id="moveWarp" class="ajax">
+				<div class="move_warp move_text move_hover" id="moveWarp">
 					<a href="<?php echo Globals::getCurrentSectorMoveHREF($Sectors['Warp']['ID']); ?>" class="<?php echo $Sectors['Warp']['Class']; ?>">
 						<?php echo $Sectors['Warp']['ID']; ?>
 					</a>


### PR DESCRIPTION
The Current Sector navigation links had the `class` attribute
specified twice, and the second one (`class="ajax"`) was being
ignored by browsers and phpquery. Since I don't see why these
elements were intending to be ajax enabled to begin with, we
simply remove it to fix the error.