### PR TITLE
current_sector.php: pre-game turns message

### DIFF
--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -62,18 +62,22 @@ $template->assign('UnreadMissions', $var['UnreadMissions']);
 // *
 // *******************************************
 $turnsMessage = '';
-switch($player->getTurnsLevel()) {
-	case 'NONE':
-		$turnsMessage = '<span class="red">WARNING</span>: You have run out of turns!';
-	break;
-	case 'LOW':
-		$turnsMessage = '<span class="red">WARNING</span>: You are almost out of turns!';
-	break;
-	case 'MEDIUM':
-		$turnsMessage = '<span class="yellow">WARNING</span>: You are running out of turns!';
-	break;
+$game = SmrGame::getGame($player->getGameID());
+if ($game->getStartTurnsDate() > TIME) {
+	$turnsMessage = 'Turns will be given when the game starts in ' . format_time($game->getStartTurnsDate() - TIME) . '!';
+} else {
+	switch($player->getTurnsLevel()) {
+		case 'NONE':
+			$turnsMessage = '<span class="red">WARNING</span>: You have run out of turns!';
+		break;
+		case 'LOW':
+			$turnsMessage = '<span class="red">WARNING</span>: You are almost out of turns!';
+		break;
+		case 'MEDIUM':
+			$turnsMessage = '<span class="yellow">WARNING</span>: You are running out of turns!';
+		break;
+	}
 }
-
 $template->assign('TurnsMessage',$turnsMessage);
 
 $protectionMessage = '';


### PR DESCRIPTION
It was confusing to players when they would join a game and they
would have 0 turns and would not be gaining any. Instead of printing
the "You are out of turns!" message, display a more information
message about when the game starts if the `StartTurnsDate` has not
been reached yet.

Before turns are given, the page will look like this:
![image](https://user-images.githubusercontent.com/846186/40083134-17b2d74c-5848-11e8-87bc-0ba0556b53d7.png)
