### PR TITLE
Make header locations relative

### DIFF
--- a/engine/Default/logoff.php
+++ b/engine/Default/logoff.php
@@ -7,5 +7,5 @@ SmrSession::destroy();
 
 // Send the player back to the login screen
 $msg = 'You have successfully logged off!';
-header('Location: '.URL.'/login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 exit;

--- a/htdocs/album/album_comment.php
+++ b/htdocs/album/album_comment.php
@@ -1,7 +1,7 @@
 <?php
 
 function create_error_offline($msg) {
-	header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+	header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 	exit;
 }
 
@@ -68,7 +68,7 @@ try {
 				VALUES ('.$db->escapeNumber($album_id).', '.$db->escapeNumber($comment_id).', '.$db->escapeNumber($curr_time).', '.$db->escapeNumber($account->getAccountID()).', '.$db->escapeString($comment).')');
 	$db->unlock();
 
-	header('Location: '.URL.'/album/?' . get_album_nick($album_id));
+	header('Location: /album/?' . get_album_nick($album_id));
 	exit;
 }
 catch(Throwable $e) {

--- a/htdocs/album/search_processing.php
+++ b/htdocs/album/search_processing.php
@@ -1,6 +1,4 @@
 <?php
 
-require_once('../config.inc');
-
-header('Location: '.URL.'/album/?' . $_GET['nick']);
+header('Location: /album/?' . $_GET['nick']);
 exit;

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -83,7 +83,7 @@ function handleException(Throwable $e) {
 	// If this is an ajax update, we don't really have a way to redirect
 	// to an error page at this time, so we just quit.
 	if(!defined('USING_AJAX')||!USING_AJAX)
-		header('location: ' . URL . '/error.php?msg='.urlencode($errorType));
+		header('location: /error.php?msg='.urlencode($errorType));
 	exit;
 }
 

--- a/htdocs/email.php
+++ b/htdocs/email.php
@@ -8,7 +8,7 @@ try {
 
 	// do we have a session?
 	if (SmrSession::$account_id == 0) {
-		header('Location: '.URL.'/login.php');
+		header('Location: /login.php');
 		exit;
 	}
 

--- a/htdocs/email_processing.php
+++ b/htdocs/email_processing.php
@@ -10,7 +10,7 @@ try {
 
 	// do we have a session?
 	if (SmrSession::$account_id == 0) {
-		header('Location: '.URL.'/login.php');
+		header('Location: /login.php');
 		exit;
 	}
 
@@ -19,13 +19,13 @@ try {
 
 	if ($_POST['email'] != $_POST['email_verify']) {
 		$msg = 'The eMail addresses you entered do not match!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
 	if ($_POST['email'] == $account->getEmail()) {
 		$msg = 'You have to use a different email than the registered one!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
@@ -35,14 +35,14 @@ try {
 	// check if the host got a MX or at least an A entry
 	if (!checkdnsrr($host, 'MX') && !checkdnsrr($host, 'A')) {
 		$msg = 'This is not a valid email address!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
 	$db->query('SELECT * FROM account WHERE email = ' . $db->escape_string($_POST['email']));
 	if ($db->getNumRows() > 0) {
 		$msg = 'This eMail address is already registered.';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -1,9 +1,4 @@
 <?php
-try {
-	require_once('config.inc');
-	header('Location: '.URL.'/login.php');
-	exit;
-}
-catch(Throwable $e) {
-	handleException($e);
-}
+
+header('Location: /login.php');
+exit;

--- a/htdocs/loader.php
+++ b/htdocs/loader.php
@@ -52,7 +52,7 @@ try {
 	//exit;
 	// do we have a session?
 	if (SmrSession::$account_id == 0) {
-		header('Location: '.URL.'/login.php');
+		header('Location: /login.php');
 		exit;
 	}
 
@@ -104,7 +104,7 @@ try {
 		// save session (incase we forward)
 		SmrSession::update();
 		if ($disabled['Reason'] == 'Invalid eMail') {
-			header('Location: '.URL.'/email.php');
+			header('Location: /email.php');
 			exit;
 		}
 		else if ($disabled['Reason'] == CLOSE_ACCOUNT_BY_REQUEST_REASON) {
@@ -117,7 +117,7 @@ try {
 			}
 		}
 		else {
-			header('Location: '.URL.'/disabled.php');
+			header('Location: /disabled.php');
 			exit;
 		}
 	}

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -10,7 +10,7 @@ try {
 
 	if (SmrSession::$account_id > 0) {
 		$msg = 'You\'re already logged in! Creating multis is against the rules!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 	$socialLogin = isset($_REQUEST['socialReg']);
@@ -19,7 +19,7 @@ try {
 		session_start();
 		if(!$_SESSION['socialLogin']) {
 			$msg = 'Tried a social registration without having a social session.';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 	}
@@ -28,7 +28,7 @@ try {
 	if (!$socialLogin && !empty(RECAPTCHA_PRIVATE)) {
 		if (!isset($_POST['g-recaptcha-response'])) {
 			$msg = 'Please make sure to complete the recaptcha!';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 
@@ -41,7 +41,7 @@ try {
 
 		if (!$resp->isSuccess()) {
 			$msg = 'Invalid captcha!';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 	}
@@ -52,36 +52,36 @@ try {
 	$password = trim($_REQUEST['password']);
 	if (strstr($login, '\'') || strstr($password, '\'')) {
 		$msg = 'Illegal character in login or password detected! Don\'t use the apostrophe.';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 	if(strpos($login,'NPC')===0) {
 		$msg = 'Login names cannot begin with "NPC".';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 	if (isset($_REQUEST['agreement']) && empty($_REQUEST['agreement'])) {
 		$msg = 'You must accept the agreement!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
 	if (empty($login)) {
 		$msg = 'Login name is missing!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
 	if (!$socialLogin && empty($password)) {
 		$msg = 'Password is missing!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
 	$pass_verify = $_REQUEST['pass_verify'];
 	if ($password != $pass_verify) {
 		$msg = 'The passwords you entered do not match.';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
@@ -89,20 +89,20 @@ try {
 		$email = trim($_REQUEST['email']);
 		if (empty($email)) {
 			$msg = 'Email address is missing!';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 
 		if (strstr($email, ' ')) {
 			$msg = 'The email is invalid! It cannot contain any spaces.';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 
 		$email_verify = $_REQUEST['email_verify'];
 		if ($email != $email_verify) {
 			$msg = 'The eMail addresses you entered do not match.';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 
@@ -112,7 +112,7 @@ try {
 		// check if the host got a MX or at least an A entry
 		if (!checkdnsrr($host, 'MX') && !checkdnsrr($host, 'A')) {
 			$msg = 'This is not a valid email address! The domain '.$host.' does not exist.';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 	}
@@ -125,28 +125,28 @@ try {
 		$first_name = $_REQUEST['first_name'];
 		if (empty($first_name)) {
 			$msg = 'First name is missing!';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 
 		$last_name = $_REQUEST['last_name'];
 		if (empty($last_name)) {
 			$msg = 'Last name is missing!';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 	}
 
 	if ($login == $password) {
 		$msg = 'Your chosen password is invalid!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
 	$db->query('SELECT * FROM account WHERE login = '.$db->escapeString($login));
 	if ($db->getNumRows() > 0) {
 		$msg = 'This user name is already registered.';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
@@ -154,7 +154,7 @@ try {
 	$db->query('SELECT * FROM account WHERE email = '.$db->escapeString($email));
 	if ($db->getNumRows() > 0) {
 		$msg = 'This email address is already registered.';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
@@ -162,7 +162,7 @@ try {
 
 	if (!is_numeric($referral)) {
 		$msg = 'Referral ID must be a number if entered!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 
@@ -175,7 +175,7 @@ try {
 	}
 	catch(AccountNotFoundException $e) {
 		$msg = 'Invalid referral account ID!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 	$account->increaseSmrRewardCredits(2 * CREDITS_PER_DOLLAR); // Give $2 worth of "reward" credits for joining.

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -29,7 +29,7 @@ try {
 			$socialLogin = new SocialLogin($_REQUEST['loginType']);
 			if(!$socialLogin->isValid()) {
 				$msg = 'Error validating login.';
-				header('Location: '.URL.'/login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+				header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 				exit;
 			}
 			$loginType = $socialLogin->getLoginType();
@@ -70,7 +70,7 @@ try {
 			// has the user submitted empty fields
 			if (empty($login) || empty($password)) {
 				$msg = 'Please enter login and password!';
-				header('Location: '.URL.'/login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+				header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 				exit;
 			}
 
@@ -85,13 +85,13 @@ try {
 			elseif (Globals::useCompatibilityDatabases()) {
 				if(!SmrAccount::upgradeAccount($login,$password)) {
 					$msg = 'Password is incorrect!';
-					header('Location: '.URL.'/login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+					header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 					exit;
 				}
 			}
 			else {
 				$msg = 'Password is incorrect!';
-				header('Location: '.URL.'/login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+				header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 				exit;
 			}
 		}
@@ -112,7 +112,7 @@ try {
 		$socialLogin = isset($_REQUEST['social']);
 		if($socialLogin && (!$_SESSION['socialLogin'])) {
 			$msg = 'Tried a social login link without having a social session.';
-			header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 			exit;
 		}
 		$account->addAuthMethod($_SESSION['socialLogin']->getLoginType(),$_SESSION['socialLogin']->getUserID());
@@ -123,7 +123,7 @@ try {
 	if ($db->nextRecord()) {
 		// allow admins to access it
 		if (!$account->hasPermission(PERMISSION_GAME_OPEN_CLOSE)) {
-			header('Location: '.URL.'/offline.php');
+			header('Location: /offline.php');
 			exit;
 		}
 	}
@@ -140,11 +140,11 @@ try {
 		// save session (incase we forward)
 		SmrSession::update();
 		if ($disabled['Reason'] == 'Invalid eMail') {
-			header('Location: '.URL.'/email.php');
+			header('Location: /email.php');
 			exit;
 		}
 		else if ($disabled['Reason'] != CLOSE_ACCOUNT_BY_REQUEST_REASON) {
-			header('Location: '.URL.'/disabled.php');
+			header('Location: /disabled.php');
 			exit;
 		}
 	}

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -33,7 +33,7 @@ try {
 	// do we have a session?
 	if (SmrSession::$account_id == 0 || SmrSession::$game_id == 0) {
 	
-		header('Location: '.URL.'/login.php');
+		header('Location: /login.php');
 		exit;
 	
 	}
@@ -41,27 +41,27 @@ try {
 	if(isset($_REQUEST['sector_id'])) {
 		$sectorID = $_REQUEST['sector_id'];
 		if(!is_numeric($sectorID)) {
-			header('location: ' . URL . '/error.php?msg=Sector id was not a number.');
+			header('location: /error.php?msg=Sector ID was not a number.');
 			exit;
 		}
 		try {
 			$galaxy = SmrGalaxy::getGalaxyContaining(SmrSession::$game_id, $sectorID);
 		} catch (SectorNotFoundException $e) {
-			header('location: ' . URL . '/error.php?msg=Invalid sector id');
+			header('location: /error.php?msg=Invalid sector ID');
 			exit;
 		}
 	}
 	else if(isset($_REQUEST['galaxy_id'])) {
 		$galaxyID = $_REQUEST['galaxy_id'];
 		if(!is_numeric($galaxyID)) {
-			header('location: ' . URL . '/error.php?msg=Galaxy id was not a number.');
+			header('location: /error.php?msg=Galaxy ID was not a number.');
 			exit;
 		}
 		try {
 			$galaxy =& SmrGalaxy::getGalaxy(SmrSession::$game_id,$galaxyID);
 		}
 		catch(Exception $e) {
-			header('location: ' . URL . '/error.php?msg=Invalid galaxy id');
+			header('location: /error.php?msg=Invalid galaxy ID');
 			exit;
 		}
 	}

--- a/htdocs/resend_password_processing.php
+++ b/htdocs/resend_password_processing.php
@@ -2,7 +2,7 @@
 try {
 
 	if (empty($_REQUEST['email'])) {
-		header('Location: error.php?msg=' . rawurlencode('You must specify an e-mail address!'));
+		header('Location: /error.php?msg=' . rawurlencode('You must specify an e-mail address!'));
 		exit;
 	}
 
@@ -14,7 +14,7 @@ try {
 	$account = SmrAccount::getAccountByEmail($_REQUEST['email']);
 	if ($account==null) {
 		// unknown user
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode('The specified e-mail address is not registered!'));
+		header('Location: /error.php?msg=' . rawurlencode('The specified e-mail address is not registered!'));
 		exit;
 	}
 
@@ -36,7 +36,7 @@ try {
 	$mail->addAddress($account->getEmail(), $account->getHofName());
 	$mail->send();
 
-	header('Location: '.URL.'/reset_password.php');
+	header('Location: /reset_password.php');
 	exit;
 
 }

--- a/htdocs/reset_password_processing.php
+++ b/htdocs/reset_password_processing.php
@@ -8,20 +8,20 @@ try {
 	$password = $_REQUEST['password'];
 	if (strstr($password, '\'')) {
 		$msg = 'Illegal character in password detected! Don\'t use the apostrophe.';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 	
 	if (empty($password)) {
 		$msg = 'Password is missing!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 	
 	$pass_verify = $_REQUEST['pass_verify'];
 	if ($password != $pass_verify) {
 		$msg = 'The passwords you entered do not match.';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 	
@@ -30,7 +30,7 @@ try {
 	$login = $_REQUEST['login'];
 	if ($login == $password) {
 		$msg = 'Your chosen password is invalid!';
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
 	
@@ -39,14 +39,14 @@ try {
 	$passwordReset = $_REQUEST['password_reset'];
 	if ($account==null || empty($passwordReset) || $account->getPasswordReset() != $passwordReset) {
 		// unknown user
-		header('Location: '.URL.'/error.php?msg=' . rawurlencode('User does not exist or reset password code is incorrect.'));
+		header('Location: /error.php?msg=' . rawurlencode('User does not exist or reset password code is incorrect.'));
 		exit;
 	}
 	
 	$account->setPassword($password);
 	
 	
-	header('Location: '.URL.'/login.php');
+	header('Location: /login.php');
 }
 catch(Throwable $e) {
 	handleException($e);

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -669,7 +669,7 @@ abstract class AbstractSmrAccount {
 				$db->query('SELECT * FROM account WHERE `'.$databaseInfo['Column'].'` = '.$db->escapeNumber($db2->getInt('account_id')).' LIMIT 1');
 				if($db->nextRecord()) {
 					$msg = 'The specified old account is already linked to a 1.6 account.';
-					header('Location: '.URL.'/login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+					header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 				}
 
 				$db3 = new $databaseClassName();
@@ -682,11 +682,11 @@ abstract class AbstractSmrAccount {
 						// save session (incase we forward)
 						SmrSession::update();
 						if ($db3->getField('reason') == 'Invalid eMail') {
-							header('Location: '.URL.'/email.php');
+							header('Location: /email.php');
 							exit;
 						}
 						else {
-							header('Location: '.URL.'/disabled.php');
+							header('Location: /disabled.php');
 							exit;
 						}
 					}


### PR DESCRIPTION
When specifying the `Location` header, we can use a value relative
to the webserver instead of manually specifying the full URL.

We will use the leading '/' to indicate that the location is relative
to the webserver root instead of the current directory (e.g. to avoid
issues with '/album').

This also allows us to simplify some pages, since we needed to
include configuration files to define the `URL` constant.