### PR TITLE
Remove "Past Maintenance" feature

### DIFF
--- a/engine/Default/game_play.php
+++ b/engine/Default/game_play.php
@@ -62,7 +62,7 @@ if ($db->getNumRows() > 0) {
 		$container_game['body'] = 'game_stats.php';
 		$container_game['game_id'] = $game_id;
 		$games['Play'][$game_id]['GameStatsLink'] = SmrSession::getNewHREF($container_game);
-		$games['Play'][$game_id]['Maintenance'] = $curr_player->getTurns();
+		$games['Play'][$game_id]['Turns'] = $curr_player->getTurns();
 		$games['Play'][$game_id]['LastMovement'] = format_time(TIME-$curr_player->getLastActive(),TRUE);
 
 	}

--- a/lib/Default/AbstractSmrCombatWeapon.class.inc
+++ b/lib/Default/AbstractSmrCombatWeapon.class.inc
@@ -2,6 +2,11 @@
 require_once('AbstractSmrPlayer.class.inc');
 require_once('SmrForce.class.inc');
 abstract class AbstractSmrCombatWeapon {
+	/**
+	 * Reduce the damage done to planets by this factor
+	 */
+	const PLANET_DAMAGE_MOD = 0.2;
+
 	protected $gameTypeID;
 	protected $name;
 	protected $raceID;

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -35,8 +35,6 @@ abstract class AbstractSmrPlayer {
 	protected $deaths;
 	protected $gadgets;
 	protected $stats;
-	protected $pastMaintBought;
-	protected $pastMaintCredit;
 	protected $pureRelations;
 	protected $relations;
 	protected $militaryPayment;
@@ -585,14 +583,6 @@ abstract class AbstractSmrPlayer {
 		$this->hasChanged=true;
 	}
 
-	public abstract function getPastMaintBought();
-	public abstract function getPastMaintCredit();
-	public function getPastMaint() {
-		$pastMaint = $this->getPastMaintBought()+$this->getPastMaintCredit();
-		if ($pastMaint < 0) return 0;
-		return $pastMaint;
-	}
-
 	protected abstract function getGadgetsData();
 	public function getGadgets() {
 		$this->getGadgetsData();
@@ -655,22 +645,6 @@ abstract class AbstractSmrPlayer {
 	}
 
 	abstract public function &getShip();
-
-	public function getDiminishingPortAttack() {
-		return max(0,min(1, 1 - ($this->getPastMaint() / ($this->getShip()->getSpeed() * 25 + 450))));
-	}
-
-	public function getDiminishingPlanetAttack() {
-		return max(0,min(1, 1 - ($this->getPastMaint() / ($this->getShip()->getSpeed() * 25 + 450))));
-	}
-
-	public function getDiminishingForceAttack() {
-		return max(0,min(1, 1 - ($this->getPastMaint() / ($this->getShip()->getSpeed() * 25 + 900))));
-	}
-
-	public function getDiminishingTraderAttack() {
-		return max(0,min(1, 1 - ($this->getPastMaint() / ($this->getShip()->getSpeed() * 25 + 475))));
-	}
 
 	public function &shootPlayer(AbstractSmrPlayer $targetPlayer) {
 		return $this->getShip()->shootPlayer($targetPlayer);
@@ -979,9 +953,6 @@ abstract class AbstractSmrPlayer {
 		if ($this->newbieTurns < 0)
 			$this->newbieTurns = 0;
 
-		if (has_privilege('Unlimited Maintenance'))
-			$this->turns = $this->getMaxTurns();
-
 		$this->hasChanged=true;
 		if($updateLastActive === true) {
 			$this->setLastActive(TIME);
@@ -989,16 +960,15 @@ abstract class AbstractSmrPlayer {
 		}
 	}
 
-	public function takeTurns($take, $noob = 0,$updateLastActive = true) { // taking maint counts as activity by default
+	public function takeTurns($take, $noob = 0, $updateLastActive = true) {
 		if($take < 0 || $noob < 0)
 			throw new Exception('Trying to take negative turns.');
 		$take = ceil($take);
-		$new_maint = $this->getTurns() - $take;
+		$new_turns = $this->getTurns() - $take;
 		$newbiesTaken = min($this->getNewbieTurns(),$noob);
 		$new_noob = $this->getNewbieTurns() - $noob;
 
-		if(!has_beta_privilege('No SC Loss'))
-			$this->setTurns($new_maint,$new_noob,$updateLastActive);
+		$this->setTurns($new_turns, $new_noob, $updateLastActive);
 		$this->increaseHOF($take,array('Movement','Turns Used','Since Last Death'), HOF_ALLIANCE);
 		$this->increaseHOF($take,array('Movement','Turns Used','Total'), HOF_ALLIANCE);
 		$this->increaseHOF($newbiesTaken,array('Movement','Turns Used','Newbie'), HOF_ALLIANCE);

--- a/lib/Default/DummyPlayer.class.inc
+++ b/lib/Default/DummyPlayer.class.inc
@@ -11,8 +11,6 @@ class DummyPlayer extends AbstractSmrPlayer {
 		$this->sectorID					= 0;
 		$this->lastSectorID				= 0;
 		$this->turns					= 1000;
-		$this->originalMaintenance		= $this->turns;
-		$this->lastMaintenanceUpdate	= 0;
 		$this->newbieTurns				= 0;
 		$this->lastNewsUpdate			= 0;
 		$this->dead						= false;

--- a/lib/Default/DummyPlayer.class.inc
+++ b/lib/Default/DummyPlayer.class.inc
@@ -35,14 +35,6 @@ class DummyPlayer extends AbstractSmrPlayer {
 		$this->bounties = array();
 	}
 	
-	public function getPastMaintBought() {
-		return 0;
-	}
-	
-	public function getPastMaintCredit() {
-		return 0;
-	}
-	
 	protected function getGadgetsData() {
 	}
 	

--- a/lib/Default/SmrCombatDrones.class.inc
+++ b/lib/Default/SmrCombatDrones.class.inc
@@ -141,11 +141,6 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
 		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
 		
-		$diminishing = $weaponPlayer->getDiminishingForceAttack();
-		$damage['MaxDamage'] = ceil($diminishing * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($diminishing * $damage['Shield']);
-		$damage['Armour'] = ceil($diminishing * $damage['Armour']);
-		
 		$damage['Launched'] += $damage['Kamikaze'];
 		$damage['MaxDamage'] += $damage['Kamikaze'] * MINE_ARMOUR;
 		$damage['Shield'] += $damage['Kamikaze'] * MINE_ARMOUR;
@@ -159,15 +154,10 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		$damage =& $this->getModifiedDamage();
 		$damage['Launched'] = ceil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPort($weaponPlayer,$port) / 100);
-		$damage['MaxDamage'] = $damage['Launched'] * $damage['MaxDamage'];
-		$damage['Shield'] = $damage['Launched'] * $damage['Shield'];
-		$damage['Armour'] = $damage['Launched'] * $damage['Armour'];
+		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage']);
+		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
+		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
 		
-		$diminishing = $weaponPlayer->getDiminishingPortAttack();
-		$damage['MaxDamage'] = ceil($diminishing * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($diminishing * $damage['Shield']);
-		$damage['Armour'] = ceil($diminishing * $damage['Armour']);
-			
 		return $damage;
 	}
 	
@@ -176,19 +166,11 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		$damage =& $this->getModifiedDamage();
 		$damage['Launched'] = ceil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPlanet($weaponPlayer,$planet) / 100);
-		$damage['MaxDamage'] = $damage['Launched'] * $damage['MaxDamage'];
-		$damage['Shield'] = $damage['Launched'] * $damage['Shield'];
-		$damage['Armour'] = $damage['Launched'] * $damage['Armour'];
+		$planetMod = self::PLANET_DAMAGE_MOD;
+		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage'] * $planetMod);
+		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield'] * $planetMod);
+		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour'] * $planetMod);
 		
-		$damage['MaxDamage'] /= 5;
-		$damage['Shield'] /= 5;
-		$damage['Armour'] /= 5;
-		
-		$diminishing = $weaponPlayer->getDiminishingPlanetAttack();
-		$damage['MaxDamage'] = ceil($diminishing * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($diminishing * $damage['Shield']);
-		$damage['Armour'] = ceil($diminishing * $damage['Armour']);
-			
 		return $damage;
 	}
 	
@@ -198,10 +180,6 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			return $return;
 		}
 		$damage =& $this->getModifiedDamage();
-		$diminishing = $weaponPlayer->getDiminishingTraderAttack();
-		$damage['MaxDamage'] = ceil($diminishing * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($diminishing * $damage['Shield']);
-		$damage['Armour'] = ceil($diminishing * $damage['Armour']);
 		if($targetPlayer->getShip()->hasDCS()) {
 			$damage['MaxDamage'] *= DCS_PLAYER_DAMAGE_DECIMAL_PERCENT;
 			$damage['Shield'] *= DCS_PLAYER_DAMAGE_DECIMAL_PERCENT;

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -20,7 +20,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	protected $tickers;
 
-	protected $originalMaintenance;
 	protected $lastTurnUpdate;
 	protected $lastNewsUpdate;
 	protected $attackColour;
@@ -152,7 +151,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$this->sectorID						= (int) $result['sector_id'];
 			$this->lastSectorID					= (int) $result['last_sector_id'];
 			$this->turns						= (int) $result['turns'];
-			$this->originalMaintenance			= $this->turns;
 			$this->lastTurnUpdate				= (int) $result['last_turn_update'];
 			$this->newbieTurns					= (int) $result['newbie_turns'];
 			$this->lastNewsUpdate				= (int) $result['last_news_update'];
@@ -474,10 +472,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 //	function getPastKnowledge() {
 //		return $this->pastKnowledge;
 //	}
-
-	function getOriginalMaintenance() {
-		return $this->originalMaintenance;
-	}
 
 	/**
 	 * Calculate the time in seconds between the given time and when the

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -264,10 +264,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 				return $this->zoom;
 			case 'Bank':
 				return $this->bank;
-			case 'Maintenance':
 			case 'Turns':
 				return $this->turns;
-			case 'Last Maintenance Update':
 			case 'Last Turn Update':
 				return $this->lastTurnUpdate;
 			case 'Last Active':
@@ -585,44 +583,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->lastTurnUpdate=$time;
 		$this->hasChanged=true;
 //		$sql = $this->db->query('UPDATE player SET last_turn_update = ' . $this->lastTurnUpdate . ' WHERE '. $this->SQL . ' LIMIT 1');
-	}
-
-	function getPastMaintBought() {
-		if(!isset($this->pastMaintBought)) {
-			//get past maint
-			$this->db->query('DELETE FROM player_repaired WHERE time < ' . $this->db->escapeNumber(TIME - 3600 * 20));
-			$this->db->query('SELECT sum(amount) as sum FROM player_repaired WHERE ' . $this->SQL . ' AND amount > 0 LIMIT 1');
-			if ($this->db->nextRecord()) {
-				$this->pastMaintBought = $this->db->getInt('sum');
-			}
-			else {
-				$this->pastMaintBought = 0;
-			}
-		}
-		return $this->pastMaintBought;
-	}
-
-	function getPastMaintCredit() {
-		if(!isset($this->pastMaintCredit)) {
-			//get past maint
-			$this->db->query('DELETE FROM player_repaired WHERE time < ' . $this->db->escapeNumber(TIME - 3600 * 20));
-			$this->db->query('SELECT sum(amount) as sum FROM player_repaired WHERE '.$this->SQL.' AND amount < 0 LIMIT 1');
-			if ($this->db->nextRecord()) $this->pastMaintCredit = $this->db->getInt('sum');
-			else $this->pastMaintCredit = 0;
-		}
-		return $this->pastMaintCredit;
-	}
-
-	function removePastMaint() {
-		$this->pastMaint=0;
-		$this->db->query('DELETE FROM player_repaired WHERE '.$this->SQL);
-	}
-
-	function addPastMaintBought($amount,$type='Normal') {
-		$this->getPastMaintBought();
-		$this->db->query('REPLACE INTO player_repaired (account_id, game_id, time, amount, source) VALUES (' . $this->db->escapeNumber($this->accountID) . ',' . $this->db->escapeNumber($this->gameID) . ',' . $this->db->escapeNumber(TIME) . ',' . $this->db->escapeNumber($amount) . ',' . $this->db->escapeString($type) . ')');
-		$this->giveTurns($amount*10);
-		$this->pastMaintBought+=$amount;
 	}
 
 	protected function getPureRelationsData() {

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -220,10 +220,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 		return $results;
 	}
 
-	public function getSQL() {
-		return $this->SQL;
-	}
-
 	function get($bit) {
 		switch($bit) {
 			case 'Sector ID':

--- a/lib/Default/SmrWeapon.class.inc
+++ b/lib/Default/SmrWeapon.class.inc
@@ -183,11 +183,6 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 		if(!$this->canShootForces()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		$damage =& $this->getModifiedDamage($weaponPlayer);
-		
-		$diminishing = $weaponPlayer->getDiminishingForceAttack();
-		$damage['MaxDamage'] = ceil($diminishing * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($diminishing * $damage['Shield']);
-		$damage['Armour'] = ceil($diminishing * $damage['Armour']);
 		return $damage;
 	}
 	
@@ -195,11 +190,6 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 		if(!$this->canShootPorts()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		$damage =& $this->getModifiedDamage($weaponPlayer);
-		
-		$diminishing = $weaponPlayer->getDiminishingPortAttack();
-		$damage['MaxDamage'] = ceil($diminishing * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($diminishing * $damage['Shield']);
-		$damage['Armour'] = ceil($diminishing * $damage['Armour']);
 		return $damage;
 	}
 	
@@ -208,14 +198,11 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		$damage =& $this->getModifiedDamage($weaponPlayer);
 		
-		$damage['MaxDamage'] /= 5;
-		$damage['Shield'] /= 5;
-		$damage['Armour'] /= 5;
+		$planetMod = self::PLANET_DAMAGE_MOD;
+		$damage['MaxDamage'] = ceil($damage['MaxDamage'] * $planetMod);
+		$damage['Shield'] = ceil($damage['Shield'] * $planetMod);
+		$damage['Armour'] = ceil($damage['Armour'] * $planetMod);
 		
-		$diminishing = $weaponPlayer->getDiminishingPlanetAttack();
-		$damage['MaxDamage'] = ceil($diminishing * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($diminishing * $damage['Shield']);
-		$damage['Armour'] = ceil($diminishing * $damage['Armour']);
 		return $damage;
 	}
 	
@@ -230,11 +217,6 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 			return $return;
 		}
 		$damage =& $this->getModifiedDamage($weaponPlayer);
-		
-		$diminishing = $weaponPlayer->getDiminishingTraderAttack();
-		$damage['MaxDamage'] = ceil($diminishing * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($diminishing * $damage['Shield']);
-		$damage['Armour'] = ceil($diminishing * $damage['Armour']);
 		return $damage;
 	}
 	

--- a/templates/Default/engine/Default/game_play.php
+++ b/templates/Default/engine/Default/game_play.php
@@ -31,7 +31,7 @@ if(isset($Message)) {
 					</td>
 					<td width="35%"><a href="<?php echo $Game['GameStatsLink']; ?>"><?php echo $Game['Name']; ?> (<?php echo $Game['ID']; ?>)</a></td>
 
-					<td class="center"><?php echo $Game['Maintenance']; ?></td>
+					<td class="center"><?php echo $Game['Turns']; ?></td>
 					<td class="center"><?php echo $Game['NumberPlaying']; ?></td>
 					<td><?php echo $Game['LastMovement']; ?></td>
 					<td class="noWrap"><?php echo $Game['EndDate']; ?></td>


### PR DESCRIPTION
Past Maintenance was a feature from SMR 1.5 that allowed players
to get more turns while reducing the effectiveness of their actions.

This was only partially implemented in SMR 1.6, but also entirely
unused.

If it were to ever be re-implemented, it would take more work to
modify the existing methods than to write it from scratch, so we
remove the no-op methods to help reduce the complexity of the
existing code and to avoid unnecessary database calls when
attacking.

Rename "Maintenance" to "Turns" in some places where the two concepts
were entangled.

NOTE: we also add the `PLANET_DAMAGE_MOD` constant to the
AbstractSmrCombatWeapon class to ensure that we consistently
reduce damage done to planets.
