### PR TITLE
SmrPlanet: change how we choose structure to destroy

### DIFF
--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -331,12 +331,12 @@ class SmrPlanet {
 				$this->setArmour($this->getMaxArmour());
 		}
 		// Remove a random (0-indexed) mounted weapon, if over max mount slots
-		while (max(array_keys($this->getMountedWeapons())) >= $this->getMaxMountedWeapons()) {
-			$removeKey = array_rand($this->getMountedWeapons());
-			$this->removeMountedWeapon($removeKey);
+		while ($this->getMountedWeapons() && max(array_keys($this->getMountedWeapons())) >= $this->getMaxMountedWeapons()) {
+			$removeID = array_rand($this->getMountedWeapons());
+			$this->removeMountedWeapon($removeID);
 			foreach ($this->getMountedWeapons() as $orderID => $weapon) {
-				if ($orderID > $removeKey) {
-					$this->moveMountedWeaponUp($OrderID);
+				if ($orderID > $removeID) {
+					$this->moveMountedWeaponUp($orderID);
 				}
 			}
 		}
@@ -1153,63 +1153,24 @@ class SmrPlanet {
 
 	function &checkForDowngrade($damage) {
 		$results = '';
-		// Chance of planetary structure damage = For every 70 damage there is a 15% chance of destroying a structure.
-		// Turrets/Weapon Mounts have a 1 in 6 chance of being destroyed
-		// Hangers have a 2 in 6 chance of being destroyed
-		// Generators/Bunkers 3 in 6 chance of being destroyed
-		//iterate over all chances
+		// For every 70 damage there is a 15% chance of destroying a structure.
+		// Which structure is destroyed depends on the ratio of buildings and
+		// the time it takes to build them.
 		for ($i = 0; $damage > self::DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE; $damage-=self::DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE) {
+			// Stop if the planet has no more buildlings
+			if ($this->getLevel() == 0) {
+				break;
+			}
 			//15% chance to destroy something
 			if (mt_rand(1, 100) <= self::CHANCE_TO_DOWNGRADE) {
-				$rand = mt_rand(1, 6);
-				switch ($rand) {
-					case 1:
-						//destroy a turret
-						if ($this->hasBuilding(PLANET_TURRET)) {
-							$results .= 'This team destroys <span style = "color:red;">1</span> turret.<br />';
-							$this->destroyBuilding(PLANET_TURRET, 1);
-							break;
-						}
-						//if no turrets try weapon mounts
-						if ($this->hasBuilding(PLANET_WEAPON_MOUNT)) {
-							$results .= 'This team destroys <span style = "color:red;">1</span> weapon mount.<br />';
-							$this->destroyBuilding(PLANET_WEAPON_MOUNT, 1);
-							break;
-						}
-					case 2:
-					case 3:
-						//destroy a hangar
-						if ($this->hasBuilding(PLANET_HANGAR)) {
-							$results .= 'This team destroys <span style ="color:red;">1</span> hangar.<br />';
-							$this->destroyBuilding(PLANET_HANGAR, 1);
-							$this->checkForExcessDefense();
-							break;
-						}
-						//if no hangars we fall through
-					case 4:
-					case 5:
-					case 6:
-						//destroy a gen
-						if ($this->hasBuilding(PLANET_GENERATOR)) {
-							$results .= 'This team destroys <span style ="color:red;">1</span> generator.<br />';
-							$this->destroyBuilding(PLANET_GENERATOR, 1);
-							$this->checkForExcessDefense();
-							break;
-						}
-						//if no gens try bunker
-						if ($this->hasBuilding(PLANET_BUNKER)) {
-							$results .= 'This team destroys <span style ="color:red;">1</span> bunker.<br />';
-							$this->destroyBuilding(PLANET_BUNKER, 1);
-							$this->checkForExcessDefense();
-							break;
-						}
-						
-						//if no bunker then we fall through
-					default:
-						//very rare that we will not have a gen to destroy.
-						$results .= 'A planetary structure barely survived the onslaught.<br />';
-					break;
+				$chanceFactors = [];
+				foreach ($this->getStructureTypes() as $structureID => $structure) {
+					$chanceFactors[$structureID] = ($this->getBuilding($structureID) / $this->getMaxBuildings($structureID)) / $structure->baseTime();
 				}
+				$destroyID = getWeightedRandom($chanceFactors);
+				$this->destroyBuilding($destroyID, 1);
+				$this->checkForExcessDefense();
+				$results .= 'This team destroys <span class="red">1</span> '.$this->getStructureTypes($destroyID)->name().'.<br />';
 			}
 		}
 		return $results;

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -1019,3 +1019,34 @@ function number_colour_format($number,$justSign = false) {
 	$formatted .= '</span>';
 	return $formatted;
 }
+
+
+/**
+ * Randomly choose an array key weighted by the array values.
+ * Probabilities are relative to the total weight. For example:
+ *
+ * array(
+ *    'A' => 1, // 10% chance
+ *    'B' => 3, // 30% chance
+ *    'C' => 6, // 60% chance
+ * );
+ */
+function getWeightedRandom($choices) {
+	// Normalize the weights so that their sum is much larger than 1.
+	$maxWeight = max($choices);
+	foreach ($choices as $key => &$weight) {
+		$weight = round($weight * 1000/$maxWeight);
+	} unset($weight);
+
+	// Generate a random number that is lower than the sum of the weights.
+	$rand = rand(1, array_sum($choices));
+
+	// Subtract weights from the random number until it is negative,
+	// then return the key associated with that weight.
+	foreach ($choices as $key => $weight) {
+		$rand -= $weight;
+		if ($rand <= 0) {
+			return $key;
+		}
+	}
+}


### PR DESCRIPTION
Previously, there was a flat chance to destroy each type of structure.

Generators/Bunkers = 50%
Hangars = 33%
Turrets = 17%

With the addition of new structures, we need a more formulaic method
to choose a structure. So we use the following formula:

% Chance = (Num Buildings / Max Buildings) / Build Time

Therefore, you're more likely to lose structure types that you have
a lot of (compared to how many the planet can support), and types
that take longer to build have a lower chance to be lost.

For a max level Terran planet, the chances work out to be similar
to the original constant values:

Generators = 60%
Hangars = 30%
Turrets = 10%

(Added a `getWeightedRandom` function to help pick the structure
to lose given an array of keys and weights.)