### PR TITLE
Add interactive warp map

### DIFF
--- a/htdocs/images/warp_chart.svg
+++ b/htdocs/images/warp_chart.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg64"
+   width="160"
+   height="160"
+   viewBox="0 0 160 160"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata70">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs68" />
+  <g
+     id="g76"
+     transform="translate(-5.2332039,36.656789)">
+    <circle
+       style="fill:#000;stroke:#fff;stroke-width:6;"
+       id="circ1"
+       cx="49.59901"
+       cy="-8.1203756"
+       r="19.274036" />
+    <circle
+       style="fill:#000;stroke:#fff;stroke-width:6;"
+       id="circ2"
+       cx="123.78256"
+       cy="2.2807992"
+       r="11.174816" />
+    <circle
+       style="fill:#000;stroke:#fff;stroke-width:6;"
+       id="circ3"
+       cx="79.599068"
+       cy="44.74509"
+       r="14.957062" />
+    <circle
+       style="fill:#000;stroke:#fff;stroke-width:6;"
+       id="circ4"
+       cx="142.52188"
+       cy="45.776615"
+       r="19.274036" />
+    <circle
+       style="fill:#000;stroke:#fff;stroke-width:6;"
+       id="circ5"
+       cx="28.194921"
+       cy="75.862648"
+       r="19.274036" />
+    <circle
+       style="fill:#000;stroke:#fff;stroke-width:6;"
+       id="circ6"
+       cx="20.802351"
+       cy="28.928434"
+       r="11.174816" />
+    <circle
+       style="fill:#000;stroke:#fff;stroke-width:6;"
+       id="circ7"
+       cx="96.275345"
+       cy="102.85413"
+       r="11.174816" />
+    <path
+       style="fill:none;stroke:#fff;stroke-width:6;"
+       d="M 89.333431,33.389496 114.79381,8.9197958"
+       id="path1"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#circ3"
+       inkscape:connection-end="#circ2" />
+    <path
+       style="fill:none;stroke:#fff;stroke-width:6;"
+       d="M 65.778139,39.027181 31.932698,29.922562"
+       id="path2"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#circ3"
+       inkscape:connection-end="#circ6" />
+    <path
+       style="fill:none;stroke:#fff;stroke-width:6;"
+       d="m 94.452359,42.988588 28.935091,0.474347"
+       id="path3"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#circ3"
+       inkscape:connection-end="#circ4" />
+    <path
+       style="fill:none;stroke:#fff;stroke-width:6;"
+       d="m 84.252372,58.959684 9.474516,33.014268"
+       id="path4"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#circ3"
+       inkscape:connection-end="#circ7" />
+    <path
+       style="fill:none;stroke:#fff;stroke-width:6;"
+       d="M 66.001782,50.976223 43.731808,64.457376"
+       id="path5"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#circ3"
+       inkscape:connection-end="#circ5" />
+    <path
+       style="fill:none;stroke:#fff;stroke-width:6;"
+       d="M 59.957544,8.1332137 73.091758,31.278047"
+       id="path6"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#circ3"
+       inkscape:connection-end="#circ1" />
+  </g>
+</svg>

--- a/htdocs/js/map_warps.js
+++ b/htdocs/js/map_warps.js
@@ -1,0 +1,105 @@
+// Larger scale => smaller graph in the svg viewBox
+var scale = 1.1
+var width = scale * window.innerWidth;
+var height = scale * window.innerHeight;
+
+// Set the color cycle for the nodes
+var color = d3.scaleOrdinal(d3.schemeCategory10);
+
+var svg = d3.select("body")
+	.append("svg")
+		.attr("preserveAspectRatio", "xMinYMin meet")
+		.attr("viewBox", [0, 0, width, height])
+		.classed("svg-content", true)
+		// Enable zoom and pan
+		.call(d3.zoom().on("zoom", function () {
+			$("g.nodes").attr("transform", d3.event.transform);
+			$("g.links").attr("transform", d3.event.transform);
+		}));
+
+// Load the link data into the svg
+var link = svg.append("g")
+	.attr("class", "links")
+	.selectAll("line")
+		.data(graph.links)
+		.enter().append("line")
+			.attr("stroke", "#aaa");
+
+// Load the node data into the svg
+var node = svg.append("g")
+	.attr("class", "nodes")
+	.selectAll("g")
+		.data(graph.nodes)
+		.enter().append("g");
+
+var circles = node.append("a")
+	.attr("xlink:href", function(d) { return "map_galaxy.php?galaxy_id=" + d.id; })
+	.append("circle")
+		.attr("r", function(d) { return Math.sqrt(d.size); })
+		.attr("fill", function(d) { return color(d.group); })
+		.call(d3.drag()
+			.on("start", dragstarted)
+			.on("drag", dragged)
+			.on("end", dragended));
+
+var labels = node.append("text")
+	.text(function(d) { return d.name; })
+	.attr("font-family", "sans-serif")
+	.style("fill", "white");
+
+var simulation = d3.forceSimulation()
+	.force("link", d3.forceLink()
+		.distance(100)
+		.id(function(d) { return d.name; }))
+	.force("charge", d3.forceManyBody().strength(-500))
+	.force("center", d3.forceCenter(width / 2, height / 2));
+
+// Load the node data into the simulation
+simulation
+	.nodes(graph.nodes);
+
+// Load the link data into the simulation
+simulation.force("link")
+	.links(graph.links);
+
+// Set the listener for tick events
+simulation.on("tick", function () {
+	link
+		.attr("x1", function(d) { return d.source.x; })
+		.attr("y1", function(d) { return d.source.y; })
+		.attr("x2", function(d) { return d.target.x; })
+		.attr("y2", function(d) { return d.target.y; });
+
+	// Ideally we would modify the "transform" attribute of the node
+	// variable using "translate", but this creates jittery movement
+	// (probably a browser bug), so we instead reposition the circles
+	// and labels individually.
+	circles
+		.attr("cx", function(d) { return d.x; })
+		.attr("cy", function(d) { return d.y; });
+
+	labels
+		.attr("x", function(d) { return d.x + 10; })
+		.attr("y", function(d) { return d.y + 4; });
+});
+
+function dragstarted(d) {
+	if (!d3.event.active) {
+		simulation.alphaTarget(0.3).restart();
+	}
+	d.fx = d.x;
+	d.fy = d.y;
+}
+
+function dragged(d) {
+	d.fx = d3.event.x;
+	d.fy = d3.event.y;
+}
+
+function dragended(d) {
+	if (!d3.event.active) {
+		simulation.alphaTarget(0);
+	}
+	d.fx = null;
+	d.fy = null;
+}

