### PR TITLE
Head.inc: fix title when in a game

### DIFF
--- a/templates/Default/engine/Default/includes/Head.inc
+++ b/templates/Default/engine/Default/includes/Head.inc
@@ -1,5 +1,5 @@
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-<title><?php echo $Title; ?> <?php if(isset($GameName)) echo $GameName; ?></title>
+<title><?php echo $Title; ?><?php if(isset($GameName)) echo ": $GameName"; ?></title>
 <meta http-equiv="pragma" content="no-cache" /><?php
 if(!is_object($ThisAccount) || $ThisAccount->isDefaultCSSEnabled()) { ?>
 	<link rel="stylesheet" type="text/css" href="<?php echo $CSSLink; ?>" />


### PR DESCRIPTION
Re-add the semi-colon removed in 796845c8939, but only in cases
where we're in a game (so that we don't get a trailing semi-colon
outside of a game).