### PR TITLE
message_delete_processing.php: fix PHP warning

### DIFF
--- a/engine/Default/message_delete_processing.php
+++ b/engine/Default/message_delete_processing.php
@@ -1,6 +1,7 @@
 <?php
-$action = $_REQUEST['action'];
-if ($action == 'Marked Messages') {
+
+// If not deleting marked messages, we are deleting entire folders
+if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'Marked Messages') {
 	$message_id = $_REQUEST['message_id'];
 	if (!isset($message_id))
 		create_error('You must choose the messages you want to delete.');


### PR DESCRIPTION
When clicking the "Empty Read Messages" link, the processing page
will not post an `action`. We now check to see if the `action`
exists in `$_REQUESTS` before using it to fix an undefined index
PHP warning.