### PR TITLE
admin_message_send.php: allow fractional hours

### DIFF
--- a/admin/Default/admin_message_send.php
+++ b/admin/Default/admin_message_send.php
@@ -20,7 +20,7 @@ else {
 	$container['SendGameID'] = $gameID;
 	$template->assign('AdminMessageSendFormHref',SmrSession::getNewHREF($container));
 	$template->assign('MessageGameID',$gameID);
-	$template->assign('ExpireTime', 1);
+	$template->assign('ExpireTime', 0.5);
 
 	if ($gameID != 20000) {
 		$gamePlayers = array();

--- a/admin/Default/admin_message_send_processing.php
+++ b/admin/Default/admin_message_send_processing.php
@@ -10,9 +10,8 @@ if($_REQUEST['action'] == 'Preview message') {
 	forward($container);
 }
 
-$account_id = $_REQUEST['account_id'];
 $game_id = $var['SendGameID'];
-if (!empty($account_id) || $game_id == 20000) {
+if (isset($_REQUEST['account_id']) || $game_id == 20000) {
 	if (!is_numeric($expire)) {
 		create_error('Expire time must be numeric!');
 	}
@@ -23,7 +22,7 @@ if (!empty($account_id) || $game_id == 20000) {
 	if ($expire > 0) $expire = ($expire * 3600) + TIME;
 
 	if ($game_id != 20000) {
-		SmrPlayer::sendMessageFromAdmin($game_id, $account_id, $message,$expire);
+		SmrPlayer::sendMessageFromAdmin($game_id, $_REQUEST['account_id'], $message,$expire);
 	}
 	else {
 		//send to all players in games that haven't ended yet

--- a/admin/Default/admin_message_send_processing.php
+++ b/admin/Default/admin_message_send_processing.php
@@ -13,7 +13,15 @@ if($_REQUEST['action'] == 'Preview message') {
 $account_id = $_REQUEST['account_id'];
 $game_id = $var['SendGameID'];
 if (!empty($account_id) || $game_id == 20000) {
+	if (!is_numeric($expire)) {
+		create_error('Expire time must be numeric!');
+	}
+	if ($expire < 0) {
+		create_error('Expire time cannot be negative!');
+	}
+	// When expire==0, message will not expire
 	if ($expire > 0) $expire = ($expire * 3600) + TIME;
+
 	if ($game_id != 20000) {
 		SmrPlayer::sendMessageFromAdmin($game_id, $account_id, $message,$expire);
 	}

--- a/templates/Default/admin/Default/admin_message_send.php
+++ b/templates/Default/admin/Default/admin_message_send.php
@@ -29,7 +29,7 @@ else {
 			} ?>
 		</p>
 		<textarea spellcheck="true" name="message" id="InputFields"><?php if(isset($Preview)) { echo $Preview; } ?></textarea><br />
-		Hours Till Expire: <input type="number" name="expire" value="<?php echo $ExpireTime; ?>" size="2" id="InputFields"> (0 = never expire)<br />
+		Hours Till Expire: <input type="number" step="0.01" name="expire" value="<?php echo $ExpireTime; ?>" size="2" id="InputFields"> (0 = never expire)<br />
 		<br />
 		<input type="submit" name="action" value="Send message" id="InputFields" />&nbsp;<input type="submit" name="action" value="Preview message" id="InputFields" />
 	</form><?php


### PR DESCRIPTION
Change the client-side html5 restrictions to allow the Expire time
specified in hours to be fractional (in units of 0.01 hours).
We do this by specifying the "step" field for the input element.

We also change the default Expire time from 1 hour to 0.5 hours
so that it is more obvious that fractional hours are allowed.

We add a couple sanity checks on the `expire` POST variable.

Also fix a PHP warning with `account_id`.