### PR TITLE
Add alliance invitations

### DIFF
--- a/db/patches/V1_6_62_09__alliance_invites.sql
+++ b/db/patches/V1_6_62_09__alliance_invites.sql
@@ -1,0 +1,9 @@
+-- Keep a log of pending alliance invitations
+CREATE TABLE `alliance_invites_player` (
+  `game_id` int(10) unsigned NOT NULL,
+  `account_id` smallint(6) unsigned NOT NULL,
+  `alliance_id` smallint(6) unsigned NOT NULL,
+  `invited_by_id` smallint(6) unsigned NOT NULL,
+  `expires` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`game_id`,`account_id`,`alliance_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/engine/Default/alliance_invite_accept.php
+++ b/engine/Default/alliance_invite_accept.php
@@ -1,0 +1,34 @@
+<?php
+
+// Remove any expired invitations
+$db->query('DELETE FROM alliance_invites_player WHERE expires < ' . $db->escapeNumber(TIME));
+
+// Check that the invitation is registered in the database
+$newAlliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
+$db->query('SELECT 1 FROM alliance_invites_player
+            WHERE game_id = '.$db->escapeNumber($player->getGameID()).'
+              AND alliance_id = '.$db->escapeNumber($newAlliance->getAllianceID()).'
+              AND account_id = '.$db->escapeNumber($player->getAccountID()));
+if (!$db->nextRecord()) {
+	create_error('You do not have an invitation to join this alliance!');
+}
+
+// Make sure the player can join the new alliance before leaving the current one
+$canJoin = $newAlliance->canJoinAlliance($player, false);
+if ($canJoin !== true) {
+	create_error($canJoin);
+}
+
+// Leave current alliance
+if ($player->hasAlliance()) {
+	if ($player->isAllianceLeader()) {
+		create_error('You are the alliance leader! You must handover leadership first.');
+	}
+	$player->leaveAlliance();
+}
+
+// Join new alliance (this deletes the invitation)
+$player->joinAlliance($newAlliance->getAllianceID());
+
+$container = create_container('skeleton.php', 'alliance_mod.php');
+forward($container);

--- a/engine/Default/alliance_invite_player.php
+++ b/engine/Default/alliance_invite_player.php
@@ -1,0 +1,53 @@
+<?php
+
+$alliance = $player->getAlliance();
+$game = $player->getGame();
+
+$template->assign('PageTopic', $alliance->getAllianceName(false, true));
+require_once(get_file_loc('menu.inc'));
+create_alliance_menu($alliance->getAllianceID(), $alliance->getLeaderID());
+
+// Remove any expired invitations
+$db->query('DELETE FROM alliance_invites_player WHERE expires < ' . $db->escapeNumber(TIME));
+
+// Get list of pending invitations
+$pendingInvites = array();
+$db->query('SELECT * FROM alliance_invites_player
+            WHERE game_id = '.$db->escapeNumber($player->getGameID()).'
+              AND alliance_id = '.$db->escapeNumber($alliance->getAllianceID()));
+while ($db->nextRecord()) {
+	$invited = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID());
+	$invitedBy = SmrPlayer::getPlayer($db->getInt('invited_by_id'), $player->getGameID());
+	$pendingInvites[$invited->getAccountID()] = array(
+		'invited' => $invited->getDisplayName(true),
+		'invited_by' => $invitedBy->getDisplayName(),
+		'expires' => format_time($db->getInt('expires') - TIME, true),
+	);
+}
+$template->assign('PendingInvites', $pendingInvites);
+
+// Get list of players eligible to join this alliance.
+// List those who joined the game most recently first.
+$invitePlayers = array();
+if ($alliance->getNumMembers() < $game->getAllianceMaxPlayers()) {
+	$db->query('SELECT account_id FROM player
+	            WHERE game_id = '.$db->escapeNumber($player->getGameID()).'
+	              AND alliance_id != '.$db->escapeNumber($alliance->getAllianceID()).'
+	              AND npc = '.$db->escapeBoolean(false).'
+	            ORDER BY player_id DESC');
+	while ($db->nextRecord()) {
+		$invitePlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID());
+		if (in_array($invitePlayer->getAccountID(), array_keys($pendingInvites))) {
+			// Don't display players we've already invited
+			continue;
+		}
+		if ($alliance->getNumVeterans() < $game->getAllianceMaxVets() || !$invitePlayer->isVeteran()) {
+			$invitePlayers[] = $invitePlayer;
+		}
+	}
+}
+$template->assign('InvitePlayers', $invitePlayers);
+
+$template->assign('ThisGame', $game);
+$template->assign('ThisAlliance', $alliance);
+$template->assign('InviteHREF', SmrSession::getNewHREF(create_container('alliance_invite_player_processing.php')));

--- a/engine/Default/alliance_invite_player_processing.php
+++ b/engine/Default/alliance_invite_player_processing.php
@@ -1,0 +1,38 @@
+<?php
+
+$receiverID = $_POST['account_id'];
+$addMessage = $_POST['message'];
+$expireDays = $_POST['expire_days'];
+
+if (!is_numeric($expireDays)) {
+	create_error('Expiration must be a number of days!');
+}
+$expires = TIME + 86400 * $expireDays;
+
+// If sender is mail banned or blacklisted by receiver, omit the custom message
+$db->query('SELECT 1 FROM message_blacklist
+            WHERE account_id='.$db->escapeNumber($receiverID).'
+              AND blacklisted_id='.$db->escapeNumber($player->getAccountID()));
+if ($db->nextRecord() || $account->isMailBanned()) {
+	$addMessage = '';
+}
+
+// Construct the mail to send to the receiver
+$msg = 'You have been invited to join an alliance!
+This invitation will remain open for '.$expireDays.' '.pluralise('day', $expireDays).' or until you join another alliance.
+If you are currently in an alliance, you will leave it if you accept this invitation.
+
+[join_alliance='.$player->getAllianceID().']
+';
+if (!empty($addMessage)) {
+	$msg .= '<br />' . $addMessage;
+}
+
+// Send mail to player
+$player->sendMessage($receiverID, MSG_PLAYER, $msg, false, true, $expires, true);
+
+// Record invitation in the database
+$db->query('INSERT INTO alliance_invites_player (game_id, account_id, alliance_id, invited_by_id, expires) VALUES('.$db->escapeNumber($player->getGameID()).', '.$db->escapeNumber($receiverID).', '.$db->escapeNumber($player->getAllianceID()).', '.$db->escapeNumber($player->getAccountID()).', '.$db->escapeNumber($expires).')');
+
+$container = create_container('skeleton.php', 'alliance_invite_player.php');
+forward($container);

--- a/engine/Default/alliance_join_processing.php
+++ b/engine/Default/alliance_join_processing.php
@@ -2,28 +2,16 @@
 
 require_once(get_file_loc('SmrAlliance.class.inc'));
 
-// ********************************
-// *
-// * V a l i d a t e d ?
-// *
-// ********************************
-
 // is account validated?
 if (!$account->isValidated()) {
 	create_error('You are not validated. You can\'t join an alliance yet.');
 }
-	
 
-// ********************************
-// *
-// * B e g i n
-// *
-// ********************************
+$alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
 
-$alliance =& SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
-
-if ($alliance->canJoinAlliance($player) !== true) {
-	create_error('You are not able to join this alliance currently.');
+$canJoin = $alliance->canJoinAlliance($player);
+if ($canJoin !== true) {
+	create_error($canJoin);
 }
 
 if ($_REQUEST['password'] != $alliance->getPassword()) {

--- a/engine/Default/alliance_join_processing.php
+++ b/engine/Default/alliance_join_processing.php
@@ -2,11 +2,6 @@
 
 require_once(get_file_loc('SmrAlliance.class.inc'));
 
-// is account validated?
-if (!$account->isValidated()) {
-	create_error('You are not validated. You can\'t join an alliance yet.');
-}
-
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
 
 $canJoin = $alliance->canJoinAlliance($player);

--- a/engine/Default/alliance_option.php
+++ b/engine/Default/alliance_option.php
@@ -31,6 +31,13 @@ $db->nextRecord();
 $container['url'] = 'skeleton.php';
 $container['alliance_id'] = $alliance->getAllianceID();
 
+if ($db->getBoolean('change_pass')) {
+	$container['body'] = 'alliance_invite_player.php';
+	$links[] = array(
+		'link' => create_link($container, 'Invite Player'),
+		'text' => 'Invite a player to the alliance.',
+	);
+}
 if ($db->getBoolean('remove_member')) {
 	$container['body'] = 'alliance_remove_member.php';
 	$links[] = array(

--- a/engine/Default/alliance_roster.php
+++ b/engine/Default/alliance_roster.php
@@ -80,7 +80,9 @@ if ($alliance->getAllianceID() == $player->getAllianceID()) {
 	$template->assign('ToggleRolesHREF', SmrSession::getNewHREF($container));
 }
 
-$canJoin = $alliance->canJoinAlliance($player);
+// If the player is already in an alliance, we don't want to print
+// any messages, so we simply omit the "join alliance" section.
+$canJoin = $player->hasAlliance() ? false : $alliance->canJoinAlliance($player);
 $template->assign('CanJoin', $canJoin);
 if ($canJoin === true) {
 	$container = create_container('alliance_join_processing.php');

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -260,6 +260,9 @@ class SmrAlliance {
 	}
 
 	public function canJoinAlliance(SmrPlayer $player) {
+		if (!$player->getAccount()->isValidated()) {
+			return 'You cannot join an alliance until you validate your account.';
+		}
 		if($player->hasAlliance()) {
 			return 'You are already in an alliance!';
 		}

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -259,11 +259,11 @@ class SmrAlliance {
 		$this->flagshipID = $accountID;
 	}
 
-	public function canJoinAlliance(SmrPlayer $player) {
+	public function canJoinAlliance(SmrPlayer $player, $doAllianceCheck=true) {
 		if (!$player->getAccount()->isValidated()) {
 			return 'You cannot join an alliance until you validate your account.';
 		}
-		if($player->hasAlliance()) {
+		if ($doAllianceCheck && $player->hasAlliance()) {
 			return 'You are already in an alliance!';
 		}
 		if($this->getPassword()=='*') {

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -261,7 +261,7 @@ class SmrAlliance {
 
 	public function canJoinAlliance(SmrPlayer $player) {
 		if($player->hasAlliance()) {
-			return false;
+			return 'You are already in an alliance!';
 		}
 		if($this->getPassword()=='*') {
 			return 'This alliance is not currently accepting new recruits.';

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -473,6 +473,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I joined your alliance!', false);
 		$this->db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getAccountID()) . ', 2,' . $this->db->escapeNumber($alliance->getAllianceID()) . ')');
 		$this->actionTaken('JoinAlliance', array('Alliance' => $alliance));
+
+		// Joining an alliance cancels all open invitations
+		$this->db->query('DELETE FROM alliance_invites_player WHERE ' . $this->SQL);
 	}
 
 	function getAllianceJoinable() {
@@ -1712,7 +1715,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->sendMessage($this->getAccountID(), MSG_GLOBAL, $message, $canBeIgnored, false);
 	}
 
-	public function sendMessage($receiverID, $messageTypeID, $message, $canBeIgnored = true, $unread = true) {
+	public function sendMessage($receiverID, $messageTypeID, $message, $canBeIgnored = true, $unread = true, $expires = false, $senderDelete = false) {
 		//get expire time
 		if($canBeIgnored) {
 			if($this->getAccount()->isMailBanned())
@@ -1725,37 +1728,46 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 		$message = word_filter($message);
 
-		switch ($messageTypeID) {
-			case MSG_GLOBAL: //We don't send globals to the box here or it gets done loads of times.
-				$expires = 3600; // 1h
-			break;
-			case MSG_PLAYER:
-				$expires = 86400 * 31;
-			break;
-			case MSG_PLANET:
-				$expires = 86400 * 7;
-			break;
-			case MSG_SCOUT:
-				$expires = 86400 * 3;
-			break;
-			case MSG_POLITICAL:
-				$expires = 86400 * 31;
-			break;
-			case MSG_ALLIANCE:
-				$expires = 86400 * 31;
-			break;
-			case MSG_ADMIN:
-				$expires = 86400 * 365;
-			break;
-			case MSG_CASINO:
-				$expires = 86400 * 31;
-			break;
-			default:
-				$expires = 86400 * 7;
+		// If expires not specified, use default based on message type
+		if ($expires === false) {
+			switch ($messageTypeID) {
+				case MSG_GLOBAL: //We don't send globals to the box here or it gets done loads of times.
+					$expires = 3600; // 1h
+				break;
+				case MSG_PLAYER:
+					$expires = 86400 * 31;
+				break;
+				case MSG_PLANET:
+					$expires = 86400 * 7;
+				break;
+				case MSG_SCOUT:
+					$expires = 86400 * 3;
+				break;
+				case MSG_POLITICAL:
+					$expires = 86400 * 31;
+				break;
+				case MSG_ALLIANCE:
+					$expires = 86400 * 31;
+				break;
+				case MSG_ADMIN:
+					$expires = 86400 * 365;
+				break;
+				case MSG_CASINO:
+					$expires = 86400 * 31;
+				break;
+				default:
+					$expires = 86400 * 7;
+			}
+			$expires += TIME;
 		}
-		$expires += TIME;
+
+		// Do not put scout messages in the sender's sent box
+		if ($messageTypeID == MSG_SCOUT) {
+			$senderDelete = true;
+		}
+
 		// send him the message
-		self::doMessageSending($this->getAccountID(),$receiverID, $this->getGameID(), $messageTypeID, $message, $expires, $messageTypeID == MSG_SCOUT, $unread);
+		self::doMessageSending($this->getAccountID(),$receiverID, $this->getGameID(), $messageTypeID, $message, $expires, $senderDelete, $unread);
 	}
 
 	public function sendMessageFromOpAnnounce($receiverID, $message, $expires=false) {

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -132,7 +132,15 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 				}
 
 				return $sectorTag;
-
+			break;
+			case 'join_alliance':
+				$alliance = SmrAlliance::getAlliance($default, $overrideGameID);
+				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+					return true;
+				}
+				$container = create_container('alliance_invite_accept.php');
+				$container['alliance_id'] = $alliance->getAllianceID();
+				return '<div class="buttonA"><a class="buttonA" href="' . SmrSession::getNewHREF($container) . '">&nbsp;Join ' . $alliance->getAllianceName() . '&nbsp;</a></div>';
 			break;
 		}
 	}
@@ -174,6 +182,7 @@ function bbifyMessage($message, $noLinks=false) {
 		$bbParser->AddRule('servertimetouser',$smrRule);
 		$bbParser->AddRule('chess',$smrRule);
 		$bbParser->AddRule('sector',$smrRule);
+		$bbParser->addRule('join_alliance',$smrRule);
 	}
 	global $disableBBLinks;
 	if($noLinks===true)

--- a/templates/Default/engine/Default/alliance_invite_player.php
+++ b/templates/Default/engine/Default/alliance_invite_player.php
@@ -1,0 +1,70 @@
+<table class="standard">
+	<tr>
+		<th>Members</th>
+		<th>Current</th>
+		<th>Max</th>
+	</tr>
+	<tr>
+		<td>Veteran</td>
+		<td class="center"><?php echo $ThisAlliance->getNumVeterans(); ?></td>
+		<td class="center"><?php echo $ThisGame->getAllianceMaxVets(); ?></td>
+	</tr>
+	<tr>
+		<td>Total</td>
+		<td class="center"><?php echo $ThisAlliance->getNumMembers(); ?></td>
+		<td class="center"><?php echo $ThisGame->getAllianceMaxPlayers(); ?></td>
+	</tr>
+</table>
+
+<br /><br />
+<h2>Invite Player</h2>
+
+<?php
+if (count($InvitePlayers) == 0) { ?>
+	<p>There are no players eligible to be invited to your alliance!</p><?php
+} else { ?>
+
+	<p>Select a player to invite to your alliance:</p>
+
+	<form method="POST" action="<?php echo $InviteHREF; ?>">
+		<select name="account_id" id="InputFields" size="1">
+			<?php
+			foreach ($InvitePlayers as $InvitePlayer) { ?>
+				<option value="<?php echo $InvitePlayer->getAccountID(); ?>">
+					<?php echo $InvitePlayer->getDisplayName(true); ?>
+				</option><?php
+			} ?>
+		</select>
+		<br />
+		<p>Optional invitation message:</p>
+		<textarea spellcheck="true" name="message" style="height: 5em"></textarea>
+		<p>Days until invitation expires:</p>
+		<input type="number" name="expire_days" value="7" />
+		<br /><br />
+		<input type="submit" name="action" id="InputFields" value="Invite Player" />
+	</form><?php
+} ?>
+
+<br /><br />
+<h2>Pending Invitations</h2>
+
+<?php
+if (count($PendingInvites) == 0) { ?>
+	<p>Your alliance has no pending invitations.</p><?php
+} else { ?>
+	<br />
+	<table class="standard">
+		<tr>
+			<th>Invited Player</th>
+			<th>Invited By</th>
+			<th>Expires</th>
+		</tr><?php
+		foreach ($PendingInvites as $invite) { ?>
+			<tr>
+				<td><?php echo $invite['invited']; ?></td>
+				<td><?php echo $invite['invited_by']; ?></td>
+				<td><?php echo $invite['expires']; ?></td>
+			</tr><?php
+		} ?>
+	</table><?php
+} ?>


### PR DESCRIPTION
Allow alliance members with permission to change the alliance password
to invite players into the alliance.

Add a new alliance option "Invite Player", which links to a page that
displays the current alliance quotas (vet/total), allows you to invite
specific players, and lists all pending invitations.

Players who are invited will receive an automatic player message with
a link to join the alliance (achieved through a new `join_alliance`
BBCode tag). You can optionally attach a personal message to the
invitation (this is omitted if you are blacklisted or mail banned,
but the invitation is still sent).

Library changes:

* Add `doAllianceCheck=true` argument to `SmrAlliance::canJoinAlliance`
  so that we can check if a player can join an alliance before making
  him leave his current alliance. If `false`, this doesn't do the
  `hasAlliance` check.

* `SmrPlayer::joinAlliance` now deletes all pending invitations for
  the player, to prevent alliance hopping.

* `SmrAlliance::canJoinAlliance` now does the validation check instead of
  doing the check only in `alliance_join_processing.php`.

* Return a text error message in `SmrAlliance::canJoinAlliance` if the
  player is already in an alliance instead of returning `false`.

Additional alliance option:
![image](https://user-images.githubusercontent.com/846186/39182154-d6c16dd0-4770-11e8-8081-04ea9a168ee3.png)

"Invite Player" alliance tool:
![image](https://user-images.githubusercontent.com/846186/39182032-50a227a8-4770-11e8-8b2c-69806aaa0457.png)

Message sent to invited players:
![image](https://user-images.githubusercontent.com/846186/39181926-0790ab2a-4770-11e8-9883-79483eb81057.png)
