### PR TITLE
port_attack_warning.php: fix undefined Port variable

### DIFF
--- a/engine/Default/port_attack_warning.php
+++ b/engine/Default/port_attack_warning.php
@@ -11,3 +11,4 @@ if($sector->getPort()->isDestroyed()) {
 $template->assign('PageTopic','Port Raid');
 
 $template->assign('PortAttackHREF',SmrSession::getNewHREF(create_container('port_attack_processing.php')));
+$template->assign('Port', $sector->getPort());

--- a/templates/Default/engine/Default/port_attack_warning.php
+++ b/templates/Default/engine/Default/port_attack_warning.php
@@ -8,8 +8,7 @@ Without an armada behind you, the outcome may not be pleasant.
 <br /><br />
 
 <?php
-if ($ThisShip->hasScanner()) {
-	$Port = $ThisSector->getPort(); ?>
+if ($ThisShip->hasScanner()) { ?>
 	<table class="standard">
 		<tr>
 			<th>Port</th>


### PR DESCRIPTION
Make sure `$Port` is always defined. Previously, if the ship
didn't have a scanner, then (as of f18adce1) the player would
hit an undefined variable and call methods on `null`.