### PR TITLE
Remove obsolete align attribute

### DIFF
--- a/admin/Default/keyword_processing.php
+++ b/admin/Default/keyword_processing.php
@@ -10,5 +10,5 @@ else {
 	}
 }
 $container = create_container('skeleton.php', 'keyword_search.php');
-$container['msg'] = '<div align=center><span class="red"><b>Added Exceptions</b></span></div>';
+$container['msg'] = '<div class="center"><span class="red"><b>Added Exceptions</b></span></div>';
 forward($container);

--- a/admin/Default/keyword_search.php
+++ b/admin/Default/keyword_search.php
@@ -57,31 +57,31 @@ while ($db->nextRecord()) {
 			$PHP_OUTPUT.=('<a href=#button1>Goto Exception Button/Personal Messages Start</a>');
 			$PHP_OUTPUT.= create_table();
 			$PHP_OUTPUT.=('<tr>');
-			$PHP_OUTPUT.=('<th align=center>Game ID</th>');
-			$PHP_OUTPUT.=('<th align=center>Alliance ID</th>');
-			$PHP_OUTPUT.=('<th align=center>Thread ID</th>');
-			$PHP_OUTPUT.=('<th align=center>Reply ID</th>');
-			$PHP_OUTPUT.=('<th align=center>Sender ID</th>');
-			$PHP_OUTPUT.=('<th align=center>Bad text</th>');
-			$PHP_OUTPUT.=('<th align=center>Ignore</th>');
+			$PHP_OUTPUT.=('<th>Game ID</th>');
+			$PHP_OUTPUT.=('<th>Alliance ID</th>');
+			$PHP_OUTPUT.=('<th>Thread ID</th>');
+			$PHP_OUTPUT.=('<th>Reply ID</th>');
+			$PHP_OUTPUT.=('<th>Sender ID</th>');
+			$PHP_OUTPUT.=('<th>Bad text</th>');
+			$PHP_OUTPUT.=('<th>Ignore</th>');
 			$PHP_OUTPUT.=('</tr>');
 		}
 
 		//lets echo this message
 		$PHP_OUTPUT.=('<tr>');
-		$PHP_OUTPUT.=('<td align=center>'.$game_id.'</td>');
-		$PHP_OUTPUT.=('<td align=center>'.$alliance_id.'</td>');
-		$PHP_OUTPUT.=('<td align=center>'.$thread_id.'</td>');
-		$PHP_OUTPUT.=('<td align=center>'.$reply_id.'</td>');
+		$PHP_OUTPUT.=('<td class="center">'.$game_id.'</td>');
+		$PHP_OUTPUT.=('<td class="center">'.$alliance_id.'</td>');
+		$PHP_OUTPUT.=('<td class="center">'.$thread_id.'</td>');
+		$PHP_OUTPUT.=('<td class="center">'.$reply_id.'</td>');
 		//make sure we check for Word, WORD, and word...after phpv5 use str_ireplace
 		$array = array();
 		$array[] = ucfirst($word);
 		$array[] = strtoupper($word);
 		$array[] = strtolower($word);
 		$bad = str_replace($array, '<b><span class="red">'.$word.'</span></b>', $db->escapeString($bad));
-		$PHP_OUTPUT.=('<td align=center>' . $db2->getField('sender_id') . '</td>');
-		$PHP_OUTPUT.=('<td align=center>'.$bad.'</td>');
-		$PHP_OUTPUT.=('<td align=center><input type=checkbox name=alliance[] value='.$array_filler.'></td>');
+		$PHP_OUTPUT.=('<td class="center">' . $db2->getField('sender_id') . '</td>');
+		$PHP_OUTPUT.=('<td class="center">'.$bad.'</td>');
+		$PHP_OUTPUT.=('<td class="center"><input type=checkbox name=alliance[] value='.$array_filler.'></td>');
 		$PHP_OUTPUT.=('</tr>');
 		//update count
 		$count += 1;
@@ -142,24 +142,24 @@ while ($db->nextRecord()) {
 			$PHP_OUTPUT.=('<a href=#button2>Goto Exception Button</a>');
 			$PHP_OUTPUT.= create_table();
 			$PHP_OUTPUT.=('<tr>');
-			$PHP_OUTPUT.=('<th align=center>Game ID</th>');
-			$PHP_OUTPUT.=('<th align=center>Sender ID</th>');
-			$PHP_OUTPUT.=('<th align=center>Bad text</th>');
-			$PHP_OUTPUT.=('<th align=center>Ignore</th>');
+			$PHP_OUTPUT.=('<th>Game ID</th>');
+			$PHP_OUTPUT.=('<th>Sender ID</th>');
+			$PHP_OUTPUT.=('<th>Bad text</th>');
+			$PHP_OUTPUT.=('<th>Ignore</th>');
 			$PHP_OUTPUT.=('</tr>');
 		}
 
 		//lets echo this message
 		$PHP_OUTPUT.=('<tr>');
-		$PHP_OUTPUT.=('<td align=center>' . $db2->getField('game_id') . '</td>');
-		$PHP_OUTPUT.=('<td align=center>' . $db2->getField('sender_id') . '</td>');
+		$PHP_OUTPUT.=('<td class="center">' . $db2->getField('game_id') . '</td>');
+		$PHP_OUTPUT.=('<td class="center">' . $db2->getField('sender_id') . '</td>');
 		$array = array();
 		$array[] = ucfirst($word);
 		$array[] = strtoupper($word);
 		$array[] = strtolower($word);
 		$bad = str_replace($array, '<b><span class="red">'.$word.'</span></b>', $db->escapeString($bad));
-		$PHP_OUTPUT.=('<td align=center>'.$bad.'</td>');
-		$PHP_OUTPUT.=('<td align=center><input type=checkbox name=personal[] value='.$msg_id.'></td>');
+		$PHP_OUTPUT.=('<td class="center">'.$bad.'</td>');
+		$PHP_OUTPUT.=('<td class="center"><input type=checkbox name=personal[] value='.$msg_id.'></td>');
 		$PHP_OUTPUT.=('</tr>');
 		//update count
 		$count += 1;

