### PR TITLE
smr_file_create.php: fix call to getAllBaseShips

### DIFF
--- a/engine/Default/smr_file_create.php
+++ b/engine/Default/smr_file_create.php
@@ -40,7 +40,7 @@ foreach ($hardwares as $hardware) {
 $file.='[Ships]
 ; Name = Race,Cost,TPH,Hardpoints,Power,+Equipment (Optional),+Restrictions(Optional)
 ; Restrictions:Align(Integer)' . EOL;
-foreach (AbstractSmrShip::getAllBaseShips($gameID) as $ship) {
+foreach (AbstractSmrShip::getAllBaseShips(Globals::getGameType($gameID)) as $ship) {
 	$file.=inify($ship['Name']).'='.Globals::getRaceName($ship['RaceID']).','.$ship['Cost'].','.$ship['Speed'].','.$ship['Hardpoint'].','.$ship['MaxPower'];
 	if($ship['MaxHardware']>0) {
 		$shipEquip=',ShipEquipment=';

--- a/lib/Default/AbstractSmrShip.class.inc
+++ b/lib/Default/AbstractSmrShip.class.inc
@@ -113,8 +113,8 @@ abstract class AbstractSmrShip {
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT * FROM ship_type ORDER BY ship_type_id ASC'); //TODO add game type id
 		while($db->nextRecord()) {
-			if(!isset(self::$CACHE_BASE_SHIPS[$gameTypeID][$db->getField('ship_type_id')])) {
-				self::$CACHE_BASE_SHIPS[$gameTypeID][$db->getField('ship_type_id')] = self::buildBaseShip($db);
+			if(!isset(self::$CACHE_BASE_SHIPS[$gameTypeID][$db->getInt('ship_type_id')])) {
+				self::$CACHE_BASE_SHIPS[$gameTypeID][$db->getInt('ship_type_id')] = self::buildBaseShip($db);
 			}
 		}
 		return self::$CACHE_BASE_SHIPS[$gameTypeID];


### PR DESCRIPTION
This call to `getAllBaseShips` passed `game_id` to the function
instead of `game_type_id`. Even though this argument is unused
(the ships are independent of game type at the moment), it is
implemented as an array key for the base ship cache.

By passing the wrong argument, we were unable to re-use the cache
for later calls. These later calls were also done serially for
each ship, which dramatically increased the query overhead.

Now that we pass the expected argument, we can re-use the cache
as expected, and significantly optimize the ship-related calls.