### PR TITLE
universe_create_sectors.php: fix ajax click disabling

### DIFF
--- a/templates/Default/admin/Default/1.6/universe_create_sectors.php
+++ b/templates/Default/admin/Default/1.6/universe_create_sectors.php
@@ -47,7 +47,7 @@
 			<a href="<?php echo $ModifyPlanetsHREF; ?>" class="submitStyle">Modify Planets</a><br /><br />
 			<a href="<?php echo $ModifyPortsHREF; ?>" class="submitStyle">Modify Ports</a><br /><br />
 			<a href="<?php echo $ModifyWarpsHREF; ?>" class="submitStyle">Modify Warps</a><br /><br />
-			<a href="<?php echo $SMRFileHREF; ?>" class="submitStyle">Create SMR file</a><br /><br />
+			<a href="<?php echo $SMRFileHREF; ?>" class="submitStyle" target="_self">Create SMR file</a><br /><br />
 			<br /><?php
 			if (isset($PreviousGalaxyHREF)) { ?>
 				<a href="<?php echo $PreviousGalaxyHREF; ?>" class="submitStyle">Previous Galaxy</a><br /><br /><?php


### PR DESCRIPTION
Our auto-refresh javascript disables clicking after a link is
clicked _unless_ the link has specific properties that indicate
that it is not modifying the current page.

On this page, we want "Create SMR file" to have this property,
so we add `target="_self"` to tell javascript not to disable
clicking.