### PR TITLE
config.php: simplify Title

### DIFF
--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -395,9 +395,7 @@ $GLOBALS['template'] =& $template;
 $template->assign('URL',URL);
 $template->assign('CSSLink',DEFAULT_CSS);
 $template->assign('CSSColourLink',DEFAULT_CSS_COLOUR);
-$template->assign('Title','Space Merchant Realms 1.6:');
-//	$template->assign('isFirefox',preg_match('/(firefox|minefield)/i',$_SERVER['HTTP_USER_AGENT']));
-//	$template->assign('isAprilFools',(date('n') == 4 && date('j') == 1));
+$template->assign('Title', 'Space Merchant Realms');
 
 $links = array('Register' => 'login_create.php',
 					'ResetPassword' => 'resend_password.php');


### PR DESCRIPTION
Just display the title as "Space Merchant Realms" instead of
"Space Merchant Realms 1.6:". This removes the unexpected colon
and the unneeded version number (there is no other version of SMR,
but even if we do a major version number increment, there isn't
a good reason to display it here).