### PR TITLE
login.css: fix inputbox padding for Firefox

### DIFF
--- a/htdocs/css/login.css
+++ b/htdocs/css/login.css
@@ -35,6 +35,7 @@ table.standard {
 input.inputbox {
 	width:123px;
 	height:20px;
+	padding: 1px 0px;
 }
 a {
 	color:#ffffff;


### PR DESCRIPTION
The default input element padding in Chrome sized everything
correctly, but the img layout in Firefox was off by 1px.

Set the padding explicitly so that the login page looks the
same between Chrome and Firefox.

Without this change, the login box in Firefox/IE looked like this:
![image](https://user-images.githubusercontent.com/846186/46930476-b299d600-cffa-11e8-8d22-d3a182272d2f.png)
