### PR TITLE
ajax.js: fix a longstanding cause of ajax freezing

### DIFF
--- a/htdocs/js/ajax.js
+++ b/htdocs/js/ajax.js
@@ -75,12 +75,10 @@ var exec = function(s) {
 				$('#'+e.tagName).html($(e).text());
 			}
 		});
-		if(all.length !== 0) {
-			refreshReady = true;
-			if(ajaxRunning === true) {
-				clearTimeout(updateRefreshTimeout);
-				updateRefreshTimeout = setTimeout(updateRefreshRequest, refreshSpeed);
-			}
+		refreshReady = true;
+		if(ajaxRunning === true) {
+			clearTimeout(updateRefreshTimeout);
+			updateRefreshTimeout = setTimeout(updateRefreshRequest, refreshSpeed);
 		}
 	};
 


### PR DESCRIPTION
If no elements on the page changed, then ajax would stop refreshing.
In practice, this would usually happen any time the `tod` (server time)
and `rt` (script runtime) elements were identical between updates,
which happened just often enough for people to notice it freezing
from time to time, but not often enough to feel like it was
reproducible.

To fix this, we simply remove the restriction that there must be at
least one updated element.

Thanks to @Page-  for helping to debug this issue!