### PR TITLE
Rename "Game Open/Close" admin tool

### DIFF
--- a/admin/Default/game_status.php
+++ b/admin/Default/game_status.php
@@ -3,19 +3,19 @@
 $db->query('SELECT * FROM game_disable');
 if (!$db->getNumRows()) {
 
-	$template->assign('PageTopic','Close Game');
+	$template->assign('PageTopic','Close Server');
 
 	$container = array();
 	$container['url'] = 'game_status_processing.php';
 	$PHP_OUTPUT.=create_echo_form($container);
-	$PHP_OUTPUT.=('If you wish to close the game please enter a reason for the closure.<br /><br />');
+	$PHP_OUTPUT.=('If you wish to close Space Merchant Realms, please enter a reason for the closure.<br /><br />');
 	$PHP_OUTPUT.=('<input spellcheck="true" type="text" name="close_reason" maxlength="255" size="100" id="InputFields"><br /><br />');
 	$PHP_OUTPUT.=create_submit('Close');
 	$PHP_OUTPUT.=('</form>');
 
 } else {
 
-	$template->assign('PageTopic','Open Game');
+	$template->assign('PageTopic','Open Server');
 
 	$container = array();
 	$container['url'] = 'game_status_processing.php';

--- a/admin/Default/game_status.php
+++ b/admin/Default/game_status.php
@@ -1,27 +1,13 @@
 <?php
 
+$processingHREF = SmrSession::getNewHREF(create_container('game_status_processing.php'));
+$template->assign('ProcessingHREF', $processingHREF);
+
 $db->query('SELECT * FROM game_disable');
 if (!$db->getNumRows()) {
-
 	$template->assign('PageTopic','Close Server');
-
-	$container = array();
-	$container['url'] = 'game_status_processing.php';
-	$PHP_OUTPUT.=create_echo_form($container);
-	$PHP_OUTPUT.=('If you wish to close Space Merchant Realms, please enter a reason for the closure.<br /><br />');
-	$PHP_OUTPUT.=('<input spellcheck="true" type="text" name="close_reason" maxlength="255" size="100" id="InputFields"><br /><br />');
-	$PHP_OUTPUT.=create_submit('Close');
-	$PHP_OUTPUT.=('</form>');
-
+	$template->assign('ServerIsOpen', true);
 } else {
-
 	$template->assign('PageTopic','Open Server');
-
-	$container = array();
-	$container['url'] = 'game_status_processing.php';
-	$PHP_OUTPUT.=create_echo_form($container);
-	$PHP_OUTPUT.=('Do you want to reopen Space Merchant Realms?<br /><br />');
-	$PHP_OUTPUT.=create_submit('Open');
-	$PHP_OUTPUT.=('</form>');
-
+	$template->assign('ServerIsOpen', false);
 }

--- a/admin/Default/game_status_processing.php
+++ b/admin/Default/game_status_processing.php
@@ -1,13 +1,17 @@
 <?php
 
-//we are closing
+$container = create_container('skeleton.php', 'admin_tools.php');
+
 $action = $_REQUEST['action'];
 if ($action == 'Close') {
-	$db->query('REPLACE INTO game_disable (reason) VALUES (' . $db->escape_string($_REQUEST['close_reason'], true) . ');');
+	$reason = $_REQUEST['close_reason'];
+	$db->query('REPLACE INTO game_disable (reason) VALUES (' . $db->escapeString($reason, true) . ');');
 	$db->query('DELETE FROM active_session;');
+	$container['msg'] = '<span class="green">SUCCESS: </span>You have closed the server. You will now be logged out!';
 }
 elseif ($action == 'Open') {
 	$db->query('DELETE FROM game_disable;');
+	$container['msg'] = '<span class="green">SUCCESS: </span>You have opened the server.';
 }
 
-forward(create_container('skeleton.php', 'admin_tools.php'));
+forward($container);

--- a/lib/Default/AdminPermissions.class.inc
+++ b/lib/Default/AdminPermissions.class.inc
@@ -7,7 +7,7 @@ class AdminPermissions {
 	// Info is [Permission Name, Page to Link, Category].
 	private const PERMISSION_TABLE = [
 		1  => ['Manage Admin Permissions', 'permission_manage.php', 3],
-		3  => ['Game Open/Close', 'game_status.php', 3],
+		3  => ['Server Open/Close', 'game_status.php', 3],
 		4  => ['Delete Game', 'game_delete.php', 5],
 		5  => ['Create Announcement', 'announcement_create.php', 3],
 		6  => ['Send Message', 'admin_message_send.php', 3],

--- a/templates/Default/admin/Default/game_status.php
+++ b/templates/Default/admin/Default/game_status.php
@@ -1,0 +1,13 @@
+<form method="POST" action="<?php echo $ProcessingHREF; ?>">
+<?php
+if ($ServerIsOpen) { ?>
+	If you wish to close Space Merchant Realms, please enter a reason for the closure.<br /><br />
+	<input spellcheck="true" type="text" name="close_reason" maxlength="255" size="100" id="InputFields"><br /><br />
+	<b>NOTE:</b> Closing the server will kick all players and disable general logins.
+	Only admins with permission to reopen the game will be allowed to log in while closed.<br /><br />
+	<input type="submit" name="action" value="Close"><?php
+} else { ?>
+	Do you want to reopen Space Merchant Realms?<br /><br />
+	<input type="submit" name="action" value="Open"><?php
+} ?>
+</form>


### PR DESCRIPTION
Since we usually use the term 'Game' to refer to an individual
`SmrGame`, we change this tool to refer to 'Server' instead,
which should clarify for admins what this tool actually does.

* Add success messages
* Convert `game_status.php` to template

![image](https://user-images.githubusercontent.com/846186/39459011-82708dbe-4cad-11e8-9f5f-02002d03d07f.png)

![image](https://user-images.githubusercontent.com/846186/39459018-8974b478-4cad-11e8-8cf7-e3a163584f35.png)

![image](https://user-images.githubusercontent.com/846186/39459034-977f5e2e-4cad-11e8-9752-2ebcb71cbbf0.png)
