### PR TITLE
shop_goods_trade.php: convert to template and minor tweaks

### DIFF
--- a/engine/Default/shop_goods_trade.php
+++ b/engine/Default/shop_goods_trade.php
@@ -11,71 +11,39 @@ $transaction = $port->getGoodTransaction($good_id);
 if ($var['bargain_price'] > 0) {
 	$bargain_price = $var['bargain_price'];
 
-	$PHP_OUTPUT.=('<p>I can\'t accept your offer. It\'s still too ');
-	if ($transaction == 'Sell')
-		$PHP_OUTPUT.=('high');
-	elseif ($transaction == 'Buy')
-		$PHP_OUTPUT.=('low');
-	$PHP_OUTPUT.=('.</p>');
-}
-else
+	if ($transaction == 'Sell') {
+		$template->assign('OfferToo', 'high');
+	} elseif ($transaction == 'Buy') {
+		$template->assign('OfferToo', 'low');
+	}
+} else {
 	$bargain_price = $var['offered_price'];
+}
 
-$PHP_OUTPUT.=('<p>I would ');
-if ($transaction == 'Sell')
-	$PHP_OUTPUT.=('buy ');
-elseif ($transaction == 'Buy')
-	$PHP_OUTPUT.=('offer you ');
-$PHP_OUTPUT.=($var['amount'] . ' pcs. of ' . $portGood['Name'] . ' for ' . $var['offered_price'] . ' credits!<br />');
-$PHP_OUTPUT.=('Note: In order to maximize your experience you have to bargain with the port owner, unless you have maximum relations (1000) with that race, which gives full experience without the need to bargain.</p>');
+if ($transaction == 'Sell') {
+	$template->assign('PortAction', 'buy');
+} elseif ($transaction == 'Buy') {
+	$template->assign('PortAction', 'offer you');
+}
 
-$container = array();
-$container['url'] = 'shop_goods_processing.php';
-
+$container = create_container('shop_goods_processing.php');
 transfer('amount');
 transfer('good_id');
 transfer('offered_price');
 transfer('ideal_price');
 transfer('number_of_bargains');
 transfer('overall_number_of_bargains');
+$template->assign('BargainHREF', SmrSession::getNewHREF($container));
 
-$PHP_OUTPUT.=create_echo_form($container);
-//gives value 0-1
-if (isset($var['ideal_price'])) {
-	// transfer this value
-	transfer('ideal_price');
+$template->assign('BargainPrice', $bargain_price);
+$template->assign('OfferedPrice', $var['offered_price']);
+$template->assign('Transaction', $transaction);
+$template->assign('Good', $portGood);
+$template->assign('Amount', $var['amount']);
+$template->assign('Port', $port);
 
-	// return this value
-	$ideal_price = $var['ideal_price'];
-}
-if (isset($var['offered_price'])) {
-	// transfer this value
-	transfer('offered_price');
+$container = create_container('skeleton.php', 'shop_goods.php');
+$template->assign('ShopHREF', SmrSession::getNewHREF($container));
 
-	// return this value
-	$offered_price = $var['offered_price'];
-}
-
-$PHP_OUTPUT.=('<input type="number" name="bargain_price" value="'.$bargain_price.'" id="InputFields" class="center" style="width:75;vertical-align:middle;">&nbsp;');
-$PHP_OUTPUT.=('<!-- all needed information to calculate the ideal price -->');
-$PHP_OUTPUT.=('<!-- Trade.Amount:Good.BasePrice:Good.Distance:Port.Good.Amount:Port.Good.Max:Relations:Port.Level -->');
-$PHP_OUTPUT.=('<!--('.$var['amount'].':'.$portGood['BasePrice'].':'.$port->getGoodDistance($good_id).':'.$port->getGoodAmount($good_id).':'.$portGood['Max'].':'.$player->getRelation($port->getRaceID()).':'.$port->getLevel().')-->');
-$PHP_OUTPUT.=create_submit('Bargain (1)');
-$PHP_OUTPUT.=('</form>');
-
-$PHP_OUTPUT.= '<script type="text/javascript">
-					window.document.FORM.bargain_price.select();
-					window.document.FORM.bargain_price.focus();
-				</script>';
-
-$PHP_OUTPUT.=('<p>Distance Index: '. $port->getGoodDistance($good_id) .'</p>');
-
-$PHP_OUTPUT.=('<h2>Or do you want:</h2>');
-
-$PHP_OUTPUT.=create_echo_form(create_container('skeleton.php', 'shop_goods.php'));
-$PHP_OUTPUT.=create_submit('Select a different good');
-$PHP_OUTPUT.=('</form>');
-$PHP_OUTPUT.=('<br /><br />');
-$PHP_OUTPUT.=create_echo_form(create_container('skeleton.php', 'current_sector.php'));
-$PHP_OUTPUT.=create_submit('Leave Port');
-$PHP_OUTPUT.=('</form>');
+$container = create_container('skeleton.php', 'current_sector.php');
+$template->assign('LeaveHREF', SmrSession::getNewHREF($container));

