### PR TITLE
Op leader permission for alliance roles

### DIFF
--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -399,9 +399,10 @@ function createGame($gameID) {
 	$exemptWith = TRUE;
 	$mbMessages = TRUE;
 	$sendAllMsg = TRUE;
+	$opLeader = TRUE;
 	$viewBonds = TRUE;
-	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds)
-				VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds)
+				VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 	$withPerDay = ALLIANCE_BANK_UNLIMITED;
 	$removeMember = FALSE;
 	$changePass = FALSE;
@@ -411,9 +412,10 @@ function createGame($gameID) {
 	$exemptWith = FALSE;
 	$mbMessages = FALSE;
 	$sendAllMsg = FALSE;
+	$opLeader = FALSE;
 	$viewBonds = FALSE;
-	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds) ' .
-				'VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember).', '.$db->escapeBoolean($changePass).', '.$db->escapeBoolean($changeMOD).', '.$db->escapeBoolean($changeRoles).', '.$db->escapeBoolean($planetAccess).', '.$db->escapeBoolean($exemptWith).', '.$db->escapeBoolean($mbMessages).', '.$db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
+				'VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember).', '.$db->escapeBoolean($changePass).', '.$db->escapeBoolean($changeMOD).', '.$db->escapeBoolean($changeRoles).', '.$db->escapeBoolean($planetAccess).', '.$db->escapeBoolean($exemptWith).', '.$db->escapeBoolean($mbMessages).', '.$db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 	$db->query('REPLACE INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', 1,' . $db->escapeNumber(NHA_ID) . ')');
 	
 	// NHA default topics

--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -386,37 +386,12 @@ function addLocationToSector(SmrLocation $location, SmrSector $sector) {
 
 function createGame($gameID) {
 	$db = new SmrMySqlDatabase();
-	// Newbie Help Alliance
-	
+
+	// create the Newbie Help Alliance
 	$db->query('REPLACE INTO alliance (alliance_id, game_id, alliance_name, alliance_description, alliance_password, leader_id, `mod`) VALUES
 				(' . $db->escapeNumber(NHA_ID) . ',' . $db->escapeNumber($gameID) . ',\'Newbie Help Alliance\',\'Newbie Help Alliance\',\'*\',' . $db->escapeNumber(ACCOUNT_ID_NHL) . ',\'Alliance message board includes tips and FAQs.\')');
-	$withPerDay = ALLIANCE_BANK_UNLIMITED;
-	$removeMember = TRUE;
-	$changePass = TRUE;
-	$changeMOD = TRUE;
-	$changeRoles = TRUE;
-	$planetAccess = TRUE;
-	$exemptWith = TRUE;
-	$mbMessages = TRUE;
-	$sendAllMsg = TRUE;
-	$opLeader = TRUE;
-	$viewBonds = TRUE;
-	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds)
-				VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
-	$withPerDay = ALLIANCE_BANK_UNLIMITED;
-	$removeMember = FALSE;
-	$changePass = FALSE;
-	$changeMOD = FALSE;
-	$changeRoles = FALSE;
-	$planetAccess = TRUE;
-	$exemptWith = FALSE;
-	$mbMessages = FALSE;
-	$sendAllMsg = FALSE;
-	$opLeader = FALSE;
-	$viewBonds = FALSE;
-	$db->query('REPLACE INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
-				'VALUES (' . $db->escapeNumber(NHA_ID) . ', ' . $db->escapeNumber($gameID) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember).', '.$db->escapeBoolean($changePass).', '.$db->escapeBoolean($changeMOD).', '.$db->escapeBoolean($changeRoles).', '.$db->escapeBoolean($planetAccess).', '.$db->escapeBoolean($exemptWith).', '.$db->escapeBoolean($mbMessages).', '.$db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
-	$db->query('REPLACE INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', 1,' . $db->escapeNumber(NHA_ID) . ')');
+
+	SmrAlliance::getAlliance(NHA_ID, $gameID)->createDefaultRoles();
 	
 	// NHA default topics
 	

--- a/db/patches/V1_6_63_05__op_leader_role.sql
+++ b/db/patches/V1_6_63_05__op_leader_role.sql
@@ -1,0 +1,5 @@
+-- Add op_leader permission so it's not limited to leader
+ALTER TABLE alliance_has_roles ADD COLUMN op_leader enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE';
+
+-- Retain op_leader permission for leaders in existing games
+UPDATE alliance_has_roles SET op_leader = 'TRUE' WHERE role_id = 1;

--- a/engine/Default/alliance_create_processing.php
+++ b/engine/Default/alliance_create_processing.php
@@ -57,51 +57,6 @@ $db->query('INSERT INTO alliance (alliance_id, game_id, alliance_name, alliance_
 $player->setAllianceID($alliance_id);
 $player->update();
 
-$withPerDay = ALLIANCE_BANK_UNLIMITED;
-$removeMember = TRUE;
-$changePass = TRUE;
-$changeMOD = TRUE;
-$changeRoles = TRUE;
-$planetAccess = TRUE;
-$exemptWith = TRUE;
-$mbMessages = TRUE;
-$sendAllMsg = TRUE;
-$opLeader = TRUE;
-$viewBonds = TRUE;
-$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
-			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
-switch ($perms) {
-	case 'full':
-		//do nothing, perms already set above.
-	break;
-	case 'none':
-		$withPerDay = 0;
-		$removeMember = FALSE;
-		$changePass = FALSE;
-		$changeMOD = FALSE;
-		$changeRoles = FALSE;
-		$planetAccess = FALSE;
-		$exemptWith = FALSE;
-		$mbMessages = FALSE;
-		$sendAllMsg = FALSE;
-		$opLeader = FALSE;
-		$viewBonds = FALSE;
-	break;
-	case 'basic':
-		$withPerDay = ALLIANCE_BANK_UNLIMITED;
-		$removeMember = FALSE;
-		$changePass = FALSE;
-		$changeMOD = FALSE;
-		$changeRoles = FALSE;
-		$planetAccess = TRUE;
-		$exemptWith = FALSE;
-		$mbMessages = FALSE;
-		$sendAllMsg = FALSE;
-		$opLeader = FALSE;
-		$viewBonds = FALSE;
-	break;
-}
-$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
-			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
-$db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id,alliance_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', 1,' . $db->escapeNumber($alliance_id) . ')');
+$player->getAlliance()->createDefaultRoles($perms);
+
 forward(create_container('skeleton.php', 'alliance_roster.php'));

--- a/engine/Default/alliance_create_processing.php
+++ b/engine/Default/alliance_create_processing.php
@@ -66,9 +66,10 @@ $planetAccess = TRUE;
 $exemptWith = TRUE;
 $mbMessages = TRUE;
 $sendAllMsg = TRUE;
+$opLeader = TRUE;
 $viewBonds = TRUE;
-$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds) ' .
-			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
+			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 switch ($perms) {
 	case 'full':
 		//do nothing, perms already set above.
@@ -83,6 +84,7 @@ switch ($perms) {
 		$exemptWith = FALSE;
 		$mbMessages = FALSE;
 		$sendAllMsg = FALSE;
+		$opLeader = FALSE;
 		$viewBonds = FALSE;
 	break;
 	case 'basic':
@@ -95,10 +97,11 @@ switch ($perms) {
 		$exemptWith = FALSE;
 		$mbMessages = FALSE;
 		$sendAllMsg = FALSE;
+		$opLeader = FALSE;
 		$viewBonds = FALSE;
 	break;
 }
-$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, view_bonds) ' .
-			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
+			'VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 $db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id,alliance_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', 1,' . $db->escapeNumber($alliance_id) . ')');
 forward(create_container('skeleton.php', 'alliance_roster.php'));

--- a/engine/Default/alliance_option.php
+++ b/engine/Default/alliance_option.php
@@ -80,7 +80,7 @@ if ($db->getBoolean('treaty_entry')) {
 		'text' => 'Negotitate treaties with other alliances.',
 	);
 }
