### PR TITLE
Dockerfile: disable apache access logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN [ "$PHP_DEBUG" = "1" ] && echo "Using development php.ini" || \
 		&& cp /usr/src/php/php.ini-production /usr/local/etc/php/php.ini; \
 	}
 
+# Disable apache access logging (error logging is still enabled)
+RUN sed -i 's|CustomLog.*|CustomLog /dev/null common|' /etc/apache2/sites-enabled/000-default.conf
+
 # Disable apache .htaccess files (suggested optimization)
 RUN sed -i 's/AllowOverride All/AllowOverride None/g' /etc/apache2/conf-enabled/docker-php.conf
 


### PR DESCRIPTION
Access logging bloats the container size and is not needed in
dev environments. On the live server, we are logging with the
nginx reverse proxy, so the apache logging was redundant.

Also, since `docker logs` shows combined error/access logs, it
was very difficult to display only the errors (mostly because
the access log is so huge that even redirecting the stdout to
`/dev/null` takes an excessively long time.