### PR TITLE
universe_create_sectors.php: Add connectivity display

### DIFF
--- a/admin/Default/1.6/universe_create_sectors.php
+++ b/admin/Default/1.6/universe_create_sectors.php
@@ -8,6 +8,10 @@ if (!isset($var['gal_on'])) SmrSession::updateVar('gal_on', 1);
 $galaxy = SmrGalaxy::getGalaxy($var['game_id'],$var['gal_on']);
 $galaxies = SmrGalaxy::getGameGalaxies($var['game_id']);
 
+$connectivity = round($galaxy->getConnectivity());
+$template->assign('ActualConnectivity', $connectivity);
+
+// Call this after all sectors have been cached in an efficient way.
 $mapSectors = $galaxy->getMapSectors();
 
 $template->assign('Galaxy', $galaxy);
@@ -25,7 +29,7 @@ if (isset($_REQUEST['connect']) && $_REQUEST['connect'] > 0) {
 else if (!isset($var['conn'])) {
 	SmrSession::updateVar('conn',100);
 }
-$template->assign('Connectivity', $var['conn']);
+$template->assign('RequestedConnectivity', $var['conn']);
 
 
 $container = $var;

--- a/lib/Default/SmrGalaxy.class.inc
+++ b/lib/Default/SmrGalaxy.class.inc
@@ -292,7 +292,20 @@ class SmrGalaxy {
 		}
 		return $problemTimes <= 350;
 	}
-	
+
+	/**
+	 * Returns the sector connectivity of the galaxy as a percent.
+	 */
+	public function getConnectivity() {
+		$totalLinks = 0;
+		foreach ($this->getSectors() as $galSector) {
+			$totalLinks += $galSector->getNumberOfLinks();
+		}
+		// There are 4 possible links per sector
+		$connectivity = 100 * $totalLinks / (4 * $this->getSize());
+		return $connectivity;
+	}
+
 	public function contains($sectorID) {
 		if($sectorID instanceof SmrSector) {
 			return $sectorID->getGalaxyID()==$this->getGalaxyID();

--- a/templates/Default/admin/Default/1.6/universe_create_sectors.php
+++ b/templates/Default/admin/Default/1.6/universe_create_sectors.php
@@ -11,12 +11,14 @@
 			<th>Type</th>
 			<th>Size</th>
 			<th>Max Force Time</th>
+			<th>Connectivity</th>
 		</tr>
 		<tr>
 			<td><?php echo $Galaxy->getName(); ?></td>
 			<td><?php echo $Galaxy->getGalaxyType(); ?></td>
 			<td><?php echo $Galaxy->getWidth(); ?> x <?php echo $Galaxy->getHeight(); ?></td>
 			<td><?php echo $Galaxy->getMaxForceTime() / 3600; ?> hours</td>
+			<td><?php echo $ActualConnectivity; ?>%</td>
 		</tr>
 	</table>
 	<br />
@@ -38,7 +40,7 @@
 		<td>
 			<form method="POST" action="<?php echo $SubmitChangesHREF; ?>">
 				Connection Percent<br />
-				<input type="number" name="connect" value="<?php echo $Connectivity; ?>" size="3"><br />
+				<input type="number" name="connect" value="<?php echo $RequestedConnectivity; ?>" size="3"><br />
 				<input type="submit" name="submit" value="Redo Connections">
 			</form>
 		</td>


### PR DESCRIPTION
Since the method to set the sector connectivity is random,
the resulting connectivity will not necessarily match the
requested connectivity. Therefore, it is useful to display
the actual connectivity of the sectors in each galaxy.

![image](https://user-images.githubusercontent.com/846186/41699974-49374762-74db-11e8-9462-b22ef9047013.png)
