### PR TITLE
sector_jump_calculate.php: fix short tags issue

### DIFF
--- a/templates/Default/engine/Default/sector_jump_calculate.php
+++ b/templates/Default/engine/Default/sector_jump_calculate.php
@@ -5,7 +5,7 @@ Within moments, the onboard computer dictates the report in a reassuringly confi
 It will cost <span class="red"><?php echo $TurnCost; ?></span> turns to jump to Sector #<?php echo $Target; ?>.
 <?php
 if ($MaxMisjump > 0) { ?>
-	There is a possibility to misjump up to <? echo $MaxMisjump . ' ' . pluralise('sector', $MaxMisjump); ?>.<?php
+	There is a possibility to misjump up to <?php echo $MaxMisjump . ' ' . pluralise('sector', $MaxMisjump); ?>.<?php
 } else { ?>
 	There is no possibility to misjump.<?php
 } ?>


### PR DESCRIPTION
The `short_open_tag` php option is on by default, and the dev
environment uses the default php options at the moment.
Unfortunately, the production value is off, and so any code
that uses short tags will break in production.