### PR TITLE
Convert a few bar pages to templates

### DIFF
--- a/engine/Default/bar_gambling_bet.php
+++ b/engine/Default/bar_gambling_bet.php
@@ -1,31 +1,20 @@
 <?php
 if(isset($var['message'])) {
-	$PHP_OUTPUT.=$var['message'];
+	$template->assign('Message', $var['message']);
 	return;
 }
 
-$PHP_OUTPUT.=('<div align=center>How much do you want to bet? ');
-if ($player->getNewbieTurns() > 0) {
-	$value = 100;
-	$PHP_OUTPUT.=('(Since you have newbie protection max bet is '.$value.')<br />');
+if ($player->hasNewbieTurns()) {
+	$maxBet = 100;
+	$maxBetMsg = 'Since you have newbie protection, your max bet is '.$maxBet.'.';
 } else {
-	$value = 10000;
-	$PHP_OUTPUT.=('(Max bet is '.$value.')<br />');
+	$maxBet = 10000;
+	$maxBetMsg = 'Max bet is '.$maxBet.'.';
 }
+$template->assign('MaxBet', $maxBet);
+$template->assign('MaxBetMsg', $maxBetMsg);
 
 $container = create_container('skeleton.php', 'bar_main.php');
 $container['script'] = 'bar_gambling_processing.php';
 $container['action'] = 'blackjack';
-$PHP_OUTPUT.=create_echo_form($container);
-$PHP_OUTPUT.=('<input type="number" value="'.$value.'" name="bet" id="InputFields" style="width:100px;" class="center">&nbsp;&nbsp;&nbsp;');
-$PHP_OUTPUT.=create_submit('Play the Game');
-$PHP_OUTPUT.=('</form></div>');
-$PHP_OUTPUT.=('<br /><br />');
-$PHP_OUTPUT.=('Don\'t know how about BlackJack?  Not a problem...Check out the following!<br />');
-$PHP_OUTPUT.=('<h1>HISTORY</h1>Blackjack comes from a family of games that includes baccarat, vingt-et-un and seven-and-a-half. Blackjack gained popularity in the United States during World War I as weary troops looked for interesting pastimes. Also known as Twenty-One, the game made fortunes for a number of expert "card counters" in the 1960s. These experts were able to identify points in the game when players temporarily had an edge over the house, at which time they would greatly increase the size of their bets. Casinos have since made it more difficult for players to win by adding decks and shuffling more often, but it\'s still a game where skillful players have a relatively good chance for a winning session.<br /><br />');
-$PHP_OUTPUT.=('<h1>BASICS</h1>You compete against the dealer. The object of the game is to have a higher point total than the dealer without going over 21. Each ace counts as either 1 point or 11 points, face cards (kings, queens, jacks) count 10 points each, and all other cards (2 through 9) count their face value.<br /><br />');
-$PHP_OUTPUT.=('<h1>BETTING</h1>Before the deal, you place you bet. In order to place a bet you enter the amount you wish to bet and then click \'Play the Game\'. The maximum bet per hand is always $'.$value.'.<br /><br />');
-$PHP_OUTPUT.=('<h1>THE PLAY</h1>The dealer deals two cards to you and two cards to himself. One of the dealer\'s cards is dealt faceup and the other is facedown. After the deal, the dealer "asks" you whether you want an additional card. A player may "Stay" -- play just the two cards originally dealt or may "Hit"-- take another card. After being dealt an additional card, you may stop or may take still another card. You may take as many cards as you want, but as soon as your total exceeds 21, you lose.<br /><br />');
-$PHP_OUTPUT.=('After you have drawn, the dealer\'s remaining card is exposed. Under SMR rules, a dealer with a total less than 17 must "hit" (take a card); with 17 or more, dealer must stand.<br /><br />');
-$PHP_OUTPUT.=('If dealer "busts" by going over 21, any players still in the game win. Otherwise, players with totals higher than the dealer win, while players with totals less than the dealer lose. In case of a tie, or "push" the player\'s bet is returned (no money changes hands).<br /><br />');
-$PHP_OUTPUT.=('If your or the dealer\'s first two cards total 21 (an ace and a 10 or face card), the holding is known as a blackjack. A player with blackjack is paid extra--two and a half times the original bet--unless dealer also has blackjack, in which case the player loses.<br /><br />');
+$template->assign('PlayHREF', SmrSession::getNewHREF($container));

--- a/engine/Default/bar_gambling_lotto.php
+++ b/engine/Default/bar_gambling_lotto.php
@@ -2,20 +2,9 @@
 require_once(get_file_loc('bar.functions.inc'));
 checkForLottoWinner($player->getGameID());
 $lottoInfo = getLottoInfo($player->getGameID());
+$template->assign('LottoInfo', $lottoInfo);
 
-//find the time remaining in this jackpot. (which is 2 days from the first purchased ticket)
-$PHP_OUTPUT.=('<br /><div align="center">Currently <b>'.format_time($lottoInfo['TimeRemaining']).'</b> remain until the winning ticket');
-$PHP_OUTPUT.=(' is drawn, and the prize is $' . number_format($lottoInfo['Prize']) . '.<br /><br />');
-$PHP_OUTPUT.=('Ahhhh so your interested in the lotto huh?  ');
-$PHP_OUTPUT.=('Well here is how it works.  First you will need to buy a ticket, ');
-$PHP_OUTPUT.=('they cost $1,000,000 a piece.  Next you need to watch the news.  Once the winning ');
-$PHP_OUTPUT.=('lotto ticket is drawn there will be a section in the news with the winner.');
-$PHP_OUTPUT.=('  If you win you can come to any bar and claim your prize!');
-$PHP_OUTPUT.=('<br /><br />');
-$container = array();
-$container['url'] = 'skeleton.php';
-$container['body'] = 'bar_main.php';
+$container = create_container('skeleton.php', 'bar_main.php');
 $container['script'] = 'bar_gambling_processing.php';
 $container['action'] = 'process';
-$PHP_OUTPUT.=create_button($container,'Buy a Ticket ($1,000,000)');
-$PHP_OUTPUT.=('</div>');
+$template->assign('BuyTicketHREF', SmrSession::getNewHREF($container));

--- a/engine/Default/bar_main.php
+++ b/engine/Default/bar_main.php
@@ -37,6 +37,4 @@ $db->query('DELETE FROM player_has_drinks WHERE time < ' . $db->escapeNumber(TIM
 //include bar part
 require_once(get_file_loc($script));
 
-if($script == 'bar_opening.php') {
-	$template->assign('IncludeScript',$script);
-}
+$template->assign('IncludeScript',$script);

--- a/templates/Default/engine/Default/bar_gambling_bet.php
+++ b/templates/Default/engine/Default/bar_gambling_bet.php
@@ -1,0 +1,30 @@
+<?php
+if (isset($Message)) {
+	echo $Message;
+	return;
+} ?>
+
+<div class=center>
+	How much do you want to bet? <?php $MaxBetMsg; ?><br />
+	<form method="POST" action="<?php echo $PlayHREF; ?>">
+		<input type="number" value="<?php echo $MaxBet; ?>" name="bet" id="InputFields" style="width:100px;" class="center">&nbsp;&nbsp;&nbsp;
+		<input type="submit" name="action" id="InputFields" value="Play the Game" />
+	</form>
+</div>
+
+<p>Don't know how about BlackJack?  Not a problem...Check out the following!</p>
+
+<h2>HISTORY</h2>
+<p>Blackjack comes from a family of games that includes baccarat, vingt-et-un and seven-and-a-half. Blackjack gained popularity in the United States during World War I as weary troops looked for interesting pastimes. Also known as Twenty-One, the game made fortunes for a number of expert "card counters" in the 1960s. These experts were able to identify points in the game when players temporarily had an edge over the house, at which time they would greatly increase the size of their bets. Casinos have since made it more difficult for players to win by adding decks and shuffling more often, but it's still a game where skillful players have a relatively good chance for a winning session.</p>
+
+<h2>BASICS</h2>
+<p>You compete against the dealer. The object of the game is to have a higher point total than the dealer without going over 21. Each ace counts as either 1 point or 11 points, face cards (kings, queens, jacks) count 10 points each, and all other cards (2 through 9) count their face value.</p>
+
+<h2>BETTING</h2>
+<p>Before the deal, you place you bet. In order to place a bet you enter the amount you wish to bet and then click 'Play the Game'. The maximum bet per hand is always $<?php echo $MaxBet; ?>.</p>
+
+<h2>THE PLAY</h2>
+<p>The dealer deals two cards to you and two cards to himself. One of the dealer's cards is dealt faceup and the other is facedown. After the deal, the dealer "asks" you whether you want an additional card. A player may "Stay" -- play just the two cards originally dealt or may "Hit"-- take another card. After being dealt an additional card, you may stop or may take still another card. You may take as many cards as you want, but as soon as your total exceeds 21, you lose.</p>
+<p>After you have drawn, the dealer's remaining card is exposed. Under SMR rules, a dealer with a total less than 17 must "hit" (take a card); with 17 or more, dealer must stand.</p>
+<p>If dealer "busts" by going over 21, any players still in the game win. Otherwise, players with totals higher than the dealer win, while players with totals less than the dealer lose. In case of a tie, or "push" the player's bet is returned (no money changes hands).</p>
+<p>If your or the dealer's first two cards total 21 (an ace and a 10 or face card), the holding is known as a blackjack. A player with blackjack is paid extra--two and a half times the original bet--unless dealer also has blackjack, in which case the player loses.</p>

--- a/templates/Default/engine/Default/bar_gambling_lotto.php
+++ b/templates/Default/engine/Default/bar_gambling_lotto.php
@@ -4,7 +4,7 @@
 	is drawn.<br />
 	The prize is $<?php echo number_format($LottoInfo['Prize']); ?>.
 	<br /><br />
-	Ahhhh so your interested in the lotto huh?
+	Ahhhh so you're interested in the lotto huh?
 	Well here is how it works. First you need to buy a ticket,
 	they cost $1,000,000 each. Next you need to watch the news. Once the winning
 	ticket is drawn there will be a section in the news announcing the winner.

--- a/templates/Default/engine/Default/bar_gambling_lotto.php
+++ b/templates/Default/engine/Default/bar_gambling_lotto.php
@@ -1,0 +1,16 @@
+<br />
+<div class="center">
+	Currently <b><?php echo format_time($LottoInfo['TimeRemaining']); ?></b> remain until the winning ticket
+	is drawn.<br />
+	The prize is $<?php echo number_format($LottoInfo['Prize']); ?>.
+	<br /><br />
+	Ahhhh so your interested in the lotto huh?
+	Well here is how it works. First you need to buy a ticket,
+	they cost $1,000,000 each. Next you need to watch the news. Once the winning
+	ticket is drawn there will be a section in the news announcing the winner.
+	If you win you can claim your prize at any bar!
+	<br /><br />
+	<div class="buttonA">
+		<a class="buttonA" href="<?php echo $BuyTicketHREF; ?>">&nbsp;Buy a Ticket ($1,000,000)&nbsp;</a>
+	</div>
+</div>

--- a/templates/Default/engine/Default/bar_main.php
+++ b/templates/Default/engine/Default/bar_main.php
@@ -1,5 +1,5 @@
 <?php
-if(isset($IncludeScript)) {
+if (empty($PHP_OUTPUT)) {
 	$this->includeTemplate($IncludeScript);
 }
 else {


### PR DESCRIPTION
* bar_gambling_bet.php
* bar_gambling_lotto.php

We need to generalize bar_main.php to accomodate any bar-related
script that has been templatized. We do this by always including
the template if `$PHP_OUTPUT` is empty (which it should be for
templatized scripts).