### PR TITLE
smr.inc: make errors during ajax updates more recoverable

### DIFF
--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -325,10 +325,19 @@ function create_submit_style($value, $style) {
 }
 
 function create_error($message) {
-	if(USING_AJAX)
-		throw new Exception('No errors should be created when using AJAX as nothing should have changed from the last time the page loaded: ' . $message);
 	$container = create_container('skeleton.php','error.php');
 	$container['message'] = $message;
+	if (USING_AJAX) {
+		// To avoid the page just not refreshing when an error is encountered
+		// during ajax updates, use javascript to auto-redirect to the
+		// appropriate error page.
+		global $template;
+		if (is_object($template) && method_exists($template, 'addJavascriptForAjax')) {
+			$errorHREF = SmrSession::getNewHREF($container);
+			// json_encode the HREF as a safety precaution
+			$template->addJavascriptForAjax('EVAL', 'location.href = ' . json_encode($errorHREF));
+		}
+	}
 	forward($container);
 }
 


### PR DESCRIPTION
One of the biggest problems with ajax is when it just silently
dies. The primary culprit for this behavior is when something
triggers an error while auto-refreshing, which then throws an
exception in `create_error` since ajax is not handled there.

We don't want that to happen, so we can instead use javascript to
redirect to the error page (like we did with being ejected from
a planet in 1b2d59c6b21).

Because we both forward to the error page and redirect with
javascript (for safety in case javascript is disabled), players
may see the old error page flash briefly before it displays the
`current_sector.php` page with error message.