### PR TITLE
shared.css: use pointer cursor for submittables

### DIFF
--- a/htdocs/css/shared.css
+++ b/htdocs/css/shared.css
@@ -1,3 +1,6 @@
+button, input[type=submit] {
+	cursor: pointer;
+}
 th {
 	font-size: 110%;
 	text-align: center;


### PR DESCRIPTION
Style `button` and `input[type=submit]` elements with pointer
cursors by default.

Since our default style is not obviously a button, this makes
it clearer when elements are clickable.