### PR TITLE
password_check.php: fix Select All button

### DIFF
--- a/admin/Default/password_check.php
+++ b/admin/Default/password_check.php
@@ -2,6 +2,8 @@
 
 $template->assign('PageTopic','Password Checker');
 
+$action = SmrSession::getRequestVar('action');
+
 // create account object
 $db2 = new SmrMySqlDatabase();
 $db3 = new SmrMySqlDatabase();


### PR DESCRIPTION
The "Select All" button wasn't working previously because the
`$action` variable was undefined. Storing the `action` request
variable fixes this bug and also fixes the undefined variable
PHP warning.