### PR TITLE
Major enhancements to the SmrPlanet class

### DIFF
--- a/engine/Default/planet_list.inc
+++ b/engine/Default/planet_list.inc
@@ -26,8 +26,6 @@ function planet_list_common($allianceId, $getPlanets) {
 		if ($playerOnly || $player->getAllianceID() == $allianceId) {
 			$playerPlanet = $player->getPlanet();
 			if ($playerPlanet !== false) {
-				// Update planet properties to make sure list is self-consistent
-				$playerPlanet->getCurrentlyBuilding();
 				$template->assign('PlayerPlanet', $playerPlanet);
 			}
 		}

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -371,10 +371,7 @@ class SmrAlliance {
 		');
 		$planets = array();
 		while ($this->db->nextRecord()) {
-			$planet = SmrPlanet::getPlanet($this->gameID, $this->db->getInt('sector_id'));
-			// Call to make sure planet properties are up-to-date.
-			$planet->getCurrentlyBuilding();
-			$planets[] = $planet;
+			$planets[] = SmrPlanet::getPlanet($this->gameID, $this->db->getInt('sector_id'));
 		}
 		return $planets;
 	}

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -64,8 +64,7 @@ class SmrPlanet {
 
 	public static function &getPlanet($gameID,$sectorID,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_PLANETS[$gameID][$sectorID])) {
-			$p = new SmrPlanet($gameID,$sectorID);
-			self::$CACHE_PLANETS[$gameID][$sectorID] = $p;
+			self::$CACHE_PLANETS[$gameID][$sectorID] = new SmrPlanet($gameID, $sectorID);
 		}
 		return self::$CACHE_PLANETS[$gameID][$sectorID];
 	}
@@ -83,11 +82,6 @@ class SmrPlanet {
 				VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber($sectorID) . ', ' . $db->escapeNumber($inhabitableTime) . ', ' . $db->escapeNumber($type) . ')');
 		}
 		return self::getPlanet($gameID,$sectorID,true);
