### PR TITLE
Prevent mysql password leaking in backtraces

### DIFF
--- a/config/SmrMySqlSecrets.sample.inc
+++ b/config/SmrMySqlSecrets.sample.inc
@@ -1,6 +1,6 @@
 <?php
 trait SmrMySqlSecrets {
-	private static $databaseName = 'smr_live';
+	protected static $databaseName = 'smr_live';
 	private static $host = 'smr-mysql'; // must match MYSQL_HOST in .env
 	private static $user = 'smr';       // must match MYSQL_USER in .env
 	private static $password = 'smr';   // must match MYSQL_PASSWORD in .env
@@ -10,6 +10,6 @@ trait SmrMySqlSecrets {
 	private static $socket = null;
 
 	// Uncomment if using history databases
-	//private static $dbName_Smr12History = 'smr_12_history';
-	//private static $dbName_SmrClassicHistory = 'smr_classic_history';
+	//protected static $dbName_Smr12History = 'smr_12_history';
+	//protected static $dbName_SmrClassicHistory = 'smr_classic_history';
 }

--- a/lib/Default/MySqlDatabase.class.inc
+++ b/lib/Default/MySqlDatabase.class.inc
@@ -1,14 +1,19 @@
 <?php
+require_once(CONFIG . 'SmrMySqlSecrets.inc');
 
 abstract class MySqlDatabase {
+	// add configuration static members via traits
+	use SmrMySqlSecrets;
+
 	protected static $dbConn;
 	protected static $selectedDbName;
 	protected $dbResult = null;
 	protected $dbRecord = null;
 	
-	public function __construct($host, $user, $password, $dbName, $port, $socket) {
+	public function __construct($dbName) {
 		if(!self::$dbConn) {
-			self::$dbConn = new mysqli($host, $user, $password, $dbName, $port, $socket);
+			self::$dbConn = new mysqli(self::$host, self::$user, self::$password,
+			                           $dbName, self::$port, self::$socket);
 			if (self::$dbConn->connect_errno) {
 				$this->error('Connection failed: ' . self::$dbConn->connect_error);
 			}

--- a/lib/Default/Smr12HistoryMySqlDatabase.class.inc
+++ b/lib/Default/Smr12HistoryMySqlDatabase.class.inc
@@ -1,11 +1,7 @@
 <?php
 
-require_once(CONFIG . 'SmrMySqlSecrets.inc');
-
 class Smr12HistoryMySqlDatabase extends MySqlDatabase {
-	use SmrMySqlSecrets;
 	public function __construct() {
-		parent::__construct(self::$host, self::$user, self::$password, self::$dbName_Smr12History,
-		                    self::$port, self::$socket);
+		parent::__construct(self::$dbName_Smr12History);
 	}
 }

--- a/lib/Default/SmrClassicHistoryMySqlDatabase.class.inc
+++ b/lib/Default/SmrClassicHistoryMySqlDatabase.class.inc
@@ -1,11 +1,7 @@
 <?php
 
-require_once(CONFIG . 'SmrMySqlSecrets.inc');
-
 class SmrClassicHistoryMySqlDatabase extends MySqlDatabase {
-	use SmrMySqlSecrets;
 	public function __construct() {
-		parent::__construct(self::$host, self::$user, self::$password, self::$dbName_SmrClassicHistory,
-		                    self::$port, self::$socket);
+		parent::__construct(self::$dbName_SmrClassicHistory);
 	}
 }

--- a/lib/Default/SmrMySqlDatabase.class.inc
+++ b/lib/Default/SmrMySqlDatabase.class.inc
@@ -1,11 +1,7 @@
 <?php
-require_once(CONFIG . 'SmrMySqlSecrets.inc');
 
 class SmrMySqlDatabase extends MySqlDatabase {
-	// add static members via traits
-	use SmrMySqlSecrets;
 	public function __construct() {
-		parent::__construct(self::$host, self::$user, self::$password, self::$databaseName,
-		                    self::$port, self::$socket);
+		parent::__construct(self::$databaseName);
 	}
 }


### PR DESCRIPTION
The mysqli database connector provides a (relatively) secure error
message when a database connection fails, e.g.,

Connection failed: Access denied for user 'smr'@'XXX.XX.X.X' (using password: YES)

and does not directly throw an exception, which would display the
password passed to its constructor (since PHP backtraces will print
function arguments in plain text). However, since our function
`MySqlDatabase::error` takes the mysqli error message and packages
it into an exception, the password is leaked by the `MySqlDatabase`
constructor line of the resulting backtrace. But we want to be able
to raise an exception (securely) since that's how we perform our
standard error handling.

Fortunately, we can plug this leak by loading the password directly
in MySqlDatabase instead of the derived classes (so it doesn't need
to be passed to any function other than `mysqli`, which is outside
the scope of the backtrace).

This does somewhat contaminate the SMR-agnostic design of the
MySqlDatabase base class, but it is still effectively generic, and
it is well worth the added security.

NOTE: Our solution here would not have worked if we were using PDO
instead of mysqli, because PDO prints the database password in the
connection error message (because it internally raises an exception).
It seems that people recommend the very unsatisfying workaround of
catching the exception and then filtering the password out of the
error message string.