### PR TITLE
hof.functions.inc: fix getHofRank error

### DIFF
--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -23,6 +23,13 @@ function getHofRank($view,$viewType,$accountID,$gameID,&$db) {
 		$db->query('SELECT SUM(amount) amount FROM player_hof WHERE type='.$db->escapeArray($viewType,false,true,':',false) .' AND account_id='.$db->escapeNumber($accountID).$gameIDSql.' GROUP BY account_id LIMIT 1');
 	}
 
+	// What we will show for the amount:
+	// * Game specified:
+	//  - Ally: real amount
+	//  - Enemy: "-"
+	// * No game specified (All Time HoF):
+	//  - Current player: real total amount
+	//  - Other Player: total amount from completed games
 	$realAmount = 0;
 	if($db->nextRecord()) {
 		if($db->getField('amount')!=null) {
@@ -33,19 +40,16 @@ function getHofRank($view,$viewType,$accountID,$gameID,&$db) {
 		$rank['Amount'] = $realAmount;
 	}
 	else if($vis==HOF_ALLIANCE&&$account->getAccountID()!=$accountID) {
-		try {
-			$hofPlayer =& SmrPlayer::getPlayer($accountID, $gameID);
-			if($hofPlayer->sameAlliance($player)) {
+		if (isset($gameID)) {
+			$hofPlayer = SmrPlayer::getPlayer($accountID, $gameID);
+			// Only show the real amount if player is in your alliance.
+			if ($hofPlayer->sameAlliance($player)) {
 				$rank['Amount'] = $realAmount;
+			} else {
+				$rank['Amount'] = '-';
 			}
-			else {
-				$rank['Amount'] = '-'; //Show a - rather than 0 when hidden due to alliance restrictions so that it is clearer.
-			}
-		}
-		catch(PlayerNotFoundException $e) {
-			$rank['Amount'] = '-';
-		}
-		if($rank['Amount'] == '-' && !isset($gameID)) {
+		} else {
+			$rank['Amount'] = 0; //default
 			$db->query('SELECT SUM(amount) amount FROM player_hof WHERE type='.$db->escapeArray($viewType,false,true,':',false) .' AND account_id='.$accountID.' AND game_id IN (SELECT game_id FROM game WHERE end_date < '.TIME.' AND ignore_stats = '.$db->escapeBoolean(false).') GROUP BY account_id LIMIT 1');
 			if($db->nextRecord()) {
 				if($db->getField('amount')!=null) {


### PR DESCRIPTION
When getting the HoF amount for another player, we don't want to
even try to construct an `SmrPlayer` if we know there is no game
specified. This was previously caught by a generic try-catch, which
was replaced by specifically catching `PlayerNotFoundException` in
1f638bbdb; however, when `$gameID=null`, a regular `Exception` was
thrown, which broke this piece of code.

Rather than bothering with exception handling at all, we can skip
the `SmrPlayer` construction if we know that we haven't specified
a game. When we have specified a game, we expect the `SmrPlayer`
construction to succeed in all cases.