### PR TITLE
Fix invalid MySQL syntax in Flyway patch

### DIFF
--- a/db/patches/V1_6_59_01__classic_ship_reverts.sql
+++ b/db/patches/V1_6_59_01__classic_ship_reverts.sql
@@ -206,7 +206,7 @@ UPDATE ship_type SET cost=2074860, hardpoint=2 WHERE ship_type_id = 65;
 UPDATE ship_type_support_hardware SET max_amount = 425 WHERE ship_type_id = 65 AND hardware_type_id = 1;
 UPDATE ship_type_support_hardware SET max_amount = 550 WHERE ship_type_id = 65 AND hardware_type_id = 2;
 
---Blockade Runner speed to 9, HP to 3, Cargo Holds to 175
+-- Blockade Runner speed to 9, HP to 3, Cargo Holds to 175
 UPDATE ship_type SET speed=9, hardpoint=3 WHERE ship_type_id = 66;
 UPDATE ship_type_support_hardware SET max_amount = 175 WHERE ship_type_id = 66 AND hardware_type_id = 3;
 


### PR DESCRIPTION
Flyway recently (v5.2.1) switched from the MariaDB driver to MySQL.
Unlike MariaDB, MySQL has a strict requirement that comment lines
beginning with "--" have at least one whitespace after them before
the comment begins.

One of our patches was missing this whitespace, and needs to be
updated for compliance with the MySQL requirement. The checksum
for any previous applications of this patch will need to be updated.
(The new checksum is -884764634.)