### PR TITLE
{government,underground}.php: convert to template

### DIFF
--- a/engine/Default/government.php
+++ b/engine/Default/government.php
@@ -18,35 +18,30 @@ if ($player->getRelation($raceID) <= RELATIONS_WAR) {
 	create_error('We are at WAR with your race! Get outta here before I call the guards!');
 }
 
-$template->assign('PageTopic','Federal Headquarters');
+$template->assign('PageTopic', $location->getName());
 
 // header menu
 require_once(get_file_loc('menu_hq.inc'));
 create_hq_menu();
 
-$PHP_OUTPUT.='<div align="center">';
+$warRaces = [];
 if ($raceID != RACE_NEUTRAL) {
 	$races = Globals::getRaces();
 	$raceRelations = Globals::getRaceRelations($player->getGameID(), $raceID);
-	$PHP_OUTPUT.=('We are at WAR with<br /><br />');
 	foreach($raceRelations as $otherRaceID => $relation) {
 		if ($relation <= RELATIONS_WAR) {
-			$PHP_OUTPUT.=('<span class="red">The '.$races[$otherRaceID]['Race Name'].'<br /></span>');
+			$warRaces[] = $races[$otherRaceID]['Race Name'];
 		}
 	}
-	$PHP_OUTPUT.=('<br />The government will PAY for the destruction of their ships!');
 }
+$template->assign('WarRaces', $warRaces);
 
 require_once(get_file_loc('gov.functions.inc'));
-displayBountyList($PHP_OUTPUT,'HQ',0);
-displayBountyList($PHP_OUTPUT,'HQ',$player->getAccountID());
-
+$template->assign('AllBounties', getBounties('HQ'));
+$template->assign('MyBounties', $player->getClaimableBounties('HQ'));
 
 if ($player->getAlignment() > ALIGNMENT_EVIL && $player->getAlignment() <= ALIGNMENT_GOOD) {
 	$container = create_container('government_processing.php');
 	transfer('LocationID');
-	$PHP_OUTPUT.=create_echo_form($container);
-	$PHP_OUTPUT.=create_submit('Become a deputy');
-	$PHP_OUTPUT.=('</form>');
+	$template->assign('JoinHREF', SmrSession::getNewHREF($container));
 }
-$PHP_OUTPUT.='</div>';

--- a/engine/Default/government_processing.php
+++ b/engine/Default/government_processing.php
@@ -1,18 +1,12 @@
 <?php
+
+// Player has selected to become a deputy/smuggler
 $location = SmrLocation::getLocation($var['LocationID']);
