### PR TITLE
reset_password.php: minor cleanup

### DIFF
--- a/htdocs/reset_password.php
+++ b/htdocs/reset_password.php
@@ -44,7 +44,7 @@
 														<td><input name="password" type="password" id="InputFields" /></td>
 												</tr>
 												<tr>
-														<th align="right">Reset New Password:</th>
+														<th align="right">Verify New Password:</th>
 														<td><input name="pass_verify" type="password" id="InputFields" /></td>
 												</tr>
 											</table>

--- a/htdocs/reset_password_processing.php
+++ b/htdocs/reset_password_processing.php
@@ -6,12 +6,6 @@ try {
 	
 	
 	$password = $_REQUEST['password'];
-	if (strstr($password, '\'')) {
-		$msg = 'Illegal character in password detected! Don\'t use the apostrophe.';
-		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
-		exit;
-	}
-	
 	if (empty($password)) {
 		$msg = 'Password is missing!';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
@@ -25,11 +19,9 @@ try {
 		exit;
 	}
 	
-	
-	// get this user from db
 	$login = $_REQUEST['login'];
 	if ($login == $password) {
-		$msg = 'Your chosen password is invalid!';
+		$msg = 'Your password cannot be the same as your login!';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}


### PR DESCRIPTION
* Allow an apostrophe in the password. Since we're hashing passwords,
  this does not cause any issues with database injection attacks.
  (Note: we didn't enforce this restriction consistently anyway.)

* Rename "Reset New Password" input field to "Verify New Password".

* Provide a better error message when the login name and passwords
  match (since they're providing the login, this is not a data leak).