### PR TITLE
Minor ship changes starting Game 122

### DIFF
--- a/db/patches/V1_6_63_07__ship_changes_game122.sql
+++ b/db/patches/V1_6_63_07__ship_changes_game122.sql
@@ -1,0 +1,17 @@
+-- Thief +10 holds (150 -> 160)
+UPDATE ship_type_support_hardware SET max_amount = 160 WHERE ship_type_id = 23 AND hardware_type_id = 3;
+
+-- Assasin +1 hp (4 -> 5)
+UPDATE ship_type SET hardpoint = 5 WHERE ship_type_id = 24;
+
+-- Death Cruiser +1 hp (5 -> 6)
+UPDATE ship_type SET hardpoint = 6 WHERE ship_type_id = 25;
+-- Death Cruiser -25 mines (125 -> 100)
+UPDATE ship_type_support_hardware SET max_amount = 100 WHERE ship_type_id = 25 AND hardware_type_id = 6;
+
+-- Advanced Carrier -50 shields (750 -> 700)
+UPDATE ship_type_support_hardware SET max_amount = 700 WHERE ship_type_id = 48 AND hardware_type_id = 1;
+-- Advanced Carrier +50 armour (100 -> 150)
+UPDATE ship_type_support_hardware SET max_amount = 150 WHERE ship_type_id = 48 AND hardware_type_id = 2;
+-- Advanced Carrier -25 CDs (275 -> 250)
+UPDATE ship_type_support_hardware SET max_amount = 250 WHERE ship_type_id = 48 AND hardware_type_id = 4;


### PR DESCRIPTION
Thief:
    +10 holds (150 -> 160)

Assassin:
    +1 hp (4 -> 5)

Death Cruiser:
    +1 hp (5 -> 6)
    -25 mines (125 -> 100)

Advanced Carrier:
    -50 shields (750 -> 700)
    +50 armour (100 -> 150)
    -25 drones (275 -> 250)

The changes to the Assassin and ITAC are to help fix the relative
win % chances of the hunter ships. This addresses the most over-
and under-powered hunters.

The Thief and DC are modified in relation to the Assassin. The
Thief gets a very minor boost to trade potential, and the DC trades
a little bit of utility for a more reasonable number of weapons.

![image](https://user-images.githubusercontent.com/846186/44127785-cf501d40-9ff3-11e8-986a-210ded0335b0.png)
![image](https://user-images.githubusercontent.com/846186/44127810-ecb14e72-9ff3-11e8-8a24-ff1eba0768d1.png)
