### PR TITLE
irc.php: prevent stale mysql connections

### DIFF
--- a/tools/irc/irc.php
+++ b/tools/irc/irc.php
@@ -134,6 +134,9 @@ while ($running) {
 			stream_set_blocking($fp, true);
 			while (!feof($fp)) {
 				readFromStream($fp);
+				// Close database connection between calls to avoid
+				// stale or timed out server errors.
+				$db->close();
 			}
 			fclose($fp); // close socket
 


### PR DESCRIPTION
Close connections after each callback to ensure that the mysql
connection isn't idly sitting open, because doing so makes it
prone to becoming stale and triggering a timeout error, e.g.:

> mysqli::query(): MySQL server has gone away

This can occur even if the `mysql` service is a dependency of
the `irc` service.