### PR TITLE
log_anonymous_account.php: convert to template

### DIFF
--- a/admin/Default/log_anonymous_account.php
+++ b/admin/Default/log_anonymous_account.php
@@ -1,73 +1,30 @@
 <?php
 
-$template->assign('PageTopic','Check Anonymous Accounts');
+$template->assign('PageTopic', 'Anonymous Account Access');
 
-// a second db object
-$db2 = new SmrMySqlDatabase();
-
-$db->query('SELECT account_id, login, player_name, count(account_id) as number_of_entries
-			FROM account_has_logs
-			JOIN account USING(account_id)
-			JOIN player USING(account_id)
-			GROUP BY account_id');
-if (!$db->getNumRows()) {
-	$PHP_OUTPUT.=create_error('There are no log entries at all!');
-	return;
-}
-
-$account_list = array(0);
+$db->query('SELECT account_id FROM account_has_logs GROUP BY account_id');
+$log_account_ids = [];
 while ($db->nextRecord()) {
-	$account_list[] = $db->getInt('account_id');
+	$log_account_ids[] = $db->getInt('account_id');
 }
 
 // get all anon bank transactions that are logged in an array
-$db->query('SELECT * FROM anon_bank_transactions WHERE account_id IN ('.$db->escapeArray($account_list).') ORDER BY anon_id');
-if (!$db->getNumRows()) {
-	$PHP_OUTPUT.=create_error('None of the entries in all the log files contains anonymous bank transaction!');
-	return;
-}
-
-// variable to remember the group of anon_ids in which we currently are
-$anon_id = 0;
-
-$PHP_OUTPUT.=('Following accounts where accessed by these logged people:');
-$PHP_OUTPUT.=('<p>&nbsp;</p>');
-$PHP_OUTPUT.=('<p>');
-
+$db->query('SELECT * FROM anon_bank_transactions
+            JOIN account USING(account_id)
+            WHERE account_id IN ('.$db->escapeArray($log_account_ids).')
+            ORDER BY game_id DESC, anon_id ASC');
+$anon_logs = [];
 while ($db->nextRecord()) {
-	if ($anon_id != $db->getField('anon_id')) {
-		// if this is not the first entry we have to close previous list
-		if ($anon_id > 0)
-			$PHP_OUTPUT.=('</ul>');
-
-		// set current anon_id
-		$anon_id = $db->getInt('anon_id');
-
-		// start topic for it
-		$PHP_OUTPUT.=('Account #'.$anon_id);
-		$PHP_OUTPUT.=('<ul>');
-	}
-
-	$curr_account = SmrAccount::getAccount($db->getInt('account_id'));
-
-	$transaction_id = $db->getInt('transaction_id');
-
-	$db2->query('SELECT * FROM anon_bank_transactions
-				 WHERE account_id = '.$db2->escapeNumber($curr_account->getAccountID()).' AND
-					   anon_id = '.$db2->escapeNumber($anon_id).' AND
-					   transaction_id = '.$db2->escapeNumber($transaction_id));
-	if ($db2->nextRecord()) {
-		$text = strtolower($db2->getField('transaction')) . ' ' . number_format($db2->getInt('amount')) . ' credits';
-	}
-
-	$PHP_OUTPUT.=('<li>'.$curr_account->getLogin().' '.$text.'</li>');
-
+	$transaction = strtolower($db->getField('transaction'));
+	$anon_logs[$db->getInt('game_id')][$db->getInt('anon_id')][] = [
+		'login' => $db->getField('login'),
+		'amount' => number_format($db->getInt('amount')),
+		'date' => date(DATE_FULL_SHORT, $db->getField('time')),
+		'type' => $transaction,
+		'color' => $transaction == 'payment' ? 'tomato' : 'green',
+	];
 }
-$PHP_OUTPUT.=('</ul>');
-$PHP_OUTPUT.=('</p>');
+$template->assign('AnonLogs', $anon_logs);
 
-$PHP_OUTPUT.=('<p>&nbsp;</p>');
-
-$PHP_OUTPUT.=('<p>');
-$PHP_OUTPUT.=create_link(create_container('skeleton.php', 'log_console.php'), '<b>&lt; Back</b>');
-$PHP_OUTPUT.=('</p>');
+$container = create_container('skeleton.php', 'log_console.php');
+$template->assign('BackHREF', SmrSession::getNewHREF($container));

--- a/templates/Default/admin/Default/log_anonymous_account.php
+++ b/templates/Default/admin/Default/log_anonymous_account.php
@@ -1,0 +1,29 @@
+<a href="<?php echo $BackHREF; ?>"><b>&lt; Back</b></a>
+
+<?php
+if (!$AnonLogs) { ?>
+	<p>None of the entries in all the log files contains anonymous bank transaction!</p><?php
+	return;
+} ?>
+
+<p>The following anonymous bank accounts were accessed by logged players:</p>
+
+<?php
+foreach ($AnonLogs as $gameID => $AnonAccounts) { ?>
+	<h2>Game <?php echo $gameID; ?></h2><?php
+	foreach ($AnonAccounts as $anonID => $logs) { ?>
+		<table>
+			<tr>
+				<th colspan="4">Anon Account #<?php echo $anonID; ?></th>
+			</tr><?php
+			foreach ($logs as $log) { ?>
+				<tr>
+					<td><?php echo $log['date']; ?></td>
+					<td><?php echo $log['login']; ?></td>
+					<td style="color:<?php echo $log['color']; ?>"><?php echo $log['type']; ?></td>
+					<td><?php echo $log['amount']; ?> credits</td>
+				</tr><?php
+			} ?>
+		</table><br /><?php
+	}
+} ?>


### PR DESCRIPTION
Also completely rewrite its guts.

* Vastly simplify database queries and logic for organizing the logs.

* Fix the display so that transactions are separated by game.
  Previously, all transactions for each anon account number were
  displayed together (no delineation by game_id, but anon_id is
  not a unique index!).

* Display the time of each transaction.

* Color the transaction for deposits (green) and withdrawals (red).

* Move the back button to the top of the page so you don't have to
  scroll all the way to the bottom.

![image](https://user-images.githubusercontent.com/846186/52465169-7acb1700-2b32-11e9-8276-f218c514ffc8.png)
