### PR TITLE
Remove unused rankings table

### DIFF
--- a/admin/Default/game_maintainance.php
+++ b/admin/Default/game_maintainance.php
@@ -112,7 +112,6 @@ $db->query('OPTIMIZE TABLE
 	`race`,
 	`race_has_relation`,
 	`race_has_voting`,
-	`rankings`,
 	`sector`,
 	`sector_has_forces`,
 	`ship_has_cargo`,

--- a/db/patches/V1_6_62_14__remove_rankings.sql
+++ b/db/patches/V1_6_62_14__remove_rankings.sql
@@ -1,0 +1,2 @@
+-- Remove `rankings` table, superseded by `user_rankings`.
+DROP TABLE `rankings`;

--- a/engine/Default/rankings_view.php
+++ b/engine/Default/rankings_view.php
@@ -7,10 +7,6 @@ require_once(get_file_loc('menu.inc'));
 if (SmrSession::$game_id != 0)
 	create_trader_menu();
 
-$db->query('SELECT * FROM rankings WHERE rankings_id = '.$rank_id);
-if ($db->nextRecord())
-	$rank_name = $db->getField('rankings_name');
-
 $PHP_OUTPUT.=('You have a score of <span class="red">'.number_format($account->getScore()).'</span>.<br /><br />');
 $PHP_OUTPUT.=('You are ranked as a <font size="4" color="greenyellow">'.$account->getRankName().'</font> player.<p><br />');
 $db->query('SELECT * FROM user_rankings ORDER BY rank');


### PR DESCRIPTION
The `rankings` table was superseded by the `user_rankings` table.

Since the `rankings` table was never formally populated in version control, I copy the live server entries for historical purposes:
![image](https://user-images.githubusercontent.com/846186/39613813-611a764c-4f1f-11e8-95a2-df1f42adfd14.png)
