### PR TITLE
rankings_alliance_vs_alliance.php: clean up

### DIFF
--- a/engine/Default/rankings_alliance_vs_alliance.php
+++ b/engine/Default/rankings_alliance_vs_alliance.php
@@ -130,11 +130,12 @@ $PHP_OUTPUT.=('</div>');
 if (isset($var['alliance_id'])) {
 	$PHP_OUTPUT.=('<table align="center"><tr><td width="45%" align="center" valign="top">');
 	$main_alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
+	$mainName = $main_alliance->getAllianceID() == 0 ? 'No Alliance' : $main_alliance->getAllianceName();
 	$db->query('SELECT * FROM alliance_vs_alliance
 				WHERE alliance_id_1 = '.$db->escapeNumber($var['alliance_id']) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC');
 	if ($db->getNumRows() > 0) {
-		$PHP_OUTPUT.=('<div align="center">Kills for '.$main_alliance->getAllianceName());
+		$PHP_OUTPUT.=('<div align="center">Kills for '.$mainName);
 		$PHP_OUTPUT.=('<table class="standard"><tr><th align=center>Alliance Name</th>');
 		$PHP_OUTPUT.=('<th align="center">Amount</th></tr>');
 		while ($db->nextRecord()) {
@@ -153,13 +154,13 @@ if (isset($var['alliance_id'])) {
 		}
 		$PHP_OUTPUT.=('</table>');
 	}
-	else $PHP_OUTPUT.=($main_alliance->getAllianceName().' has no kills!');
+	else $PHP_OUTPUT.=($mainName.' has no kills!');
 	$PHP_OUTPUT.=('</td><td width="10%">&nbsp;</td><td width="45%" align="center" valign="top">');
 	$db->query('SELECT * FROM alliance_vs_alliance
 				WHERE alliance_id_2 = '.$db->escapeNumber($var['alliance_id']) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC');
 	if ($db->getNumRows() > 0) {
-		$PHP_OUTPUT.=('<div align="center">Deaths for '.$main_alliance->getAllianceName());
+		$PHP_OUTPUT.=('<div align="center">Deaths for '.$mainName);
 		$PHP_OUTPUT.=('<table class="standard"><tr><th align=center>Alliance Name</th>');
 		$PHP_OUTPUT.=('<th align="center">Amount</th></tr>');
 		while ($db->nextRecord()) {

--- a/engine/Default/rankings_alliance_vs_alliance.php
+++ b/engine/Default/rankings_alliance_vs_alliance.php
@@ -28,13 +28,12 @@ if (empty($alliancer)) {
 } else $alliance_vs = $alliancer;
 $alliance_vs[] = 0;
 
-foreach ($alliance_vs as $key => $id) {
+foreach ($alliance_vs as $curr_id) {
 	// get current alliance
-	$curr_alliance_id = $id;
-	if ($id > 0) {
+	if ($curr_id > 0) {
 
 		$PHP_OUTPUT.=('<td width=15% valign="top"');
-		if ($player->getAllianceID() == $curr_alliance_id)
+		if ($player->getAllianceID() == $curr_id)
 			$PHP_OUTPUT.=(' class="bold"');
 		$PHP_OUTPUT.=('>');
 		$PHP_OUTPUT.=('<select name="alliancer[]" id="InputFields" style="width:105">');
@@ -42,7 +41,7 @@ foreach ($alliance_vs as $key => $id) {
 		while ($db->nextRecord()) {
 			$curr_alliance = SmrAlliance::getAlliance($db->getField('alliance_id'), $player->getGameID());
 			$PHP_OUTPUT.=('<option value=' . $db->getField('alliance_id'));
-			if ($id == $db->getField('alliance_id'))
+			if ($curr_id == $db->getField('alliance_id'))
 				$PHP_OUTPUT.=(' selected');
 			$PHP_OUTPUT.=('>' . $curr_alliance->getAllianceName() . '</option>');
 		}
@@ -52,13 +51,14 @@ foreach ($alliance_vs as $key => $id) {
 }
 $PHP_OUTPUT.=('<td width=10% valign="top">None</td>');
 $PHP_OUTPUT.=('</tr>');
-foreach ($alliance_vs as $key => $id) {
+
+foreach ($alliance_vs as $curr_id) {
 	$PHP_OUTPUT.=('<tr>');
 	// get current alliance
+	$curr_alliance = SmrAlliance::getAlliance($curr_id, $player->getGameID());
 	$container1 = create_container('skeleton.php', 'rankings_alliance_vs_alliance.php');
-	$curr_id = $id;
-	if ($id > 0) {
-		$curr_alliance = SmrAlliance::getAlliance($id, $player->getGameID());
+	$container1['alliance_id'] = $curr_alliance->getAllianceID();
+	if ($curr_id > 0) {
 
 		$PHP_OUTPUT.=('<td width=10% valign="top"');
 		if ($player->getAllianceID() == $curr_alliance->getAllianceID())
@@ -66,20 +66,19 @@ foreach ($alliance_vs as $key => $id) {
 		if ($curr_alliance->hasDisbanded())
 			$PHP_OUTPUT.=(' class="red"');
 		$PHP_OUTPUT.=('>');
-		$container1['alliance_id']	= $curr_alliance->getAllianceID();
 		$PHP_OUTPUT.=create_link($container1, $curr_alliance->getAllianceName());
 		$PHP_OUTPUT.=('</td>');
 	}
 	else {
-		$container1['alliance_id']	= 0;
 		$PHP_OUTPUT.=('<td width=10% valign="top">');
 		$PHP_OUTPUT.=create_link($container1, 'None');
 		$PHP_OUTPUT.=('</td>');
 	}
 
-	foreach ($alliance_vs as $key => $id) {
+	foreach ($alliance_vs as $id) {
 		$row_alliance = SmrAlliance::getAlliance($id, $player->getGameID());
-		$showRed = $curr_alliance->hasDisbanded() || $row_alliance->hasDisbanded();
+		$showRed = ($curr_alliance->getAllianceID() != 0 && $curr_alliance->hasDisbanded()) ||
+		           ($row_alliance->getAllianceID() != 0 && $row_alliance->hasDisbanded());
 		$showBold = $curr_id == $player->getAllianceID() || $id == $player->getAllianceID();
 		if ($curr_id == $id && $id != 0) {
 			if ($showRed)

--- a/engine/Default/rankings_alliance_vs_alliance.php
+++ b/engine/Default/rankings_alliance_vs_alliance.php
@@ -68,6 +68,7 @@ $PHP_OUTPUT.=('</tr>');
 foreach ($alliance_vs as $key => $id) {
 	$PHP_OUTPUT.=('<tr>');
 	// get current alliance
+	$container1 = create_container('skeleton.php', 'rankings_alliance_vs_alliance.php');
 	$curr_id = $id;
 	if ($id > 0) {
 		$curr_alliance = SmrAlliance::getAlliance($id, $player->getGameID());
@@ -80,18 +81,12 @@ foreach ($alliance_vs as $key => $id) {
 		if ($out)
 			$PHP_OUTPUT.=(' class="red"');
 		$PHP_OUTPUT.=('>');
-		$container1 = array();
-		$container1['url']			= 'skeleton.php';
-		$container1['body']		= 'rankings_alliance_vs_alliance.php';
 		$container1['alliance_id']	= $curr_alliance->getAllianceID();
 		$PHP_OUTPUT.=create_link($container1, $curr_alliance->getAllianceName());
 		//$PHP_OUTPUT.=('.$db->escapeString($curr_alliance->getAllianceName()');
 		$PHP_OUTPUT.=('</td>');
 	}
 	else {
-		$container1 = array();
-		$container1['url']			= 'skeleton.php';
-		$container1['body']		= 'rankings_alliance_vs_alliance.php';
 		$container1['alliance_id']	= 0;
 		$PHP_OUTPUT.=('<td width=10% valign="top">');
 		$PHP_OUTPUT.=create_link($container1, 'None');

--- a/engine/Default/rankings_alliance_vs_alliance.php
+++ b/engine/Default/rankings_alliance_vs_alliance.php
@@ -27,7 +27,6 @@ if (empty($alliancer)) {
 	$alliance_vs = array();
 	$db->query('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY alliance_kills DESC, alliance_name LIMIT 5');
 	while ($db->nextRecord()) $alliance_vs[] = $db->getField('alliance_id');
-	//$PHP_OUTPUT.=('empty '.$alliancer);
 
 } else $alliance_vs = $alliancer;
 $alliance_vs[] = 0;
@@ -41,11 +40,6 @@ foreach ($alliance_vs as $key => $id) {
 		if ($player->getAllianceID() == $curr_alliance_id)
 			$PHP_OUTPUT.=(' class="bold"');
 		$PHP_OUTPUT.=('>');
-		/*$container = array();
-		$container['url']			= 'skeleton.php';
-		$container['body']			= 'alliance_roster.php';
-		$container['alliance_id']	= $curr_alliance_id;
-		$PHP_OUTPUT.=create_link($container, '.$db->escapeString($curr_alliance->getAllianceName()');*/
 		$PHP_OUTPUT.=('<select name="alliancer[]" id="InputFields" style="width:105">');
 		$db->query('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_deaths > 0 OR alliance_kills > 0) ORDER BY alliance_name');
 		while ($db->nextRecord()) {
@@ -58,11 +52,9 @@ foreach ($alliance_vs as $key => $id) {
 		$PHP_OUTPUT.='</select>';
 		$PHP_OUTPUT.=('</td>');
 	}
-	//$alliance_vs[] = $curr_alliance_id;
 }
 $PHP_OUTPUT.=('<td width=10% valign="top">None</td>');
 $PHP_OUTPUT.=('</tr>');
-//$db->query('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY alliance_kills DESC, alliance_name LIMIT 5');
 foreach ($alliance_vs as $key => $id) {
 	$PHP_OUTPUT.=('<tr>');
 	// get current alliance
@@ -79,7 +71,6 @@ foreach ($alliance_vs as $key => $id) {
 		$PHP_OUTPUT.=('>');
 		$container1['alliance_id']	= $curr_alliance->getAllianceID();
 		$PHP_OUTPUT.=create_link($container1, $curr_alliance->getAllianceName());
-		//$PHP_OUTPUT.=('.$db->escapeString($curr_alliance->getAllianceName()');
 		$PHP_OUTPUT.=('</td>');
 	}
 	else {

--- a/engine/Default/rankings_alliance_vs_alliance.php
+++ b/engine/Default/rankings_alliance_vs_alliance.php
@@ -36,8 +36,6 @@ foreach ($alliance_vs as $key => $id) {
 	// get current alliance
 	$curr_alliance_id = $id;
 	if ($id > 0) {
-		$db->query('SELECT 1 FROM player WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-		$out = $db2->getNumRows() == 0;
 
 		$PHP_OUTPUT.=('<td width=15% valign="top"');
 		if ($player->getAllianceID() == $curr_alliance_id)
@@ -72,13 +70,11 @@ foreach ($alliance_vs as $key => $id) {
 	$curr_id = $id;
 	if ($id > 0) {
 		$curr_alliance = SmrAlliance::getAlliance($id, $player->getGameID());
-		$db2->query('SELECT 1 FROM player WHERE alliance_id = ' . $db2->escapeNumber($curr_id) . ' AND game_id = ' . $db2->escapeNumber($player->getGameID()) . ' LIMIT 1');
-		$out = $db2->nextRecord();
 
 		$PHP_OUTPUT.=('<td width=10% valign="top"');
 		if ($player->getAllianceID() == $curr_alliance->getAllianceID())
 			$PHP_OUTPUT.=(' class="bold"');
-		if ($out)
+		if ($curr_alliance->hasDisbanded())
 			$PHP_OUTPUT.=(' class="red"');
 		$PHP_OUTPUT.=('>');
 		$container1['alliance_id']	= $curr_alliance->getAllianceID();
@@ -94,13 +90,13 @@ foreach ($alliance_vs as $key => $id) {
 	}
 
 	foreach ($alliance_vs as $key => $id) {
-		$db2->query('SELECT 1 FROM player WHERE alliance_id = ' . $db2->escapeNumber($id) . ' AND game_id = ' . $db2->escapeNumber($player->getGameID()) . ' LIMIT 1');
-		if ($db2->nextRecord() == 0) $out2 = TRUE;
-		else $out2 = FALSE;
+		$row_alliance = SmrAlliance::getAlliance($id, $player->getGameID());
+		$showRed = $curr_alliance->hasDisbanded() || $row_alliance->hasDisbanded();
+		$showBold = $curr_id == $player->getAllianceID() || $id == $player->getAllianceID();
 		if ($curr_id == $id && $id != 0) {
-			if (($out || $out2))
+			if ($showRed)
 				$PHP_OUTPUT.=('<td class="red">-');
-			elseif ($id == $player->getAllianceID() || $curr_id == $player->getAllianceID())
+			elseif ($showBold)
 				$PHP_OUTPUT.=('<td class="bold">-');
 			else $PHP_OUTPUT.=('<td>-');
 		}
@@ -109,24 +105,17 @@ foreach ($alliance_vs as $key => $id) {
 						WHERE alliance_id_2 = ' . $db2->escapeNumber($curr_id) . '
 							AND alliance_id_1 = ' . $db2->escapeNumber($id) . '
 							AND game_id = ' . $db2->escapeNumber($player->getGameID()));
+			$PHP_OUTPUT.=('<td');
+			if ($showRed && $showBold)
+				$PHP_OUTPUT.=(' class="bold red"');
+			elseif ($showRed)
+				$PHP_OUTPUT.=(' class="red"');
+			elseif ($showBold)
+				$PHP_OUTPUT.=(' class="bold"');
+			$PHP_OUTPUT.=('>');
 			if ($db2->nextRecord()) {
-				$PHP_OUTPUT.=('<td');
-				if (($out || $out2) && ($id == $player->getAllianceID() || $curr_id == $player->getAllianceID()))
-					$PHP_OUTPUT.=(' class="bold red"');
-				elseif ($out || $out2)
-					$PHP_OUTPUT.=(' class="red"');
-				elseif ($id == $player->getAllianceID() || $curr_id == $player->getAllianceID()) $PHP_OUTPUT.=(' class="bold"');
-				$PHP_OUTPUT.=('>');
 				$PHP_OUTPUT.= $db2->getField('kills');
-			}
-			else {
-				$PHP_OUTPUT.=('<td');
-				if (($out || $out2) && ($id == $player->getAllianceID() || $curr_id == $player->getAllianceID()))
-					$PHP_OUTPUT.=(' class="bold red"');
-				elseif ($out || $out2)
-					$PHP_OUTPUT.=(' class="red"');
-				elseif ($id == $player->getAllianceID() || $curr_id == $player->getAllianceID()) $PHP_OUTPUT.=(' class="bold"');
-				$PHP_OUTPUT.=('>');
+			} else {
 				$PHP_OUTPUT.=('0');
 			}
 		}

--- a/engine/Default/rankings_alliance_vs_alliance.php
+++ b/engine/Default/rankings_alliance_vs_alliance.php
@@ -11,10 +11,7 @@ $container['body'] = 'rankings_alliance_vs_alliance.php';
 
 $PHP_OUTPUT.=create_echo_form($container);
 
-if (isset($_REQUEST['alliancer'])) {
-	SmrSession::updateVar('alliancer',$_REQUEST['alliancer']);
-	$alliancer = $var['alliancer'];
-}
+$alliancer = SmrSession::getRequestVar('alliancer');
 
 $PHP_OUTPUT.=('<div align="center">');
 $PHP_OUTPUT.=('<p>Here are the rankings of alliances vs other alliances<br />');


### PR DESCRIPTION
Bug fixes:
* Display 'No Alliance' instead of the empty string when selecting details of allianceless player kills/deaths.
* Fix PHP warning resulting from calling `getNumRows` on a query-less database instance.
* Fix inverted color scheme of defunct vs. existing alliances (red vs. white).
* Avoid an incorrect display name for displayed data when there are fewer than 5 active alliances by only displaying active alliances.

Also a bunch of file/logic cleanup and a few minor display changes that should not affect functionality.

![image](https://user-images.githubusercontent.com/846186/41514243-3f45f092-725a-11e8-946d-9d5d932762f9.png)
