### PR TITLE
Minor chess display changes

### DIFF
--- a/htdocs/css/shared.css
+++ b/htdocs/css/shared.css
@@ -498,8 +498,8 @@ table.chess {
 	width: 44px;
 	height: 44px;
 	color: black;
-	background-color: #47525D;
-	border-color: #47525D;
+	background-color: #999;
+	border-color: #999;
 }
 
 .chess td.lastMove {

--- a/templates/Default/engine/Default/chess_play.php
+++ b/templates/Default/engine/Default/chess_play.php
@@ -39,7 +39,7 @@
 			</div>
 		</td>
 		<td>
-			<div class="chat" style="height: 500px; width: 300px; overflow-y:scroll;">
+			<div class="chat" style="height: 500px; width: 160px; overflow-y:scroll;">
 				<table id="moveTable" class="ajax chessFont">
 					<?php $this->includeTemplate('includes/ChessMoves.inc'); ?>
 				</table>

--- a/templates/Default/engine/Default/includes/ChessMoves.inc
+++ b/templates/Default/engine/Default/includes/ChessMoves.inc
@@ -2,7 +2,7 @@
 $Moves = $ChessGame->getMoves();
 foreach($Moves as $MoveNumber => $Move) { ?>
 	<tr>
-		<td><?php echo $MoveNumber; ?>.</td>
+		<td><?php echo $MoveNumber + 1; ?>.</td>
 		<td><?php echo $Move; ?></td>
 	</tr><?php
 } ?>


### PR DESCRIPTION
* Use lighter color black squares. Since the unicode chess symbols
  have transparent white pieces, a darker black square makes them
  harder to see. A light gray square makes both player colors more
  visible.

* Make the chatbox for the move list less wide so that the middle
  panel fits within the default page width.

* Start the chess move display at move 1 instead of move 0 (since
  it comes from the index of an array, we just add 1).

New:
![image](https://user-images.githubusercontent.com/846186/53693170-98665780-3d51-11e9-8aa6-6befc1b94bca.png)

Old:
![image](https://user-images.githubusercontent.com/846186/53693175-a9af6400-3d51-11e9-9267-52fa304d340a.png)

