### PR TITLE
Change how full exp is awarded for stealing

### DIFF
--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -121,8 +121,6 @@ if ($transaction == 'Steal' ||
 	}
 	elseif ($transaction == 'Steal') {
 		$msg_transaction = 'stolen';
-		$bargain_price = 0;
-		$gained_exp = round($base_xp);
 		$ship->increaseCargo($good_id,$amount);
 		$player->increaseHOF($amount, array('Trade','Goods','Stolen'), HOF_ALLIANCE);
 		$player->increaseHOF($gained_exp, array('Trade','Experience','Stealing'), HOF_PUBLIC);

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -928,8 +928,10 @@ class AbstractSmrPort {
 	public function calculateExperiencePercent($idealPrice,$offerPrice,$bargainPrice,$transactionType) {
 		if(($transactionType == 'Sell' && $bargainPrice < $offerPrice) || ($transactionType == 'Buy' && $bargainPrice > $offerPrice))
 			return 0;
-		if ($bargainPrice == $idealPrice)
+		if ($bargainPrice == $idealPrice || $transactionType == 'Steal') {
+			// Stealing always gives full exp
 			return 1;
+		}
 		$bargainLeniency = min($idealPrice*self::BARGAIN_LENIENCY_PERCENT,abs($idealPrice-$bargainPrice));
 		if ($transactionType == 'Sell')
 			$bargainLeniency = -$bargainLeniency;


### PR DESCRIPTION
Instead of overwriting `$gained_exp` when stealing, handle this case
in `SmrPort::calculateExperiencePercent` directly. Doing this has
three benefits:

1. We can early return from the function, avoiding a bunch of math.

2. Everything is handled consistently in this one function.

3. We avoid a division-by-zero warning in a specific case.

The division-by-zero was occuring when stealing with low relations
(i.e. between -300 and 0) and for low cost goods (e.g Tier 1). For
this regime, the ideal price was ludicrously low (e.g. 7 credits
for 100 Food). At this point, the 0-relations offer price is always
going to be equal to the ideal price (since it is ~87% of the ideal
price). Since `$idealPrice - $offerPriceZeroRelations` is in the
denominator, we get a div-by-0. This does not occur for normal buying
or selling, because when these prices are equal, the `$bargainPrice`
is also equal, which triggers an early return from the function.