### PR TITLE
Add planet modifiers to Beta Functions

### DIFF
--- a/engine/Default/beta_func_processing.php
+++ b/engine/Default/beta_func_processing.php
@@ -94,6 +94,25 @@ elseif ($var['func'] == 'Race_Relations') {
 	}
 	$player->setRaceID($race);
 }
+elseif ($var['func'] == 'planet_buildings') {
+	$planet = $sector->getPlanet();
+	foreach ($planet->getMaxBuildings() as $id => $amount) {
+		$planet->setBuilding($id, $amount);
+	}
+}
+elseif ($var['func'] == 'planet_defenses') {
+	$planet = $sector->getPlanet();
+	$planet->setShields($planet->getMaxShields());
+	$planet->setCDs($planet->getMaxCDs());
+	$planet->setArmour($planet->getMaxArmour());
+}
+elseif ($var['func'] == 'planet_stockpile') {
+	$planet = $sector->getPlanet();
+	foreach (Globals::getGoods() as $goodID => $good) {
+		$planet->setStockpile($goodID, SmrPlanet::MAX_STOCKPILE);
+	}
+}
+
 $container = create_container('skeleton.php', $var['body']);
 forward($container);
 

--- a/engine/Default/beta_functions.php
+++ b/engine/Default/beta_functions.php
@@ -90,3 +90,14 @@ $template->assign('RaceRelationsHREF', SmrSession::getNewHREF($container));
 //change race
 $container['func'] = 'Race';
 $template->assign('ChangeRaceHREF', SmrSession::getNewHREF($container));
+
+if ($sector->hasPlanet()) {
+	$container['func'] = 'planet_buildings';
+	$template->assign('MaxBuildingsHREF', SmrSession::getNewHREF($container));
+
+	$container['func'] = 'planet_defenses';
+	$template->assign('MaxDefensesHREF', SmrSession::getNewHREF($container));
+
+	$container['func'] = 'planet_stockpile';
+	$template->assign('MaxStockpileHREF', SmrSession::getNewHREF($container));
+}

--- a/engine/Default/planet_stockpile_processing.php
+++ b/engine/Default/planet_stockpile_processing.php
@@ -38,7 +38,7 @@ elseif ($action == 'Planet') {
 
 	// do we want to transfer more than the planet can hold?
 	if ($amount > $planet->getRemainingStockpile($var['good_id']))
-		create_error('You can only put 600 per item at planet!');
+		create_error('This planet cannot store more than '.SmrPlanet::MAX_STOCKPILE.' of each good!');
 
 	// now transfer
 	$planet->increaseStockpile($var['good_id'],$amount);

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -7,6 +7,7 @@ class SmrPlanet {
 	const CHANCE_TO_DOWNGRADE = 15;
 	const TIME_TO_CREDIT_BUST = 10800; // 3 hours
 	const TIME_ATTACK_NEWS_COOLDOWN = 3600; // 1 hour
+	const MAX_STOCKPILE = 600;
 
 	protected $db;
 	protected $SQL;
@@ -871,7 +872,7 @@ class SmrPlanet {
 	}
 
 	function getRemainingStockpile($id) {
-		return 600 - $this->getStockpile($id);
+		return self::MAX_STOCKPILE - $this->getStockpile($id);
 	}
 
 	/**

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -698,7 +698,9 @@ class SmrPlanet {
 
 	public function getMaxBuildings($buildingTypeID=false) {
 		if($buildingTypeID===false) {
-			return array_column($this->typeInfo::STRUCTURES, 'max_amount');
+			$structs = $this->typeInfo::STRUCTURES;
+			return array_combine(array_keys($structs),
+			                     array_column($structs, 'max_amount'));
 		}
 		return $this->getStructureTypes($buildingTypeID)->maxAmount();
 	}

--- a/templates/Default/engine/Default/beta_functions.php
+++ b/templates/Default/engine/Default/beta_functions.php
@@ -96,3 +96,12 @@
 	</select>&nbsp;&nbsp;
 	<input type="submit" value="Change Race" />
 </form>
+
+<?php
+if ($ThisSector->hasPlanet()) { ?>
+	<br /><br />
+	<h2>Modify Planet</h2>
+	<p><a href="<?php echo $MaxBuildingsHREF; ?>">Set buildings to max</a></p>
+	<p><a href="<?php echo $MaxDefensesHREF; ?>">Set defenses to max</a></p>
+	<p><a href="<?php echo $MaxStockpileHREF; ?>">Set stockpile to max</a></p><?php
+} ?>


### PR DESCRIPTION
Add the following options to Beta Functions:

1. Set the planet buildings to max
2. Set the planet defenses to max
3. Set the planet stockpile to max

These options can be accessed when you are in a sector with a planet,
which should help with debugging / testing planets.

Some minor adjustments to SmrPlanet were needed to accomplish this.