### PR TITLE
Fix stale social login URLs

### DIFF
--- a/htdocs/login_social_processing.php
+++ b/htdocs/login_social_processing.php
@@ -1,0 +1,33 @@
+<?php
+
+try {
+
+	if (isset($_GET['type'])) {
+		$type = $_GET['type'];
+
+		// Social logins often verify authenticity by checking login URL query
+		// parameters against data stored in a PHP session by the login URL
+		// generator. The SocialLogin class starts the PHP session, so to
+		// ensure that the session cannot expire before validation, this script
+		// immediately forwards to the social login URL after it is generated.
+
+		require_once('config.inc');
+		require_once(LIB . 'Login/SocialLogin.class.inc');
+		if ($type == 'facebook') {
+			$url = SocialLogin::getFacebookLoginUrl();
+		} elseif ($type == 'twitter') {
+			$url = SocialLogin::getTwitterLoginUrl();
+		} elseif ($type == 'google') {
+			$url = SocialLogin::getOpenIdLoginUrl('Google');
+		} else {
+			throw new Exception('Unknown social login type');
+		}
+
+		header('Location: ' . $url);
+		exit;
+	}
+
+}
+catch(Throwable $e) {
+	handleException($e);
+}

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -191,15 +191,14 @@
 					<td class="center" style="padding: 3px; width: 200px;">
 						<span style="font-size: 14px;">Or login with:</span>
 						<span style="font-size: 3px;"><br /><br />
-							<?php require_once(LIB.'Login/SocialLogin.class.inc'); ?>
-							<a style="display: inline;margin:10px;" href="<?php echo str_replace('&', '&amp;', SocialLogin::getFacebookLoginUrl()); ?>">
+							<a style="display: inline;margin:10px;" href="login_social_processing.php?type=facebook">
 								<img alt="Facebook Login" src="images/login/facebook.png" width="65" height="22">
 							</a><br /><br />
 							<?php /*
-							<a style="display: inline;margin:10px;" href="<?php echo str_replace('&', '&amp;', SocialLogin::getOpenIdLoginUrl('Google')); ?>">
+							<a style="display: inline;margin:10px;" href="login_social_processing.php?type=google">
 								<img alt="Google Login" src="images/login/google.png" width="32" height="32">
 							</a>
-							<a style="display: inline;margin:10px;" href="<?php echo str_replace('&', '&amp;', SocialLogin::getTwitterLoginUrl()); ?>">
+							<a style="display: inline;margin:10px;" href="login_social_processing.php?type=twitter">
 								<img alt="Twitter Login" src="images/login/twitter.png">
 							</a>
 							*/ ?>

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -195,15 +195,14 @@
 							<a style="display: inline;margin:10px;" href="<?php echo str_replace('&', '&amp;', SocialLogin::getFacebookLoginUrl()); ?>">
 								<img alt="Facebook Login" src="images/login/facebook.png" width="65" height="22">
 							</a><br /><br />
-							<!-- <a style="display: inline;margin:10px;" href="<?php /* echo str_replace('&', '&amp;', SocialLogin::getOpenIdLoginUrl('Google')); */ ?>">
-								<img alt="Google Login" src="images/login/google.png" width="32" height="32">
-							</a>-->
 							<?php /*
-							<a style="display: inline;margin:10px;" href="<?php echo str_replace('&', '&amp;', SocialLogin::getTwitterLoginUrl()); ?>">
-								<img alt="Twiiter Login" src="images/login/twitter.png">
+							<a style="display: inline;margin:10px;" href="<?php echo str_replace('&', '&amp;', SocialLogin::getOpenIdLoginUrl('Google')); ?>">
+								<img alt="Google Login" src="images/login/google.png" width="32" height="32">
 							</a>
-							*/
-							?>
+							<a style="display: inline;margin:10px;" href="<?php echo str_replace('&', '&amp;', SocialLogin::getTwitterLoginUrl()); ?>">
+								<img alt="Twitter Login" src="images/login/twitter.png">
+							</a>
+							*/ ?>
 						</span>
 					</td>
 					<td style="width:470px"><?php


### PR DESCRIPTION
If you leave the login page open for longer than the PHP session
timeout and then click a social login link, then an exception is
thrown because the PHP session data has expired.

For Facebook, the error will look something like:

```
FacebookSDKException: Cross-site request forgery validation failed.
Required param "state" missing from persistent data.
```

To fix this, we no longer display the social login URL on the login
page. Instead, we link to a wrapper `login_social_processing.php`,
construct the social login URL there, and then immediately forward
to it to ensure that the session that's created while generating
the URL is still active.
