### PR TITLE
SmrPlayer: refactor getHome

### DIFF
--- a/engine/Default/game_join_processing.php
+++ b/engine/Default/game_join_processing.php
@@ -52,16 +52,7 @@ if ($credits > 0) {
 }
 
 // put him in a sector with a hq
-$hq_id = $race_id + 101;
-$db->query('SELECT * FROM location JOIN sector USING(game_id, sector_id) ' .
-		'WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND ' .
-		'location_type_id = '.$db->escapeNumber($hq_id));
-if ($db->nextRecord()) {
-	$home_sector_id = $db->getInt('sector_id');
-}
-else {
-	$home_sector_id = 1;
-}
+$home_sector_id = SmrPlayer::getHome($gameID, $race_id);
 
 // for newbie and beginner another ship, more shields and armour
 $isNewbie = !$account->isVeteran();
@@ -148,7 +139,7 @@ $db->query('INSERT INTO player_visited_sector (account_id, game_id, sector_id)
               FROM sector WHERE game_id = ' . $db->escapeNumber($gameID));
 
 // Mark the player's start sector as visited
-SmrSector::getSector($gameID, $home_sector_id)->markVisited($player);
+$player->getSector()->markVisited($player);
 
 if ($isNewbie) {
 	//we are a newb set our alliance to be Newbie Help Allaince

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -946,7 +946,6 @@ abstract class AbstractSmrPlayer {
 	abstract public function &killPlayerByForces(SmrForce $forces);
 	abstract public function &killPlayerByPort(SmrPort $port);
 	abstract public function &killPlayerByPlanet(SmrPlanet $planet);
-	abstract public function getHome();
 
 
 	public function getTurns() {

--- a/lib/Default/DummyPlayer.class.inc
+++ b/lib/Default/DummyPlayer.class.inc
@@ -91,17 +91,13 @@ class DummyPlayer extends AbstractSmrPlayer {
 		// adapt turns
 //		$this->setTurns(round($this->turns / $old_speed * $new_speed),100);
 
-		$this->setSectorID($this->getHome());
+		$this->setSectorID(1);
 		$this->increaseDeaths(1);
 		$this->setLandedOnPlanet(false);
 		$this->setDead(true);
 //		$this->setNewbieWarning(true);
 		$this->getShip()->getPod();
 		
-	}
-	
-	public function getHome() {
-		return 1;
 	}
 	
 	public function setAllianceID($ID) {

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -925,7 +925,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$newCredits = 100000;
 		$this->setCredits($newCredits);
 
-		$this->setSectorID($this->getHome());
+		$this->setSectorID($this::getHome($this->getGameID(), $this->getRaceID()));
 		$this->increaseDeaths(1);
 		$this->setLandedOnPlanet(false);
 		$this->setDead(true);
@@ -937,16 +937,16 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->setTurns(round($this->turns / $old_speed * $new_speed),100);
 	}
 
-	public function getHome() {
+	static public function getHome($gameID, $raceID) {
 		// get his home sector
-		$hq_id = GOVERNMENT + $this->getRaceID();
-		$this->db->query('SELECT sector_id FROM location JOIN sector USING(game_id, sector_id)
-							WHERE game_id = ' . $this->db->escapeNumber($this->getGameID()) . '
-							AND location_type_id = ' . $this->db->escapeNumber($hq_id) . ' LIMIT 1');
-		if ($this->db->nextRecord())
-			return $this->db->getInt('sector_id');
-		else
+		$hq_id = GOVERNMENT + $raceID;
+		$raceHqSectors = SmrSector::getLocationSectors($gameID, $hq_id);
+		if (!empty($raceHqSectors)) {
+			// If race has multiple HQ's for some reason, use the first one
+			return key($raceHqSectors);
+		} else {
 			return 1;
+		}
 	}
 
 	public function &killPlayerByPlayer(AbstractSmrPlayer $killer) {


### PR DESCRIPTION
Use `SmrSector::getLocationSectors` to avoid an explicit database
query. This also has the benefit of caching the sector, since we
will certainly need it.

We also make the method static so that it can be used in
game_join_processing.php before the `player` record has been
created (and thus we do not have access to an SmrPlayer instance).

Remove `getHome` from the abstract base class, because we remove
it completely from DummyPlayer (it serves no real purpose there).
