### PR TITLE
MySqlDatabase: optimize escapeNumber

### DIFF
--- a/lib/Default/MySqlDatabase.class.inc
+++ b/lib/Default/MySqlDatabase.class.inc
@@ -141,10 +141,7 @@ abstract class MySqlDatabase implements Database {
 				return $this->escapeBoolean($escape,$quotes);
 		}
 		if(is_numeric($escape)) {
-			if($autoQuotes)
-				return $this->escapeNumber($escape);
-			else
-				return $this->escapeNumber($escape,$quotes);
+			return $this->escapeNumber($escape);
 		}
 		if(is_string($escape)) {
 			if($autoQuotes)
@@ -204,11 +201,14 @@ abstract class MySqlDatabase implements Database {
 		return $string;
 	}
 	
-	public function escapeNumber($num,$quotes=false) {
-		if(is_numeric($num))
-			return $this->escapeString($num,$quotes);
-		else
+	public function escapeNumber($num) {
+		// Numbers need not be quoted in MySQL queries, so if we know $num is
+		// numeric, we can simply return its value (no quoting or escaping).
+		if (is_numeric($num)) {
+			return $num;
+		} else {
 			throw new Exception('Not a number! ('.$num.')');
+		}
 	}
 	
 	public function escapeMicrotime($microtime,$quotes=false) {


### PR DESCRIPTION
Even with our SQL member enhancements, `escapeNumber` often shows up
as the 2nd or 3rd highest cost in profiling. This is due to the sheer
number of calls.

Numbers, including hexidecimals, do not need to be quoted in mysql
(and most query languages don't even allow you to quote numbers),
and so we remove the option to quote them. Since we are not quoting
them, then there is no need to escape them.

Calling `escapeString` in the guts of `escapeNumber` is therefore
essentially a no-op, and we should just return the number directly
once we have verified that it is numeric. This reduces the cost of
`escapeNumber` by a factor of ~3 or 4.