### PR TITLE
Refactor voting code to fix game start timer

### DIFF
--- a/engine/Default/vote_link.php
+++ b/engine/Default/vote_link.php
@@ -6,14 +6,16 @@ $container = create_container('skeleton.php', 'current_sector.php');
 if ($var['can_get_turns'] == true) {
 	// Turns are updated by setting the last turn update to an earlier time.
 	// Make sure not to set their last turn update to before start time.
-	if ($player->getLastTurnUpdate() > $player->getGame()->getStartTurnsDate() + VOTE_BONUS_TURNS_TIME) {
+	$maxFreeTurnsTime = count(VoteSite::getAllSites()) * VOTE_BONUS_TURNS_TIME;
+	$startFreeTurnsDate = $player->getGame()->getStartTurnsDate() + $maxFreeTurnsTime;
+	if ($player->getLastTurnUpdate() > $startFreeTurnsDate) {
 		// Allow vote
 		// Don't start the timeout until the vote actually goes through.
 		$db->query('REPLACE INTO vote_links (account_id, link_id, timeout, turns_claimed) VALUES(' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($var['link_id']) . ',' . $db->escapeNumber(0) . ',' . $db->escapeBoolean(false) . ')');
 		$voting = '<b><span class="red">v</span>o<span class="blue">t</span><span class="red">i</span>n<span class="blue">g</span></b>';
 		$container['msg'] = "Thank you for $voting! You will receive bonus turns once your vote is processed.";
 	} else {
-		create_error('You cannot gain bonus turns in this game yet, please wait '.format_time( $player->getGame()->getStartTurnsDate() + VOTE_BONUS_TURNS_TIME - min(TIME, $player->getLastTurnUpdate())).'.');
+		create_error('You cannot gain bonus turns in this game yet, please wait '.format_time($startFreeTurnsDate - min(TIME, $player->getLastTurnUpdate())).'.');
 	}
 }
 

--- a/lib/Default/VoteSite.class.inc
+++ b/lib/Default/VoteSite.class.inc
@@ -62,7 +62,7 @@ class VoteSite {
 			$db = new SmrMySqlDatabase();
 			$db->query('SELECT link_id, timeout FROM vote_links WHERE account_id=' . $db->escapeNumber($accountID) . ' AND link_id IN (' . join(',', $activeLinkIDs) . ') LIMIT ' . $db->escapeNumber(count($activeLinkIDs)));
 			while ($db->nextRecord()) {
-				// 'timeout' is the last time the player clicked this vote site link
+				// 'timeout' is the last time the player claimed free turns (or 0, if unclaimed)
 				$WAIT_TIMES[$db->getInt('link_id')] = ($db->getField('timeout') + TIME_BETWEEN_VOTING) - TIME;
 			}
 			// If not in the vote_link database, this site is eligible now.

--- a/lib/Default/VoteSite.class.inc
+++ b/lib/Default/VoteSite.class.inc
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Handles links to external game voting sites.
+ */
+class VoteSite {
+
+	// MPOGD no longer exists
+	//1 => array('default_img' => 'mpogd.png', 'star_img' => 'mpogd_vote.png', 'base_url' => 'http://www.mpogd.com/games/game.asp?ID=1145'),
+	// OMGN no longer do voting - the link actually just redirects to archive site.
+	//2 => array('default_img' => 'omgn.png', 'star_img' => 'omgn_vote.png', 'base_url' => 'http://www.omgn.com/topgames/vote.php?Game_ID=30'),
+
+	private static function getAllSiteData() {
+		// This can't be a static/constant attribute due to `url_func` closures.
+		// NOTE: array keys (a.k.a. link ID's) should never be changed!
+		return array(
+			3 => array(
+				'img_default' => 'twg.png',
+				'img_star' => 'twg_vote.png',
+				'url_base' => 'http://topwebgames.com/in.aspx?ID=136&alwaysreward=1',
+				'url_func' => function ($baseUrl, $accountId, $gameId, $linkId) {
+					$query = array('account' => $accountId, 'game' => $gameId, 'link' => $linkId);
+					return $baseUrl . '&' . http_build_query($query);
+				},
+			),
+			4 => array(
+				'img_default' => 'dog.png',
+				'img_star' => 'dog_vote.png',
+				'url_base' => 'http://www.directoryofgames.com/main.php?view=topgames&action=vote&v_tgame=2315',
+				'url_func' => function ($baseUrl, $accountId, $gameId, $linkId) {
+					return "$baseUrl&votedef=$accountId,$gameId,$linkId";
+				},
+			),
+		);
+	}
+
+	public static function getAllSites() {
+		static $ALL_SITES;
+		if (!isset($allSites)) {
+			$ALL_SITES = array(); // ensure this is set
+			foreach (self::getAllSiteData() as $linkID => $siteData) {
+				$ALL_SITES[$linkID] = new VoteSite($linkID, $siteData);
+			}
+		}
+		return $ALL_SITES;
+	}
+
+	function __construct($linkID, $siteData) {
+		$this->linkID = $linkID;
+		$this->data = $siteData;
+	}
+
+	/**
+	 * Time until the account can get free turns from voting at this site.
+	 * If the time is 0, this site is eligible for free turns.
+	 */
+	public function getTimeUntilFreeTurns($accountID) {
+		static $WAIT_TIMES;
+		if (!isset($WAIT_TIMES)) {
+			$WAIT_TIMES = array(); // ensure this is set
+			$activeLinkIDs = array_keys(self::getAllSites());
+			$db = new SmrMySqlDatabase();
+			$db->query('SELECT link_id, timeout FROM vote_links WHERE account_id=' . $db->escapeNumber($accountID) . ' AND link_id IN (' . join(',', $activeLinkIDs) . ') LIMIT ' . $db->escapeNumber(count($activeLinkIDs)));
+			while ($db->nextRecord()) {
+				// 'timeout' is the last time the player clicked this vote site link
+				$WAIT_TIMES[$db->getInt('link_id')] = ($db->getField('timeout') + TIME_BETWEEN_VOTING) - TIME;
+			}
+			// If not in the vote_link database, this site is eligible now.
+			foreach ($activeLinkIDs as $linkID) {
+				if (!isset($WAIT_TIMES[$linkID])) {
+					$WAIT_TIMES[$linkID] = 0;
+				}
+			}
+		}
+		return $WAIT_TIMES[$this->linkID];
+	}
+
+	/**
+	 * Returns the image to display for this voting site.
+	 */
+	public function getLinkImg($accountID, $gameID) {
+		if ($gameID !=0 && $this->getTimeUntilFreeTurns($accountID) <= 0) {
+			return $this->data['img_star'];
+		} else {
+			return $this->data['img_default'];
+		}
+	}
+
+	/**
+	 * Returns the URL that should be used for this voting site.
+	 */
+	public function getLinkUrl($accountID, $gameID) {
+		$baseUrl = $this->data['url_base'];
+		if ($gameID != 0 && $this->getTimeUntilFreeTurns($accountID) <= 0) {
+			$container = create_container('vote_link.php');
+			$container['link_id'] = $this->linkID;
+			$container['can_get_turns'] = true;
+			$internalUrl = SmrSession::getNewHREF($container, true);
+			$externalUrl = $this->data['url_func']($baseUrl, $accountID, $gameID, $this->linkID);
+			return 'javascript:voteSite("' . $externalUrl . '","' . $internalUrl . '")';
+		} else {
+			return $baseUrl;
+		}
+	}
+
+}

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -1,6 +1,7 @@
 <?php
 
 require_once(LIB . '/Default/Globals.class.inc');
+require_once(LIB . '/Default/VoteSite.class.inc');
 require_once(get_file_loc('SmrPlayer.class.inc'));
 require_once(get_file_loc('SmrAccount.class.inc'));
 require_once(get_file_loc('SmrShip.class.inc'));
@@ -947,65 +948,16 @@ function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account) {
 	}
 
 	// ------- VOTING --------
-	$container = create_container('vote_link.php');
 	$voteSites = array();
-
-	// MPOGD no longer exists
-	//$voteSites[1] = array('default_img' => 'mpogd.png', 'star_img' => 'mpogd_vote.png', 'base_url' => 'http://www.mpogd.com/games/game.asp?ID=1145');
-
-	// OMGN no longer do voting - the link actually just redirects to archive site.
-	//$voteSites[2] = array('default_img' => 'omgn.png', 'star_img' => 'omgn_vote.png', 'base_url' => 'http://www.omgn.com/topgames/vote.php?Game_ID=30');
-
-	$voteSites[3] = array(
-		'default_img' => 'twg.png',
-		'star_img' => 'twg_vote.png',
-		'base_url' => 'http://topwebgames.com/in.aspx?ID=136&alwaysreward=1',
-		'url' => function ($baseUrl, $accountId, $gameId, $linkId) {
-			$query = array('account' => $accountId, 'game' => $gameId, 'link' => $linkId);
-			return $baseUrl . '&' . http_build_query($query);
-		},
-	);
-	$voteSites[4] = array(
-		'default_img' => 'dog.png',
-		'star_img' => 'dog_vote.png',
-		'base_url' => 'http://www.directoryofgames.com/main.php?view=topgames&action=vote&v_tgame=2315',
-		'url' => function ($baseUrl, $accountId, $gameId, $linkId) {
-			return "$baseUrl&votedef=$accountId,$gameId,$linkId";
-		},
-	);
-
-	// Determine the time left until the account can vote again at each site
-	// We ignore rows with links that are no longer active
-	// (note: try not to change the $voteSites keys)
 	$voteWait = array();
-	$activeLinks = array_keys($voteSites);
-	$db->query('SELECT link_id, timeout FROM vote_links WHERE account_id=' . $db->escapeNumber(SmrSession::$account_id) . ' AND link_id IN (' . join(',', $activeLinks) . ') LIMIT ' . $db->escapeNumber(count($activeLinks)));
-	while($db->nextRecord()) {
-		// 'timeout' is the last time the player clicked this vote site link
-		$voteWait[$db->getInt('link_id')] = ($db->getField('timeout') + TIME_BETWEEN_VOTING) - TIME;
+	foreach (VoteSite::getAllSites() as $site) {
+		$voteSites[] = array(
+			'img' => $site->getLinkImg($account->getAccountID(), SmrSession::$game_id),
+			'url' => $site->getLinkUrl($account->getAccountID(), SmrSession::$game_id),
+		);
+		$voteWait[] = $site->getTimeUntilFreeTurns($account->getAccountID());
 	}
-
-	$modVoteSites = array();
-	foreach ($voteSites as $linkId => $voteSite) {
-		// If not in the vote_link database, we can vote for turns at this site now
-		if (!isset($voteWait[$linkId])) {
-			$voteWait[$linkId] = 0;
-		}
-
-		// update attributes if we can vote for free turns here
-		if (SmrSession::$game_id != 0 && $voteWait[$linkId] <= 0) {
-			$container['link_id'] = $linkId;
-			$container['can_get_turns'] = true;
-			$internalUrl = SmrSession::getNewHREF($container, true);
-			$externalUrl = $voteSite['url']($voteSite['base_url'], $player->getAccountID(), $player->getGameID(), $linkId);
-			$modVoteSites[] = array('url' => 'javascript:voteSite("' . $externalUrl . '","' . $internalUrl . '")',
-			                        'img' => $voteSite['star_img']);
-		} else {
-			$modVoteSites[] = array('url' => $voteSite['base_url'],
-			                        'img' => $voteSite['default_img']);
-		}
-	}
-	$template->assign('VoteSites', $modVoteSites);
+	$template->assign('VoteSites', $voteSites);
 
 	// Determine the minimum time until the next vote across all sites
 	$minVoteWait = min($voteWait);


### PR DESCRIPTION
* Refactor voting code out of `smr.inc` and into a new `VoteSite` class.
* Prohibit voting until after the _max_ time you can gain from free turns. Previously it was only prohibiting it based on the time you get from one site.

See commit messages for more details.