### PR TITLE
SmrSector: rename methods for clarity

### DIFF
--- a/engine/Default/sector_scan.php
+++ b/engine/Default/sector_scan.php
@@ -88,5 +88,5 @@ else
 	$turns = TURNS_PER_SECTOR;
 
 $PHP_OUTPUT.= '<a href="'.$scanSector->getScanSectorHREF().'" class="submitStyle">Rescan ' . $scanSector->getSectorID() . '</a>&nbsp;';
-$PHP_OUTPUT.= '<a href="'.$scanSector->getCurrentSectorHREF().'" class="submitStyle">Enter ' . $scanSector->getSectorID() . ' ('.$turns.')</a>';
+$PHP_OUTPUT.= '<a href="'.$scanSector->getCurrentSectorMoveHREF().'" class="submitStyle">Enter ' . $scanSector->getSectorID() . ' ('.$turns.')</a>';
 $PHP_OUTPUT.=('</form></p>');

--- a/lib/Default/SmrSector.class.inc
+++ b/lib/Default/SmrSector.class.inc
@@ -952,11 +952,11 @@ class SmrSector {
 		return $this->visited[$player->getAccountID()];
 	}
 
-	public function getLocalMapHREF() {
+	public function getLocalMapMoveHREF() {
 		return Globals::getSectorMoveHREF($this->getSectorID(), 'map_local.php');
 	}
 
-	public function getCurrentSectorHREF() {
+	public function getCurrentSectorMoveHREF() {
 		return Globals::getCurrentSectorMoveHREF($this->getSectorID());
 	}
 

--- a/templates/Default/engine/Default/includes/PlottedCourse.inc
+++ b/templates/Default/engine/Default/includes/PlottedCourse.inc
@@ -15,7 +15,7 @@ if($ThisPlayer->hasPlottedCourse()) {
 			<td class="top right"><?php
 				if ($ThisSector->isLinked($NextSector->getSectorID())) { ?>
 					<div class="buttonA">
-						<a class="buttonA" href="<?php echo $NextSector->getCurrentSectorHREF(); ?>">&nbsp; Follow Course (#<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
+						<a class="buttonA" href="<?php echo $NextSector->getCurrentSectorMoveHREF(); ?>">&nbsp; Follow Course (#<?php echo $PlottedCourse->getNextOnPath(); ?>) &nbsp;</a>
 					</div><?php
 					if($ThisShip->hasScanner()) { ?>
 						<br /><br />

--- a/templates/Default/engine/Default/includes/SectorMap.inc
+++ b/templates/Default/engine/Default/includes/SectorMap.inc
@@ -92,7 +92,7 @@
 								if($isVisited) {
 									if($Sector->hasWarp()) {
 										if($GalaxyMap){ ?><a href="<?php echo $Sector->getWarpSector()->getGalaxyMapHREF(); ?>"><?php }
-										else if($isCurrentSector){ ?><a href="<?php echo $Sector->getWarpSector()->getLocalMapHREF(); ?>"><?php } ?>
+										else if($isCurrentSector){ ?><a href="<?php echo $Sector->getWarpSector()->getLocalMapMoveHREF(); ?>"><?php } ?>
 											<img title="Warp to #<?php echo $Sector->getWarp(); ?> (<?php echo $Sector->getWarpSector()->getGalaxyName(); ?>)" alt="Warp to #<?php echo $Sector->getWarp(); ?>" src="images/warp.png" width="16" height="16" /><?php
 										if($isCurrentSector || $GalaxyMap){ ?></a><?php }
 									}
@@ -142,7 +142,7 @@
 							<a class="move_hack" href="<?php echo $Sector->getGalaxyMapHREF(); ?>"></a><?php
 						}
 						else if($isLinkedSector) { ?>
-							<a class="move_hack" href="<?php echo $Sector->getLocalMapHREF(); ?>"></a><?php
+							<a class="move_hack" href="<?php echo $Sector->getLocalMapMoveHREF(); ?>"></a><?php
 						}
 						else if($isCurrentSector) { ?>
 							<a class="move_hack" href="<?php echo Globals::getCurrentSectorHREF(); ?>"></a><?php


### PR DESCRIPTION
getLocalMapHREF -> getLocalMapMoveHREF
getCurrentSectorHREF -> getCurrentSectorMoveHREF

These methods were renamed for consistency with the `Globals`
methods `get*SectorMoveHREF` and to avoid confusion with the
other methods of `Globals` with the same name as the originals
but that only link to the Local Map or Current Sector pages
(i.e. no movement involved).