### PR TITLE
Optimize queries for constructing multiple class instances

### DIFF
--- a/engine/Default/alliance_forces.php
+++ b/engine/Default/alliance_forces.php
@@ -36,7 +36,7 @@ $template->assign('Total', $total);
 $template->assign('TotalCost', $totalCost);
 
 $db->query('
-SELECT sector_has_forces.sector_id, sector_has_forces.owner_id
+SELECT sector_has_forces.*
 FROM player
 JOIN sector_has_forces ON player.game_id = sector_has_forces.game_id AND player.account_id = sector_has_forces.owner_id
 WHERE player.game_id=' . $db->escapeNumber($alliance->getGameID()) . '
@@ -44,10 +44,8 @@ AND player.alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
 AND expire_time >= ' . $db->escapeNumber(TIME) . '
 ORDER BY sector_id ASC');
 
-$PHP_OUTPUT.= '<div align="center"><a href="' . WIKI_URL . '/game-guide/forces" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/></a>';
-
 $forces = array();
 while ($db->nextRecord()) {
-	$forces[] = SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'));
+	$forces[] = SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'), false, $db);
 }
 $template->assign('Forces', $forces);

--- a/engine/Default/current_players.php
+++ b/engine/Default/current_players.php
@@ -52,7 +52,7 @@ if ($count_last_active > 0) {
 	while ($db->nextRecord()) {
 		$row = array();
 
-		$curr_player = SmrPlayer::getPlayer($db->getRow(), $player->getGameID());
+		$curr_player = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
 		$row['player'] = $curr_player;
 
 		// How should we style the row for this player?

--- a/engine/Default/forces_list.php
+++ b/engine/Default/forces_list.php
@@ -2,7 +2,7 @@
 
 $template->assign('PageTopic','View Forces');
 
-$db->query('SELECT sector_id, owner_id
+$db->query('SELECT *
 			FROM sector_has_forces
 			WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . '
 			AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
@@ -11,6 +11,6 @@ $db->query('SELECT sector_id, owner_id
 
 $forces = array();
 while ($db->nextRecord()) {
-	$forces[] = SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'));
+	$forces[] = SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'), false, $db);
 }
 $template->assign('Forces', $forces);

--- a/engine/Default/game_stats.php
+++ b/engine/Default/game_stats.php
@@ -27,7 +27,7 @@ if ($db->getNumRows() > 0) {
 	$rank = 0;
 	$expRankings = array();
 	while ($db->nextRecord()) {
-		$expRankings[++$rank] = SmrPlayer::getPlayer($db->getRow(), $gameID);
+		$expRankings[++$rank] = SmrPlayer::getPlayer($db->getInt('account_id'), $gameID, false, $db);
 	}
 	$template->assign('ExperienceRankings',$expRankings);
 }
@@ -38,7 +38,7 @@ if ($db->getNumRows() > 0) {
 	$rank = 0;
 	$killRankings = array();
 	while ($db->nextRecord()) {
-		$killRankings[++$rank] = SmrPlayer::getPlayer($db->getRow(), $gameID);
+		$killRankings[++$rank] = SmrPlayer::getPlayer($db->getInt('account_id'), $gameID, false, $db);
 	}
 	$template->assign('KillRankings',$killRankings);
 }

--- a/engine/Default/shop_weapon_processing.php
+++ b/engine/Default/shop_weapon_processing.php
@@ -3,7 +3,7 @@ if(!$player->getSector()->hasLocation($var['LocationID'])) {
 	create_error('That location does not exist in this sector');
 }
 
-$weapon = SmrWeapon::getWeapon($player->getGameID(), $var['WeaponTypeID']);
+$weapon = SmrWeapon::getWeapon($var['WeaponTypeID']);
 // Are we buying?
 if (!isset($var['OrderID'])) {
 	$location = SmrLocation::getLocation($var['LocationID']);

--- a/engine/Default/trader_search_result.php
+++ b/engine/Default/trader_search_result.php
@@ -22,7 +22,7 @@ if (!empty($player_id)) {
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND player_name = ' . $db->escapeString($player_name) . ' LIMIT 1');
 	if ($db->nextRecord()) {
-		$resultPlayer = SmrPlayer::getPlayer($db->getRow(), $player->getGameID());
+		$resultPlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
 	}
 
 	$db->query('SELECT * FROM player
@@ -32,7 +32,7 @@ if (!empty($player_id)) {
 				ORDER BY player_name LIMIT 5');
 	$similarPlayers = array();
 	while ($db->nextRecord()) {
-		$similarPlayers[] = SmrPlayer::getPlayer($db->getRow(), $player->getGameID());
+		$similarPlayers[] = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
 	}
 }
 

--- a/engine/Draft/alliance_pick.php
+++ b/engine/Draft/alliance_pick.php
@@ -17,7 +17,7 @@ $template->assign('CanPick', $teams[$player->getAccountID()]['CanPick']);
 $players = array();
 $db->query('SELECT * FROM player WHERE game_id='.$db->escapeNumber($player->getGameID()).' AND (alliance_id=0 OR alliance_id='.$db->escapeNumber(NHA_ID).') AND account_id NOT IN (SELECT account_id FROM draft_leaders WHERE draft_leaders.game_id=player.game_id) AND sector_id!=1 AND account_id != '.$db->escapeNumber(ACCOUNT_ID_NHL).';');
 while($db->nextRecord()) {
-	$pickPlayer = SmrPlayer::getPlayer($db->getRow(), $player->getGameID());
+	$pickPlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
 	$players[] = array('Player' => $pickPlayer,
 						'HREF' => SmrSession::getNewHREF(create_container('alliance_pick_processing.php','',array('PickedAccountID'=>$pickPlayer->getAccountID()))));
 }

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -104,9 +104,9 @@ abstract class AbstractSmrPlayer {
 	 * Returns false if this player does not own a planet.
 	 */
 	public function getPlanet() {
-		$this->db->query('SELECT sector_id FROM planet WHERE game_id=' . $this->db->escapeNumber($this->getGameID()) . ' AND owner_id=' . $this->db->escapeNumber($this->getAccountID()));
+		$this->db->query('SELECT * FROM planet WHERE game_id=' . $this->db->escapeNumber($this->getGameID()) . ' AND owner_id=' . $this->db->escapeNumber($this->getAccountID()));
 		if ($this->db->nextRecord()) {
-			return SmrPlanet::getPlanet($this->getGameID(), $this->db->getInt('sector_id'));
+			return SmrPlanet::getPlanet($this->getGameID(), $this->db->getInt('sector_id'), false, $this->db);
 		} else {
 			return false;
 		}

--- a/lib/Default/AbstractSmrShip.class.inc
+++ b/lib/Default/AbstractSmrShip.class.inc
@@ -232,7 +232,7 @@ abstract class AbstractSmrShip {
 
 	public function &addWeapon($weaponTypeID) {
 		if($this->hasOpenWeaponSlots() && $this->hasRemainingPower()) {
-			$weapon = SmrWeapon::getWeapon($this->getGameID(),$weaponTypeID);
+			$weapon = SmrWeapon::getWeapon($weaponTypeID);
 			if($this->getRemainingPower()>=$weapon->getPowerLevel()) {
 				$this->weapons[count($this->weapons)] = $weapon;
 				$this->hasChangedWeapons = true;

--- a/lib/Default/DummyShip.class.inc
+++ b/lib/Default/DummyShip.class.inc
@@ -30,7 +30,7 @@ class DummyShip extends AbstractSmrShip {
 		$this->doFullUNO();
 //		for($i=0;$i<$this->getHardpoints();++$i) {
 //			if(!isset($this->weapons[$i]))
-//				$this->weapons[$i] = SmrWeapon::getWeapon($player->getGameID(),1);
+//				$this->weapons[$i] = SmrWeapon::getWeapon(1);
 //		}
 		$this->checkForExcessWeapons();
 	}

--- a/lib/Default/Plotter.class.inc
+++ b/lib/Default/Plotter.class.inc
@@ -11,7 +11,7 @@ class Plotter {
 			case 'Ships':
 				return AbstractSmrShip::getBaseShip(Globals::getGameType($gameID),$X);
 			case 'Weapons':
-				return SmrWeapon::getWeapon(Globals::getGameType($gameID),$X);
+				return SmrWeapon::getWeapon($X);
 			case 'Locations':
 				if(is_numeric($X)) {
 					return SmrLocation::getLocation($X);

--- a/lib/Default/Rankings.inc
+++ b/lib/Default/Rankings.inc
@@ -34,7 +34,7 @@ class Rankings {
 		while ($db->nextRecord()) {
 			// increase rank counter
 			$rank++;
-			$currentPlayer = SmrPlayer::getPlayer($db->getRow(), $player->getGameID());
+			$currentPlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
 
 			$class='';
 			if ($player->equals($currentPlayer)) {

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -365,7 +365,7 @@ class SmrAlliance {
 	 * Return all planets owned by members of this alliance.
 	 */
 	public function getPlanets() {
-		$this->db->query('SELECT planet.sector_id
+		$this->db->query('SELECT planet.*
 			FROM player
 			JOIN planet ON player.game_id = planet.game_id AND player.account_id = planet.owner_id
 			WHERE player.game_id=' . $this->db->escapeNumber($this->gameID) . '
@@ -374,7 +374,7 @@ class SmrAlliance {
 		');
 		$planets = array();
 		while ($this->db->nextRecord()) {
-			$planets[] = SmrPlanet::getPlanet($this->gameID, $this->db->getInt('sector_id'));
+			$planets[] = SmrPlanet::getPlanet($this->gameID, $this->db->getInt('sector_id'), false, $this->db);
 		}
 		return $planets;
 	}

--- a/lib/Default/SmrForce.class.inc
+++ b/lib/Default/SmrForce.class.inc
@@ -60,20 +60,17 @@ class SmrForce {
 			$forces = array();
 			while($db->nextRecord()) {
 				$ownerID = $db->getInt('owner_id');
-				$forces[$ownerID] = self::getForce($db->getRow(), $sectorID, $ownerID, $forceUpdate);
+				$forces[$ownerID] = self::getForce($gameID, $sectorID, $ownerID, $forceUpdate, $db);
 			}
 			self::$CACHE_SECTOR_FORCES[$gameID][$sectorID] = $forces;
 		}
 		return self::$CACHE_SECTOR_FORCES[$gameID][$sectorID];
 	}
 
-	public static function &getForce($gameIDOrResultArray, $sectorID, $ownerID, $forceUpdate = false) {
-		$gameID = is_array($gameIDOrResultArray) ?
-		          $gameIDOrResultArray['game_id'] :
-		          $gameIDOrResultArray;
+	public static function &getForce($gameID, $sectorID, $ownerID, $forceUpdate=false, $db=null) {
 		if($forceUpdate || !isset(self::$CACHE_FORCES[$gameID][$sectorID][$ownerID])) {
 			self::tidyUpForces(SmrGalaxy::getGalaxyContaining($gameID,$sectorID));
-			$p = new SmrForce($gameIDOrResultArray, $sectorID, $ownerID);
+			$p = new SmrForce($gameID, $sectorID, $ownerID, $db);
 			self::$CACHE_FORCES[$gameID][$sectorID][$ownerID] = $p;
 		}
 		return self::$CACHE_FORCES[$gameID][$sectorID][$ownerID];
@@ -94,32 +91,28 @@ class SmrForce {
 		}
 	}
 
-	protected function __construct($gameIDOrResultArray, $sectorID, $ownerID) {
+	protected function __construct($gameID, $sectorID, $ownerID, $db=null) {
 		$this->db = new SmrMySqlDatabase();
-		if (is_array($gameIDOrResultArray)) {
-			$result = $gameIDOrResultArray;
-			$this->gameID = $result['game_id'];
+
+		if (isset($db)) {
+			$this->isNew = false;
 		} else {
+			$db = $this->db;
 			$this->db->query('SELECT * FROM sector_has_forces
-							WHERE game_id = '.$this->db->escapeNumber($gameIDOrResultArray).'
+							WHERE game_id = '.$this->db->escapeNumber($gameID).'
 								AND sector_id = '.$this->db->escapeNumber($sectorID).'
 								AND owner_id = '.$this->db->escapeNumber($ownerID).' LIMIT 1');
-			$this->db->nextRecord();
-			$result = $this->db->getRow();
-			$this->gameID = $gameIDOrResultArray;
+			$this->isNew = !$db->nextRecord();
 		}
 
+		$this->gameID = $gameID;
 		$this->ownerID = $ownerID;
 		$this->sectorID = $sectorID;
-		if ($result) {
-			$this->combatDrones = (int) $result['combat_drones'];
-			$this->scoutDrones = (int) $result['scout_drones'];
-			$this->mines = (int) $result['mines'];
-			$this->expire = (int) $result['expire_time'];
-			$this->isNew = false;
-		}
-		else {
-			$this->isNew = true;
+		if (!$this->isNew) {
+			$this->combatDrones = $db->getInt('combat_drones');
+			$this->scoutDrones = $db->getInt('scout_drones');
+			$this->mines = $db->getInt('mines');
+			$this->expire = $db->getInt('expire_time');
 		}
 	}
 

--- a/lib/Default/SmrForce.class.inc
+++ b/lib/Default/SmrForce.class.inc
@@ -15,6 +15,7 @@ class SmrForce {
 	protected static $refreshAllHREF;
 
 	protected $db;
+	protected $SQL;
 
 	protected $ownerID;
 	protected $sectorID;
@@ -93,15 +94,15 @@ class SmrForce {
 
 	protected function __construct($gameID, $sectorID, $ownerID, $db=null) {
 		$this->db = new SmrMySqlDatabase();
+		$this->SQL = 'game_id = '.$this->db->escapeNumber($gameID).'
+		              AND sector_id = '.$this->db->escapeNumber($sectorID).'
+		              AND owner_id = '.$this->db->escapeNumber($ownerID);
 
 		if (isset($db)) {
 			$this->isNew = false;
 		} else {
 			$db = $this->db;
-			$this->db->query('SELECT * FROM sector_has_forces
-							WHERE game_id = '.$this->db->escapeNumber($gameID).'
-								AND sector_id = '.$this->db->escapeNumber($sectorID).'
-								AND owner_id = '.$this->db->escapeNumber($ownerID).' LIMIT 1');
+			$this->db->query('SELECT * FROM sector_has_forces WHERE ' . $this->SQL);
 			$this->isNew = !$db->nextRecord();
 		}
 
@@ -366,15 +367,11 @@ class SmrForce {
 	public function update() {
 		if(!$this->isNew) {
 			if (!$this->exists()) {
-				$this->db->query('DELETE FROM sector_has_forces ' .
-							 'WHERE game_id = '.$this->db->escapeNumber($this->gameID).' AND ' .
-									'sector_id = '.$this->db->escapeNumber($this->sectorID).' AND ' .
-									'owner_id = '.$this->db->escapeNumber($this->ownerID));
+				$this->db->query('DELETE FROM sector_has_forces WHERE ' . $this->SQL);
 				$this->isNew=true;
 			}
 			else if ($this->hasChanged) {
-				$this->db->query('UPDATE sector_has_forces SET combat_drones = '.$this->db->escapeNumber($this->combatDrones).', scout_drones = ' . $this->db->escapeNumber($this->scoutDrones) . ', mines = ' . $this->db->escapeNumber($this->mines) . ', expire_time = ' . $this->db->escapeNumber($this->expire) . '
-									WHERE game_id = ' . $this->db->escapeNumber($this->gameID) . ' AND sector_id = ' . $this->db->escapeNumber($this->sectorID) . ' AND owner_id = ' . $this->db->escapeNumber($this->ownerID) . ' LIMIT 1 ');
+				$this->db->query('UPDATE sector_has_forces SET combat_drones = '.$this->db->escapeNumber($this->combatDrones).', scout_drones = ' . $this->db->escapeNumber($this->scoutDrones) . ', mines = ' . $this->db->escapeNumber($this->mines) . ', expire_time = ' . $this->db->escapeNumber($this->expire) . ' WHERE ' . $this->SQL);
 			}
 		}
 		else if($this->exists()) {
@@ -390,7 +387,7 @@ class SmrForce {
 	 * Update the table fields associated with using Refresh All
 	 */
 	public function updateRefreshAll(SmrPlayer $player, $refreshTime) {
-		$this->db->query('UPDATE sector_has_forces SET refresh_at=' . $this->db->escapeNumber($refreshTime) . ', refresher=' . $this->db->escapeNumber($player->getAccountID()) . ' WHERE game_id = ' . $this->db->escapeNumber($this->getGameID()) . ' AND sector_id = ' . $this->db->escapeNumber($this->getSectorID()) . ' AND owner_id=' . $this->db->escapeNumber($this->getOwnerID()) . ' LIMIT 1');
+		$this->db->query('UPDATE sector_has_forces SET refresh_at=' . $this->db->escapeNumber($refreshTime) . ', refresher=' . $this->db->escapeNumber($player->getAccountID()) . ' WHERE ' . $this->SQL);
 	}
 
 	public function getExamineDropForcesHREF() {

--- a/lib/Default/SmrGalaxy.class.inc
+++ b/lib/Default/SmrGalaxy.class.inc
@@ -21,20 +21,20 @@ class SmrGalaxy {
 	public static function &getGameGalaxies($gameID,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_GAME_GALAXIES[$gameID])) {
 			$db = new SmrMySqlDatabase();
-			$db->query('SELECT galaxy_id FROM game_galaxy WHERE game_id = ' . $db->escapeNumber($gameID) .' ORDER BY galaxy_id ASC');
+			$db->query('SELECT * FROM game_galaxy WHERE game_id = ' . $db->escapeNumber($gameID) .' ORDER BY galaxy_id ASC');
 			$galaxies = array();
 			while($db->nextRecord()) {
 				$galaxyID = $db->getField('galaxy_id');
-				$galaxies[$galaxyID] = self::getGalaxy($gameID,$galaxyID,$forceUpdate);
+				$galaxies[$galaxyID] = self::getGalaxy($gameID, $galaxyID, $forceUpdate, $db);
 			}
 			self::$CACHE_GAME_GALAXIES[$gameID] = $galaxies;
 		}
 		return self::$CACHE_GAME_GALAXIES[$gameID];
 	}
 
-	public static function &getGalaxy($gameID,$galaxyID,$forceUpdate = false) {
+	public static function &getGalaxy($gameID, $galaxyID, $forceUpdate=false, $db=null) {
 		if($forceUpdate || !isset(self::$CACHE_GALAXIES[$gameID][$galaxyID])) {
-			$g = new SmrGalaxy($gameID,$galaxyID);
+			$g = new SmrGalaxy($gameID, $galaxyID, false, $db);
 			self::$CACHE_GALAXIES[$gameID][$galaxyID] = $g;
 		}
 		return self::$CACHE_GALAXIES[$gameID][$galaxyID];
@@ -56,27 +56,27 @@ class SmrGalaxy {
 		return self::$CACHE_GALAXIES[$gameID][$galaxyID];
 	}
 	
-	protected function __construct($gameID, $galaxyID,$create=false) {
+	protected function __construct($gameID, $galaxyID, $create=false, $db=null) {
 		$this->db = new SmrMySqlDatabase();
 
-		$this->db->query('SELECT * FROM game_galaxy WHERE game_id = ' . $this->db->escapeNumber($gameID) . '
+		if (isset($db)) {
+			$this->isNew = false;
+		} else {
+			$db = $this->db;
+			$db->query('SELECT * FROM game_galaxy WHERE game_id = ' . $this->db->escapeNumber($gameID) . '
 							AND galaxy_id = ' . $this->db->escapeNumber($galaxyID) . ' LIMIT 1');
-		if($this->db->nextRecord()) {
-			$this->gameID		= $this->db->getInt('game_id');
-			$this->galaxyID		= $this->db->getInt('galaxy_id');
-			$this->name			= $this->db->getField('galaxy_name');
-			$this->width		= $this->db->getInt('width');
-			$this->height		= $this->db->getInt('height');
-			$this->galaxyType	= $this->db->getField('galaxy_type');
-			$this->maxForceTime	= $this->db->getInt('max_force_time');
+			$this->isNew = !$db->nextRecord();
 		}
-		else if($create===true) {
-			$this->gameID		= (int)$gameID;
-			$this->galaxyID		= (int)$galaxyID;
-			$this->isNew		= true;
-			$this->maxForceTime	= 0;
-		}
-		else {
+
+		$this->gameID = (int) $gameID;
+		$this->galaxyID = (int) $galaxyID;
+		if (!$this->isNew) {
+			$this->name = $db->getField('galaxy_name');
+			$this->width = $db->getInt('width');
+			$this->height = $db->getInt('height');
+			$this->galaxyType = $db->getField('galaxy_type');
+			$this->maxForceTime = $db->getInt('max_force_time');
+		} elseif ($create === false) {
 			throw new Exception('No such galaxy: '.$gameID.'-'.$galaxyID);
 		}
 	}

--- a/lib/Default/SmrGalaxy.class.inc
+++ b/lib/Default/SmrGalaxy.class.inc
@@ -4,6 +4,7 @@ class SmrGalaxy {
 	protected static $CACHE_GAME_GALAXIES = array();
 	
 	protected $db;
+	protected $SQL;
 
 	protected $gameID;
 	protected $galaxyID;
@@ -58,13 +59,14 @@ class SmrGalaxy {
 	
 	protected function __construct($gameID, $galaxyID, $create=false, $db=null) {
 		$this->db = new SmrMySqlDatabase();
+		$this->SQL = 'game_id = ' . $this->db->escapeNumber($gameID) . '
+		              AND galaxy_id = ' . $this->db->escapeNumber($galaxyID);
 
 		if (isset($db)) {
 			$this->isNew = false;
 		} else {
 			$db = $this->db;
-			$db->query('SELECT * FROM game_galaxy WHERE game_id = ' . $this->db->escapeNumber($gameID) . '
-							AND galaxy_id = ' . $this->db->escapeNumber($galaxyID) . ' LIMIT 1');
+			$db->query('SELECT * FROM game_galaxy WHERE ' . $this->SQL);
 			$this->isNew = !$db->nextRecord();
 		}
 
@@ -89,8 +91,7 @@ class SmrGalaxy {
 										', height = ' . $this->db->escapeNumber($this->getHeight()) .
 										', galaxy_type = ' . $this->db->escapeString($this->getGalaxyType()) .
 										', max_force_time = ' . $this->db->escapeNumber($this->getMaxForceTime()) .
-									' WHERE game_id = ' . $this->db->escapeNumber($this->getGameID()) .
-										' AND galaxy_id = ' . $this->db->escapeNumber($this->getGalaxyID()) . ' LIMIT 1');
+									' WHERE ' . $this->SQL);
 			}
 			else {
 				$this->db->query('INSERT INTO game_galaxy (game_id,galaxy_id,galaxy_name,width,height,galaxy_type,max_force_time)

--- a/lib/Default/SmrLocation.class.inc
+++ b/lib/Default/SmrLocation.class.inc
@@ -302,9 +302,9 @@ class SmrLocation {
 		if(!isset($this->weaponsSold)) {
 			require_once(get_file_loc('SmrWeapon.class.inc'));
 			$this->weaponsSold = array();
-			$this->db->query('SELECT * FROM location_sells_weapons WHERE ' . $this->SQL);
+			$this->db->query('SELECT * FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) WHERE ' . $this->SQL);
 			while($this->db->nextRecord())
-				$this->weaponsSold[$this->db->getInt('weapon_type_id')] = SmrWeapon::getWeapon(Globals::getGameType(SmrSession::$game_id),$this->db->getInt('weapon_type_id'));
+				$this->weaponsSold[$this->db->getInt('weapon_type_id')] = SmrWeapon::getWeapon(Globals::getGameType(SmrSession::$game_id),$this->db->getInt('weapon_type_id'), false, $this->db);
 		}
 		return $this->weaponsSold;
 	}

--- a/lib/Default/SmrLocation.class.inc
+++ b/lib/Default/SmrLocation.class.inc
@@ -25,10 +25,11 @@ class SmrLocation {
 	public static function &getAllLocations($forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_ALL_LOCATIONS)) {
 			$db = new SmrMySqlDatabase();
-			$db->query('SELECT location_type_id FROM location_type ORDER BY location_type_id');
+			$db->query('SELECT * FROM location_type ORDER BY location_type_id');
 			$locations = array();
 			while($db->nextRecord()) {
-				$locations[$db->getField('location_type_id')] = SmrLocation::getLocation($db->getField('location_type_id'));
+				$locationTypeID = $db->getInt('location_type_id');
+				$locations[$locationTypeID] = SmrLocation::getLocation($locationTypeID, $forceUpdate, $db);
 			}
 			self::$CACHE_ALL_LOCATIONS = $locations;
 		}
@@ -38,33 +39,41 @@ class SmrLocation {
 	public static function &getSectorLocations($gameID,$sectorID,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID])) {
 			$db = new SmrMySqlDatabase();
-			$db->query('SELECT location_type_id FROM location WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID));
+			$db->query('SELECT * FROM location JOIN location_type USING (location_type_id) WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID));
 			$locations = array();
 			while($db->nextRecord()) {
-				$locations[] = self::getLocation($db->getField('location_type_id'));
+				$locationTypeID = $db->getInt('location_type_id');
+				$locations[] = self::getLocation($locationTypeID, $forceUpdate, $db);
 			}
 			self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] = $locations;
 		}
 		return self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID];
 	}
 	
-	public static function &getLocation($locationTypeID,$forceUpdate = false) {
+	public static function &getLocation($locationTypeID, $forceUpdate=false, $db=null) {
 		if($forceUpdate || !isset(self::$CACHE_LOCATIONS[$locationTypeID])) {
-			self::$CACHE_LOCATIONS[$locationTypeID] = new SmrLocation($locationTypeID);
+			self::$CACHE_LOCATIONS[$locationTypeID] = new SmrLocation($locationTypeID, $db);
 		}
 		return self::$CACHE_LOCATIONS[$locationTypeID];
 	}
 	
-	protected function __construct($locationTypeID) {
+	protected function __construct($locationTypeID, $db=null) {
 		$this->db = new SmrMySqlDatabase();
 		$this->SQL = 'location_type_id = ' . $this->db->escapeNumber($locationTypeID);
-		$this->db->query('SELECT location_type_id,location_name,location_processor,location_image FROM location_type WHERE ' . $this->SQL . ' LIMIT 1');
-		
-		if($this->db->nextRecord()) {
-			$this->typeID = $this->db->getField('location_type_id');
-			$this->name = $this->db->getField('location_name');
-			$this->processor = $this->db->getField('location_processor');
-			$this->image = $this->db->getField('location_image');
+
+		if (isset($db)) {
+			$locationExists = true;
+		} else {
+			$db = $this->db;
+			$db->query('SELECT * FROM location_type WHERE ' . $this->SQL . ' LIMIT 1');
+			$locationExists = $db->nextRecord();
+		}
+
+		if ($locationExists) {
+			$this->typeID = $db->getInt('location_type_id');
+			$this->name = $db->getField('location_name');
+			$this->processor = $db->getField('location_processor');
+			$this->image = $db->getField('location_image');
 		}
 		else {
 			throw new Exception('Cannot find location: '.$locationTypeID);

--- a/lib/Default/SmrLocation.class.inc
+++ b/lib/Default/SmrLocation.class.inc
@@ -304,7 +304,7 @@ class SmrLocation {
 			$this->weaponsSold = array();
 			$this->db->query('SELECT * FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) WHERE ' . $this->SQL);
 			while($this->db->nextRecord())
-				$this->weaponsSold[$this->db->getInt('weapon_type_id')] = SmrWeapon::getWeapon(Globals::getGameType(SmrSession::$game_id),$this->db->getInt('weapon_type_id'), false, $this->db);
+				$this->weaponsSold[$this->db->getInt('weapon_type_id')] = SmrWeapon::getWeapon($this->db->getInt('weapon_type_id'), false, $this->db);
 		}
 		return $this->weaponsSold;
 	}
@@ -320,7 +320,7 @@ class SmrLocation {
 		if($this->isWeaponSold($weaponTypeID))
 			return;
 		require_once(get_file_loc('SmrWeapon.class.inc'));
-		$weapon = SmrWeapon::getWeapon(Globals::getGameType(SmrSession::$game_id),$weaponTypeID);
+		$weapon = SmrWeapon::getWeapon($weaponTypeID);
 		if($weapon===false)
 			throw new Exception('Invalid weapon type id given');
 		$this->db->query('INSERT INTO location_sells_weapons (location_type_id,weapon_type_id) values (' . $this->db->escapeNumber($this->getTypeID()). ',' . $this->db->escapeNumber($weaponTypeID) . ')');

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -87,16 +87,13 @@ class SmrPlanet {
 
 	public static function removePlanet($gameID,$sectorID) {
 		$db = new SmrMySqlDatabase();
-		$db->query('DELETE FROM planet
-					WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND sector_id = ' . $db->escapeNumber($sectorID));
-		$db->query('DELETE FROM planet_has_cargo
-					WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND sector_id = ' . $db->escapeNumber($sectorID));
-		$db->query('DELETE FROM planet_has_building
-					WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND sector_id = ' . $db->escapeNumber($sectorID));
-		$db->query('DELETE FROM planet_is_building
-					WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND sector_id = ' . $db->escapeNumber($sectorID));
+		$SQL = 'game_id = ' . $db->escapeNumber($gameID) . ' AND sector_id = ' . $db->escapeNumber($sectorID);
+		$db->query('DELETE FROM planet WHERE ' . $SQL);
+		$db->query('DELETE FROM planet_has_cargo WHERE ' . $SQL);
+		$db->query('DELETE FROM planet_has_building WHERE ' . $SQL);
+		$db->query('DELETE FROM planet_is_building WHERE ' . $SQL);
 		//kick everyone from planet
-		$db->query('UPDATE player SET land_on_planet = \'FALSE\' WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id = ' . $db->escapeNumber($gameID));
+		$db->query('UPDATE player SET land_on_planet = \'FALSE\' WHERE ' . $SQL);
 
 		self::$CACHE_PLANETS[$gameID][$sectorID] = null;
 		unset(self::$CACHE_PLANETS[$gameID][$sectorID]);

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -1064,7 +1064,7 @@ class SmrPlanet {
 	public function &getWeapons() {
 		$weapons = array();
 		for($i=0;$i<$this->getBuilding(PLANET_TURRET);++$i) {
-			$weapons[$i] = SmrWeapon::getWeapon(Globals::getGameType($this->getGameID()),WEAPON_PLANET_TURRET);
+			$weapons[$i] = SmrWeapon::getWeapon(WEAPON_PLANET_TURRET);
 		}
 		return $weapons;
 	}

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -1,4 +1,5 @@
 <?php
+
 require_once(get_file_loc('SmrPlayer.class.inc'));
 class SmrPlanet {
 	protected static $CACHE_PLANETS = array();
@@ -63,9 +64,9 @@ class SmrPlanet {
 		}
 	}
 
-	public static function &getPlanet($gameID,$sectorID,$forceUpdate = false) {
+	public static function &getPlanet($gameID, $sectorID, $forceUpdate=false, $db=null) {
 		if($forceUpdate || !isset(self::$CACHE_PLANETS[$gameID][$sectorID])) {
-			self::$CACHE_PLANETS[$gameID][$sectorID] = new SmrPlanet($gameID, $sectorID);
+			self::$CACHE_PLANETS[$gameID][$sectorID] = new SmrPlanet($gameID, $sectorID, $db);
 		}
 		return self::$CACHE_PLANETS[$gameID][$sectorID];
 	}
@@ -99,25 +100,32 @@ class SmrPlanet {
 		unset(self::$CACHE_PLANETS[$gameID][$sectorID]);
 	}
 
-	protected function __construct($gameID, $sectorID) {
+	protected function __construct($gameID, $sectorID, $db=null) {
 		$this->db = new SmrMySqlDatabase();
 		$this->SQL = 'game_id = ' . $this->db->escapeNumber($gameID) . ' AND sector_id = ' . $this->db->escapeNumber($sectorID);
 
-		$this->db->query('SELECT * FROM planet WHERE ' . $this->SQL);
-		if ($this->db->nextRecord()) {
-			$this->sectorID			= $this->db->getInt('sector_id');
-			$this->gameID			= $this->db->getInt('game_id');
-			$this->planetName		= stripslashes($this->db->getField('planet_name'));
-			$this->ownerID			= $this->db->getInt('owner_id');
-			$this->password			= $this->db->getField('password');
-			$this->shields			= $this->db->getInt('shields');
-			$this->armour 			= $this->db->getInt('armour');
-			$this->drones			= $this->db->getInt('drones');
-			$this->credits			= $this->db->getInt('credits');
-			$this->bonds			= $this->db->getInt('bonds');
-			$this->maturity			= $this->db->getInt('maturity');
-			$this->inhabitableTime	= $this->db->getInt('inhabitable_time');
-			$this->typeID 			= $this->db->getInt('planet_type_id');
+		if (isset($db)) {
+			$planetExists = true;
+		} else {
+			$db = $this->db;
+			$db->query('SELECT * FROM planet WHERE ' . $this->SQL);
+			$planetExists = $db->nextRecord();
+		}
+
+		if ($planetExists) {
+			$this->gameID = (int) $gameID;
+			$this->sectorID = (int) $sectorID;
+			$this->planetName = stripslashes($db->getField('planet_name'));
+			$this->ownerID = $db->getInt('owner_id');
+			$this->password = $db->getField('password');
+			$this->shields = $db->getInt('shields');
+			$this->armour = $db->getInt('armour');
+			$this->drones = $db->getInt('drones');
+			$this->credits = $db->getInt('credits');
+			$this->bonds = $db->getInt('bonds');
+			$this->maturity = $db->getInt('maturity');
+			$this->inhabitableTime = $db->getInt('inhabitable_time');
+			$this->typeID = $db->getInt('planet_type_id');
 			
 			$this->initTypeInfo();
 			$this->checkBondMaturity();

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -14,12 +14,10 @@ class SmrPlayer extends AbstractSmrPlayer {
 	protected static $CACHE_PLAYERS = array();
 
 	protected $db;
+	protected $SQL;
 
 	protected $newbieWarning;
-
-
 	protected $tickers;
-
 	protected $lastTurnUpdate;
 	protected $lastNewsUpdate;
 	protected $attackColour;
@@ -35,10 +33,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 	protected $plottedCourseFrom;
 	protected $nameChanged;
 	protected $combatDronesKamikazeOnMines;
-
 	protected $customShipName;
-
-	protected $SQL;
 
 
 	public static function refreshCache() {
@@ -78,7 +73,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$players = array();
 			while($db->nextRecord()) {
 				$accountID = $db->getInt('account_id');
-				$players[$accountID] = self::getPlayer($db->getRow(), $gameID, $forceUpdate);
+				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $db);
 			}
 			self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] = $players;
 		}
@@ -92,7 +87,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$players = array();
 			while($db->nextRecord()) {
 				$accountID = $db->getField('account_id');
-				$players[$accountID] = self::getPlayer($db->getRow(), $gameID, $forceUpdate);
+				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $db);
 			}
 			self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID] = $players;
 		}
@@ -106,20 +101,16 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$players = array();
 			while($db->nextRecord()) {
 				$accountID = $db->getInt('account_id');
-				$players[$accountID] = self::getPlayer($db->getRow(), $gameID, $forceUpdate);
+				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $db);
 			}
 			self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID] = $players;
 		}
 		return self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID];
 	}
 
-	public static function &getPlayer($accountIDOrResultArray, $gameID, $forceUpdate = false) {
-		$accountID = is_array($accountIDOrResultArray) ?
-		             $accountIDOrResultArray['account_id'] :
-		             $accountIDOrResultArray;
+	public static function &getPlayer($accountID, $gameID, $forceUpdate=false, $db=null) {
 		if ($forceUpdate || !isset(self::$CACHE_PLAYERS[$gameID][$accountID])) {
-			$p = new SmrPlayer($gameID,$accountIDOrResultArray);
-			self::$CACHE_PLAYERS[$gameID][$p->getAccountID()] = $p;
+			self::$CACHE_PLAYERS[$gameID][$accountID] = new SmrPlayer($gameID, $accountID, $db);
 		}
 		return self::$CACHE_PLAYERS[$gameID][$accountID];
 	}
@@ -127,66 +118,66 @@ class SmrPlayer extends AbstractSmrPlayer {
 	public static function &getPlayerByPlayerID($playerID,$gameID,$forceUpdate = false) {
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT * FROM player WHERE game_id = '.$db->escapeNumber($gameID).' AND player_id = '.$db->escapeNumber($playerID).' LIMIT 1');
-		if($db->nextRecord())
-			return self::getPlayer($db->getRow(), $gameID, $forceUpdate);
+		if ($db->nextRecord()) {
+			return self::getPlayer($db->getInt('account_id'), $gameID, $forceUpdate, $db);
+		}
 		throw new PlayerNotFoundException('Player ID not found.');
 	}
 
-	protected function __construct($gameID, $accountIDOrResultArray) {
+	protected function __construct($gameID, $accountID, $db=null) {
 		parent::__construct();
 		$this->db = new SmrMySqlDatabase();
-		$result=false;
-		if (is_array($accountIDOrResultArray))
-			$result = $accountIDOrResultArray;
-		else {
-			$this->db->query('SELECT * FROM player WHERE account_id = ' . $this->db->escapeNumber($accountIDOrResultArray) . ' AND game_id = ' . $this->db->escapeNumber($gameID) . ' LIMIT 1');
-			$this->db->nextRecord();
-			$result = $this->db->getRow();
-		}
-		if($result) {
-			$this->accountID					= (int) $result['account_id'];
-			$this->gameID						= (int) $result['game_id'];
-			$this->playerName					= (string) $result['player_name'];
-			$this->playerID						= (int) $result['player_id'];
-			$this->sectorID						= (int) $result['sector_id'];
-			$this->lastSectorID					= (int) $result['last_sector_id'];
-			$this->turns						= (int) $result['turns'];
-			$this->lastTurnUpdate				= (int) $result['last_turn_update'];
-			$this->newbieTurns					= (int) $result['newbie_turns'];
-			$this->lastNewsUpdate				= (int) $result['last_news_update'];
-			$this->attackColour					= (string) $result['attack_warning'];
-			$this->dead							= $result['dead']=='TRUE';
-			$this->npc							= $result['npc']=='TRUE';
-			$this->newbieStatus					= $result['newbie_status'] == 'TRUE';
-			$this->landedOnPlanet				= $result['land_on_planet']=='TRUE';
-			$this->lastActive					= (int) $result['last_active'];
-			$this->lastCPLAction				= (int) $result['last_cpl_action'];
-			$this->raceID						= (int) $result['race_id'];
-			$this->credits						= (int) $result['credits'];
-			$this->experience					= (int) $result['experience'];
-			$this->alignment					= (int) $result['alignment'];
-			$this->militaryPayment				= (int) $result['military_payment'];
-//			$this->pastKnowledge = $result['past_knowledge'];
-			$this->allianceID					= (int) $result['alliance_id'];
-			$this->allianceJoinable				= (int) $result['alliance_join'];
-			$this->shipID						= (int) $result['ship_type_id'];
-			$this->kills						= (int) $result['kills'];
-			$this->deaths						= (int) $result['deaths'];
-			$this->lastPort						= (int) $result['last_port'];
-			$this->bank							= (int) $result['bank'];
-			$this->zoom							= (int) $result['zoom'];
-			$this->displayMissions				= $result['display_missions']=='TRUE';
-			$this->displayWeapons				= $result['display_weapons']=='TRUE';
-			$this->forceDropMessages			= $result['force_drop_messages']=='TRUE';
-			$this->ignoreGlobals				= $result['ignore_globals']=='TRUE';
-			$this->newbieWarning				= $result['newbie_warning']=='TRUE';
-			$this->nameChanged					= $result['name_changed']=='TRUE';
-			$this->combatDronesKamikazeOnMines	= $result['combat_drones_kamikaze_on_mines']=='TRUE';
+		$this->SQL = 'account_id = ' . $this->db->escapeNumber($accountID) . ' AND game_id = ' . $this->db->escapeNumber($gameID);
 
-			$this->SQL = 'account_id = ' . $this->db->escapeNumber($this->accountID) . ' AND game_id = ' . $this->db->escapeNumber($this->gameID);
+		if (isset($db)) {
+			$playerExists = true;
+		} else {
+			$db = $this->db;
+			$this->db->query('SELECT * FROM player WHERE ' . $this->SQL . ' LIMIT 1');
+			$playerExists = $db->nextRecord();
+		}
+
+		if ($playerExists) {
+			$this->accountID = (int) $accountID;
+			$this->gameID = (int) $gameID;
+			$this->playerName = $db->getField('player_name');
+			$this->playerID = $db->getInt('player_id');
+			$this->sectorID = $db->getInt('sector_id');
+			$this->lastSectorID = $db->getInt('last_sector_id');
+			$this->turns = $db->getInt('turns');
+			$this->lastTurnUpdate = $db->getInt('last_turn_update');
+			$this->newbieTurns = $db->getInt('newbie_turns');
+			$this->lastNewsUpdate = $db->getInt('last_news_update');
+			$this->attackColour = $db->getField('attack_warning');
+			$this->dead = $db->getBoolean('dead');
+			$this->npc = $db->getBoolean('npc');
+			$this->newbieStatus = $db->getBoolean('newbie_status');
+			$this->landedOnPlanet = $db->getBoolean('land_on_planet');
+			$this->lastActive = $db->getInt('last_active');
+			$this->lastCPLAction = $db->getInt('last_cpl_action');
+			$this->raceID = $db->getInt('race_id');
+			$this->credits = $db->getInt('credits');
+			$this->experience = $db->getInt('experience');
+			$this->alignment = $db->getInt('alignment');
+			$this->militaryPayment = $db->getInt('military_payment');
+			$this->allianceID = $db->getInt('alliance_id');
+			$this->allianceJoinable = $db->getInt('alliance_join');
+			$this->shipID = $db->getInt('ship_type_id');
+			$this->kills = $db->getInt('kills');
+			$this->deaths = $db->getInt('deaths');
+			$this->lastPort = $db->getInt('last_port');
+			$this->bank = $db->getInt('bank');
+			$this->zoom = $db->getInt('zoom');
+			$this->displayMissions = $db->getBoolean('display_missions');
+			$this->displayWeapons = $db->getBoolean('display_weapons');
+			$this->forceDropMessages = $db->getBoolean('force_drop_messages');
+			$this->ignoreGlobals = $db->getBoolean('ignore_globals');
+			$this->newbieWarning = $db->getBoolean('newbie_warning');
+			$this->nameChanged = $db->getBoolean('name_changed');
+			$this->combatDronesKamikazeOnMines = $db->getBoolean('combat_drones_kamikaze_on_mines');
 		}
 		else {
-			throw new PlayerNotFoundException('Invalid accountID: '.$accountIDOrResultArray . ' OR gameID:'.$gameID);
+			throw new PlayerNotFoundException('Invalid accountID: '.$accountID. ' OR gameID:'.$gameID);
 		}
 	}
 

--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -806,7 +806,7 @@ class SmrPort {
 	public function &getWeapons() {
 		$weapons = array();
 		for ($i=0; $i<$this->getNumWeapons(); ++$i) {
-			$weapons[$i] = SmrWeapon::getWeapon(Globals::getGameType($this->getGameID()),WEAPON_PORT_TURRET);
+			$weapons[$i] = SmrWeapon::getWeapon(WEAPON_PORT_TURRET);
 		}
 		return $weapons;
 	}

--- a/lib/Default/SmrShip.class.inc
+++ b/lib/Default/SmrShip.class.inc
@@ -57,7 +57,7 @@ class SmrShip extends AbstractSmrShip {
 		$this->weapons = array();
 		// generate list of weapon names the user transports
 		while ($this->db->nextRecord()) {
-			$this->weapons[$this->db->getInt('order_id')] = SmrWeapon::getWeapon($this->gameID, $this->db->getInt('weapon_type_id'), false, $this->db);
+			$this->weapons[$this->db->getInt('order_id')] = SmrWeapon::getWeapon($this->db->getInt('weapon_type_id'), false, $this->db);
 		}
 		$this->checkForExcessWeapons();
 	}

--- a/lib/Default/SmrShip.class.inc
+++ b/lib/Default/SmrShip.class.inc
@@ -50,14 +50,14 @@ class SmrShip extends AbstractSmrShip {
 	
 	protected function loadWeapon() {
 		// determine weapon
-		$this->db->query('SELECT order_id,weapon_type_id FROM ship_has_weapon
+		$this->db->query('SELECT weapon_type.*, order_id FROM ship_has_weapon JOIN weapon_type USING (weapon_type_id)
 							WHERE ' . $this->SQL .'
 							ORDER BY order_id LIMIT ' . $this->db->escapeNumber($this->getHardpoints()));
 		
 		$this->weapons = array();
 		// generate list of weapon names the user transports
 		while ($this->db->nextRecord()) {
-			$this->weapons[$this->db->getInt('order_id')] = SmrWeapon::getWeapon($this->gameID,$this->db->getInt('weapon_type_id'));
+			$this->weapons[$this->db->getInt('order_id')] = SmrWeapon::getWeapon($this->gameID, $this->db->getInt('weapon_type_id'), false, $this->db);
 		}
 		$this->checkForExcessWeapons();
 	}

--- a/lib/Default/SmrWeapon.class.inc
+++ b/lib/Default/SmrWeapon.class.inc
@@ -21,7 +21,7 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	public static function &getWeapon($gameTypeID,$weaponTypeID,$forceUpdate = false) {
 		if($forceUpdate || !isset(self::$CACHE_WEAPONS[$gameTypeID][$weaponTypeID])) {
 			$w = new SmrWeapon($gameTypeID,$weaponTypeID);
-			if($w->getName()!='')
+			if ($w->exists())
 				self::$CACHE_WEAPONS[$gameTypeID][$weaponTypeID] = $w;
 			else
 				self::$CACHE_WEAPONS[$gameTypeID][$weaponTypeID] = false;
@@ -60,6 +60,10 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 			$this->raidWeapon = false;
 			$this->maxDamage = max($this->shieldDamage,$this->armourDamage);
 		}
+	}
+
+	public function exists() {
+		return !empty($this->name);
 	}
 
 	public function getBuyHREF(SmrLocation $location) {

--- a/lib/Default/SmrWeapon.class.inc
+++ b/lib/Default/SmrWeapon.class.inc
@@ -18,9 +18,9 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 			self::$db = new SmrMySqlDatabase();
 	}
 
-	public static function &getWeapon($gameTypeID,$weaponTypeID,$forceUpdate = false) {
+	public static function &getWeapon($gameTypeID, $weaponTypeID, $forceUpdate=false, $db=null) {
 		if($forceUpdate || !isset(self::$CACHE_WEAPONS[$gameTypeID][$weaponTypeID])) {
-			$w = new SmrWeapon($gameTypeID,$weaponTypeID);
+			$w = new SmrWeapon($gameTypeID, $weaponTypeID, $db);
 			if ($w->exists())
 				self::$CACHE_WEAPONS[$gameTypeID][$weaponTypeID] = $w;
 			else
@@ -31,31 +31,37 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 
 	public static function &getAllWeapons($gameTypeID,$forceUpdate = false) {
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT weapon_type_id FROM weapon_type');
+		$db->query('SELECT * FROM weapon_type');
 		$weapons=array();
 		while($db->nextRecord()) {
-			$weapons[] = self::getWeapon($gameTypeID,$db->getInt('weapon_type_id'),$forceUpdate);
+			$weapons[] = self::getWeapon($gameTypeID, $db->getInt('weapon_type_id'), $forceUpdate, $db);
 		}
 		return $weapons;
 	}
 	
-	protected function __construct($gameTypeID,$weaponTypeID) {
-		self::initialiseDatabase();
+	protected function __construct($gameTypeID, $weaponTypeID, $db=null) {
 		
 		$this->gameTypeID = $gameTypeID;
 		$this->weaponTypeID = $weaponTypeID;
-			
-		self::$db->query('SELECT weapon_name,race_id,cost,shield_damage,armour_damage,accuracy,power_level,buyer_restriction FROM weapon_type WHERE weapon_type_id = ' . self::$db->escapeNumber($weaponTypeID) . ' LIMIT 1');
 		
-		if(self::$db->nextRecord()) {
-			$this->name = self::$db->getField('weapon_name');
-			$this->raceID = self::$db->getInt('race_id');
-			$this->cost = self::$db->getInt('cost');
-			$this->shieldDamage = self::$db->getInt('shield_damage');
-			$this->armourDamage = self::$db->getInt('armour_damage');
-			$this->accuracy = self::$db->getInt('accuracy');
-			$this->powerLevel = self::$db->getInt('power_level');
-			$this->buyerRestriction = self::$db->getInt('buyer_restriction');
+		if (isset($db)) {
+			$weaponExists = true;
+		} else {
+			self::initialiseDatabase();
+			$db = self::$db;
+			self::$db->query('SELECT * FROM weapon_type WHERE weapon_type_id = ' . $db->escapeNumber($weaponTypeID) . ' LIMIT 1');
+			$weaponExists = $db->nextRecord();
+		}
+
+		if ($weaponExists) {
+			$this->name = $db->getField('weapon_name');
+			$this->raceID = $db->getInt('race_id');
+			$this->cost = $db->getInt('cost');
+			$this->shieldDamage = $db->getInt('shield_damage');
+			$this->armourDamage = $db->getInt('armour_damage');
+			$this->accuracy = $db->getInt('accuracy');
+			$this->powerLevel = $db->getInt('power_level');
+			$this->buyerRestriction = $db->getInt('buyer_restriction');
 			$this->damageRollover = false;
 			$this->raidWeapon = false;
 			$this->maxDamage = max($this->shieldDamage,$this->armourDamage);

--- a/lib/Default/SmrWeapon.class.inc
+++ b/lib/Default/SmrWeapon.class.inc
@@ -18,30 +18,29 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 			self::$db = new SmrMySqlDatabase();
 	}
 
-	public static function &getWeapon($gameTypeID, $weaponTypeID, $forceUpdate=false, $db=null) {
-		if($forceUpdate || !isset(self::$CACHE_WEAPONS[$gameTypeID][$weaponTypeID])) {
-			$w = new SmrWeapon($gameTypeID, $weaponTypeID, $db);
+	public static function &getWeapon($weaponTypeID, $forceUpdate=false, $db=null) {
+		if($forceUpdate || !isset(self::$CACHE_WEAPONS[$weaponTypeID])) {
+			$w = new SmrWeapon($weaponTypeID, $db);
 			if ($w->exists())
-				self::$CACHE_WEAPONS[$gameTypeID][$weaponTypeID] = $w;
+				self::$CACHE_WEAPONS[$weaponTypeID] = $w;
 			else
-				self::$CACHE_WEAPONS[$gameTypeID][$weaponTypeID] = false;
+				self::$CACHE_WEAPONS[$weaponTypeID] = false;
 		}
-		return self::$CACHE_WEAPONS[$gameTypeID][$weaponTypeID];
+		return self::$CACHE_WEAPONS[$weaponTypeID];
 	}
 
-	public static function &getAllWeapons($gameTypeID,$forceUpdate = false) {
+	public static function &getAllWeapons($forceUpdate=false) {
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT * FROM weapon_type');
 		$weapons=array();
 		while($db->nextRecord()) {
-			$weapons[] = self::getWeapon($gameTypeID, $db->getInt('weapon_type_id'), $forceUpdate, $db);
+			$weapons[] = self::getWeapon($db->getInt('weapon_type_id'), $forceUpdate, $db);
 		}
 		return $weapons;
 	}
 	
-	protected function __construct($gameTypeID, $weaponTypeID, $db=null) {
+	protected function __construct($weaponTypeID, $db=null) {
 		
-		$this->gameTypeID = $gameTypeID;
 		$this->weaponTypeID = $weaponTypeID;
 		
 		if (isset($db)) {


### PR DESCRIPTION
Set up a consistent infrastructure for all classes that can be used to construct multiple class instances with a single query. This is necessary because query overhead is the biggest static expense (behind the dynamic expense of sector lock), so we want to minimize the number of queries we make.

We modify class construction and multi-instance query infrastructure for the following:
* SmrLocation
* SmrForce
* SmrGalaxy
* SmrPlanet
* SmrPlayer
* SmrWeapon