### PR TITLE
Simplify and clean up pages that new users see

### DIFF
--- a/admin/Default/info.php
+++ b/admin/Default/info.php
@@ -58,13 +58,10 @@ if (!isset($number)) {
 		if ($db->nextRecord()) {
 
 			$PHP_OUTPUT.=('<tr>');
-			$aname = $db->getField('first_name');
 			$login_name = $db->getField('login');
-			$aname .= '&nbsp;';
-			$aname .= $db->getField('last_name');
 			$email = $db->getField('email');
 			$id = $db->getField('account_id');
-			$PHP_OUTPUT.=('<td align="center">'.$aname.'<br />'.$name.'<br />Account:'.$id.'</td>');
+			$PHP_OUTPUT.=('<td align="center">'.$name.'<br />Account:'.$id.'</td>');
 			$PHP_OUTPUT.=('<td align="center">'.$email.'</td>');
 			//check who they match...first find out the method.
 			$db2->query('SELECT * FROM account_is_closed WHERE account_id = '.$db2->escapeNumber($id));

--- a/admin/Default/info_check.php
+++ b/admin/Default/info_check.php
@@ -41,7 +41,6 @@ if (!isset($number) && !isset($var['number'])) {
 	$PHP_OUTPUT.= create_table();
 	$PHP_OUTPUT.=('<tr>');
 	$PHP_OUTPUT.=('<th align="center noWrap">Name</th>');
-	$PHP_OUTPUT.=('<th align="center noWrap">First and Last Name</th>');
 	$PHP_OUTPUT.=('<th align="center noWrap">Email</th>');
 	$PHP_OUTPUT.=('<th align="center noWrap">Disabled Info</th>');
 	$PHP_OUTPUT.=('<th algin="center noWrap">Exception Reason</th>');
@@ -54,14 +53,10 @@ if (!isset($number) && !isset($var['number'])) {
 		if ($db->nextRecord()) {
 
 			$PHP_OUTPUT.=('<tr>');
-			$aname = $db->getField('first_name');
 			$login_name = $db->getField('login');
-			$aname .= '&nbsp;';
-			$aname .= $db->getField('last_name');
 			$email = $db->getField('email');
 			$id = $db->getField('account_id');
 			$PHP_OUTPUT.=('<td align="center">'.$name.'</td>');
-			$PHP_OUTPUT.=('<td align="center">'.$aname.'</td>');
 			$PHP_OUTPUT.=('<td align="center">'.$email.'</td>');
 			$names = array();
 			$db2->query('SELECT * FROM account_is_closed WHERE account_id = '.$db->escapeNumber($id));

--- a/admin/Default/newsletter_send_processing.php
+++ b/admin/Default/newsletter_send_processing.php
@@ -44,7 +44,7 @@ if($_REQUEST['to_email']=='*') {
 	ob_implicit_flush(true);    // instruct PHP to flush after every output call
 	ob_end_flush();     // turn off PHP output buffering
 
-	$db->query('SELECT account_id, email, first_name, last_name FROM account WHERE validated="TRUE" AND email NOT IN ("noone@smrealms.de","NPC@smrealms.de") AND NOT(EXISTS(SELECT account_id FROM account_is_closed WHERE account_is_closed.account_id=account.account_id))');
+	$db->query('SELECT account_id, email, login FROM account WHERE validated="TRUE" AND email NOT IN ("noone@smrealms.de","NPC@smrealms.de") AND NOT(EXISTS(SELECT account_id FROM account_is_closed WHERE account_is_closed.account_id=account.account_id))');
 
 	$total = $db->getNumRows();
 	echo 'Will send ' . $total . ' mails...<br /><br />';
@@ -61,7 +61,7 @@ if($_REQUEST['to_email']=='*') {
 		// get account data
 		$account_id	= $db->getField('account_id');
 		$to_email	= $db->getField('email');
-		$to_name	= $db->getField('first_name') . ' ' . $db->getField('last_name');
+		$to_name	= $db->getField('login');
 
 		// Reset the message body with personalized salutation, if requested
 		if ($_REQUEST['salutation']) {

--- a/db/patches/V1_6_63_08__remove_first_last_name.sql
+++ b/db/patches/V1_6_63_08__remove_first_last_name.sql
@@ -1,0 +1,3 @@
+-- Do not track account holder's name anymore
+ALTER TABLE account DROP COLUMN first_name,
+                    DROP COLUMN last_name;

--- a/engine/Default/validate.php
+++ b/engine/Default/validate.php
@@ -1,4 +1,6 @@
 <?php
 if(isset($var['msg']))
 	$template->assign('Message', $var['msg']);
+
+$template->assign('PageTopic', 'Validation Reminder');
 $template->assign('ValidateFormHref', SmrSession::getNewHREF(create_container('validate_processing.php')));

--- a/htdocs/login_create.php
+++ b/htdocs/login_create.php
@@ -64,10 +64,6 @@ require_once('config.inc');
 						<td width='73%'><input type='email' name='email' size='50' maxlength='128' id='InputFields'></td>
 					</tr>
 					<tr>
-						<td width='27%'>Verify E-Mail Address:</td>
-						<td width='73%'><input type='email' name='email_verify' size='50' maxlength='128' id='InputFields'></td>
-					</tr>
-					<tr>
 						<td width='27%'>Local Time:</td>
 						<td width='73%'>
 							<select name="timez" id="InputFields"><?php

--- a/htdocs/login_create.php
+++ b/htdocs/login_create.php
@@ -83,23 +83,6 @@ require_once('config.inc');
 						<td width='73%'><input type='text' name='referral_id' size='10' maxlength='20' id='InputFields'<?php if(isset($_REQUEST['ref'])){ echo 'value="'.htmlspecialchars($_REQUEST['ref']).'"'; }?>></td>
 					</tr>
 					<tr>
-						<td colspan='2'>&nbsp;</td>
-					</tr>
-					<tr>
-						<th colspan='2'>User Information</th>
-					</tr>
-					<tr>
-						<td colspan='2'>&nbsp;</td>
-					</tr>
-					<tr>
-						<td width='27%'>First Name:</td>
-						<td width='73%'><input type='text' name='first_name' size='20' maxlength='50' id='InputFields'></td>
-					</tr>
-					<tr>
-						<td width='27%'>Last Name:</td>
-						<td width='73%'><input type='text' name='last_name' size='20' maxlength='50' id='InputFields'></td>
-					</tr>
-					<tr>
 						<td colspan='2'><div class="g-recaptcha" data-sitekey="<?php echo RECAPTCHA_PUBLIC; ?>"></div></td>
 					</tr>
 					</table>

--- a/htdocs/login_create.php
+++ b/htdocs/login_create.php
@@ -34,19 +34,10 @@ require_once('config.inc');
 					<a href='https://wiki.smrealms.de/rules' target="_blank" style='font-weight:bold;'>Click HERE</a> for more information.
 				</p>
 
+				<p class="red">Personal information is confidential and will not be sold to third parties.</p>
 				<form action='login_create_processing.php' method='POST'>
-					<div align='center' style='color:red;'>*** Any personal information is confidential and will not be sold to third parties. ***</div>
 
 					<table border='0' cellspacing='0' cellpadding='1'>
-					<tr>
-						<td colspan='2'>&nbsp;</td>
-					</tr>
-					<tr>
-						<th colspan='2'>Game Information</th>
-					</tr>
-					<tr>
-						<td colspan='2'>&nbsp;</td>
-					</tr>
 					<tr>
 						<td width='27%'>User name:</td>
 						<td width='73%'><input type='text' name='login' size='20' maxlength='32' id='InputFields'></td>
@@ -83,14 +74,10 @@ require_once('config.inc');
 					</tr>
 					</table>
 
-					<p>&nbsp;</p>
-
-					<div align='center' style='font-size:80%;'>
-						I have read and accept the
-						<a href='https://wiki.smrealms.de/rules' target="_blank" style='font-weight:bold;'>User Agreement</a>.<br />
-						I understand that my account can be closed or deleted<br />
-						without warning should it contain invalid or false information.<br /><br />
+					<div style='font-size:80%;'>
 						<input type='checkbox' name='agreement' value='checkbox'>
+						I have read and accept the
+						<a href='https://wiki.smrealms.de/rules' target="_blank" style='font-weight:bold;'>Terms of Use</a>.
 					</div>
 
 					<p><input type='submit' name='create_login' value='Create Login'></p>

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -120,23 +120,6 @@ try {
 		$email = $_SESSION['socialLogin']->getEmail();
 	}
 
-
-	if(!$socialLogin) {
-		$first_name = $_REQUEST['first_name'];
-		if (empty($first_name)) {
-			$msg = 'First name is missing!';
-			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
-			exit;
-		}
-
-		$last_name = $_REQUEST['last_name'];
-		if (empty($last_name)) {
-			$msg = 'Last name is missing!';
-			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
-			exit;
-		}
-	}
-
 	if ($login == $password) {
 		$msg = 'Your chosen password is invalid!';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
@@ -171,7 +154,7 @@ try {
 
 	// creates a new user account object
 	try {
-		$account = SmrAccount::createAccount($login,$password,$email,$first_name,$last_name,$timez,$referral);
+		$account = SmrAccount::createAccount($login, $password, $email, $timez, $referral);
 	}
 	catch(AccountNotFoundException $e) {
 		$msg = 'Invalid referral account ID!';

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -99,13 +99,6 @@ try {
 			exit;
 		}
 
-		$email_verify = $_REQUEST['email_verify'];
-		if ($email != $email_verify) {
-			$msg = 'The eMail addresses you entered do not match.';
-			header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
-			exit;
-		}
-
 		// get user and host for the provided address
 		list($user, $host) = explode('@', $email);
 

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -42,7 +42,6 @@ abstract class AbstractSmrAccount {
 	protected $login;
 	protected $password;
 	protected $email;
-	protected $first_name;
 	protected $validated;
 	protected $validation_code;
 	protected $last_login;
@@ -140,15 +139,14 @@ abstract class AbstractSmrAccount {
 		return $return;
 	}
 
-	public static function &createAccount($login,$password,$email,$first_name,$last_name,$timez,$referral) {
+	public static function &createAccount($login, $password, $email, $timez, $referral) {
 		if($referral!=0) {
 			// Will throw if referral account doesn't exist
 			SmrAccount::getAccount($referral);
 		}
 		$db = new SmrMySqlDatabase();
-		$db->query('INSERT INTO account (login, password, email, first_name, last_name, validation_code, last_login, offset,referral_id,hof_name) VALUES(' .
+		$db->query('INSERT INTO account (login, password, email, validation_code, last_login, offset,referral_id,hof_name) VALUES(' .
 			$db->escape_string($login) . ', ' . $db->escape_string(md5($password)) . ', ' . $db->escape_string($email) . ', ' .
-			$db->escape_string($first_name) . ', ' . $db->escape_string($last_name) . ', ' .
 			$db->escape_string(substr(SmrSession::$session_id, 0, 10)) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($timez) . ',' . $db->escapeNumber($referral).','.$db->escapeString($login).')');
 		return self::getAccountByName($login);
 	}
@@ -177,7 +175,6 @@ abstract class AbstractSmrAccount {
 			$this->login			= $row['login'];
 			$this->password			= $row['password'];
 			$this->email			= $row['email'];
-			$this->first_name		= $row['first_name'];
 			$this->validated		= $this->db->getBoolean('validated');
 
 			$this->last_login		= $row['last_login'];
@@ -693,9 +690,8 @@ abstract class AbstractSmrAccount {
 				}
 
 				$db = new SmrMySqlDatabase();
-				$db->query('INSERT INTO account (login, password, email, first_name, last_name, validation_code, veteran, last_login, logging, offset,images,fontsize,referral_id,hof_name,validated) VALUES(' .
+				$db->query('INSERT INTO account (login, password, email, validation_code, veteran, last_login, logging, offset,images,fontsize,referral_id,hof_name,validated) VALUES(' .
 							$db->escape_string($db2->getField('login')) . ', ' . $db->escape_string(md5($db2->getField('password'))) . ', ' . $db->escape_string($db2->getField('email')) . ', ' .
-							$db->escape_string($db2->getField('first_name')) . ', ' . $db->escape_string($db2->getField('last_name')) . ', ' .
 							$db->escape_string($db2->getField('validation_code')) . ',' .
 							$db->escape_string($db2->getField('veteran')) . ',' . $db->escapeBoolean(false) . ',' . TIME . ',' .$db->escapeNumber($db2->getInt('offset')).',' .
 							$db->escapeString($db2->getField('images')).','.$db->escapeString($db2->getField('fontsize')+20).','.$db->escapeNumber(0).','.$db->escapeString($db2->getField('login')).','.$db->escapeString($db2->getField('validated')).')');
@@ -716,10 +712,6 @@ abstract class AbstractSmrAccount {
 
 	public function getLogin() {
 		return $this->login;
-	}
-
-	public function getFirstName() {
-		return $this->first_name;
 	}
 
 	public function getEmail() {

--- a/lib/Login/SocialLogin.class.inc
+++ b/lib/Login/SocialLogin.class.inc
@@ -10,8 +10,6 @@ class SocialLogin {
 	private $loginType = null;
 	private $userID = null;
 	private $email = null;
-	private $firstName = null;
-	private $lastName = null;
 	private static $facebook=null;
 	private static $twitter=null;
 	private static $openID=null;
@@ -88,7 +86,7 @@ class SocialLogin {
 			throw new Exception('OpenID does not exist for login type: '.$loginType);
 		}
 		$openID =& self::getOpenIdObj();
-		$openID->required = array('contact/email','namePerson/first','namePerson/last');
+		$openID->required = array('contact/email');
 		$openID->returnUrl = self::getRedirectUrl($loginType);
 		$openID->identity = self::$OPEN_ID_IDENTITIES[$loginType];
 		return $openID->authUrl();
@@ -100,12 +98,10 @@ class SocialLogin {
 		if($loginType == self::FACEBOOK) {
 			$helper = self::getFacebookObj()->getRedirectLoginHelper();
 			$accessToken = $helper->getAccessToken(self::getRedirectUrl($loginType));
-			$response = self::getFacebookObj()->get('/me?fields=first_name,last_name,email', $accessToken);
+			$response = self::getFacebookObj()->get('/me?fields=email', $accessToken);
 			$userInfo = $response->getGraphUser();
 			$this->userID = $userInfo->getId();
 			$this->email = $userInfo->getEmail();
-			$this->firstName = $userInfo->getFirstName();
-			$this->lastName = $userInfo->getLastName();
 			$this->valid = true;
 		}
 		else if($loginType == self::TWITTER) {
@@ -114,14 +110,6 @@ class SocialLogin {
 
 				$userInfo = self::getTwitterObj()->get('account/verify_credentials');
 				$this->userID=$userInfo->id_str;
-				$spaceIndex = strpos($userInfo->name, ' ');
-				if($spaceIndex===false) {
-					$this->firstName=$userInfo->name;
-				}
-				else {
-					$this->firstName=substr($userInfo->name, 0, $spaceIndex);
-					$this->lastName=substr($userInfo->name, $spaceIndex);
-				}
 				$this->valid = true;
 			}
 		}
@@ -131,8 +119,6 @@ class SocialLogin {
 					$this->userID=self::getOpenIdObj()->identity;
 					$userInfo = self::getOpenIdObj()->getAttributes();
 					$this->email=$userInfo['contact/email'];
-					$this->firstName=$userInfo['namePerson/first'];
-					$this->lastName=$userInfo['namePerson/last'];
 					$this->valid = true;
 				}
 			}

--- a/templates/Default/socialRegister.inc
+++ b/templates/Default/socialRegister.inc
@@ -39,28 +39,17 @@
 				</form>
 				<br/>
 
-				<h1>Or Create Login</h1>
-				<p align="justify">
-					Creating multiple logins will not be tolerated. If we discover someone playing with several
-					logins, then all of them will be deleted. We have implemented architecture elements to help
-					us detect this. There will be no toleration for multis! If an player is caught using a multi
-					that player's accounts WILL be deleted without ANY warning.<br />
-					<a href="http://smrcnn.smrealms.de/viewtopic.php?t=382" style="font-weight:bold;">Click HERE</a> for more information.
+				<h1>Or Create New Login</h1>
+				<p align='justify'>
+					Creating multiple logins is not allowed.
+					<a href='https://wiki.smrealms.de/rules' target="_blank" style='font-weight:bold;'>Click HERE</a> for more information.
 				</p>
 
+
+				<p class="red">Personal information is confidential and will not be sold to third parties.</p>
 				<form action="login_create_processing.php?socialReg=1" method="POST">
-					<div align="center" style="color:red;">*** Any personal information is confidential and will not be sold to third parties. ***</div>
 
 					<table border="0" cellspacing="0" cellpadding="1">
-						<tr>
-							<td colspan="2">&nbsp;</td>
-						</tr>
-						<tr>
-							<th colspan="2">Game Information</th>
-						</tr>
-						<tr>
-							<td colspan="2">&nbsp;</td>
-						</tr>
 						<tr>
 							<td width="27%">User name:</td>
 							<td width="73%"><input type="text" name="login" size="20" maxlength="32" id="InputFields"></td>
@@ -103,15 +92,10 @@
 						</tr>
 					</table>
 
-					<p>&nbsp;</p>
-
-					<div align="center" style="font-size:80%;">
-						I have read and accepted the User Agreement above,<br />
-						made sure all information submitted is correct,<br />
-						and understand that my account can be closed or deleted<br />
-						with no warning should it contain<br />
-						invalid or false information.<br /><br />
-						<input type="checkbox" name="agreement" value="checkbox">
+					<div style='font-size:80%;'>
+						<input type='checkbox' name='agreement' value='checkbox'>
+						I have read and accept the
+						<a href='https://wiki.smrealms.de/rules' target="_blank" style='font-weight:bold;'>Terms of Use</a>.
 					</div>
 
 					<p><input type="submit" name="create_login" value="Create Login"></p>

--- a/templates/Default/validate.php
+++ b/templates/Default/validate.php
@@ -7,7 +7,6 @@ if(isset($Message)) {
 	echo $Message; ?><br /><?php
 } ?>
 
-<p>Welcome <?php echo $ThisAccount->getFirstName() ?></p>
 <p>
 	Thank you for trying out Space Merchant Realms! We hope that you are enjoying the game. However,
 	in order for you to experience the full features of the game, you need to validate your login.

--- a/templates/Default/validate.php
+++ b/templates/Default/validate.php
@@ -1,5 +1,3 @@
-<h1>VALIDATION REMINDER</h1><br />
-
 <form name="FORM" method="POST" action="<?php echo $ValidateFormHref ?>">
 
 <?php
@@ -9,11 +7,12 @@ if(isset($Message)) {
 
 <p>
 	Thank you for trying out Space Merchant Realms! We hope that you are enjoying the game. However,
-	in order for you to experience the full features of the game, you need to validate your login.
-	When you first created your login, you should have received an email confirmation which includes
-	your validation code. If you have not received this email, please verify that you gave us the
-	correct address by going to the user preferences page. If the address is incorrect, please edit
-	it and a new validation code will be sent to you.
+	in order for you to experience the full features of the game, you need to validate your e-mail address.
+	When you first created your account, a validation code was sent to: <b><?php echo $ThisAccount->getEmail(); ?></b>.
+</p>
+<p>
+	If this address is incorrect, please edit it in your <a href="<?php echo $PreferencesLink; ?>"><u>Preferences</u></a> and a new validation code will be sent to you.
+	Otherwise, if you have not received an e-mail yet, please contact an admin for help.
 </p>
 <p>
 	The following restrictions are placed on users who have not validated their account:


### PR DESCRIPTION
Account creation:
* Do not require first name, last name (removed from the `account` database)
* Do not ask them to repeat their e-mail address

Social account creation:
* Synchronize with normal account creation

E-mail validation:
* Display the address the validation e-mail was sent to
* Add a more explicit link to preferences in case they need to change it


![image](https://user-images.githubusercontent.com/846186/44302793-beac3480-a2e4-11e8-98ad-ea2ea7aa9348.png)

![image](https://user-images.githubusercontent.com/846186/44302798-cec41400-a2e4-11e8-9fd2-49bcdc83ba85.png)

![image](https://user-images.githubusercontent.com/846186/44302774-a9370a80-a2e4-11e8-925d-4a61ee8d1303.png)
