### PR TITLE
current_sector.php: don't reassign sector

### DIFF
--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -5,9 +5,6 @@ if($player->isLandedOnPlanet()) {
 	forward(create_container('skeleton.php', 'planet_main.php', $var));
 }
 
-$sector =& $player->getSector();
-
-$template->assign('ThisSector',$sector);
 $template->assign('SpaceView',true);
 
 $template->assign('PageTopic','Current Sector: ' . $player->getSectorID() . ' (' .$sector->getGalaxyName() . ')');


### PR DESCRIPTION
The `$sector` global and `ThisSector` template variable are already
assigned by `do_voodoo` in smr.inc. As such, there is no need to
set them again in current_sector.php.