### PR TITLE
Minor improvements to Admin Send Message

### DIFF
--- a/admin/Default/admin_message_send_processing.php
+++ b/admin/Default/admin_message_send_processing.php
@@ -18,8 +18,8 @@ if (!empty($account_id) || $game_id == 20000) {
 		SmrPlayer::sendMessageFromAdmin($game_id, $account_id, $message,$expire);
 	}
 	else {
-		//send to all players
-		$db->query('SELECT game_id,account_id FROM player');
+		//send to all players in games that haven't ended yet
+		$db->query('SELECT game_id,account_id FROM player JOIN game USING(game_id) WHERE end_date > ' . $db->escapeNumber(TIME));
 		while ($db->nextRecord()) {
 			SmrPlayer::sendMessageFromAdmin($db->getField('game_id'), $db->getField('account_id'), $message,$expire);
 		}

--- a/templates/Default/admin/Default/admin_message_send.php
+++ b/templates/Default/admin/Default/admin_message_send.php
@@ -24,6 +24,8 @@ else {
 					?><option value="<?php echo $GamePlayer['AccountID']; ?>"><?php echo $GamePlayer['Name']; ?> (<?php echo $GamePlayer['PlayerID']; ?>)</option><?php
 				} ?>
 				</select><br /><br /><?php
+			} else { ?>
+				All Players<?php
 			} ?>
 		</p>
 		<textarea spellcheck="true" name="message" id="InputFields"><?php if(isset($Preview)) { echo $Preview; } ?></textarea><br />


### PR DESCRIPTION
* When sending to "All Players", only send messages in games that haven't ended.
* Display that the message is being sent to "All Players" when that's what the admin is doing.