### PR TITLE
preferences.php: move Chat Sharing to game options

### DIFF
--- a/templates/Default/engine/Default/preferences.php
+++ b/templates/Default/engine/Default/preferences.php
@@ -82,6 +82,20 @@ if(isset($GameID)) { ?>
 				<td>&nbsp;</td>
 				<td><input type="submit" name="action" value=" Alter Player <?php if($ThisPlayer->isNameChanged()) { ?>(<?php echo CREDITS_PER_NAME_CHANGE; ?> SMR Credits) <?php } ?>" id="InputFields" /></td>
 			</tr>
+
+			<tr>
+				<td colspan="2">&nbsp;</td>
+			</tr>
+
+			<tr>
+				<td>Chat Sharing:</td>
+				<td><div class="buttonA"><a href="<?php echo $ChatSharingHREF; ?>" class="buttonA">&nbsp;Manage Chat Sharing Settings&nbsp;</a></div></td>
+			</tr>
+			<tr>
+				<td>&nbsp;</td>
+				<td>These settings specify who you share your game information with in supported chat services.</td>
+			<tr>
+
 		</table>
 	</form>
 	<br /><?php
@@ -192,19 +206,6 @@ if(isset($GameID)) { ?>
 			<td><input type="submit" name="action" value="Change Name" id="InputFields" /></td>
 		</tr>
 	
-		<tr>
-			<td colspan="2">&nbsp;</td>
-		</tr>
-
-		<tr>
-			<td>Chat Sharing:</td>
-			<td><div class="buttonA"><a href="<?php echo $ChatSharingHREF; ?>" class="buttonA">&nbsp;Manage Chat Sharing Settings&nbsp;</a></div></td>
-		</tr>
-		<tr>
-			<td>&nbsp;</td>
-			<td>These settings specify who you share your game information with in supported chat services.</td>
-		<tr>
-
 		<tr>
 			<td colspan="2">&nbsp;</td>
 		</tr>


### PR DESCRIPTION
Opening the Chat Sharing preferences without first joining a game
was causing a database error, since the Chat Sharing engine code
depends on `$player`. The easiest way to fix this is to add the
link to the game-specific preferences at the top of the page, rather
than with the account-specific preferences below.

This moves the Chat Sharing away from its natural place next to
the Discord ID/IRC Username options, but it is a small price to pay.

![image](https://user-images.githubusercontent.com/846186/44170768-35e78b80-a08d-11e8-9b46-76d98715b94a.png)
