### PR TITLE
Use php-cli-alpine for api-docs image

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,17 +1,20 @@
-FROM php:7.2-cli as builder
+FROM php:7.2-cli-alpine as builder
 
 # Install phpDox - https://github.com/theseer/phpdox
 # - dependency: XSL
 # - dependency: git (for composer and git enricher)
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
-RUN apt-get update && apt-get install -y \
+RUN apk upgrade --update && apk add --no-cache \
     libxslt-dev \
     git \
-    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-install xsl
 
+# See https://github.com/docker-library/php/issues/240#issuecomment-305038173
+RUN apk add --no-cache --repository https://dl-4.alpinelinux.org/alpine/edge/testing gnu-libiconv
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+
+# Install phpdox with composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 RUN composer global require --no-plugins --no-scripts --dev theseer/phpdox
 ENV PATH /root/.composer/vendor/bin:$PATH


### PR DESCRIPTION
This reduces the intermediate image size from ~1.2GB (with the
standard php-cli image) to ~0.7GB. All auxilliary php services
now use the php-cli-alpine image.

To get alpine to work with phpDox, we needed to use an updated
iconv extension. This is a bit of a hack, but gets the job done.
See https://github.com/docker-library/php/issues/240.