### PR TITLE
Remove old_account_id from SmrSession

### DIFF
--- a/db/patches/V1_6_63_09__remove_old_account_id.sql
+++ b/db/patches/V1_6_63_09__remove_old_account_id.sql
@@ -1,0 +1,2 @@
+-- Remove `old_account_id` from `active_session` table
+ALTER TABLE active_session DROP COLUMN old_account_id;

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -34,17 +34,16 @@ try {
 			}
 			$loginType = $socialLogin->getLoginType();
 			$authKey = $socialLogin->getUserID();
-			$db->query('SELECT account_id,old_account_id FROM account JOIN account_auth USING(account_id)
+			$db->query('SELECT account_id FROM account JOIN account_auth USING(account_id)
 						WHERE login_type = '.$db->escapeString($loginType).'
 						   AND auth_key = '.$db->escapeString($authKey).' LIMIT 1');
 			if ($db->nextRecord()) {
 				// register session
 				SmrSession::$account_id = $db->getInt('account_id');
-				SmrSession::$old_account_id = $db->getInt('old_account_id');
 			}
 			else {
 				if($socialLogin->getEmail()!=null) {
-					$db->query('SELECT account_id,old_account_id FROM account ' .
+					$db->query('SELECT account_id FROM account ' .
 					   'WHERE email = '.$db->escapeString($socialLogin->getEmail()).' LIMIT 1');
 				}
 				if ($socialLogin->getEmail()!=null && $db->nextRecord()) { //Email already has an account so let's link.
@@ -52,7 +51,6 @@ try {
 					$account->addAuthMethod($socialLogin->getLoginType(),$socialLogin->getUserID());
 					$account->setValidated(true);
 					SmrSession::$account_id = $db->getField('account_id');
-					SmrSession::$old_account_id = $db->getField('old_account_id');
 				}
 				else {
 					session_start(); //Pass the data in a standard session as we don't want to initialise a normal one.
@@ -74,13 +72,12 @@ try {
 				exit;
 			}
 
-			$db->query('SELECT account_id,old_account_id FROM account ' .
+			$db->query('SELECT account_id FROM account ' .
 					   'WHERE login = '.$db->escapeString($login).' AND ' .
 							 'password = '.$db->escapeString(md5($password)).' LIMIT 1');
 			if ($db->nextRecord()) {
 				// register session
 				SmrSession::$account_id = $db->getField('account_id');
-				SmrSession::$old_account_id = $db->getField('old_account_id');
 			}
 			elseif (Globals::useCompatibilityDatabases()) {
 				if(!SmrAccount::upgradeAccount($login,$password)) {

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -640,9 +640,6 @@ abstract class AbstractSmrAccount {
 				$this->increaseSmrCredits($credits);
 				$this->oldAccountIDs[$databaseClassName] = $accountID;
 
-				// register session
-				SmrSession::$old_account_id = $accountID;
-
 				$result = true;
 			}
 		}
@@ -675,9 +672,6 @@ abstract class AbstractSmrAccount {
 				if ($db3->nextRecord()) {
 					$expire_time = $db3->getInt('expires');
 					if(!($expire_time > 0 && $expire_time < TIME)) {
-						SmrSession::$old_account_id = $db2->getInt('account_id');
-						// save session (incase we forward)
-						SmrSession::update();
 						if ($db3->getField('reason') == CLOSE_ACCOUNT_INVALID_EMAIL_REASON) {
 							header('Location: /email.php');
 							exit;

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -132,7 +132,6 @@ class SmrSession {
 
 	public static $session_id;
 	public static $account_id;
-	public static $old_account_id;
 	public static $game_id;
 	public static $last_accessed;
 	public static $fast_forward;
@@ -189,7 +188,6 @@ class SmrSession {
 			self::$generate = false;
 			self::$session_id		= self::$db->getField('session_id');
 			self::$account_id		= self::$db->getInt('account_id');
-			self::$old_account_id	= self::$db->getInt('old_account_id');
 			self::$game_id			= self::$db->getInt('game_id');
 			self::$last_accessed	= self::$db->getInt('last_accessed');
 			self::$var = @unserialize(@gzuncompress(self::$db->getField('session_var')));
@@ -202,7 +200,6 @@ class SmrSession {
 			}
 			if(!is_array(self::$var)) {
 				self::$account_id	= 0;
-				self::$old_account_id	= 0;
 				self::$game_id		= 0;
 				self::$var			= array();
 			}
@@ -228,7 +225,6 @@ class SmrSession {
 		else {
 			self::$generate = true;
 			self::$account_id	= 0;
-			self::$old_account_id	= 0;
 			self::$game_id		= 0;
 			self::$var			= array();
 			self::$commonIDs	= array();
@@ -245,13 +241,13 @@ class SmrSession {
 		} unset($value);
 		$compressed = gzcompress(serialize(self::$var));
 		if(!self::$generate) {
-			self::$db->query('UPDATE active_session SET account_id=' . self::$db->escapeNumber(self::$account_id) . ',old_account_id=' . self::$db->escapeNumber(is_numeric(self::$old_account_id)?self::$old_account_id:0) . ',game_id=' . self::$db->escapeNumber(self::$game_id) . (!USING_AJAX ? ',last_accessed=' . self::$db->escapeNumber(TIME) : '') . ',session_var=' . self::$db->escapeBinary($compressed) .
+			self::$db->query('UPDATE active_session SET account_id=' . self::$db->escapeNumber(self::$account_id) . ',game_id=' . self::$db->escapeNumber(self::$game_id) . (!USING_AJAX ? ',last_accessed=' . self::$db->escapeNumber(TIME) : '') . ',session_var=' . self::$db->escapeBinary($compressed) .
 					',last_sn='.self::$db->escapeString(self::$SN).
 					' WHERE session_id=' . self::$db->escapeString(self::$session_id) . (USING_AJAX ? ' AND last_sn='.self::$db->escapeString(self::$lastSN) : '') . ' LIMIT 1');
 		}
 		else {
 			self::$db->query('DELETE FROM active_session WHERE account_id = ' . self::$db->escapeNumber(self::$account_id) . ' AND game_id = ' . self::$db->escapeNumber(self::$game_id));
-			self::$db->query('INSERT INTO active_session (session_id, account_id, old_account_id, game_id, last_accessed, session_var) VALUES(' . self::$db->escapeString(self::$session_id) . ',' . self::$db->escapeNumber(self::$account_id) . ',' . self::$db->escapeNumber(is_numeric(self::$old_account_id)?self::$old_account_id:0) . ',' . self::$db->escapeNumber(self::$game_id) . ',' . self::$db->escapeNumber(TIME) . ',' . self::$db->escapeBinary($compressed) . ')');
+			self::$db->query('INSERT INTO active_session (session_id, account_id, game_id, last_accessed, session_var) VALUES(' . self::$db->escapeString(self::$session_id) . ',' . self::$db->escapeNumber(self::$account_id) . ',' . self::$db->escapeNumber(self::$game_id) . ',' . self::$db->escapeNumber(TIME) . ',' . self::$db->escapeBinary($compressed) . ')');
 			self::$generate = false;
 		}
 		// This takes us back to the standard database if we had to change it.
@@ -281,10 +277,9 @@ class SmrSession {
 
 	public static function destroy() {
 		self::$db = new SmrSessionMySqlDatabase();
-		self::$db->query('UPDATE active_session SET account_id=0,old_account_id=0,game_id=0,session_var=\'\',ajax_returns=\'\' WHERE session_id = ' . self::$db->escapeString(self::$session_id) . ' LIMIT 1');
+		self::$db->query('UPDATE active_session SET account_id=0,game_id=0,session_var=\'\',ajax_returns=\'\' WHERE session_id = ' . self::$db->escapeString(self::$session_id) . ' LIMIT 1');
 		self::$session_id = '';
 		self::$account_id = 0;
-		self::$old_account_id = 0;
 		self::$game_id = 0;
 		$db = new SmrMySqlDatabase();
 	}


### PR DESCRIPTION
This static variable is no longer used, so there is no need to
keep it around. We also remove it from the `active_session` table.