--- a/admin/Default/ship_check.php
+++ b/admin/Default/ship_check.php
@@ -31,9 +31,9 @@ if ($db->getNumRows()) {
 		$PHP_OUTPUT.=('<tr>');
 		$PHP_OUTPUT.=('<td>'.$player_name.'</td>');
 		$PHP_OUTPUT.=('<td>'.$type.'</td>');
-		$PHP_OUTPUT.=('<td align="center">'.$amount.'</td>');
-		$PHP_OUTPUT.=('<td align="center">'.$max_amount.'</td>');
-		$PHP_OUTPUT.=('<td align="center">');
+		$PHP_OUTPUT.=('<td class="center">'.$amount.'</td>');
+		$PHP_OUTPUT.=('<td class="center">'.$max_amount.'</td>');
+		$PHP_OUTPUT.=('<td class="center">');
 
 		$container = create_container('ship_check_processing.php');
 		$container['account_id'] = $db->getField('account_id');

--- a/engine/Default/alliance_exempt_authorize.php
+++ b/engine/Default/alliance_exempt_authorize.php
@@ -4,7 +4,6 @@ $template->assign('PageTopic', $alliance->getAllianceName(false, true));
 Menu::alliance($alliance->getAllianceID(), $alliance->getLeaderID());
 
 $PHP_OUTPUT.= '<h2>Exemption Requests</h2><br />';
-$PHP_OUTPUT.=('Selecting a box will authorize it, leaving a box unselected will make it unauthorized after you submit.<br />');
 //get rid of already approved entries
 $db->query('UPDATE alliance_bank_transactions SET request_exempt = 0 WHERE exempt = 1');
 //build player array
@@ -17,6 +16,7 @@ $db->query('SELECT * FROM alliance_bank_transactions WHERE request_exempt = 1 ' 
 if ($db->getNumRows()) {
 	$container=create_container('bank_alliance_exempt_processing.php');
 	$form = create_form($container,'Make Exempt');
+	$PHP_OUTPUT.=('Selecting a box will authorize it, leaving a box unselected will make it unauthorized after you submit.<br />');
 	$PHP_OUTPUT.= $form['form'];
 	$PHP_OUTPUT.=create_table();
 	$PHP_OUTPUT.=('<tr><th>Player Name</th><th>Type</th><th>Reason</th><th>Amount</th><th>Approve</th></tr>');
@@ -26,11 +26,10 @@ if ($db->getNumRows()) {
 		$PHP_OUTPUT.=('<td><input type="checkbox" name="exempt[' . $db->getField('transaction_id') . ']"></td>');
 		$PHP_OUTPUT.=('</tr>');
 	}
-	$PHP_OUTPUT.=('</table>');
-	$PHP_OUTPUT.=('<div align="center">');
+	$PHP_OUTPUT.=('</table><br />');
 	$PHP_OUTPUT.= $form['submit'];
-	$PHP_OUTPUT.=('</div></form>');
+	$PHP_OUTPUT.=('</form>');
 }
 else {
-	$PHP_OUTPUT.=('<div align="center">Nothing to authorize.</div>');
+	$PHP_OUTPUT.=('Nothing to authorize.');
 }

--- a/engine/Default/bank_report.php
+++ b/engine/Default/bank_report.php
@@ -35,7 +35,7 @@ while ($db->nextRecord()) {
 }
 
 //format it this way so its easy to send to the alliance MB if requested.
-$text = '<table class="nobord" cellspacing="1" align="center">';
+$text = '<table class="nobord centered" cellspacing="1">';
 $text .= '<tr><th>Player</th><th>Deposits</th><th>Withdrawals</th><th>Total</th></tr>';
 $balance = 0;
 foreach ($totals as $accId => $total) {
@@ -61,7 +61,7 @@ foreach ($totals as $accId => $total) {
 	$text .= '</tr>';
 }
 $text .= '</table>';
-$text = '<div align="center"><br />Ending Balance: ' . number_format($balance) . '</div><br />' . $text;
+$text = '<div class="center"><br />Ending Balance: ' . number_format($balance) . '</div><br />' . $text;
 
 $container=create_container('skeleton.php', 'bank_report.php');
 $container['alliance_id'] = $alliance_id;
@@ -90,10 +90,10 @@ if (isset($var['text'])) {
 		$db->query('DELETE FROM player_read_thread WHERE thread_id = ' . $db->escapeNumber($thread_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id));
 	}
 
-	$PHP_OUTPUT.=('<div align="center">A statement has been sent to the alliance.</div><br />');
+	$PHP_OUTPUT.=('<div class="center">A statement has been sent to the alliance.</div><br />');
 }
 else {
-	$PHP_OUTPUT.=('<div align="center">');
+	$PHP_OUTPUT.=('<div class="center">');
 	$PHP_OUTPUT.=create_button($container,'Send Report to Alliance');
 	$PHP_OUTPUT.=('</div>');
 }

--- a/engine/Default/bar_buy_drink_processing.php
+++ b/engine/Default/bar_buy_drink_processing.php
@@ -1,6 +1,6 @@
 <?php
 
-$message = '<div align=center>';
+$message = '<div class="center">';
 
 if ($player->getCredits() < 10) {
 	create_error('Come back when you get some money!');

--- a/engine/Default/bar_galmap_buy.php
+++ b/engine/Default/bar_galmap_buy.php
@@ -44,7 +44,7 @@ if (isset($var['process'])) {
 	
 	$container=create_container('skeleton.php','bar_main.php');
 	transfer('LocationID');
-	$container['message'] = '<div align="center">Galaxy maps have been added. Enjoy!</div><br />';
+	$container['message'] = '<div class="center">Galaxy maps have been added. Enjoy!</div><br />';
 	forward($container);
 }
 else {

--- a/engine/Default/bar_gambling_processing.php
+++ b/engine/Default/bar_gambling_processing.php
@@ -50,14 +50,14 @@ function create_card($card, $show) {
 
 	$return=('<td>');
 	//lets try and echo cards
-	$return.=('<table style="border:1px solid green"><tr><td><table><tr><td valign=top align=left height='.$card_height.' width='.$card_width.'>');
+	$return.=('<table style="border:1px solid green"><tr><td><table><tr><td valign=top class="left" height='.$card_height.' width='.$card_width.'>');
 	if ($show) {
 		$return.=('<h1>'.$card_name.'<img src="images/'.$suit.'.gif"></h1></td></tr>');
 	}
 	else {
 		$return.=('</td></tr>');
 	}
-	$return.=('<tr><td valign=bottom align=right height='.$card_height.' width='.$card_width.'>');
+	$return.=('<tr><td valign=bottom class="right" height='.$card_height.' width='.$card_width.'>');
 	if ($show) {
 		$return.=('<h1><img src="images/'.$suit.'.gif">'.$card_name.'</h1></td></tr></table>');
 	}
@@ -189,7 +189,7 @@ if ($do != 'STAY' && get_value($player_card) != 21) {
 	    (get_value($player_card) > 21 && get_value($ai_card) <= 21)) {
 		$message.=('<h1 class="red center">Bank Wins</h1>');
 	}
-	$message.=('<div align="center">Bank\'s Cards are</div><br /><table align="center"><tr>');
+	$message.=('<div class="center">Bank\'s Cards are</div><br /><table class="center"><tr>');
 	foreach ($ai_card as $key => $value) {
 		if ($key == 0) {
 			//do we need a new row?
@@ -215,14 +215,14 @@ if ($do != 'STAY' && get_value($player_card) != 21) {
 
 	$message.=('</tr></table>');
 	if (get_value($ai_card) == 21 && sizeof($ai_card) == 2) {
-		$message.=('<div align=center>Bank has BLACKJACK!</div><br />');
+		$message.=('<div class="center">Bank has BLACKJACK!</div><br />');
 		$win = 'no';
 	}
 	elseif (get_value($player_card) >= 21) {
-		$message.=('<div align=center>Bank has ' . get_value($ai_card) . '</div><br /><br />');
+		$message.=('<div class="center">Bank has ' . get_value($ai_card) . '</div><br />');
 	}
 	else {
-		$message.=('<div align=center>Bank has at least '.$ai_val.'</div><br />');
+		$message.=('<div class="center">Bank has at least '.$ai_val.'</div><br />');
 	}
 }
 
@@ -250,7 +250,7 @@ if ($do == 'STAY' || get_value($player_card) == 21) {
 	else {
 		$message.=('<h1 class="red center">Bank Wins</h1>');
 	}
-	$message.=('<div align=center>Bank\'s Cards are</div><br /><table align=center><tr>');
+	$message.=('<div class="center">Bank\'s Cards are</div><br /><table class="center"><tr>');
 	foreach ($ai_card as $key => $value) {
 		//now row?
 		if ($i == 4 || $i == 7 || $i == 10) {
@@ -259,7 +259,7 @@ if ($do == 'STAY' || get_value($player_card) == 21) {
 		$message.=create_card($value, TRUE);
 		$i++;
 	}
-	$message.=('</tr></table><div align=center>');
+	$message.=('</tr></table><div class="center">');
 	if (get_value($ai_card) > 21) {
 		$message.=('Bank <span class="red"><b>BUSTED</b></span><br /><br />');
 	}
@@ -273,7 +273,7 @@ $i = 1;
 
 $val1 = get_value($player_card);
 
-$message.=('<div align=center>Your Cards are</div><br /><table align=center><tr>');
+$message.=('<div class="center">Your Cards are</div><br /><table class="center"><tr>');
 foreach ($player_card as $key => $value) {
 	if ($i == 4 || $i == 7 || $i == 10) {
 		$message.=('</tr><tr>');
@@ -283,7 +283,7 @@ foreach ($player_card as $key => $value) {
 }
 $message.=('</tr></table>');
 
-$message.=('<div align=center>You have a total of ' . get_value($player_card) . ' </div><br />');
+$message.=('<div class="center">You have a total of ' . get_value($player_card) . ' </div><br />');
 //check for win
 if ($do == 'STAY') {
 	$win = check_for_win($ai_card, $player_card);
@@ -294,7 +294,7 @@ transfer('LocationID');
 $container['cards'] = $cards;
 $container['bet'] = $bet;
 
-$message.=('<div align=center>');
+$message.=('<div class="center">');
 if (get_value($player_card) > 21) {
 	$message.=('You have <span class="red"><b>BUSTED</b></span>');
 	$player->increaseHOF($bet,array('Blackjack','Money','Lost'), HOF_PUBLIC);

--- a/engine/Default/bar_lotto_buy_processing.php
+++ b/engine/Default/bar_lotto_buy_processing.php
@@ -23,7 +23,7 @@ $db->query('SELECT count(*) as num FROM player_has_ticket WHERE game_id = ' . $d
 	AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND time > 0 GROUP BY account_id');
 $db->nextRecord();
 $num = $db->getInt('num');
-$message=('<div align=center>Thanks for your purchase and good luck!  You currently');
+$message=('<div class="center">Thanks for your purchase and good luck!  You currently');
 $message.=(' own '.$num.' '.pluralise('ticket', $num).'!</div><br />');
 
 $container=create_container('skeleton.php','bar_main.php');

--- a/engine/Default/bar_lotto_claim.php
+++ b/engine/Default/bar_lotto_claim.php
@@ -11,7 +11,7 @@ if ($db->nextRecord()) {
 	$player->increaseCredits($prize);
 	$player->increaseHOF($prize,array('Bar','Lotto','Money','Claimed'), HOF_PUBLIC);
 	$player->increaseHOF(1,array('Bar','Lotto','Results','Claims'), HOF_PUBLIC);
-	$message .= '<div align="center">You have claimed <span class="red">$' . number_format($prize) . '</span>!<br /></div><br />';
+	$message .= '<div class="center">You have claimed <span class="red">$' . number_format($prize) . '</span>!<br /></div><br />';
 	$db->query('DELETE FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND prize = ' . $db->escapeNumber($prize) . ' AND time = 0 LIMIT 1');
 	$db->query('DELETE FROM news WHERE type = \'lotto\' AND game_id = '.$db->escapeNumber($player->getGameID()));

--- a/engine/Default/bar_read_wall.php
+++ b/engine/Default/bar_read_wall.php
@@ -19,8 +19,8 @@ $db->query('SELECT * FROM bar_wall WHERE game_id = ' . $db->escapeNumber($player
 if ($db->getNumRows()) {
 	$PHP_OUTPUT.=('<table class="standard">');
 	$PHP_OUTPUT.=('<tr>');
-	$PHP_OUTPUT.=('<th align="center">Time written</th>');
-	$PHP_OUTPUT.=('<th align="center">Message</th>');
+	$PHP_OUTPUT.=('<th>Time written</th>');
+	$PHP_OUTPUT.=('<th>Message</th>');
 	$PHP_OUTPUT.=('</tr>');
 
 	while ($db->nextRecord()) {
@@ -28,8 +28,8 @@ if ($db->getNumRows()) {
 		$message_on_wall = $db->getField('message');
 
 		$PHP_OUTPUT.=('<tr>');
-		$PHP_OUTPUT.=('<td align="center"><b> ' . date(DATE_FULL_SHORT, $time) . ' </b></td>');
-		$PHP_OUTPUT.=('<td align="center"><b>'.$message_on_wall.'</b></td>');
+		$PHP_OUTPUT.=('<td class="center"><b> ' . date(DATE_FULL_SHORT, $time) . ' </b></td>');
+		$PHP_OUTPUT.=('<td class="center"><b>'.$message_on_wall.'</b></td>');
 		$PHP_OUTPUT.=('</tr>');
 	}
 	$PHP_OUTPUT.=('</table>');

--- a/engine/Default/bar_ticker_buy.php
+++ b/engine/Default/bar_ticker_buy.php
@@ -31,7 +31,7 @@ if (isset($var['process'])) {
 	//offer another drink and such
 	$container=create_container('skeleton.php','bar_main.php');
 	transfer('LocationID');
-	$container['message'] = '<div align="center">Your system has been added.  Enjoy!</div><br />';
+	$container['message'] = '<div class="center">Your system has been added.  Enjoy!</div><br />';
 	forward($container);
 }
 else {

--- a/engine/Default/buy_ship_name_processing.php
+++ b/engine/Default/buy_ship_name_processing.php
@@ -61,7 +61,7 @@ if(!isset($var['ShipName'])) {
 						VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($name) . ')');
 			$account->decreaseTotalSmrCredits($cred_cost);
 			$container = create_container('skeleton.php','current_sector.php');
-			$container['msg'] = '<div align="center">Your logo was successfully painted!</div><br />';
+			$container['msg'] = 'Your logo was successfully painted!';
 			forward($container);
 		}
 		else {
@@ -159,11 +159,10 @@ $db->query('REPLACE INTO ship_has_name (game_id, account_id, ship_name)
 			VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($name) . ')');
 $account->decreaseTotalSmrCredits($cred_cost);
 
-$message = '<div align="center">Thanks for your purchase! Your ship is ready!';
+$message = 'Thanks for your purchase! Your ship is ready!';
 if (isset($var['ShipName'])) {
 	$message .= '<br />If your ship is found to use HTML inappropriately you may be banned.  If your ship does contain inappropriate HTML talk to an admin ASAP.';
 }
-$message .= '</div>';
 $container=create_container('skeleton.php','current_sector.php');
 $container['msg'] = $message;
 forward($container);

--- a/engine/Default/galactic_post_view_members.php
+++ b/engine/Default/galactic_post_view_members.php
@@ -14,9 +14,9 @@ if ($db->getNumRows()) {
 
 	$PHP_OUTPUT.=create_table();
 	$PHP_OUTPUT.=('<tr>');
-	$PHP_OUTPUT.=('<th align="center">Player Name</th>');
-	$PHP_OUTPUT.=('<th align="center">Last Wrote</th>');
-	$PHP_OUTPUT.=('<th align="center">Options</th>');
+	$PHP_OUTPUT.=('<th>Player Name</th>');
+	$PHP_OUTPUT.=('<th>Last Wrote</th>');
+	$PHP_OUTPUT.=('<th>Options</th>');
 	$PHP_OUTPUT.=('</tr>');
 
 	while ($db->nextRecord()) {
@@ -24,8 +24,8 @@ if ($db->getNumRows()) {
 		$curr_writter = SmrPlayer::getPlayer($db->getField('account_id'), $player->getGameID());
 		$time = $db->getField('last_wrote');
 		$PHP_OUTPUT.=('<tr>');
-		$PHP_OUTPUT.=('<td align="center">'.$curr_writter->getPlayerName().'</td>');
-		$PHP_OUTPUT.=('<td align="center"> ' . date(DATE_FULL_SHORT, $time) . '</td>');
+		$PHP_OUTPUT.=('<td class="center">'.$curr_writter->getPlayerName().'</td>');
+		$PHP_OUTPUT.=('<td class="center"> ' . date(DATE_FULL_SHORT, $time) . '</td>');
 		$container['id'] = $curr_writter->getAccountID();
 		$PHP_OUTPUT.=create_echo_form($container);
 		$PHP_OUTPUT.=('<td>');

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -38,7 +38,7 @@ while($db->nextRecord()) {
 	$hof = true;
 }
 $PHP_OUTPUT .= buildBreadcrumb($var,$hofTypes,isset($game_id)?'Current HoF':'Global HoF');
-$PHP_OUTPUT.= '<table class="standard" align="center">';
+$PHP_OUTPUT.= '<table class="standard centered">';
 
 if(!isset($var['view'])) {
 	$PHP_OUTPUT.=('<tr><th>Category</th><th width="60%">Subcategory</th></tr>');

--- a/engine/Default/hall_of_fame_player_detail.php
+++ b/engine/Default/hall_of_fame_player_detail.php
@@ -47,7 +47,7 @@ while($db->nextRecord()) {
 	$hof = true;
 }
 $PHP_OUTPUT .= buildBreadcrumb($var,$hofTypes,'Personal HoF');
-$PHP_OUTPUT.= '<table class="standard" align="center">';
+$PHP_OUTPUT.= '<table class="standard centered">';
 
 if(!isset($var['view'])) {
 	$PHP_OUTPUT.=('<tr><th>Category</th><th width="60%">Subcategory</th></tr>');

--- a/engine/Default/help.inc
+++ b/engine/Default/help.inc
@@ -78,7 +78,7 @@ function echo_nav($topic_id) {
 		}
 		echo ('</th>');
 
-		echo ('<th width="100%" align="center" validn="middle" style="font-size:18pt;font-weight:bold;">' . get_numbering($topic_id) . $topic.'</th>');
+		echo ('<th width="100%" class="center" validn="middle" style="font-size:18pt;font-weight:bold;">' . get_numbering($topic_id) . $topic.'</th>');
 		echo ('<th width="32"><a href="/manual_toc.php"><img src="/images/help/contents.jpg" width="32" height="32" border="0"></a></th>');
 
 		echo ('</tr>');
@@ -125,7 +125,7 @@ function echo_subsection($topic_id) {
 	// check if there are subsections
 	$db->query('SELECT * FROM manual WHERE parent_topic_id = '.$db->escapeNumber($topic_id).' ORDER BY order_id');
 	if ($db->getNumRows()) {
-		echo ('<hr noshade width="75%" size="1" align="center"/>');
+		echo ('<hr noshade width="75%" size="1" class="center"/>');
 		echo ('<div id="help_menu">');
 		echo ('<h2>Subsections:</h2>');
 

--- a/htdocs/album/index.php
+++ b/htdocs/album/index.php
@@ -18,9 +18,9 @@ try {
 	</head>
 	<body>
 	
-	<table width="850" border="0" align="center" cellpadding="0" cellspacing="0" >
+	<table class="center" width="850" border="0" cellpadding="0" cellspacing="0" >
 	<tr>
-	<td align="center" colspan="2"><h1>Space Merchant Realms - Photo Album</h1></td>
+	<td colspan="2"></td>
 	</tr>
 	<tr>
 	<td>
@@ -29,12 +29,13 @@ try {
 	<td>
 	
 	<table cellspacing="0" cellpadding="0" border="0" width="700">
+	<tr><td class="center" colspan="3"><h1>Space Merchant Realms - Photo Album</h1></td></tr>
 	<tr>
 	<td colspan="3" height="1" bgcolor="#0B8D35"></td>
 	</tr>
 	<tr>
 	<td width="1" bgcolor="#0B8D35"></td>
-	<td align="left" valign="top" bgcolor="#06240E">
+	<td class="left" valign="top" bgcolor="#06240E">
 	<table width="100%" height="100%" border="0" cellspacing="5" cellpadding="5">
 	<tr>
 	<td valign="top">
@@ -110,10 +111,10 @@ catch(Throwable $e) {
 </tr>
 <tr>
 <td width="1" bgcolor="#0B8D35"></td>
-<td align="left" valign="top" bgcolor="#06240E">
+<td valign="top" bgcolor="#06240E">
 <table width="100%" height="100%" border="0" cellspacing="5" cellpadding="5">
 <tr>
-<td valign="top" align="center">
+<td valign="top" class="center">
 <form action="search_processing.php">
 Quick Search:<br />
 <input type="text" name="nick" size="10" class="InputFields"><br />

--- a/htdocs/error.php
+++ b/htdocs/error.php
@@ -18,9 +18,9 @@
 				<td></td>
 			</tr>
 			<tr>
-				<td align='right' valign='top' width='135'>&nbsp;</td>
+				<td valign='top' width='135'>&nbsp;</td>
 				<td width='1' bgcolor='#0B8D35'></td>
-				<td align='left' valign='top' width='600' bgcolor='#06240E'>
+				<td valign='top' width='600' bgcolor='#06240E'>
 					<table width='100%' height='100%' border='0' cellspacing='5' cellpadding='5'>
 					<tr>
 						<td style='vertical-align:top;'>
@@ -39,7 +39,7 @@
 					</table>
 				</td>
 				<td width='1' bgcolor='#0B8D35'></td>
-				<td align='right' valign='top' width='135'>&nbsp;</td>
+				<td valign='top' width='135'>&nbsp;</td>
 			</tr>
 			<tr>
 				<td></td>

--- a/htdocs/imprint.html
+++ b/htdocs/imprint.html
@@ -17,9 +17,9 @@
 				<td></td>
 			</tr>
 			<tr>
-				<td align='right' valign='top' width='135'>&nbsp;</td>
+				<td valign='top' width='135'>&nbsp;</td>
 				<td width='1' bgcolor='#0B8D35'></td>
-				<td align='left' valign='top' width='600' bgcolor='#06240E'>
+				<td valign='top' width='600' bgcolor='#06240E'>
 					<table width='100%' height='100%' border='0' cellspacing='5' cellpadding='5'>
 						<tr>
 							<td style='vertical-align:top;'>
@@ -59,7 +59,7 @@
 					</table>
 				</td>
 				<td width='1' bgcolor='#0B8D35'></td>
-				<td align='right' valign='top' width='135'>&nbsp;</td>
+				<td valign='top' width='135'>&nbsp;</td>
 			</tr>
 			<tr>
 				<td></td>

--- a/htdocs/login_create.php
+++ b/htdocs/login_create.php
@@ -23,13 +23,13 @@ require_once('config.inc');
 <tr>
 	<td width='135'>&nbsp;</td>
 	<td width='1' bgcolor='#0B8D35'></td>
-	<td align='left' valign='top' width='600' bgcolor='#06240E'>
+	<td valign='top' width='600' bgcolor='#06240E'>
 		<table width='100%' height='100%' border='0' cellspacing='5' cellpadding='5'>
 		<tr>
 			<td valign='top'>
 
 				<h1>Create Login</h1>
-				<p align='justify'>
+				<p>
 					Creating multiple logins is not allowed.
 					<a href='https://wiki.smrealms.de/rules' target="_blank" style='font-weight:bold;'>Click HERE</a> for more information.
 				</p>

--- a/htdocs/manual_toc.php
+++ b/htdocs/manual_toc.php
@@ -31,7 +31,7 @@ try {
 							<th width="32">
 								<img src="/images/help/empty.jpg" width="32" height="32">
 							</th>
-							<th width="100%" align="center" valign="middle" style="font-size:18pt;font-weight:bold;">Table of Content</th>
+							<th width="100%" class="center" valign="middle" style="font-size:18pt;font-weight:bold;">Table of Content</th>
 							<th width="32"><a href="/manual_toc.php"><img src="/images/help/contents.jpg" width="32" height="32" border="0"></a></th>
 						</tr>
 					</table>
@@ -57,7 +57,7 @@ try {
 							<th width="32">
 								<img src="/images/help/empty.jpg" width="32" height="32">
 							</th>
-							<th width="100%" align="center" valign="middle" style="font-size:18pt;font-weight:bold;">Table of Content</th>
+							<th width="100%" class="center" valign="middle" style="font-size:18pt;font-weight:bold;">Table of Content</th>
 							<th width="32"><a href="/manual_toc.php"><img src="/images/help/contents.jpg" width="32" height="32" border="0"></a></th>
 						</tr>
 					</table>

--- a/htdocs/resend_password.php
+++ b/htdocs/resend_password.php
@@ -19,7 +19,7 @@
 			<tr>
 				<td width="100">&nbsp;</td>
 				<td width="1" bgcolor="#0B8D35"></td>
-				<td align="left" valign="top" width="600" bgcolor="#06240E">
+				<td valign="top" width="600" bgcolor="#06240E">
 					<table width="100%" height="100%" border="0" cellspacing="5" cellpadding="5">
 						<tr>
 							<td valign="top">
@@ -30,10 +30,10 @@
 								<br /><br />
 
 								<form action="resend_password_processing.php" method="POST">
-									<div align="center">
-										<table border="0">
+									<div class="center">
+										<table class="center" border="0">
 											<tr>
-												<th align="right">Email:</th>
+												<th class="right">Email:</th>
 												<td><input type="email" name="email" class="InputFields"></td>
 											</tr>
 										</table>

--- a/htdocs/reset_password.php
+++ b/htdocs/reset_password.php
@@ -19,7 +19,7 @@
 			<tr>
 				<td width="100">&nbsp;</td>
 				<td width="1" bgcolor="#0B8D35"></td>
-				<td align="left" valign="top" width="600" bgcolor="#06240E">
+				<td valign="top" width="600" bgcolor="#06240E">
 					<table width="100%" height="100%" border="0" cellspacing="5" cellpadding="5">
 					<tr>
 						<td valign="top">
@@ -29,22 +29,22 @@
 							For security reasons, please enter your username and the password reset code you requested:
 
 							<form action="reset_password_processing.php" method="POST">
-									<div align="center">
-											<table border="0">
+									<div class="center">
+											<table class="center" border="0">
 												<tr>
-														<th align="right">Username:</th>
+														<th class="right">Username:</th>
 														<td><input name="login" type="text" class="InputFields" value="<?php echo isset($_REQUEST['login']) ? htmlspecialchars($_REQUEST['login']) : ''; ?>" /></td>
 												</tr>
 												<tr>
-														<th align="right">Password Reset Code:</th>
+														<th class="right">Password Reset Code:</th>
 														<td><input name="password_reset" type="text" class="InputFields" value="<?php echo isset($_REQUEST['resetcode']) ? htmlspecialchars($_REQUEST['resetcode']) : ''; ?>" /></td>
 												</tr>
 												<tr>
-														<th align="right">New Password:</th>
+														<th class="right">New Password:</th>
 														<td><input name="password" type="password" class="InputFields" /></td>
 												</tr>
 												<tr>
-														<th align="right">Verify New Password:</th>
+														<th class="right">Verify New Password:</th>
 														<td><input name="pass_verify" type="password" class="InputFields" /></td>
 												</tr>
 											</table>

--- a/htdocs/ship_list.php
+++ b/htdocs/ship_list.php
@@ -107,36 +107,36 @@ try {
 	?>
 	<div id="container" style="padding: 0;">
 	<div style="width:1400px; margin-left:auto; margin-right:auto;">
-	<table id="table" class="standard">
+	<table id="table" class="center standard">
 		<?php /*<tr style="position:fixed">*/ ?>
 		<tr >
-			<th align="center"><a href="?order=ship_name&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Ship Name</span></a></th>
-			<th align="center"><a href="?order=race_name&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Race</span></a>
+			<th><a href="?order=ship_name&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Ship Name</span></a></th>
+			<th><a href="?order=race_name&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Race</span></a>
 				<?php echo $race ?></th>
-			<th align="center">Class<?php echo $class; ?></th>
-			<th align="center"><a href="?order=cost&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Cost</span></a></th>
-			<th align="center"><a href="?order=speed&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Speed</span></a>
+			<th>Class<?php echo $class; ?></th>
+			<th><a href="?order=cost&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Cost</span></a></th>
+			<th><a href="?order=speed&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Speed</span></a>
 				<?php echo $speed ?></th>
-			<th align="center"><a href="?order=hardpoint&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Hardpoints</span></a>
+			<th><a href="?order=hardpoint&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Hardpoints</span></a>
 				<?php echo $hardpoint ?></th>
-			<th align="center"><a href="?order=buyer_restriction&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Restriction</span></a>
+			<th><a href="?order=buyer_restriction&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Restriction</span></a>
 				<?php echo $restrict ?></th><?php
-/*			<th align="center"><a href="?order=lvl_needed&seq=<?php echo $seq; ?>"><span style="color:#80C870;">Level Needed(Semi War)</span></a></th>*/ ?>
-			<th align="center"><a href="?hardwarea=1&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Shields</span></a></th>
-			<th align="center"><a href="?hardwarea=2&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Armour</span></a></th>
-			<th align="center"><a href="?hardwarea=3&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Cargo</span></a></th>
-			<th align="center"><a href="?hardwarea=4&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Drones</span></a></th>
-			<th align="center"><a href="?hardwarea=5&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Scouts</span></a></th>
-			<th align="center"><a href="?hardwarea=6&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Mines</span></a></th>
-			<th align="center"><a href="?hardwarea=7&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Scanner</span></a>
+/*			<th><a href="?order=lvl_needed&seq=<?php echo $seq; ?>"><span style="color:#80C870;">Level Needed(Semi War)</span></a></th>*/ ?>
+			<th><a href="?hardwarea=1&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Shields</span></a></th>
+			<th><a href="?hardwarea=2&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Armour</span></a></th>
+			<th><a href="?hardwarea=3&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Cargo</span></a></th>
+			<th><a href="?hardwarea=4&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Drones</span></a></th>
+			<th><a href="?hardwarea=5&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Scouts</span></a></th>
+			<th><a href="?hardwarea=6&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Mines</span></a></th>
+			<th><a href="?hardwarea=7&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Scanner</span></a>
 				<?php echo $scanner ?></th>
-			<th align="center"><a href="?hardwarea=8&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Cloak</span></a>
+			<th><a href="?hardwarea=8&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Cloak</span></a>
 				<?php echo $cloak ?></th>
-			<th align="center"><a href="?hardwarea=9&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Illusion</span></a>
+			<th><a href="?hardwarea=9&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Illusion</span></a>
 				<?php echo $illusion ?></th>
-			<th align="center"><a href="?hardwarea=10&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Jump</span></a>
+			<th><a href="?hardwarea=10&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Jump</span></a>
 				<?php echo $jump ?></th>
-			<th align="center"><a href="?hardwarea=11&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Scrambler</span></a>
+			<th><a href="?hardwarea=11&amp;seq=<?php echo $seq; ?>"><span style="color:#80C870;">Scrambler</span></a>
 				<?php echo $scramble ?></th>
 		</tr><?php
 	$search = array("'", " ", ",", "<", ">", "\"");
@@ -148,7 +148,7 @@ try {
 				$class = 'class="' . $value[0] . '"';
 				$value = $value[1];
 			}
-			echo ('<td align="center" '.$class.'>'.$value.'</td>');
+			echo ('<td '.$class.'>'.$value.'</td>');
 		}
 		echo ('</tr>');
 	} ?>

--- a/htdocs/weapon_list.php
+++ b/htdocs/weapon_list.php
@@ -59,44 +59,44 @@ try {
 	echo ('<div id="main" style="width:810px; margin-left:auto; margin-right:auto;">');
 	echo (buildRaceBox($db));	
 	$db->query('SELECT * FROM weapon_type JOIN race USING(race_id) ORDER BY '.$order_by.' '.$seq);
-	echo ('<table id="table" class="standard">');
+	echo ('<table id="table" class="standard center">');
 	echo ('<tr>');
-	echo ('<th align="center" style="width: 240px;"><a href="?order=weapon_name&amp;seq='.$seq.'"><span style=color:#80C870;>Weapon Name</span></a></th>');
-	echo ('<th align="center" style="width: 90px;"><a href="?order=race_name&amp;seq='.$seq.'"><span style=color:#80C870;>Race</span></a>'.$race.'</th>');
-	echo ('<th align="center" style="width: 64px;"><a href="?order=cost&amp;seq='.$seq.'"><span style=color:#80C870;>Cost</span></a></th>');
-	echo ('<th align="center" style="width: 74px;"><a href="?order=shield_damage&amp;seq='.$seq.'"><span style=color:#80C870;>Shield<br>Damage</span></a></th>');
-	echo ('<th align="center" style="width: 74px;"><a href="?order=armour_damage&amp;seq='.$seq.'"><span style=color:#80C870;>Armour<br>Damage</span></a></th>');
-	echo ('<th align="center" style="width: 85px;"><a href="?order=accuracy&amp;seq='.$seq.'"><span style=color:#80C870;>Accuracy<br>%</span></a></th>');
-	echo ('<th align="center" style="width: 51px;"><a href="?order=power_level&amp;seq='.$seq.'"><span style=color:#80C870;>Level</span></a>'.$power.'</th>');
-	echo ('<th align="center" style="width: 92px;"><a href="?order=buyer_restriction&amp;seq='.$seq.'"><span style=color:#80C870;>Restriction</span></a>'.$restrict.'</th>');
+	echo ('<th style="width: 240px;"><a href="?order=weapon_name&amp;seq='.$seq.'"><span style=color:#80C870;>Weapon Name</span></a></th>');
+	echo ('<th style="width: 90px;"><a href="?order=race_name&amp;seq='.$seq.'"><span style=color:#80C870;>Race</span></a>'.$race.'</th>');
+	echo ('<th style="width: 64px;"><a href="?order=cost&amp;seq='.$seq.'"><span style=color:#80C870;>Cost</span></a></th>');
+	echo ('<th style="width: 74px;"><a href="?order=shield_damage&amp;seq='.$seq.'"><span style=color:#80C870;>Shield<br>Damage</span></a></th>');
+	echo ('<th style="width: 74px;"><a href="?order=armour_damage&amp;seq='.$seq.'"><span style=color:#80C870;>Armour<br>Damage</span></a></th>');
+	echo ('<th style="width: 85px;"><a href="?order=accuracy&amp;seq='.$seq.'"><span style=color:#80C870;>Accuracy<br>%</span></a></th>');
+	echo ('<th style="width: 51px;"><a href="?order=power_level&amp;seq='.$seq.'"><span style=color:#80C870;>Level</span></a>'.$power.'</th>');
+	echo ('<th style="width: 92px;"><a href="?order=buyer_restriction&amp;seq='.$seq.'"><span style=color:#80C870;>Restriction</span></a>'.$restrict.'</th>');
 	echo ('</tr>');
 	while ($db->nextRecord()) {
 		echo ('<tr>');
-		echo ('<td align="center">'.$db->getField('weapon_name').'</td>');
-		echo ('<td align="center" class="race'.$db->getInt('race_id').'">'.$db->getField('race_name').'</td>');
-		echo ('<td align="center">'.number_format($db->getInt('cost')).'</td>');
-		echo ('<td align="center">'.$db->getInt('shield_damage').'</td>');
-		echo ('<td align="center">'.$db->getInt('armour_damage').'</td>');
-		echo ('<td align="center">'.$db->getInt('accuracy').'</td>');
-		echo ('<td align="center">'.$db->getInt('power_level').'</td>');
+		echo ('<td>'.$db->getField('weapon_name').'</td>');
+		echo ('<td class="race'.$db->getInt('race_id').'">'.$db->getField('race_name').'</td>');
+		echo ('<td>'.number_format($db->getInt('cost')).'</td>');
+		echo ('<td>'.$db->getInt('shield_damage').'</td>');
+		echo ('<td>'.$db->getInt('armour_damage').'</td>');
+		echo ('<td>'.$db->getInt('accuracy').'</td>');
+		echo ('<td>'.$db->getInt('power_level').'</td>');
 		switch($db->getInt('buyer_restriction')) {
 			case BUYER_RESTRICTION_GOOD:
-				echo ('<td align="center" style="color: green;">Good</td>');
+				echo ('<td style="color: green;">Good</td>');
 			break;
 			case BUYER_RESTRICTION_EVIL:
-				echo ('<td align="center" style="color: red;">Evil</td>');
+				echo ('<td style="color: red;">Evil</td>');
 			break;
 			case BUYER_RESTRICTION_NEWBIE:
-				echo ('<td align="center" style="color: #06F;">Newbie</td>');
+				echo ('<td style="color: #06F;">Newbie</td>');
 			break;
 			case BUYER_RESTRICTION_PORT:
-				echo ('<td align="center" style="color: yellow;">Port</td>');
+				echo ('<td style="color: yellow;">Port</td>');
 			break;
 			case BUYER_RESTRICTION_PLANET:
-				echo ('<td align="center" style="color: yellow;">Planet</td>');
+				echo ('<td style="color: yellow;">Planet</td>');
 			break;
 			default:
-				echo ('<td align="center">-</td>');
+				echo ('<td>-</td>');
 		}
 		echo ('</tr>');
 	}
@@ -134,7 +134,7 @@ function buildRestriction() {
 }
 
 function buildRaceBox($db) {
-	$racebox = '<form id="raceform" name="raceform" align="center" style="text-align:center;">';
+	$racebox = '<form id="raceform" name="raceform" style="text-align:center;">';
 	$db->query('SELECT race_id, race_name FROM race ORDER BY race_name');
 	while ($db->nextRecord()) {
 		$raceID = $db->getInt('race_id');

--- a/lib/Album/album_functions.php
+++ b/lib/Album/album_functions.php
@@ -96,9 +96,9 @@ function album_entry($album_id) {
 	// get this user's nick
 	$nick = get_album_nick($album_id);
 
-	echo('<table border="0" align="center" cellpadding="5" cellspacing="0">');
+	echo('<table border="0" cellpadding="5" cellspacing="0">');
 	echo('<tr>');
-	echo('<td style="text-align: center;" colspan="2">');
+	echo('<td colspan="2">');
 	echo '<div style="margin-left: auto; margin-right: auto; width: 50%">';
 	echo('<table style="width: 100%">');
 	echo('<tr>');
@@ -109,13 +109,13 @@ function album_entry($album_id) {
 					approved = \'YES\'
 				ORDER BY hof_name DESC
 				LIMIT 1');
-	echo '<td style="text-align: center; width: 30%" valign="middle">';
+	echo '<td class="center" style="width: 30%" valign="middle">';
 	if ($db->nextRecord()) {
 		$priv_nick = $db->getField('hof_name');
 		echo '<a href="?' . urlencode($priv_nick) . '"><img src="/images/album/rew.jpg" alt="'.$priv_nick.'" border="0"></a>&nbsp;&nbsp;&nbsp;';
 	}
 	echo '</td>';
-	echo('<td style="text-align: center;" valign="middle"><span style="font-size:150%;">'.$nick.'</span><br /><span style="font-size:75%;">Views: '.$page_views.'</span></td>');
+	echo('<td class="center" valign="middle"><span style="font-size:150%;">'.$nick.'</span><br /><span style="font-size:75%;">Views: '.$page_views.'</span></td>');
 
 	$db->query('SELECT hof_name
 				FROM album JOIN account USING(account_id)
@@ -123,7 +123,7 @@ function album_entry($album_id) {
 					approved = \'YES\'
 				ORDER BY hof_name
 				LIMIT 1');
-	echo '<td style="text-align: center; width: 30%" valign="middle">';
+	echo '<td class="center" style="width: 30%" valign="middle">';
 	if ($db->nextRecord()) {
 		$next_nick = $db->getField('hof_name');
 		echo '&nbsp;&nbsp;&nbsp;<a href="?' . urlencode($next_nick) . '"><img src="/images/album/fwd.jpg" alt="'.$next_nick.'" border="0"></a>';
@@ -136,7 +136,7 @@ function album_entry($album_id) {
 	echo('</td>');
 	echo('</tr>');
 	echo('<tr>');
-	echo('<td colspan="2" align="center" valign="middle">');
+	echo('<td colspan="2" class="center" valign="middle">');
 
 	if ($disabled == false)
 		echo('<img src="../upload/'.$album_id.'">');
@@ -149,13 +149,13 @@ function album_entry($album_id) {
 	if (empty($location))
 		$location = 'N/A';
 	echo('<tr>');
-	echo('<td align="right" width="10%" style="font-weight:bold;">Location:</td><td>'.$location.'</td>');
+	echo('<td class="right bold" width="10%">Location:</td><td>'.$location.'</td>');
 	echo('</tr>');
 
 	if (empty($email))
 		$email = 'N/A';
 	echo('<tr>');
-	echo('<td align="right" width="10%" style="font-weight:bold;">eMail:</td><td>'.$email.'</td>');
+	echo('<td class="right bold" width="10%">E-mail:</td><td>'.$email.'</td>');
 	echo('</tr>');
 
 	if (empty($website))
@@ -163,7 +163,7 @@ function album_entry($album_id) {
 	else
 		$website = '<a href="'.$website.'" target="_new">'.$website.'</a>';
 	echo('<tr>');
-	echo('<td align="right" width="10%" style="font-weight:bold;">Website:</td><td>'.$website.'</td>');
+	echo('<td class="right bold" width="10%">Website:</td><td>'.$website.'</td>');
 	echo('</tr>');
 
 	echo('<tr>');
@@ -173,13 +173,13 @@ function album_entry($album_id) {
 		$birthdate = 'Year '.$year;
 	if (empty($birthdate))
 		$birthdate = 'N/A';
-	echo('<td align="right" width="10%" style="font-weight:bold;">Birthdate:</td><td>'.$birthdate.'</td>');
+	echo('<td class="right bold" width="10%">Birthdate:</td><td>'.$birthdate.'</td>');
 	echo('</tr>');
 
 	if (empty($other))
 		$other = 'N/A';
 	echo('<tr>');
-	echo('<td align="right" valign="top" width="10%" style="font-weight:bold;">Other&nbsp;Info:<br /><small>(AIM/ICQ)&nbsp;&nbsp;</small></td><td>'.$other.'</td>');
+	echo('<td class="right bold" valign="top" width="10%">Other&nbsp;Info:</td><td>'.$other.'</td>');
 	echo('</tr>');
 
 	echo('<tr>');
@@ -230,12 +230,12 @@ function search_result($album_ids) {
 	// list of all first letter nicks
 	create_link_list();
 
-	echo('<div align="center" style="font-size:125%;">Please make a selection!</div>');
+	echo('<div class="center big">Please make a selection!</div>');
 
-	echo('<table border="0" align="center" cellpadding="5" cellspacing="0">');
+	echo('<table border="0" class="center" cellpadding="5" cellspacing="0">');
 
 	$count = 0;
-	echo('<tr><td width="25%" valign="top">');
+	echo('<tr><td class="left" width="25%" valign="top">');
 
 	foreach ($album_ids as $album_id) {
 		$count++;
@@ -252,7 +252,7 @@ function search_result($album_ids) {
 }
 
 function create_link_list() {
-	echo('<div align="center" style="font-size:80%;">[ ');
+	echo('<div class="center" style="font-size:80%;">[ ');
 	echo('<a href="?%">All</a> | ');
 	echo('<a href="?A">A</a> | ');
 	echo('<a href="?B">B</a> | ');
@@ -280,7 +280,7 @@ function create_link_list() {
 	echo('<a href="?X">X</a> | ');
 	echo('<a href="?Y">Y</a> | ');
 	echo('<a href="?Z">Z</a> ]</div>');
-	echo('<hr align="center">');
+	echo('<hr class="center">');
 }
 
 

--- a/lib/Default/Menu.class.inc
+++ b/lib/Default/Menu.class.inc
@@ -326,9 +326,9 @@ function create_sub_menu($menu, $active_level1, $active_level2) {
 	$return .= ('<td>');
 	$return .= ('<table class="fullwidth">');
 	$return .= ('<tr class="bar1">');
-	$return .= ('<td align="center">');
+	$return .= ('<td>');
 
-	$return .= ('<table>');
+	$return .= ('<table class="center">');
 	$return .= ('<tr>');
 	foreach ($menu as $number => $entry) {
 		// insert spacer
@@ -342,7 +342,7 @@ function create_sub_menu($menu, $active_level1, $active_level2) {
 			$active = '';
 
 		// echo entry itself
-		$return .= ('<td align="center"'.$active.'> ' . $entry['entry'] . '</td>');
+		$return .= ('<td '.$active.'> ' . $entry['entry'] . '</td>');
 
 	}
 	$return .= ('</tr>');

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -90,10 +90,10 @@ function displayHOFRow($rank,$accountID,$amount) {
 	}
 	$bold = '';
 	if ($accountID == $account->getAccountID()) {
-		$bold = ' class="bold"';
+		$bold = 'class="bold"';
 	}
 	$return=('<tr>');
-	$return.=('<td align="center"'.$bold.'>' . $rank . '</td>');
+	$return.=('<td '.$bold.'>' . $rank . '</td>');
 
 	$container = create_container('skeleton.php','hall_of_fame_player_detail.php');
 	$container['account_id'] = $accountID;
@@ -106,15 +106,15 @@ function displayHOFRow($rank,$accountID,$amount) {
 		$container['sending_page'] = 'personal_hof';
 	}
 	if(isset($hofPlayer) && is_object($hofPlayer)) {
-		$return.=('<td align="center"'.$bold.'>'.create_link($container, $hofPlayer->getPlayerName()) .'</td>');
+		$return.=('<td '.$bold.'>'.create_link($container, $hofPlayer->getPlayerName()) .'</td>');
 	}
 	else if(isset($hofAccount) && is_object($hofAccount)) {
-		$return.=('<td align="center"'.$bold.'>'.create_link($container, $hofAccount->getHofName()) .'</td>');
+		$return.=('<td '.$bold.'>'.create_link($container, $hofAccount->getHofName()) .'</td>');
 	}
 	else {
-		$return.=('<td align="center"'.$bold.'>Unknown</td>');
+		$return.=('<td '.$bold.'>Unknown</td>');
 	}
-	$return.=('<td align="center"'.$bold.'>' . $amount . '</td>');
+	$return.=('<td '.$bold.'>' . $amount . '</td>');
 	$return.=('</tr>');
 	return $return;
 }

--- a/templates/Default/admin/Default/account_edit.php
+++ b/templates/Default/admin/Default/account_edit.php
@@ -1,7 +1,7 @@
 <form name="form_acc" method="POST" action="<?php echo $EditFormHREF; ?>">
 	<table cellpadding="3" border="0">
 		<tr>
-			<td align="right" class="bold">Account ID:</td>
+			<td class="right bold">Account ID:</td>
 			<td><?php
 				if(isset($EditingAccount)) {
 					echo $EditingAccount->getAccountID();
@@ -12,7 +12,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td align="right" class="bold">Login:</td>
+			<td class="right bold">Login:</td>
 			<td><?php
 				if(isset($EditingAccount)) {
 					echo $EditingAccount->getLogin();
@@ -23,7 +23,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td align="right" class="bold">Validation Code:</td>
+			<td class="right bold">Validation Code:</td>
 			<td><?php
 				if(isset($EditingAccount)) {
 					echo $EditingAccount->getValidationCode();
@@ -34,7 +34,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td align="right" class="bold">Email:</td>
+			<td class="right bold">Email:</td>
 			<td><?php
 				if(isset($EditingAccount)) {
 					echo $EditingAccount->getEmail();
@@ -45,7 +45,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td align="right" class="bold">HoF Name:</td>
+			<td class="right bold">HoF Name:</td>
 			<td><?php
 				if(isset($EditingAccount)) {
 					echo $EditingAccount->getHofName();
@@ -58,7 +58,7 @@
 
 		if(isset($EditingAccount)) { ?>
 			<tr>
-			<td align="right" class="bold">Points:</td>
+			<td class="right bold">Points:</td>
 			<td><?php echo $EditingAccount->getPoints(); ?></td>
 			</tr>
 			<tr>
@@ -85,7 +85,7 @@
 
 		if(isset($EditingAccount)) { ?>
 			<tr>
-				<td align="right" valign="top" class="bold">Player:</td>
+				<td valign="top" class="right bold">Player:</td>
 					<td><?php
 						if(count($EditingPlayers)) { ?>
 							<a onclick="$('#accountPlayers').fadeToggle(600);">Show/Hide</a>
@@ -93,19 +93,19 @@
 								foreach ($EditingPlayers as $CurrentPlayer) {
 									$CurrentShip = $CurrentPlayer->getShip(); ?>
 									<tr>
-										<td align="right">Game ID:</td>
+										<td class="right">Game ID:</td>
 										<td><?php echo $CurrentPlayer->getGameID(); ?></td>
 									</tr>
 									<tr>
-										<td align="right">Name:</td>
+										<td class="right">Name:</td>
 										<td><input type=text name=player_name[<?php echo $CurrentPlayer->getGameID(); ?>] value="<?php echo $CurrentPlayer->getPlayerName(); ?>" />(<?php echo $CurrentPlayer->getPlayerID(); ?>)</td>
 									</tr>
 									<tr>
-										<td align="right">Experience:</td>
+										<td class="right">Experience:</td>
 										<td><?php echo number_format($CurrentPlayer->getExperience()); ?></td>
 									</tr>
 									<tr>
-										<td align="right">Ship:</td>
+										<td class="right">Ship:</td>
 										<td><?php echo $CurrentShip->getName(); ?> (<?php echo $CurrentShip->getAttackRating(); ?>/<?php echo $CurrentShip->getDefenseRating(); ?>)</td>
 									</tr>
 									<tr>
@@ -127,7 +127,7 @@
 			</tr>
 
 			<tr>
-				<td align="right" valign="top" class="bold">Donation:</td>
+				<td valign="top" class="right bold">Donation:</td>
 				<td><input type="number" name="donation" size="5" class="InputFields center">$</td>
 			</tr>
 			<tr>
@@ -136,7 +136,7 @@
 			</tr>
 
 			<tr>
-				<td align="right" valign="top" class="bold">Grant Reward SMR Credits:</td>
+				<td valign="top" class="right bold">Grant Reward SMR Credits:</td>
 				<td><input type="number" name="grant_credits" size="5" class="InputFields center"> Credits</td>
 			</tr>
 
@@ -146,7 +146,7 @@
 			</tr>
 
 			<tr>
-				<td align="right" valign="top" class="bold">Close Account:</td>
+				<td valign="top" class="right bold">Close Account:</td>
 				<td>
 					<table>
 						<tr>
@@ -193,7 +193,7 @@
 				}
 			</script>
 			<tr>
-				<td align="right" valign="top" class="bold">Ban Points:</td>
+				<td valign="top" class="right bold">Ban Points:</td>
 				<td>
 					<p>
 						<input type="radio" name="choise" value="pre_select">
@@ -242,7 +242,7 @@
 			</tr>
 
 			<tr>
-				<td align="right" valign="top" class="bold">Closing History:</td>
+				<td valign="top" class="right bold">Closing History:</td>
 				<td><?php
 					if(count($ClosingHistory) > 0) {
 						foreach($ClosingHistory as $Action) {
@@ -261,7 +261,7 @@
 			</tr>
 
 			<tr>
-				<td align="right" valign="top" class="bold">Exception:</td>
+				<td valign="top" class="right bold">Exception:</td>
 				<td><?php
 					if (isset($Exception)) {
 						echo $Exception;
@@ -278,7 +278,7 @@
 			</tr>
 
 			<tr>
-				<td align="right" valign="top" class="bold">Forced Veteran:</td>
+				<td valign="top" class="right bold">Forced Veteran:</td>
 				<td><input type="radio" name="veteran_status" value="TRUE"<?php if($EditingAccount->isVeteranForced()) { ?> checked="checked"<?php } ?>>Yes</td>
 			</tr>
 			<tr>
@@ -292,7 +292,7 @@
 			</tr>
 
 			<tr>
-				<td align="right" valign="top" class="bold">Logging:</td>
+				<td valign="top" class="right bold">Logging:</td>
 				<td><input type="radio" name="logging_status" value="TRUE"<?php if($EditingAccount->isLoggingEnabled()) { ?> checked="checked"<?php } ?>>Yes</td>
 			</tr>
 			<tr>
@@ -306,7 +306,7 @@
 			</tr>
 
 			<tr>
-				<td align="right" valign="top" class="bold">Last IP's:</td>
+				<td valign="top" class="right bold">Last IP's:</td>
 				<td><?php
 					if(count($RecentIPs) > 0) { ?>
 						<a onclick="$('#recentIPs').fadeToggle(600);">Show/Hide</a>
@@ -327,11 +327,11 @@
 		}
 		else { ?>
 			<tr>
-				<td align="right" class="bold">Player Name:</td>
+				<td class="right bold">Player Name:</td>
 				<td><input type="text" name="player_name" class="InputFields" size="20"></td>
 			</tr>
 			<tr>
-				<td align="right" class="bold">Game:</td>
+				<td class="right bold">Game:</td>
 				<td>
 					<select name="game_id" size="1" class="InputFields">
 						<option value="0">All Games</option><?php

--- a/templates/Default/admin/Default/album_moderate.php
+++ b/templates/Default/admin/Default/album_moderate.php
@@ -20,7 +20,7 @@ if (empty($Entry)) {
 	<a href="<?php echo $ModerateHREF; ?>">&lt;&lt; Back</a>
 	<table class="nobord" cellpadding="5" cellspacing="0">
 		<tr>
-			<td align="center" colspan="3">
+			<td colspan="3">
 				<span style="font-size:150%;"><b>Album&nbsp;Nickname:</b> <?php echo $Entry['nickname']; ?></span>
 			</td>
 		</tr>

--- a/templates/Default/admin/Default/log_console.php
+++ b/templates/Default/admin/Default/log_console.php
@@ -22,8 +22,8 @@ if (count($LoggedAccounts)>0) { ?>
 			foreach($LoggedAccounts as $LoggedAccount) { ?>
 				<tr>
 					<td valign="top"><?php echo $LoggedAccount['Login']; ?></td>
-					<td valign="top" align="center"><?php echo $LoggedAccount['TotalEntries']; ?></td>
-					<td valign="middle" align="center"><input type="checkbox" name="account_ids[]" value="<?php echo $LoggedAccount['AccountID']; ?>"<?php if($LoggedAccount['Checked']){ ?> checked="checked"<?php } ?>></td>
+					<td valign="top" class="center"><?php echo $LoggedAccount['TotalEntries']; ?></td>
+					<td valign="middle" class="center"><input type="checkbox" name="account_ids[]" value="<?php echo $LoggedAccount['AccountID']; ?>"<?php if($LoggedAccount['Checked']){ ?> checked="checked"<?php } ?>></td>
 					<td><?php echo $LoggedAccount['Notes']; ?></td>
 				</tr><?php
 			} ?>

--- a/templates/Default/engine/Default/album_edit.php
+++ b/templates/Default/engine/Default/album_edit.php
@@ -10,27 +10,27 @@ Your image will be posted under your <i>Hall Of Fame</i> nick!<br />
 <form name="AlbumEditForm" enctype="multipart/form-data" method="POST" action="<?php echo $AlbumEditHref; ?>">
 	<table>
 		<tr>
-			<td align="right" class="bold">Nick:</td>
+			<td class="right bold">Nick:</td>
 			<td><?php echo $ThisAccount->getHofName(); ?></td>
 		</tr>
 		
 		<tr>
-			<td align="right" class="bold">Location:</td>
+			<td class="right bold">Location:</td>
 			<td><input type="text" name="location" class="InputFields" value="<?php if(isset($AlbumEntry)){ echo htmlspecialchars($AlbumEntry['Location']); } else { ?>N/A<?php } ?>" onFocus="javascript:if (this.value == 'N/A') {this.value = '';}" onBlur="javascript:if (this.value == '') {this.value = 'N/A';}"></td>
 		</tr>
 		
 		<tr>
-			<td align="right" class="bold">Email Address:</td>
+			<td class="right bold">Email Address:</td>
 			<td><input type="email" name="email" class="InputFields" value="<?php if(isset($AlbumEntry)){ echo htmlspecialchars($AlbumEntry['Email']); } ?>" style="width:303px;"></td>
 		</tr>
 		
 		<tr>
-			<td align="right" class="bold">Website:</td>
+			<td class="right bold">Website:</td>
 			<td><input type="url" name="website" class="InputFields" style="width:303px;" value="<?php if(isset($AlbumEntry) && $AlbumEntry['Website'] != ''){ echo htmlspecialchars($AlbumEntry['Website']); } ?>"></td>
 		</tr>
 		
 		<tr>
-			<td align="right" class="bold">Birthdate:</td>
+			<td class="right bold">Birthdate:</td>
 			<td>Day:&nbsp;<input type="text" name="month" class="InputFields center" value="<?php if(isset($AlbumEntry)){ echo htmlspecialchars($AlbumEntry['Month']); } else { ?>N/A<?php } ?>" size="3" maxlength="2" onFocus="javascript:if (this.value == 'N/A') {this.value = '';}" onBlur="javascript:if (this.value == '') {this.value = 'N/A';}">&nbsp;&nbsp;&nbsp;
 				Month:&nbsp;<input type="text" name="day" class="InputFields center" value="<?php if(isset($AlbumEntry)){ echo htmlspecialchars($AlbumEntry['Day']); } else { ?>N/A<?php } ?>" size="3" maxlength="2" onFocus="javascript:if (this.value == 'N/A') {this.value = '';}" onBlur="javascript:if (this.value == '') {this.value = 'N/A';}">&nbsp;&nbsp;&nbsp;
 				Year:&nbsp;<input type="text" name="year" class="InputFields center" value="<?php if(isset($AlbumEntry)){ echo htmlspecialchars($AlbumEntry['Year']); } else { ?>N/A<?php } ?>" size="3" maxlength="4" onFocus="javascript:if (this.value == 'N/A') {this.value = '';}" onBlur="javascript:if (this.value == '') {this.value = 'N/A';}">
@@ -38,12 +38,12 @@ Your image will be posted under your <i>Hall Of Fame</i> nick!<br />
 		</tr>
 		
 		<tr>
-			<td align="right" valign="top" class="bold">Other Info:<br /><small>(AIM/ICQ)</small></td>
+			<td valign="top" class="right bold">Other Info:<br /><small>(AIM/ICQ)</small></td>
 			<td><textarea spellcheck="true" name="other" class="InputFields" style="width:303px;height:100px;" onFocus="javascript:if (this.value == 'N/A') {this.value = '';}" onBlur="javascript:if (this.value == '') {this.value = 'N/A';}"><?php if(isset($AlbumEntry)){ echo $AlbumEntry['Other']; } else { ?>N/A<?php } ?></textarea></td>
 		</tr>
 		
 		<tr>
-			<td align="right" valign="top" class="bold">Image:</td>
+			<td valign="top" class="right bold">Image:</td>
 			<td>
 				<?php if(isset($AlbumEntry) && isset($AlbumEntry['Image'])) { ?><img src="<?php echo $AlbumEntry['Image']; ?>"><br /><?php } ?>
 				<input type="file" name="photo" accept="image/jpeg, image/png" class="InputFields" style="width:303px;" >

--- a/templates/Default/engine/Default/alliance_forces.php
+++ b/templates/Default/engine/Default/alliance_forces.php
@@ -5,62 +5,62 @@ if (empty($Forces)) { ?>
 		<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/>
 	</a><?php
 } else { ?>
-	<div align="center">
+	<div class="center">
 		Your alliance currently has <?php echo count($Forces); ?> stacks of forces in the universe.
 		<a href="<?php echo WIKI_URL; ?>/game-guide/forces" target="_blank">
 			<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/>
 		</a>
-		<br /><br />
-
-		<table class="standard">
-			<tr>
-				<th>Number of Force</th>
-				<th>Value</th>
-			</tr>
-			<tr>
-				<td><span class="yellow"><?php echo number_format($Total['Mines']); ?></span> mines</td>
-				<td><span class="creds"><?php echo number_format($TotalCost['Mines']); ?></span> credits</td>
-			</tr>
-			<tr>
-				<td><span class="yellow"><?php echo number_format($Total['CDs']); ?></span> combat drones</td>
-				<td><span class="creds"><?php echo number_format($TotalCost['CDs']); ?></span> credits</td>
-			</tr>
-			<tr>
-				<td><span class="yellow"><?php echo number_format($Total['SDs']); ?></span> scout drones</td>
-				<td><span class="creds"><?php echo number_format($TotalCost['SDs']); ?></span> credits</td>
-			</tr>
-			<tr>
-				<td><span class="yellow bold"><?php echo number_format(array_sum($Total)); ?></span> forces</td>
-				<td><span class="creds bold"><?php echo number_format(array_sum($TotalCost)); ?></span> credits</td>
-			</tr>
-		</table>
-		<br />
-
-		<table id="forces-list" class="standard inset">
-		<thead>
-		<tr>
-			<th class="sort" data-sort="sort_name">Player Name</th>
-			<th class="sort shrink" data-sort="sort_sector">Sector ID</th>
-			<th class="sort shrink" data-sort="sort_cds">Combat Drones</th>
-			<th class="sort shrink" data-sort="sort_sds">Scout Drones</th>
-			<th class="sort shrink" data-sort="sort_mines">Mines</th>
-			<th class="sort shrink" data-sort="sort_expire">Expire Time</th>
-		</tr>
-		</thead>
-
-		<tbody class="list"><?php
-		foreach ($Forces as $Force) { ?>
-			<tr>
-				<td class="sort_name"><?php echo $Force->getOwner()->getLinkedDisplayName(false); ?></td>
-				<td class="sort_sector noWrap"><?php echo $Force->getSectorID(); ?> (<?php echo $Force->getGalaxy()->getName(); ?>)</td>
-				<td class="sort_cds center"><?php echo $Force->getCDs(); ?></td>
-				<td class="sort_sds center"><?php echo $Force->getSDs(); ?></td>
-				<td class="sort_mines center"><?php echo $Force->getMines(); ?></td>
-				<td class="sort_expire noWrap" data-expire="<?php echo $Force->getExpire(); ?>"><?php echo date(DATE_FULL_SHORT, $Force->getExpire()); ?></td>
-			</tr><?php
-		} ?>
-		</table>
 	</div>
+	<br /><br />
+
+	<table class="standard centered">
+		<tr>
+			<th>Number of Force</th>
+			<th>Value</th>
+		</tr>
+		<tr>
+			<td><span class="yellow"><?php echo number_format($Total['Mines']); ?></span> mines</td>
+			<td><span class="creds"><?php echo number_format($TotalCost['Mines']); ?></span> credits</td>
+		</tr>
+		<tr>
+			<td><span class="yellow"><?php echo number_format($Total['CDs']); ?></span> combat drones</td>
+			<td><span class="creds"><?php echo number_format($TotalCost['CDs']); ?></span> credits</td>
+		</tr>
+		<tr>
+			<td><span class="yellow"><?php echo number_format($Total['SDs']); ?></span> scout drones</td>
+			<td><span class="creds"><?php echo number_format($TotalCost['SDs']); ?></span> credits</td>
+		</tr>
+		<tr>
+			<td><span class="yellow bold"><?php echo number_format(array_sum($Total)); ?></span> forces</td>
+			<td><span class="creds bold"><?php echo number_format(array_sum($TotalCost)); ?></span> credits</td>
+		</tr>
+	</table>
+	<br />
+
+	<table id="forces-list" class="standard inset centered">
+	<thead>
+	<tr>
+		<th class="sort" data-sort="sort_name">Player Name</th>
+		<th class="sort shrink" data-sort="sort_sector">Sector ID</th>
+		<th class="sort shrink" data-sort="sort_cds">Combat Drones</th>
+		<th class="sort shrink" data-sort="sort_sds">Scout Drones</th>
+		<th class="sort shrink" data-sort="sort_mines">Mines</th>
+		<th class="sort shrink" data-sort="sort_expire">Expire Time</th>
+	</tr>
+	</thead>
+
+	<tbody class="list"><?php
+	foreach ($Forces as $Force) { ?>
+		<tr>
+			<td class="sort_name"><?php echo $Force->getOwner()->getLinkedDisplayName(false); ?></td>
+			<td class="sort_sector noWrap"><?php echo $Force->getSectorID(); ?> (<?php echo $Force->getGalaxy()->getName(); ?>)</td>
+			<td class="sort_cds center"><?php echo $Force->getCDs(); ?></td>
+			<td class="sort_sds center"><?php echo $Force->getSDs(); ?></td>
+			<td class="sort_mines center"><?php echo $Force->getMines(); ?></td>
+			<td class="sort_expire noWrap" data-expire="<?php echo $Force->getExpire(); ?>"><?php echo date(DATE_FULL_SHORT, $Force->getExpire()); ?></td>
+		</tr><?php
+	} ?>
+	</table>
 
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
 	<script>

--- a/templates/Default/engine/Default/alliance_list.php
+++ b/templates/Default/engine/Default/alliance_list.php
@@ -1,43 +1,47 @@
-<div align="center"><?php
-	if (!$ThisPlayer->hasAlliance()) { ?>
-		<div class="buttonA"><a class="buttonA" href="<?php echo $CreateAllianceHREF; ?>">Create your own alliance!</a></div>
-		<br /><br /><?php
-	}
-	if (count($Alliances) > 0) { ?>
-		<table id="alliance-list" class="standard inset">
-			<thead>
-				<tr>
-					<th class="sort" data-sort="name">Alliance Name</th>
-					<th class="sort shrink" data-sort="totExp">Total Experience</th>
-					<th class="sort shrink" data-sort="avgExp">Average Experience</th>
-					<th class="sort shrink" data-sort="members">Members</th>
-				</tr>
-			</thead>
+<?php
+if (!$ThisPlayer->hasAlliance()) { ?>
+	<div class="buttonA center">
+		<a class="buttonA" href="<?php echo $CreateAllianceHREF; ?>">Create your own alliance!</a>
+	</div>
+	<br /><br /><?php
+}
 
-			<tbody class="list"><?php
-				foreach($Alliances as $AllianceID => $Alliance) { ?>
-					<tr id="alliance-<?php echo $AllianceID; ?>" class="ajax">
-						<td class="name">
-							<a href="<?php echo $Alliance['ViewHREF']; ?>"><?php echo $Alliance['Name']; ?></a>
-						</td>
-						<td class="totExp right"><?php echo number_format($Alliance['TotalExperience']); ?></td>
-						<td class="avgExp right"><?php echo number_format($Alliance['AverageExperience']); ?></td>
-						<td class="members right"><?php echo number_format($Alliance['Members']); ?></td>
-					</tr><?php
-				} ?>
-			</tbody>
-		</table><br />Click column table to reorder!
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-		<script>
-		var list = new List('alliance-list', {
-			valueNames: ['name', 'totExp', 'avgExp', 'members'],
-			sortFunction: function(a, b, options) {
-				return list.utils.naturalSort(a.values()[options.valueName].replace(/<.*?>|,/g,''), b.values()[options.valueName].replace(/<.*?>|,/g,''), options);
-			}
-		});
-		</script><?php
-	}
-	else { ?>
-		Currently there are no alliances.<?php
-	} ?>
-</div>
+if (count($Alliances) > 0) { ?>
+	<table id="alliance-list" class="standard inset centered">
+		<thead>
+			<tr>
+				<th class="sort" data-sort="name">Alliance Name</th>
+				<th class="sort shrink" data-sort="totExp">Total Experience</th>
+				<th class="sort shrink" data-sort="avgExp">Average Experience</th>
+				<th class="sort shrink" data-sort="members">Members</th>
+			</tr>
+		</thead>
+
+		<tbody class="list"><?php
+			foreach($Alliances as $AllianceID => $Alliance) { ?>
+				<tr id="alliance-<?php echo $AllianceID; ?>" class="ajax">
+					<td class="name">
+						<a href="<?php echo $Alliance['ViewHREF']; ?>"><?php echo $Alliance['Name']; ?></a>
+					</td>
+					<td class="totExp right"><?php echo number_format($Alliance['TotalExperience']); ?></td>
+					<td class="avgExp right"><?php echo number_format($Alliance['AverageExperience']); ?></td>
+					<td class="members right"><?php echo number_format($Alliance['Members']); ?></td>
+				</tr><?php
+			} ?>
+		</tbody>
+	</table>
+	<p class="center">Click column table to reorder!</p>
+
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
+	<script>
+	var list = new List('alliance-list', {
+		valueNames: ['name', 'totExp', 'avgExp', 'members'],
+		sortFunction: function(a, b, options) {
+			return list.utils.naturalSort(a.values()[options.valueName].replace(/<.*?>|,/g,''), b.values()[options.valueName].replace(/<.*?>|,/g,''), options);
+		}
+	});
+	</script><?php
+}
+else { ?>
+	<p class="center">Currently there are no alliances.</p><?php
+} ?>

--- a/templates/Default/engine/Default/alliance_message_view.php
+++ b/templates/Default/engine/Default/alliance_message_view.php
@@ -26,10 +26,10 @@ if(	isset($PrevThread) || isset($NextThread) ) { ?>
 } ?>
 
 <h2>Messages</h2>
-<div align="center"><?php
+<div><?php
 	if($Thread['AllianceEyesOnly']) { ?><br />Note: This topic is for alliance eyes only.<?php } ?>
 	<br />
-	<table class="standard inset">
+	<table class="standard inset centered">
 		<tr>
 			<th>Author</th>
 			<th>Message</th>

--- a/templates/Default/engine/Default/alliance_roster.php
+++ b/templates/Default/engine/Default/alliance_roster.php
@@ -5,7 +5,7 @@ if ($ShowRoles && $CanChangeRoles) { ?>
 } ?>
 
 
-<div align="center">
+<div class="center">
 	<div id="alliance-desc" class="ajax"><?php
 		echo bbifyMessage($Alliance->getDescription()); ?>
 	</div><?php
@@ -17,7 +17,7 @@ if ($ShowRoles && $CanChangeRoles) { ?>
 
 	<br />
 
-	<table class="standard inset">
+	<table class="standard inset center">
 		<tr>
 			<th>Alliance Name</th>
 			<th>Total Experience</th>
@@ -25,17 +25,17 @@ if ($ShowRoles && $CanChangeRoles) { ?>
 			<th>Members</th>
 		</tr>
 		<tr id="alliance-info" class="ajax bold">
-			<td><?php echo $Alliance->getAllianceName(); ?></td>
-			<td class="center shrink"><?php echo number_format($AllianceExp); ?></td>
-			<td class="center shrink"><?php echo number_format($AllianceAverageExp); ?></td>
-			<td class="center shrink"><?php echo number_format($Alliance->getNumMembers()); ?></td>
+			<td class="left"><?php echo $Alliance->getAllianceName(); ?></td>
+			<td class="shrink"><?php echo number_format($AllianceExp); ?></td>
+			<td class="shrink"><?php echo number_format($AllianceAverageExp); ?></td>
+			<td class="shrink"><?php echo number_format($Alliance->getNumMembers()); ?></td>
 		</tr>
 	</table>
 	<br />
 
 	<h2>Current Members</h2><br />
 
-	<table id="alliance-roster" class="standard fullwidth">
+	<table id="alliance-roster" class="standard fullwidth center">
 		<thead>
 			<tr>
 				<th class="shrink">&nbsp;</th>
@@ -62,17 +62,17 @@ if ($ShowRoles && $CanChangeRoles) { ?>
 					$Class.= ' newbie';
 				} ?>
 				<tr id="player-<?php echo $AlliancePlayer->getPlayerID(); ?>" class="ajax<?php echo $Class; ?>">
-					<td class="center"><?php
+					<td><?php
 						if ($AlliancePlayer->getAccountID() == $Alliance->getLeaderID()) { ?>*<?php }
 						echo $Count++; ?>
 					</td>
-					<td class="name"><?php
+					<td class="left name"><?php
 						echo $AlliancePlayer->getLevelName(); ?>&nbsp;<?php echo $AlliancePlayer->getLinkedDisplayName(false); ?>
 					</td>
-					<td class="center race"><?php
+					<td class="race"><?php
 						echo $ThisPlayer->getColouredRaceName($AlliancePlayer->getRaceID()); ?>
 					</td>
-					<td class="center experience"><?php
+					<td class="experience"><?php
 						echo number_format($AlliancePlayer->getExperience()); ?>
 					</td><?php
 					if ($ShowRoles) { ?>

--- a/templates/Default/engine/Default/alliance_treaties_confirm.php
+++ b/templates/Default/engine/Default/alliance_treaties_confirm.php
@@ -1,5 +1,5 @@
 <br />
-<div align="center">
+<div class="center">
 	Are you sure you want to offer a treaty to <span class="yellow"><?php echo $AllianceName; ?></span> with the following conditions?
 	<br />
 

--- a/templates/Default/engine/Default/bank_alliance.php
+++ b/templates/Default/engine/Default/bank_alliance.php
@@ -24,9 +24,9 @@ else { ?>
 
 // only if we have at least one result
 if (!empty($BankTransactions)) { ?>
-	<div align="center">
+	<div class="center">
 		<form class="standard" method="POST" action="<?php echo $FilterTransactionsFormHREF; ?>">
-			<table cellspacing="5" cellpadding="0" class="nobord">
+			<table cellspacing="5" cellpadding="0" class="nobord center">
 				<tr>
 					<td>
 						<input class="center" type="number" name="minValue" size="3" value="<?php echo $MinValue; ?>">
@@ -44,7 +44,7 @@ if (!empty($BankTransactions)) { ?>
 		if($CanExempt) {
 			?><form class="standard" method="POST" action="<?php echo $ExemptTransactionsFormHREF; ?>"><?php
 		} ?>
-			<table class="standard inset">
+			<table class="standard inset center">
 				<tr>
 					<th class="shrink">#</th>
 					<th class="shrink">Date</th>
@@ -58,19 +58,19 @@ if (!empty($BankTransactions)) { ?>
 				</tr><?php
 				foreach($BankTransactions as $TransactionID => $BankTransaction) { ?>
 					<tr>
-						<td class="center"><?php echo number_format($TransactionID); ?></td>
-						<td class="center noWrap"><?php echo date(DATE_FULL_SHORT_SPLIT, $BankTransaction['Time']); ?></td>
-						<td><?php
+						<td><?php echo number_format($TransactionID); ?></td>
+						<td class="noWrap"><?php echo date(DATE_FULL_SHORT_SPLIT, $BankTransaction['Time']); ?></td>
+						<td class="left"><?php
 							if($BankTransaction['Exempt']) {
 								?>Alliance Funds c/o<br /><?php
 							}
 							echo $BankTransaction['Player']->getLinkedDisplayName(); ?>
 						</td>
-						<td><?php echo $BankTransaction['Reason']; ?></td>
-						<td class="center"><?php if(is_numeric($BankTransaction['Withdrawal'])){ echo number_format($BankTransaction['Withdrawal']); }else{ ?>&nbsp;<?php } ?></td>
-						<td class="center"><?php if(is_numeric($BankTransaction['Deposit'])){ echo number_format($BankTransaction['Deposit']); }else{ ?>&nbsp;<?php } ?></td><?php
+						<td class="left"><?php echo $BankTransaction['Reason']; ?></td>
+						<td><?php if(is_numeric($BankTransaction['Withdrawal'])){ echo number_format($BankTransaction['Withdrawal']); }else{ ?>&nbsp;<?php } ?></td>
+						<td><?php if(is_numeric($BankTransaction['Deposit'])){ echo number_format($BankTransaction['Deposit']); }else{ ?>&nbsp;<?php } ?></td><?php
 						if ($CanExempt) { ?>
-							<td class="center"><input type="checkbox" name="exempt[<?php echo $TransactionID; ?>]" value="true"<?php if($BankTransaction['Exempt']){ ?> checked="checked"<?php } ?>></td><?php
+							<td><input type="checkbox" name="exempt[<?php echo $TransactionID; ?>]" value="true"<?php if($BankTransaction['Exempt']){ ?> checked="checked"<?php } ?>></td><?php
 						} ?>
 					</tr><?php
 				} ?>
@@ -87,7 +87,7 @@ if (!empty($BankTransactions)) { ?>
 		} ?>
 	</div>
 	
-	<div align="center">
+	<div class="center">
 		<div class="buttonA">
 			<a class="buttonA" href="<?php echo $BankReportHREF; ?>">View Bank Report</a>
 		</div>

--- a/templates/Default/engine/Default/bank_anon.php
+++ b/templates/Default/engine/Default/bank_anon.php
@@ -19,8 +19,7 @@
 <?php
 if ($OwnedAnon) { ?>
 	<br /><h2>Your accounts</h2><br />
-	<div align=center>
-	<table class="standard inset">
+	<table class="standard inset center">
 		<tr>
 			<th>ID</th>
 			<th>Password</th>
@@ -30,8 +29,8 @@ if ($OwnedAnon) { ?>
 		</tr><?php
 		foreach ($OwnedAnon as $anon) { ?>
 			<tr>
-				<td class="shrink center"><?php echo $anon['anon_id']; ?></td>
-				<td><?php echo $anon['password']; ?></td>
+				<td class="shrink"><?php echo $anon['anon_id']; ?></td>
+				<td class="left"><?php echo $anon['password']; ?></td>
 				<td class="shrink noWrap"><?php echo $anon['last_transaction']; ?></td>
 				<td class="right shrink"><?php echo $anon['amount']; ?></td>
 				<td class="button">
@@ -42,7 +41,6 @@ if ($OwnedAnon) { ?>
 			</tr><?php
 		} ?>
 	</table>
-	</div>
 	<br /><br /><?php
 } ?>
 

--- a/templates/Default/engine/Default/buy_message_notifications.php
+++ b/templates/Default/engine/Default/buy_message_notifications.php
@@ -21,7 +21,7 @@ if (isset($MessageBoxes)) { ?>
 				<td>
 					<?php echo $MessageBox['Name']; ?>
 				</td>
-				<td align="center" class="yellow"><?php echo $MessageBox['MessagesRemaining']; ?></td>
+				<td class="center yellow"><?php echo $MessageBox['MessagesRemaining']; ?></td>
 				<td>
 					<div class="buttonA">
 						<a class="buttonA" href="<?php echo $MessageBox['BuyHref']; ?>">Buy <?php echo $MessageBox['MessagesPerCredit']; ?> Messages (1 SMR Credit)</a>

--- a/templates/Default/engine/Default/buy_ship_name.php
+++ b/templates/Default/engine/Default/buy_ship_name.php
@@ -1,6 +1,6 @@
-<div align="center"><?php
+<div class="center"><?php
 	if(isset($Preview)) { ?>
-		<div align="center">If you ship is found to use HTML inappropriately you may be banned.
+		<div class="center">If you ship is found to use HTML inappropriately you may be banned.
 		  Inappropriate HTML includes but is not limited to something that can either cause display errors or cause functionality of the game to stop.  Also it is your responsibility to make sure ALL HTML tags that need to be closed are closed!<br />
 			Preview:<br />
 			<?php echo $Preview; ?>

--- a/templates/Default/engine/Default/combat_log_list.php
+++ b/templates/Default/engine/Default/combat_log_list.php
@@ -3,7 +3,7 @@ if(isset($Message)) {?>
 	<div class="center"><?php echo $Message; ?></div><br /><?php
 } ?>
 
-<div align="center"><?php
+<div class="center"><?php
 	$NumLogs = count($Logs);
 	if($NumLogs > 0) { ?>
 		There <span id="total-logs"><?php echo pluralise('is', $TotalLogs), ' ', $TotalLogs, ' ', $LogType, pluralise(' log', $NumLogs); ?></span> available for viewing of which <?php echo $NumLogs, ' ', pluralise('is', $NumLogs); ?> being shown.<br /><br />
@@ -32,7 +32,7 @@ if(isset($Message)) {?>
 				</tr>
 			</table>
 			<br /><br />
-			<table id="logs-list" class="standard fullwidth">
+			<table id="logs-list" class="standard inset centered">
 				<thead>
 					<tr>
 						<th class="shrink">View</th>

--- a/templates/Default/engine/Default/council_embassy.php
+++ b/templates/Default/engine/Default/council_embassy.php
@@ -1,4 +1,4 @@
-<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
+<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank"><img style="float: right;" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
 <div class="center bold">Diplomatic Treaties</div><br />
 <div class="center standard">
 	Welcome President <?php echo $ThisPlayer->getDisplayName(); ?>,<br /><br />
@@ -13,8 +13,8 @@
 
 	foreach($VoteRaceHrefs as $RaceID => $FormHref) { ?>
 		<tr>
-			<td align="center"><img src="<?php echo Globals::getRaceHeadImage($RaceID); ?>" width="60" height="64" /><br /><a href="<?php echo Globals::getCouncilHREF($RaceID); ?>"><?php echo $ThisPlayer->getColouredRaceName($RaceID); ?></a></td>
-			<td align="center">
+			<td><img src="<?php echo Globals::getRaceHeadImage($RaceID); ?>" width="60" height="64" /><br /><a href="<?php echo Globals::getCouncilHREF($RaceID); ?>"><?php echo $ThisPlayer->getColouredRaceName($RaceID); ?></a></td>
+			<td>
 				<form method="POST" action="<?php echo $FormHref; ?>">
 					<input type="submit" name="action" value="Peace" class="InputFields" />
 					&nbsp;

--- a/templates/Default/engine/Default/council_list.php
+++ b/templates/Default/engine/Default/council_list.php
@@ -1,10 +1,10 @@
-<div align="center">
-	<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
+<div class="center">
+	<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank"><img style="float: right;" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
 	<h3>President</h3><br/><?php
 	$PresidentID = Council::getPresidentID($ThisPlayer->getGameID(), $RaceID);
 	if ($PresidentID !== false) {
 		$President = SmrPlayer::getPlayer($PresidentID, $ThisPlayer->getGameID()); ?>
-		<table class="standard" width="75%">
+		<table class="center standard" width="75%">
 			<thead>
 				<tr>
 					<th>Name</th>
@@ -15,8 +15,8 @@
 			</thead>
 			<tbody id="president" class="ajax">
 				<tr>
-					<td>President <?php echo $President->getLinkedDisplayName(false); ?></td>
-					<td class="center"><?php echo $ThisPlayer->getColouredRaceName($President->getRaceID(), true); ?></td>
+					<td class="left">President <?php echo $President->getLinkedDisplayName(false); ?></td>
+					<td><?php echo $ThisPlayer->getColouredRaceName($President->getRaceID(), true); ?></td>
 					<td><?php echo $President->getAllianceName(true); ?></td>
 					<td class="right"><?php echo number_format($President->getExperience()); ?></td>
 				</tr>
@@ -33,7 +33,7 @@
 	<h3>Council Members</h3><br /><?php
 	$CouncilMembers = Council::getRaceCouncil($ThisPlayer->getGameID(), $RaceID);
 	if(count($CouncilMembers) > 0) { ?>
-		<table id="council-members" class="standard" width="85%">
+		<table id="council-members" class="center standard" width="85%">
 			<thead>
 				<tr>
 					<th>&nbsp;</th>
@@ -47,9 +47,9 @@
 				foreach($CouncilMembers as $Ranking => $AccountID) {
 					$CouncilPlayer = SmrPlayer::getPlayer($AccountID, $ThisPlayer->getGameID()); ?>
 					<tr id="player-<?php echo $CouncilPlayer->getPlayerID(); ?>" class="ajax<?php if ($ThisPlayer->equals($CouncilPlayer)) { ?> bold<?php } ?>">
-						<td class="right"><?php echo $Ranking; ?></td>
-						<td class="name"><?php echo $CouncilPlayer->getLevelName(); ?> <?php echo $CouncilPlayer->getLinkedDisplayName(false); ?></td>
-						<td class="center"><?php echo $ThisPlayer->getColouredRaceName($CouncilPlayer->getRaceID(), true); ?></td>
+						<td><?php echo $Ranking; ?></td>
+						<td class="left name"><?php echo $CouncilPlayer->getLevelName(); ?> <?php echo $CouncilPlayer->getLinkedDisplayName(false); ?></td>
+						<td><?php echo $ThisPlayer->getColouredRaceName($CouncilPlayer->getRaceID(), true); ?></td>
 						<td class="alliance"><?php echo $CouncilPlayer->getAllianceName(true); ?></td>
 						<td class="experience right"><?php echo number_format($CouncilPlayer->getExperience()); ?></td>
 					</tr><?php

--- a/templates/Default/engine/Default/council_politics.php
+++ b/templates/Default/engine/Default/council_politics.php
@@ -1,4 +1,4 @@
-<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
+<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank"><img style="float: right;" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
 <div class="center">
 	<p>We currently have the following diplomatic relationships:</p>
 	<table class="center">

--- a/templates/Default/engine/Default/council_vote.php
+++ b/templates/Default/engine/Default/council_vote.php
@@ -1,4 +1,4 @@
-<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
+<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank"><img style="float: right;" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Politics"/></a>
 
 <div class="center bold">Diplomatic Treaties</div><br />
 <div class="center">
@@ -12,7 +12,7 @@ if (!$VoteTreaties) { ?>
 	<div class="center"><i>There are no treaties to vote on at this time.</i></div>
 <?php
 } else { ?>
-	<table class="standard" align="center" width="65%">
+	<table class="standard center" width="65%">
 		<tr>
 			<th>Race</th>
 			<th>Treaty</th>
@@ -23,9 +23,9 @@ if (!$VoteTreaties) { ?>
 
 	foreach($VoteTreaties as $RaceID => $VoteInfo) { ?>
 		<tr>
-			<td align="center"><a href="<?php echo Globals::getCouncilHREF($RaceID); ?>"><?php echo $ThisPlayer->getColouredRaceName($RaceID); ?></a></td>
-			<td align="center"><?php echo $VoteInfo['Type']; ?></td>
-			<td class="noWrap" align="center">
+			<td><a href="<?php echo Globals::getCouncilHREF($RaceID); ?>"><?php echo $ThisPlayer->getColouredRaceName($RaceID); ?></a></td>
+			<td><?php echo $VoteInfo['Type']; ?></td>
+			<td class="noWrap">
 				<form method="POST" action="<?php echo $VoteInfo['HREF']; ?>">
 					<input type="submit" name="action" value="Yes" class="InputFields"<?php if($VoteInfo['For']){ ?> style="background-color:green"<?php } ?> />
 					&nbsp;
@@ -36,8 +36,8 @@ if (!$VoteTreaties) { ?>
 					} ?>
 				</form>
 			</td>
-			<td align="center"><?php echo $VoteInfo['YesVotes']; ?> / <?php echo $VoteInfo['NoVotes']; ?></td>
-			<td class="noWrap" align="center"><?php echo date(DATE_FULL_SHORT_SPLIT, $VoteInfo['EndTime']); ?></td>
+			<td><?php echo $VoteInfo['YesVotes']; ?> / <?php echo $VoteInfo['NoVotes']; ?></td>
+			<td class="noWrap"><?php echo date(DATE_FULL_SHORT_SPLIT, $VoteInfo['EndTime']); ?></td>
 		</tr><?php
 	} ?>
 	</table><?php
@@ -53,7 +53,7 @@ if (!$VoteTreaties) { ?>
 	Results are updated at 00:00 daily.
 </div><br />
 
-<table class="standard" align="center" width="75%">
+<table class="standard center" width="75%">
 	<tr>
 		<th>Race</th>
 		<th>Vote</th>
@@ -62,20 +62,20 @@ if (!$VoteTreaties) { ?>
 
 	foreach($VoteRelations as $RaceID => $VoteInfo) { ?>
 		<tr>
-			<td align="center">
+			<td>
 				<a href="<?php echo Globals::getCouncilHREF($RaceID); ?>">
 					<img src="<?php echo Globals::getRaceHeadImage($RaceID); ?>" width="60" height="64" /><br /><?php
 					echo $ThisPlayer->getColouredRaceName($RaceID); ?>
 				</a>
 			</td>
-			<td align="center">
+			<td>
 				<form method="POST" action="<?php echo $VoteInfo['HREF']; ?>">
 					<input type="submit" name="action" value="Increase" class="InputFields"<?php if($VoteInfo['Increased']){ ?> style="background-color:green"<?php } ?> />
 					&nbsp;
 					<input type="submit" name="action" value="Decrease" class="InputFields"<?php if($VoteInfo['Decreased']){ ?> style="background-color:green"<?php } ?> />
 				</form>
 			</td>
-			<td align="center"><?php echo get_colored_text($VoteInfo['Relations']); ?></td>
+			<td><?php echo get_colored_text($VoteInfo['Relations']); ?></td>
 		</tr><?php
 	} ?>
 </table>

--- a/templates/Default/engine/Default/course_plot.php
+++ b/templates/Default/engine/Default/course_plot.php
@@ -1,4 +1,4 @@
-<a href="<?php echo WIKI_URL; ?>/game-guide/how-your-ship-works" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: How Your Ship Works"/></a>
+<a href="<?php echo WIKI_URL; ?>/game-guide/how-your-ship-works" target="_blank"><img style="float: right;" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: How Your Ship Works"/></a>
 <form class="standard" id="PlotCourseForm" method="POST" action="<?php echo $PlotCourseFormLink; ?>">
 	<h2>Conventional</h2>
 	<div class="standard">Enter a destination sector.</div>

--- a/templates/Default/engine/Default/current_players.php
+++ b/templates/Default/engine/Default/current_players.php
@@ -1,5 +1,5 @@
 <br />
-<div align="center">
+<div class="center">
 	<?php echo $Summary; ?>
 	<br /><br />
 
@@ -10,7 +10,7 @@
 
 	<?php
 	if (!empty($AllRows)) { ?>
-		<table id="cpl" class="standard" width="95%">
+		<table id="cpl" class="center standard" width="95%">
 			<thead>
 				<tr>
 					<th class="sort" data-sort="sort_name">Player</th>
@@ -23,8 +23,8 @@
 			<tbody class="list"><?php
 				foreach ($AllRows as $Row) { ?>
 					<tr <?php echo $Row['tr_class']; ?>>
-						<td class="sort_name" data-name="<?php echo strip_tags($Row['player']->getPlayerName()); ?>" valign="top"><?php echo $Row['name_link']; ?></td>
-						<td class="sort_race center">
+						<td class="sort_name left" data-name="<?php echo strip_tags($Row['player']->getPlayerName()); ?>" valign="top"><?php echo $Row['name_link']; ?></td>
+						<td class="sort_race">
 							<?php echo $ThisPlayer->getColouredRaceName($Row['player']->getRaceID(), true); ?>
 						</td>
 						<td class="sort_alliance"><?php echo $Row['player']->getAllianceName(true); ?></td>

--- a/templates/Default/engine/Default/feature_request.php
+++ b/templates/Default/engine/Default/feature_request.php
@@ -18,7 +18,7 @@
 <?php
 if(isset($FeatureRequests)) { ?>
 	<form name="FeatureRequestVoteForm" method="POST" action="<?php echo $FeatureRequestVoteFormHREF; ?>">
-		<div align="right"><?php
+		<div class="right"><?php
 			if ($CanVote) { ?>
 				<input type="submit" name="action" value="Vote"><?php
 			} ?>
@@ -54,12 +54,12 @@ if(isset($FeatureRequests)) { ?>
 						<td><input type="radio" name="vote[<?php echo $FeatureRequest['RequestID']; ?>]" value="NO"<?php if($FeatureRequest['VotedFor'] == 'NO') { ?> checked="checked"<?php } ?>></td><?php
 					}
 					if($FeatureModerator) {
-						?><td valign="middle" align="center"><input type="checkbox" name="set_status_ids[]" value="<?php echo $FeatureRequest['RequestID']; ?>"></td><?php
+						?><td valign="middle" class="center"><input type="checkbox" name="set_status_ids[]" value="<?php echo $FeatureRequest['RequestID']; ?>"></td><?php
 					} ?>
 				</tr><?php
 			} ?>
 		</table>
-		<div align="right"><?php
+		<div class="right"><?php
 			if($FeatureModerator) { ?>&nbsp;
 				<select name="status">
 					<option disabled selected value style="display:none"> -- Select Status -- </option>
@@ -81,16 +81,16 @@ if(isset($FeatureRequests)) { ?>
 <form name="FeatureRequestForm" method="POST" action="<?php echo $FeatureRequestFormHREF; ?>">
 	<table>
 		<tr>
-			<td align="center">Please describe your requested feature here:</td>
+			<td class="center">Please describe your requested feature here:</td>
 		</tr>
 		<tr>
-			<td align="center"><textarea spellcheck="true" name="feature" class="InputFields" maxlength="500"></textarea></td>
+			<td class="center"><textarea spellcheck="true" name="feature" class="InputFields" maxlength="500"></textarea></td>
 		</tr>
 		<tr>
-			<td align="center">Anonymous: <input name="anon" class="InputFields" type="checkbox" checked="checked"/></td>
+			<td class="center">Anonymous: <input name="anon" class="InputFields" type="checkbox" checked="checked"/></td>
 		</tr>
 		<tr>
-			<td align="center"><input type="submit" name="action" value="Submit New Feature" class="InputFields"></td>
+			<td class="center"><input type="submit" name="action" value="Submit New Feature" class="InputFields"></td>
 		</tr>
 	</table>
 </form>

--- a/templates/Default/engine/Default/feature_request_comments.php
+++ b/templates/Default/engine/Default/feature_request_comments.php
@@ -27,7 +27,7 @@ if(isset($Comments)) { ?>
 
 if ($FeatureModerator) { ?>
 	<form name="FeatureRequestStatusForm" method="POST" action="<?php echo $FeatureRequestStatusFormHREF; ?>">
-		<div align="right">&nbsp;
+		<div class="right">&nbsp;
 			<select name="status">
 				<option disabled selected value style="display:none"> -- Select Status -- </option>
 				<option value="Accepted">Accepted</option>
@@ -38,23 +38,24 @@ if ($FeatureModerator) { ?>
 			</select>&nbsp;
 			<input type="hidden" name="set_status_ids[]" value="<?php echo $FeatureRequestId; ?>" />
 			<input type="submit" name="action" value="Set Status" />
-		</div><br />
+		</div>
 	</form><?php
 } ?>
 
+<br />
 <form name="FeatureRequestCommentForm" method="POST" action="<?php echo $FeatureRequestCommentFormHREF; ?>">
 	<table>
 		<tr>
-			<td align="center">Comment:</td>
+			<td class="center">Comment:</td>
 		</tr>
 		<tr>
-			<td align="center"><textarea spellcheck="true" name="comment" class="InputFields"></textarea></td>
+			<td class="center"><textarea spellcheck="true" name="comment" class="InputFields"></textarea></td>
 		</tr>
 		<tr>
-			<td align="center">Anonymous: <input name="anon" class="InputFields" type="checkbox" checked="checked"/></td>
+			<td class="center">Anonymous: <input name="anon" class="InputFields" type="checkbox" checked="checked"/></td>
 		</tr>
 		<tr>
-			<td align="center"><input type="submit" name="action" value="Add Comment" class="InputFields"></td>
+			<td class="center"><input type="submit" name="action" value="Add Comment" class="InputFields"></td>
 		</tr>
 	</table>
 </form>

--- a/templates/Default/engine/Default/forces_attack.php
+++ b/templates/Default/engine/Default/forces_attack.php
@@ -1,11 +1,9 @@
 <?php $this->includeTemplate('includes/ForceFullCombatResults.inc'); ?><br />
 <br />
-<div align="center"><?php
+<div class="center"><?php
 	if(isset($Target)) { ?>
-		<div style="width:50%">
-			<div class="buttonA">
-				<a href="<?php echo $Target->getAttackForcesHREF() ?>" class="buttonA">Continue Attack (<?php echo $Target->getAttackTurnCost($ThisShip); ?>)</a>
-			</div>
+		<div class="buttonA">
+			<a href="<?php echo $Target->getAttackForcesHREF() ?>" class="buttonA">Continue Attack (<?php echo $Target->getAttackTurnCost($ThisShip); ?>)</a>
 		</div><?php
 	}
 	else {

--- a/templates/Default/engine/Default/forces_list.php
+++ b/templates/Default/engine/Default/forces_list.php
@@ -5,11 +5,10 @@ if (empty($Forces)) { ?>
 		<img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/>
 	</a><?php
 } else { ?>
+	<a href="<?php echo WIKI_URL; ?>/game-guide/forces" target="_blank">
+		<img style="float: right;" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/>
+	</a><br />
 	<table id="forces-list" class="standard inset">
-		<a href="<?php echo WIKI_URL; ?>/game-guide/forces" target="_blank">
-			<img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Forces"/>
-		</a><br />
-
 		<thead>
 		<tr>
 			<th class="sort shrink" data-sort="sort_sector">Sector ID</th>

--- a/templates/Default/engine/Default/galactic_post_read.php
+++ b/templates/Default/engine/Default/galactic_post_read.php
@@ -12,7 +12,7 @@ if (empty($ArticleLayout)) { ?>
 				foreach ($Columns as $Column) { ?>
 					<td class="center top" width=50%>
 						<font size="6"><?php echo bbifyMessage($Column['title']); ?></font><br /><br />
-						<div align="justify"><?php echo bbifyMessage($Column['text']); ?></div><br /><br />
+						<div style="text-align: justify;"><?php echo bbifyMessage($Column['text']); ?></div><br /><br />
 					</td><?php
 				} ?>
 			</tr><?php

--- a/templates/Default/engine/Default/game_join.php
+++ b/templates/Default/engine/Default/game_join.php
@@ -90,12 +90,12 @@ if ($Game->getDescription()) { ?>
 				<p>Now it is time for you to create your Trader and begin your quest for riches, fame and glory! Where will your destiny take you?</p>
 				<table>
 					<tr>
-						<td align="right"><b>Name:</b>&nbsp;</td>
+						<td class="right"><b>Name:</b>&nbsp;</td>
 						<td><input type="text" name="player_name" maxlength="32" class="InputFields"<?php if(!isset($JoinGameFormHref)){ ?>disabled="disabled"<?php } ?>></td>
 						<td rowspan="4" class="standard"><img id="race_image" name="race_image" src="images/race/race1.gif" alt="Please select a race."></td>
 					</tr>
 					<tr>
-						<td align="right"><b>Race:</b>&nbsp;</td>
+						<td class="right"><b>Race:</b>&nbsp;</td>
 						<td>
 						<select name="race_id" class="InputFields" size="1" OnChange="go();">
 							<?php /*<option value="1">[please select]</option> */
@@ -107,7 +107,7 @@ if ($Game->getDescription()) { ?>
 					</tr>
 					
 					<tr>
-						<td align="right">&nbsp;</td>
+						<td>&nbsp;</td>
 						<td><?php
 						if(isset($JoinGameFormHref)) {
 							?><input type="submit" name="action" value="Create Player" class="InputFields" /><?php
@@ -129,21 +129,20 @@ if ($Game->getDescription()) { ?>
 		</tr>
 
 		<tr>
-			<td align=center>
-				<table>
+			<td>
+				<table class="center">
 					<tr>
-						<td align=center colspan=4 class="center">Trading</td>
+						<td colspan="3">Trading</td>
 					</tr>
 					<tr>
-						<td align=left>Combat<br />
-						Strength</td>
-						<td align=center colspan=2>
-							<img width="440" height="440" border="0" name="graph" id="graphframe" src="images/race/graph/graph1.gif" alt="Race overview" />
+						<td>Combat<br />Strength</td>
+						<td>
+							<img width="440" height="440" border="0" id="graphframe" src="images/race/graph/graph1.gif" alt="Race overview" />
 						</td>
-						<td align=right>Hunting</td>
+						<td>Hunting</td>
 					</tr>
 					<tr>
-						<td align=center colspan=4 class="center">Utility</td>
+						<td colspan="3">Utility</td>
 					</tr>
 				</table>
 			</td>

--- a/templates/Default/engine/Default/game_stats.php
+++ b/templates/Default/engine/Default/game_stats.php
@@ -2,112 +2,118 @@
 <?php echo $StatsGame->getDescription(); ?>
 <br /><br />
 
-<div align="center">
-	<table class="standard">
+<div class="center">
+	<table class="center standard">
 		<tr>
-			<td align="center">General Info</td>
-			<td align="center">Other Info</td>
+			<td>General Info</td>
+			<td>Other Info</td>
 		</tr>
 		<tr>
-			<td valign="top" align="center">
+			<td valign="top" class="left">
 				<table class="nobord">
 					<tr>
-						<td align="right">Name</td>
+						<td class="right">Name</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo $StatsGame->getName(); ?></td>
+						<td><?php echo $StatsGame->getName(); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Start Date</td>
+						<td class="right">Start Date</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo date(DATE_FULL_SHORT, $StatsGame->getStartDate()); ?></td>
+						<td><?php echo date(DATE_FULL_SHORT, $StatsGame->getStartDate()); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Start Turns Date</td>
+						<td class="right">Start Turns Date</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo date(DATE_FULL_SHORT, $StatsGame->getStartTurnsDate()); ?></td>
+						<td><?php echo date(DATE_FULL_SHORT, $StatsGame->getStartTurnsDate()); ?></td>
 					</tr>
 					<tr>
-						<td align="right">End Date</td>
+						<td class="right">End Date</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo date(DATE_FULL_SHORT, $StatsGame->getEndDate()); ?></td>
+						<td><?php echo date(DATE_FULL_SHORT, $StatsGame->getEndDate()); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Max Turns</td>
+						<td class="right">Max Turns</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo number_format($StatsGame->getMaxTurns()); ?></td>
+						<td><?php echo number_format($StatsGame->getMaxTurns()); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Start Turn Hours</td>
+						<td class="right">Start Turn Hours</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo number_format($StatsGame->getStartTurnHours()); ?></td>
+						<td><?php echo number_format($StatsGame->getStartTurnHours()); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Max Players</td>
+						<td class="right">Max Players</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo number_format($StatsGame->getMaxPlayers()); ?></td>
+						<td><?php echo number_format($StatsGame->getMaxPlayers()); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Alliance Max Players</td>
+						<td class="right">Alliance Max Players</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo number_format($StatsGame->getAllianceMaxPlayers()); ?></td>
+						<td><?php echo number_format($StatsGame->getAllianceMaxPlayers()); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Alliance Max Vets</td>
+						<td class="right">Alliance Max Vets</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo number_format($StatsGame->getAllianceMaxVets()); ?></td>
+						<td><?php echo number_format($StatsGame->getAllianceMaxVets()); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Game Type</td>
+						<td class="right">Game Type</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo $StatsGame->getGameType(); ?></td>
+						<td><?php echo $StatsGame->getGameType(); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Game Speed</td>
+						<td class="right">Game Speed</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo $StatsGame->getGameSpeed(); ?></td>
+						<td><?php echo $StatsGame->getGameSpeed(); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Credits Needed</td>
+						<td class="right">Credits Needed</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo number_format($StatsGame->getCreditsNeeded()); ?></td>
+						<td><?php echo number_format($StatsGame->getCreditsNeeded()); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Stats Ignored</td>
+						<td class="right">Stats Ignored</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo $StatsGame->isIgnoreStats()?'Yes':'No'; ?></td>
+						<td><?php echo $StatsGame->isIgnoreStats()?'Yes':'No'; ?></td>
 					</tr>
 					<tr>
-						<td align="right">Starting Credits</td>
+						<td class="right">Starting Credits</td>
 						<td>&nbsp;</td>
-						<td align="left"><?php echo number_format($StatsGame->getStartingCredits()); ?></td>
+						<td><?php echo number_format($StatsGame->getStartingCredits()); ?></td>
 					</tr>
 				</table>
 			</td>
-			<td valign="top" align="center">
+			<td valign="top" class="left">
 				<table class="nobord">
 					<tr>
-						<td align="right">Total Players</td>
-						<td>&nbsp;</td><td align="left"><?php echo number_format($TotalPlayers); ?></td>
+						<td class="right">Total Players</td>
+						<td>&nbsp;</td>
+						<td><?php echo number_format($TotalPlayers); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Alliances</td>
-						<td>&nbsp;</td><td align="left"><?php echo number_format($TotalAlliances); ?></td>
+						<td class="right">Alliances</td>
+						<td>&nbsp;</td>
+						<td><?php echo number_format($TotalAlliances); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Highest Experience</td>
-						<td>&nbsp;</td><td align="left"><?php echo number_format($HighestExp); ?></td>
+						<td class="right">Highest Experience</td>
+						<td>&nbsp;</td>
+						<td><?php echo number_format($HighestExp); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Highest Alignment</td>
-						<td>&nbsp;</td><td align="left"><?php echo number_format($HighestAlign); ?></td>
+						<td class="right">Highest Alignment</td>
+						<td>&nbsp;</td>
+						<td><?php echo number_format($HighestAlign); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Lowest Alignment</td>
-						<td>&nbsp;</td><td align="left"><?php echo number_format($LowestAlign); ?></td>
+						<td class="right">Lowest Alignment</td>
+						<td>&nbsp;</td>
+						<td><?php echo number_format($LowestAlign); ?></td>
 					</tr>
 					<tr>
-						<td align="right">Highest Kills</td>
-						<td>&nbsp;</td><td align="left"><?php echo number_format($HighestKills); ?></td>
+						<td class="right">Highest Kills</td>
+						<td>&nbsp;</td>
+						<td><?php echo number_format($HighestKills); ?></td>
 					</tr>
 				</table>
 			</td>
@@ -115,43 +121,43 @@
 	</table>
 	<br />
 
-	<table class="standard">
+	<table class="center standard">
 		<tr>
-			<td align="center">Top 10 Players in Experience</td>
-			<td align="center">Top 10 Players in Kills</td>
+			<td>Top 10 Players in Experience</td>
+			<td>Top 10 Players in Kills</td>
 		</tr>
 		<tr>
-			<td class="center" style="border:none"><?php
+			<td><?php
 				if(isset($ExperienceRankings)) { ?>
 					<table class="nobord">
 						<tr>
-							<th align="center">Rank</th>
-							<th align="center">Player</th>
-							<th align="center">Experience</th>
+							<th>Rank</th>
+							<th>Player</th>
+							<th>Experience</th>
 						</tr><?php
 						foreach ($ExperienceRankings as $Rank => $RankedPlayer) { ?>
 							<tr>
-								<td align="center"><?php echo $Rank; ?></td>
-								<td align="center"><?php echo $RankedPlayer->getPlayerName(); ?></td>
-								<td align="center"><?php echo number_format($RankedPlayer->getExperience()); ?></td>
+								<td><?php echo $Rank; ?></td>
+								<td><?php echo $RankedPlayer->getPlayerName(); ?></td>
+								<td><?php echo number_format($RankedPlayer->getExperience()); ?></td>
 							</tr><?php
 						} ?>
 					</table><?php
 				} ?>
 			</td>
-			<td align="center"><?php
+			<td><?php
 				if(isset($KillRankings)) { ?>
 					<table class="nobord">
 						<tr>
-							<th align="center">Rank</th>
-							<th align="center">Player</th>
-							<th align="center">Kills</th>
+							<th>Rank</th>
+							<th>Player</th>
+							<th>Kills</th>
 						</tr><?php
 						foreach ($KillRankings as $Rank => $RankedPlayer) { ?>
 							<tr>
-								<td align="center"><?php echo $Rank; ?></td>
-								<td align="center"><?php echo $RankedPlayer->getPlayerName(); ?></td>
-								<td align="center"><?php echo number_format($RankedPlayer->getKills()); ?></td>
+								<td><?php echo $Rank; ?></td>
+								<td><?php echo $RankedPlayer->getPlayerName(); ?></td>
+								<td><?php echo number_format($RankedPlayer->getKills()); ?></td>
 							</tr><?php
 						} ?>
 					</table><?php
@@ -161,43 +167,43 @@
 	</table>
 	<br />
 
-	<table class="standard">
+	<table class="center standard">
 		<tr>
-			<td align="center">Top 10 Alliances in Experience</td>
-			<td align="center">Top 10 Alliances in Kills</td>
+			<td>Top 10 Alliances in Experience</td>
+			<td>Top 10 Alliances in Kills</td>
 		</tr>
 		<tr>
-			<td class="center" style="border:none"><?php
+			<td><?php
 				if (isset($AllianceExpRankings)) { ?>
 					<table class="nobord">
 						<tr>
-							<th align="center">Rank</th>
-							<th align="center">Alliance</th>
-							<th align="center">Experience</th>
+							<th>Rank</th>
+							<th>Alliance</th>
+							<th>Experience</th>
 						</tr><?php
 						foreach ($AllianceExpRankings as $Rank => $RankedAlliance) { ?>
 							<tr>
-								<td align="center"><?php echo $Rank; ?></td>
-								<td align="center"><?php echo $RankedAlliance['Alliance']->getAllianceName(); ?></td>
-								<td align="center"><?php echo number_format($RankedAlliance['Amount']); ?></td>
+								<td><?php echo $Rank; ?></td>
+								<td><?php echo $RankedAlliance['Alliance']->getAllianceName(); ?></td>
+								<td><?php echo number_format($RankedAlliance['Amount']); ?></td>
 							</tr><?php
 						} ?>
 					</table><?php
 				} ?>
 			</td>
-			<td align="center"><?php
+			<td><?php
 				if (isset($AllianceKillRankings)) { ?>
 					<table class="nobord">
 						<tr>
-							<th align="center">Rank</th>
-							<th align="center">Alliance</th>
-							<th align="center">Kills</th>
+							<th>Rank</th>
+							<th>Alliance</th>
+							<th>Kills</th>
 						</tr><?php
 						foreach ($AllianceKillRankings as $Rank => $RankedAlliance) { ?>
 							<tr>
-								<td align="center"><?php echo $Rank; ?></td>
-								<td align="center"><?php echo $RankedAlliance['Alliance']->getAllianceName(); ?></td>
-								<td align="center"><?php echo number_format($RankedAlliance['Amount']); ?></td>
+								<td><?php echo $Rank; ?></td>
+								<td><?php echo $RankedAlliance['Alliance']->getAllianceName(); ?></td>
+								<td><?php echo number_format($RankedAlliance['Amount']); ?></td>
 							</tr><?php
 						} ?>
 					</table><?php

--- a/templates/Default/engine/Default/includes/AllianceRankings.inc
+++ b/templates/Default/engine/Default/includes/AllianceRankings.inc
@@ -1,4 +1,4 @@
-<div align="center">
+<div class="center">
 	<p>Here are the rankings of alliances by their <?php echo strtolower($RankingStat); ?>.</p><?php
 	if (isset($OurRank)) { ?>
 		<p>Your alliance is ranked <?php echo number_format($OurRank); ?> out of <?php echo number_format($TotalRanks); ?> alliances.</p><?php

--- a/templates/Default/engine/Default/includes/AllianceRankingsList.inc
+++ b/templates/Default/engine/Default/includes/AllianceRankingsList.inc
@@ -1,4 +1,4 @@
-<table class="standard" width="95%">
+<table class="standard center" width="95%">
 	<tr>
 		<th class="shrink">Rank</th>
 		<th>Alliance</th>
@@ -8,11 +8,11 @@
 	</tr><?php
 	foreach($Rankings as $Ranking) { ?>
 		<tr<?php echo $Ranking['Class']; ?>>
-			<td class="top center"><?php echo $Ranking['Rank']; ?></td>
-			<td class="top"><?php echo $Ranking['Alliance']->getAllianceName(true); ?></td>
-			<td class="top center"><?php echo number_format($Ranking['Value']); ?></td>
-			<td class="top center"><?php echo number_format($Ranking['Value'] / max(1, $Ranking['Alliance']->getNumMembers())); ?></td>
-			<td class="top center"><?php echo $Ranking['Alliance']->getNumMembers(); ?></td>
+			<td class="top"><?php echo $Ranking['Rank']; ?></td>
+			<td class="top left"><?php echo $Ranking['Alliance']->getAllianceName(true); ?></td>
+			<td class="top"><?php echo number_format($Ranking['Value']); ?></td>
+			<td class="top"><?php echo number_format($Ranking['Value'] / max(1, $Ranking['Alliance']->getNumMembers())); ?></td>
+			<td class="top"><?php echo $Ranking['Alliance']->getNumMembers(); ?></td>
 		</tr><?php
 	} ?>
 </table>

--- a/templates/Default/engine/Default/includes/AllianceRole.inc
+++ b/templates/Default/engine/Default/includes/AllianceRole.inc
@@ -1,65 +1,65 @@
 <form class="standard" id="RoleEditForm<?php echo $Role['RoleID']; ?>" method="POST" action="<?php echo $Role['HREF']; ?>">
 	<table class="standard">
 		<tr>
-			<td align="left">Name</td>
+			<td>Name</td>
 			<td><input type="text" name="role" value="<?php echo htmlspecialchars($Role['Name']); ?>" maxlength="32"<?php if (!$Role['EditingRole']){ ?> disabled="disabled"<?php } ?>>
 		</tr><?php
 		if ($Role['EditingRole']) { ?>
 			<tr>
-				<td align="left" rowspan="3">Withdrawal limit per 24 hours<br>(Or max negative balance for "positive balance")</td>
-				<td align="left"><input type="number" name="maxWith" value="<?php echo max($Role['WithdrawalLimit'],0); ?>"></td>
+				<td rowspan="3">Withdrawal limit per 24 hours<br>(Or max negative balance for "positive balance")</td>
+				<td><input type="number" name="maxWith" value="<?php echo max($Role['WithdrawalLimit'],0); ?>"></td>
 			</tr>
 			<tr>
-				<td align="left">Unlimited:<input type="checkbox" name="unlimited"<?php if ($Role['WithdrawalLimit'] == ALLIANCE_BANK_UNLIMITED){ ?> checked="checked"<?php } ?>></td>
+				<td>Unlimited:<input type="checkbox" name="unlimited"<?php if ($Role['WithdrawalLimit'] == ALLIANCE_BANK_UNLIMITED){ ?> checked="checked"<?php } ?>></td>
 			</tr>
 			<tr>
-				<td align="left">Positive Balance:<input type="checkbox" name="positive" title="Members must deposit more than they withdraw"<?php if ($Role['PositiveBalance']){ ?> checked="checked"<?php } ?>></td>
+				<td>Positive Balance:<input type="checkbox" name="positive" title="Members must deposit more than they withdraw"<?php if ($Role['PositiveBalance']){ ?> checked="checked"<?php } ?>></td>
 			</tr><?php
 			if (!$Role['TreatyCreated']) { ?>
 				<tr>
-					<td align="left">Remove Member</td>
-					<td align="left"><input type="checkbox" name="removeMember"<?php if ($Role['RemoveMember']){ ?> checked="checked"<?php } ?>></td>
+					<td>Remove Member</td>
+					<td><input type="checkbox" name="removeMember"<?php if ($Role['RemoveMember']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Change Password</td>
-					<td align="left"><input type="checkbox" name="changePW"<?php if ($Role['ChangePass']){ ?> checked="checked"<?php } ?>></td>
+					<td>Change Password</td>
+					<td><input type="checkbox" name="changePW"<?php if ($Role['ChangePass']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Change Message Of The Day</td>
-					<td align="left"><input type="checkbox" name="changeMoD"<?php if ($Role['ChangeMod']){ ?> checked="checked"<?php } ?>></td>
+					<td>Change Message Of The Day</td>
+					<td><input type="checkbox" name="changeMoD"<?php if ($Role['ChangeMod']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Change Roles</td>
-					<td align="left"><input type="checkbox" name="changeRoles"<?php if ($Role['ChangeRoles']){ ?> checked="checked"<?php } ?>></td>
+					<td>Change Roles</td>
+					<td><input type="checkbox" name="changeRoles"<?php if ($Role['ChangeRoles']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Land On Planets</td>
-					<td align="left"><input type="checkbox" name="planets"<?php if ($Role['PlanetAccess']){ ?> checked="checked"<?php } ?>></td>
+					<td>Land On Planets</td>
+					<td><input type="checkbox" name="planets"<?php if ($Role['PlanetAccess']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Moderate Message Board</td>
-					<td align="left"><input type="checkbox" name="mbMessages"<?php if ($Role['ModerateMessageboard']){ ?> checked="checked"<?php } ?>></td>
+					<td>Moderate Message Board</td>
+					<td><input type="checkbox" name="mbMessages"<?php if ($Role['ModerateMessageboard']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Exempt Withdrawals</td>
-					<td align="left"><input type="checkbox" name="exemptWithdrawals" title="This user can mark withdrawals from the alliance account as 'for the alliance' instead of 'for the individual'"<?php if ($Role['ExemptWithdrawals']){ ?> checked="checked"<?php } ?>></td>
+					<td>Exempt Withdrawals</td>
+					<td><input type="checkbox" name="exemptWithdrawals" title="This user can mark withdrawals from the alliance account as 'for the alliance' instead of 'for the individual'"<?php if ($Role['ExemptWithdrawals']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td align="left">Send Alliance Message</td>
-					<td align="left"><input type="checkbox" name="sendAllMsg"<?php if ($Role['SendAllianceMessage']){ ?> checked="checked"<?php } ?>></td>
+					<td>Send Alliance Message</td>
+					<td><input type="checkbox" name="sendAllMsg"<?php if ($Role['SendAllianceMessage']){ ?> checked="checked"<?php } ?>></td>
 				</tr>
 				<tr>
-					<td class="left">Operations Leader</td>
-					<td class="left"><input type="checkbox" name="opLeader" title="Can schedule operations and designate the flagship" <?php if ($Role['OpLeader']){ ?> checked="checked"<?php } ?> /></td>
+					<td>Operations Leader</td>
+					<td><input type="checkbox" name="opLeader" title="Can schedule operations and designate the flagship" <?php if ($Role['OpLeader']){ ?> checked="checked"<?php } ?> /></td>
 				</tr>
 				<tr>
-					<td align="left">View Bonds In Planet List</td>
-					<td align="left"><input type="checkbox" name="viewBonds"<?php if ($Role['ViewBondsInPlanetList']){ ?> checked="checked"<?php } ?>></td>
+					<td>View Bonds In Planet List</td>
+					<td><input type="checkbox" name="viewBonds"<?php if ($Role['ViewBondsInPlanetList']){ ?> checked="checked"<?php } ?>></td>
 				</tr><?php
 			}
 		} ?>
 		<tr>
-			<td colspan="2" align="center"><input class="submit" type="submit" name="action" value="<?php if ($Role['CreatingRole']) { ?>Create<?php } else if($Role['EditingRole']){ ?>Submit Changes<?php }else{ ?>Edit<?php } ?>"></td>
+			<td colspan="2" class="center"><input class="submit" type="submit" name="action" value="<?php if ($Role['CreatingRole']) { ?>Create<?php } else if($Role['EditingRole']){ ?>Submit Changes<?php }else{ ?>Edit<?php } ?>"></td>
 		</tr>
 	</table>
 </form><br />

--- a/templates/Default/engine/Default/includes/CommonNews.inc
+++ b/templates/Default/engine/Default/includes/CommonNews.inc
@@ -3,12 +3,12 @@ if(isset($BreakingNews)) {
 	?><b>MAJOR NEWS! - <?php echo date(DATE_FULL_SHORT, $BreakingNews['Time']); ?></b><br />
 	<table class="standard">
 		<tr>
-			<th align="center"><span class="lgreen">Time</span></th>
-			<th align="center"><span class="lgreen">Breaking News</span></th>
+			<th><span class="lgreen">Time</span></th>
+			<th><span class="lgreen">Breaking News</span></th>
 		</tr>
 		<tr>
-			<td align="center"><?php echo date(DATE_FULL_SHORT, $BreakingNews['Time']); ?></td>
-			<td align="left"><?php echo $BreakingNews['Message']; ?></td>
+			<td class="center"><?php echo date(DATE_FULL_SHORT, $BreakingNews['Time']); ?></td>
+			<td class="left"><?php echo $BreakingNews['Message']; ?></td>
 		</tr>
 	</table>
 	<br /><br /><?php
@@ -18,12 +18,12 @@ if(isset($LottoNews)) { ?>
 	<b>Lotto News</b><br />
 	<table class="standard">
 		<tr>
-		    <th align="center"><span class="lgreen">Time</span></th>
-		    <th align="center"><span class="lgreen">Message</span></th>
+		    <th><span class="lgreen">Time</span></th>
+		    <th><span class="lgreen">Message</span></th>
 	    </tr>
 	    <tr>
-		    <td align="center"><?php echo date(DATE_FULL_SHORT, $LottoNews['Time']); ?></td>
-		    <td align="left"><?php echo $LottoNews['Message']; ?></td>
+		    <td class="center"><?php echo date(DATE_FULL_SHORT, $LottoNews['Time']); ?></td>
+		    <td class="left"><?php echo $LottoNews['Message']; ?></td>
 	    </tr>
     </table>
 	<br /><br /><?php

--- a/templates/Default/engine/Default/includes/PlanetList.inc
+++ b/templates/Default/engine/Default/includes/PlanetList.inc
@@ -1,11 +1,11 @@
 <?php
 
 if (count($Planets) > 0) { ?>
-	<table id="planet-list" class="standard inset">
+	<table id="planet-list" class="standard inset left centered">
 		<thead>
 			<tr>
 				<th class="sort shrink" data-sort="image">
-					<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a></th>
+					<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img class="bottom" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a></th>
 				<th class="sort" data-sort="name">Name</th>
 				<th class="sort shrink" data-sort="lvl">Level</th>
 				<th class="sort" data-sort="owner">Owner</th>
@@ -20,7 +20,7 @@ if (count($Planets) > 0) { ?>
 			foreach ($Planets as $Planet) { ?>
 				<tr id="planet-<?php echo $Planet->getSectorID(); ?>" class="ajax">
 					<td class="image noWrap">
-						<img class="tooltip" id="planet_image" src="<?php echo $Planet->getTypeImage(); ?>"  width="16" height="16" alt="" title="<?php echo $Planet->getTypename().': '.$Planet->getTypeDescription(); ?>" /></td>
+						<img class="tooltip" src="<?php echo $Planet->getTypeImage(); ?>"  width="16" height="16" alt="" title="<?php echo $Planet->getTypename().': '.$Planet->getTypeDescription(); ?>" /></td>
 					<td class="name"><?php echo $Planet->getName(); ?></td>
 					<td class="lvl center"><?php echo number_format($Planet->getLevel(),2); ?></td>
 					<td class="owner noWrap"><?php echo $Planet->getOwner()->getLinkedDisplayName(false); ?></td>

--- a/templates/Default/engine/Default/includes/PlanetListFinancial.inc
+++ b/templates/Default/engine/Default/includes/PlanetListFinancial.inc
@@ -1,11 +1,11 @@
 <?php
 
 if (count($Planets) > 0) { ?>
-	<table id="planet-list" class="standard inset">
+	<table id="planet-list" class="standard inset center">
 		<thead>
 			<tr>
 				<th class="sort shrink" data-sort="sort_type">
-					<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a></th>
+					<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img class="bottom" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a></th>
 				<th class="sort shrink" data-sort="sort_name">Name</th>
 				<th class="sort shrink" data-sort="sort_lvl">Level</th>
 				<th class="sort shrink" data-sort="sort_owner">Owner</th>
@@ -22,21 +22,21 @@ if (count($Planets) > 0) { ?>
 			foreach($Planets as $Planet) { ?>
 				<tr id="planet-<?php echo $Planet->getSectorID(); ?>" class="ajax">
 					<td class="sort_type shrink">
-						<img class="tooltip" id="planet_image" src="<?php echo $Planet->getTypeImage(); ?>"  width="16" height="16" alt="" title="<?php echo $Planet->getTypename().': '.$Planet->getTypeDescription(); ?>" /></td>
-					<td class="sort_name"><?php echo $Planet->getName(); ?></td>
-					<td class="sort_lvl center"><?php echo number_format($Planet->getLevel(),2); ?></td>
-					<td class="sort_owner noWrap"><?php echo $Planet->getOwner()->getLinkedDisplayName(false); ?></td>
-					<td class="sort_sector center"><a href="<?php echo Globals::getPlotCourseHREF($ThisPlayer->getSectorID(), $Planet->getSectorID()); ?>"><?php echo $Planet->getSectorID(); ?></a>&nbsp;(<a href="<?php echo $Planet->getGalaxy()->getGalaxyMapHREF(); ?>" target="gal_map"><?php echo $Planet->getGalaxy()->getName(); ?></a>)</td>
+						<img class="tooltip" src="<?php echo $Planet->getTypeImage(); ?>"  width="16" height="16" alt="" title="<?php echo $Planet->getTypename().': '.$Planet->getTypeDescription(); ?>" /></td>
+					<td class="sort_name left"><?php echo $Planet->getName(); ?></td>
+					<td class="sort_lvl"><?php echo number_format($Planet->getLevel(),2); ?></td>
+					<td class="sort_owner noWrap left"><?php echo $Planet->getOwner()->getLinkedDisplayName(false); ?></td>
+					<td class="sort_sector"><a href="<?php echo Globals::getPlotCourseHREF($ThisPlayer->getSectorID(), $Planet->getSectorID()); ?>"><?php echo $Planet->getSectorID(); ?></a>&nbsp;(<a href="<?php echo $Planet->getGalaxy()->getGalaxyMapHREF(); ?>" target="gal_map"><?php echo $Planet->getGalaxy()->getName(); ?></a>)</td>
 
 					<?php
 					if ($Planet->hasMenuOption('FINANCE')) { ?>
-						<td class="sort_credits center"><?php echo number_format($Planet->getCredits()); ?></td>
-						<td class="sort_bonds center"><?php echo number_format($Planet->getBonds()); ?></td>
-						<td class="sort_interest center"><?php echo $Planet->getInterestRate() * 100; ?>%</td>
+						<td class="sort_credits"><?php echo number_format($Planet->getCredits()); ?></td>
+						<td class="sort_bonds"><?php echo number_format($Planet->getBonds()); ?></td>
+						<td class="sort_interest"><?php echo $Planet->getInterestRate() * 100; ?>%</td>
 						<?php
 						if ($Planet->getBonds() > 0) {
 							$matureTime = $Planet->getMaturity() - TIME; ?>
-							<td class="sort_mature center noWrap" data-sort_mature="<?php echo $matureTime; ?>">
+							<td class="sort_mature noWrap" data-sort_mature="<?php echo $matureTime; ?>">
 								<?php echo format_time($matureTime, true); ?>
 							</td><?php
 						} else { ?>

--- a/templates/Default/engine/Default/includes/PlayerRankings.inc
+++ b/templates/Default/engine/Default/includes/PlayerRankings.inc
@@ -1,4 +1,4 @@
-<div align="center">
+<div class="center">
 	<p>Here are the rankings of players by their <?php echo strtolower($RankingStat); ?>.</p>
 	<p>The traders listed in <span class="italic">italics</span> are still ranked as Newbie or Beginner.</p>
 	<p>You are ranked <?php echo number_format($OurRank); ?> out of <?php echo number_format($TotalRanks); ?> players.</p>

--- a/templates/Default/engine/Default/includes/PlayerRankingsList.inc
+++ b/templates/Default/engine/Default/includes/PlayerRankingsList.inc
@@ -1,4 +1,4 @@
-<table class="standard" width="95%">
+<table class="standard center" width="95%">
 	<tr>
 		<th class="shrink">Rank</th>
 		<th>Player</th>
@@ -8,8 +8,8 @@
 	</tr><?php
 	foreach($Rankings as $Ranking) { ?>
 		<tr<?php echo $Ranking['Class']; ?>>
-			<td class="top center"><?php echo $Ranking['Rank']; ?></td>
-			<td class="top"><?php echo $Ranking['Player']->getLevelName(); ?> <?php echo $Ranking['Player']->getLinkedDisplayName(false); ?></td>
+			<td class="top"><?php echo $Ranking['Rank']; ?></td>
+			<td class="top left"><?php echo $Ranking['Player']->getLevelName(); ?> <?php echo $Ranking['Player']->getLinkedDisplayName(false); ?></td>
 			<td class="top"><?php echo $ThisPlayer->getColouredRaceName($Ranking['Player']->getRaceID(), true); ?></td>
 			<td class="top"><?php echo $Ranking['Player']->getAllianceName(true); ?></td>
 			<td class="top right"><?php echo number_format($Ranking['Value']); ?></td>

--- a/templates/Default/engine/Default/includes/SectorKillList.inc
+++ b/templates/Default/engine/Default/includes/SectorKillList.inc
@@ -1,4 +1,4 @@
-<table class="standard" width="45%">
+<table class="standard center" width="45%">
 	<tr>
 		<th class="shrink">Rank</th>
 		<th>Sector</th>
@@ -6,19 +6,19 @@
 	</tr><?php
 	foreach ($Rankings as $Rank => $RankSector) { ?>
 		<tr>
-			<td class="center<?php
+			<td class="<?php
 				if ($ThisPlayer->getSectorID() == $RankSector->getSectorID()) {
 					echo ' bold';
 				} ?>"><?php echo $Rank; ?>
 			</td>
 
-			<td class="center<?php
+			<td class="<?php
 				if ($ThisPlayer->getSectorID() == $RankSector->getSectorID()) {
 					echo ' bold';
 				} ?>"><?php echo $RankSector->getSectorID(); ?>
 			</td>
 
-			<td class="center<?php
+			<td class="<?php
 				if ($ThisPlayer->getSectorID() == $RankSector->getSectorID()) {
 					echo ' bold';
 				} ?>"><?php echo $RankSector->getBattles(); ?>

--- a/templates/Default/engine/Default/includes/SectorLocations.inc
+++ b/templates/Default/engine/Default/includes/SectorLocations.inc
@@ -11,7 +11,7 @@ if($ThisSector->hasLocation()) { ?>
 		foreach($ThisSector->getLocations() as $Location) { ?>
 			<tr>
 				<td<?php if(!$Location->hasAction() && $ThisSector->hasAnyLocationsWithAction()){ ?> colspan="2"<?php } ?>>
-					<img align="left" src="<?php echo $Location->getImage(); ?>" width="16" height="16" alt="<?php echo $Location->getName(); ?>" title="<?php echo $Location->getName(); ?>" />&nbsp;<?php echo $Location->getName(); ?>
+					<img class="bottom" src="<?php echo $Location->getImage(); ?>" width="16" height="16" alt="<?php echo $Location->getName(); ?>" title="<?php echo $Location->getName(); ?>" />&nbsp;<?php echo $Location->getName(); ?>
 				</td><?php
 				if($Location->hasAction()) { ?>
 					<td class="shrink noWrap center">

--- a/templates/Default/engine/Default/includes/SectorPlanet.inc
+++ b/templates/Default/engine/Default/includes/SectorPlanet.inc
@@ -8,7 +8,7 @@ if($ThisSector->hasPlanet()) {
 		</tr>
 		<tr>
 			<td>
-				<img align="left" src="<?php echo $Planet->getTypeImage()?>" width="16" height="16" alt="Planet" title="<?php echo $Planet->getTypeName() ?>" />
+				<img class="bottom" src="<?php echo $Planet->getTypeImage()?>" width="16" height="16" alt="Planet" title="<?php echo $Planet->getTypeName() ?>" />
 				&nbsp;<?php echo $Planet->getName() ?>&nbsp;
 				<?php echo $Planet->getTypeName() ?>&nbsp;
 				<?php if($Planet->isInhabitable()) { ?>

--- a/templates/Default/engine/Default/includes/copyright.inc
+++ b/templates/Default/engine/Default/includes/copyright.inc
@@ -1,4 +1,4 @@
-<div align="right">
+<div class="right">
 	SMR <?php echo $Version; ?>&copy;2007-<?php echo $CurrentYear; ?> Page and SMR<br />
 	Kindly Hosted by <a href="http://www.fem.tu-ilmenau.de/" target="fem">FeM</a><br />
 	Script runtime: <span id="rt"><?php echo number_format(microtime(true) - MICRO_TIME, 3); ?></span> seconds<br />

--- a/templates/Default/engine/Default/message_view.php
+++ b/templates/Default/engine/Default/message_view.php
@@ -36,7 +36,7 @@ if (isset($MessageBoxes)) { ?>
 else {
 	if ($MessageBox['Type'] == MSG_GLOBAL) { ?>
 		<form name="FORM" method="POST" action="<?php echo $PreferencesFormHREF; ?>">
-			<div align="center">Ignore global messages?&nbsp;&nbsp;
+			<div class="center">Ignore global messages?&nbsp;&nbsp;
 				<input type="submit" name="ignore_globals" value="Yes" class="InputFields"<?php if ($ThisPlayer->isIgnoreGlobals()) { ?> style="background-color:green;"<?php } ?> />&nbsp;
 				<input type="submit" name="ignore_globals" value="No" class="InputFields"<?php if (!$ThisPlayer->isIgnoreGlobals()) { ?> style="background-color:green;"<?php } ?> />
 			</div>
@@ -94,7 +94,7 @@ else {
 						<?php
 						if (isset($Message['ReplyHref'])) { ?>
 							<td>
-								<a href="<?php echo $Message['ReportHref']; ?>"><img src="images/report.png" width="16" height="16" border="0" align="right" title="Report this message to an admin" /></a>
+								<a href="<?php echo $Message['ReportHref']; ?>"><img class="bottom" src="images/report.png" width="16" height="16" border="0" title="Report this message to an admin" /></a>
 							</td>
 							<td>
 								<a href="<?php echo $Message['BlacklistHref']; ?>">Blacklist Player</a>

--- a/templates/Default/engine/Default/news_read.php
+++ b/templates/Default/engine/Default/news_read.php
@@ -1,8 +1,8 @@
 <?php $this->includeTemplate('includes/CommonNews.inc'); ?>
 
-<div align="center">View News entries</div><br />
+<div class="center">View News entries</div><br />
 <form name="ViewNewsForm" method="POST" action="<?php echo $ViewNewsFormHref; ?>">
-	<div align="center">
+	<div class="center">
 		<input type="text" name="min_news" value="1" size="3" class="InputFields center">&nbsp;-&nbsp;<input type="text" name="max_news" value="50" size="3" class="InputFields center">&nbsp;<br />
 		<input type="submit" name="action" value="View" class="InputFields" />
 	</div>
@@ -11,7 +11,7 @@
 <?php
 if(isset($NewsItems) && count($NewsItems) > 0) { ?>
 	<br />
-	<div align="center">
+	<div class="center">
 		Showing <span class="yellow"><?php echo count($NewsItems); ?></span> news items.<br />
 	</div>
 	<table class="standard">

--- a/templates/Default/engine/Default/news_read_advanced.php
+++ b/templates/Default/engine/Default/news_read_advanced.php
@@ -1,4 +1,4 @@
-<div align="center">
+<div class="center">
 	<form name="AdvancedNewsForm" method="POST" action="<?php echo $AdvancedNewsFormHref; ?>">
 		<table class="standardnobord fullwidth"><tr>
 			<td class="center">
@@ -63,8 +63,8 @@
 		Showing most recent <span class="yellow"><?php echo count($NewsItems); ?></span> news items.<br />
 		<table class="standard">
 			<tr>
-				<th class="center">Time</th>
-				<th class="center">News</th>
+				<th>Time</th>
+				<th>News</th>
 			</tr>
 			<?php
 			foreach($NewsItems as $NewsItem) { ?>

--- a/templates/Default/engine/Default/news_read_current.php
+++ b/templates/Default/engine/Default/news_read_current.php
@@ -2,13 +2,13 @@
 $this->includeTemplate('includes/CommonNews.inc');
 
 if(isset($NewsItems) && count($NewsItems) > 0) { ?>
-	<div align="center">
+	<div class="center">
 		Showing most recent <span class="yellow"><?php echo count($NewsItems); ?></span> news items.<br />
 	</div>
 	<table class="standard">
 		<tr>
-			<th class="center">Time</th>
-			<th class="center">News</th>
+			<th>Time</th>
+			<th>News</th>
 		</tr>
 		<?php
 		foreach($NewsItems as $NewsItem) { ?>

--- a/templates/Default/engine/Default/planet_attack.php
+++ b/templates/Default/engine/Default/planet_attack.php
@@ -1,11 +1,9 @@
 <?php $this->includeTemplate('includes/PlanetFullCombatResults.inc'); ?><br />
 <br />
-<div align="center"><?php
+<div class="center"><?php
 if(!$OverrideDeath && !$Planet->isDestroyed()) { ?>
-	<div style="width:50%">
-		<div class="buttonA">
-			<a href="<?php echo $Planet->getAttackHREF() ?>" class="buttonA">Continue Attack</a>
-		</div>
+	<div class="buttonA">
+		<a href="<?php echo $Planet->getAttackHREF() ?>" class="buttonA">Continue Attack</a>
 	</div><?php
 }
 else {

--- a/templates/Default/engine/Default/planet_defense.php
+++ b/templates/Default/engine/Default/planet_defense.php
@@ -16,9 +16,9 @@
 	<form name="TransferShieldsForm" method="POST" action="<?php echo $TransferShieldsHref; ?>">
 		<tr>
 			<td><img src="images/shields.png"  width="16" height="16" alt="" title="Shields"/>Shields</td>
-			<td align="center"><?php echo $ThisShip->getShields(); ?></td>
-			<td align="center"><?php echo $ThisPlanet->getShields(); ?></td>
-			<td align="center"><input type="number" name="amount" value="<?php echo min($ThisShip->getShields(),$ThisPlanet->getMaxShields()-$ThisPlanet->getShields()); ?>" class="InputFields center" size="4"></td>
+			<td class="center"><?php echo $ThisShip->getShields(); ?></td>
+			<td class="center"><?php echo $ThisPlanet->getShields(); ?></td>
+			<td class="center"><input type="number" name="amount" value="<?php echo min($ThisShip->getShields(),$ThisPlanet->getMaxShields()-$ThisPlanet->getShields()); ?>" class="InputFields center" size="4"></td>
 			<td>
 				<input type="submit" name="action" value="Ship" class="InputFields" />&nbsp;<input type="submit" name="action" value="Planet" class="InputFields" />
 			</td>
@@ -28,9 +28,9 @@
 	<form name="TransferCDsForm" method="POST" action="<?php echo $TransferCDsHref; ?>">
 		<tr>
 			<td><img src="images/cd.png"  width="16" height="16" alt="" title="Combat Drones"/>Combat Drones</td>
-			<td align="center"><?php echo $ThisShip->getCDs(); ?></td>
-			<td align="center"><?php echo $ThisPlanet->getCDs(); ?></td>
-			<td align="center"><input type="number" name="amount" value="<?php echo min($ThisShip->getCDs(),$ThisPlanet->getMaxCDs()-$ThisPlanet->getCDs()); ?>" class="InputFields center" size="4"></td>
+			<td class="center"><?php echo $ThisShip->getCDs(); ?></td>
+			<td class="center"><?php echo $ThisPlanet->getCDs(); ?></td>
+			<td class="center"><input type="number" name="amount" value="<?php echo min($ThisShip->getCDs(),$ThisPlanet->getMaxCDs()-$ThisPlanet->getCDs()); ?>" class="InputFields center" size="4"></td>
 			<td>
 				<input type="submit" name="action" value="Ship" class="InputFields" />&nbsp;<input type="submit" name="action" value="Planet" class="InputFields" />
 			</td>
@@ -41,9 +41,9 @@
 	<form name="TransferArmourForm" method="POST" action="<?php echo $TransferArmourHref; ?>">
 		<tr>
 			<td><img src="images/armour.png"  width="16" height="16" alt="" title="Armour"/>Armour</td>
-			<td align="center"><?php echo $ThisShip->getArmour(); ?></td>
-			<td align="center"><?php echo $ThisPlanet->getArmour(); ?></td>
-			<td align="center"><input type="number" name="amount" value="<?php echo min($ThisShip->getArmour()-1,$ThisPlanet->getMaxArmour()-($ThisPlanet->getArmour())); ?>" class="InputFields center" size="4"></td>
+			<td class="center"><?php echo $ThisShip->getArmour(); ?></td>
+			<td class="center"><?php echo $ThisPlanet->getArmour(); ?></td>
+			<td class="center"><input type="number" name="amount" value="<?php echo min($ThisShip->getArmour()-1,$ThisPlanet->getMaxArmour()-($ThisPlanet->getArmour())); ?>" class="InputFields center" size="4"></td>
 			<td>
 				<input type="submit" name="action" value="Ship" class="InputFields" />&nbsp;<input type="submit" name="action" value="Planet" class="InputFields" />
 			</td>

--- a/templates/Default/engine/Default/planet_examine.php
+++ b/templates/Default/engine/Default/planet_examine.php
@@ -55,7 +55,7 @@
 </table>
 
 <br />
-<div align="center"><?php
+<div class="center"><?php
 	if (!$PlanetLand) { ?>
 		<div class="buttonA"><a class="buttonA" href="<?php echo $ThisPlanet->getAttackHREF(); ?>">Attack Planet (3)</a></div><?php
 	}

--- a/templates/Default/engine/Default/planet_financial.php
+++ b/templates/Default/engine/Default/planet_financial.php
@@ -3,7 +3,7 @@
 <form id="BondForm" method="POST" action="<?php echo $ThisPlanet->getFinancesHREF(); ?>">
 	<table>
 		<tr>
-			<td colspan="2" align="center"><input type="number" name="amount" value="0" class="InputFields" style="text-align:right;width:152;"></td>
+			<td colspan="2"><input type="number" name="amount" value="0" class="InputFields" style="text-align:right;width:152;"></td>
 		</tr>
 		<tr>
 			<td><input type="submit" name="action" value="Deposit" class="InputFields" /></td>

--- a/templates/Default/engine/Default/planet_list.inc
+++ b/templates/Default/engine/Default/planet_list.inc
@@ -1,4 +1,4 @@
-<div align="center">
+<div class="center">
 	<?php
 	if (isset($PlayerPlanet)) { ?>
 		You own the planet in sector <a href="#planet-<?php echo $PlayerPlanet->getSectorID(); ?>" target="_self">#<?php echo $PlayerPlanet->getSectorID(); ?></a>.<br /><?php
@@ -7,11 +7,11 @@
 	if (count($AllPlanets) == 0) {
 		if ($PlayerOnly) { ?>
 			You do not own a planet!
-			<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
+			<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
 			<?php
 		} else { ?>
 			<?php echo $Alliance->getAllianceName(true); ?> has no claimed planets.
-			<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
+			<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
 			<?php
 		}
 	} else {

--- a/templates/Default/engine/Default/planet_list_financial.php
+++ b/templates/Default/engine/Default/planet_list_financial.php
@@ -1,6 +1,6 @@
 <?php
 if (!$CanViewBonds) { ?>
-	<div align="center">
+	<div class="center">
 		You do not have permission to view planet financials!
 	</div><?php
 } else {

--- a/templates/Default/engine/Default/planet_main.php
+++ b/templates/Default/engine/Default/planet_main.php
@@ -12,12 +12,12 @@ if (isset($Msg)) {
 
 	<tr>
 		<td>
-			<img align="left" src="<?php echo $ThisPlanet->getTypeImage()?>" width="16" height="16" alt="Planet" title="<?php echo $ThisPlanet->getTypeName(); ?>" /> 
+			<img class="bottom" src="<?php echo $ThisPlanet->getTypeImage()?>" width="16" height="16" alt="Planet" title="<?php echo $ThisPlanet->getTypeName(); ?>" /> 
 			&nbsp;<b><?php echo $ThisPlanet->getTypeName() ?>:</b> <?php echo $ThisPlanet->getTypeDescription(); ?>
+			<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img style="float: right;" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
 		</td>
 	<tr>
 		<td style="width:50%">
-			<a href="<?php echo WIKI_URL; ?>/game-guide/locations#planets" target="_blank"><img align="right" src="images/silk/help.png" width="16" height="16" alt="Wiki Link" title="Goto SMR Wiki: Planets"/></a>
 			<table class="standard">
 				<tr>
 					<th width="145">&nbsp;</th>
@@ -27,8 +27,8 @@ if (isset($Msg)) {
 				
 				<tr>
 					<td>Planet Level</td>
-					<td align="center"><span id="planetLevel"><?php echo number_format($ThisPlanet->getLevel(),2); ?></span></td>
-					<td align="center"><?php echo number_format($ThisPlanet->getMaxLevel(),2); ?></td>
+					<td class="center"><span id="planetLevel"><?php echo number_format($ThisPlanet->getLevel(),2); ?></span></td>
+					<td class="center"><?php echo number_format($ThisPlanet->getMaxLevel(),2); ?></td>
 				</tr>
 			</table>
 			<br />
@@ -42,8 +42,8 @@ if (isset($Msg)) {
 				<tr>
 					<td><img class="tooltip" id="tip<?php echo $StructureID; ?>" src="images/<?php echo $Structure->image(); ?>" width="16" height="16" alt="" title="<?php echo $Structure->tooltip(); ?>" />
 						<label for="tip<?php echo $StructureID; ?>">&nbsp;<?php echo $Structure->name(); ?></td>
-					<td align="center"><span id="planetStructure<?php echo $StructureID; ?>"><?php echo $ThisPlanet->getBuilding($StructureID); ?></span></td>
-					<td align="center"><?php echo $ThisPlanet->getMaxBuildings($StructureID); ?></td>
+					<td class="center"><span id="planetStructure<?php echo $StructureID; ?>"><?php echo $ThisPlanet->getBuilding($StructureID); ?></span></td>
+					<td class="center"><?php echo $ThisPlanet->getMaxBuildings($StructureID); ?></td>
 				</tr><?php
 				} ?>
 			</table>
@@ -58,32 +58,32 @@ if (isset($Msg)) {
 				<?php if ($ThisPlanet->hasBuilding(PLANET_GENERATOR)) { ?>
 				<tr>
 					<td><img src="images/shields.png"  width="16" height="16" alt="" title="Shields"/>&nbsp;Shields</td>
-					<td align="center"><span id="planetShields"><?php echo $ThisPlanet->getShields(); ?></span> / <span id="planetMaxShields"><?php echo $ThisPlanet->getMaxShields(); ?></span></td>
+					<td class="center"><span id="planetShields"><?php echo $ThisPlanet->getShields(); ?></span> / <span id="planetMaxShields"><?php echo $ThisPlanet->getMaxShields(); ?></span></td>
 					<td>&nbsp;</td>
 				</tr>
 				<?php } if ($ThisPlanet->hasBuilding(PLANET_HANGAR)) { ?>
 				<tr>
 					<td><img src="images/cd.png"  width="16" height="16" alt="" title="Combat Drones"/>&nbsp;Combat Drones</td>
-					<td align="center"><span id="planetCDs"><?php echo $ThisPlanet->getCDs(); ?></span> / <span id="planetMaxCDs"><?php echo $ThisPlanet->getMaxCDs(); ?></span></td>
-					<td align="center">100 %</td>
+					<td class="center"><span id="planetCDs"><?php echo $ThisPlanet->getCDs(); ?></span> / <span id="planetMaxCDs"><?php echo $ThisPlanet->getMaxCDs(); ?></span></td>
+					<td class="center">100 %</td>
 				</tr>
 				<?php } if ($ThisPlanet->hasBuilding(PLANET_BUNKER)) { ?>
 				<tr>
 					<td><img src="images/armour.png"  width="16" height="16" alt="" title="Armour"/>&nbsp;Armour</td>
-					<td align="center"><span id="planetArmour"><?php echo $ThisPlanet->getArmour(); ?></span> / <span id="planetMaxArmour"><?php echo $ThisPlanet->getMaxArmour(); ?></span></td>
-					<td align="center">&nbsp;</td>
+					<td class="center"><span id="planetArmour"><?php echo $ThisPlanet->getArmour(); ?></span> / <span id="planetMaxArmour"><?php echo $ThisPlanet->getMaxArmour(); ?></span></td>
+					<td class="center">&nbsp;</td>
 				</tr>
 				<?php }	if ($ThisPlanet->hasBuilding(PLANET_TURRET)) { ?>
 				<tr>
 					<td><img src="images/turrets.png"  width="16" height="16" alt="" title="Turret"/>&nbsp;Turrets</td>
-					<td align="center"><span id="planetTurrets2"><?php echo $ThisPlanet->getBuilding(PLANET_TURRET); ?></span> / <?php echo $ThisPlanet->getMaxBuildings(PLANET_TURRET); ?></td>
-					<td align="center"><span id="planetAcc"><?php echo number_format($ThisPlanet->accuracy(), 2); ?></span> %</td>
+					<td class="center"><span id="planetTurrets2"><?php echo $ThisPlanet->getBuilding(PLANET_TURRET); ?></span> / <?php echo $ThisPlanet->getMaxBuildings(PLANET_TURRET); ?></td>
+					<td class="center"><span id="planetAcc"><?php echo number_format($ThisPlanet->accuracy(), 2); ?></span> %</td>
 				</tr>
 				<?php }	if ($ThisPlanet->hasBuilding(PLANET_WEAPON_MOUNT)) { ?>
 				<tr>
 					<td><img src="images/weapon_shop.png"  width="16" height="16" alt="" title="Weapon"/>&nbsp;Mounted Weapons</td>
-					<td align="center"><span id="planetWeapons"><?php echo count($ThisPlanet->getMountedWeapons()); ?></span> / <?php echo $ThisPlanet->getBuilding(PLANET_WEAPON_MOUNT); ?></td>
-					<td align="center">+<?php echo $ThisPlanet->getAccuracyBonus(); ?>%</td>
+					<td class="center"><span id="planetWeapons"><?php echo count($ThisPlanet->getMountedWeapons()); ?></span> / <?php echo $ThisPlanet->getBuilding(PLANET_WEAPON_MOUNT); ?></td>
+					<td class="center">+<?php echo $ThisPlanet->getAccuracyBonus(); ?>%</td>
 				</tr>
 				<?php } ?>
 				</table>

--- a/templates/Default/engine/Default/port_attack.php
+++ b/templates/Default/engine/Default/port_attack.php
@@ -1,11 +1,9 @@
 <?php $this->includeTemplate('includes/PortFullCombatResults.inc'); ?><br />
 <br />
-<div align="center"><?php
+<div class="center"><?php
 	if(!$OverrideDeath && !$Port->isDestroyed()) { ?>
-		<div style="width:50%">
-			<div class="buttonA">
-				<a href="<?php echo $Port->getAttackHREF() ?>" class="buttonA">Continue Attack</a>
-			</div>
+		<div class="buttonA">
+			<a href="<?php echo $Port->getAttackHREF() ?>" class="buttonA">Continue Attack</a>
 		</div><?php
 	}
 	else {

--- a/templates/Default/engine/Default/rankings_alliance_vs_alliance.php
+++ b/templates/Default/engine/Default/rankings_alliance_vs_alliance.php
@@ -45,9 +45,9 @@
 </form>
 </div>
 
-<table align="center">
+<table class="center">
 	<tr>
-		<td width="45%" class="center top"><?php
+		<td width="45%" class="top"><?php
 			if ($Kills) { ?>
 				<p>Kills for <?php echo $DetailsName; ?></p>
 				<table class="standard center">
@@ -68,7 +68,7 @@
 		</td>
 
 		<td width="10%">&nbsp;</td>
-		<td width="45%" class="center top"><?php
+		<td width="45%" class="top"><?php
 			if ($Deaths) { ?>
 				<p>Deaths for <?php echo $DetailsName; ?></p>
 				<table class="standard center">

--- a/templates/Default/engine/Default/rankings_sector_kill.php
+++ b/templates/Default/engine/Default/rankings_sector_kill.php
@@ -1,4 +1,4 @@
-<div align="center">
+<div class="center">
 	<p>Here are the most deadly Sectors!</p>
 	<?php $this->includeTemplate('includes/SectorKillList.inc', array('Rankings' => $TopTen)); ?>
 

--- a/templates/Default/engine/Default/skeleton.php
+++ b/templates/Default/engine/Default/skeleton.php
@@ -4,7 +4,7 @@
 		$this->includeTemplate('includes/Head.inc'); ?>
 	</head>
 	<body>
-		<table class="m" align="center">
+		<table class="m centered">
 			<tr>
 				<td class="l0" rowspan="2">
 					<div class="l1">

--- a/templates/Default/engine/Default/trader_attack.php
+++ b/templates/Default/engine/Default/trader_attack.php
@@ -1,6 +1,6 @@
 <?php $this->includeTemplate('includes/TraderFullCombatResults.inc'); ?><br />
 <br />
-<div align="center"><?php
+<div class="center"><?php
 	if(isset($Target)) { ?>
 		<div class="buttonA">
 			<a href="<?php echo $Target->getAttackTraderHREF(); ?>" class="buttonA">Continue Attack</a>

--- a/templates/Default/engine/Default/trader_examine.php
+++ b/templates/Default/engine/Default/trader_examine.php
@@ -36,41 +36,40 @@ if(!$canAttack)
 	$fightingPlayers = $ThisSector->getPotentialFightingTraders($ThisPlayer);
 $fightingPlayers['Attackers'][$ThisPlayer->getAccountID()] = $ThisPlayer;
 ?>
-<div align="center">
-	<table class="standard" width="95%">
-		<tr><th width="50%">Attacker</th><th width="50%">Defender</th></tr>
-		<tr><?php
-			foreach ($fightingPlayers as $fleet) {
-				?><td class="top"><?php
-				if (is_array($fleet)) {
-					foreach ($fleet as $fleetPlayer) {
-						$fleetShip = $fleetPlayer->getShip();
-						if ($fleetPlayer->hasNewbieStatus()) { ?><span class="newbie"><?php }
-						echo $fleetPlayer->getLevelName(); ?><br /><?php
-						echo $fleetPlayer->getDisplayName() ?><br />
-						Race: <?php echo $fleetPlayer->getRaceName() ?><br />
-						Level: <?php echo $fleetPlayer->getLevelName() ?><br />
-						Alliance: <?php echo $fleetPlayer->getAllianceName() ?><br /><br /><?php
-						echo $fleetShip->getName() ?><br />
-						Rating : <?php echo $fleetShip->getDisplayAttackRating($ThisPlayer) .'/'. $fleetShip->getDisplayDefenseRating($ThisPlayer) ?><br /><?php
-						if ($ThisShip->hasScanner()) { ?>
-							Shields : <?php echo $fleetShip->getShieldLow() . '-' . $fleetShip->getShieldHigh() ?><br />
-							Armour : <?php echo $fleetShip->getArmourLow() . '-' . $fleetShip->getArmourHigh() ?><br />
-							Hard Points: <?php echo $fleetShip->getNumWeapons() ?><br />
-							Combat Drones: <?php echo $fleetShip->getCDsLow() . '-' . $fleetShip->getCDsHigh() ?><br /><?php
-						}
-						if ($fleetPlayer->hasNewbieStatus()) { ?></span><?php } ?>
-						<br /><br /><?php
+
+<table class="standard centered" width="95%">
+	<tr><th width="50%">Attacker</th><th width="50%">Defender</th></tr>
+	<tr><?php
+		foreach ($fightingPlayers as $fleet) {
+			?><td class="top"><?php
+			if (is_array($fleet)) {
+				foreach ($fleet as $fleetPlayer) {
+					$fleetShip = $fleetPlayer->getShip();
+					if ($fleetPlayer->hasNewbieStatus()) { ?><span class="newbie"><?php }
+					echo $fleetPlayer->getLevelName(); ?><br /><?php
+					echo $fleetPlayer->getDisplayName() ?><br />
+					Race: <?php echo $fleetPlayer->getRaceName() ?><br />
+					Level: <?php echo $fleetPlayer->getLevelName() ?><br />
+					Alliance: <?php echo $fleetPlayer->getAllianceName() ?><br /><br /><?php
+					echo $fleetShip->getName() ?><br />
+					Rating : <?php echo $fleetShip->getDisplayAttackRating($ThisPlayer) .'/'. $fleetShip->getDisplayDefenseRating($ThisPlayer) ?><br /><?php
+					if ($ThisShip->hasScanner()) { ?>
+						Shields : <?php echo $fleetShip->getShieldLow() . '-' . $fleetShip->getShieldHigh() ?><br />
+						Armour : <?php echo $fleetShip->getArmourLow() . '-' . $fleetShip->getArmourHigh() ?><br />
+						Hard Points: <?php echo $fleetShip->getNumWeapons() ?><br />
+						Combat Drones: <?php echo $fleetShip->getCDsLow() . '-' . $fleetShip->getCDsHigh() ?><br /><?php
 					}
+					if ($fleetPlayer->hasNewbieStatus()) { ?></span><?php } ?>
+					<br /><br /><?php
 				}
-				else {
-					?>&nbsp;<?php
-				} ?>
-				</td><?php
 			}
-			if(!$canAttack) {
-				?><td>&nbsp;</td><?php
+			else {
+				?>&nbsp;<?php
 			} ?>
-		</tr>
-	</table>
-</div>
+			</td><?php
+		}
+		if(!$canAttack) {
+			?><td>&nbsp;</td><?php
+		} ?>
+	</tr>
+</table>

--- a/templates/Default/engine/Default/trader_planet.php
+++ b/templates/Default/engine/Default/trader_planet.php
@@ -1,5 +1,4 @@
-
-<div align="center"><?php
+<div class="center"><?php
 	if (count($TraderPlanets) > 0) {
 		$this->includeTemplate('includes/PlanetList.inc',array('Planets'=>$TraderPlanets));
 	}

--- a/templates/Default/engine/Default/trader_relations.php
+++ b/templates/Default/engine/Default/trader_relations.php
@@ -1,18 +1,16 @@
-<div align="center">
-	<table width="50%" class="standard">
+<table width="50%" class="standard center">
+	<tr>
+		<th width="31%">Race</th>
+		<th width="23%">Political Relations</th>
+		<th width="23%">Personal Relations</th>
+		<th width="23%">Total</th>
+	</tr><?php
+	foreach (array_keys($PoliticalRelations) as $Race) { ?>
 		<tr>
-			<th width="31%">Race</th>
-			<th width="23%">Political Relations</th>
-			<th width="23%">Personal Relations</th>
-			<th width="23%">Total</th>
+			<td><?php echo $Race; ?></td>
+			<td><?php echo get_colored_text($PoliticalRelations[$Race]); ?></td>
+			<td><?php echo get_colored_text($PersonalRelations[$Race]); ?></td>
+			<td><?php echo get_colored_text($PoliticalRelations[$Race] + $PersonalRelations[$Race]); ?></td>
 		</tr><?php
-		foreach (array_keys($PoliticalRelations) as $Race) { ?>
-			<tr>
-				<td><?php echo $Race; ?></td>
-				<td class="center"><?php echo get_colored_text($PoliticalRelations[$Race]); ?></td>
-				<td class="center"><?php echo get_colored_text($PersonalRelations[$Race]); ?></td>
-				<td class="center"><?php echo get_colored_text($PoliticalRelations[$Race] + $PersonalRelations[$Race]); ?></td>
-			</tr><?php
-		} ?>
-	</table>
-</div>
+	} ?>
+</table>

--- a/templates/Default/engine/Default/trader_status.php
+++ b/templates/Default/engine/Default/trader_status.php
@@ -144,9 +144,7 @@
 	</table>
 
 	<br />
-	<div align="center>">
-		<input class="submit" type="submit" name="action" value="Delete Selected" />
-	</div>
+	<input class="submit" type="submit" name="action" value="Delete Selected" />
 </form>
 <br />
 

--- a/templates/Default/engine/Default/weapon_reorder.php
+++ b/templates/Default/engine/Default/weapon_reorder.php
@@ -1,6 +1,6 @@
 <?php
 if($ThisShip->hasWeapons()) { ?>
-	<div align="center">
+	<div class="center">
 		<p>To reorder your weapons simply drag and drop them into the desired order.</p>
 		<noscript><p>It has been detected that you do not have javascript or that it is disabled, you will have to use the arrows to reorder your weapons</p></noscript>
 		

--- a/templates/Default/socialRegister.inc
+++ b/templates/Default/socialRegister.inc
@@ -18,7 +18,7 @@
 <tr>
 	<td width="135">&nbsp;</td>
 	<td width="1" bgcolor="#0B8D35"></td>
-	<td align="left" valign="top" width="600" bgcolor="#06240E">
+	<td valign="top" width="600" bgcolor="#06240E">
 		<table width="100%" height="100%" border="0" cellspacing="5" cellpadding="5">
 		<tr>
 			<td valign="top">
@@ -42,7 +42,7 @@
 				<?php
 				if (!isset($MatchingLogin)) { ?>
 					<h1>Or Create New Login</h1>
-					<p align='justify'>
+					<p>
 						Creating multiple logins is not allowed.
 						<a href='https://wiki.smrealms.de/rules' target="_blank" style='font-weight:bold;'>Click HERE</a> for more information.
 					</p>

--- a/templates/Default/validate.php
+++ b/templates/Default/validate.php
@@ -28,7 +28,7 @@ if(isset($Message)) {
 	Enter validation code:&nbsp;&nbsp;
 	<input type="text" name="validation_code" maxlength="10" size="10" class="InputFields center">
 </p>
-<p align="center">
+<p class="center">
 	<input type="submit" name="action" value="Validate me now!" class="InputFields">
 	&nbsp;&nbsp;
 	<input type="submit" name="action" value="I'll validate later." class="InputFields">


### PR DESCRIPTION
The `align` attribute is not valid in HTML5 and needs to be replaced.
This is mostly a simple change, either removing `align="center"`
altogether, or replacing it with `class="center"`.

Since each page needs to be individually checked for more complex
CSS interactions, the changes are not always trivial. Some formatting
changes were made, but they are not independently identified here.

A few special notes:

* Table headers do not need to be centered, because the CSS does
  that automatically for all tables.

* When a table is included in a (align)-centered `<div>`, it is
  also centered, but the text inside the table is not. In this case,
  we want to use `centered` instead of `center` as the table class.

* For `<img>` tags with `align`, we generally want to use either
  `class="bottom"` (for making it align better with text) or
  `style="float: right;"` to position it in the same way on the page.

NOTE: also fixed a small number of unrelated issues:

* PlanetList{,Financial}.inc: remove duplicate `id` elements
* Modified spacing and alignment to visual taste
* Replace some HTML styles with CSS classes (e.g. bold and big)
* combat_log_list.php: make table `inset`