--- a/templates/Default/engine/Default/shop_goods_trade.php
+++ b/templates/Default/engine/Default/shop_goods_trade.php
@@ -11,10 +11,10 @@ $TradeCalcInfo = [
 ];
 
 if (isset($OfferToo)) { ?>
-	<p>I can't accept your offer. It's too <?php echo $OfferToo; ?>.</p><?php
+	<p class="red">I can't accept your offer. It's too <?php echo $OfferToo; ?>.</p><?php
 } ?>
 
-<p>I would <?php echo $PortAction; ?> <?php echo $Amount; ?> units of <?php echo $Good['Name']; ?> for <?php echo $OfferedPrice; ?> credits!<br />
+<p>I would <?php echo $PortAction; ?> <?php echo $Amount; ?> units of <?php echo $Good['Name']; ?> for <span class="creds"><?php echo $OfferedPrice; ?></span> credits!<br />
 Note: In order to maximize your experience you have to bargain with the port owner, unless you have maximum relations (1000) with that race, which gives full experience without the need to bargain.</p>
 
 <form name="FORM" method="POST" action="<?php echo $BargainHREF; ?>">

--- a/templates/Default/engine/Default/shop_goods_trade.php
+++ b/templates/Default/engine/Default/shop_goods_trade.php
@@ -1,0 +1,37 @@
+<?php
+// Create an array for use later
+$TradeCalcInfo = [
+	$Amount,
+	$Good['BasePrice'],
+	$Port->getGoodDistance($Good['ID']),
+	$Port->getGoodAmount($Good['ID']),
+	$Good['Max'],
+	$ThisPlayer->getRelation($Port->getRaceID()),
+	$Port->getLevel()
+];
+
+if (isset($OfferToo)) { ?>
+	<p>I can't accept your offer. It's too <?php echo $OfferToo; ?>.</p><?php
+} ?>
+
+<p>I would <?php echo $PortAction; ?> <?php echo $Amount; ?> units of <?php echo $Good['Name']; ?> for <?php echo $OfferedPrice; ?> credits!<br />
+Note: In order to maximize your experience you have to bargain with the port owner, unless you have maximum relations (1000) with that race, which gives full experience without the need to bargain.</p>
+
+<form name="FORM" method="POST" action="<?php echo $BargainHREF; ?>">
+	<input type="number" name="bargain_price" value="<?php echo $BargainPrice; ?>" id="InputFields" class="center" style="width:75;vertical-align:middle;">&nbsp;
+	<!-- all needed information to calculate the ideal price -->
+	<!-- Trade.Amount:Good.BasePrice:Good.Distance:Port.Good.Amount:Port.Good.Max:Relations:Port.Level -->
+	<!-- (<?php echo join(':', $TradeCalcInfo); ?>)-->
+	<input type="submit" name="action" id="InputFields" value="Bargain (1)" />
+</form>
+
+<script type="text/javascript">
+	window.document.FORM.bargain_price.select();
+	window.document.FORM.bargain_price.focus();
+</script>
+
+<p>Distance Index: <?php echo $Port->getGoodDistance($Good['ID']); ?></p>
+
+<h2>Or do you want to:</h2>
+<p><a href="<?php echo $ShopHREF; ?>" class="submitStyle">Select a different good</a></p>
+<p><a href="<?php echo $LeaveHREF; ?>" class="submitStyle">Leave Port</a></p>


### PR DESCRIPTION
* Convert the "Leave Port" and "Select a different good" forms
  to submit-style links.

* Replace "pcs." -> "units".

* Removed a few lines of engine code that weren't doing anything.

* Display failed bargain text as red.

* Display offered price in a class "creds" span (i.e. yellow).

![image](https://user-images.githubusercontent.com/846186/42413772-054b742a-81dc-11e8-9653-9e25feb5a9a0.png)
