### PR TITLE
Remove restriction on admin announcement message length

### DIFF
--- a/admin/Default/announcement_create_processing.php
+++ b/admin/Default/announcement_create_processing.php
@@ -6,10 +6,6 @@ if($_REQUEST['action'] == 'Preview announcement') {
 	forward($container);
 }
 
-if (strlen($message) > 255) {
-	create_error('No more than 255 characters per announcement!');
-}
-
 // put the msg into the database
 $db->query('INSERT INTO announcement (time, admin_id, msg) VALUES('.$db->escapeNumber(TIME).', '.$db->escapeNumber(SmrSession::$account_id).', '.$db->escapeString($message).')');
 


### PR DESCRIPTION
Messages can now be unlimited in size, instead of limited to
255 characters.