### PR TITLE
Display flagship on right panel

### DIFF
--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1570,6 +1570,13 @@ class SmrPlayer extends AbstractSmrPlayer {
 		return $bounties;
 	}
 
+	/**
+	 * Has this player been designated as the alliance flagship?
+	 */
+	public function isFlagship() {
+		return $this->hasAlliance() && $this->getAlliance()->getFlagshipID() == $this->getAccountID();
+	}
+
 	public function isPresident() {
 		$president = Council::getPresident($this->getGameID(),$this->getRaceID());
 		return is_object($president) && $this->equals($president);

--- a/templates/Default/engine/Default/includes/RightPanelShip.inc
+++ b/templates/Default/engine/Default/includes/RightPanelShip.inc
@@ -1,5 +1,10 @@
 <?php
 if(isset($GameID)) { ?>
+	<span id="flagship"><?php
+	if ($ThisPlayer->isFlagship()) {
+		?><img title="Alliance Flagship" alt="Alliance Flagship" src="images/flagship.png" width="16" height="12" />&nbsp;<span style="color:#06F">Flagship</span><br /><?php
+	}
+	?></span>
 	<a href="ship_list.php" target="shipList">
 		<span id="ship_name"><?php /*<a href="<?php echo $ThisShip->getUpgradeShipHREF(); ?>">*/ ?>
 			<span class="yellow bold"><?php echo $ThisShip->getName(); ?></span><?php /*</a>*/ ?>

--- a/templates/Default/engine/Default/includes/SectorMap.inc
+++ b/templates/Default/engine/Default/includes/SectorMap.inc
@@ -115,7 +115,7 @@
 									if($CanScanSector && $Sector->hasProtectedTraders($MapPlayer)) {
 										?><img class="neutralBack" title="Protected Trader" alt="Protected Trader" src="images/trader.png" width="13" height="16"/><?php
 									}
-									if ($Sector->hasAllianceFlagship($MapPlayer)) {
+									if ($Sector->hasAllianceFlagship($MapPlayer) && !$MapPlayer->isFlagship()) {
 										?><img class="friendlyBack" title="Alliance Flagship" alt="Alliance Flagship" src="images/flagship.png" width="16" height="16" /><?php
 									}
 									if($Sector->hasFriendlyTraders($MapPlayer)) {

--- a/templates/Default/engine/Default/skeleton.php
+++ b/templates/Default/engine/Default/skeleton.php
@@ -38,6 +38,7 @@
 				<td class="r0">
 					<div id="right_panel">
 						<?php $this->includeTemplate('includes/RightPanelPlayer.inc'); ?>
+						<br />
 						<?php $this->includeTemplate('includes/RightPanelShip.inc'); ?>
 					</div>
 				</td>


### PR DESCRIPTION
Since the player does not see itself on the Local Map, it shouldn't
see the flagship icon either if they are the alliance flagship.
Instead, a natural place to display the flagship icon is on the
right panel.

Add convenience function `SmrPlayer::isFlagship`.

![image](https://user-images.githubusercontent.com/846186/38777125-83b361cc-4057-11e8-97ac-c6806c899f6c.png)

Local Map for flagship player
![image](https://user-images.githubusercontent.com/846186/38777130-9818b4dc-4057-11e8-9d99-346cd84fa321.png)

Local Map for non-flagship player
![image](https://user-images.githubusercontent.com/846186/38777133-a41098d6-4057-11e8-810d-a18c3fd7f3a5.png)
