### PR TITLE
Simplify plotted course management

### DIFF
--- a/engine/Default/course_plot_result.php
+++ b/engine/Default/course_plot_result.php
@@ -12,11 +12,7 @@ $path->removeStart();
 $next_sector = $path->getNextOnPath();
 
 if ($player->getSector()->isLinked($next_sector)) {
-
-	// save this to db (if we still have something)
-	if ($path->getTotalSectors()>0) {
 		$player->setPlottedCourse($path);
-	}
 
 	if (!$player->isLandedOnPlanet()) {
 		// If the course can immediately be followed, display it on the current sector page

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -100,15 +100,6 @@ acquire_lock($player->getSectorID());
 // get new sector object
 $sector =& $player->getSector();
 
-// If we have jumped into a future of our plotted course, update!
-if ($player->hasPlottedCourse()) {
-	$path = $player->getPlottedCourse();
-	if ($path->isInPath($sector->getSectorID())) {
-		$path->skipToSector($sector->getSectorID());
-		$player->setPlottedCourse($path);
-	}
-}
-
 // make current sector visible to him
 $sector->markVisited($player);
 

--- a/engine/Default/sector_move_processing.php
+++ b/engine/Default/sector_move_processing.php
@@ -10,19 +10,6 @@ else
 
 //allow hidden players (admins that don't play) to move without pinging, hitting mines, losing turns
 if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
-	//update plot
-	if ($player->hasPlottedCourse()) {
-		$path = $player->getPlottedCourse();
-		if ($path->getNextOnPath() == $var['target_sector']) {
-			$path->followPath($sector->getWarp() == $var['target_sector']);
-			$player->setPlottedCourse($path);
-		} elseif ($path->isInPath($var['target_sector'])) {
-			// Did we re-enter the course down the line?
-			$path->skipToSector($var['target_sector']);
-			$player->setPlottedCourse($path);
-		}
-	}
-	
 	//make them pop on CPL
 	$player->updateLastCPLAction();
 	$player->setSectorID($var['target_sector']);
@@ -79,19 +66,6 @@ if ($player->getLastSectorID() != $var['target_sector']) {
 			$container['owner_id'] = $mine_owner_id;
 			forward($container);
 		}
-	}
-}
-
-// check if this came from a plotted course from db
-if ($player->hasPlottedCourse()) {
-	$path = $player->getPlottedCourse();
-	if ($path->getNextOnPath() == $var['target_sector']) {
-		$path->followPath($sector->getWarp() == $var['target_sector']);
-		$player->setPlottedCourse($path);
-	} elseif ($path->isInPath($var['target_sector'])) {
-		// Did we re-enter the course down the line?
-		$path->skipToSector($var['target_sector']);
-		$player->setPlottedCourse($path);
 	}
 }
 

--- a/lib/Default/Plotter.class.inc
+++ b/lib/Default/Plotter.class.inc
@@ -293,12 +293,13 @@ class Distance {
 		return $this->path[0];
 	}
 	
