### PR TITLE
port_attack_warning.php: add reinforcements timer

### DIFF
--- a/templates/Default/engine/Default/port_attack_warning.php
+++ b/templates/Default/engine/Default/port_attack_warning.php
@@ -17,19 +17,19 @@ if ($ThisShip->hasScanner()) {
 		<tr>
 		<tr>
 			<td>Shields</td>
-			<td align="center"><?php echo $Port->getShields(); ?></td>
+			<td id="port_shields" class="center ajax"><?php echo $Port->getShields(); ?></td>
 		</tr>
 		<tr>
 			<td>Combat Drones</td>
-			<td align="center"><?php echo $Port->getCDs(); ?></td>
+			<td id="port_cds" class="center ajax"><?php echo $Port->getCDs(); ?></td>
 		</tr>
 		<tr>
 			<td>Armour</td>
-			<td align="center"><?php echo $Port->getArmour(); ?></td>
+			<td id="port_armour" class="center ajax"><?php echo $Port->getArmour(); ?></td>
 		</tr>
 		<tr>
 			<td>Turrets</td>
-			<td align="center"><?php echo $Port->getNumWeapons(); ?></td>
+			<td id="port_turrets" class="center ajax"><?php echo $Port->getNumWeapons(); ?></td>
 		</tr>
 	</table>
 	<br /><?php
@@ -43,3 +43,12 @@ Are you sure you want to attack this port?<br /><br />
 <div class="buttonA">
 	<a class="buttonA" href="<?php echo Globals::getCurrentSectorHREF(); ?>">&nbsp;No&nbsp;</a>
 </div>
+
+<br /><br />
+<span id="reinforce" class="red"><?php
+if ($Port->isUnderAttack()) { ?>
+	The port is under attack and has activated its distress beacon!<br />
+	Federal reinforcements will arrive to defend the port in
+	<?php echo format_time($Port->getReinforceTime() - TIME) . '.';
+}
+?></span>


### PR DESCRIPTION
It is surprising to people when reinforcements arrive and the
defenses suddenly shoot up dramatically. Adding a message in the
port attack warning page should help mitigate this confusion.

![image](https://user-images.githubusercontent.com/846186/40092157-b7521204-5870-11e8-8463-eaa280361744.png)
