### PR TITLE
Prevent NHL from casting votes

### DIFF
--- a/engine/Default/feature_request_vote_processing.php
+++ b/engine/Default/feature_request_vote_processing.php
@@ -1,6 +1,8 @@
 <?php
 if($_REQUEST['action']=='Vote') {
-//	$db->query('DELETE FROM account_votes_for_feature WHERE account_id='.SmrSession::$account_id);
+	if ($account->getAccountID() == ACCOUNT_ID_NHL) {
+		create_error('This account is not allowed to cast a vote!');
+	}
 	if(is_array($_REQUEST['vote'])) {
 		$query = 'REPLACE INTO account_votes_for_feature VALUES ';
 		foreach($_REQUEST['vote'] as $requestID => $vote) {

--- a/engine/Default/vote_processing.php
+++ b/engine/Default/vote_processing.php
@@ -1,11 +1,8 @@
 <?php
 
-//////////////////////////////////////////////////
-//
-//	Script:		vote_processing.php
-//	Purpose:	Registers Votes
-//
-//////////////////////////////////////////////////
+if ($account->getAccountID() == ACCOUNT_ID_NHL) {
+	create_error('This account is not allowed to cast a vote!');
+}
 
 if (!is_numeric($_REQUEST['vote']))
 	create_error('You must choose an option.');


### PR DESCRIPTION
The NHL account is a special account used by a player who already
has an account. Therefore, it should not be given any voting
privileges because it would essentially give that player two votes.