-	public function followPath($isWarp=false) {
-		if($isWarp===false)
-			$this->distance--;
-		else
+	public function followPath() {
+		$nextSectorID = array_shift($this->path);
+		if (in_array($nextSectorID, array_values($this->warpMap))) {
 			$this->numWarps--;
-		return array_shift($this->path);
+		} else {
+			$this->distance--;
+		}
 	}
 	
 	public function removeStart() {

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1888,9 +1888,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 		return $this->plottedCourse;
 	}
 
-	public function setPlottedCourse(Distance &$plottedCourse) {
+	public function setPlottedCourse(Distance $plottedCourse) {
 		$hadPlottedCourse = $this->hasPlottedCourse();
-		$this->plottedCourse =& $plottedCourse;
+		$this->plottedCourse = $plottedCourse;
 		if ($this->plottedCourse->getTotalSectors()>0)
 			$this->db->query('REPLACE INTO player_plotted_course
 				(account_id, game_id, course)

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -43,6 +43,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 //	protected $changedStats;
 	protected $mining;
 	protected $plottedCourse;
+	protected $plottedCourseFrom;
 	protected $nameChanged;
 	protected $combatDronesKamikazeOnMines;
 
@@ -1865,14 +1866,25 @@ class SmrPlayer extends AbstractSmrPlayer {
 			if ($this->db->nextRecord()) {
 				// get the course back
 				$this->plottedCourse = unserialize($this->db->getField('course'));
-				$endSectorID = $this->plottedCourse->getEndSectorID();
-				if ($endSectorID != $this->getSectorID() && $this->isPartOfCourse($this->getSector())) {
-					// Current sector is in the path, we have jumped along it somehow
-					$this->setPlottedCourse($this->plottedCourse->skipToSector($this->getSectorID()));
-				}
-			}
-			else
+			} else {
 				$this->plottedCourse = false;
+			}
+		}
+
+		// Update the plotted course if we have moved since the last query
+		if ($this->plottedCourse !== false && (!isset($this->plottedCourseFrom) || $this->plottedCourseFrom != $this->getSectorID())) {
+			$this->plottedCourseFrom = $this->getSectorID();
+
+			if ($this->plottedCourse->getNextOnPath() == $this->getSectorID()) {
+				// We have walked into the next sector of the course
+				$usedWarp = $this->getSector()->hasWarp() && $this->getSector()->getWarp() == $this->lastSectorID;
+				$this->plottedCourse->followPath($usedWarp);
+				$this->setPlottedCourse($this->plottedCourse);
+			} elseif ($this->plottedCourse->isInPath($this->getSectorID())) {
+				// We have skipped to some later sector in the course
+				$this->plottedCourse->skipToSector($this->getSectorID());
+				$this->setPlottedCourse($this->plottedCourse);
+			}
 		}
 		return $this->plottedCourse;
 	}

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1857,7 +1857,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 							WHERE '.$this->SQL.' AND message_type_id = ' . $this->db->escapeNumber($messageTypeID));
 	}
 
-	public function &getPlottedCourse() {
+	public function getPlottedCourse() {
 		if(!isset($this->plottedCourse)) {
 			require_once(get_file_loc('Plotter.class.inc'));
 			// check if we have a course plotted

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1877,8 +1877,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 			if ($this->plottedCourse->getNextOnPath() == $this->getSectorID()) {
 				// We have walked into the next sector of the course
-				$usedWarp = $this->getSector()->hasWarp() && $this->getSector()->getWarp() == $this->lastSectorID;
-				$this->plottedCourse->followPath($usedWarp);
+				$this->plottedCourse->followPath();
 				$this->setPlottedCourse($this->plottedCourse);
 			} elseif ($this->plottedCourse->isInPath($this->getSectorID())) {
 				// We have skipped to some later sector in the course

--- a/templates/Default/engine/Default/includes/PlottedCourse.inc
+++ b/templates/Default/engine/Default/includes/PlottedCourse.inc
@@ -1,6 +1,6 @@
 <?php
 if($ThisPlayer->hasPlottedCourse()) {
-	$PlottedCourse =& $ThisPlayer->getPlottedCourse();
+	$PlottedCourse = $ThisPlayer->getPlottedCourse();
 	$CancelCourseHREF = SmrSession::getNewHREF(create_container('course_plot_cancel_processing.php'));
 	$ReplotCourseHREF = SmrSession::getNewHREF(create_container('course_plot_processing.php', '', array('to' => $PlottedCourse->getEndSectorID(), 'from' => $ThisSector->getSectorID())));
 	$NextSector =& SmrSector::getSector($ThisPlayer->getGameID(),$PlottedCourse->getNextOnPath(),$ThisPlayer->getAccountID()); ?>


### PR DESCRIPTION
Updating the plotted course is now only handled inside
`SmrPlayer::getPlottedCourse` rather than in the various
movement scripts. This reduces code redundancy.

Unlike the movement scripts, `getPlottedCourse` cannot know if we just
moved, so we separate the database query cache from the path updating:

Any time we call `getPlottedCourse` from a new sector (or script),
it will check to see if the path needs to be updated (using the
`plottedCourseFrom` class member). In principle, this update check
could be run every time `getPlottedCourse` is called, especially
since it is very inexpensive, but since `getPlottedCourse` can be
called many times in a single script, it seemed better to simply
avoid repeating the work at the cost of storing an int.