### PR TITLE
Make followPath more performant

### DIFF
--- a/lib/Default/Plotter.class.inc
+++ b/lib/Default/Plotter.class.inc
@@ -295,7 +295,7 @@ class Distance {
 	
 	public function followPath() {
 		$nextSectorID = array_shift($this->path);
-		if (in_array($nextSectorID, array_values($this->warpMap))) {
+		if (in_array($nextSectorID, $this->warpMap)) {
 			$this->numWarps--;
 		} else {
 			$this->distance--;


### PR DESCRIPTION
When using `in_array`, the haystack for an associate array input
is already the array values, so there is no need to perform the
extra work of creating a new array of only the array values.