### PR TITLE
Create a new Template for each page

### DIFF
--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -120,8 +120,3 @@ require_once('config.php');
 require_once(ROOT . 'vendor/autoload.php');
 require_once(LIB . 'autoload.inc');
 spl_autoload_register('get_class_loc');
-
-// Initialize the template
-$template = new Template();
-$GLOBALS['template'] =& $template;
-

--- a/htdocs/login.php
+++ b/htdocs/login.php
@@ -26,6 +26,7 @@ try {
 		exit;
 	}
 	
+	$template = new Template();
 	if(isset($_REQUEST['msg']))
 		$template->assign('Message',htmlentities(trim($_REQUEST['msg']),ENT_COMPAT,'utf-8'));
 

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -64,6 +64,9 @@ try {
 		throw new Exception('Failed to start session');
 	}
 
+	// Initialize the template
+	$template = new Template();
+
 	// Set temporary options
 	if ($player->hasAlliance()) {
 		if (isset($_POST['change_settings'])) {
@@ -92,8 +95,6 @@ try {
 		$mapSectors = $galaxy->getMapSectors();
 	}
 
-	// Unset the default template page title so we can rename it
-	$template->unassign('Title');
 	$template->assign('Title', 'Galaxy Map');
 
 	if($account->getCssLink()!=null)

--- a/htdocs/offline.php
+++ b/htdocs/offline.php
@@ -6,6 +6,7 @@ try {
 	
 	$db = new SmrMySqlDatabase();
 	
+	$template = new Template();
 	$db->query('SELECT * FROM game_disable');
 	if ($db->nextRecord()) {
 		$template->assign('Message', '<span class="red">Space Merchant Realms is temporarily offline.<br />'.$db->getField('reason').'</span>');

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -396,7 +396,7 @@ function getIpAddress() {
 
 // This function is a hack around the old style http forward mechanism
 function do_voodoo() {
-	global $lock, $var, $template, $account;
+	global $lock, $var;
 	if(!defined('AJAX_CONTAINER')) {
 		define('AJAX_CONTAINER', isset($var['AJAX']) && $var['AJAX'] === true);
 	}
@@ -485,6 +485,10 @@ function do_voodoo() {
 			$var['url'] != 'newbie_warning_processing.php')
 			forward(create_container('newbie_warning_processing.php'));
 	}
+
+	// Initialize the template
+	$template = new Template();
+	$GLOBALS['template'] =& $template;
 
 	if($var['url'] != 'skeleton.php') {
 		require(get_file_loc($var['url']));


### PR DESCRIPTION
If we initialize the Template at the config.inc level, then it will
be reused between pages that call `forward`. In general, this is not
a problem, because we typically don't set template variables until
we're on the final page that we intend to display. However, it has
caused a problem in at least one case, where we forwarded to the
error.php page after the `PageTopic` variable had already been set
(thus triggering an Exception).

This particular issue could have been obviated by not setting the
`PageTopic` template variable until after all `create_error` sanity
checks had been performed on the display page. But this is not a
safe assumption (it depends on the coder always remembering when to
assign to the template), nor does it fix any cases that we haven't
yet encountered.

Instead, creating the template in `do_voodoo` ensures that we have
a fresh template for each page, guaranteed to be free of any stale
template variables.

(This does require that we also create a Template on any page that
doesn't use `do_voodoo`, e.g., the Galaxy Map and the login page.)