### PR TITLE
Use SmrAccount::getAccountID when possible

### DIFF
--- a/admin/Default/announcement_create_processing.php
+++ b/admin/Default/announcement_create_processing.php
@@ -7,6 +7,6 @@ if($_REQUEST['action'] == 'Preview announcement') {
 }
 
 // put the msg into the database
-$db->query('INSERT INTO announcement (time, admin_id, msg) VALUES('.$db->escapeNumber(TIME).', '.$db->escapeNumber(SmrSession::$account_id).', '.$db->escapeString($message).')');
+$db->query('INSERT INTO announcement (time, admin_id, msg) VALUES('.$db->escapeNumber(TIME).', '.$db->escapeNumber($account->getAccountID()).', '.$db->escapeString($message).')');
 
 forward(create_container('skeleton.php', 'admin_tools.php'));

--- a/engine/Default/album_delete_processing.php
+++ b/engine/Default/album_delete_processing.php
@@ -3,11 +3,11 @@
 if ($_REQUEST['action'] == 'Yes') {
 	$db->query('DELETE
 				FROM album
-				WHERE account_id = ' . $db->escapeNumber(SmrSession::$account_id) . ' LIMIT 1');
+				WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
 
 	$db->query('DELETE
 				FROM album_has_comments
-				WHERE album_id = ' . $db->escapeNumber(SmrSession::$account_id));
+				WHERE album_id = ' . $db->escapeNumber($account->getAccountID()));
 }
 
 $container = create_container('skeleton.php');

--- a/engine/Default/album_edit.php
+++ b/engine/Default/album_edit.php
@@ -1,7 +1,7 @@
 <?php
 $template->assign('PageTopic','Edit Photo');
 
-$db->query('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber(SmrSession::$account_id));
+$db->query('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 if ($db->nextRecord()) {
 	$albumEntry['Location'] = stripslashes($db->getField('location'));
 	$albumEntry['Email'] = stripslashes($db->getField('email'));
@@ -25,8 +25,8 @@ if ($db->nextRecord()) {
 		$albumEntry['Status']=('<a href="album/?'.$account->getHofName().'" class="dgreen">Online</a>');
 	}
 		
-	if(is_readable(UPLOAD . SmrSession::$account_id)) {
-		$albumEntry['Image'] = URL.'/upload/'.SmrSession::$account_id;
+	if(is_readable(UPLOAD . $account->getAccountID())) {
+		$albumEntry['Image'] = URL.'/upload/'.$account->getAccountID();
 	}
 	
 	$template->assign('AlbumEntry',$albumEntry);

--- a/engine/Default/album_edit_processing.php
+++ b/engine/Default/album_edit_processing.php
@@ -63,14 +63,14 @@ if ($_FILES['photo']['error'] == UPLOAD_ERR_OK) {
 		create_error('Image is higher than 500 pixels!');
 	}
 
-	if (!move_uploaded_file($_FILES['photo']['tmp_name'], UPLOAD . SmrSession::$account_id)) {
+	if (!move_uploaded_file($_FILES['photo']['tmp_name'], UPLOAD . $account->getAccountID())) {
 		create_error('Failed to upload image!');
 	}
 }
 
 
 // check if we had a album entry so far
-$db->query('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber(SmrSession::$account_id));
+$db->query('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 if ($db->nextRecord()) {
 	if ($noPicture == false) {
 		$comment = '<span class="green">*** Picture changed</span>';
@@ -88,7 +88,7 @@ if ($db->nextRecord()) {
 					last_changed = ' . $db->escapeNumber(TIME) . ',
 					approved = \'TBC\',
 					disabled = \'FALSE\'
-				WHERE account_id = ' . $db->escapeNumber(SmrSession::$account_id) . ' LIMIT 1');
+				WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
 }
 else {
 	// if he didn't upload a picture before
@@ -101,14 +101,14 @@ else {
 
 	// add album entry
 	$db->query('INSERT INTO album (account_id, location, email, website, day, month, year, other, created, last_changed, approved)
-				VALUES(' . $db->escapeNumber(SmrSession::$account_id) . ', ' . $db->escapeString($location) . ', ' . $db->escapeString($email) . ', ' . $db->escapeString($website) . ', ' . $db->escapeNumber($day) . ', ' . $db->escapeNumber($month) . ', ' . $db->escapeNumber($year) . ', ' . $db->escapeString($other) . ', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ', \'TBC\')');
+				VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($location) . ', ' . $db->escapeString($email) . ', ' . $db->escapeString($website) . ', ' . $db->escapeNumber($day) . ', ' . $db->escapeNumber($month) . ', ' . $db->escapeNumber($year) . ', ' . $db->escapeString($other) . ', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ', \'TBC\')');
 }
 
 if (!empty($comment)) {
 	// check if we have comments for this album already
 	$db->lockTable('album_has_comments');
 
-	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = '.$db->escapeNumber(SmrSession::$account_id));
+	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = '.$db->escapeNumber($account->getAccountID()));
 	if ($db->nextRecord()) {
 		$comment_id = $db->getField('MAX(comment_id)') + 1;
 	}

--- a/engine/Default/feature_request.php
+++ b/engine/Default/feature_request.php
@@ -42,7 +42,7 @@ $template->assign('CanVote', $canVote);
 
 if ($canVote) {
 	$featureVotes = array();
-	$db->query('SELECT * FROM account_votes_for_feature WHERE account_id = '.SmrSession::$account_id);
+	$db->query('SELECT * FROM account_votes_for_feature WHERE account_id = '.$account->getAccountID());
 	while($db->nextRecord())
 		$featureVotes[$db->getInt('feature_request_id')] = $db->getField('vote_type');
 }

--- a/engine/Default/feature_request_comment_processing.php
+++ b/engine/Default/feature_request_comment_processing.php
@@ -5,7 +5,7 @@ if (empty($_REQUEST['comment']))
 
 // add this feature comment
 $db->query('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
-			VALUES(' . $db->escapeNumber($var['RequestID']) . ', ' . $db->escapeNumber(SmrSession::$account_id) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeBoolean(isset($_REQUEST['anon'])) . ',' . $db->escapeString(word_filter($_REQUEST['comment'])).')');
+			VALUES(' . $db->escapeNumber($var['RequestID']) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeBoolean(isset($_REQUEST['anon'])) . ',' . $db->escapeString(word_filter($_REQUEST['comment'])).')');
 
 $container = $var;
 $container['url'] = 'skeleton.php';

--- a/engine/Default/feature_request_processing.php
+++ b/engine/Default/feature_request_processing.php
@@ -11,9 +11,9 @@ if(strlen($_REQUEST['feature']) > 500) {
 $db->query('INSERT INTO feature_request (feature_request_id) VALUES (NULL)');
 $featureRequestID = $db->getInsertID();
 $db->query('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text) ' .
-								'VALUES(' . $db->escapeNumber($featureRequestID) . ', ' . $db->escapeNumber(SmrSession::$account_id) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeBoolean(isset($_REQUEST['anon'])) . ',' . $db->escapeString(word_filter($_REQUEST['feature'])).')');
+								'VALUES(' . $db->escapeNumber($featureRequestID) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeBoolean(isset($_REQUEST['anon'])) . ',' . $db->escapeString(word_filter($_REQUEST['feature'])).')');
 
 // vote for this feature
-$db->query('INSERT INTO account_votes_for_feature VALUES('.$db->escapeNumber(SmrSession::$account_id).', '.$db->escapeNumber($featureRequestID).',\'YES\')');
+$db->query('INSERT INTO account_votes_for_feature VALUES('.$db->escapeNumber($account->getAccountID()).', '.$db->escapeNumber($featureRequestID).',\'YES\')');
 
 forward(create_container('skeleton.php', 'feature_request.php'));

--- a/engine/Default/feature_request_vote_processing.php
+++ b/engine/Default/feature_request_vote_processing.php
@@ -4,12 +4,12 @@ if($_REQUEST['action']=='Vote') {
 	if(is_array($_REQUEST['vote'])) {
 		$query = 'REPLACE INTO account_votes_for_feature VALUES ';
 		foreach($_REQUEST['vote'] as $requestID => $vote) {
-			$query.='('.$db->escapeNumber(SmrSession::$account_id).', '.$db->escapeNumber($requestID).','.$db->escapeString($vote).'),';
+			$query.='('.$db->escapeNumber($account->getAccountID()).', '.$db->escapeNumber($requestID).','.$db->escapeString($vote).'),';
 		}
 		$db->query(substr($query,0,-1));
 	}
 	if(!empty($_REQUEST['favourite']) && is_numeric($_REQUEST['favourite']))
-		$db->query('REPLACE INTO account_votes_for_feature VALUES('.$db->escapeNumber(SmrSession::$account_id).', '.$db->escapeNumber($_REQUEST['favourite']).',\'FAVOURITE\')');
+		$db->query('REPLACE INTO account_votes_for_feature VALUES('.$db->escapeNumber($account->getAccountID()).', '.$db->escapeNumber($_REQUEST['favourite']).',\'FAVOURITE\')');
 
 	forward(create_container('skeleton.php', 'feature_request.php'));
 }
@@ -45,7 +45,7 @@ else if($_REQUEST['action']=='Set Status') {
 			WHERE feature_request_id IN (' . $db->escapeArray($_REQUEST['set_status_ids']) . ')');
 	foreach($_REQUEST['set_status_ids'] as $featureID) {
 		$db->query('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
-					VALUES(' . $db->escapeNumber($featureID) . ', ' . $db->escapeNumber(SmrSession::$account_id) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeBoolean(false) . ',' . $db->escapeString($status) . ')');
+					VALUES(' . $db->escapeNumber($featureID) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeBoolean(false) . ',' . $db->escapeString($status) . ')');
 	}
 
 	forward(create_container('skeleton.php', 'feature_request.php'));

--- a/engine/Default/game_join_processing.php
+++ b/engine/Default/game_join_processing.php
@@ -107,7 +107,7 @@ else {
 $last_turn_update = SmrGame::getGame($gameID)->getStartTurnsDate();
 
 //// newbie leaders need to put into there alliances
-if (SmrSession::$account_id == ACCOUNT_ID_NHL) {
+if ($account->getAccountID() == ACCOUNT_ID_NHL) {
 	$alliance_id = NHA_ID;
 }
 else {
@@ -127,11 +127,11 @@ else {
 
 // insert into player table.
 $db->query('INSERT INTO player (account_id, game_id, player_id, player_name, race_id, ship_type_id, credits, alliance_id, sector_id, last_turn_update, last_cpl_action, last_active, newbie_turns, npc)
-			VALUES(' . $db->escapeNumber(SmrSession::$account_id) . ', ' . $db->escapeNumber($gameID) . ', '.$db->escapeNumber($player_id).', ' . $db->escape_string($player_name, true) . ', '.$db->escapeNumber($race_id).', '.$db->escapeNumber($ship_id).', '.$db->escapeNumber(Globals::getStartingCredits($gameID)).', '.$db->escapeNumber($alliance_id).', '.$db->escapeNumber($home_sector_id).', '.$db->escapeNumber($last_turn_update).', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($startingNewbieTurns) . ',' . $db->escapeBoolean(defined('NPC_SCRIPT')) . ')');
+			VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($gameID) . ', '.$db->escapeNumber($player_id).', ' . $db->escape_string($player_name, true) . ', '.$db->escapeNumber($race_id).', '.$db->escapeNumber($ship_id).', '.$db->escapeNumber(Globals::getStartingCredits($gameID)).', '.$db->escapeNumber($alliance_id).', '.$db->escapeNumber($home_sector_id).', '.$db->escapeNumber($last_turn_update).', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($startingNewbieTurns) . ',' . $db->escapeBoolean(defined('NPC_SCRIPT')) . ')');
 
 $db->unlock();
 
-$player = SmrPlayer::getPlayer(SmrSession::$account_id, $gameID);
+$player = SmrPlayer::getPlayer($account->getAccountID(), $gameID);
 
 // Equip the ship
 $ship = $player->getShip();
@@ -143,7 +143,7 @@ $ship->addWeapon(46);  // Laser
 // The `player_visited_sector` table holds *unvisited* sectors, so that once
 // all sectors are visited (the majority of the game), the table is empty.
 $db->query('INSERT INTO player_visited_sector (account_id, game_id, sector_id)
-            SELECT ' . $db->escapeNumber(SmrSession::$account_id) . ', game_id, sector_id
+            SELECT ' . $db->escapeNumber($account->getAccountID()) . ', game_id, sector_id
               FROM sector WHERE game_id = ' . $db->escapeNumber($gameID));
 
 // Mark the player's start sector as visited

--- a/engine/Default/game_play.php
+++ b/engine/Default/game_play.php
@@ -20,7 +20,7 @@ $games['Play'] = array();
 $game_id_list = array();
 $db->query('SELECT end_date, game_id, game_name, game_speed, game_type
 			FROM game JOIN player USING (game_id)
-			WHERE account_id = '.$db->escapeNumber(SmrSession::$account_id).'
+			WHERE account_id = '.$db->escapeNumber($account->getAccountID()).'
 				AND enabled = \'TRUE\'
 				AND end_date >= ' . $db->escapeNumber(TIME) . '
 			ORDER BY start_date DESC');
@@ -39,7 +39,7 @@ if ($db->getNumRows() > 0) {
 		$games['Play'][$game_id]['PlayGameLink'] = SmrSession::getNewHREF($container);
 
 		// creates a new player object
-		$curr_player =& SmrPlayer::getPlayer(SmrSession::$account_id, $game_id);
+		$curr_player = SmrPlayer::getPlayer($account->getAccountID(), $game_id);
 
 		// update turns for this game
 		$curr_player->updateTurns();

--- a/engine/Default/game_play_processing.php
+++ b/engine/Default/game_play_processing.php
@@ -3,7 +3,7 @@
 // register game_id
 SmrSession::updateGame($var['game_id']);
 
-$player =& SmrPlayer::getPlayer(SmrSession::$account_id, $var['game_id']);
+$player = SmrPlayer::getPlayer($account->getAccountID(), $var['game_id']);
 $player->updateLastCPLAction();
 
 // get rid of old plotted course


### PR DESCRIPTION
Replace instances of `SmrSession::$account_id` with calls to the
read-only method `SmrAccount::getAccountID` whenever we have the
global variable `$account` available.

Ultimately, we want to make `SmrSession::$account_id` private so
that it is harder to accidentally modify.