### PR TITLE
Make exception logs available in-game and in e-mail

### DIFF
--- a/admin/Default/box_view.php
+++ b/admin/Default/box_view.php
@@ -35,26 +35,35 @@ else {
 			$messages[$messageID] = array(
 				'ID' => $messageID
 			);
-			$senderAccount =& SmrAccount::getAccount($db->getField('sender_id'));
-			$senderName = $senderAccount->getLogin().' ('.$senderAccount->getAccountID().')';
-			if ($validGame) {
-				$senderPlayer =& SmrPlayer::getPlayer($senderAccount->getAccountID(), $gameID);
-				if($senderAccount->getLogin() != $senderPlayer->getPlayerName()) {
-					$senderName .= ' a.k.a ' . $senderPlayer->getPlayerName();
-				}
+
+			$senderID = $db->getInt('sender_id');
+			if ($senderID == 0) {
+				$senderName = 'User not logged in';
+			} else {
+				$senderAccount = SmrAccount::getAccount($senderID);
+				$senderName = $senderAccount->getLogin().' ('.$senderID.')';
+				if ($validGame) {
+					$senderPlayer = SmrPlayer::getPlayer($senderID, $gameID);
+					if($senderAccount->getLogin() != $senderPlayer->getPlayerName()) {
+						$senderName .= ' a.k.a ' . $senderPlayer->getPlayerName();
+					}
 				
-				$container = create_container('skeleton.php', 'box_reply.php');
-				$container['sender_id'] = $senderAccount->getAccountID();
-				$container['game_id'] = $gameID;
-				$messages[$messageID]['ReplyHREF'] = SmrSession::getNewHREF($container);
+					$container = create_container('skeleton.php', 'box_reply.php');
+					$container['sender_id'] = $senderID;
+					$container['game_id'] = $gameID;
+					$messages[$messageID]['ReplyHREF'] = SmrSession::getNewHREF($container);
+				}
 			}
 			$messages[$messageID]['SenderName'] = $senderName;
-			if (!$validGame) {
+
+			if ($gameID == 0) {
+				$messages[$messageID]['GameName'] = 'No game selected';
+			} elseif (!$validGame) {
 				$messages[$messageID]['GameName'] = 'Game no longer exists';
-			}
-			else {
+			} else {
 				$messages[$messageID]['GameName'] = Globals::getGameName($gameID);
 			}
+
 			$messages[$messageID]['SendTime'] = date(DATE_FULL_SHORT, $db->getField('send_time'));
 			$messages[$messageID]['Message'] = bbifyMessage(htmliseMessage($db->getField('message_text')));
 		}

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -46,27 +46,39 @@ function logException(Exception $e) {
 		exit;
 	}
 
+	// Send error message to the in-game auto bugs mailbox
+	if (is_object($player) && method_exists($player,'sendMessageToBox')) {
+		$player->sendMessageToBox(BOX_BUGS_AUTO, $message);
+	} elseif (is_object($account) && method_exists($account,'sendMessageToBox')) {
+		// Will be logged without a game_id
+		$account->sendMessageToBox(BOX_BUGS_AUTO, $message);
+	} else {
+		// Will be logged without a game_id or sender_id
+		SmrAccount::doMessageSendingToBox(0, BOX_BUGS_AUTO, $message, 0);
+	}
+
+	// Send error message to e-mail so that we have a permanent record
 	$mail = setupMailer();
 	$mail->Subject = 'Automatic Bug Report';
 	$mail->setFrom('bugs@smrealms.de');
 	$mail->Body = $message;
 	$mail->addAddress('bugs@smrealms.de');
-	try {
-		if(is_object($player) && method_exists($player,'sendMessageToBox'))
-			$player->sendMessageToBox(BOX_BUGS_AUTO, $message);
-		else if(is_object($account) && method_exists($account,'sendMessageToBox'))
-			$account->sendMessageToBox(BOX_BUGS_AUTO, $message);
-		else
-			$mail->send();
-	}
-	catch(Exception $e) {
-		$mail->send();
-	}
+	$mail->send();
+
 	return $errorType;
 }
 
 function handleException(Exception $e) {
-	$errorType = logException($e);
+	// The real error message may display sensitive information, so we
+	// need to catch any exceptions that are thrown while logging the error.
+	try {
+		$errorType = logException($e);
+	} catch (Exception $e) {
+		$errorType = 'This error cannot be automatically reported. Please notify an admin!';
+	}
+
+	// If this is an ajax update, we don't really have a way to redirect
+	// to an error page at this time, so we just quit.
 	if(!defined('USING_AJAX')||!USING_AJAX)
 		header('location: ' . URL . '/error.php?msg='.urlencode($errorType));
 	exit;

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -1,7 +1,7 @@
 <?php
 function logException(Exception $e) {
 	global $account,$var,$player;
-	$errorType = 'Error';
+	$errorType = 'Unexpected Game Error!';
 	$message='';
 	$currMySQLError='';
 

--- a/templates/Default/admin/Default/box_view.php
+++ b/templates/Default/admin/Default/box_view.php
@@ -29,7 +29,9 @@ else { ?>
 			<table width="100%" class="standard"><?php
 				foreach($Messages as $Message) { ?>
 					<tr>
-						<td><input type="checkbox" name="message_id[]" value="<?php echo $Message['ID']; ?>"></td>
+						<td class="shrink">
+							<input type="checkbox" name="message_id[]" value="<?php echo $Message['ID']; ?>">
+						</td>
 						<td class="noWrap">From: <?php
 							if(isset($Message['ReplyHREF'])) {
 								?><a href="<?php echo $Message['ReplyHREF']; ?>"><?php


### PR DESCRIPTION
config.inc: restructure how exceptions are handled

* Always send the automatic bug report to both the in-game box
  (so that devs who can't access `bugs@smrealms.de` can still see
  every automatic bug report) and to the `bugs@smrealms.de` e-mail
  so that we have a permanent record of the report.

* If there is neither a `SmrPlayer` nor a `SmrAccount`, send the
  error message to the in-game box with both account ID and game ID
  set to 0.

* When handling exceptions, always redirect the user to the next
  appropriate game page even if the error logging fails.
