### PR TITLE
Fix edge case where course plot does nothing

### DIFF
--- a/engine/Default/course_plot_result.php
+++ b/engine/Default/course_plot_result.php
@@ -7,12 +7,9 @@ $path = unserialize($var['Distance']);
 // Throw start sector away (it's useless for the route),
 // but save the full path in case we end up needing to display it.
 $fullPath = implode(' - ', $path->getPath());
-$path->removeStart();
+$startSectorID = $path->removeStart();
 
-// now get the sector we are going to but don't remove it (sector_move_processing does it)
-$next_sector = $path->getNextOnPath();
-
-if ($player->getSector()->isLinked($next_sector)) {
+if ($player->getSectorID() == $startSectorID) {
 	$player->setPlottedCourse($path);
 
 	if (!$player->isLandedOnPlanet()) {


### PR DESCRIPTION
To determine if the course was plotted from the current sector,
it checks if the start of the path (after the start sector is
removed) is linked to the current sector. This is degenerate
because more than just the current sector is linked to this
start sector.

For example, if you plot _from_ 2 sectors away from your current
sector _to_ your current sector, the course will not be displayed
because both your current sector and the "from" sector are linked
to the start of the path. This will then forward you to the
Current Sector page, but you're already at the destination sector,
so the course is unset.

Since we have access to the "from" sector directly, we can simply
check if the current sector is the "from" sector. There's no need
to do anything with the start of the path or linked sectors.
This change fixes this edge case bug.