### PR TITLE
Refactor COMPATIBILITY_DATABASES

### DIFF
--- a/config/config.specific.sample.php
+++ b/config/config.specific.sample.php
@@ -1,6 +1,4 @@
 <?php
-const USE_COMPATIBILITY = false;
-
 const URL = 'http://localhost';
 
 const ENABLE_DEBUG = true; // This is useful for debugging on dev machines.
@@ -22,24 +20,20 @@ const ENABLE_NPCS_CHESS = false;
 // Use the default value if using the provided docker-compose orchestration.
 const SMTP_HOSTNAME = 'smtp';
 
-const COMPATIBILITY_DATABASES = array();
+//const COMPATIBILITY_DATABASES =
 //	array(
-//		'Game' => array(
 //			'SmrClassicMySqlDatabase' => array(
-//				'GameType' => '1.2',
-//				'Column' => 'old_account_id'
-//			),
-//			'Smr12MySqlDatabase' => array(
-//				'GameType' => '1.2',
-//				'Column' => 'old_account_id2'
-//			)
+//			'GameType' => '1.2',
+//			'Column' => 'old_account_id'
 //		),
-//		'History' => array(
-//			'SmrClassicHistoryMySqlDatabase' => array(
-//				'GameType' => '1.2'
-//			),
-//			'Smr12HistoryMySqlDatabase' => array(
-//				'GameType' => '1.2'
-//			)
+//		'Smr12MySqlDatabase' => array(
+//			'GameType' => '1.2',
+//			'Column' => 'old_account_id2'
 //		)
+//	);
+
+//const HISTORY_DATABASES =
+//	array(
+//		'SmrClassicHistoryMySqlDatabase',
+//		'Smr12HistoryMySqlDatabase',
 //	);

--- a/engine/Default/game_play.php
+++ b/engine/Default/game_play.php
@@ -148,42 +148,40 @@ if ($db->getNumRows()) {
 	}
 }
 
