### PR TITLE
Fix bug when bumping into forces with no weapons

### DIFF
--- a/engine/Default/forces_attack_processing.php
+++ b/engine/Default/forces_attack_processing.php
@@ -11,8 +11,6 @@ if($player->isLandedOnPlanet())
 	create_error('You cannot attack forces whilst on a planet!');
 if(!$player->canFight())
 	create_error('You are not allowed to fight!');
-if (!$ship->hasWeapons() && !$ship->hasCDs())
-	create_error('You cannot attack without weapons!');
 if ($player->forceNAPAlliance($forceOwner))
 	create_error('You cannot attack allied forces!');
 
@@ -34,6 +32,8 @@ if ($bump) {
 		create_error('These forces no longer exist.');
 	if ($player->getTurns() < $forces->getAttackTurnCost($ship))
 		create_error('You do not have enough turns to attack these forces!');
+	if (!$ship->hasWeapons() && !$ship->hasCDs())
+		create_error('You cannot attack without weapons!');
 }
 
 // take the turns


### PR DESCRIPTION
When removing the Examine button in a50cedfb430, the check to see if
the player can attack the forces was moved into the wrong place.
This resulted in ships with no offense being unable to bump into mines
(i.e. if you have no weapons and move into a sector with mines,
instead of being hit by mines, you would get an error message saying
you couldn't attack the forces).

The error message needs to be moved to where it's only triggered by
an explicit attack (not a bump).

Thanks to RedRocket for reporting this error!