### PR TITLE
Fix obsolete html

### DIFF
--- a/engine/Default/error.php
+++ b/engine/Default/error.php
@@ -10,7 +10,7 @@ if (SmrSession::hasGame() && is_object($player) && $lock) {
 }
 else {
 	$PHP_OUTPUT.=('<h1>ERROR</h1>');
-	$PHP_OUTPUT.=('<p><b><big>' . $var['message'] . '</big></b></p>');
+	$PHP_OUTPUT.=('<p class="big bold">' . $var['message'] . '</p>');
 	$PHP_OUTPUT.=('<br /><br /><br />');
 	$PHP_OUTPUT.=('<p><small>If the error was caused by something you entered, press back and try again.</small></p>');
 	$PHP_OUTPUT.=('<p><small>If it was a DB Error, press back and try again, or logoff and log back on.</small></p>');

--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -22,7 +22,7 @@ $port = $sector->getPort();
 
 // check if the player has the right relations to trade at the current port
 if ($player->getRelation($port->getRaceID()) < RELATIONS_WAR)
-	create_error('This port refuses to trade with you because you are at <big><span class="bold red">WAR!</span></big>');
+	create_error('This port refuses to trade with you because you are at <span class="big bold red">WAR!</span>');
 
 // does the port actually buy or sell this good?
 $transaction = $port->getGoodTransaction($good_id);

--- a/htdocs/error.php
+++ b/htdocs/error.php
@@ -27,8 +27,8 @@
 
 							<h1>ERROR</h1>
 
-							<p><b><big><?php echo (addslashes(htmlentities($_REQUEST['msg'], ENT_NOQUOTES,'utf-8'))); ?>
-							</big></b></p>
+							<p class="big bold"><?php echo (addslashes(htmlentities($_REQUEST['msg'], ENT_NOQUOTES,'utf-8'))); ?>
+							</p>
 							<br /><br /><br />
 							<p><small>If the error was caused by something you entered, press back and try again.</small></p>
 							<p><small>If it was a DB Error, press back and try again, or logoff and log back on.</small></p>

--- a/templates/Default/admin/Default/1.6/universe_create_locations.php
+++ b/templates/Default/admin/Default/1.6/universe_create_locations.php
@@ -11,7 +11,7 @@ foreach ($LocTypes as $category => $LocIDs) { ?>
 <br />
 Click a category heading to toggle its display.
 
-<style type="text/css">
+<style>
 	tr.collapsible:hover {
 		cursor:pointer;
 	}

--- a/templates/Default/admin/Default/1.6/universe_create_warps.php
+++ b/templates/Default/admin/Default/1.6/universe_create_warps.php
@@ -45,7 +45,7 @@ if (isset($Message)) {
 </table>
 <br />
 
-<style type="text/css">
+<style>
 p.vert {
 	writing-mode: tb-rl;
 	padding: 1px;

--- a/templates/Default/admin/Default/account_edit.php
+++ b/templates/Default/admin/Default/account_edit.php
@@ -177,7 +177,7 @@
 				<td><hr noshade style="height:1px; border:1px solid white;"></td>
 			</tr>
 
-			<script type="text/javascript">
+			<script>
 				function go() {
 					var val = window.document.form_acc.reason_pre_select.value;
 					if (val == 2) {

--- a/templates/Default/admin/Default/ip_view.php
+++ b/templates/Default/admin/Default/ip_view.php
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script>
 	function go() {
 		var val = window.document.form_ip.type.value;
 		if (val == "search") {
@@ -58,7 +58,7 @@ Please select the type of IP search you would like.<br />
 	<br /><br />
 	<input type="submit" name="action" value="Continue" class="InputFields" />
 </form>
-<script type="text/javascript">
+<script>
 	window.document.form_ip.variable.select();
 	window.document.form_ip.variable.focus();
 </script>

--- a/templates/Default/engine/Default/GalaxyMap.inc
+++ b/templates/Default/engine/Default/GalaxyMap.inc
@@ -19,7 +19,7 @@
 		<div class="gal_map_header">
 			<table cellspacing="0" cellpadding="0">
 				<tr>
-					<td>Map of the known <b><big><?php echo $ThisGalaxy->getName(); ?></big></b> galaxy.</td>
+					<td>Map of the known <span class="big bold"><?php echo $ThisGalaxy->getName(); ?></span> galaxy.</td>
 					<td>
 						&thinsp;
 						<a href="map_warps.php">

--- a/templates/Default/engine/Default/alliance_option.php
+++ b/templates/Default/engine/Default/alliance_option.php
@@ -1,6 +1,6 @@
 <?php
 foreach ($Links as $Link) { ?>
-	<b><big><?php echo $Link['link']; ?></big></b>
+	<span class="big bold"><?php echo $Link['link']; ?></span>
 	<br />
 	<?php echo $Link['text']; ?>
 	<br /><br /><?php

--- a/templates/Default/engine/Default/changelog_view.php
+++ b/templates/Default/engine/Default/changelog_view.php
@@ -7,7 +7,7 @@ if (isset($ContinueHREF)) {
 		<a class="buttonA" href="<?php echo $ContinueHREF; ?>">Continue</a>
 	</div>
 	<br /><br />
-	<big>Here are the updates that have gone live since your last visit, enjoy!</big>
+	<span class="big">Here are the updates that have gone live since your last visit, enjoy!</span>
 	<br /><br /><?php
 } ?>
 

--- a/templates/Default/engine/Default/chess_play.php
+++ b/templates/Default/engine/Default/chess_play.php
@@ -55,7 +55,8 @@
 		</td>
 	</tr>
 </table>
-<script type="text/javascript" ><?php
+
+<script><?php
 	$AvailableMoves = array_pad(array(), count($Board), array());
 	foreach($Board as $Y => $Row) {
 		foreach($Row as $X => $Cell) {

--- a/templates/Default/engine/Default/game_join.php
+++ b/templates/Default/engine/Default/game_join.php
@@ -153,7 +153,7 @@ if ($Game->getDescription()) { ?>
 	</table>
 </form>
 
-<script type="text/javascript">
+<script>
 var	desc = new Array(<?php echo $RaceDescriptions; ?>);
 function go() {
 	var race_id = document.forms[0].race_id.options[document.forms[0].race_id.selectedIndex].value;

--- a/templates/Default/engine/Default/includes/EndingJavascript.inc
+++ b/templates/Default/engine/Default/includes/EndingJavascript.inc
@@ -1,14 +1,14 @@
-<script type="text/javascript" src="js/jquery.hotkeys.js"></script>
-<script type="text/javascript" src="js/ajax.js"></script><?php
+<script src="js/jquery.hotkeys.js"></script>
+<script src="js/ajax.js"></script><?php
 if(!empty($js)) {
-	?><script type="text/javascript" src="<?php echo $js; ?>"></script><?php
+	?><script src="<?php echo $js; ?>"></script><?php
 }
 foreach($this->jsAlerts as $string) {
 	?>alert(<?php echo json_encode($string); ?>);<?php
 }
 
 $AvailableLinks = Globals::getAvailableLinks(); ?>
-<script type="text/javascript">$(function(){<?php
+<script>$(function(){<?php
 	if ($AJAX_ENABLE_REFRESH) { ?>
 		startRefresh('<?php echo $AJAX_ENABLE_REFRESH; ?>');<?php
 	}

--- a/templates/Default/engine/Default/includes/Head.inc
+++ b/templates/Default/engine/Default/includes/Head.inc
@@ -42,6 +42,6 @@ if(isset($HeaderTemplateInclude)) {
 } ?>
 <link rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />
 <link rel="stylesheet" href="css/colorpicker.css" />
-<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
-<script type="text/javascript" src="js/smr15.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
+<script src="js/smr15.js"></script>

--- a/templates/Default/engine/Default/includes/Head.inc
+++ b/templates/Default/engine/Default/includes/Head.inc
@@ -8,7 +8,7 @@ if(!is_object($ThisAccount) || $ThisAccount->isDefaultCSSEnabled()) { ?>
 if(isset($ExtraCSSLink)) {
 	?><link rel="stylesheet" type="text/css" href="<?php echo $ExtraCSSLink; ?>" /><?php
 } ?>
-<style type="text/css">
+<style>
 	body {
 		font-size:<?php echo $FontSize; ?>%;
 	}<?php

--- a/templates/Default/engine/Default/includes/LeftPanel.inc
+++ b/templates/Default/engine/Default/includes/LeftPanel.inc
@@ -3,18 +3,17 @@
 </span><br />
 <br /><?php
 if(isset($GameID)) {
-	?><big><?php
 	// Use the current sector link for Planet Main to enable the hotkey
 	if ($ThisPlayer->isLandedOnPlanet()) { ?>
-		<a class="bold" href="<?php echo Globals::getCurrentSectorHREF(); ?>">Planet Main</a><br /><?php
+		<a class="big bold" href="<?php echo Globals::getCurrentSectorHREF(); ?>">Planet Main</a><br /><?php
 	} else { ?>
-		<a class="bold" href="<?php echo Globals::getCurrentSectorHREF(); ?>">Current Sector</a><br />
-		<a class="bold" href="<?php echo Globals::getLocalMapHREF(); ?>">Local Map</a><br /><?php
+		<a class="big bold" href="<?php echo Globals::getCurrentSectorHREF(); ?>">Current Sector</a><br />
+		<a class="big bold" href="<?php echo Globals::getLocalMapHREF(); ?>">Local Map</a><br /><?php
 	}
 	if(isset($PlotCourseLink)) {
-		?><a class="bold" href="<?php echo $PlotCourseLink; ?>">Plot A Course</a><br /><?php
+		?><a class="big bold" href="<?php echo $PlotCourseLink; ?>">Plot A Course</a><br /><?php
 	}
-	?></big>
+	?>
 	<a href="map_galaxy.php" target="gal_map">Galaxy Map</a><br />
 	<br />
 	<a href="<?php echo $TraderLink; ?>">Trader</a><br />

--- a/templates/Default/engine/Default/includes/LocalMapJS.inc
+++ b/templates/Default/engine/Default/includes/LocalMapJS.inc
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script>
 /** This is high-level function.
  * It must react to delta being more/less than zero.
  */

--- a/templates/Default/engine/Default/includes/RightPanelPlayer.inc
+++ b/templates/Default/engine/Default/includes/RightPanelPlayer.inc
@@ -3,7 +3,7 @@ if(isset($GameID)) { ?>
 	<span id="attack_area"><?php if($UnderAttack) { ?><p class="attack_warning">You Are Under Attack!</p><script>triggerAttackBlink('3B1111');</script><?php } ?></span><?php
 	$this->includeTemplate('includes/UnreadMessages.inc'); ?>
 	<a href="level_requirements.php" target="levelRequirements"><span id="lvlName"><?php echo $ThisPlayer->getLevelName(); ?></span></a><br />
-	<big><a href="<?php echo $PlayerNameLink; ?>"><?php echo $ThisPlayer->getDisplayName(); ?></a></big><br /><?php
+	<a class="big" href="<?php echo $PlayerNameLink; ?>"><?php echo $ThisPlayer->getDisplayName(); ?></a><br /><?php
 	if(isset($PlayerInvisible)) { ?>
 		<span class="smallFont smallCaps red">INVISIBLE</span><br /><?php
 	} ?>

--- a/templates/Default/engine/Default/includes/RightPanelPlayer.inc
+++ b/templates/Default/engine/Default/includes/RightPanelPlayer.inc
@@ -1,6 +1,6 @@
 <?php
 if(isset($GameID)) { ?>
-	<span id="attack_area"><?php if($UnderAttack) { ?><p class="attack_warning">You Are Under Attack!</p><script type="text/javascript">triggerAttackBlink('3B1111');</script><?php } ?></span><?php
+	<span id="attack_area"><?php if($UnderAttack) { ?><p class="attack_warning">You Are Under Attack!</p><script>triggerAttackBlink('3B1111');</script><?php } ?></span><?php
 	$this->includeTemplate('includes/UnreadMessages.inc'); ?>
 	<a href="level_requirements.php" target="levelRequirements"><span id="lvlName"><?php echo $ThisPlayer->getLevelName(); ?></span></a><br />
 	<big><a href="<?php echo $PlayerNameLink; ?>"><?php echo $ThisPlayer->getDisplayName(); ?></a></big><br /><?php

--- a/templates/Default/engine/Default/preferences.php
+++ b/templates/Default/engine/Default/preferences.php
@@ -1,6 +1,6 @@
 <?php
 if (isset($Reason)) {
-	?><p><big><span class="bold red"><?php echo $Reason; ?></span></big></p><?php
+	?><p><span class="big bold red"><?php echo $Reason; ?></span></p><?php
 }
 
 if(isset($GameID)) { ?>

--- a/templates/Default/engine/Default/preferences.php
+++ b/templates/Default/engine/Default/preferences.php
@@ -434,4 +434,4 @@ if(isset($GameID)) { ?>
 	</table>
 </form>
 
-<script type="text/javascript" src="js/colorpicker.js"></script>
+<script src="js/colorpicker.js"></script>

--- a/templates/Default/engine/Default/shop_goods_trade.php
+++ b/templates/Default/engine/Default/shop_goods_trade.php
@@ -25,7 +25,7 @@ Note: In order to maximize your experience you have to bargain with the port own
 	<input type="submit" name="action" class="InputFields" value="Bargain (1)" />
 </form>
 
-<script type="text/javascript">
+<script>
 	window.document.FORM.bargain_price.select();
 	window.document.FORM.bargain_price.focus();
 </script>

--- a/templates/Default/engine/Default/shop_hardware.php
+++ b/templates/Default/engine/Default/shop_hardware.php
@@ -1,6 +1,6 @@
 <?php
 if (isset($HardwareSold)) { ?>
-	<script type="text/javascript">
+	<script>
 		function recalcOnKeyUp(transaction, hardwareTypeID, cost) {
 			var form = document.getElementById(transaction + hardwareTypeID);
 			form.total.value = form.amount.value * cost;

--- a/templates/Default/engine/Default/skeleton.php
+++ b/templates/Default/engine/Default/skeleton.php
@@ -49,6 +49,7 @@
 				<td class="footer_right">
 					<?php $this->includeTemplate('includes/copyright.inc'); ?>
 				</td>
+				<td></td>
 			</tr>
 		</table>
 		<?php $this->includeTemplate('includes/EndingJavascript.inc'); ?>

--- a/templates/Default/engine/Default/trader_examine.php
+++ b/templates/Default/engine/Default/trader_examine.php
@@ -2,25 +2,25 @@
 $canAttack=false;
 
 if($ThisPlayer->hasNewbieTurns()) {
-	?><p><big class="green">You are under newbie protection!</big></p><?php
+	?><p class="big green">You are under newbie protection!</p><?php
 }
 else if($TargetPlayer->hasNewbieTurns()) {
-	?><p><big class="green">Your target is under newbie protection!</big></p><?php
+	?><p class="big green">Your target is under newbie protection!</p><?php
 }
 else if($ThisPlayer->sameAlliance($TargetPlayer)) {
-	?><p><big class="blue">This is your alliancemate.</big></p><?php
+	?><p class="big blue">This is your alliancemate.</p><?php
 }
 else if(!$ThisShip->canAttack()) {
-	?><p><big class="red">You ready your weapons, you take aim, you...realise you have no weapons.</big></p><?php
+	?><p class="big red">You ready your weapons, you take aim, you...realise you have no weapons.</p><?php
 }
 else if($ThisPlayer->traderNAPAlliance($TargetPlayer)) {
-	?><p><big class="blue">This is your ally.</big></p><?php
+	?><p class="big blue">This is your ally.</p><?php
 }
 else if($ThisPlayer->hasFederalProtection()) {
-	?><p><big class="blue">You are under federal protection! That wouldn't be fair.</big></p><?php
+	?><p class="big blue">You are under federal protection! That wouldn't be fair.</p><?php
 }
 else if($TargetPlayer->hasFederalProtection()) {
-	?><p><big class="blue">Your target is under federal protection!</big></p><?php
+	?><p class="big blue">Your target is under federal protection!</p><?php
 }
 else {
 	$canAttack=true;
@@ -29,7 +29,7 @@ else {
 		?><p><a class="submitStyle" href="<?php echo $TargetPlayer->getAttackTraderHREF(); ?>">Attack Trader (3)</a></p><?php
 	}
 	else {
-		?><p><big class="red">You have no targets!</big></p><?php
+		?><p class="big red">You have no targets!</p><?php
 	}
 }
 if(!$canAttack)


### PR DESCRIPTION
Make the following changes for better adoption of HTML5:

* Remove `type` attributes from `<script>` and `<style>` tags.
* Replace the `<big>` element with CSS.

Also fix an issue with the wrong number of columns in the skeleton table.