### PR TITLE
 SmrPort: enable multi-port queries

### DIFF
--- a/admin/Default/map_show_processing.php
+++ b/admin/Default/map_show_processing.php
@@ -20,9 +20,10 @@ if (!empty($account_id)) {
 	$db->query('DELETE FROM player_visited_sector WHERE account_id IN ('.$db->escapeArray($account_id).') AND game_id = '.$db->escapeNumber($game_id));
 
 	// add port infos
-	$db->query('SELECT sector_id FROM port WHERE game_id = '.$game_id.' ORDER BY sector_id');
+	$db->query('SELECT * FROM port WHERE game_id = '.$db->escapeNumber($game_id));
 	while ($db->nextRecord()) {
-		SmrPort::getPort($game_id,$db->getField('sector_id'))->addCachePorts($account_id);
+		$port = SmrPort::getPort($game_id, $db->getField('sector_id'), false, $db);
+		$port->addCachePorts($account_id);
 	}
 
 }

--- a/engine/Default/bar_galmap_buy.php
+++ b/engine/Default/bar_galmap_buy.php
@@ -37,9 +37,10 @@ if (isset($var['process'])) {
 	
 	require_once(get_file_loc('SmrPort.class.inc'));
 	// add port infos
-	$db->query('SELECT sector_id FROM port WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND sector_id >= ' . $db->escapeNumber($low) . ' ORDER BY sector_id');
+	$db->query('SELECT * FROM port WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND sector_id >= ' . $db->escapeNumber($low));
 	while ($db->nextRecord()) {
-		SmrPort::getPort($player->getGameID(),$db->getField('sector_id'))->addCachePort($player->getAccountID());
+		$port = SmrPort::getPort($player->getGameID(), $db->getField('sector_id'), false, $db);
+		$port->addCachePort($player->getAccountID());
 	}
 	
 	$container=create_container('skeleton.php','bar_main.php');

--- a/engine/Default/beta_func_processing.php
+++ b/engine/Default/beta_func_processing.php
@@ -8,9 +8,10 @@ if ($var['func'] == 'Map') {
 	$db->query('DELETE FROM player_visited_sector WHERE account_id = ' . $db->escapeNumber($account_id) . ' AND game_id = ' . $db->escapeNumber($game_id));
 
 	// add port infos
-	$db->query('SELECT sector_id FROM port WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY sector_id');
+	$db->query('SELECT * FROM port WHERE game_id = ' . $db->escapeNumber($game_id));
 	while ($db->nextRecord()) {
-		SmrPort::getPort($game_id,$db->getField('sector_id'))->addCachePort($account_id);
+		$port = SmrPort::getPort($game_id, $db->getField('sector_id'), false, $db);
+		$port->addCachePort($account_id);
 	}
 
 }

--- a/lib/Default/SmrPort.class.inc
+++ b/lib/Default/SmrPort.class.inc
@@ -68,9 +68,9 @@ class SmrPort {
 		self::$CACHE_CACHED_PORTS = array();
 	}
 
-	public static function &getPort($gameID,$sectorID,$forceUpdate = false) {
+	public static function &getPort($gameID, $sectorID, $forceUpdate=false, $db=null) {
 		if($forceUpdate || !isset(self::$CACHE_PORTS[$gameID][$sectorID])) {
-			self::$CACHE_PORTS[$gameID][$sectorID] = new SmrPort($gameID,$sectorID);
+			self::$CACHE_PORTS[$gameID][$sectorID] = new SmrPort($gameID, $sectorID, $db);
 		}
 		return self::$CACHE_PORTS[$gameID][$sectorID];
 	}
@@ -107,32 +107,37 @@ class SmrPort {
 		return ($cargo / 13) * $distance;
 	}
 	
-	protected function __construct($gameID,$sectorID) {
+	protected function __construct($gameID, $sectorID, $db=null) {
 		$this->db = new SmrMySqlDatabase();
 		$this->SQL = 'sector_id = ' . $this->db->escapeNumber($sectorID) . ' AND game_id = ' . $this->db->escapeNumber($gameID);
-		$this->db->query('SELECT * FROM port WHERE ' . $this->SQL . ' LIMIT 1');
-		if ($this->db->nextRecord()) {
-			$this->gameID = $this->db->getInt('game_id');
-			$this->sectorID = $this->db->getInt('sector_id');
-			$this->shields = $this->db->getInt('shields');
-			$this->combatDrones = $this->db->getInt('combat_drones');
-			$this->armour = $this->db->getInt('armour');
-			$this->reinforceTime = $this->db->getInt('reinforce_time');
-			$this->attackStarted = $this->db->getInt('attack_started');
-			$this->raceID = $this->db->getInt('race_id');
-			$this->level = $this->db->getInt('level');
-			$this->credits = $this->db->getInt('credits');
-			$this->upgrade = $this->db->getInt('upgrade');
-			$this->experience = $this->db->getInt('experience');
+
+		if (isset($db)) {
+			$this->isNew = false;
+		} else {
+			$db = $this->db;
+			$db->query('SELECT * FROM port WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->isNew = !$db->nextRecord();
+		}
+
+		$this->gameID = (int) $gameID;
+		$this->sectorID = (int) $sectorID;
+		if (!$this->isNew) {
+			$this->shields = $db->getInt('shields');
+			$this->combatDrones = $db->getInt('combat_drones');
+			$this->armour = $db->getInt('armour');
+			$this->reinforceTime = $db->getInt('reinforce_time');
+			$this->attackStarted = $db->getInt('attack_started');
+			$this->raceID = $db->getInt('race_id');
+			$this->level = $db->getInt('level');
+			$this->credits = $db->getInt('credits');
+			$this->upgrade = $db->getInt('upgrade');
+			$this->experience = $db->getInt('experience');
 			
 			$this->checkDefenses();
 			$this->getGoods();
 			$this->checkForUpgrade();
 		}
 		else {
-			$this->isNew = true;
-			$this->gameID = $gameID;
-			$this->sectorID = $sectorID;
 			$this->shields = 0;
 			$this->combatDrones = 0;
 			$this->armour = 0;


### PR DESCRIPTION
Add an optional `$db` argument to `getPort` and the class ctor,
which if specified should contain a loaded query with all the
fields of the `port` table.

This allows us to perform a single multi-port query, and then
construct many SmrPort instances without incurring the cost from
the overhead of multiple queries.