### PR TITLE
shared.css: change lm_seedlist stripe color

### DIFF
--- a/htdocs/css/shared.css
+++ b/htdocs/css/shared.css
@@ -328,8 +328,8 @@ div.lm_seedlist {
 			45deg,
 			transparent,
 			transparent 8%,
-			#00f 10%,
-			#00f 13%
+			rgba(0,0,255,0.5) 10%,
+			rgba(0,0,255,0.5) 13%
 		);
 }
 div.currentSeclm_seedlist {
@@ -339,8 +339,8 @@ div.currentSeclm_seedlist {
 			45deg,
 			transparent,
 			transparent 8%,
-			#00f 10%,
-			#00f 13%
+			rgba(0,0,255,0.5) 10%,
+			rgba(0,0,255,0.5) 13%
 		);
 }
 table.lmt {


### PR DESCRIPTION
The full blue color was a bit hard to look at for some people,
so reduce the opacity of the blue stripes to 50% (note that
`rgba` is a well-supported CSS function, but 8-digit hex is not).

Before / After
<img src="https://user-images.githubusercontent.com/846186/38776206-1a58b24a-4048-11e8-84cf-c43df826b51b.png" width="333" /><img src="https://user-images.githubusercontent.com/846186/38776203-0d02d26a-4048-11e8-918b-b0b804ce2632.png" width="333" />
