### PR TITLE
Use real shop names

### DIFF
--- a/engine/Default/shop_ship.php
+++ b/engine/Default/shop_ship.php
@@ -1,5 +1,7 @@
 <?php
-$template->assign('PageTopic','Ship Dealer');
+
+$location = SmrLocation::getLocation($var['LocationID']);
+$template->assign('PageTopic', $location->getName());
 
 $shipsSold = $location->getShipsSold();
 if ($shipsSold) {

--- a/engine/Default/shop_weapon.php
+++ b/engine/Default/shop_weapon.php
@@ -1,3 +1,5 @@
 <?php
-$template->assign('PageTopic','Weapon Dealer');
-$template->assign('ThisLocation', SmrLocation::getLocation($var['LocationID']));
+
+$location = SmrLocation::getLocation($var['LocationID']);
+$template->assign('PageTopic', $location->getName());
+$template->assign('ThisLocation', $location);


### PR DESCRIPTION
Instead of naming shops "Ship Dealer" or "Weapon Dealer", use the actual name of each shop location.

Closes #582.