### PR TITLE
smr.inc: Remove functions has_{,_beta}_privilege

### DIFF
--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -376,8 +376,6 @@ abstract class AbstractSmrPlayer {
 	public function setCredits($credits) {
 		if($this->credits == $credits)
 			return;
-		if (has_privilege('Money Doesn\'t Matter',$this->accountID)) 
-			return;
 		if($credits < 0)
 			throw new Exception('Trying to set negative credits.');
 		if($credits > MAX_MONEY)
@@ -939,14 +937,8 @@ abstract class AbstractSmrPlayer {
 		if($this->turns == $turns && ($this->newbieTurns == $newNoob || $newNoob==false) && !$updateLastActive)
 			return;
 
-		$this->turns = $turns;
-
-		if(!has_beta_privilege('No SC Change')) {
-			if ($this->turns < 0)
-				$this->turns = 0;
-			if ($this->turns > $this->getMaxTurns())
-				$this->turns = $this->getMaxTurns();
-		}
+		// Make sure turns are in range [0, MaxTurns]
+		$this->turns = max(0, min($turns, $this->getMaxTurns()));
 
 		if($newNoob !== false)
 			$this->newbieTurns = $newNoob;
@@ -979,8 +971,7 @@ abstract class AbstractSmrPlayer {
 			throw new Exception('Trying to give negative turns.');
 		$give = floor($give);
 
-		if(!has_beta_privilege('No SC Gain'))
-			$this->setTurns($this->getTurns() + $give,$this->getNewbieTurns() + $noob,$updateLastActive);
+		$this->setTurns($this->getTurns() + $give, $this->getNewbieTurns() + $noob, $updateLastActive);
 	}
 
 	public function getLastActive() {

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -437,7 +437,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 	function setBank($credits) {
 		if($this->bank == $credits)
 			return;
-		if (has_privilege('Money Doesn\'t Matter',$this->accountID)) return;
 		if($credits < 0)
 			throw new Exception('Trying to set negative credits.');
 		if($credits > MAX_MONEY)

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -205,47 +205,6 @@ function enableProtectionDependantRefresh($template, $player) {
 	$template->assign('AJAX_ENABLE_REFRESH',$ajaxRefresh);
 }
 
-function has_beta_privilege($priv = '', $acc = 0) {
-	//PAGE
-	return false;
-	global $PRIVILEGES, $ACCOUNT_ID,$BETA_CONSTANTS,$USE_BETA_CONSTANTS;
-	if($USE_BETA_CONSTANTS !== true)
-		return false;
-	if ($acc == 0) $acc = $ACCOUNT_ID;
-	switch($priv) {
-		case 'Create Universe':
-			if(isset($BETA_CONSTANTS['Anyone Create Games']) && $BETA_CONSTANTS['Anyone Create Games']===true)
-			return true;
-	}
-
-	if(isset($BETA_CONSTANTS[$priv])) {
-		if ($BETA_CONSTANTS[$priv] === true) return true;
-		if (is_array($BETA_CONSTANTS[$priv]) && in_array($acc, $BETA_CONSTANTS[$priv])) return true;
-	}
-	if (!isset($BETA_CONSTANTS['Privileges'][$acc])) return false; //means they have no privs
-	if ($priv == '') return true; //means they have some kind of priv
-	if(!isset($PRIVILEGES[$priv]))
-		return false;
-	if (in_array($PRIVILEGES[$priv], $BETA_CONSTANTS['Privileges'][$acc])) return true; //specific priv allowed
-	return false;
-}
-
-function has_privilege($priv = '', $acc = 0) {
-	//PAGE
-	return false;
-	//if ($priv == 'Always Join Alliances') return TRUE;
-	//if ($priv == 'See Location') return TRUE;
-	//if ($priv == 'Money Doesn\'t Matter') return TRUE;
-	global $ADMINS, $PRIVILEGES, $ACCOUNT_ID;
-	if ($acc == 0) $acc = $ACCOUNT_ID;
-	if(has_beta_privilege($priv,$acc))
-		return true;
-	if (!isset($ADMINS[$acc])) return FALSE; //means they have no privs
-	if ($priv == '') return TRUE; //means they have some kind of priv
-	if (in_array($PRIVILEGES[$priv], $ADMINS[$acc])) return TRUE; //specific priv allowed
-	return FALSE;
-}
-
 function create_echo_error($message) {
 
 	$return=('<h1>ERROR</h1>');


### PR DESCRIPTION
These functions specified privileges in some older version of the
game, but they currently don't do anything.

We have newer and better supported ways to specify privileges
now, so we simply remove these obsolete functions.