### PR TITLE
 phplint.sh: fix omitting .php files

### DIFF
--- a/engine/Default/contact_processing.php
+++ b/engine/Default/contact_processing.php
@@ -10,7 +10,7 @@ $mail->setFrom($account->getEmail(), $account->getHofName());
 $mail->Body =
 	'Login:'.EOL.'------'.EOL.$account->getLogin().EOL.EOL .
 	'Account ID:'.EOL.'-----------'.EOL.$account->getAccountID().EOL.EOL .
-	'Message:'.EOL.'------------'.EOL.$msg,
+	'Message:'.EOL.'------------'.EOL.$msg;
 $mail->addAddress($receiver);
 $mail->send();
 

--- a/tests/phplint.sh
+++ b/tests/phplint.sh
@@ -15,7 +15,7 @@ do
         echo "$RESULTS"
         ERROR="true"
     fi
-done < <(find $ROOT -type f -name "*.php" -o -name "*.inc" -print0)
+done < <(find $ROOT -type f \( -name "*.php" -o -name "*.inc" \) -print0)
 
 if [[ "$ERROR" == "true" ]] ; then
     exit 1

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -37,7 +37,7 @@ require_once(get_file_loc('Plotter.class.inc'));
 require_once(get_file_loc('RouteGenerator.class.inc'));
 require_once(get_file_loc('shop_goods.inc'));
 
-const 'SHIP_UPGRADE_PATH' = array(
+const SHIP_UPGRADE_PATH = array(
 	2 => array( //Alskant
 		SHIP_TYPE_TRADE_MASTER,
 		SHIP_TYPE_TRIP_MAKER,


### PR DESCRIPTION
Due to a lack of parentheses in the `find` command, the tests
were only being run on `.inc` files. Now with this fix we test
both `.inc` and `.php` files.

Fix discovered errors in:
* contact_processing.php
* npc.php