### PR TITLE
location_edit.php: fix editing single location

### DIFF
--- a/templates/Default/admin/Default/location_edit.php
+++ b/templates/Default/admin/Default/location_edit.php
@@ -1,4 +1,4 @@
-<?php if(!$Locations) {
+<?php if (!isset($Locations)) {
 	?><a href="<?php echo $ViewAllLocationsLink; ?>">View All Locations</a><br /><br />
 	<form action="<?php echo $Location->getEditHREF(); ?>" method="POST"><?php
 } ?>
@@ -17,7 +17,7 @@
 		<th>Weapons</th>
 		<th>Edit</th>
 	</tr><?php
-if($Locations) {
+if (isset($Locations)) {
 	$this->includeTemplate('includes/ViewLocations.inc',array('Locations'=>$Locations));
 }
 else { ?>
@@ -100,6 +100,6 @@ else { ?>
 } ?>
 </table>
 <?php
-if(!$Locations) {
+if (!isset($Locations)) {
 	?></form><?php
 } ?>


### PR DESCRIPTION
When editing a single location, `$Locations` is not set, and so
causes an undefined variable warning. Instead of just casting the
variable to a bool, check for its existence, which fixes the warning.