### PR TITLE
universe_create_locations.php: don't unset $sector

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,18 +220,33 @@ $link = SmrSession::getNewHREF($container);
 ## Global variables
 All pages are called with the following variables available (there may be more)
 
+### $db
+This is a global instance of the SmrMySqlDatabase class. It can be used for
+database queries anywhere, but be careful to avoid using it in two places
+simultaneously (doing so will cause database errors).
+
 ### $var
 $var contains all information passed using the $container from the previous page.
 This *can* be assigned to, but only using SmrSession::updateVar($name, $value)
 
+### $template
+The global instance of the Template class should be the _only_ instance, and
+it is used to assign variables for display processing.
+
 ### $account
-For any page loaded whilst logged in this contains the current SmrAccount object and should not be assigned to.
+This contains the current SmrAccount object and should not be assigned to.
 
 ### $player
-For any page loaded whilst within a game this contains the current SmrPlayer object and should not be assigned to.
+_[Scope: in game]_ This contains the current SmrPlayer object and should
+not be assigned to.
 
 ### $ship
-For any page loaded whilst within a game this contains the current SmrShip object and should not be assigned to.
+_[Scope: in game]_ This contains the current SmrShip object and should not be
+assigned to.
+
+### $sector
+_[Scope: in game]_ This contains the current SmrSector object and should not
+be assigned to.
 
 
 ## Request variables

--- a/admin/Default/1.6/universe_create_locations.php
+++ b/admin/Default/1.6/universe_create_locations.php
@@ -10,13 +10,12 @@ foreach ($locations as &$location) {
 }
 
 // Determine the current amount of each location
-$galSectors =& SmrSector::getGalaxySectors($var['game_id'],$var['gal_on']);
-foreach ($galSectors as &$sector) {
-	$sectorLocations =& $sector->getLocations();
-	foreach ($sectorLocations as &$sectorLocation) {
+$galSectors = SmrSector::getGalaxySectors($var['game_id'],$var['gal_on']);
+foreach ($galSectors as $galSector) {
+	foreach ($galSector->getLocations() as $sectorLocation) {
 		$totalLocs[$sectorLocation->getTypeID()]++;
-	} unset($sectorLocation);
-} unset($sector);
+	}
+}
 $template->assign('TotalLocs', $totalLocs);
 
 $galaxy =& SmrGalaxy::getGalaxy($var['game_id'],$var['gal_on']);


### PR DESCRIPTION
The `$sector` variable is a special global, and should not be
overwritten (i.e. dont' use it as the temporary object of a for-loop).

This also fixes a PHP warning that `$sector` is unset in `smr.inc`.

Also update the README with a more complete list of special global variables.