### PR TITLE
RightPanelShip.inc: fix nesting rules violation

### DIFF
--- a/templates/Default/engine/Default/includes/RightPanelShip.inc
+++ b/templates/Default/engine/Default/includes/RightPanelShip.inc
@@ -72,15 +72,16 @@ if(isset($GameID)) { ?>
 	<a href="<?php echo $WeaponReorderLink; ?>"><span class="bold">Weapons</span></a>&nbsp;<a href="weapon_list.php" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Weapon List" title="Weapon List"/></a><br /><?php
 	if($ThisShip->hasWeapons()) { ?>
 		<div class="wep_drop1" id="hide-show" onclick="toggleWepD('<?php echo $ThisPlayer->getToggleWeaponHidingHREF(); ?>');">
-			<noscript><a href="<?php echo $ThisPlayer->getToggleWeaponHidingHREF(); ?>"></noscript>
-				Show/Hide (<?php echo $ThisShip->getNumWeapons(); ?>)<br />
-				<span class="wep1"<?php if(!$ThisPlayer->isDisplayWeapons()){ ?>style="display: none;"<?php } ?>><?php
-					$Weapons =& $ThisShip->getWeapons();
-					foreach($Weapons as &$Weapon) { 
-						echo $Weapon->getName(); ?><br /><?php
-					} unset($Weapon); unset($Weapons); ?>
-				</span>
-			<noscript></a></noscript>
+			<noscript>
+				<a href="<?php echo $ThisPlayer->getToggleWeaponHidingHREF(); ?>">Click to</a>
+			</noscript>
+			Show/Hide (<?php echo $ThisShip->getNumWeapons(); ?>)<br />
+			<span class="wep1"<?php if(!$ThisPlayer->isDisplayWeapons()){ ?>style="display: none;"<?php } ?>><?php
+				$Weapons =& $ThisShip->getWeapons();
+				foreach($Weapons as &$Weapon) {
+					echo $Weapon->getName(); ?><br /><?php
+				} unset($Weapon); unset($Weapons); ?>
+			</span>
 		</div><?php
 	} ?>
 	Open : <?php echo $ThisShip->getOpenWeaponSlots(); ?><br />


### PR DESCRIPTION
We used the `<noscript>` tags around opening and closing `<a>`
tags separately. Since this results in open elements when the
`</noscript>` tag is called, it violates nesting rules.

While this still works correctly in most browsers, it breaks
HTML validators in non-recoverable ways.

To fix this, we essentially need to add some content that will
only display when JavaScript is disabled (rather than trying to
share the same content, which may not be possible without
violating nesting rules).

While we don't expect many (if any) people to have JavaScript
disabled, we do need _some_ link to the weapon reordering page,
so we just append a link with the text "Click to" in front of
"Show/Hide" in this case. It is not ideal, but I think it's the
best we can do without a significantly more complicated solution.

![image](https://user-images.githubusercontent.com/846186/38764333-a17bafee-3f61-11e8-9f24-cbadba0248f5.png)
