### PR TITLE
Simplify code to determine the racial President

### DIFF
--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -75,6 +75,7 @@ const BUYER_RESTRICTION_PLANET = 5;
  */
 const ALIGNMENT_GOOD = 100;
 const ALIGNMENT_EVIL = -100;
+const ALIGNMENT_PRESIDENT = 150;
 
 /*
  * Log types

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -1581,8 +1581,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function isPresident() {
-		$president = Council::getPresident($this->getGameID(),$this->getRaceID());
-		return is_object($president) && $this->equals($president);
+		return Council::getPresidentID($this->getGameID(), $this->getRaceID()) == $this->getAccountID();
 	}
 
 	public function isOnCouncil() {

--- a/lib/Default/council.inc
+++ b/lib/Default/council.inc
@@ -1,8 +1,8 @@
 <?php
 require_once(get_file_loc('SmrPlayer.class.inc'));
 class Council {
-	protected static $RACE_COUNCIL = array();
-	protected static $RACE_PRESIDENTS = array();
+	protected static $COUNCILS = array();
+	protected static $PRESIDENTS = array();
 	protected static $db = null;
 
 	private function __construct() {
@@ -13,19 +13,16 @@ class Council {
 			self::$db = new SmrMySqlDatabase();
 	}
 
+	/**
+	 * Returns an array of Account ID's of the Council for this race.
+	 */
 	public static function &getRaceCouncil($gameID,$raceID) {
-		if(!isset(self::$RACE_COUNCIL[$gameID])) {
-			self::$RACE_COUNCIL[$gameID] = array();
-			self::$RACE_PRESIDENTS[$gameID] = array();
-		}
-
-		if(!isset(self::$RACE_COUNCIL[$gameID][$raceID])) {
+		if (!isset(self::$COUNCILS[$gameID][$raceID])) {
 			self::initialiseDatabase();
-			self::$RACE_COUNCIL[$gameID][$raceID] = array();
-			self::$RACE_PRESIDENTS[$gameID][$raceID] = false;
+			self::$COUNCILS[$gameID][$raceID] = array();
 
 			$i=1;
-			self::$db->query('SELECT account_id, alignment
+			self::$db->query('SELECT account_id
 								FROM player
 								WHERE game_id = ' . self::$db->escapeNumber($gameID) . '
 									AND race_id = ' . self::$db->escapeNumber($raceID) . '
@@ -33,22 +30,29 @@ class Council {
 								ORDER by experience DESC
 								LIMIT ' . MAX_COUNCIL_MEMBERS);
 			while(self::$db->nextRecord()) {
-				self::$RACE_COUNCIL[$gameID][$raceID][$i] = self::$db->getField('account_id');
-				if(self::$RACE_PRESIDENTS[$gameID][$raceID]==false && self::$db->getField('alignment')>=150) {
-					self::$RACE_PRESIDENTS[$gameID][$raceID] = self::$db->getField('account_id');
-				}
+				self::$COUNCILS[$gameID][$raceID][$i] = self::$db->getField('account_id');
 				$i++;
 			}
 		}
-		return self::$RACE_COUNCIL[$gameID][$raceID];
+		return self::$COUNCILS[$gameID][$raceID];
 	}
 
-	public static function &getPresident($gameID,$raceID) {
-		self::getRaceCouncil($gameID,$raceID);
-		if(isset(self::$RACE_PRESIDENTS[$gameID][$raceID])&&self::$RACE_PRESIDENTS[$gameID][$raceID]!==false&&is_numeric(self::$RACE_PRESIDENTS[$gameID][$raceID])) {
-			self::$RACE_PRESIDENTS[$gameID][$raceID] = SmrPlayer::getPlayer(self::$RACE_PRESIDENTS[$gameID][$raceID],$gameID);
+	/**
+	 * Returns the Account ID of the President for this race (or false if no President).
+	 */
+	public static function getPresidentID($gameID, $raceID) {
+		if (!isset(self::$PRESIDENTS[$gameID][$raceID])) {
+			self::initialiseDatabase();
+			self::$db->query('SELECT account_id FROM player
+			                  WHERE game_id = ' . self::$db->escapeNumber($gameID) . '
+			                    AND race_id = ' . self::$db->escapeNumber($raceID) . '
+			                    AND alignment >= ' . self::$db->escapeNumber(ALIGNMENT_PRESIDENT) . '
+			                    AND npc = \'FALSE\'
+			                  ORDER BY experience DESC
+			                  LIMIT 1');
+			self::$PRESIDENTS[$gameID][$raceID] = self::$db->nextRecord() ? self::$db->getInt('account_id') : false;
 		}
-		return self::$RACE_PRESIDENTS[$gameID][$raceID];
+		return self::$PRESIDENTS[$gameID][$raceID];
 	}
 
 	public static function isOnCouncil($gameID,$raceID,$accountID) {

--- a/templates/Default/engine/Default/council_list.php
+++ b/templates/Default/engine/Default/council_list.php
@@ -1,8 +1,9 @@
 <div align="center">
 	<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
 	<h3>President</h3><br/><?php
-	$President =& Council::getPresident($ThisPlayer->getGameID(),$RaceID);
-	if ($President !== false) { ?>
+	$PresidentID = Council::getPresidentID($ThisPlayer->getGameID(), $RaceID);
+	if ($PresidentID !== false) {
+		$President = SmrPlayer::getPlayer($PresidentID, $ThisPlayer->getGameID()); ?>
 		<table class="standard" width="75%">
 			<thead>
 				<tr>


### PR DESCRIPTION
* Change `Council::getPresident` to `getPresidentID` and return
  only the ID instead of performing an addition query to get
  the associated `SmrPlayer`. Since we call this on every page
  to display the player name, it needs to be quick, and in these
  cases we have no need for the `SmrPlayer` of the President.

* Do not query `getCouncil` from within `getPresidentID`.
  Most of the time when we are querying the President, we don't
  need to know the entire council. This should be a faster query
  since we only need to return 1 result.

* Add constant `ALIGNMENT_PRESIDENT` to config.php so that the
  alignment qualification for President is not hard-coded.