### PR TITLE
Replace Announcements with Twitter Feed on login page

### DIFF
--- a/htdocs/css/login.css
+++ b/htdocs/css/login.css
@@ -78,7 +78,6 @@ table.center {
 	border-spacing: 0px;
 	border-collapse: collapse;
 	padding: 0px;
-	margin: 0px;
 	font-size: 0px;
 }
 input.uncollapse {
@@ -86,4 +85,8 @@ input.uncollapse {
 }
 table.nobord {
 	border: 0px;
+}
+.hide {
+	/* hide element but preserve page layout (note: "visibility" didn't work) */
+	opacity: 0;
 }

--- a/htdocs/js/login.js
+++ b/htdocs/js/login.js
@@ -1,0 +1,19 @@
+/**
+ * Inject CSS into the Twitter Feed iframe once it has loaded
+ * to change the styling of the iframe scrollbar.
+ */
+function tryInject() {
+	var widget = $("iframe#twitter-widget-0");
+	if (widget.length == 0) {
+		// If the iframe hasn't loaded yet, rerun this function again before
+		// the next repaint.
+		window.requestAnimationFrame(tryInject);
+	} else {
+		// Inject scrollbar CSS into the iframe (webkit only).
+		widget.contents().find('head').append('<style>::-webkit-scrollbar { width: 10px; } ::-webkit-scrollbar-track { -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.8); border-radius: 10px; } ::-webkit-scrollbar-thumb { border-radius: 10px; -webkit-box-shadow: inset 0 0 6px rgba(128,200,112,1); }</style>');
+		// Unhide the twitter feed element.
+		$("td#twitter-feed").removeClass("hide");
+	}
+}
+
+tryInject();

--- a/lib/Login/loginSmarty.php
+++ b/lib/Login/loginSmarty.php
@@ -2,19 +2,6 @@
 // new db object
 $db = new SmrMySqlDatabase();
 
-$loginNews = array();
-$db->query('SELECT * FROM game_news ORDER BY time DESC LIMIT 2');
-while ($db->nextRecord()) {
-	$loginNews[] = array('Message' => $db->getField('message'),'AdminName' => $db->getField('admin_name'),'Time' => date(DEFAULT_DATE_DATE_SHORT,$db->getField('time')), 'Recent' => (TIME - $db->getField('time') < 24 * 3600));
-}
-if(count($loginNews)>0)
-	$template->assign('LoginNews',$loginNews);
-
-// Users can have a session for each open game, so only count unique accounts
-$db->query('SELECT count(DISTINCT account_id) AS active_sessions FROM active_session WHERE account_id!=0 AND last_accessed > '.$db->escapeNumber(TIME - SmrSession::TIME_BEFORE_EXPIRY));
-$db->nextRecord();
-$template->assign('ActiveSessions',$db->getField('active_sessions'));
-
 $gameNews = array();
 $db->query('SELECT * FROM news ORDER BY time DESC LIMIT 4');
 while ($db->nextRecord()) {

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -40,11 +40,11 @@
 				<h4 style="margin-bottom: 0px;"><?php echo $Message ?></h4><?php
 			} ?>
 
-			<table class="center nobord" style="width:770px; border-spacing:20px; padding:10px">
+			<table class="center nobord" style="width:690px; border-spacing:30px;">
 				<tr>
-					<td style="width:300px">
+					<td>
 						<form action="login_processing.php" method="post">
-							<table class="collapsed">
+							<table class="collapsed center">
 								<tr>
 									<td colspan="3">
 										<img src="images/login/login_top.png" width="258" height="43" alt="">
@@ -68,7 +68,7 @@
 									</td>
 								</tr>
 							</table>
-							<table class="collapsed">
+							<table class="collapsed center">
 								<tr>
 									<td>
 										<img src="images/login/regLeft.png" width="30" height="11"  alt="">
@@ -98,13 +98,14 @@
 								</tr>
 							</table>
 						</form>
-					</td>
-					<td class="center" style="padding: 3px; width: 200px;">
+
+						<br />
 						<span style="font-size: 14px;">Or login with:</span>
-						<span style="font-size: 3px;"><br /><br />
-							<a style="display: inline;margin:10px;" href="login_social_processing.php?type=facebook">
-								<img alt="Facebook Login" src="images/login/facebook.png" width="65" height="22">
-							</a><br /><br />
+						<br />
+						<span>
+							<a href="login_social_processing.php?type=facebook">
+								<img style="padding-top:5px;" alt="Facebook Login" src="images/login/facebook.png" width="65" height="22">
+							</a>
 							<?php /*
 							<a style="display: inline;margin:10px;" href="login_social_processing.php?type=google">
 								<img alt="Google Login" src="images/login/google.png" width="32" height="32">
@@ -115,51 +116,30 @@
 							*/ ?>
 						</span>
 					</td>
-					<td style="width:470px"><?php
-						if(isset($LoginNews)) { ?>
-							<table class="standard">
-							<tr><th>Date</th><th>Announcements</th></tr><?php
-							foreach($LoginNews as $News) { ?>
-								<tr>
-									<td>
-										<span class="small"><?php
-											if($News['Recent']){ ?> * <?php }
-											echo $News['Time'] ?>
-										</span>
-									</td>
-									<td>
-										<span class="small"><?php echo bbifyMessage($News['Message']);
-											if($News['AdminName']) { ?>
-												<br /><br />- <?php echo $News['AdminName'];
-											} ?>
-										</span>
-									</td>
-								</tr><?php
-							} ?>
-							</table><?php
-						} ?>
+					<td id="twitter-feed" class="hide" style="height:256px;width:90%;">
+						<a class="twitter-timeline" data-dnt="true" data-height="250" data-theme="dark" data-chrome="transparent nofooter noheader noborders" href="https://twitter.com/SMRealms?ref_src=twsrc%5Etfw"></a>
+						<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 					</td>
 				</tr>
+			</table><?php
 
-				<tr>
-					<td class="center" colspan="3">
-						Players Online Now: <?php echo $ActiveSessions; ?><br /><br /><?php
-						if(isset($GameNews)) { ?>
-							<table class="standard" style="width:100%"><tr><th class="center">Time</th><th class="center">Recent News</th></tr><?php
-								foreach($GameNews as $News) { ?>
-									<tr>
-										<td><?php
-											echo $News['Date']; ?><br /><?php
-											echo $News['Time']; ?>
-										</td>
-										<td><?php echo $News['Message']; ?></td>
-									</tr><?php
-								} ?>
-							</table><?php
-						} ?>
-					</td>
-				</tr>
-			</table>
+			if(isset($GameNews)) { ?>
+				<table class="standard center" style="width:730px;">
+					<tr>
+						<th>Time</th>
+						<th>Recent News</th>
+					</tr><?php
+					foreach($GameNews as $News) { ?>
+						<tr>
+							<td><?php
+								echo $News['Date']; ?><br /><?php
+								echo $News['Time']; ?>
+							</td>
+							<td><?php echo $News['Message']; ?></td>
+						</tr><?php
+					} ?>
+				</table><?php
+			} ?>
 
 			<br /><?php
 
@@ -181,5 +161,9 @@
 			<br /><br />
 			<span class="small"><a href="imprint.html">[Imprint]</a></span>
 		</div>
+
+		<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+		<script src="js/login.js"></script>
+
 	</body>
 </html>


### PR DESCRIPTION
* Replace "Announcements" query from `game_news` table with
  the @SMRealms twitter feed. We'll keep the `game_news` table
  around for now for historical reasons.

* Remove the "Players Online Now" counter. This is usually not
  a good advertisement for the game, since the number of concurrent
  players isn't a good indication of activity. Perhaps better would
  be the number of sessions from the past 24 hours (but we don't
  have a way to track this yet).

* Re-organize the login page elements to fit better with the
  Twitter feed:
    - Center the login form in its <td> element by adding the
      `center` class (this also requires removing the `margin`
      attribute from the `collapsed` class).
    - Split the "Recent News" table into a separate table from
      the login form and announcements table.

NOTE: For the Twitter iframe, we use webkit to restyle the scrollbar
to fit the SMR color theme, but this is not available for Firefox/IE.
There's a lot of special machinery needed to restyle the content
inside an iframe, and we delay the display of the content until it
is completely restyled to avoid the content shifting around as we
update it.

Here's what the new login page looks like:
![image](https://user-images.githubusercontent.com/846186/47133580-28ea4280-d25e-11e8-9bea-85e16f99e938.png)
