### PR TITLE
config.php: don't create links array

### DIFF
--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -393,14 +393,10 @@ require_once(LIB . 'Default/SmrSession.class.inc');
 require_once(LIB . 'Default/Template.class.inc');
 $template = new Template();
 $GLOBALS['template'] =& $template;
-//	$template->assign('links',$db->_LINKS);
-//	$template->assign('javaScriptFiles',$db->_JS);
+
 $template->assign('URL',URL);
 $template->assign('CSSLink',DEFAULT_CSS);
 $template->assign('CSSColourLink',DEFAULT_CSS_COLOUR);
 $template->assign('Title', 'Space Merchant Realms');
 
-$links = array('Register' => 'login_create.php',
-					'ResetPassword' => 'resend_password.php');
-$template->assign('Links',$links);
 $template->assign('AJAX_ENABLE_REFRESH',AJAX_DEFAULT_REFRESH_TIME);

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -161,7 +161,7 @@
 								<tr>
 									<td>
 										<img src="images/login/regLeft.png" width="30" height="11"  alt="">
-										<a href="<?php echo $Links['Register'] ?>">
+										<a href="login_create.php">
 											<img src="images/login/register.png" width="83" height="11" alt="Register">
 										</a>
 										<a href="resend_password.php">

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -160,7 +160,14 @@
 							<table class="collapsed">
 								<tr>
 									<td>
-										<img src="images/login/regLeft.png" width="30" height="11"  alt=""><a href="<?php echo $Links['Register'] ?>"><img src="images/login/register.png" width="83" height="11" alt="Register"></a><a href="resend_password.php"><img src="images/login/pw_reset.png" width="127" height="11"  alt="Reset Password"></a><img src="images/login/regRight.png" width="18" height="11" alt="">
+										<img src="images/login/regLeft.png" width="30" height="11"  alt="">
+										<a href="<?php echo $Links['Register'] ?>">
+											<img src="images/login/register.png" width="83" height="11" alt="Register">
+										</a>
+										<a href="resend_password.php">
+											<img src="images/login/pw_reset.png" width="127" height="11" alt="Reset Password">
+										</a>
+										<img src="images/login/regRight.png" width="18" height="11" alt="">
 									</td>
 								</tr>
 								<tr>


### PR DESCRIPTION
This array was only (partially) used for the login page. It doesn't
need to be constructed for every page. It makes more sense to simply
hard-code the one URL it was supplying in `login.inc` directly.

Also reformat a long html line.