### PR TITLE
Serialize Distance before storing in SmrSession

### DIFF
--- a/engine/Default/course_plot_nearest_processing.php
+++ b/engine/Default/course_plot_nearest_processing.php
@@ -25,5 +25,5 @@ $path = Plotter::findReversiblePathToX($realX, $sector, true, $player, $player);
 
 // Forward to do common processing of path
 $container = create_container('skeleton.php', 'course_plot_result.php');
-$container['Distance'] = $path;
+$container['Distance'] = serialize($path);
 forward($container);

--- a/engine/Default/course_plot_processing.php
+++ b/engine/Default/course_plot_processing.php
@@ -39,5 +39,5 @@ $path = Plotter::findReversiblePathToX(SmrSector::getSector($player->getGameID()
 
 // Forward to do common processing of path
 $container = create_container('skeleton.php', 'course_plot_result.php');
-$container['Distance'] = $path;
+$container['Distance'] = serialize($path);
 forward($container);

--- a/engine/Default/course_plot_result.php
+++ b/engine/Default/course_plot_result.php
@@ -1,7 +1,8 @@
 <?php
 // Load the Distance object to do the common processing
 // for both "Conventional" and "Plot To Nearest".
-$path = $var['Distance'];
+require_once(get_file_loc('Plotter.class.inc'));
+$path = unserialize($var['Distance']);
 
 // Throw start sector away (it's useless for the route),
 // but save the full path in case we end up needing to display it.


### PR DESCRIPTION
The definition for a class has to be loaded _before_ `unserialize`
is called on a serialized instance of that class; otherwise, there
must be an autoloader for that class.

While autoloading is the better long-term goal, we can circumvent
this particular issue by serializing the `Distance` object before
it is stored in the `SmrSession`. This way, when the session
automatically unserializes its objects internally (something for
which we cannot predict what class definitions we'll need), it
will not be unserializing a `Distance` object, and therefore when
we unserialize it a second time in the script where it's used, we
can make sure to load the class definition first.

Note that while this creates a "PHP Fatal Error" on the server,
it does not seem to prevent it from working correctly nonetheless,
nor does it evoke this error in my development environment.