### PR TITLE
Change how globals are handled

### DIFF
--- a/htdocs/loader.php
+++ b/htdocs/loader.php
@@ -31,15 +31,15 @@ try {
 	// ********************************
 	
 	// We want these to be already defined as globals
-	$player=null;
-	$ship=null;
-	$sector=null;
-	$container=null;
-	$var=null;
-	$lock=false;
-
-	// new db object
+	$account = null;
+	$player = null;
+	$ship = null;
+	$sector = null;
+	$container = null;
+	$var = null;
+	$lock = false;
 	$db = new SmrMySqlDatabase();
+	$template = null;
 	
 	// ********************************
 	// *

--- a/lib/Default/shop_goods.inc
+++ b/lib/Default/shop_goods.inc
@@ -68,7 +68,7 @@ function check_bargain_number($amount,$ideal_price,$offered_price,$bargain_price
 }
 
 function get_amount() {
-	global $var, $_REQUEST;
+	global $var;
 
 	// retrieve amount
 	if (isset($var['amount']))
@@ -93,7 +93,7 @@ function get_amount() {
 }
 
 function get_bargain_price() {
-	global $_REQUEST,$var;
+	global $var;
 
 	// we get it from form
 	if (isset($_REQUEST['bargain_price']))

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -394,9 +394,14 @@ function getIpAddress() {
     }
 }
 
-// This function is a hack around the old style http forward mechanism
+/**
+ * This function is a hack around the old style http forward mechanism.
+ * It is also responsible for setting most of the global variables
+ * (see loader.php for the initialization of the globals).
+ */
 function do_voodoo() {
-	global $lock, $var;
+	global $lock, $var, $container, $player, $ship, $sector, $account, $db, $template;
+
 	if(!defined('AJAX_CONTAINER')) {
 		define('AJAX_CONTAINER', isset($var['AJAX']) && $var['AJAX'] === true);
 	}
@@ -405,21 +410,13 @@ function do_voodoo() {
 	}
 //	ob_clean();
 
-	foreach ($GLOBALS as $key => $value) {
-		$$key = &$GLOBALS[$key];
-	}
 	// create account object
-	$account =& SmrAccount::getAccount(SmrSession::$account_id);
-	$GLOBALS['account'] =& $account;
+	$account = SmrAccount::getAccount(SmrSession::$account_id);
 
 	if(!defined('DATE_DATE_SHORT')) define('DATE_DATE_SHORT',$account->getShortDateFormat());
 	if(!defined('DATE_TIME_SHORT')) define('DATE_TIME_SHORT',$account->getShortTimeFormat());
 	if(!defined('DATE_FULL_SHORT')) define('DATE_FULL_SHORT',DATE_DATE_SHORT.' '.DATE_TIME_SHORT);
 	if(!defined('DATE_FULL_SHORT_SPLIT')) define('DATE_FULL_SHORT_SPLIT',DATE_DATE_SHORT.'\<b\r /\>'.DATE_TIME_SHORT);
-
-
-	$db = new SmrMySqlDatabase();
-	$GLOBALS['db'] =& $db;
 
 	if($var['url'] == 'game_play_preprocessing.php') { // Would rather not have these here but if we go through the initialisation based on game id when leaving a classic game it breaks.
 		SmrSession::clearLinks();
@@ -464,18 +461,14 @@ function do_voodoo() {
 		}
 
 		// Now that they've acquire a lock we can move on
-		$player =& SmrPlayer::getPlayer(SmrSession::$account_id, SmrSession::getGameID());
-		$GLOBALS['player'] =& $player;
+		$player = SmrPlayer::getPlayer(SmrSession::$account_id, SmrSession::getGameID());
 
 		if($player->isDead() && $var['url'] != 'death_processing.php' && !isset($var['override_death'])) {
 			forward(create_container('death_processing.php'));
 		}
 
-		$ship	=& $player->getShip();
-		$GLOBALS['ship'] =& $ship;
-
-		$sector	=& $player->getSector();
-		$GLOBALS['sector'] =& $sector;
+		$ship = $player->getShip();
+		$sector = $player->getSector();
 
 		// update turns on that player
 		$player->updateTurns();
@@ -488,7 +481,6 @@ function do_voodoo() {
 
 	// Initialize the template
 	$template = new Template();
-	$GLOBALS['template'] =& $template;
 
 	if($var['url'] != 'skeleton.php') {
 		require(get_file_loc($var['url']));


### PR DESCRIPTION
For pages generated by `loader.php`, initialize all globals at global
scope (usually as null, unless the variable is sufficiently simple).
Then load them with the `globals` keyword within `do_voodoo`, which
will be primarily responsible for setting the appropriate values.

We no longer need to use the `$GLOBALS` superglobal, so we remove
that altogether.

Also, do not use global keyword with $_REQUESTS (since it is a
superglobal).