### PR TITLE
Remove many remaining uses of references

### DIFF
--- a/engine/Default/chess.php
+++ b/engine/Default/chess.php
@@ -1,6 +1,6 @@
 <?php
 
-$chessGames =& ChessGame::getOngoingAccountGames($player->getAccountID());
+$chessGames = ChessGame::getOngoingAccountGames($player->getAccountID());
 $template->assign('ChessGames', $chessGames);
 
 $playersChallenged = array($player->getAccountID() => true);

--- a/engine/Default/chess_move_processing.php
+++ b/engine/Default/chess_move_processing.php
@@ -1,6 +1,6 @@
 <?php
 
-$chessGame =& ChessGame::getChessGame($var['ChessGameID']);
+$chessGame = ChessGame::getChessGame($var['ChessGameID']);
 $template->assign('ChessGame',$chessGame);
 if(is_numeric($_REQUEST['x']) && is_numeric($_REQUEST['y']) && is_numeric($_REQUEST['toX']) && is_numeric($_REQUEST['toY'])) {
 	$x = $_REQUEST['x'];

--- a/engine/Default/chess_resign_processing.php
+++ b/engine/Default/chess_resign_processing.php
@@ -1,6 +1,6 @@
 <?php
 
-$chessGame =& ChessGame::getChessGame($var['ChessGameID']);
+$chessGame = ChessGame::getChessGame($var['ChessGameID']);
 $result = $chessGame->resign($player->getAccountID());
 
 $container = create_container('skeleton.php', 'current_sector.php');

--- a/engine/Default/combat_simulator.php
+++ b/engine/Default/combat_simulator.php
@@ -77,15 +77,15 @@ function runAnAttack($realAttackers,$realDefenders) {
 	global $template;
 	$results = array('Attackers' => array('Traders' => array(), 'TotalDamage' => 0), 
 					'Defenders' => array('Traders' => array(), 'TotalDamage' => 0));
-	foreach($realAttackers as $accountID => &$teamPlayer) {
+	foreach ($realAttackers as $accountID => $teamPlayer) {
 		$playerResults =& $teamPlayer->shootPlayers($realDefenders);
 		$results['Attackers']['Traders'][] =& $playerResults;
 		$results['Attackers']['TotalDamage'] += $playerResults['TotalDamage'];
-	} unset($teamPlayer);
-	foreach($realDefenders as $accountID => &$teamPlayer) {
+	}
+	foreach ($realDefenders as $accountID => $teamPlayer) {
 		$playerResults =& $teamPlayer->shootPlayers($realAttackers);
 		$results['Defenders']['Traders'][]  =& $playerResults;
 		$results['Defenders']['TotalDamage'] += $playerResults['TotalDamage'];
-	} unset($teamPlayer);
+	}
 	$template->assign('TraderCombatResults',$results);
 }

--- a/engine/Default/edit_dummys.php
+++ b/engine/Default/edit_dummys.php
@@ -8,8 +8,8 @@ $template->assign('Weapons',SmrWeapon::getAllWeapons(0));
 
 $template->assign('EditDummysLink',SmrSession::getNewHREF(create_container('skeleton.php','edit_dummys.php')));
 
-$dummyPlayer =& DummyPlayer::getCachedDummyPlayer($_REQUEST['dummy_name']);
-$dummyShip =& $dummyPlayer->getShip();
+$dummyPlayer = DummyPlayer::getCachedDummyPlayer($_REQUEST['dummy_name']);
+$dummyShip = $dummyPlayer->getShip();
 
 if(isset($_REQUEST['save_dummy'])) {
 	$dummyPlayer->setPlayerName($_REQUEST['dummy_name']);

--- a/engine/Default/galactic_post_view_applications.php
+++ b/engine/Default/galactic_post_view_applications.php
@@ -11,7 +11,7 @@ if ($db->getNumRows()) {
 else
 	$PHP_OUTPUT.=('You have no applications to view at the current time.');
 while ($db->nextRecord()) {
-	$appliee =& SmrPlayer::getPlayer($db->getField('account_id'), $player->getGameID());
+	$appliee = SmrPlayer::getPlayer($db->getField('account_id'), $player->getGameID());
 
 	$container = array();
 	$container['url'] = 'skeleton.php';
@@ -30,7 +30,7 @@ if (isset($var['id'])) {
 	$db->query('SELECT * FROM galactic_post_applications WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id = '.$db->escapeNumber($var['id']));
 	$db->nextRecord();
 	$desc = stripslashes($db->getField('description'));
-	$applie =& SmrPlayer::getPlayer($var['id'], $player->getGameID());
+	$applie = SmrPlayer::getPlayer($var['id'], $player->getGameID());
 	$PHP_OUTPUT.=('Name : '.$applie->getPlayerName().'<br />');
 	$PHP_OUTPUT.=('Have you written for some kind of newspaper before? ' . $db->getField('written_before'));
 	$PHP_OUTPUT.=('<br />');

--- a/engine/Default/galactic_post_view_members.php
+++ b/engine/Default/galactic_post_view_members.php
@@ -21,7 +21,7 @@ if ($db->getNumRows()) {
 
 	while ($db->nextRecord()) {
 
-		$curr_writter =& SmrPlayer::getPlayer($db->getField('account_id'), $player->getGameID());
+		$curr_writter = SmrPlayer::getPlayer($db->getField('account_id'), $player->getGameID());
 		$time = $db->getField('last_wrote');
 		$PHP_OUTPUT.=('<tr>');
 		$PHP_OUTPUT.=('<td align="center">'.$curr_writter->getPlayerName().'</td>');

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -94,7 +94,7 @@ release_lock();
 acquire_lock($player->getSectorID());
 
 // get new sector object
-$sector =& $player->getSector();
+$sector = $player->getSector();
 
 // make current sector visible to him
 $sector->markVisited($player);

--- a/engine/Default/sector_move_processing.php
+++ b/engine/Default/sector_move_processing.php
@@ -16,7 +16,7 @@ if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 	$player->update();
 					
 	// get new sector object
-	$sector =& $player->getSector();
+	$sector = $player->getSector();
 	$sector->markVisited($player);
 	forward(create_container('skeleton.php', $var['target_page']));
 }
@@ -89,7 +89,7 @@ release_lock();
 acquire_lock($var['target_sector']);
 
 // get new sector object
-$sector =& $player->getSector();
+$sector = $player->getSector();
 
 //add that the player explored here if it hasnt been explored...for HoF
 if (!$sector->isVisited($player)) {

--- a/engine/Default/shop_ship_processing.php
+++ b/engine/Default/shop_ship_processing.php
@@ -1,7 +1,7 @@
 <?php
 
 $shipID = $var['ship_id'];
-$newShip =& AbstractSmrShip::getBaseShip(Globals::getGameType($player->getGameID()),$shipID);
+$newShip = AbstractSmrShip::getBaseShip(Globals::getGameType($player->getGameID()),$shipID);
 $cost = $ship->getCostToUpgrade($shipID);
 
 // trade master 33

--- a/lib/Default/ChessGame.class.inc
+++ b/lib/Default/ChessGame.class.inc
@@ -33,9 +33,9 @@ class ChessGame {
 					WHERE end_time > ' . TIME . ' OR end_time IS NULL;');
 		$games = array();
 		while($db->nextRecord()) {
-			$game =& self::getChessGame($db->getInt('chess_game_id'), $forceUpdate);
+			$game = self::getChessGame($db->getInt('chess_game_id'), $forceUpdate);
 			if($game->getCurrentTurnAccount()->isNPC()) {
-				$games[] =& $game;
+				$games[] = $game;
 			}
 		}
 		return $games;
@@ -46,7 +46,7 @@ class ChessGame {
 		$db->query('SELECT chess_game_id FROM chess_game WHERE (black_id = ' . $db->escapeNumber($accountID) . ' OR white_id = ' . $db->escapeNumber($accountID) . ') AND (end_time > ' . TIME . ' OR end_time IS NULL);');
 		$games = array();
 		while($db->nextRecord()) {
-			$games[] =& self::getChessGame($db->getInt('chess_game_id'));
+			$games[] = self::getChessGame($db->getInt('chess_game_id'));
 		}
 		return $games;
 	}
@@ -56,7 +56,7 @@ class ChessGame {
 		$db->query('SELECT chess_game_id FROM chess_game WHERE black_id = ' . $db->escapeNumber($accountID) . ' OR white_id = ' . $db->escapeNumber($accountID) . ';');
 		$games = array();
 		while($db->nextRecord()) {
-			$games[] =& self::getChessGame($db->getInt('chess_game_id'));
+			$games[] = self::getChessGame($db->getInt('chess_game_id'));
 		}
 		return $games;
 	}
@@ -642,7 +642,7 @@ class ChessGame {
 		if($this->getCurrentTurnAccountID() != $forAccountID) {
 			return 4;
 		}
-		$lastTurnPlayer =& $this->getCurrentTurnPlayer();
+		$lastTurnPlayer = $this->getCurrentTurnPlayer();
 		$this->getBoard();
 		$p = $this->board[$y][$x];
 		if($p == null || $p->colour != $this->getColourForAccountID($forAccountID)) {
@@ -653,7 +653,7 @@ class ChessGame {
 		foreach($moves as $move) {
 			if($move[0]==$toX && $move[1]==$toY) {
 				$chessType = $this->isNPCGame() ? 'Chess (NPC)' : 'Chess';
-				$currentPlayer =& $this->getCurrentTurnPlayer();
+				$currentPlayer = $this->getCurrentTurnPlayer();
 
 				$moveInfo = ChessGame::movePiece($this->board, $this->getHasMoved(), $x, $y, $toX, $toY, $pawnPromotionPiece);
 
@@ -689,7 +689,7 @@ class ChessGame {
 					return 3;
 				}
 
-				$otherPlayer =& $this->getCurrentTurnPlayer();
+				$otherPlayer = $this->getCurrentTurnPlayer();
 				if($moveInfo['PawnPromotion'] !== false) {
 					$piecePromotedSymbol = $p->getPieceSymbol();
 					$currentPlayer->increaseHOF(1, array($chessType,'Moves','Own Pawns Promoted','Total'), HOF_PUBLIC);

--- a/lib/Default/DummyPlayer.class.inc
+++ b/lib/Default/DummyPlayer.class.inc
@@ -47,7 +47,7 @@ class DummyPlayer extends AbstractSmrPlayer {
 	}
 	
 	public function killPlayer($sectorID) {
-//		$sector =& SmrSector::getSector($this->getGameID(),$sectorID);
+//		$sector = SmrSector::getSector($this->getGameID(),$sectorID);
 		//msg taken care of in trader_att_proc.php
 		// forget plotted course
 //		$this->deletePlottedCourse();

--- a/lib/Default/RouteGenerator.class.inc
+++ b/lib/Default/RouteGenerator.class.inc
@@ -101,15 +101,14 @@ class RouteGenerator {
 				if ($goods[GOOD_NOTHING]===true)
 					$rl[] = new OneWayRoute($currentSectorId, $targetSectorId, $races[$raceID], $sectors[$targetSectorId]->getPort()->getRaceID(), 0, 0, $distance, GOOD_NOTHING);
 
-				$gameGoods = Globals::getGoods();
-				foreach($gameGoods as $goodId => &$value) {
+				foreach (Globals::getGoods() as $goodId => $value) {
 					if ($goods[$goodId]===true) {
 						if ($sectors[$currentSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_SELLS &&
 						    $sectors[$targetSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_BUYS) {
 							$rl[] = new OneWayRoute($currentSectorId, $targetSectorId, $races[$raceID], $sectors[$targetSectorId]->getPort()->getRaceID(), $sectors[$currentSectorId]->getPort()->getGoodDistance($goodId), $sectors[$targetSectorId]->getPort()->getGoodDistance($goodId), $distance, $goodId);
 						}
 					}
-				} unset($value);
+				}
 			} unset($distance);
 			$routes[$sectors[$currentSectorId]->getSectorID()] = $rl;
 		} unset($d);
@@ -128,8 +127,7 @@ class RouteGenerator {
 				if($routesForPort!==-1 && $currentSectorId !== $routesForPort && $targetSectorId !== $routesForPort)
 					continue;
 
-				$gameGoods =& Globals::getGoods();
-				foreach($gameGoods as $goodId => &$value) {
+				foreach (Globals::getGoods() as $goodId => $value) {
 					if ($goods[$goodId]===true) {
 						if ($sectors[$currentSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_SELLS &&
 						    $sectors[$targetSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_BUYS) {
@@ -140,7 +138,7 @@ class RouteGenerator {
 							self::addMoneyRoute($mpr);
 						}
 					}
-				} unset($value);
+				}
 			} unset($distance);
 		} unset($d);
 		$allRoutes = array();

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -87,7 +87,7 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 			break;
 			case 'chess':
 				$chessGameID = $default;
-				$chessGame =& ChessGame::getChessGame($chessGameID);
+				$chessGame = ChessGame::getChessGame($chessGameID);
 				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
 					return true;
 				}

--- a/templates/Default/admin/Default/1.6/universe_create_sectors.php
+++ b/templates/Default/admin/Default/1.6/universe_create_sectors.php
@@ -23,7 +23,7 @@
 		<td>
 			<form method="POST" action="<?php echo $JumpGalaxyHREF; ?>">
 				<select name="gal_on" onchange="this.form.submit()"><?php
-					foreach($Galaxies as &$CurrentGalaxy) { ?>
+					foreach($Galaxies as $CurrentGalaxy) { ?>
 						<option value="<?php echo $CurrentGalaxy->getGalaxyID(); ?>"<?php if($CurrentGalaxy->equals($Galaxy)) { ?> selected="SELECTED"<?php } ?>><?php
 							echo $CurrentGalaxy->getName(); ?>
 						</option><?php

--- a/templates/Default/admin/Default/account_edit.php
+++ b/templates/Default/admin/Default/account_edit.php
@@ -91,8 +91,8 @@
 							if(count($EditingPlayers)) { ?>
 								<a onclick="$('#accountPlayers').fadeToggle(600);">Show/Hide</a>
 								<table id="accountPlayers" style="display:none"><?php
-									foreach($EditingPlayers as &$CurrentPlayer) {
-										$CurrentShip =& $CurrentPlayer->getShip(); ?>
+									foreach ($EditingPlayers as $CurrentPlayer) {
+										$CurrentShip = $CurrentPlayer->getShip(); ?>
 										<tr>
 											<td align="right">Game ID:</td>
 											<td><?php echo $CurrentPlayer->getGameID(); ?></td>

--- a/templates/Default/admin/Default/log_console.php
+++ b/templates/Default/admin/Default/log_console.php
@@ -19,7 +19,7 @@ if (count($LoggedAccounts)>0) { ?>
 				<th>Notes</th>
 			</tr><?php
 	
-			foreach($LoggedAccounts as &$LoggedAccount) { ?>
+			foreach($LoggedAccounts as $LoggedAccount) { ?>
 				<tr>
 					<td valign="top"><?php echo $LoggedAccount['Login']; ?></td>
 					<td valign="top" align="center"><?php echo $LoggedAccount['TotalEntries']; ?></td>

--- a/templates/Default/engine/Default/alliance_pick.php
+++ b/templates/Default/engine/Default/alliance_pick.php
@@ -5,7 +5,7 @@
 		<th>Members</th>
 		<th>Pick</th>
 	</tr><?php
-	foreach ($Teams as &$Team) {
+	foreach ($Teams as $Team) {
 		// boldface this row if it is the current player's alliance
 		$Class = ($Team['Leader']->getPlayerID() == $PlayerID) ? "bold" : ""; ?>
 		<tr class="<?php echo $Class; ?>">
@@ -43,7 +43,7 @@ if(count($PickPlayers)>0) { ?>
 			<th>HoF Name</th>
 			<th>User Score</th>
 		</tr><?php
-		foreach($PickPlayers as &$PickPlayer) { ?>
+		foreach($PickPlayers as $PickPlayer) { ?>
 			<tr>
 				<td class="center"><?php
 				if ($CanPick) { ?>
@@ -84,7 +84,7 @@ if (count($History) > 0) { ?>
 			<th>HoF Name</th>
 			<th>User Score</th>
 		</tr><?php
-		foreach(array_reverse($History, true) as $i => &$Pick) { ?>
+		foreach(array_reverse($History, true) as $i => $Pick) { ?>
 			<tr>
 				<td class="center"><?php echo $i+1; ?></td>
 				<td><?php echo $Pick['Leader']->getPlayerName(); ?></td>

--- a/templates/Default/engine/Default/alliance_roles.php
+++ b/templates/Default/engine/Default/alliance_roles.php
@@ -1,9 +1,9 @@
 <h2>Current Roles</h2><br /><?php
-foreach($AllianceRoles as $RoleID => &$Role) {
-	$this->includeTemplate('includes/AllianceRole.inc',array('Role' => &$Role));
+foreach($AllianceRoles as $RoleID => $Role) {
+	$this->includeTemplate('includes/AllianceRole.inc',array('Role' => $Role));
 } ?><br />
 <h2>Create Role</h2><br /><?php
-$this->includeTemplate('includes/AllianceRole.inc',array('Role' => &$CreateRole)); ?>
+$this->includeTemplate('includes/AllianceRole.inc',array('Role' => $CreateRole)); ?>
 <b>Usage:</b><br />
 To add a new entry input the name of the role in the name field and press 'Create'.<br />
 To delete an entry clear the box and click 'Edit'.

--- a/templates/Default/engine/Default/bank_alliance.php
+++ b/templates/Default/engine/Default/bank_alliance.php
@@ -56,7 +56,7 @@ if (!empty($BankTransactions)) { ?>
 						?><th class="shrink noWrap">Make Exempt</th><?php
 					} ?>
 				</tr><?php
-				foreach($BankTransactions as $TransactionID => &$BankTransaction) { ?>
+				foreach($BankTransactions as $TransactionID => $BankTransaction) { ?>
 					<tr>
 						<td class="center"><?php echo number_format($TransactionID); ?></td>
 						<td class="center noWrap"><?php echo date(DATE_FULL_SHORT_SPLIT, $BankTransaction['Time']); ?></td>

--- a/templates/Default/engine/Default/chess.php
+++ b/templates/Default/engine/Default/chess.php
@@ -11,8 +11,8 @@ if(isset($CreateGameMessage)) {
 	foreach($ChessGames as $ChessGame) { ?>
 		<tr>
 			<td><?php
-				$WhitePlayer =& $ChessGame->getWhitePlayer();
-				$BlackPlayer =& $ChessGame->getBlackPlayer();
+				$WhitePlayer = $ChessGame->getWhitePlayer();
+				$BlackPlayer = $ChessGame->getBlackPlayer();
 				if($WhitePlayer == null) {
 					?>Unknown<?php
 				}
@@ -27,7 +27,7 @@ if(isset($CreateGameMessage)) {
 				} ?>
 			</td>
 			<td><?php
-				$CurrentTurnPlayer =& $ChessGame->getCurrentTurnPlayer();
+				$CurrentTurnPlayer = $ChessGame->getCurrentTurnPlayer();
 				if($CurrentTurnPlayer == null) {
 					?>Unknown<?php
 				}

--- a/templates/Default/engine/Default/chess_play.php
+++ b/templates/Default/engine/Default/chess_play.php
@@ -1,5 +1,5 @@
 <p>It is currently <span id="turn"><?php
-	$CurrentTurnPlayer =& $ChessGame->getCurrentTurnPlayer();
+	$CurrentTurnPlayer = $ChessGame->getCurrentTurnPlayer();
 	if($CurrentTurnPlayer == null) {
 		?>Unknown<?php
 	}

--- a/templates/Default/engine/Default/council_list.php
+++ b/templates/Default/engine/Default/council_list.php
@@ -45,7 +45,7 @@
 			</thead>
 			<tbody class="list"><?php
 				foreach($CouncilMembers as $Ranking => $AccountID) {
-					$CouncilPlayer =& SmrPlayer::getPlayer($AccountID, $ThisPlayer->getGameID()); ?>
+					$CouncilPlayer = SmrPlayer::getPlayer($AccountID, $ThisPlayer->getGameID()); ?>
 					<tr id="player-<?php echo $CouncilPlayer->getPlayerID(); ?>" class="ajax<?php if ($ThisPlayer->equals($CouncilPlayer)) { ?> bold<?php } ?>">
 						<td class="right"><?php echo $Ranking; ?></td>
 						<td class="name"><?php echo $CouncilPlayer->getLevelName(); ?> <?php echo $CouncilPlayer->getLinkedDisplayName(false); ?></td>
@@ -64,8 +64,7 @@
 <br /><br />
 
 <b>View Council For:</b><br /><?php
-$Races =& Globals::getRaces();
-foreach($Races as $RaceID => $RaceInfo) {
+foreach (Globals::getRaces() as $RaceID => $RaceInfo) {
 	if($RaceID != RACE_NEUTRAL) { ?>
 		<span class="smallFont"><?php
 			echo $ThisPlayer->getColouredRaceName($RaceID, true); ?>

--- a/templates/Default/engine/Default/current_sector.php
+++ b/templates/Default/engine/Default/current_sector.php
@@ -47,6 +47,6 @@
 $this->includeTemplate('includes/SectorPlanet.inc');
 $this->includeTemplate('includes/SectorPort.inc');
 $this->includeTemplate('includes/SectorLocations.inc');
-$this->includeTemplate('includes/SectorPlayers.inc',array('PlayersContainer'=>&$ThisSector));
+$this->includeTemplate('includes/SectorPlayers.inc',array('PlayersContainer'=>$ThisSector));
 $this->includeTemplate('includes/SectorForces.inc'); ?>
 <br />

--- a/templates/Default/engine/Default/edit_dummys.php
+++ b/templates/Default/engine/Default/edit_dummys.php
@@ -9,7 +9,7 @@
 	</select><br />
 	<input type="submit" value="Select Dummy" />
 </form>
-<?php $DummyShip =& $DummyPlayer->getShip(); ?>
+<?php $DummyShip = $DummyPlayer->getShip(); ?>
 <table>
 	<tr>
 		<td class="top">
@@ -33,7 +33,7 @@
 					Weapon: <?php echo $OrderID+1; ?>
 					<select name="weapons[]">
 						<option value="0">None</option><?php
-						foreach($Weapons as &$Weapon) {
+						foreach($Weapons as $Weapon) {
 							?><option value="<?php echo $Weapon->getWeaponTypeID(); ?>"<?php if($Weapon->getWeaponTypeID()==$ShipWeapon->getWeaponTypeID()){ ?> selected="selected"<?php } ?>><?php echo $Weapon->getName(); ?> (dmg: <?php echo $Weapon->getShieldDamage(); ?>/<?php echo $Weapon->getArmourDamage(); ?> acc: <?php echo $Weapon->getBaseAccuracy(); ?>% lvl:<?php echo $Weapon->getPowerLevel(); ?>)</option><?php
 						} ?>
 					</select><br /><?php
@@ -42,7 +42,7 @@
 					Weapon: <?php echo $OrderID+1; ?>
 					<select name="weapons[]">
 						<option value="0">None</option><?php
-						foreach($Weapons as &$Weapon) {
+						foreach($Weapons as $Weapon) {
 							?><option value="<?php echo $Weapon->getWeaponTypeID(); ?>"><?php echo $Weapon->getName(); ?> (dmg: <?php echo $Weapon->getShieldDamage(); ?>/<?php echo $Weapon->getArmourDamage(); ?> acc: <?php echo $Weapon->getBaseAccuracy(); ?>% lvl:<?php echo $Weapon->getPowerLevel(); ?>)</option><?php
 						} ?>
 					</select><br /><?php

--- a/templates/Default/engine/Default/includes/CombatSimTeamDetails.inc
+++ b/templates/Default/engine/Default/includes/CombatSimTeamDetails.inc
@@ -15,12 +15,12 @@
 		<td>
 			<span class="underline">Current Details</span><?php
 				if($Dummy) {
-					$Ship =& $Dummy->getShip();
-					$ShipWeapons =& $Ship->getWeapons(); ?>
+					$Ship = $Dummy->getShip();
+					$ShipWeapons = $Ship->getWeapons(); ?>
 					<br />Level: <?php echo $Dummy->getLevelID(); ?><br />
 					Ship: <?php echo $Ship->getName(); ?> (<?php echo $Ship->getAttackRating(); ?>/<?php echo $Ship->getDefenseRating(); ?>)<br />
 					DCS: <?php if($Ship->hasDCS()){ ?>Yes<?php }else{ ?>No<?php } ?><br />
-					Weapons: <?php foreach($ShipWeapons as &$ShipWeapon){ ?>* <?php echo $ShipWeapon->getName(); ?><br /><?php }
+					Weapons: <?php foreach($ShipWeapons as $ShipWeapon){ ?>* <?php echo $ShipWeapon->getName(); ?><br /><?php }
 				}
 				else{ ?>No Dummy<?php } ?>
 		</td>

--- a/templates/Default/engine/Default/includes/ForcesCombatResults.inc
+++ b/templates/Default/engine/Default/includes/ForcesCombatResults.inc
@@ -61,7 +61,7 @@ if(isset($ForcesCombatResults['Results']) && is_array($ForcesCombatResults['Resu
 		} ?>.
 		<br /><?php
 		if($ActualDamage['KillingShot']) {
-			$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>&$ForceResults['KillResults'],'TargetPlayer'=>&$TargetPlayer));
+			$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$ForceResults['KillResults'],'TargetPlayer'=>$TargetPlayer));
 		}
 	}
 }

--- a/templates/Default/engine/Default/includes/PlanetCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PlanetCombatResults.inc
@@ -61,7 +61,7 @@ if(isset($PlanetCombatResults['Weapons']) && is_array($PlanetCombatResults['Weap
 		} ?>.
 		<br /><?php
 		if($ActualDamage['KillingShot']) {
-			$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>&$WeaponResults['KillResults'],'TargetPlayer'=>&$TargetPlayer));
+			$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPlayer'=>$TargetPlayer));
 		}
 	}
 }
@@ -116,7 +116,7 @@ if(isset($PlanetCombatResults['Drones'])) {
 	} ?>.
 	<br /><?php
 	if($ActualDamage['KillingShot']) {
-		$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>&$Drones['KillResults'],'TargetPlayer'=>&$TargetPlayer));
+		$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$Drones['KillResults'],'TargetPlayer'=>$TargetPlayer));
 	}
 }
 

--- a/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc
@@ -67,7 +67,7 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 				} ?>.
 				<br /><?php
 				if($ActualDamage['KillingShot']) {
-					$this->includeTemplate('includes/PlanetKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPlanet'=>&$TargetPlanet));
+					$this->includeTemplate('includes/PlanetKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPlanet'=>$TargetPlanet));
 				}
 			}
 		}
@@ -126,7 +126,7 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 			} ?>.
 			<br /><?php
 			if($ActualDamage['KillingShot']) {
-				$this->includeTemplate('includes/PlanetKillMessage.inc',array('KillResults'=>$Drones['KillResults'],'TargetPlanet'=>&$TargetPlanet));
+				$this->includeTemplate('includes/PlanetKillMessage.inc',array('KillResults'=>$Drones['KillResults'],'TargetPlanet'=>$TargetPlanet));
 			}
 		}
 	}

--- a/templates/Default/engine/Default/includes/PortCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PortCombatResults.inc
@@ -61,7 +61,7 @@ if(isset($PortCombatResults['Weapons']) && is_array($PortCombatResults['Weapons'
 		} ?>.
 		<br />
 		<?php if($ActualDamage['KillingShot']) {
-			$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>&$WeaponResults['KillResults'],'TargetPlayer'=>&$TargetPlayer));
+			$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPlayer'=>$TargetPlayer));
 		}
 	}
 }
@@ -116,7 +116,7 @@ if(isset($PortCombatResults['Drones'])) {
 	} ?>.
 	<br /><?php
 	if($ActualDamage['KillingShot']) {
-		$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>&$Drones['KillResults'],'TargetPlayer'=>&$TargetPlayer));
+		$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$Drones['KillResults'],'TargetPlayer'=>$TargetPlayer));
 	}
 }
 

--- a/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc
@@ -67,7 +67,7 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 				} ?>.
 				<br /><?php
 				if($ActualDamage['KillingShot']) {
-					$this->includeTemplate('includes/PortKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPort'=>&$TargetPort,'ShootingPlayer'=>&$ShootingPlayer));
+					$this->includeTemplate('includes/PortKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPort'=>$TargetPort,'ShootingPlayer'=>$ShootingPlayer));
 				}
 			}
 		}
@@ -127,7 +127,7 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 			} ?>.
 			<br /><?php
 			if($ActualDamage['KillingShot']) {
-				$this->includeTemplate('includes/PortKillMessage.inc',array('KillResults'=>&$Drones['KillResults'],'TargetPort'=>&$TargetPort,'ShootingPlayer'=>&$ShootingPlayer));
+				$this->includeTemplate('includes/PortKillMessage.inc',array('KillResults'=>$Drones['KillResults'],'TargetPort'=>$TargetPort,'ShootingPlayer'=>$ShootingPlayer));
 			}
 		}
 	}

--- a/templates/Default/engine/Default/includes/RightPanelShip.inc
+++ b/templates/Default/engine/Default/includes/RightPanelShip.inc
@@ -69,7 +69,7 @@ if(isset($GameID)) { ?>
 	<?php
 	if($ThisShip->hasCargo()) {
 		foreach($ThisShip->getCargo() as $GoodID => $GoodAmount) {
-			$Good =& Globals::getGood($GoodID); ?>
+			$Good = Globals::getGood($GoodID); ?>
 			<img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name']; ?>" alt="<?php echo $Good['Name']; ?>"> : <?php echo $GoodAmount; ?><br /><?php
 		}
 	} ?>

--- a/templates/Default/engine/Default/includes/SectorForces.inc
+++ b/templates/Default/engine/Default/includes/SectorForces.inc
@@ -1,6 +1,6 @@
 <div id="sector_forces" class="ajax"><?php
 	if($ThisSector->hasForces()) {
-		$Forces =& $ThisSector->getForces();
+		$Forces = $ThisSector->getForces();
 		Sorter::sortByNumMethod($Forces,'getExpire');
 		$RefreshAny = false; ?>
 		<table class="standard fullwidth csForces">

--- a/templates/Default/engine/Default/includes/SectorMap.inc
+++ b/templates/Default/engine/Default/includes/SectorMap.inc
@@ -58,10 +58,10 @@
 							}
 							if((($UniGen || $isCurrentSector) && $Sector->hasPort()) || $Sector->hasCachedPort($MapPlayer)) {
 								if(($UniGen || $isCurrentSector) && $Sector->hasPort()) {
-									$Port =& $Sector->getPort();
+									$Port = $Sector->getPort();
 								}
 								else if($Sector->hasCachedPort($MapPlayer)) {
-									$Port =& $Sector->getCachedPort($MapPlayer);
+									$Port = $Sector->getCachedPort($MapPlayer);
 								} ?>
 								<div class="lmport <?php if($Sector->getLinkLeft()) { ?>a<?php } else { ?>b<?php } ?> 
 									"><?php
@@ -71,13 +71,13 @@
 										<img src="images/port/buy.png" width="5" height="16" alt="Buy (<?php echo $Port->getRaceName(); ?>)" 
 											title="Buy (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
 											foreach($Port->getVisibleGoodsSold($MapPlayer) as $GoodID) {
-												$Good =& Globals::getGood($GoodID); ?>
+												$Good = Globals::getGood($GoodID); ?>
 												<img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name'] ?>" alt="<?php echo $Good['Name']; ?>" /><?php
 											} ?><br />
 										<img src="images/port/sell.png" width="5" height="16" alt="Sell (<?php echo $Port->getRaceName(); ?>)" 
 										title="Sell (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
 											foreach($Port->getVisibleGoodsBought($MapPlayer) as $GoodID) {
-												$Good =& Globals::getGood($GoodID); ?>
+												$Good = Globals::getGood($GoodID); ?>
 												<img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name'] ?>" alt="<?php echo $Good['Name']; ?>" /><?php
 											}
 									if($isCurrentSector && !$GalaxyMap){ ?></a><?php } ?>

--- a/templates/Default/engine/Default/includes/SectorPort.inc
+++ b/templates/Default/engine/Default/includes/SectorPort.inc
@@ -13,13 +13,13 @@
 							<img src="images/port/buy.png" width="5" height="16" alt="Buy" 
 								title="Buy" class="port<?php echo $Port->getRaceID(); ?>"/><?php
 							foreach ($Port->getVisibleGoodsSold($ThisPlayer) as $GoodID) {
-								$Good =& Globals::getGood($GoodID);
+								$Good = Globals::getGood($GoodID);
 								?><img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name']; ?>" alt="<?php echo $Good['Name']; ?>" /><?php
 							}
 							?><br /><img src="images/port/sell.png" width="5" height="16" alt="Sell" 
 								title="Sell" class="port<?php echo $Port->getRaceID(); ?>"/><?php
 							foreach ($Port->getVisibleGoodsBought($ThisPlayer) as $GoodID) {
-								$Good =& Globals::getGood($GoodID);
+								$Good = Globals::getGood($GoodID);
 								?><img src="<?php echo $Good['ImageLink']; ?>" width="13" height="16" title="<?php echo $Good['Name']; ?>" alt="<?php echo $Good['Name']; ?>" /><?php
 							} ?>
 						</div>

--- a/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc
+++ b/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc
@@ -62,7 +62,7 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 					} ?>.
 					<br /><?php
 					if($ActualDamage['KillingShot']) {
-						$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>&$WeaponResults['KillResults'],'TargetPlayer'=>&$TargetPlayer,'ShootingPlayer'=>&$ShootingPlayer));
+						$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPlayer'=>$TargetPlayer,'ShootingPlayer'=>$ShootingPlayer));
 					}
 				}
 			}
@@ -121,7 +121,7 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 				} ?>.
 				<br /><?php
 				if($ActualDamage['KillingShot']) {
-					$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>&$Drones['KillResults'],'TargetPlayer'=>&$TargetPlayer,'ShootingPlayer'=>&$ShootingPlayer));
+					$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$Drones['KillResults'],'TargetPlayer'=>$TargetPlayer,'ShootingPlayer'=>$ShootingPlayer));
 				}
 			}
 		}

--- a/templates/Default/engine/Default/planet_list.inc
+++ b/templates/Default/engine/Default/planet_list.inc
@@ -18,6 +18,6 @@
 		if (!$PlayerOnly) { ?>
 			<?php echo $Alliance->getAllianceName(true); ?> currently has <span id="numplanets"><?php echo count($AllPlanets); ?></span> <?php echo pluralise('planet', count($AllPlanets)); ?> in the universe!<br /><br /><?php
 		}
-		$this->includeTemplate($ExtraInclude, array('Planets'=>&$AllPlanets));
+		$this->includeTemplate($ExtraInclude, array('Planets'=>$AllPlanets));
 	} ?>
 </div>

