### PR TITLE
box_reply.php: clarify points input

### DIFF
--- a/templates/Default/admin/Default/box_reply.php
+++ b/templates/Default/admin/Default/box_reply.php
@@ -3,7 +3,8 @@
 	<b>From: </b><span class="admin">Administrator</span><br />
 	<b>To: </b><?php echo $Sender->getPlayerName(); ?> a.k.a <?php echo $SenderAccount->getLogin(); ?>
 	<br />
-	<input type="number" value="<?php if(isset($BanPoints)) { echo htmlspecialchars($BanPoints); } else { ?>0<?php } ?>" name="BanPoints" size="4" /> Points<br />
 	<textarea spellcheck="true" name="message" id="InputFields"><?php if(isset($Preview)) { echo $Preview; } ?></textarea><br /><br />
+	<input type="number" value="<?php if(isset($BanPoints)) { echo htmlspecialchars($BanPoints); } else { ?>0<?php } ?>" name="BanPoints" size="4" /> Add Ban Points<br />
+	<p>Sending the message will add ban points, if specified above.</p>
 	<input type="submit" name="action" value="Send message" id="InputFields" />&nbsp;<input type="submit" name="action" value="Preview message" id="InputFields" />
 </form>


### PR DESCRIPTION
When replying to messages reported by players, clarify that the
"Points" input box specifies ban points, which are added when the
message is sent.

![image](https://user-images.githubusercontent.com/846186/38776285-41fd8f72-4049-11e8-9747-9267478f1735.png)
