### PR TITLE
universe_create_ports.php: fix port total not updating

### DIFF
--- a/htdocs/js/smr15.js
+++ b/htdocs/js/smr15.js
@@ -17,8 +17,8 @@
 	};
 
 	// Recalculate total number of ports, summing over level
-	window.levelCalc = function() {
-		doCalc('port', 9, 'total');
+	window.levelCalc = function(maxPortLevel) {
+		doCalc('port', maxPortLevel, 'total');
 	};
 
 	// Recalculate sum of port race percentages

--- a/templates/Default/admin/Default/1.6/universe_create_ports.php
+++ b/templates/Default/admin/Default/1.6/universe_create_ports.php
@@ -12,7 +12,7 @@
 					foreach ($TotalPorts as $Level => $Count) { ?>
 						<tr>
 							<td class="right">Level <?php echo $Level; ?></td>
-							<td><input type="number" value="<?php echo $Count; ?>" size="5" name="port<?php echo $Level; ?>" onInput="levelCalc();"></td>
+							<td><input type="number" value="<?php echo $Count; ?>" size="5" name="port<?php echo $Level; ?>" onInput="levelCalc(<?php echo SmrPort::MAX_LEVEL; ?>);"></td>
 						</tr><?php
 					} ?>
 					<tr>


### PR DESCRIPTION
The javascript responsible for updating the total number of ports
(by level) in realtime had a hard-coded maximum level for the ports.
This stops working if the actual max level is not what is hardcoded.
To fix this, we simply pass the max port level constant to the
javascript function.