### PR TITLE
PlanetList.inc: none -> None

### DIFF
--- a/templates/Default/engine/Default/includes/PlanetList.inc
+++ b/templates/Default/engine/Default/includes/PlanetList.inc
@@ -51,7 +51,7 @@ if (count($Planets) > 0) { ?>
 							}
 						}
 						if ($Supply === false) {
-							?>none<?php
+							?>None<?php
 						} ?>
 					</td>
 					<td class="build noWrap center"><?php


### PR DESCRIPTION
Capitalize the word "none" when there are no Supplies on a planet,
for consistency with the "Nothing" when there is no Build.