-if ($player->isAllianceLeader()) {
+if ($db->getBoolean('op_leader')) {
 	$container['body'] = 'alliance_set_op.php';
 	$links[] = array(
 		'link' => create_link($container, 'Schedule Operation'),

--- a/engine/Default/alliance_roles.php
+++ b/engine/Default/alliance_roles.php
@@ -34,6 +34,7 @@ while ($db->nextRecord()) {
 		$allianceRoles[$roleID]['ModerateMessageboard'] = $db->getBoolean('mb_messages');
 		$allianceRoles[$roleID]['ExemptWithdrawals'] = $db->getBoolean('exempt_with');
 		$allianceRoles[$roleID]['SendAllianceMessage'] = $db->getBoolean('send_alliance_msg');
+		$allianceRoles[$roleID]['OpLeader'] = $db->getBoolean('op_leader');
 		$allianceRoles[$roleID]['ViewBondsInPlanetList'] = $db->getBoolean('view_bonds');
 	}
 	else {
@@ -69,4 +70,5 @@ $template->assign('CreateRole', array(
 	'ModerateMessageboard' => false,
 	'ExemptWithdrawals' => false,
 	'SendAllianceMessage' => false,
+	'OpLeader' => false,
 	'ViewBondsInPlanetList' => false));

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -400,4 +400,63 @@ class SmrAlliance {
 		return in_array($sector->getSectorID(), $this->getSeedlist());
 	}
 
+	/**
+	 * Create the default roles for this alliance.
+	 * This should only be called once after the alliance is created.
+	 */
+	public function createDefaultRoles($newMemberPermission='basic') {
+		$db = $this->db; //for convenience
+
+		$withPerDay = ALLIANCE_BANK_UNLIMITED;
+		$removeMember = TRUE;
+		$changePass = TRUE;
+		$changeMOD = TRUE;
+		$changeRoles = TRUE;
+		$planetAccess = TRUE;
+		$exemptWith = TRUE;
+		$mbMessages = TRUE;
+		$sendAllMsg = TRUE;
+		$opLeader = TRUE;
+		$viewBonds = TRUE;
+		$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
+			'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+
+		switch ($newMemberPermission) {
+			case 'full':
+				//do nothing, perms already set above.
+			break;
+			case 'none':
+				$withPerDay = 0;
+				$removeMember = FALSE;
+				$changePass = FALSE;
+				$changeMOD = FALSE;
+				$changeRoles = FALSE;
+				$planetAccess = FALSE;
+				$exemptWith = FALSE;
+				$mbMessages = FALSE;
+				$sendAllMsg = FALSE;
+				$opLeader = FALSE;
+				$viewBonds = FALSE;
+			break;
+			case 'basic':
+				$withPerDay = ALLIANCE_BANK_UNLIMITED;
+				$removeMember = FALSE;
+				$changePass = FALSE;
+				$changeMOD = FALSE;
+				$changeRoles = FALSE;
+				$planetAccess = TRUE;
+				$exemptWith = FALSE;
+				$mbMessages = FALSE;
+				$sendAllMsg = FALSE;
+				$opLeader = FALSE;
+				$viewBonds = FALSE;
+			break;
+		}
+		$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
+					'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', '.$db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', '.$db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+
+		// Set the leader permissions
+		$db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber($this->getLeaderID()) . ', 1,' . $db->escapeNumber($this->getAllianceID()) . ')');
+	}
+
 }

--- a/templates/Default/engine/Default/includes/AllianceRole.inc
+++ b/templates/Default/engine/Default/includes/AllianceRole.inc
@@ -49,6 +49,10 @@
 					<td align="left"><input type="checkbox" name="sendAllMsg"<?php if ($Role['SendAllianceMessage']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
+					<td class="left">Operations Leader</td>
+					<td class="left"><input type="checkbox" name="opLeader" alt="Can schedule operations and designate the flagship" <?php if ($Role['OpLeader']){ ?> checked="checked"<?php } ?></td>
+				</tr>
+				<tr>
 					<td align="left">View Bonds In Planet List</td>
 					<td align="left"><input type="checkbox" name="viewBonds"<?php if ($Role['ViewBondsInPlanetList']){ ?> checked="checked"<?php } ?>></td>
 				</tr><?php

--- a/templates/Default/engine/Default/includes/AllianceRole.inc
+++ b/templates/Default/engine/Default/includes/AllianceRole.inc
@@ -13,7 +13,7 @@
 				<td align="left">Unlimited:<input type="checkbox" name="unlimited"<?php if ($Role['WithdrawalLimit'] == ALLIANCE_BANK_UNLIMITED){ ?> checked="checked"<?php } ?>></td>
 			</tr>
 			<tr>
-				<td align="left">Positive Balance:<input type="checkbox" name="positive" alt="Members must deposit more than they withdraw."<?php if ($Role['PositiveBalance']){ ?> checked="checked"<?php } ?>></td>
+				<td align="left">Positive Balance:<input type="checkbox" name="positive" title="Members must deposit more than they withdraw"<?php if ($Role['PositiveBalance']){ ?> checked="checked"<?php } ?>></td>
 			</tr><?php
 			if (!$Role['TreatyCreated']) { ?>
 				<tr>
@@ -42,7 +42,7 @@
 				</tr>
 				<tr>
 					<td align="left">Exempt Withdrawals</td>
-					<td align="left"><input type="checkbox" name="exemptWithdrawals" alt="This user can mark withdrawals from the alliance account as 'for the alliance' instead of 'for the individual'"<?php if ($Role['ExemptWithdrawals']){ ?> checked="checked"<?php } ?>></td>
+					<td align="left"><input type="checkbox" name="exemptWithdrawals" title="This user can mark withdrawals from the alliance account as 'for the alliance' instead of 'for the individual'"<?php if ($Role['ExemptWithdrawals']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
 					<td align="left">Send Alliance Message</td>
@@ -50,7 +50,7 @@
 				</tr>
 				<tr>
 					<td class="left">Operations Leader</td>
-					<td class="left"><input type="checkbox" name="opLeader" alt="Can schedule operations and designate the flagship" <?php if ($Role['OpLeader']){ ?> checked="checked"<?php } ?></td>
+					<td class="left"><input type="checkbox" name="opLeader" title="Can schedule operations and designate the flagship" <?php if ($Role['OpLeader']){ ?> checked="checked"<?php } ?></td>
 				</tr>
 				<tr>
 					<td align="left">View Bonds In Planet List</td>


### PR DESCRIPTION
Adds the ability for access to the "Schedule Operations" page to be given to any alliance role. Previously this was restricted to the "*".

![image](https://user-images.githubusercontent.com/846186/43985952-92b4849c-9cc0-11e8-9129-c4e49e21ff34.png)
