### PR TITLE
Password-related bugfixes and cosmetics

### DIFF
--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -32,7 +32,7 @@ elseif ($action == 'Change Password') {
 	if (empty($new_password))
 		create_error('You must enter a non empty password!');
 
-	if ($account->checkPassword($old_password))
+	if (!$account->checkPassword($old_password))
 		create_error('Your current password is wrong!');
 
 	if ($new_password != $retype_password)

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -50,8 +50,8 @@ try {
 	$db = new SmrMySqlDatabase();
 	$login = trim($_REQUEST['login']);
 	$password = trim($_REQUEST['password']);
-	if (strstr($login, '\'') || strstr($password, '\'')) {
-		$msg = 'Illegal character in login or password detected! Don\'t use the apostrophe.';
+	if (strstr($login, '\'')) {
+		$msg = 'Illegal character in login detected! Don\'t use the apostrophe.';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
@@ -114,7 +114,7 @@ try {
 	}
 
 	if ($login == $password) {
-		$msg = 'Your chosen password is invalid!';
+		$msg = 'Your login and password cannot be the same!';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}

--- a/lib/Default/AbstractSmrAccount.class.inc
+++ b/lib/Default/AbstractSmrAccount.class.inc
@@ -942,7 +942,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function checkPassword($password) {
-		return $this->getPassword()==$password;
+		return $this->getPassword() == md5($password);
 	}
 
 	public function setPassword($password) {

--- a/templates/Default/engine/Default/preferences.php
+++ b/templates/Default/engine/Default/preferences.php
@@ -163,7 +163,7 @@ if(isset($GameID)) { ?>
 		</tr>
 		
 		<tr>
-			<td>Old Password:</td>
+			<td>Current Password:</td>
 			<td><input type="password" name="old_password" id="InputFields" size="25" /></td>
 		</tr>
 		
@@ -173,7 +173,7 @@ if(isset($GameID)) { ?>
 		</tr>
 		
 		<tr>
-			<td>Retype Password:</td>
+			<td>Verify New Password:</td>
 			<td><input type="password" name="retype_password" id="InputFields" size="25" /></td>
 		</tr>
 		


### PR DESCRIPTION
Three somewhat independent password-related improvements:

---------------

preferences_processing.php: fix change password bug

Fix a bug that let you change your password even if you entered the
wrong current password.

The SmrAccount::checkPassword method was wrong because it didn't
hash the input password before checking it against the stored hash,
so it always returned "false".

However, the "Current Password" input in the "Change Password"
option in preferences was also wrong in a way that cancelled out
the SmrAccount error, because it would only trigger the "Your current
password is wrong" error if `checkPassword` returned "true"!

To fix this:
* flip the logic in the `checkPassword` call in preferences
* compare the hashed input password to the stored password

---------------
  preferences.php: clearer password change fields

Rename input fields for clarity:

* "Old Password" -> "Current Password"
* "Retype Password" -> "Verify New Password"

----------------

  login_create_processing.php: minor improvements

* Remove restriction that password not contain an apostrophe.
  This is not necessary, since passwords are hashed (no issues with
  sql injection), and this restriction wasn't consistently enforced
  anyway.

* Provide a better error message when account login name and password
  are equal, since that is an insecure thing to do. This is not a
  data breach because the user is explicitly providing both fields.
