### PR TITLE
Replace some tables with PHP arrays

### DIFF
--- a/admin/Default/box_view.php
+++ b/admin/Default/box_view.php
@@ -3,20 +3,22 @@
 $template->assign('PageTopic','Viewing Message Boxes');
 
 if(!isset($var['box_type_id'])) {
-	$db->query('SELECT count(message_id), box_type_name, box_type_id
-				FROM message_box_types
-				LEFT JOIN message_boxes USING(box_type_id)
-				GROUP BY box_type_id, box_type_name');
 	$container = create_container('skeleton.php', 'box_view.php');
 	$boxes = array();
-	while($db->nextRecord()) {
-		$boxTypeID = $db->getInt('box_type_id');
+	require_once(get_file_loc('message.functions.inc'));
+	foreach (getAdminBoxNames() as $boxTypeID => $boxName) {
 		$container['box_type_id'] = $boxTypeID;
 		$boxes[$boxTypeID] = array(
 			'ViewHREF' => SmrSession::getNewHREF($container),
-			'BoxName' => $db->getField('box_type_name'),
-			'TotalMessages' => $db->getField('count(message_id)')
+			'BoxName' => $boxName,
+			'TotalMessages' => 0,
 		);
+	}
+	$db->query('SELECT count(message_id), box_type_id
+				FROM message_boxes
+				GROUP BY box_type_id');
+	while($db->nextRecord()) {
+		$boxes[$db->getInt('box_type_id')]['TotalMessages'] = $db->getInt('count(message_id)');
 	}
 	$template->assign('Boxes', $boxes);
 }

--- a/admin/Default/game_maintainance.php
+++ b/admin/Default/game_maintainance.php
@@ -78,7 +78,6 @@ $db->query('OPTIMIZE TABLE
 	`mb_keywords`,
 	`message`,
 	`message_notify`,
-	`message_type`,
 	`multi_checking_cookie`,
 	`news`,
 	`newsletter`,

--- a/db/patches/V1_6_62_12__remove_message_types.sql
+++ b/db/patches/V1_6_62_12__remove_message_types.sql
@@ -1,0 +1,3 @@
+-- Replace `message_type` and `message_box_types` tables with PHP arrays
+DROP TABLE `message_type`;
+DROP TABLE `message_box_types`;

--- a/engine/Default/buy_message_notifications.php
+++ b/engine/Default/buy_message_notifications.php
@@ -1,4 +1,5 @@
 <?php
+require_once(get_file_loc('message.functions.inc'));
 
 if(isset($var['Message'])) {
 	$template->assign('Message',$var['Message']);
@@ -8,12 +9,13 @@ $template->assign('PageTopic','Message Notifications');
 
 $container = create_container('buy_message_notifications_processing.php');
 
-$db->query('SELECT * FROM message_type WHERE message_type_id = ' . $db->escapeNumber(MSG_PLAYER) . ' ORDER BY message_type_id');
+// Presently only player messages are eligible for notifications
+$notifyTypeIDs = array(MSG_PLAYER);
+
 $messageBoxes = array ();
-while ($db->nextRecord()) {
-	$messageTypeID = $db->getInt('message_type_id');
+foreach ($notifyTypeIDs as $messageTypeID) {
 	$messageBox = array();
-	$messageBox['Name'] = $db->getField('message_type_name');
+	$messageBox['Name'] = getMessageTypeNames($messageTypeID);
 	
 	$messageBox['MessagesRemaining'] = $account->getMessageNotifications($messageTypeID);
 	$messageBox['MessagesPerCredit'] = MESSAGES_PER_CREDIT[$messageTypeID];

--- a/lib/Default/message.functions.inc
+++ b/lib/Default/message.functions.inc
@@ -1,5 +1,30 @@
 <?php
 
+function getMessageTypeNames($typeID = false) {
+	$typeNames = [
+		MSG_GLOBAL => 'Global Messages',
+		MSG_PLAYER => 'Player Messages',
+		MSG_PLANET => 'Planet Messages',
+		MSG_SCOUT => 'Scout Messages',
+		MSG_POLITICAL => 'Political Messages',
+		MSG_ALLIANCE => 'Alliance Messages',
+		MSG_ADMIN => 'Admin Messages',
+		MSG_CASINO => 'Casino Messages',
+	];
+	return $typeID === false ? $typeNames : $typeNames[$typeID];
+}
+
+function getAdminBoxNames() {
+	return [
+		BOX_BUGS_AUTO => 'Automatic Bug Reports',
+		BOX_BUGS_REPORTED => 'Player Bug Reports',
+		BOX_GLOBALS => 'Global Messages',
+		BOX_ALLIANCE_DESCRIPTIONS => 'Alliance Descriptions',
+		BOX_BETA_APPLICATIONS => 'Beta Applications',
+		BOX_ALBUM_COMMENTS => 'Photo Album Comments',
+	];
+}
+
 function &getMessagePlayer($accountID, $gameID, $messageType = false) {
 	if($accountID==ACCOUNT_ID_PORT)
 		$return = '<span class="yellow">Port Defenses</span>';


### PR DESCRIPTION
The following tables have been replaced with function calls
defined in `message.functions.inc`:

* `message_box_types` -> `getAdminBoxNames()`
* `message_types` -> `getMessageTypeNames()`

We do gain a performance improvement by avoiding the database calls,
but they are not significant. The bigger advantage is being able to
modify these tables if needed without the hassle of modifying the
database.