### PR TITLE
Migrate away from anonymous data volumes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,6 @@ composer.lock
 
 # docker-compose environment variable file
 .env
+
+# Docker data volumes
+vol_*

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@
 # DKIM private keys
 /opendkim/*.private
 
+# Docker data volumes
+/vol_*
+
 /sys$command
 
 /newsletters

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ x-smr-common: &smr-common
         - mysql
         - smtp
     volumes:
-        - smr_upload:/smr/htdocs/upload
+        - ./vol_upload:/smr/htdocs/upload
         - ./config:/smr/config:ro
 
 services:
@@ -45,7 +45,7 @@ services:
     smr-dev:
         << : *smr-common
         volumes:
-            - smr_upload:/smr/htdocs/upload
+            - ./vol_upload:/smr/htdocs/upload
             - ./config:/smr/config:ro
             # Mount the source code instead of copying it.
             - ./admin:/smr/admin
@@ -91,7 +91,7 @@ services:
             MYSQL_PASSWORD:      ${MYSQL_PASSWORD}
             MYSQL_DATABASE:      smr_live
         volumes:
-            - smr_mysql_data:/var/lib/mysql
+            - ./vol_db:/var/lib/mysql
         labels:
             - "traefik.enable=false"
         # The mysql:5.7+ docker default sql mode uses STRICT_TRANS_TABLES,
@@ -203,6 +203,4 @@ services:
 
 # We want persistent, anonymous data volumes
 volumes:
-    smr_upload:
-    smr_mysql_data:
     portainer_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,13 +194,12 @@ services:
             - frontend
         labels:
             - "traefik.enable=true"
-            - "traefik.frontend.rule=PathPrefixStrip:/docker/;AddPrefix:/"
+            - "traefik.backend=portainer"
+            - "traefik.docker.network=frontend"
+            - "traefik.frontend.passHostHeader=true"
+            - "traefik.frontend.rule=PathPrefixStrip:/docker"
             - "traefik.port=9000"
         command: -H unix:///var/run/docker.sock
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
-            - portainer_data:/data
-
-# We want persistent, anonymous data volumes
-volumes:
-    portainer_data:
+            - ./vol_portainer:/data


### PR DESCRIPTION
For data that we care about (in this case, the game database
and the player uploads), it is easier to manage a local directory
than an anonymous data volume. In particular, back up and restore
can be done without interacting with docker (if desired), and we
have more control over where the data is located (e.g. if we want
it on a raided partition instead of confined to wherever docker
puts the data volumes in the OS partition).
