### PR TITLE
Improve error handling

### DIFF
--- a/admin/Default/manage_draft_leaders_processing.php
+++ b/admin/Default/manage_draft_leaders_processing.php
@@ -12,7 +12,7 @@ $action = $_POST['submit'];
 
 try {
 	$selectedPlayer = SmrPlayer::getPlayerByPlayerID($playerId, $gameId);
-} catch (Exception $e) {
+} catch (PlayerNotFoundException $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
 	SmrSession::updateVar('processing_msg', $msg);
 	forward(create_container('skeleton.php', 'manage_draft_leaders.php', $var));

--- a/admin/Default/manage_post_editors_processing.php
+++ b/admin/Default/manage_post_editors_processing.php
@@ -12,7 +12,7 @@ $action = $_POST['submit'];
 
 try {
 	$selected_player = SmrPlayer::getPlayerByPlayerID($player_id, $game_id);
-} catch (Exception $e) {
+} catch (PlayerNotFoundException $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
 	SmrSession::updateVar('processing_msg', $msg);
 	forward(create_container('skeleton.php', 'manage_post_editors.php', $var));

--- a/engine/Default/hall_of_fame_player_detail.php
+++ b/engine/Default/hall_of_fame_player_detail.php
@@ -13,7 +13,7 @@ if(isset($var['game_id'])) {
 	try {
 		$hofPlayer =& SmrPlayer::getPlayer($account_id,$var['game_id']);
 	}
-	catch(Exception $e) {
+	catch(PlayerNotFoundException $e) {
 		create_error('That player has not yet joined this game.');
 	}
 	$template->assign('PageTopic',$hofPlayer->getPlayerName().'\'s Personal Hall of Fame For '.Globals::getGameName($var['game_id']));

--- a/htdocs/album/album_comment.php
+++ b/htdocs/album/album_comment.php
@@ -71,6 +71,6 @@ try {
 	header('Location: '.URL.'/album/?' . get_album_nick($album_id));
 	exit;
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/album/index.php
+++ b/htdocs/album/index.php
@@ -89,7 +89,7 @@ try {
 	else
 		main_page();
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }
 ?>

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -42,7 +42,7 @@ function logException(Throwable $e) {
 	}
 
 	if(ENABLE_DEBUG) {
-		var_dump($message);
+		echo nl2br($message);
 		exit;
 	}
 

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -1,5 +1,5 @@
 <?php
-function logException(Exception $e) {
+function logException(Throwable $e) {
 	global $account,$var,$player;
 	$errorType = 'Unexpected Game Error!';
 	$message='';
@@ -25,7 +25,7 @@ function logException(Exception $e) {
 		if(function_exists('release_lock'))
 			release_lock(); //Try to release lock so they can carry on normally
 	}
-	catch(Exception $ee) {
+	catch(Throwable $ee) {
 		$message .= EOL.EOL.'-----------'.EOL.EOL.
 					'Releasing Lock Failed' .EOL.
 					'Message: ' . $ee->getMessage() .EOL.EOL;
@@ -68,12 +68,12 @@ function logException(Exception $e) {
 	return $errorType;
 }
 
-function handleException(Exception $e) {
+function handleException(Throwable $e) {
 	// The real error message may display sensitive information, so we
 	// need to catch any exceptions that are thrown while logging the error.
 	try {
 		$errorType = logException($e);
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		$errorType = 'This error cannot be automatically reported. Please notify an admin!';
 	}
 

--- a/htdocs/disabled.php
+++ b/htdocs/disabled.php
@@ -25,6 +25,6 @@ try {
 	$template->assign('Message',$reason);
 	require_once(LIB . 'Login/loginSmarty.php');
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/email.php
+++ b/htdocs/email.php
@@ -81,7 +81,7 @@ try {
 </html>
 <?php
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }
 ?>

--- a/htdocs/email_processing.php
+++ b/htdocs/email_processing.php
@@ -79,6 +79,6 @@ try {
 	forwardURL($container);
 	exit;
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -4,6 +4,6 @@ try {
 	header('Location: '.URL.'/login.php');
 	exit;
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/level_requirements.php
+++ b/htdocs/level_requirements.php
@@ -34,7 +34,7 @@ try {
 	} ?>
 	</table><?php
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }
 ?>

--- a/htdocs/loader.php
+++ b/htdocs/loader.php
@@ -124,6 +124,6 @@ try {
 	
 	do_voodoo();
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/login.php
+++ b/htdocs/login.php
@@ -42,6 +42,6 @@ try {
 	require_once(LIB . 'Login/loginSmarty.php');
 
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -173,8 +173,8 @@ try {
 	try {
 		$account =& SmrAccount::createAccount($login,$password,$email,$first_name,$last_name,$timez,$referral);
 	}
-	catch(Exception $e) {
-		$msg = 'Invalid referral id!';
+	catch(AccountNotFoundException $e) {
+		$msg = 'Invalid referral account ID!';
 		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -213,6 +213,6 @@ try {
 	$container['password'] = $password;
 	forwardURL($container);
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -250,6 +250,6 @@ try {
 	header('Location: '.$href);
 	exit;
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/manual.php
+++ b/htdocs/manual.php
@@ -50,7 +50,7 @@ try {
 	</body>
 	</html><?php
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }
 ?>

--- a/htdocs/manual_toc.php
+++ b/htdocs/manual_toc.php
@@ -70,7 +70,7 @@ try {
 	</body>
 </html><?php
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }
 ?>

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -151,6 +151,6 @@ try {
 
 	$template->display('GalaxyMap.inc');
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/offline.php
+++ b/htdocs/offline.php
@@ -17,6 +17,6 @@ try {
 	
 	require_once(LIB . 'Login/loginSmarty.php');
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/resend_password_processing.php
+++ b/htdocs/resend_password_processing.php
@@ -43,6 +43,6 @@ try {
 	exit;
 
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/reset_password_processing.php
+++ b/htdocs/reset_password_processing.php
@@ -48,6 +48,6 @@ try {
 	
 	header('Location: '.URL.'/login.php');
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/ship_list.php
+++ b/htdocs/ship_list.php
@@ -224,7 +224,7 @@ try {
 	} ?>
 	</table></div></div><?php
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }
 

--- a/htdocs/weapon_list.php
+++ b/htdocs/weapon_list.php
@@ -190,7 +190,7 @@ try {
 
 
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	handleException($e);
 }
 

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -1,4 +1,8 @@
 <?php
+
+// Exception thrown when an account cannot be found in the database
+class AccountNotFoundException extends Exception {}
+
 abstract class AbstractSmrAccount {
 	const USER_RANKINGS_EACH_STAT_POW = .9;
 	const USER_RANKINGS_TOTAL_SCORE_POW = .3;
@@ -138,12 +142,8 @@ abstract class AbstractSmrAccount {
 
 	public static function &createAccount($login,$password,$email,$first_name,$last_name,$timez,$referral) {
 		if($referral!=0) {
-			try {
-				SmrAccount::getAccount($referral);
-			}
-			catch(Exception $e) {
-				throw new Exception('Referral account does not exist: '.$e->getMessage());
-			}
+			// Will throw if referral account doesn't exist
+			SmrAccount::getAccount($referral);
 		}
 		$db = new SmrMySqlDatabase();
 		$db->query('INSERT INTO account (login, password, email, first_name, last_name, validation_code, last_login, offset,referral_id,hof_name) VALUES(' .
@@ -231,7 +231,7 @@ abstract class AbstractSmrAccount {
 				$this->hofName=$this->login;
 		}
 		else {
-			throw new Exception('This account does not exist!');
+			throw new AccountNotFoundException('This account does not exist!');
 		}
 	}
 

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -42,7 +42,7 @@ function getHofRank($view,$viewType,$accountID,$gameID,&$db) {
 				$rank['Amount'] = '-'; //Show a - rather than 0 when hidden due to alliance restrictions so that it is clearer.
 			}
 		}
-		catch(Exception $e) {
+		catch(PlayerNotFoundException $e) {
 			$rank['Amount'] = '-';
 		}
 		if($rank['Amount'] == '-' && !isset($gameID)) {
@@ -77,7 +77,7 @@ function displayHOFRow($rank,$accountID,$amount) {
 		try {
 			$hofPlayer =& SmrPlayer::getPlayer($accountID,$var['game_id']);
 		}
-		catch(Exception $e) {
+		catch(PlayerNotFoundException $e) {
 			$hofAccount =& SmrAccount::getAccount($accountID);
 		}
 	}

--- a/tools/discord/mysql_cleanup.php
+++ b/tools/discord/mysql_cleanup.php
@@ -9,7 +9,7 @@ function mysql_cleanup(callable $func) {
 		// First, call the original closure
 		try {
 			$func($message, $params);
-		} catch (Exception $e) {  // NOTE: in PHP7, switch to Throwable
+		} catch (Throwable $e) {
 			print('Error in '.$e->getFile().' line '.$e->getLine().':'.EOL);
 			print($e->getMessage() . EOL);
 			$message->reply('I encountered an error. Please report this to an admin!');

--- a/tools/irc/channel_msg.php
+++ b/tools/irc/channel_msg.php
@@ -48,7 +48,7 @@ function check_for_registration(&$account, &$player, $fp, $nick, $channel, $call
 	try {
 		$player = SmrPlayer::getPlayer($account->getAccountID(), $alliance->getGameId(), true);
 	}
-	catch(Exception $e) {
+	catch(PlayerNotFoundException $e) {
 		if($validationMessages === true) {
 			fputs($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', you have not joined the game that this channel belongs to.' . EOL);
 		}

--- a/tools/npc/chess.php
+++ b/tools/npc/chess.php
@@ -84,7 +84,7 @@ try {
 	fclose($fromEngine);
 	proc_close($engine);
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	logException($e);
 	exit;
 }

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -111,7 +111,7 @@ try {
 
 	NPCStuff();
 }
-catch(Exception $e) {
+catch(Throwable $e) {
 	logException($e);
 	// Try to shut down cleanly
 	exitNPC();


### PR DESCRIPTION
* Catch `Throwable` instead of `Exception` so we can cleanly log fatal PHP errors instead of getting 500 Internal Server Error pages.
* Add `AccountNotFoundException` and use `PlayerNotFoundException` more thoroughly to avoid catching unrelated errors.
* In debug-mode, display error messages on the page in human-readable format.