### PR TITLE
composer.json: switch to phpquery dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "SMR",
     "license": "AGPL-3.0",
     "require": {
-        "electrolinux/phpquery": "0.9.6",
+        "electrolinux/phpquery": "dev-master#a9b8ff556091a2fc3c73038ae5f4dfb0f5a09d67",
         "ext-curl": "*",
         "ext-json": "^1.0.0",
         "ext-mysqli": "*",


### PR DESCRIPTION
We need some PHP7 fixes that have been added to phpquery in the
5 years since v0.9.6 was released.

In particular, this fixes the error in phpQueryObject.php:3124

> Error: Call to undefined function split()

I believe this is only an issue if you enable debugging in
phpquery with `phpQuery::$debug = 1`, but it being broken
makes debugging other phpquery issues more difficult.