--- a/htdocs/map_warps.php
+++ b/htdocs/map_warps.php
@@ -1,0 +1,73 @@
+<?php
+try {
+	require_once('config.inc');
+	require_once(LIB . 'Default/SmrMySqlDatabase.class.inc');
+	require_once(LIB . 'Default/Globals.class.inc');
+	require_once(get_file_loc('SmrSector.class.inc'));
+	require_once(get_file_loc('SmrGalaxy.class.inc'));
+
+	// Require that we are logged and have joined a game
+	if (SmrSession::$account_id == 0 || SmrSession::$game_id == 0) {
+		header('Location: /login.php');
+		exit;
+	}
+
+	$galaxyTypes = [
+		'Racial' => 1,
+		'Neutral' => 2,
+		'Planet' => 3,
+	];
+
+	$nodes = [];
+	$links = [];
+
+	// The d3 graph nodes are the galaxies
+	$gameID = SmrSession::$game_id;
+	foreach (SmrGalaxy::getGameGalaxies($gameID) as $galaxy) {
+		$nodes[] = [
+			'name' => $galaxy->getName(),
+			'id' => $galaxy->getGalaxyID(),
+			'group' => $galaxyTypes[$galaxy->getGalaxyType()],
+			'size' => $galaxy->getSize(),
+		];
+	}
+
+	// The d3 graph links are the warp connections between galaxies
+	$db = new SmrMySqlDatabase();
+	$db->query('SELECT sector_id, warp FROM sector WHERE warp !=0 AND game_id = '.$db->escapeNumber($gameID));
+	while ($db->nextRecord()) {
+		$warp1 = SmrSector::getSector($gameID, $db->getInt('sector_id'));
+		$warp2 = SmrSector::getSector($gameID, $db->getInt('warp'));
+		$links[] = [
+			'source' => $warp1->getGalaxyName(),
+			'target' => $warp2->getGalaxyName(),
+		];
+	}
+
+	// Encode the data for use in the javascript
+	$data = json_encode([
+		'nodes' => $nodes,
+		'links' => $links,
+	]);
+
+}
+catch(Throwable $e) {
+	handleException($e);
+}
+?>
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<style>
+body { background-image: url("images/stars2.png"); }
+</style>
+
+<body></body>
+
+<script src="https://d3js.org/d3.v5.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+<script>
+	const graph = <?php echo $data; ?>;
+</script>
+<script src="js/map_warps.js"></script>

--- a/templates/Default/engine/Default/GalaxyMap.inc
+++ b/templates/Default/engine/Default/GalaxyMap.inc
@@ -23,7 +23,7 @@
 					<td class="nopad top">
 						<form name="GalaxyMapForm" method="GET">
 							<label for="galaxy_id">Switch galaxy</label>&nbsp;
-							<select name="galaxy_id" id="galaxy_id" onchange="this.form.submit()"><?php
+							<select name="galaxy_id" id="galaxy_id" class="InputFields" onchange="this.form.submit()"><?php
 								foreach ($GameGalaxies as $GameGalaxy) {
 									$GalaxyID = $GameGalaxy->getGalaxyID(); ?>
 									<option value="<?php echo $GalaxyID; ?>"<?php if($ThisGalaxy->equals($GameGalaxy)){ ?> selected="selected"<?php } ?>>

--- a/templates/Default/engine/Default/GalaxyMap.inc
+++ b/templates/Default/engine/Default/GalaxyMap.inc
@@ -17,10 +17,18 @@
 	
 	<body>
 		<div class="gal_map_header">
-			<p>Map of the known <b><big><?php echo $ThisGalaxy->getName(); ?></big></b> galaxy.</p>
 			<table cellspacing="0" cellpadding="0">
 				<tr>
-					<td class="nopad top">
+					<td>Map of the known <b><big><?php echo $ThisGalaxy->getName(); ?></big></b> galaxy.</td>
+					<td>
+						&thinsp;
+						<a href="map_warps.php">
+							<img src="images/warp_chart.svg" height="24px" width="24px" style="vertical-align: middle;" />&thinsp;Open warp chart
+						</a>
+					</td>
+				</tr>
+				<tr>
+					<td class="top">
 						<form name="GalaxyMapForm" method="GET">
 							<label for="galaxy_id">Switch galaxy</label>&nbsp;
 							<select name="galaxy_id" id="galaxy_id" class="InputFields" onchange="this.form.submit()"><?php


### PR DESCRIPTION
Use the d3 directed graph javascript library to create an interactive
warp map.

The map is accessible through a link in the Galaxy Map.

Also restyle the "Switch galaxy" dropdown menu in a consistent style.

![image](https://user-images.githubusercontent.com/846186/47970088-93102f00-e035-11e8-829c-0a7a08cdeafc.png)

![image](https://user-images.githubusercontent.com/846186/47970094-a7542c00-e035-11e8-9433-31d2d29f914b.png)
