### PR TITLE
Do not display previous name when admin changes player name

### DIFF
--- a/admin/Default/account_edit_processing.php
+++ b/admin/Default/account_edit_processing.php
@@ -116,16 +116,13 @@ if (!empty($names))
 		if(!empty($new_name)) {
 			$db->query('SELECT * FROM player WHERE game_id = '.$db->escapeNumber($game_id).' AND player_name = ' . $db->escape_string($new_name, FALSE));
 			if (!$db->nextRecord()) {
-				$db->query('SELECT player_name, player_id FROM player WHERE game_id='.$db->escapeNumber($game_id).' AND account_id = '.$db->escapeNumber($account_id).' LIMIT 1');
-				$db->nextRecord();
-				$old_name = $db->getField('player_name');
-				$player_id = $db->getInt('player_id');
+				$editPlayer = SmrPlayer::getPlayer($account_id, $game_id);
+				$editPlayer->setPlayerName($new_name);
 
-				$db->query('UPDATE player SET player_name = ' . $db->escape_string($new_name, FALSE) . ' WHERE game_id = '.$db->escapeNumber($game_id).' AND account_id = '.$db->escapeNumber($account_id));
 				$actions[] = 'changed players name to '.$new_name;
 
 				//insert news message
-				$news = '<span class="blue">ADMIN</span> Please be advised that <span class="yellow">' . $old_name . '(' . $player_id . ')</span> has had their name changed to <span class="yellow">' . $new_name . '(' . $player_id . ')</span>';
+				$news = '<span class="blue">ADMIN</span> Please be advised that player ' . $editPlayer->getPlayerID() . ' has had their name changed to ' . $editPlayer->getBBLink();
 
 				$db->query('INSERT INTO news (time, news_message, game_id) VALUES (' . $db->escapeNumber(TIME) . ',' . $db->escape_string($news, FALSE) . ','.$db->escapeNumber($game_id).')');
 			}

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -186,9 +186,7 @@ else if (strpos(trim($action),'Alter Player')===0) {
 	// trim input now
 	$player_name = trim($_POST['PlayerName']);
 
-	$old_name = $player->getPlayerName();
-
-	if($old_name == $player_name) {
+	if ($player->getPlayerName() == $player_name) {
 		create_error('Your player already has that name!');
 	}
 
@@ -229,7 +227,9 @@ else if (strpos(trim($action),'Alter Player')===0) {
 		$account->decreaseTotalSmrCredits(CREDITS_PER_NAME_CHANGE);
 	}
 
-	$player->setPlayerName($player_name);
+	$old_name = $player->getDisplayName();
+
+	$player->setPlayerNameByPlayer($player_name);
 
 	$news = '<span class="blue">ADMIN</span> Please be advised that ' . $old_name . ' has changed their name to ' . $player->getBBLink() . '</span>';
 	$db->query('INSERT INTO news (time, news_message, game_id, dead_id,dead_alliance) VALUES (' . $db->escapeNumber(TIME) . ',' . $db->escape_string($news, FALSE) . ',' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ')');

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -655,7 +655,11 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->db->query('REPLACE INTO player_has_relation (account_id,game_id,race_id,relation) values (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber($raceID) . ',' . $this->db->escapeNumber($this->pureRelations[$raceID]) . ')');
 	}
 
-	public function setPlayerName($playerName) {
+	/**
+	 * Use this method when the player is changing their own name.
+	 * This will flag the player as having used their free name change.
+	 */
+	public function setPlayerNameByPlayer($playerName) {
 		$this->playerName=$playerName;
 		$this->setNameChanged(true);
 		$this->hasChanged=true;


### PR DESCRIPTION
Since names that are changed by admins are usually inappropriate,
we will no longer display what the original name was in the news
message, only the player ID.

When players change their own name, both the old and new name will
continue to be displayed.

![image](https://user-images.githubusercontent.com/846186/48978460-ac1e6580-f060-11e8-92b2-2536dcfc6437.png)
