### PR TITLE
Avoid redundant db calls when constructing SmrPlayers

### DIFF
--- a/engine/Default/current_players.php
+++ b/engine/Default/current_players.php
@@ -52,8 +52,7 @@ if ($count_last_active > 0) {
 	while ($db->nextRecord()) {
 		$row = array();
 
-		$accountID = $db->getField('account_id');
-		$curr_player =& SmrPlayer::getPlayer($accountID, $player->getGameID());
+		$curr_player = SmrPlayer::getPlayer($db->getRow(), $player->getGameID());
 		$row['player'] = $curr_player;
 
 		// How should we style the row for this player?

--- a/engine/Default/game_stats.php
+++ b/engine/Default/game_stats.php
@@ -22,25 +22,23 @@ if ($db->nextRecord()) {
 	$template->assign('TotalAlliances',$db->getField('num_alliance'));
 }
 
-$db->query('SELECT account_id FROM player WHERE game_id = '.$gameID.' ORDER BY experience DESC LIMIT 10');
+$db->query('SELECT * FROM player WHERE game_id = '.$gameID.' ORDER BY experience DESC LIMIT 10');
 if ($db->getNumRows() > 0) {
 	$rank = 0;
 	$expRankings = array();
 	while ($db->nextRecord()) {
-		++$rank;
-		$expRankings[$rank] =& SmrPlayer::getPlayer($db->getField('account_id'), $gameID);
+		$expRankings[++$rank] = SmrPlayer::getPlayer($db->getRow(), $gameID);
 	}
 	$template->assign('ExperienceRankings',$expRankings);
 }
 
 
-$db->query('SELECT account_id FROM player WHERE game_id = '.$gameID.' ORDER BY kills DESC LIMIT 10');
+$db->query('SELECT * FROM player WHERE game_id = '.$gameID.' ORDER BY kills DESC LIMIT 10');
 if ($db->getNumRows() > 0) {
 	$rank = 0;
 	$killRankings = array();
 	while ($db->nextRecord()) {
-		++$rank;
-		$killRankings[$rank] =& SmrPlayer::getPlayer($db->getField('account_id'), $gameID);
+		$killRankings[++$rank] = SmrPlayer::getPlayer($db->getRow(), $gameID);
 	}
 	$template->assign('KillRankings',$killRankings);
 }

--- a/engine/Default/rankings_player_death.php
+++ b/engine/Default/rankings_player_death.php
@@ -22,7 +22,7 @@ $template->assign('OurRank', $ourRank);
 
 $totalPlayers = $player->getGame()->getTotalPlayers();
 
-$db->query('SELECT account_id, deaths amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY deaths DESC, player_name LIMIT 10');
+$db->query('SELECT *, deaths AS amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY deaths DESC, player_name LIMIT 10');
 $template->assign('Rankings', Rankings::collectRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
@@ -30,5 +30,5 @@ Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_player_death.php')));
 
 $lowerLimit = $var['MinRank'] - 1;
-$db->query('SELECT account_id, deaths amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY deaths DESC, player_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
+$db->query('SELECT *, deaths AS amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY deaths DESC, player_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
 $template->assign('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));

--- a/engine/Default/rankings_player_experience.php
+++ b/engine/Default/rankings_player_experience.php
@@ -22,7 +22,7 @@ $template->assign('OurRank', $ourRank);
 
 $totalPlayers = $player->getGame()->getTotalPlayers();
 
-$db->query('SELECT account_id, experience amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY experience DESC, player_name LIMIT 10');
+$db->query('SELECT *, experience AS amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY experience DESC, player_name LIMIT 10');
 $template->assign('Rankings', Rankings::collectRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
@@ -30,5 +30,5 @@ Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_player_experience.php')));
 
 $lowerLimit = $var['MinRank'] - 1;
-$db->query('SELECT account_id, experience amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY experience DESC, player_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
+$db->query('SELECT *, experience AS amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY experience DESC, player_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
 $template->assign('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));

--- a/engine/Default/rankings_player_kills.php
+++ b/engine/Default/rankings_player_kills.php
@@ -22,7 +22,7 @@ $template->assign('OurRank', $ourRank);
 
 $totalPlayers = $player->getGame()->getTotalPlayers();
 
-$db->query('SELECT account_id, kills amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC, player_name LIMIT 10');
+$db->query('SELECT *, kills AS amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC, player_name LIMIT 10');
 $template->assign('Rankings', Rankings::collectRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
@@ -30,5 +30,5 @@ Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_player_kills.php')));
 
 $lowerLimit = $var['MinRank'] - 1;
-$db->query('SELECT account_id, kills amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC, player_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
+$db->query('SELECT *, kills AS amount FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC, player_name LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
 $template->assign('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));

--- a/engine/Default/rankings_player_profit.php
+++ b/engine/Default/rankings_player_profit.php
@@ -27,7 +27,7 @@ $template->assign('OurRank', $ourRank);
 
 $totalPlayers = $player->getGame()->getTotalPlayers();
 
-$db->query('SELECT p.account_id, COALESCE(ph.amount,0) amount FROM player p LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $profitTypeEscaped . ' WHERE p.game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, player_name ASC LIMIT 10');
+$db->query('SELECT p.*, COALESCE(ph.amount,0) amount FROM player p LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $profitTypeEscaped . ' WHERE p.game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, player_name ASC LIMIT 10');
 $template->assign('Rankings', Rankings::collectRankings($db, $player, 0));
 
 Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
@@ -35,5 +35,5 @@ Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 $template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_player_profit.php')));
 
 $lowerLimit = $var['MinRank'] - 1;
-$db->query('SELECT p.account_id, COALESCE(ph.amount,0) amount FROM player p LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $profitTypeEscaped . ' WHERE p.game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, player_name ASC LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
+$db->query('SELECT p.*, COALESCE(ph.amount,0) amount FROM player p LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $profitTypeEscaped . ' WHERE p.game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY amount DESC, player_name ASC LIMIT ' . $lowerLimit . ', ' . ($var['MaxRank'] - $lowerLimit));
 $template->assign('FilteredRankings', Rankings::collectRankings($db, $player, $lowerLimit));

--- a/lib/Default/Rankings.inc
+++ b/lib/Default/Rankings.inc
@@ -29,12 +29,12 @@ class Rankings {
 		return $rankings;
 	}
 
-	public static function &collectRankings(SmrMySqlDatabase &$db, AbstractSmrPlayer &$player, $rank) {
+	public static function &collectRankings(SmrMySqlDatabase &$db, AbstractSmrPlayer $player, $rank) {
 		$rankings = array();
 		while ($db->nextRecord()) {
 			// increase rank counter
 			$rank++;
-			$currentPlayer =& SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID());
+			$currentPlayer = SmrPlayer::getPlayer($db->getRow(), $player->getGameID());
 
 			$class='';
 			if ($player->equals($currentPlayer)) {
@@ -49,7 +49,7 @@ class Rankings {
 
 			$rankings[$rank] = array(
 				'Rank' => $rank,
-				'Player' => &$currentPlayer,
+				'Player' => $currentPlayer,
 				'Class' => $class,
 				'Value' => $db->getInt('amount')
 			);

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -136,9 +136,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	public static function &getPlayerByPlayerID($playerID,$gameID,$forceUpdate = false) {
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT account_id FROM player WHERE game_id = '.$db->escapeNumber($gameID).' AND player_id = '.$db->escapeNumber($playerID).' LIMIT 1');
+		$db->query('SELECT * FROM player WHERE game_id = '.$db->escapeNumber($gameID).' AND player_id = '.$db->escapeNumber($playerID).' LIMIT 1');
 		if($db->nextRecord())
-			return self::getPlayer($db->getInt('account_id'),$gameID,$forceUpdate);
+			return self::getPlayer($db->getRow(), $gameID, $forceUpdate);
 		throw new PlayerNotFoundException('Player ID not found.');
 	}
 


### PR DESCRIPTION
When we need to gather a list of `SmrPlayer`'s, we often will perform
one query to get the list of `account_id`'s, and then another query
for each call to `SmrPlayer::getPlayer` for each ID.

Instead, we can get all the data we need from the original single
call, and then pass the entire array into `getPlayer`, thus avoiding
the N extra database calls.

This significantly speeds up pages like:

* Current Players
* Rankings
* Game Stats