### PR TITLE
validate_processing.php: don't silently skip check

### DIFF
--- a/engine/Default/validate_processing.php
+++ b/engine/Default/validate_processing.php
@@ -1,9 +1,12 @@
 <?php
 
-if (!empty($_REQUEST['validation_code'])) {
-	// is this our validation code?
-	if ($account->getValidationCode() != $_REQUEST['validation_code'])
-		create_error('The validation code you entered is incorrect.');
+// Only skip validation check if we explicitly chose to validate later
+if ($_REQUEST['action'] != "I'll validate later.") {
+	if ($account->getValidationCode() != $_REQUEST['validation_code']) {
+		$container = create_container('skeleton.php', 'validate.php');
+		$container['msg'] = '<span class="red">The validation code you entered is incorrect!</span>';
+		forward($container);
+	}
 
 	$account->setValidated(true);
 


### PR DESCRIPTION
If you clicked "Validate me now!" without entering a validation
code, we would silently skip the validation check (and the account
would still not be validated). This was misleading, so now we
always do the validation check unless "I'll validate later." is
clicked.

We also display any error messages on the validation page itself,
since otherwise you can't get back to it after an error (e.g. an
incorrect validation code is entered) without relogging, which was
not very intuitive.

![image](https://user-images.githubusercontent.com/846186/44348036-3fd30b00-a44e-11e8-9b0a-26437ff44eb2.png)