### PR TITLE
Use actual shop names

### DIFF
--- a/engine/Default/shop_ship.inc
+++ b/engine/Default/shop_ship.inc
@@ -1,5 +1,7 @@
 <?php
-$template->assign('PageTopic','Ship Dealer');
+
+$location = SmrLocation::getLocation($var['LocationID']);
+$template->assign('PageTopic', $location->getName());
 
 $shipsSold = array();
 if ($db->getNumRows() > 0 ) {

--- a/engine/Default/shop_weapon.php
+++ b/engine/Default/shop_weapon.php
@@ -1,3 +1,5 @@
 <?php
-$template->assign('PageTopic','Weapon Dealer');
-$template->assign('ThisLocation', SmrLocation::getLocation($var['LocationID']));
+
+$location = SmrLocation::getLocation($var['LocationID']);
+$template->assign('PageTopic', $location->getName());
+$template->assign('ThisLocation', $location);


### PR DESCRIPTION
Replace the generic names used for ship and weapon shops with the actual names of the shop.