### PR TITLE
PlanetList.inc: fix non-shrinking table columns

### DIFF
--- a/templates/Default/engine/Default/includes/PlanetList.inc
+++ b/templates/Default/engine/Default/includes/PlanetList.inc
@@ -7,14 +7,14 @@ if (count($Planets) > 0) { ?>
 			<tr>
 				<th class="sort shrink" data-sort="image">
 					<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a></th>
-				<th class="sort shrink" data-sort="name">Name</th>
+				<th class="sort" data-sort="name">Name</th>
 				<th class="sort shrink" data-sort="lvl">Level</th>
-				<th class="sort shrink" data-sort="owner">Owner</th>
+				<th class="sort" data-sort="owner">Owner</th>
 				<th class="sort shrink" data-sort="sector">Sector</th>
 				<th class="shrink">Structures</th>
 				<th class="shrink">Hardware</th>
 				<th class="shrink">Supplies</th>
-				<th class="sort shrink" data-sort="build">Build</th>
+				<th class="sort" data-sort="build">Build</th>
 			</tr>
 		</thead>
 		<tbody class="list"><?php


### PR DESCRIPTION
At least one column of a table has to _not_ have the `shrink`
attribute for any of the `shrink` attributes to have an effect.

We want the planet image (column 1) to shrink, so we remove the
attribute from the "Name", "Owner", and "Build" columns. This
results in a spacing that seems okay.

![image](https://user-images.githubusercontent.com/846186/44760865-a6fb5a00-aaf5-11e8-8673-3cebd40bb322.png)
