### PR TITLE
shop_weapon.php: Sell Weapons shows power level

### DIFF
--- a/templates/Default/engine/Default/shop_weapon.php
+++ b/templates/Default/engine/Default/shop_weapon.php
@@ -49,12 +49,14 @@ if ($ThisShip->hasWeapons()) { ?>
 	<table class="standard">
 		<tr class="center">
 			<th>Name</th>
-			<th>Cash</th>
+			<th>Power<br />Level</th>
+			<th>Credits</th>
 			<th>Action</th>
 		</tr><?php
 		foreach ($ThisShip->getWeapons() as $OrderID => $Weapon) { ?>
 			<tr class="center">
 				<td><?php echo $Weapon->getName(); ?></td>
+				<td><?php echo $Weapon->getPowerLevel(); ?></td>
 				<td><?php echo number_format(floor($Weapon->getCost() * WEAPON_REFUND_PERCENT)); ?></td>
 				<td><a href="<?php echo $Weapon->getSellHREF($ThisLocation, $OrderID); ?>" class="submitStyle">Sell</a></td>
 			</tr><?php


### PR DESCRIPTION
It may be useful to know the power level of your weapons when
selling them. Previously only the Value was shown. Now we show
Power Level as well.

Also rename header "Cash" to "Credits" for consistency.

![image](https://user-images.githubusercontent.com/846186/43691036-2c13b162-98ca-11e8-800f-4a51ab4e2bf3.png)