-		//		if(!isset(self::$CACHE_PLANETS[$gameID][$sectorID])) {
-		//			$p = new SmrPlanet($gameID,$sectorID,true);
-		//			self::$CACHE_PLANETS[$gameID][$sectorID] =& $p;
-		//		}
-		//		return self::$CACHE_PLANETS[$gameID][$sectorID];
 	}
 
 	public static function removePlanet($gameID,$sectorID) {
@@ -107,7 +101,7 @@ class SmrPlanet {
 		unset(self::$CACHE_PLANETS[$gameID][$sectorID]);
 	}
 
-	protected function __construct($gameID,$sectorID,$create=false) {
+	protected function __construct($gameID, $sectorID) {
 		$this->db = new SmrMySqlDatabase();
 		$this->SQL = 'game_id = ' . $this->db->escapeNumber($gameID) . ' AND sector_id = ' . $this->db->escapeNumber($sectorID);
 
@@ -130,15 +124,6 @@ class SmrPlanet {
 			$this->updateTypeInfo();
 			$this->calculateInterest();
 		}
-		//		else if($create) {
-		//			$this->gameID		= (int)$gameID;
-		//			$this->sectorID		= (int)$sectorID;
-		//			$this->isNew		= true;
-		//			return;
-		//		}
-		//		else {
-		//			throw new Exception('No such sector: '.$gameID.'-'.$sectorID);
-		//		}
 	}
 
 	public function getInterestRate() {

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -820,7 +820,7 @@ class SmrPlanet {
 	}
 
 	function getLevel() {
-		return ($this->getBuilding(PLANET_GENERATOR) + $this->getBuilding(PLANET_HANGAR) + $this->getBuilding(PLANET_BUNKER) + $this->getBuilding(PLANET_TURRET)) / 3;
+		return array_sum($this->getBuildings())/3;
 	}
 	
 	function getMaxLevel() {

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -128,7 +128,6 @@ class SmrPlanet {
 			$this->typeID 			= $this->db->getInt('planet_type_id');
 			
 			$this->updateTypeInfo();
-			$this->getOptions();
 			$this->getStockpile();
 			$this->getBuildings();
 			$this->getCurrentlyBuilding();
@@ -737,28 +736,37 @@ class SmrPlanet {
 		return $this->typeInfo['planet_max_landed'];
 	}
 
+	/**
+	 * Specifies which menu options the planet has.
+	 */
 	public function getOptions($option=false) {
-
-		if(!isset($this->canOptions)) {
-			// initialize options menu array
-			$this->canOptions = array();
-			// get options from db
-			$this->db->query('SELECT * FROM planet_type_has_section WHERE planet_type_id = ' . $this->db->escapeNumber($this->getTypeID()));
-			// adding options to array
-			while ($this->db->nextRecord()) {
-				$this->canOptions[$this->db->getField('planet_section')] = true;	
-			}
-		}	
-
-		if ($option) {
-			if (isset ($this->canOptions[$option])) {
-				return $this->canOptions[$option];
-			}
-			return false;
+		$this->setOptions(); // Make sure the data is populated
+		if ($option === false) {
+			return $this->canOptions;
 		}
-		return $this->canOptions;
+		// We do not set options that are unavailable
+		return isset($this->canOptions[$option]);
 	}
-	
+
+	/**
+	 * Populate the `canOptions` attribute from the `planet_type_has_section` database table.
+	 */
+	private function setOptions() {
+		if (isset($this->canOptions)) {
+			return;
+		}
+		// Cache the options for this type of planet
+		static $OPTIONS = array();
+		if (!isset($OPTIONS[$this->getTypeID()])) {
+			$this->db->query('SELECT * FROM planet_type_has_section WHERE planet_type_id = ' . $this->db->escapeNumber($this->getTypeID()));
+			while ($this->db->nextRecord()) {
+				$OPTIONS[$this->getTypeID()][$this->db->getField('planet_section')] = true;
+			}
+		}
+		// Set the options for this planet instance
+		$this->canOptions = $OPTIONS[$this->getTypeID()];
+	}
+
 	public function doDelayedUpdates() {
 		$this->setShields($this->getShields(true));
 		$this->delayedShieldsDelta = 0;

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -601,14 +601,6 @@ class SmrPlanet {
 		$this->setBuilding($buildingTypeID,$this->getBuilding($buildingTypeID)-$number);
 	}
 
-	public function getTotalBuildings() {
-		$totalBuildings = 0;
-		foreach($this->getBuildings() as $building) {
-			$totalBuildings += $building;
-		}
-		return $totalBuildings;
-	}
-
 	function getCurrentlyBuilding() {
 		if(!isset($this->currentlyBuilding)) {
 			$this->currentlyBuilding = array();

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -33,6 +33,7 @@ class SmrPlanet {
 	
 	protected $canOptions;
 	protected $hasChanged = false;
+	protected $hasChangedFinancial = false;  // for credits, bond, maturity
 	protected $hasChangedStockpile = false;
 	protected $hasChangedBuildings = array();
 	protected $hasStoppedBuilding = array();
@@ -172,9 +173,6 @@ class SmrPlanet {
 
 			// reset maturity
 			$this->setMaturity(0);
-
-			// update planet
-			$this->update();
 		}
 	}
 
@@ -183,9 +181,7 @@ class SmrPlanet {
 	}
 
 	public function bond() {
-		if($this->getMaturity() > 0) {
-			$this->calculateInterest(true);
-		}
+		$this->calculateInterest(true);
 
 		// add it to bond
 		$this->increaseBonds($this->getCredits());
@@ -257,7 +253,7 @@ class SmrPlanet {
 			throw new Exception('You cannot set negative credits.');
 		}
 		$this->credits = $num;
-		$this->hasChanged = true;
+		$this->hasChangedFinancial = true;
 	}
 
 	public function increaseCredits($num) {
@@ -286,7 +282,7 @@ class SmrPlanet {
 			throw new Exception('You cannot set negative maturity.');
 		}
 		$this->maturity = $num;
-		$this->hasChanged = true;
+		$this->hasChangedFinancial = true;
 	}
 
 	public function getBonds() {
@@ -301,7 +297,7 @@ class SmrPlanet {
 			throw new Exception('You cannot set negative bonds.');
 		}
 		$this->bonds = $num;
-		$this->hasChanged = true;
+		$this->hasChangedFinancial = true;
 	}
 	
 	public function increaseBonds($num) {
@@ -770,17 +766,27 @@ class SmrPlanet {
 		}
 		$this->doDelayedUpdates();
 		if($this->hasChanged) {
-			$this->db->query('UPDATE planet SET owner_id = ' . $this->db->escapeNumber($this->ownerID) . ',
+			$this->db->query('UPDATE planet SET
+									owner_id = ' . $this->db->escapeNumber($this->ownerID) . ',
 									password = '.$this->db->escapeString($this->password) .',
 									planet_name = ' . $this->db->escapeString($this->planetName) . ',
 									shields = ' . $this->db->escapeNumber($this->shields) . ',
 									armour = ' . $this->db->escapeNumber($this->armour) . ',
-									drones = ' . $this->db->escapeNumber($this->drones) . ',
+									drones = ' . $this->db->escapeNumber($this->drones) . '
+								WHERE ' . $this->SQL);
+			$this->hasChanged = false;
+		}
+
+		// Separate update for financial since these can be modified by looking
+		// at the planet list (i.e. you might not have sector lock and could
+		// cause a race condition with events happening in the planet sector).
+		if ($this->hasChangedFinancial) {
+			$this->db->query('UPDATE planet SET
 									credits = ' . $this->db->escapeNumber($this->credits) . ',
 									bonds = ' . $this->db->escapeNumber($this->bonds) . ',
 									maturity = ' . $this->db->escapeNumber($this->maturity) . '
 								WHERE ' . $this->SQL);
-			$this->hasChanged = false;
+			$this->hasChangedFinancial = false;
 		}
 
 		if($this->hasChangedStockpile) {

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -335,12 +335,7 @@ class SmrPlanet {
 	}
 
 	public function setShields($shields) {
-		if($shields<0) {
-			$shields=0;
-		}
-		if ($shields > $this->getMaxShields()) {
-			$shields = $this->getMaxShields();
-		}
+		$shields = max(0, min($shields, $this->getMaxShields()));
 		if($this->shields == $shields) {
 			return;
 		}
@@ -385,12 +380,7 @@ class SmrPlanet {
 	}
 
 	public function setArmour($armour) {
-		if($armour<0) {
-			$armour=0;
-		}
-		if ($armour > $this->getMaxArmour()) {
-			$armour = $this->getMaxArmour();
-		}
+		$armour = max(0, min($armour, $this->getMaxArmour()));
 		if($this->armour == $armour) {
 			return;
 		}
@@ -435,12 +425,7 @@ class SmrPlanet {
 	}
 
 	public function setCDs($combatDrones) {
-		if($combatDrones<0) {
-			$combatDrones=0;
-		}
-		if ($combatDrones > $this->getMaxCDs()) {
-			$combatDrones = $this->getMaxCDs();
-		}
+		$combatDrones = max(0, min($combatDrones, $this->getMaxCDs()));
 		if($this->drones == $combatDrones) {
 			return;
 		}

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -128,7 +128,6 @@ class SmrPlanet {
 			$this->typeID 			= $this->db->getInt('planet_type_id');
 			
 			$this->updateTypeInfo();
-			$this->getCurrentlyBuilding();
 			$this->calculateInterest();
 		}
 		//		else if($create) {
@@ -564,6 +563,9 @@ class SmrPlanet {
 			while ($this->db->nextRecord()) {
 				$this->buildings[$this->db->getInt('construction_id')] = $this->db->getInt('amount');
 			}
+
+			// Update building counts if construction has finished
+			$this->getCurrentlyBuilding();
 		}
 		return $this->buildings;
 	}
@@ -613,23 +615,34 @@ class SmrPlanet {
 
 			$this->db->query('SELECT * FROM planet_is_building WHERE ' . $this->SQL);
 			while($this->db->nextRecord()) {
-				if($this->db->getInt('time_complete') <= TIME) {
-					$expGain = $this->getConstructionExp($this->db->getInt('construction_id'));
-					$player = SmrPlayer::getPlayer($this->db->getInt('constructor_id'),$this->getGameID());
-					$player->increaseHOF(1,array('Planet','Buildings','Built'), HOF_ALLIANCE);
+				$this->currentlyBuilding[$this->db->getInt('building_slot_id')] = array(
+					'BuildingSlotID' => $this->db->getInt('building_slot_id'),
+					'ConstructionID' => $this->db->getInt('construction_id'),
+					'ConstructorID' => $this->db->getInt('constructor_id'),
+					'Finishes' => $this->db->getInt('time_complete'),
+					'TimeRemaining' => $this->db->getInt('time_complete') - TIME,
+				);
+			}
+
+			// Check if construction has completed
+			foreach ($this->currentlyBuilding as $id => $building) {
+				if ($building['TimeRemaining'] <= 0) {
+					unset($this->currentlyBuilding[$id]);
+					$expGain = $this->getConstructionExp($building['ConstructionID']);
+					$player = SmrPlayer::getPlayer($building['ConstructorID'], $this->getGameID());
+					$player->increaseHOF(1, array('Planet','Buildings','Built'), HOF_ALLIANCE);
 					$player->increaseExperience($expGain);
-					$player->increaseHOF($expGain,array('Planet','Buildings','Experience'), HOF_ALLIANCE);
-					$this->hasStoppedBuilding[] = $this->db->getInt('building_slot_id');
-					$this->increaseBuilding($this->db->getInt('construction_id'), 1);
-				}
-				else {
-					$this->currentlyBuilding[$this->db->getInt('building_slot_id')] = array(
-						'BuildingSlotID' => $this->db->getInt('building_slot_id'),
-						'ConstructionID' => $this->db->getInt('construction_id'),
-						'ConstructorID' => $this->db->getInt('constructor_id'),
-						'Finishes' => $this->db->getInt('time_complete'),
-						'TimeRemaining' => $this->db->getInt('time_complete') - TIME
-					);
+					$player->increaseHOF($expGain, array('Planet','Buildings','Experience'), HOF_ALLIANCE);
+					$this->hasStoppedBuilding[] = $building['BuildingSlotID'];
+					$this->increaseBuilding($building['ConstructionID'], 1);
+
+					// WARNING: The above modifications to the player/planet are dangerous because
+					// they may not be part of the current sector lock. But since they might not be,
+					// we may as well just update now to avoid either a) needing to remember to call
+					// this explicitly in all appropriate engine files or b) inconsistent exp display
+					// if this is called during the template display only and therefore unsaved.
+					$player->update();
+					$this->update();
 				}
 			}
 		}
@@ -923,10 +936,9 @@ class SmrPlanet {
 	}
 
 	function stopBuilding($constructionID) {
-		$currentlyBuilding = $this->getCurrentlyBuilding();
 		$matchingBuilding = false;
 		$latestFinish = 0;
-		foreach($currentlyBuilding as $key => $building) {
+		foreach($this->getCurrentlyBuilding() as $key => $building) {
 			if($building['ConstructionID'] == $constructionID && $building['Finishes'] > $latestFinish) {
 				$latestFinish = $building['Finishes'];
 				$matchingBuilding = $building;

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -29,9 +29,7 @@ class SmrPlanet {
 	protected $inhabitableTime;
 	protected $currentlyBuilding;
 	protected $typeID;
-	protected $typeName;
-	protected $typeImage;
-	protected $typeDescription;
+	protected $typeInfo;
 	
 	protected $canOptions;
 	protected $hasChanged = false;
@@ -39,8 +37,6 @@ class SmrPlanet {
 	protected $hasChangedBuildings = array();
 	protected $hasStoppedBuilding = array();
 	protected $isNew = false;
-	protected $maxAttackers;
-	protected $maxLanded;
 
 	protected $delayedShieldsDelta = 0;
 	protected $delayedCDsDelta = 0;
@@ -696,55 +692,47 @@ class SmrPlanet {
 		$this->update();
 	}
 	
-	public function updateTypeInfo() {
-	
-		$this->db->query('SELECT * FROM planet_type WHERE planet_type_id = ' . $this->getTypeID());
-		if ($this->db->nextRecord()) {
-			$this->setTypeName($this->db->getField('planet_type_name'));
-			$this->setTypeImage($this->db->getField('planet_image_link'));
-			$this->setTypeDescription($this->db->getField('planet_type_description'));
-			$this->setMaxAttackers($this->db->getInt('planet_max_attackers'));
-			$this->maxLanded = $this->db->getInt('planet_max_landed');
-		} else {
-			$this->setTypeName("No Type Defined");
-			$this->setTypeImage("image/planet.gif");
-			$this->setTypeDescription("No description defined in database, cotnact admins!");
-			$this->setMaxAttackers(0);
-			$this->maxLanded = 0;
+	/**
+	 * Populates the `typeInfo` attribute from the `planet_type` database table.
+	 */
+	private function updateTypeInfo() {
+		if (isset($this->typeInfo)) {
+			return;
 		}
+		// Cache the type info for this type of planet
+		static $TYPE_INFO = array();
+		if (!isset($TYPE_INFO[$this->getTypeID()])) {
+			$this->db->query('SELECT * FROM planet_type WHERE planet_type_id = ' . $this->getTypeID());
+			if ($this->db->nextRecord()) {
+				$TYPE_INFO[$this->getTypeID()] = $this->db->getRow();
+			} else {
+				throw new Exception('Planet type not found: ' . $this->getTypeID());
+			}
+		}
+		// Set the type info for this planet instance
+		$this->typeInfo = $TYPE_INFO[$this->getTypeID()];
 	}
-	//not public on purpose
-	function setTypeName($name) {
-		$this->typeName = $name;
-	}
-	
-	function setTypeImage($img) {
-		$this->typeImage = $img;
-	}
-	
-	function setTypeDescription($des) {
-		$this->typeDescription = $des;
-	}
-	
-	
+
 	public function getTypeImage() {
-		if (isset($this->typeImage))
-			return $this->typeImage;
-		return "Error";
+		return $this->typeInfo['planet_image_link'];
 	}
-	
+
 	public function getTypeName() {
-		if (isset($this->typeName))
-			return $this->typeName;
-		return "Error";
+		return $this->typeInfo['planet_type_name'];
 	}
-	
+
 	public function getTypeDescription() {
-		if (isset($this->typeDescription))
-			return $this->typeDescription;
-		return "Error";
+		return $this->typeInfo['planet_type_description'];
 	}
-	
+
+	public function getMaxAttackers() {
+		return $this->typeInfo['planet_max_attackers'];
+	}
+
+	public function getMaxLanded() {
+		return $this->typeInfo['planet_max_landed'];
+	}
+
 	public function getOptions($option=false) {
 
 		if(!isset($this->canOptions)) {
@@ -774,18 +762,6 @@ class SmrPlanet {
 		$this->delayedCDsDelta = 0;
 		$this->setArmour($this->getArmour(true));
 		$this->delayedArmourDelta = 0;
-	}
-	
-	public function getMaxAttackers() {
-		return $this->maxAttackers;
-	}
-	
-	public function setMaxAttackers($value) {
-		$this->maxAttackers = $value;
-	}
-
-	public function getMaxLanded() {
-		return $this->maxLanded;
 	}
 	
 	public function update() {

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -128,8 +128,6 @@ class SmrPlanet {
 			$this->typeID 			= $this->db->getInt('planet_type_id');
 			
 			$this->updateTypeInfo();
-			$this->getStockpile();
-			$this->getBuildings();
 			$this->getCurrentlyBuilding();
 			$this->calculateInterest();
 		}
@@ -680,7 +678,7 @@ class SmrPlanet {
 		
 		//trim buildings first
 		$this->setMaxBuildings();
-		foreach ($this->buildings as $id => $amt) {
+		foreach ($this->getBuildings() as $id => $amt) {
 			if ($this->getMaxBuildings($id) < $amt) {
 				$this->destroyBuilding($id,$amt - $this->getMaxBuildings($id));
 			}

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -130,7 +130,6 @@ class SmrPlanet {
 			$this->updateTypeInfo();
 			$this->getOptions();
 			$this->getStockpile();
-			$this->setMaxBuildings();
 			$this->getBuildings();
 			$this->getCurrentlyBuilding();
 			$this->calculateInterest();
@@ -641,26 +640,31 @@ class SmrPlanet {
 	}
 
 	public function getMaxBuildings($buildingTypeID=false) {
-		if (!isset($this->maxBuildings)) {
-			$this->setMaxBuildings();
-		}
+		// Make sure the data is populated
+		$this->setMaxBuildings();
 		if($buildingTypeID===false) {
 			return $this->maxBuildings;
 		}
-		
-		if (isset($this->maxBuildings[$buildingTypeID])) {
-			return $this->maxBuildings[$buildingTypeID];
-		}
-		return 0;
+		return $this->maxBuildings[$buildingTypeID];
 	}
 	
-	public function setMaxBuildings() {
-		$this->maxBuildings = array();
-
-		$this->db->query('SELECT construction_id, max_amount FROM planet_can_build WHERE planet_type_id='.$this->getTypeID());
-		while ($this->db->nextRecord()) {
-			$this->maxBuildings[$this->db->getInt('construction_id')] = $this->db->getInt('max_amount');
+	/**
+	 * Populates the `maxBuildings` attribute from the `planet_can_build` database table.
+	 */
+	private function setMaxBuildings() {
+		if (isset($this->maxBuildings)) {
+			return;
 		}
+		// Cache the max buildings for this type of planet
+		static $MAX_BUILDINGS = array();
+		if (!isset($MAX_BUILDINGS[$this->getTypeID()])) {
+			$this->db->query('SELECT construction_id, max_amount FROM planet_can_build WHERE planet_type_id='.$this->getTypeID());
+			while ($this->db->nextRecord()) {
+				$MAX_BUILDINGS[$this->getTypeID()][$this->db->getInt('construction_id')] = $this->db->getInt('max_amount');
+			}
+		}
+		// Set the max buildings for this planet instance
+		$this->maxBuildings = $MAX_BUILDINGS[$this->getTypeID()];
 	}
 	
 	

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -645,7 +645,7 @@ class SmrPlanet {
 			$this->setMaxBuildings();
 		}
 		if($buildingTypeID===false) {
-			return $this->$maxBuildings;
+			return $this->maxBuildings;
 		}
 		
 		if (isset($this->maxBuildings[$buildingTypeID])) {

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -824,15 +824,7 @@ class SmrPlanet {
 	}
 	
 	function getMaxLevel() {
-		$level = 0;
-		$level += $this->maxBuildings[PLANET_GENERATOR];
-		$level += $this->maxBuildings[PLANET_HANGAR];
-		$level += $this->maxBuildings[PLANET_BUNKER];
-		$level += $this->maxBuildings[PLANET_TURRET];
-		//foreach ($this->maxBuildings as $id => $amount) {
-		//	$level += $amount/3;
-		//}
-		return ($level / 3);
+		return array_sum($this->getMaxBuildings())/3;
 	}
 
 	function accuracy() {


### PR DESCRIPTION
There are a lot of changes here, but the commits are in logical units that clearly delineate each change. See the commit messages for (very detailed) explanations of each change.

Updating the database is less error-prone, but still has the opportunity for rare race conditions. Since these changes are only internal to SmrPlanet, we do not address any of the fundamental infrastructure problems with "action at a distance" (modifying objects that are not in your sector).

The constructor is changed to prevent querying the database unnecessarily -- data is now (mostly) fetched on demand.

Fix bugs in the following methods:
* getMaxBuildings - didn't work when the optional argument was unspecified
* getCurrentlyBuilding - caused player exp to display inconsistently
* update - split financial updates from the rest to avoid possible race conditions

Cache the results of the following methods to reduce database queries:
* updateTypeInfo
* setMaxBuildings
* setOptions

Removed the following methods:
* getTotalBuildings
* setMaxAttackers
* setTypeDescription
* setTypeImage
* setTypeName

Simply the following methods:
* getMaxLevel
* getLevel
* getOptions
* set{CDs,Armour,Shields}