### PR TITLE
message_view.php: revamp scout message grouping

### DIFF
--- a/engine/Default/message_view.php
+++ b/engine/Default/message_view.php
@@ -252,15 +252,6 @@ function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $me
 	$senderName = getMessagePlayer($sender_id,$player->getGameID(),$type);
 	if ($senderName instanceof SmrPlayer) {
 		$sender = $senderName;
-		unset($senderName);
-		$replace = explode('?', $message_text);
-		foreach ($replace as $key => $timea) {
-			if ($sender_id > 0 && $timea != '' && ($final = strtotime($timea)) !== false) { //WARNING: Expects PHP 5.1.0 or later
-				$send_acc = $sender->getAccount();
-				$final += ($account->getOffset() * 3600 - $send_acc->getOffset() * 3600);
-				$message_text = str_replace('?' . $timea . '?', date(DATE_FULL_SHORT, $final), $message_text);
-			}
-		}
 		$container = create_container('skeleton.php', 'trader_search_result.php');
 		$container['player_id'] = $sender->getPlayerID();
 		$senderName = create_link($container, $sender->getDisplayName());

--- a/engine/Default/message_view.php
+++ b/engine/Default/message_view.php
@@ -160,23 +160,21 @@ else {
 	$messageBox['NumberMessages'] = $db->getNumRows();
 	$messageBox['Messages'] = array ();
 
-	if ($var['folder_id'] == MSG_SCOUT && !isset ($var['show_all'])) {
+	// Group scout messages if they wouldn't fit on a single page
+	if ($var['folder_id'] == MSG_SCOUT && !isset($var['show_all']) && $messageBox['TotalMessages'] > MESSAGES_PER_PAGE) {
 		// get rid of all old scout messages (>48h)
 		$db->query('DELETE FROM message WHERE expire_time < ' . $db->escapeNumber(TIME) . ' AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT));
 
-		if ($messageBox['UnreadMessages'] > MESSAGE_SCOUT_GROUP_LIMIT || $messageBox['NumberMessages'] - $messageBox['UnreadMessages'] > MESSAGE_SCOUT_GROUP_LIMIT) {
-			$dispContainer = create_container('skeleton.php', 'message_view.php');
-			$dispContainer['folder_id'] = MSG_SCOUT;
-			$dispContainer['show_all'] = true;
-			$messageBox['ShowAllHref'] = SmrSession::getNewHREF($dispContainer);
-		}
-		$db2 = new SmrMySqlDatabase();
-		displayScouts($db2, $messageBox, $player, false, $messageBox['UnreadMessages'] > MESSAGE_SCOUT_GROUP_LIMIT);
-		displayScouts($db2, $messageBox, $player, true, $messageBox['NumberMessages'] - $messageBox['UnreadMessages'] > MESSAGE_SCOUT_GROUP_LIMIT);
+		$dispContainer = create_container('skeleton.php', 'message_view.php');
+		$dispContainer['folder_id'] = MSG_SCOUT;
+		$dispContainer['show_all'] = true;
+		$messageBox['ShowAllHref'] = SmrSession::getNewHREF($dispContainer);
+
+		displayScouts($messageBox, $player);
 	}
 	else {
 		while ($db->nextRecord()) {
-			displayMessage($messageBox, $db->getField('message_id'), $db->getField('account_id'), $db->getField('sender_id'), $db->getField('message_text'), $db->getField('send_time'), $db->getField('msg_read'), $var['folder_id'], $var['folder_id'] == 0);
+			displayMessage($messageBox, $db->getField('message_id'), $db->getField('account_id'), $db->getField('sender_id'), $db->getField('message_text'), $db->getField('send_time'), $db->getField('msg_read'), $var['folder_id']);
 		}
 	}
 	if (!USING_AJAX) {
@@ -186,46 +184,52 @@ else {
 	$template->assign('MessageBox', $messageBox);
 }
 
-function displayScouts(&$db, &$messageBox, &$player, $read, $group) {
-	if ($group) {
-		//here we group new messages
-		$query = 'SELECT alignment, player_id, sender_id, player_name AS sender, count( message_id ) AS number, min( send_time ) as first, max( send_time) as last, msg_read
+function displayScouts(&$messageBox, $player) {
+	// Generate the group messages
+	$db = new SmrMySqlDatabase();
+	$db->query('SELECT alignment, player_id, sender_id, player_name AS sender, count( message_id ) AS number, min( send_time ) as first, max( send_time) as last, sum(msg_read=\'FALSE\') as total_unread
 					FROM message
 					JOIN player ON player.account_id = message.sender_id AND message.game_id = player.game_id
 					WHERE message.account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND player.game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT) . '
 					AND receiver_delete = ' . $db->escapeBoolean(false) . '
-					AND msg_read = ' . $db->escapeBoolean($read) . '
-					GROUP BY sender_id, msg_read
-					ORDER BY send_time DESC';
+					GROUP BY sender_id
+					ORDER BY last DESC');
 
-		$db->query($query);
-		while ($db->nextRecord()) {
-			//display grouped stuff (allow for deletion)
-			$playerName = get_colored_text($db->getField('alignment'), stripslashes($db->getField('sender')) . ' (' . $db->getField('player_id') . ')');
-			$message = 'Your forces have spotted ' . $playerName . ' passing your forces ' . $db->getField('number') . ' times.';
-			displayGrouped($messageBox, $playerName, $db->getField('player_id'), $db->getField('sender_id'), $message, $db->getField('first'), $db->getField('last'), $db->getField('msg_read') == 'FALSE');
-		}
+	while ($db->nextRecord()) {
+		$senderName = get_colored_text($db->getField('alignment'), stripslashes($db->getField('sender')) . ' (' . $db->getField('player_id') . ')');
+		$totalUnread = $db->getInt('total_unread');
+		$message = 'Your forces have spotted ' . $senderName . ' passing your forces ' . $db->getField('number') . ' ' . pluralise('time', $db->getField('number'));
+		$message .= ($totalUnread > 0) ? ' (' . $totalUnread . ' unread).' : '.';
+		displayGrouped($messageBox, $senderName, $db->getField('player_id'), $db->getField('sender_id'), $message, $db->getField('first'), $db->getField('last'), $totalUnread > 0);
 	}
-	else {
-		//not enough to group, display separately
-		$query = 'SELECT message_id, account_id, sender_id, message_text, send_time, msg_read
+
+	// Now display individual messages in each group
+	// Perform a single query to minimize query overhead
+	$db->query('SELECT message_id, account_id, sender_id, message_text, send_time, msg_read
 					FROM message
 					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT) . '
 					AND receiver_delete = ' . $db->escapeBoolean(false) . '
-					AND msg_read = ' . $db->escapeBoolean($read) . '
-					ORDER BY send_time DESC';
-		$db->query($query);
-		while ($db->nextRecord()) {
-			displayMessage($messageBox, $db->getField('message_id'), $db->getField('account_id'), $db->getField('sender_id'), stripslashes($db->getField('message_text')), $db->getField('send_time'), $db->getField('msg_read'), MSG_SCOUT);
+					ORDER BY send_time DESC');
+	while ($db->nextRecord()) {
+		$groupBox =& $messageBox['GroupedMessages'][$db->getInt('sender_id')];
+		// Limit the number of messages in each group
+		if (!isset($groupBox['Messages']) || count($groupBox['Messages']) < MESSAGE_SCOUT_GROUP_LIMIT) {
+			displayMessage($groupBox, $db->getField('message_id'), $db->getField('account_id'), $db->getField('sender_id'), stripslashes($db->getField('message_text')), $db->getField('send_time'), $db->getField('msg_read'), MSG_SCOUT);
 		}
 	}
+
+	// In the default view (groups), we're always displaying all messages
+	$messageBox['NumberMessages'] = $db->getNumRows();
+	global $template;
+	$template->unassign('NextPageHREF');
 }
 
 function displayGrouped(&$messageBox, $playerName, $player_id, $sender_id, $message_text, $first, $last, $star) {
+	// Define a unique array so we can delete grouped messages
 	$array = array (
 		$sender_id,
 		$first,
@@ -237,54 +241,57 @@ function displayGrouped(&$messageBox, $playerName, $player_id, $sender_id, $mess
 	$message['Unread'] = $star;
 	$container = create_container('skeleton.php', 'trader_search_result.php');
 	$container['player_id'] = $player_id;
+	$message['SenderID'] = $sender_id;
 	$message['SenderDisplayName'] = create_link($container, $playerName);
 	$message['SendTime'] = date(DATE_FULL_SHORT, $first) . " - " . date(DATE_FULL_SHORT, $last);
 	$message['Text'] = $message_text;
 	$messageBox['Messages'][] = $message;
 }
-function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $message_text, $send_time, $msg_read, $type, $sentMessage = false) {
-	require_once(get_file_loc('message.functions.inc'));
-	global $player, $account;
+
+function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $message_text, $send_time, $msg_read, $type) {
+	global $player;
 
 	$message = array ();
-
-	$sender = false;
-	$senderName = getMessagePlayer($sender_id,$player->getGameID(),$type);
-	if ($senderName instanceof SmrPlayer) {
-		$sender = $senderName;
-		$container = create_container('skeleton.php', 'trader_search_result.php');
-		$container['player_id'] = $sender->getPlayerID();
-		$senderName = create_link($container, $sender->getDisplayName());
-	}
-
-	$container = create_container('skeleton.php', 'message_notify_confirm.php');
-	$container['message_id'] = $message_id;
-	$container['sent_time'] = $send_time;
-	$message['ReportHref'] = SmrSession::getNewHREF($container);
-	if (is_object($sender)) {
-		$container = create_container('skeleton.php', 'message_blacklist_add.php');
-		$container['account_id'] = $sender_id;
-		$message['BlacklistHref'] = SmrSession::getNewHREF($container);
-
-		$container = create_container('skeleton.php', 'message_send.php');
-		$container['receiver'] = $sender->getAccountID();
-		$message['ReplyHref'] = SmrSession::getNewHREF($container);
-
-		$message['Sender'] = $sender;
-	}
-
 	$message['ID'] = $message_id;
 	$message['Text'] = $message_text;
-	$message['SenderDisplayName'] = $senderName;
+	$message['Unread'] = $msg_read == 'FALSE';
+	$message['SendTime'] = date(DATE_FULL_SHORT, $send_time);
 
-	$receiver = SmrPlayer::getPlayer($receiver_id, $player->getGameID());
-	if ($sentMessage && is_object($receiver)) {
+	require_once(get_file_loc('message.functions.inc'));
+	$sender = getMessagePlayer($sender_id, $player->getGameID(), $type);
+	if ($sender instanceof SmrPlayer) {
+		$message['Sender'] = $sender;
+		$container = create_container('skeleton.php', 'trader_search_result.php');
+		$container['player_id'] = $sender->getPlayerID();
+		$message['SenderDisplayName'] = create_link($container, $sender->getDisplayName());
+
+		// Add actions that we can take on messages sent by players.
+		// Scout messages are always procedural and don't need these options.
+		if ($type != MSG_SCOUT) {
+			$container = create_container('skeleton.php', 'message_notify_confirm.php');
+			$container['message_id'] = $message_id;
+			$container['sent_time'] = $send_time;
+			$message['ReportHref'] = SmrSession::getNewHREF($container);
+
+			$container = create_container('skeleton.php', 'message_blacklist_add.php');
+			$container['account_id'] = $sender_id;
+			$message['BlacklistHref'] = SmrSession::getNewHREF($container);
+
+			$container = create_container('skeleton.php', 'message_send.php');
+			$container['receiver'] = $sender->getAccountID();
+			$message['ReplyHref'] = SmrSession::getNewHREF($container);
+		}
+	} else {
+		$message['SenderDisplayName'] = $sender;
+	}
+
+	if ($type == MSG_SENT) {
+		$receiver = SmrPlayer::getPlayer($receiver_id, $player->getGameID());
 		$container = create_container('skeleton.php', 'trader_search_result.php');
 		$container['player_id'] = $receiver->getPlayerID();
 		$message['ReceiverDisplayName'] = create_link($container, $receiver->getDisplayName());
 	}
 
-	$message['Unread'] = $msg_read == 'FALSE';
-	$message['SendTime'] = date(DATE_FULL_SHORT, $send_time);
+	// Append the message to this box
 	$messageBox['Messages'][] = $message;
 }

--- a/engine/Default/message_view.php
+++ b/engine/Default/message_view.php
@@ -7,8 +7,6 @@ if (!isset ($var['folder_id'])) {
 
 	$db2 = new SmrMySqlDatabase();
 
-	require_once(get_file_loc('council.inc'));
-
 	$db->query('SELECT 1 FROM message
 				WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND message_type_id = ' . $db->escapeNumber(MSG_POLITICAL) . '

--- a/htdocs/js/ajax.js
+++ b/htdocs/js/ajax.js
@@ -191,4 +191,8 @@ var exec = function(s) {
 		$('.wep1:hidden').fadeToggle(600);
 		$.get(link);
 	};
+
+	window.toggleScoutGroup = function(senderID) {
+		$('#group'+senderID).toggle();
+	};
 })();

--- a/templates/Default/engine/Default/message_view.php
+++ b/templates/Default/engine/Default/message_view.php
@@ -70,7 +70,7 @@ else {
 		} ?>
 		<table class="standard fullwidth"><?php
 			if(isset($MessageBox['Messages'])) {
-				foreach($MessageBox['Messages'] as &$Message) { ?>
+				foreach($MessageBox['Messages'] as $Message) { ?>
 					<tr>
 						<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $Message['ID']; ?>" /><?php if($Message['Unread']) { ?>*<?php } ?></td>
 						<td class="noWrap" width="100%"><?php
@@ -81,9 +81,9 @@ else {
 								?>From: <?php echo $Message['SenderDisplayName'];
 							} ?>
 						</td>
-						<td class="noWrap"<?php if(!isset($Message['Sender'])) { ?> colspan="4"<?php } ?>>Date: <?php echo $Message['SendTime']; ?></td>
+						<td class="noWrap"<?php if(!isset($Message['ReplyHref'])) { ?> colspan="4"<?php } ?>>Date: <?php echo $Message['SendTime']; ?></td>
 						<?php
-						if (isset($Message['Sender'])) { ?>
+						if (isset($Message['ReplyHref'])) { ?>
 							<td>
 								<a href="<?php echo $Message['ReportHref']; ?>"><img src="images/report.png" width="16" height="16" border="0" align="right" title="Report this message to an admin" /></a>
 							</td>
@@ -96,10 +96,30 @@ else {
 						} ?>
 					</tr>
 					<tr>
-						<td colspan="6"><?php echo bbifyMessage($Message['Text']); ?></td>
-					</tr>
-					<?php
-				} unset($Message);
+						<td colspan="6"><?php
+							echo bbifyMessage($Message['Text']);
+							if (isset($MessageBox['GroupedMessages'])) {
+								$SubMessages = $MessageBox['GroupedMessages'][$Message['SenderID']]['Messages']; ?>
+								<br />
+								<a id="toggle-recent<?php echo $Message['SenderID']; ?>" href="javascript:toggleScoutGroup(<?php echo $Message['SenderID']; ?>)" target="_blank">
+									Show/Hide Recent (<?php echo count($SubMessages); ?>)
+								</a>
+								<table id="group<?php echo $Message['SenderID']; ?>" class="standard fullwidth" style="display:none;margin:5px 0 2px 0;"><?php
+									foreach ($SubMessages as $SubMessage) { ?>
+										<tr>
+											<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $SubMessage['ID']; ?>" /><?php if($SubMessage['Unread']) { ?>*<?php } ?></td>
+											<td class="noWrap" width="100%">From: <?php echo $SubMessage['SenderDisplayName']; ?></td>
+											<td class="noWrap" colspan="4">Date: <?php echo $SubMessage['SendTime']; ?></td>
+										</tr>
+										<tr>
+											<td colspan="6"><?php echo bbifyMessage($SubMessage['Text']); ?></td>
+										</tr><?php
+									} ?>
+								</table><?php
+							} ?>
+						</td>
+					</tr><?php
+				}
 			} ?>
 		</table>
 


### PR DESCRIPTION
The previous design had two main problems:

1. It was difficult to see specific individual scout messages.

2. Messages are marked as read as soon as you open the message box.
   However, scout messages were previously grouped according to how
   many read/unread messages you had from a player. If that number
   crossed the `MESSAGE_SCOUT_GROUP_LIMIT` threshold as a result of
   marking them read, then links that were displayed when you first
   opened the page become stale by the time you click on them.
   (The page doesn't change, but the auto refreshes invalidate any
   links that aren't either `ALWAYS_AVAILABLE` or generated in
   subsequent calls to the code.)

   While we could have simply made all links `ALWAYS_AVAILABLE`, the
   more correct solution is to ensure that the generation of links
   doesn't depend on whether or not messages are marked as read.

The new design makes two (possibly large) database queries to
fetch the scout message groups, and then to fetch all the
individual messages. The latter allows us to ensure that all
possible links away from the page are always generated.

We hide all the individual messages inside each scout message group
(grouped by player), which now also indicates how many of the
individual messages are unread. We use javascript to "Show/Hide" the
X most recent individual messages in each group (we use
`MESSAGE_SCOUT_GROUP_LIMIT` for now). You can still click
"Show all Messages" to display a chronological list of scout messages
that isn't grouped by player.

NOTE: ideally we would have made the javascript dynamically
generate the list of individual scout messages when we click on
"Show/Hide" (as is done for the weapon list, so that we don't need
to fetch _every_ scout message since most will go unlooked at);
however, we would then be unable to display whether or not the
messages are unread, since that is only known on the very first page
load, at which point all messages are marked as read.

Initial view:
![image](https://user-images.githubusercontent.com/846186/39025763-fd6410d0-43fd-11e8-8737-5de6d7d06b89.png)

Expanded:
![image](https://user-images.githubusercontent.com/846186/39025771-07a563a0-43fe-11e8-8259-08e6b6f55f6c.png)
