### PR TITLE
 Make bug reporting recipients configurable

### DIFF
--- a/config/config.specific.sample.php
+++ b/config/config.specific.sample.php
@@ -20,6 +20,9 @@ const ENABLE_NPCS_CHESS = false;
 // Use the default value if using the provided docker-compose orchestration.
 const SMTP_HOSTNAME = 'smtp';
 
+// E-mail addresses to receive bug reports
+const BUG_REPORT_TO_ADDRESSES = ['bugs@smrealms.de'];
+
 //const COMPATIBILITY_DATABASES =
 //	array(
 //			'SmrClassicMySqlDatabase' => array(

--- a/engine/Default/bug_report_processing.php
+++ b/engine/Default/bug_report_processing.php
@@ -11,17 +11,24 @@ $message = 'Login: '.$account->getLogin().EOL.EOL.'-----------'.EOL.EOL.
 	'Description: '.$description.EOL.EOL.'-----------'.EOL.EOL.
 	'Steps to repeat: '.$steps.EOL.EOL.'-----------'.EOL.EOL.
 	'Error Message: '.$error_msg;
-	
-//mail('bugs@smrealms.de',
-//	$new_sub,
-//	$message,
-//	'From: '.$account->getEmail());
 
 if(is_object($player)) {
 	$player->sendMessageToBox(BOX_BUGS_REPORTED, $message);
 }
 else {
 	$account->sendMessageToBox(BOX_BUGS_REPORTED, $message);
+}
+
+// Send report to e-mail so that we have a permanent record
+if (!empty(BUG_REPORT_TO_ADDRESSES)) {
+	$mail = setupMailer();
+	$mail->Subject = 'Player Bug Report';
+	$mail->setFrom('bugs@smrealms.de');
+	$mail->Body = $message;
+	foreach (BUG_REPORT_TO_ADDRESSES as $toAddress) {
+		$mail->addAddress($toAddress);
+	}
+	$mail->send();
 }
 
 $container = array();

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -58,12 +58,16 @@ function logException(Exception $e) {
 	}
 
 	// Send error message to e-mail so that we have a permanent record
-	$mail = setupMailer();
-	$mail->Subject = 'Automatic Bug Report';
-	$mail->setFrom('bugs@smrealms.de');
-	$mail->Body = $message;
-	$mail->addAddress('bugs@smrealms.de');
-	$mail->send();
+	if (!empty(BUG_REPORT_TO_ADDRESSES)) {
+		$mail = setupMailer();
+		$mail->Subject = 'Automatic Bug Report';
+		$mail->setFrom('bugs@smrealms.de');
+		$mail->Body = $message;
+		foreach (BUG_REPORT_TO_ADDRESSES as $toAddress) {
+			$mail->addAddress($toAddress);
+		}
+		$mail->send();
+	}
 
 	return $errorType;
 }

--- a/templates/Default/engine/Default/bug_report.php
+++ b/templates/Default/engine/Default/bug_report.php
@@ -1,16 +1,12 @@
-<span style="font-size:75%;">All information you can see on this page will be sent via email to the developer team!<br />
-Be as accurate as possible with your bug description.</span>
+All information on this page will be sent to the admin team.<br />
+Be as accurate as possible with your bug description.
+<p><i>Thank you for helping to improve the game!</i></p>
 
 <form method="POST" action="<?php echo Globals::getBugReportProcessingHREF(); ?>">
 	<table>
 		<tr>
 			<td class="bold">Login:</td>
 			<td><?php echo $ThisAccount->getLogin(); ?></td>
-		</tr>
-
-		<tr>
-			<td class="bold">eMail:</td>
-			<td><?php echo $ThisAccount->getEmail(); ?></td>
 		</tr>
 
 		<tr>


### PR DESCRIPTION
Add new const `BUG_REPORT_TO_ADDRESSES`, which is a configurable
array of e-mail addresses that automatic bug reports will be sent to.

Just like with automatic bug reports, we now send player-submitted
bug reports to the bug report e-mail recipients as well.

This provides a way to keep a permanent record of reports as well
as customizing the recipients with the configurable option
`BUG_REPORT_TO_ADDRESSES`.

 