--- a/templates/Default/engine/Default/planet_main.php
+++ b/templates/Default/engine/Default/planet_main.php
@@ -101,5 +101,5 @@ if (isset($Msg)) {
 	<input type="submit" name="action" value="Launch" class="InputFields"/>
 </form>
 <br /><?php
-$this->includeTemplate('includes/SectorPlayers.inc',array('PlayersContainer'=>&$ThisPlanet));
+$this->includeTemplate('includes/SectorPlayers.inc',array('PlayersContainer'=>$ThisPlanet));
 ?>

--- a/templates/Default/engine/Default/port_loot.php
+++ b/templates/Default/engine/Default/port_loot.php
@@ -7,7 +7,7 @@
 		<th>Amount to Trade</th>
 		<th>Action</th>
 	</tr><?php
-	$BoughtGoodIDs =& $ThisPort->getVisibleGoodsBought($ThisPlayer);
+	$BoughtGoodIDs = $ThisPort->getVisibleGoodsBought($ThisPlayer);
 	foreach ($BoughtGoodIDs as $GoodID) {
 		$Good = Globals::getGood($GoodID);
 		$Amount = $ThisPort->getGoodAmount($GoodID); ?>

--- a/templates/Default/engine/Default/trader_planet.php
+++ b/templates/Default/engine/Default/trader_planet.php
@@ -1,7 +1,7 @@
 
 <div align="center"><?php
 	if (count($TraderPlanets) > 0) {
-		$this->includeTemplate('includes/PlanetList.inc',array('Planets'=>&$TraderPlanets));
+		$this->includeTemplate('includes/PlanetList.inc',array('Planets'=>$TraderPlanets));
 	}
 	else {
 		?>You don't have a planet claimed!<br /><br /><?php
@@ -9,7 +9,7 @@
 
 	if($ThisPlayer->hasAlliance()) {
 		if (count($AlliancePlanets) > 0) {
-			$this->includeTemplate('includes/PlanetList.inc',array('Planets'=>&$AlliancePlanets));
+			$this->includeTemplate('includes/PlanetList.inc',array('Planets'=>$AlliancePlanets));
 		}
 		elseif (count($TraderPlanets) == 0) {
 			?>Your alliance has no claimed planets!<?php

--- a/tools/irc/channel_msg.php
+++ b/tools/irc/channel_msg.php
@@ -22,7 +22,7 @@ function check_for_registration(&$account, &$player, $fp, $nick, $channel, $call
 	$registeredNick = $db->getField('registered_nick');
 
 	// get alliance_id and game_id for this channel
-	$alliance =& SmrAlliance::getAllianceByIrcChannel($channel, true);
+	$alliance = SmrAlliance::getAllianceByIrcChannel($channel, true);
 	if ($alliance == null) {
 		if($validationMessages === true) {
 			fputs($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', the channel ' . $channel . ' has not been registered with me.' . EOL);

--- a/tools/npc/chess.php
+++ b/tools/npc/chess.php
@@ -51,8 +51,7 @@ try {
 		runkit_constant_redefine('MICRO_TIME', microtime(true));
 		runkit_constant_redefine('TIME', intval(MICRO_TIME));
 
-		$chessGames =& ChessGame::getNPCMoveGames(true);
-		foreach($chessGames as &$chessGame) {
+		foreach (ChessGame::getNPCMoveGames(true) as $chessGame) {
 			debug('Looking at game: ' . $chessGame->getChessGameID());
 			writeToEngine('position fen ' . $chessGame->getFENString(), false);
 			writeToEngine('go ' . ($chessGame->getCurrentTurnColour() == ChessGame::PLAYER_WHITE ? 'w' : 'b') . 'time ' . UCI_TIME_PER_MOVE_MS, true, false);

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -179,7 +179,7 @@ function NPCStuff() {
 				&&($fedContainer==null?$fedContainer = plotToFed($player,true):$fedContainer)!==true) { //We're under attack and need to plot course to fed.
 				// Get the lock, remove under attack and update.
 				acquire_lock($player->getSectorID());
-				$ship =& $player->getShip(true);
+				$ship = $player->getShip(true);
 				$ship->removeUnderAttack();
 				$ship->updateHardware();
 				release_lock();
@@ -215,7 +215,7 @@ function NPCStuff() {
 					debug('We are in fed, time to switch to another NPC.');
 					changeNPCLogin();
 				}
-				$ship =& $player->getShip();
+				$ship = $player->getShip();
 				processContainer(plotToFed($player,!$ship->hasMaxShields()||!$ship->hasMaxArmour()||!$ship->hasMaxCargoHolds()));
 			}
 			else if(($container = checkForShipUpgrade($player))!==false) { //We have money and are at a uno, let's uno!
@@ -240,12 +240,12 @@ function NPCStuff() {
 						$sellRoute =& $forwardRoute;
 					}
 
-					$ship =& $player->getShip();
+					$ship = $player->getShip();
 					if($ship->getUsedHolds()>0) {
 						if($ship->hasCargo($sellRoute->getGoodID())) { //Sell goods
 							$goodID = $sellRoute->getGoodID();
 
-							$port =& $player->getSector()->getPort();
+							$port = $player->getSector()->getPort();
 							$tradeable = checkPortTradeable($port,$player);
 
 							if($tradeable===true && $port->getGoodAmount($goodID)>=$ship->getCargo($sellRoute->getGoodID())) { //TODO: Sell what we can rather than forcing sell all at once?
@@ -278,7 +278,7 @@ function NPCStuff() {
 					else { //Buy goods
 						$goodID = $buyRoute->getGoodID();
 
-						$port =& $player->getSector()->getPort();
+						$port = $player->getSector()->getPort();
 						$tradeable = checkPortTradeable($port,$player);
 
 						if($tradeable===true && $port->getGoodAmount($goodID)>=$ship->getEmptyHolds()) { //Buy goods
@@ -474,10 +474,10 @@ function changeNPCLogin() {
 function canWeUNO(AbstractSmrPlayer &$player, $oppurtunisticOnly) {
 	if($player->getCredits()<MINUMUM_RESERVE_CREDITS)
 		return false;
-	$ship =& $player->getShip();
+	$ship = $player->getShip();
 	if($ship->hasMaxShields()&&$ship->hasMaxArmour()&&$ship->hasMaxCargoHolds())
 		return false;
-	$sector =& $player->getSector();
+	$sector = $player->getSector();
 
 	// We buy armour in preference to shields as it's cheaper.
 	// We buy cargo holds last if we have no newbie turns because we'd rather not die
@@ -485,10 +485,9 @@ function canWeUNO(AbstractSmrPlayer &$player, $oppurtunisticOnly) {
 
 	$amount = 0;
 
-	$locations =& $sector->getLocations();
-	foreach($locations as &$location) {
+	foreach ($sector->getLocations() as $location) {
 		if($location->isHardwareSold()) {
-			$hardwareSold =& $location->getHardwareSold();
+			$hardwareSold = $location->getHardwareSold();
 			if($player->getNewbieTurns() > MIN_NEWBIE_TURNS_TO_BUY_CARGO && !$ship->hasMaxCargoHolds() && isset($hardwareSold[HARDWARE_CARGO]) && ($amount = floor(($player->getCredits()-MINUMUM_RESERVE_CREDITS)/Globals::getHardwareCost(HARDWARE_CARGO))) > 0) { // Buy cargo holds first if we have plenty of newbie turns left.
 				$hardwareID = HARDWARE_CARGO;
 			}
@@ -528,7 +527,7 @@ function doUNO($hardwareID,$amount) {
 
 function tradeGoods($goodID,AbstractSmrPlayer &$player,SmrPort &$port) {
 	sleepNPC(); //We have an extra sleep at port to make the NPC more vulnerable.
-	$ship =& $player->getShip();
+	$ship = $player->getShip();
 	$relations = $player->getRelation($port->getRaceID());
 
 	$transaction = $port->getGoodTransaction($goodID);
@@ -546,8 +545,8 @@ function tradeGoods($goodID,AbstractSmrPlayer &$player,SmrPort &$port) {
 }
 
 function dumpCargo(&$player) {
-	$ship =& $player->getShip();
-	$cargo =& $ship->getCargo();
+	$ship = $player->getShip();
+	$cargo = $ship->getCargo();
 	debug('Ship Cargo',$cargo);
 	foreach($cargo as $goodID => $amount) {
 		if($amount > 0) {
@@ -667,24 +666,20 @@ function leaveAlliance() {
 function &findRoutes(&$player) {
 	debug('Finding Routes');
 
-	$galaxies =& SmrGalaxy::getGameGalaxies($player->getGameID());
-
 	$tradeGoods = array(GOOD_NOTHING => false);
-	$goods =& Globals::getGoods();
-	foreach($goods as $goodID => &$good) {
+	foreach (Globals::getGoods() as $goodID => $good) {
 		if($player->meetsAlignmentRestriction($good['AlignRestriction']))
 			$tradeGoods[$goodID] = true;
 		else
 			$tradeGoods[$goodID] = false;
-	} unset($good);
+	}
 	$tradeRaces = array();
-	$races =& Globals::getRaces();
-	foreach($races as $raceID => &$race) {
+	foreach (Globals::getRaces() as $raceID => $race) {
 		$tradeRaces[$raceID] = false;
-	} unset($race);
+	}
 	$tradeRaces[$player->getRaceID()] = true;
 
-	$galaxy =& $player->getSector()->getGalaxy();
+	$galaxy = $player->getSector()->getGalaxy();
 
 	$maxNumberOfPorts = 2;
 	$routesForPort=-1;
@@ -704,9 +699,9 @@ function &findRoutes(&$player) {
 	else {
 		debug('Generating Routes');
 		$allSectors = array();
-		foreach($galaxies as &$galaxy) {
+		foreach (SmrGalaxy::getGameGalaxies($player->getGameID()) as $galaxy) {
 			$allSectors += $galaxy->getSectors(); //Merge arrays
-		} unset($galaxy);
+		}
 
 		$distances =& Plotter::calculatePortToPortDistances($allSectors,$maxDistance,$startSectorID,$endSectorID);
 

--- a/tools/rerunChessGames.php
+++ b/tools/rerunChessGames.php
@@ -8,7 +8,7 @@ $db->query('DELETE FROM player_hof WHERE type LIKE \'Chess%\'');
 $db->query('SELECT chess_game_id FROM chess_game');
 while($db->nextRecord()) {
 	$chessGameID = $db->getInt('chess_game_id');
-	$game =& ChessGame::getChessGame($chessGameID);
+	$game = ChessGame::getChessGame($chessGameID);
 	echo 'Running game ' . $chessGameID . ' for white id "' . $game->getWhiteID() . '", black id "' . $game->getBlackID() .'", winner "' . $game->getWinner() . '"' . EOL;
 	echoChessMoves($game);
 	

--- a/tools/testRouteGen.php
+++ b/tools/testRouteGen.php
@@ -13,12 +13,10 @@ require_once('../htdocs/config.inc');
 
 $gameID = 108;
 
-$galaxies =& SmrGalaxy::getGameGalaxies($gameID);
 $allSectors = array();
-foreach($galaxies as &$galaxy)
-{
+foreach (SmrGalaxy::getGameGalaxies($gameID) as $galaxy) {
 	$allSectors = $allSectors + $galaxy->getSectors();
-} unset($galaxy);
+}
 
 $maxNumberOfPorts = 2;
 $goods = array(true,true,true,true,false,false,false,false,false,false,false,false,false);


### PR DESCRIPTION
See #317.

This handles three major remaining usages:

* When returning objects or arrays from class methods.
  Objects should almost always be returned "by value" (since they
  are handled internally as references by PHP). Arrays should be
  returned "by value" except, perhaps, if they will be modified.

* In foreach loops. The only time a reference is needed here is
  when you want to loop over an array and modify array elements.

* In template includes. We never want to modify variables within
  templates, so there is no reason to use references here.