### PR TITLE
SmrSession: change static arrays to constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - '5.6'
+  - '7.1'
   - '7.2'
 git:
   depth: false

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker logs -f smr
 These list the known dependencies, there may be more - please update if you find any!
 
 ### Core
-* PHP 5.4+
+* PHP 7.1+
 * MySQL 5.5
 
 ### PHP Extensions

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-mysqli": "*",
         "facebook/graph-sdk": "^5.5.0",
         "google/recaptcha": "~1.1",
-        "php": "5.4.0 - 7.2",
+        "php": "7.1 - 7.2",
         "phpmailer/phpmailer": "~6.0",
         "vanilla/nbbc": "~2.0"
     }

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -5,7 +5,7 @@ if(!defined('USING_AJAX'))
 class SmrSession {
 	const ALWAYS_AVAILABLE = 999999;
 	const TIME_BEFORE_EXPIRY = 3600;
-	private static $URL_DEFAULT_REMAINING_PAGE_LOADS = array(
+	private const URL_DEFAULT_REMAINING_PAGE_LOADS = array(
 			'alliance_broadcast.php' => self::ALWAYS_AVAILABLE,
 			'alliance_forces.php' => self::ALWAYS_AVAILABLE,
 			'alliance_list.php' => self::ALWAYS_AVAILABLE,
@@ -113,7 +113,7 @@ class SmrSession {
 			'universe_create_warps.php' => self::ALWAYS_AVAILABLE
 		);
 
-	private static $URL_LOAD_DELAY = array(
+	private const URL_LOAD_DELAY = array(
 		'configure_hardware.php' => .4,
 		'forces_drop.php' => .4,
 		'forces_drop_processing.php' => .5,
@@ -165,7 +165,7 @@ class SmrSession {
 		if(!USING_AJAX && isset($_REQUEST['sn']) && isset(self::$var[$_REQUEST['sn']]) && !empty(self::$var[$_REQUEST['sn']])) {
 			$var = self::$var[$_REQUEST['sn']];
 			$currentPage = $var['url'] == 'skeleton.php' ? $var['body'] : $var['url'];
-			$loadDelay = isset(self::$URL_LOAD_DELAY[$currentPage]) ? self::$URL_LOAD_DELAY[$currentPage] : 0;
+			$loadDelay = isset(self::URL_LOAD_DELAY[$currentPage]) ? self::URL_LOAD_DELAY[$currentPage] : 0;
 			$initialTimeBetweenLoads = microtimeDiff(microtime(), $var['PreviousRequestTime']);
 			while(($timeBetweenLoads = microtimeDiff(microtime(), $var['PreviousRequestTime'])) < $loadDelay) {
 				$sleepTime = round(($loadDelay-$timeBetweenLoads)*1000000);
@@ -370,7 +370,7 @@ class SmrSession {
 		}
 		if(!isset($container['RemainingPageLoads'])) {
 			$pageURL = $container['url'] == 'skeleton.php' ? $container['body'] : $container['url'];
-			$container['RemainingPageLoads'] = isset(self::$URL_DEFAULT_REMAINING_PAGE_LOADS[$pageURL]) ? self::$URL_DEFAULT_REMAINING_PAGE_LOADS[$pageURL] : 1; // Allow refreshing
+			$container['RemainingPageLoads'] = isset(self::URL_DEFAULT_REMAINING_PAGE_LOADS[$pageURL]) ? self::URL_DEFAULT_REMAINING_PAGE_LOADS[$pageURL] : 1; // Allow refreshing
 		}
 
 		if($sn === false) {


### PR DESCRIPTION
Since we use OPcache, it is better to do as much as possible at
compile time so it can be cached and reloaded. Const is compile
time, and static variable are runtime, so we switch to consts
when possible.