### PR TITLE
config.php: switch from CET to UTC

### DIFF
--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -1,5 +1,5 @@
 <?php
-ini_set('date.timezone', 'CET');
+ini_set('date.timezone', 'UTC');
 
 define('MICRO_TIME', microtime());
 define('TIME', (int)microtimeSec(MICRO_TIME));


### PR DESCRIPTION
Display the server time in UTC, for two reasons:

1. It is not subject to any daylight savings shifts, which makes
   it more reliable.

2. It is a standard time that most people use (or would expect)
   when coordinating worldwide activities.

Now seems like a good time to make this change, since we're not yet adjusted to the new US time shift.