### PR TITLE
SmrSector: make clearCache more complete

### DIFF
--- a/lib/Default/SmrSector.class.inc
+++ b/lib/Default/SmrSector.class.inc
@@ -76,6 +76,7 @@ class SmrSector {
 	}
 
 	public static function clearCache() {
+		self::$CACHE_LOCATION_SECTORS = array();
 		self::$CACHE_GALAXY_SECTORS = array();
 		self::$CACHE_SECTORS = array();
 	}


### PR DESCRIPTION
This method was not clearing all the caches owned by SmrSector.
We now also clear the `CACHE_LOCATION_SECTORS` cache for
completeness (even though it is only used in one obscure place).