-if(USE_COMPATIBILITY) {
-	foreach(Globals::getCompatibilityDatabases('History') as $databaseClassName => $databaseInfo) {
-		require_once(get_file_loc($databaseClassName.'.class.inc'));
-		//Old previous games
-		$historyDB = new $databaseClassName();
-		$historyDB->query('SELECT start_date, end_date, game_name, speed, game_id
-							FROM game ORDER BY game_id DESC');
-		if ($historyDB->getNumRows()) {
-			while ($historyDB->nextRecord()) {
-				$game_id = $historyDB->getField('game_id');
-				$index = $databaseClassName.$game_id;
-				$games['Previous'][$index]['ID'] = $game_id;
-				$games['Previous'][$index]['Name'] = $historyDB->getField('game_name');
-				$games['Previous'][$index]['StartDate'] = date(DATE_DATE_SHORT,$historyDB->getField('start_date'));
-				$games['Previous'][$index]['EndDate'] = date(DATE_DATE_SHORT,$historyDB->getField('end_date'));
-				$games['Previous'][$index]['Speed'] = $historyDB->getField('speed');
-				// create a container that will hold next url and additional variables.
-				$container = array();
-				$container['url'] = 'skeleton.php';
-				$container['game_id'] = $game_id;
-				$container['HistoryDatabase'] = $databaseClassName;
-				$container['game_name'] = $games['Previous'][$index]['Name'];
-				$container['body'] = 'games_previous.php';
+foreach (Globals::getHistoryDatabases() as $databaseClassName) {
+	require_once(get_file_loc($databaseClassName.'.class.inc'));
+	//Old previous games
+	$historyDB = new $databaseClassName();
+	$historyDB->query('SELECT start_date, end_date, game_name, speed, game_id
+						FROM game ORDER BY game_id DESC');
+	if ($historyDB->getNumRows()) {
+		while ($historyDB->nextRecord()) {
+			$game_id = $historyDB->getField('game_id');
+			$index = $databaseClassName.$game_id;
+			$games['Previous'][$index]['ID'] = $game_id;
+			$games['Previous'][$index]['Name'] = $historyDB->getField('game_name');
+			$games['Previous'][$index]['StartDate'] = date(DATE_DATE_SHORT,$historyDB->getField('start_date'));
+			$games['Previous'][$index]['EndDate'] = date(DATE_DATE_SHORT,$historyDB->getField('end_date'));
+			$games['Previous'][$index]['Speed'] = $historyDB->getField('speed');
+			// create a container that will hold next url and additional variables.
+			$container = array();
+			$container['url'] = 'skeleton.php';
+			$container['game_id'] = $game_id;
+			$container['HistoryDatabase'] = $databaseClassName;
+			$container['game_name'] = $games['Previous'][$index]['Name'];
 
-				$games['Previous'][$index]['PreviousGameLink'] = SmrSession::getNewHREF($container);
-				$container['body'] = 'games_previous_hof.php';
-				$games['Previous'][$index]['PreviousGameHOFLink'] = SmrSession::getNewHREF($container);
-				$container['body'] = 'games_previous_news.php';
-				$games['Previous'][$index]['PreviousGameNewsLink'] = SmrSession::getNewHREF($container);
-				$container['body'] = 'games_previous_detail.php';
-				$games['Previous'][$index]['PreviousGameStatsLink'] = SmrSession::getNewHREF($container);
-			}
+			$container['body'] = 'games_previous.php';
+			$games['Previous'][$index]['PreviousGameLink'] = SmrSession::getNewHREF($container);
+			$container['body'] = 'games_previous_hof.php';
+			$games['Previous'][$index]['PreviousGameHOFLink'] = SmrSession::getNewHREF($container);
+			$container['body'] = 'games_previous_news.php';
+			$games['Previous'][$index]['PreviousGameNewsLink'] = SmrSession::getNewHREF($container);
+			$container['body'] = 'games_previous_detail.php';
+			$games['Previous'][$index]['PreviousGameStatsLink'] = SmrSession::getNewHREF($container);
 		}
 	}
-	$db = new SmrMySqlDatabase(); // restore database
 }
+$db = new SmrMySqlDatabase(); // restore database
 
 $template->assign('Games',$games);
 

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -19,7 +19,7 @@ $friendlyColour = $_REQUEST['friendly_color'];
 $neutralColour = $_REQUEST['neutral_color'];
 $enemyColour = $_REQUEST['enemy_color'];
 
-if (USE_COMPATIBILITY && $action == 'Link Account') {
+if (Globals::useCompatibilityDatabases() && $action == 'Link Account') {
 	if(!$account->linkAccount($_REQUEST['oldAccountLogin'],$_REQUEST['oldAccountPassword'])) {
 		create_error('There is no old account with that username/password.');
 	}

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -82,7 +82,7 @@ try {
 				SmrSession::$account_id = $db->getField('account_id');
 				SmrSession::$old_account_id = $db->getField('old_account_id');
 			}
-			else if(USE_COMPATIBILITY) {
+			elseif (Globals::useCompatibilityDatabases()) {
 				if(!SmrAccount::upgradeAccount($login,$password)) {
 					$msg = 'Password is incorrect!';
 					header('Location: '.URL.'/login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -208,8 +208,8 @@ abstract class AbstractSmrAccount {
 				}
 			}
 
-			if(USE_COMPATIBILITY) {
-				foreach(Globals::getCompatibilityDatabases('Game') as $databaseName => $databaseInfo) {
+			if (Globals::useCompatibilityDatabases()) {
+				foreach (Globals::getCompatibilityDatabases() as $databaseName => $databaseInfo) {
 					$this->oldAccountIDs[$databaseName] = $row[$databaseInfo['Column']];
 				}
 			}
@@ -612,7 +612,7 @@ abstract class AbstractSmrAccount {
 
 	public function linkAccount($login,$pass) {
 		$result = false;
-		foreach(Globals::getCompatibilityDatabases('Game') as $databaseClassName => $databaseInfo) {
+		foreach (Globals::getCompatibilityDatabases() as $databaseClassName => $databaseInfo) {
 			if($this->hasOldAccountID($databaseClassName))
 				continue;
 			require_once(get_file_loc($databaseClassName.'.class.inc'));
@@ -662,7 +662,7 @@ abstract class AbstractSmrAccount {
 		$db->query('SELECT * FROM account WHERE login = '.$db->escapeString($login).' LIMIT 1');
 		if($db->nextRecord())
 			return false;
-		foreach(Globals::getCompatibilityDatabases('Game') as $databaseClassName => $databaseInfo) {
+		foreach (Globals::getCompatibilityDatabases() as $databaseClassName => $databaseInfo) {
 			require_once(get_file_loc($databaseClassName.'.class.inc'));
 			$db2 = new $databaseClassName();
 			$db2->query('SELECT * FROM account

--- a/lib/Default/Globals.class.inc
+++ b/lib/Default/Globals.class.inc
@@ -645,11 +645,28 @@ class Globals {
 		return $templates[$templateName];
 	}
 
-	public static function getCompatibilityDatabases($dbType = false) {
-		if($dbType===false) {
-			return COMPATIBILITY_DATABASES;
+	/**
+	 * Returns an array of history database class names for which we
+	 * have ancient saved game data.
+	 */
+	public static function getHistoryDatabases() {
+		if (defined('HISTORY_DATABASES')) {
+			return HISTORY_DATABASES;
+		} else {
+			return array();
 		}
-		return COMPATIBILITY_DATABASES[$dbType];
+	}
+
+	public static function useCompatibilityDatabases() {
+		return defined('COMPATIBILITY_DATABASES');
+	}
+
+	public static function getCompatibilityDatabases() {
+		if (defined('COMPATIBILITY_DATABASES')) {
+			return COMPATIBILITY_DATABASES;
+		} else {
+			return array();
+		}
 	}
 }
 

--- a/templates/Default/engine/Default/preferences.php
+++ b/templates/Default/engine/Default/preferences.php
@@ -3,7 +3,7 @@ if (isset($Reason)) {
 	?><p><big><span class="bold red"><?php echo $Reason; ?></span></big></p><?php
 }
 
-if(USE_COMPATIBILITY && !$ThisAccount->hasAllOldAccountIDs()) { ?>
+if (Globals::useCompatibilityDatabases() && !$ThisAccount->hasAllOldAccountIDs()) { ?>
 	<form id="LinkOldAccountForm" method="POST" action="<?php echo $PreferencesFormHREF; ?>">
 		<table>
 			<tr>


### PR DESCRIPTION
This is intended to allow us to use the history databases
independently of the account-linking databases. We want to
do this because we will always want to display previous
games, but may not always want to support account linking.

* Move history component of `COMPATIBILITY_DATABASES` into
  separate (optional) `HISTORY_DATABASES` config setting.
  This is then wrapped by `Globals::getHistoryDatabases`.

* Replace the `USE_COMPATIBILITY` config setting with the
  function `Globals::useCompatibilityDatabases`, which will
  only be true if `COMPATIBILITY_DATABASES` is defined.
  Do not specify an empty array if the intention is to omit
  account linking. Simply leave it undefined.