-if ($_REQUEST['action'] == 'Become a deputy') {
-	if(!$location->isHQ()) {
-		create_error('You have to be at a HQ to become a deputy.');
-	}
+if ($location->isHQ()) {
 	$player->setAlignment(150);
-	$player->update();
 }
-elseif ($_REQUEST['action'] == 'Become a gang member') {
-	if(!$location->isUG()) {
-		create_error('You have to be at a HQ to become a deputy.');
-	}
+elseif ($location->isUG()) {
 	$player->setAlignment(-150);
-	$player->update();
 }
 
 forward(create_container('skeleton.php', 'current_sector.php'));

--- a/engine/Default/underground.php
+++ b/engine/Default/underground.php
@@ -12,21 +12,17 @@ if(!$location->isUG()) {
 	create_error('There is no underground here.');
 }
 
-$template->assign('PageTopic','Underground Headquarters');
+$template->assign('PageTopic', $location->getName());
 
 require_once(get_file_loc('menu_hq.inc'));
 create_ug_menu();
 
-$PHP_OUTPUT .= '<p>The location appears to be abandoned, until a group of heavily-armed figures advance from the shadows.</p>';
-
 require_once(get_file_loc('gov.functions.inc'));
-displayBountyList($PHP_OUTPUT,'UG',0);
-displayBountyList($PHP_OUTPUT,'UG',$player->getAccountID());
+$template->assign('AllBounties', getBounties('UG'));
+$template->assign('MyBounties', $player->getClaimableBounties('UG'));
 
 if ($player->getAlignment() < ALIGNMENT_GOOD && $player->getAlignment() >= ALIGNMENT_EVIL) {
 	$container = create_container('government_processing.php');
 	transfer('LocationID');
-	$PHP_OUTPUT.=create_echo_form($container);
-	$PHP_OUTPUT.=create_submit('Become a gang member');
-	$PHP_OUTPUT.=('</form>');
+	$template->assign('JoinHREF', SmrSession::getNewHREF($container));
 }

--- a/lib/Default/gov.functions.inc
+++ b/lib/Default/gov.functions.inc
@@ -1,29 +1,18 @@
 <?php
 
-
-function displayBountyList(&$PHP_OUTPUT,$type,$claimableBy) {
+/**
+ * Returns a list of all bounties for given location $type.
+ */
+function getBounties($type) {
 	$db = new SmrMySqlDatabase();
-	$db->query('SELECT * FROM bounty WHERE game_id = '.$db->escapeNumber(SmrSession::$game_id).' AND type ='.$db->escapeString($type).' AND claimer_id = '.$db->escapeNumber($claimableBy).' ORDER BY amount DESC');
-	$PHP_OUTPUT.=('<p>&nbsp;</p>');
-	if ($db->getNumRows()) {
-		$wantedBy = $type == 'HQ' ? 'Federal Government' : 'Underground';
-		$PHP_OUTPUT.=('<div align="center">'.($claimableBy==0 ? 'Most wanted by the '.$wantedBy : 'Claimable Bounties').'</div><br />');
-		$PHP_OUTPUT.=create_table();
-		$PHP_OUTPUT.=('<tr>');
-		$PHP_OUTPUT.=('<th>Player Name</th>');
-		$PHP_OUTPUT.=('<th>Bounty Amount (Credits)</th>');
-		$PHP_OUTPUT.=('<th>Bounty Amount (SMR credits)</th>');
-		$PHP_OUTPUT.=('</tr>');
-
-		while ($db->nextRecord()) {
-			$bountyPlayer = SmrPlayer::getPlayer($db->getField('account_id'),SmrSession::$game_id);
-			$PHP_OUTPUT.=('<tr>');
-			$PHP_OUTPUT.=('<td align="center">'.$bountyPlayer->getLinkedDisplayName().'</td>');
-			$PHP_OUTPUT.=('<td align="center"><span class="creds"> ' . number_format($db->getField('amount')) . ' </span></td>');
-			$PHP_OUTPUT.=('<td align="center"><span class="red"> ' . number_format($db->getField('smr_credits')) . ' </span></td>');
-			$PHP_OUTPUT.=('</tr>');
-
-		}
-		$PHP_OUTPUT.=('</table>');
+	$db->query('SELECT * FROM bounty WHERE game_id = '.$db->escapeNumber(SmrSession::$game_id).' AND type ='.$db->escapeString($type).' AND claimer_id = 0 ORDER BY amount DESC');
+	$bounties = [];
+	while ($db->nextRecord()) {
+		$bounties[] = [
+			'player' => SmrPlayer::getPlayer($db->getInt('account_id'), SmrSession::$game_id),
+			'credits' => $db->getInt('amount'),
+			'smr_credits' => $db->getInt('smr_credits')
+		];
 	}
+	return $bounties;
 }

--- a/lib/Default/gov.functions.inc
+++ b/lib/Default/gov.functions.inc
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Returns a list of all bounties for given location $type.
+ * Returns a list of all active (not claimable) bounties for given location $type.
  */
 function getBounties($type) {
 	$db = new SmrMySqlDatabase();

--- a/templates/Default/engine/Default/government.php
+++ b/templates/Default/engine/Default/government.php
@@ -1,0 +1,23 @@
+<div class="center"><?php
+	if ($WarRaces) { ?>
+		We are at WAR with<br /><br /><?php
+		foreach ($WarRaces as $RaceName) { ?>
+			<span class="red">The <?php echo $RaceName; ?><br /></span><?php
+		} ?>
+		<br />The government will PAY for the destruction of their ships!
+		<p>&nbsp;</p><?php
+	}
+
+	if ($AllBounties) { ?>
+		<div class="center">Most wanted by the Federal Government</div><br /><?php
+		$this->includeTemplate('includes/BountyList.inc', ['Bounties' => $AllBounties]);
+	}
+	if ($MyBounties) { ?>
+		<div class="center">Claimable Bounties</div><br /><?php
+		$this->includeTemplate('includes/BountyList.inc', ['Bounties' => $MyBounties]);
+	}
+
+	if (isset($JoinHREF)) { ?>
+		<p><a href="<?php echo $JoinHREF; ?>" class="submitStyle">Become a deputy</a></p><?php
+	} ?>
+</div>

--- a/templates/Default/engine/Default/includes/BountyList.inc
+++ b/templates/Default/engine/Default/includes/BountyList.inc
@@ -1,0 +1,16 @@
+<table class="standard center">
+	<tr>
+		<th>Player Name</th>
+		<th>Bounty Amount (Credits)</th>
+		<th>Bounty Amount (SMR credits)</th>
+	</tr>
+	<?php
+	foreach ($Bounties as $Bounty) { ?>
+		<tr>
+			<td><?php echo $Bounty['player']->getLinkedDisplayName(); ?></td>
+			<td><span class="creds"><?php echo number_format($Bounty['credits']); ?></span></td>
+			<td><span class="red"><?php echo number_format($Bounty['smr_credits']); ?></span></td>
+		</tr><?php
+	} ?>
+</table>
+<p>&nbsp;</p>

--- a/templates/Default/engine/Default/underground.php
+++ b/templates/Default/engine/Default/underground.php
@@ -1,0 +1,19 @@
+<p>The location appears to be abandoned, until a group of
+heavily-armed figures advance from the shadows.</p>
+<p>&nbsp;</p>
+
+<?php
+if ($AllBounties) { ?>
+	<div class="center">Most wanted by the Underground</div><br /><?php
+	$this->includeTemplate('includes/BountyList.inc', ['Bounties' => $AllBounties]);
+}
+if ($MyBounties) { ?>
+	<div class="center">Claimable Bounties</div><br /><?php
+	$this->includeTemplate('includes/BountyList.inc', ['Bounties' => $MyBounties]);
+}
+
+if (isset($JoinHREF)) { ?>
+	<p class="center">
+		<a href="<?php echo $JoinHREF; ?>" class="submitStyle">Become a smuggler</a>
+	</p><?php
+} ?>


### PR DESCRIPTION
Additional changes:

* Rename the HQ's based on their location name so they don't
  all say "Federal Headquarters" (instead, they will now say
  "<Race> Headquarters").

* Rename button for joining HQ from "Become a gang member" to
  "Become a smuggler". Gang member doesn't have the right
  connotation.

* Replace the "Become a ..." form with a submit-style link.
  Therefore, we remove the (redundant) check of the form action
  in government_processing.php.