### PR TITLE
alliance_treaties.php: convert to template

### DIFF
--- a/engine/Default/alliance_treaties_confirm.php
+++ b/engine/Default/alliance_treaties_confirm.php
@@ -1,0 +1,41 @@
+<?php
+
+$alliance_id_1 = $player->getAllianceID();
+$alliance_id_2 = $_REQUEST['proposedAlliance'];
+
+$db->query('SELECT alliance_id_1, alliance_id_2, game_id FROM alliance_treaties WHERE (alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_1 = '.$alliance_id_2.') AND (alliance_id_2 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()));
+if ($db->nextRecord()) {
+	$container = create_container('skeleton.php', 'alliance_treaties.php');
+	$container['message'] = '<span class="red bold">ERROR:</span> There is already an outstanding treaty with that alliance.';
+	forward($container);
+}
+
+$alliance1 = SmrAlliance::getAlliance($alliance_id_1, $player->getGameID());
+$alliance2 = SmrAlliance::getAlliance($alliance_id_2, $player->getGameID());
+$template->assign('AllianceName', $alliance2->getAllianceName());
+
+$template->assign('PageTopic', 'Alliance Treaty Confirmation');
+Menu::alliance($alliance1->getAllianceID(), $alliance1->getLeaderID());
+
+// Get the terms selected for this offer
+$terms = [];
+foreach (array_keys(SmrTreaty::TYPES) as $type) {
+	$terms[$type] = isset($_REQUEST[$type]);
+}
+// A few terms get added automatically if a more restrictive term has
+// been selected.
+$terms['trader_nap'] = $terms['trader_nap'] || $terms['trader_defend'] || $terms['trader_assist'];
+$terms['planet_land'] = $terms['planet_land'] || $terms['planet_nap'];
+$terms['mb_read'] = $terms['mb_read'] || $terms['mb_write'];
+$template->assign('Terms', $terms);
+
+// Create links for yes/no response
+$container = create_container('alliance_treaties_confirm_processing.php');
+$container['proposedAlliance'] = $alliance_id_2;
+foreach ($terms as $term => $value) {
+	$container[$term] = $value;
+}
+$template->assign('YesHREF', SmrSession::getNewHREF($container));
+
+$container = create_container('skeleton.php', 'alliance_treaties.php');
+$template->assign('NoHREF', SmrSession::getNewHREF($container));

--- a/engine/Default/alliance_treaties_confirm_processing.php
+++ b/engine/Default/alliance_treaties_confirm_processing.php
@@ -1,0 +1,21 @@
+<?php
+
+$alliance1 = $player->getAlliance();
+$alliance2 = SmrAlliance::getAlliance($var['proposedAlliance'], $player->getGameID());
+
+$alliance_id_1 = $alliance1->getAllianceID();
+$alliance_id_2 = $alliance2->getAllianceID();
+
+$db->query('INSERT INTO alliance_treaties (alliance_id_1,alliance_id_2,game_id,trader_assist,trader_defend,trader_nap,raid_assist,planet_land,planet_nap,forces_nap,aa_access,mb_read,mb_write,mod_read,official)
+			VALUES (' . $db->escapeNumber($alliance_id_1) . ', ' . $db->escapeNumber($alliance_id_2) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeBoolean($var['trader_assist']) . ', ' .
+			$db->escapeBoolean($var['trader_defend']) . ', ' . $db->escapeBoolean($var['trader_nap']) . ', ' . $db->escapeBoolean($var['raid_assist']) . ', ' . $db->escapeBoolean($var['planet_land']) . ', ' . $db->escapeBoolean($var['planet_nap']) . ', ' .
+			$db->escapeBoolean($var['forces_nap']) . ', ' . $db->escapeBoolean($var['aa_access']) . ', ' . $db->escapeBoolean($var['mb_read']) . ', ' . $db->escapeBoolean($var['mb_write']) . ', ' . $db->escapeBoolean($var['mod_read']) . ', \'FALSE\')');
+
+//send a message to the leader letting them know the offer is waiting.
+$leader2 = $alliance2->getLeaderID();
+$message = 'An ambassador from [alliance=' . $alliance1->getAllianceID() . '] has arrived with a treaty offer.';
+
+SmrPlayer::sendMessageFromAllianceAmbassador($player->getGameID(), $leader2, $message);
+$container = create_container('skeleton.php', 'alliance_treaties.php');
+$container['message'] = 'The treaty offer has been sent.';
+forward($container);

--- a/engine/Default/alliance_treaties_processing.php
+++ b/engine/Default/alliance_treaties_processing.php
@@ -1,130 +1,38 @@
 <?php
 
 //get the alliances
-if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id',$player->getAllianceID());
-}
-$alliance_id_1 = $var['alliance_id'];
-if ($alliance_id_1 == 0) create_error('You are not in an alliance!');
-if (isset($var['accept'])) {
-	if ($var['accept']) {
-		$db->query('UPDATE alliance_treaties SET official = \'TRUE\' WHERE alliance_id_1 = ' . $db->escapeNumber($var['alliance_id_1']) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_1) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-		if ($var['aa']) {
-			//make an AA entry to the alliance, use treaty_created column
+if (!$player->hasAlliance()) create_error('You are not in an alliance!');
+$alliance_id_1 = $var['alliance_id_1'];
+$alliance_id_2 = $player->getAllianceID();
+
+if ($var['accept']) {
+	$db->query('UPDATE alliance_treaties SET official = \'TRUE\' WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+
+	if ($var['aa_access']) {
+		//make an AA role for both alliances, use treaty_created column
+		$pairs = [
+			$alliance_id_1 => $alliance_id_2,
+			$alliance_id_2 => $alliance_id_1,
+		];
+		foreach ($pairs as $alliance_id_A => $alliance_id_B) {
 			// get last id
 			$db->query('SELECT MAX(role_id)
 						FROM alliance_has_roles
 						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND alliance_id = ' . $db->escapeNumber($alliance_id_1));
+							AND alliance_id = ' . $db->escapeNumber($alliance_id_A));
 			if ($db->nextRecord()) {
 				$role_id = $db->getInt('MAX(role_id)') + 1;
 			}
-			$allianceName = $var['alliance_name'];
+			$allianceName = SmrAlliance::getAlliance($alliance_id_B, $player->getGameID())->getAllianceName();
 			$db->query('INSERT INTO alliance_has_roles
 				(alliance_id, game_id, role_id, role, treaty_created)
-				VALUES (' . $db->escapeNumber($alliance_id_1) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($role_id) . ', ' . $db->escapeString($allianceName) . ',1)');
-			$db->query('SELECT MAX(role_id)
-						FROM alliance_has_roles
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND alliance_id = ' . $db->escapeNumber($var['alliance_id_1']));
-			if ($db->nextRecord()) {
-				$role_id = $db->getInt('MAX(role_id)') + 1;
-			}
-			$allianceName = $player->getAllianceName();
-			$db->query('INSERT INTO alliance_has_roles
-				(alliance_id, game_id, role_id, role, treaty_created)
-				VALUES (' . $db->escapeNumber($var['alliance_id_1']) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($role_id) . ', ' . $db->escapeString($allianceName) . ',1)');
+				VALUES (' . $db->escapeNumber($alliance_id_A) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($role_id) . ', ' . $db->escapeString($allianceName) . ',1)');
 		}
 	}
-	else {
-		$db->query('DELETE FROM alliance_treaties WHERE alliance_id_1 = ' . $db->escapeNumber($var['alliance_id_1']) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_1) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	}
-	$container = create_container('skeleton.php','alliance_treaties.php');
-	$container['alliance_id'] = $alliance_id_1;
-	forward($container);
 }
-$alliance1 = SmrAlliance::getAlliance($alliance_id_1, $player->getGameID());
-if (isset($_REQUEST['proposedAlliance'])) {
-	$alliance_id_2 = $_REQUEST['proposedAlliance'];
-	$db->query('SELECT alliance_id_1, alliance_id_2, game_id FROM alliance_treaties WHERE (alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_1 = '.$alliance_id_2.') AND (alliance_id_2 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	if ($db->nextRecord()) {
-		$container=create_container('skeleton.php', 'alliance_treaties.php');
-		$container['alliance_id'] = $alliance_id_1;
-		$container['message'] = '<span class="red bold">ERROR:</span> There is already an outstanding treaty with that alliance.';
-		forward($container);
-	}
-	//get the terms
-	$traderAssist = isset($_REQUEST['assistTrader']);
-	$raidAssist = isset($_REQUEST['assistRaids']);
-	$traderDefend = isset($_REQUEST['defendTrader']);
-	$traderNAP = $traderDefend || $traderAssist || isset($_REQUEST['napTrader']);
-	$planetLand = isset($_REQUEST['planetLand']);
-	$planetNAP = $planetLand ||isset($_REQUEST['napPlanets']);
-	$forcesNAP = isset($_REQUEST['napForces']);
-	$aaAccess = isset($_REQUEST['aaAccess']);
-	$mbWrite = isset($_REQUEST['mbWrite']);
-	$mbRead = $mbWrite || isset($_REQUEST['mbRead']);
-	$modRead = isset($_REQUEST['modRead']);
-	//get confirmation
-	$template->assign('PageTopic', $alliance1->getAllianceName(false, true));
-	Menu::alliance($alliance1->getAllianceID(), $alliance1->getLeaderID());
-
-	$PHP_OUTPUT.=('<br /><br /');
-	$PHP_OUTPUT.=('<div align="center">Are you sure you want to offer a treaty to <span class="yellow">');
-	$db->query('SELECT leader_id, alliance_name, alliance_id FROM alliance WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($alliance_id_2) . ' LIMIT 1');
-	$db->nextRecord();
-	$PHP_OUTPUT.=(stripslashes($db->getField('alliance_name')));
-	$PHP_OUTPUT.=('</span> with the following conditions:<br /><ul>');
-	if ($traderAssist) $PHP_OUTPUT.=('<li>Assist - Trader Attacks</li>');
-	if ($traderDefend) $PHP_OUTPUT.=('<li>Defend - Trader Attacks</li>');
-	if ($traderNAP) $PHP_OUTPUT.=('<li>Non Aggression - Traders</li>');
-	if ($raidAssist) $PHP_OUTPUT.=('<li>Assist - Planet & Port Attacks</li>');
-	if ($planetNAP) $PHP_OUTPUT.=('<li>Non Aggression - Planets</li>');
-	if ($forcesNAP) $PHP_OUTPUT.=('<li>Non Aggression - Forces</li>');
-	if ($aaAccess) $PHP_OUTPUT.=('<li>Alliance Account Access</li>');
-	if ($mbRead) $PHP_OUTPUT.=('<li>Message Board Read Rights</li>');
-	if ($mbWrite) $PHP_OUTPUT.=('<li>Message Board Write Rights</li>');
-	if ($modRead) $PHP_OUTPUT.=('<li>Message of the Day Read Rights</li>');
-	if ($planetLand) $PHP_OUTPUT.=('<li>Planet Landing Rights</li>');
-	$PHP_OUTPUT.=('</ul>');
-
-	//give them options
-	$container=create_container('alliance_treaties_processing.php');
-	$container['alliance_id'] = $alliance_id_1;
-	$container['proposedAlliance'] = $alliance_id_2;
-	$container['traderAssist'] = $traderAssist;
-	$container['raidAssist'] = $raidAssist;
-	$container['traderDefend'] = $traderDefend;
-	$container['traderNAP'] = $traderNAP;
-	$container['planetNAP'] = $planetNAP;
-	$container['forcesNAP'] = $forcesNAP;
-	$container['aaAccess'] = $aaAccess;
-	$container['mbRead'] = $mbRead;
-	$container['mbWrite'] = $mbWrite;
-	$container['modRead'] = $modRead;
-	$container['planetLand'] = $planetLand;
-	$PHP_OUTPUT.=create_button($container,'Yes');
-	$PHP_OUTPUT.=('&nbsp;');
-	$container=create_container('skeleton.php', 'alliance_treaties.php');
-	$container['alliance_id'] = $alliance_id_1;
-	$PHP_OUTPUT.=create_button($container,'No');
-	$PHP_OUTPUT.=('</div>');
-
-} else {
-	$alliance_id_2 = $var['proposedAlliance'];
-	$db->query('INSERT INTO alliance_treaties (alliance_id_1,alliance_id_2,game_id,trader_assist,trader_defend,trader_nap,raid_assist,planet_land,planet_nap,forces_nap,aa_access,mb_read,mb_write,mod_read,official)
-				VALUES (' . $db->escapeNumber($alliance_id_1) . ', ' . $db->escapeNumber($alliance_id_2) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeBoolean($var['traderAssist']) . ', ' .
-				$db->escapeBoolean($var['traderDefend']) . ', ' . $db->escapeBoolean($var['traderNAP']) . ', ' . $db->escapeBoolean($var['raidAssist']) . ', ' . $db->escapeBoolean($var['planetLand']) . ', ' . $db->escapeBoolean($var['planetNAP']) . ', ' .
-				$db->escapeBoolean($var['forcesNAP']) . ', ' . $db->escapeBoolean($var['aaAccess']) . ', ' . $db->escapeBoolean($var['mbRead']) . ', ' . $db->escapeBoolean($var['mbWrite']) . ', ' . $db->escapeBoolean($var['modRead']) . ', \'FALSE\')');
-	//send a message to the leader letting them know the offer is waiting.
-	$db->query('SELECT leader_id FROM alliance WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($alliance_id_2) . ' LIMIT 1');
-	$db->nextRecord();
-	$leader_2 = $db->getField('leader_id');
-	$message = 'An ambassador from <span class="yellow">' . $alliance1->getAllianceName() . '</span> has arrived.';
-
-	SmrPlayer::sendMessageFromAllianceAmbassador($player->getGameID(), $leader_2, $message);
-	$container=create_container('skeleton.php', 'alliance_treaties.php');
-	$container['alliance_id'] = $alliance_id_1;
-	$container['message'] = 'The treaty offer has been sent.';
-	forward($container);
+else {
+	$db->query('DELETE FROM alliance_treaties WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 }
+
+$container = create_container('skeleton.php', 'alliance_treaties.php');
+forward($container);

--- a/lib/Default/SmrTreaty.class.inc
+++ b/lib/Default/SmrTreaty.class.inc
@@ -1,0 +1,50 @@
+<?php
+
+class SmrTreaty {
+	const TYPES = [
+		'trader_assist' => array(
+			'Assist - Trader Attacks',
+			'Assist your ally in attacking traders.'
+		),
+		'raid_assist' => array(
+			'Assist - Planet & Port Attacks',
+			'Assist your ally in attacking planets and ports.'
+		),
+		'trader_defend' => array(
+			'Defend - Trader Attacks',
+			'Defend your ally when they are attacked.'
+		),
+		'trader_nap' => array(
+			'Non Aggression - Traders',
+			'Cease Fire against Traders.'
+		),
+		'planet_nap' => array(
+			'Non Aggression - Planets',
+			'Cease Fire against Planets.'
+		),
+		'forces_nap' => array(
+			'Non Aggression - Forces',
+			'Cease Fire against Forces. Also allows refreshing of allied forces.'
+		),
+		'aa_access' => array(
+			'Alliance Account Access',
+			'Restrictions can be set in the roles section.'
+		),
+		'mb_read' => array(
+			'Message Board Read Rights',
+			'Allow your ally to read your message board.'
+		),
+		'mb_write' => array(
+			'Message Board Write Rights',
+			'Allow your ally to post on your message board.'
+		),
+		'mod_read' => array(
+			'Message of the Day Read Rights',
+			'Allow your ally to read your message of the day.'
+		),
+		'planet_land' => array(
+			'Planet Landing Rights',
+			'Allow your ally to land on your planets.'
+		),
+	];
+}

--- a/templates/Default/engine/Default/alliance_treaties.php
+++ b/templates/Default/engine/Default/alliance_treaties.php
@@ -1,0 +1,52 @@
+<div class="center">
+	<?php
+	if (isset($Message)) {
+		echo $Message . '<br /><br />';
+	} ?>
+
+	<?php
+	foreach ($Offers as $Offer) { ?>
+		Treaty offer from <span class="yellow"><?php echo $Offer['Alliance']->getAllianceName(true); ?></span>.
+		Terms as follows:<br />
+		<ul class="noWrap left" style="display: inline-block"><?php
+			foreach ($Offer['Terms'] as $Term) { ?>
+				<li><?php echo SmrTreaty::TYPES[$Term][0]; ?></li><?php
+			} ?>
+		</ul>
+		<br />
+		<div class="buttonA">
+			<a class="buttonA" href="<?php echo $Offer['AcceptHREF']; ?>">&nbsp;Accept&nbsp;</a>
+			&nbsp;&nbsp;
+			<a class="buttonA" href="<?php echo $Offer['RejectHREF']; ?>">&nbsp;Reject&nbsp;</a>
+		</div>
+		<br /><br /><?php
+	} ?>
+
+	<br />
+	<h2>Offer A Treaty</h2>
+	Select the alliance you wish to offer a treaty.<br />
+	<small>Note: Treaties require 24 hours to be canceled once in effect</small><br />
+
+	<form method="POST" action="<?php echo $SendOfferHREF; ?>">
+		<select name="proposedAlliance" id="InputFields"><?php
+			foreach ($Alliances as $allId => $allName) { ?>
+				<option value="<?php echo $allId; ?>"><?php echo $allName; ?></option><?php
+			} ?>
+		</select>
+		<br /><br />
+		Choose the treaty terms:<br />
+		<table class="center standard"><?php
+			foreach (SmrTreaty::TYPES as $checkName => $displayInfo) { ?>
+				<tr>
+					<td><input type="checkbox" name="<?php echo $checkName; ?>"></td>
+					<td class="left"><?php echo $displayInfo[0]; ?><br /><small><?php echo $displayInfo[1]; ?></small></td>
+				</tr><?php
+			} ?>
+			<tr>
+				<td colspan="2">
+					<input type="submit" name="action" value="Send the Offer" />
+				</td>
+			</tr>
+		</table>
+	</form>
+</div>

--- a/templates/Default/engine/Default/alliance_treaties_confirm.php
+++ b/templates/Default/engine/Default/alliance_treaties_confirm.php
@@ -1,0 +1,19 @@
+<br />
+<div align="center">
+	Are you sure you want to offer a treaty to <span class="yellow"><?php echo $AllianceName; ?></span> with the following conditions?
+	<br />
+
+	<ul class="noWrap left" style="display: inline-block"><?php
+		foreach ($Terms as $Term => $Offered) {
+			if ($Offered) { ?>
+				<li><?php echo SmrTreaty::TYPES[$Term][0]; ?></li><?php
+			}
+		} ?>
+	</ul>
+	<br />
+	<div class="buttonA">
+		<a class="buttonA" href="<?php echo $YesHREF; ?>">&nbsp;Yes&nbsp;</a>
+		&nbsp;&nbsp;
+		<a class="buttonA" href="<?php echo $NoHREF; ?>">&nbsp;No&nbsp;</a>
+	</div>
+</div>


### PR DESCRIPTION
Break up the monolithic treaty scripts into template, confirm,
and processing pages.

Factor the treaty types into a new SmrTreaty class, and use the
treaty type keys consistently to facilitate looping over each of
the types instead of writing them all out explicitly.

![image](https://user-images.githubusercontent.com/846186/52148719-67461a80-261f-11e9-9316-abc5e2e8b3cc.png)

![image](https://user-images.githubusercontent.com/846186/52148742-7b8a1780-261f-11e9-8411-ec1bd83050b2.png)
