### PR TITLE
SectorForces.inc: modify spacing

### DIFF
--- a/templates/Default/engine/Default/includes/SectorForces.inc
+++ b/templates/Default/engine/Default/includes/SectorForces.inc
@@ -60,18 +60,17 @@
 							} ?>
 						</td>
 						<td><?php echo $Owner->getLinkedDisplayName(); ?></td>
-						<td align="center" class="shrink center"><?php
+						<td class="shrink noWrap center"><?php
 							if ($SharedForceAlliance) { ?>
 								<div class="buttonA">
-									<a class="buttonA" href="<?php echo $Force->getExamineDropForcesHREF(); ?>"> Examine </a>
+									<a class="buttonA" href="<?php echo $Force->getExamineDropForcesHREF(); ?>">&nbsp;Examine&nbsp;</a>
 								</div>
-								<br /><br />
 								<div class="buttonA">
-									<a href="<?php echo $Force->getRefreshHREF(); ?>" class="buttonA"> Refresh </a>
+									<a href="<?php echo $Force->getRefreshHREF(); ?>" class="buttonA">&nbsp;Refresh&nbsp;</a>
 								</div><?php
 							} else { ?>
 								<div class="buttonA">
-									<a class="buttonA enemyExamine" href="<?php echo $Force->getAttackForcesHREF(); ?>"> Attack (<?php echo $Force->getAttackTurnCost($ThisShip); ?>) </a>
+									<a class="buttonA enemyExamine" href="<?php echo $Force->getAttackForcesHREF(); ?>">&nbsp;Attack (<?php echo $Force->getAttackTurnCost($ThisShip); ?>)&nbsp;</a>
 								</div><?php
 							} ?>
 						</td>
@@ -80,7 +79,7 @@
 				if($RefreshAny) { ?>
 					<tr>
 						<td class="center" colspan="6">
-							<div class="buttonA"><a href="<?php echo $Force->getRefreshAllHREF() ?>" class="buttonA"> Refresh All </a></div>
+							<div class="buttonA"><a href="<?php echo $Force->getRefreshAllHREF() ?>" class="buttonA">&nbsp;Refresh All&nbsp;</a></div>
 						</td>
 					</tr><?php
 				} ?>


### PR DESCRIPTION
We put both the Examine and Refresh button for friendly forces on
the same line. This does two helpful things:

1. It is easier to go down the list of forces and click either the
   Examine or Refresh button (since they're now aligned in separate
   vertical columns).

2. More forces can be seen on a single page since the row was always
   vertically extended to fit the two buttons.

One downside is that the "Attack" button will shift position as the
sector goes from having only enemy forces to enemy + allied forces.
We could just right-align the "Attack" button to ensure it stays
in the same place, but this might look even more strange.

Before:
![image](https://user-images.githubusercontent.com/846186/39461522-379ab0a4-4cc0-11e8-8ff1-ad1132758286.png)

After:
![image](https://user-images.githubusercontent.com/846186/39461513-20463af4-4cc0-11e8-8d74-0069f0a4a81c.png)
