### PR TITLE
Modify trading formulas

### DIFF
--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -932,30 +932,27 @@ class AbstractSmrPort {
 	}
 	
 	public function calculateExperiencePercent($idealPrice,$offerPrice,$bargainPrice,$transactionType) {
-		if(($transactionType == 'Sell' && $bargainPrice < $offerPrice) || ($transactionType == 'Buy' && $bargainPrice > $offerPrice))
+		if (($transactionType == 'Sell' && $bargainPrice < $offerPrice) ||
+		    ($transactionType == 'Buy' && $bargainPrice > $offerPrice)) {
 			return 0;
+		}
 		if ($bargainPrice == $idealPrice || $transactionType == 'Steal') {
 			// Stealing always gives full exp
 			return 1;
 		}
+
 		$bargainLeniency = min($idealPrice*self::BARGAIN_LENIENCY_PERCENT,abs($idealPrice-$bargainPrice));
-		if ($transactionType == 'Sell')
+		if ($transactionType == 'Sell') {
 			$bargainLeniency = -$bargainLeniency;
+		}
 		$bargainPrice -= $bargainLeniency;
 		
-		$val = ($idealPrice-$bargainPrice)/($idealPrice-$this->getOfferPrice($idealPrice,0,$transactionType));
-//			if ($transactionType == 'Sell' && $val>0)
-//				$val=1;
-//			else if($transactionType == 'Buy' && $val<0)
-//				$val=1;
-		$val=abs($val);
-		if($val>1)
-			$val=1;
-		$expPercent = pow(1-$val,15);
-		if($expPercent>1)
-			$expPercent=1;
-		else if($expPercent<0)
-			$expPercent=0;
+		$offerPriceNoRelations = $this->getOfferPrice($idealPrice, 0, $transactionType);
+		$val = abs(($idealPrice - $bargainPrice) / ($idealPrice - $offerPriceNoRelations));
+		if ($val >= 1) {
+			return 0;
+		}
+		$expPercent = max(0, min(1, pow(1-$val,15)));
 		return $expPercent;
 	}
 	

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -952,7 +952,7 @@ class AbstractSmrPort {
 		if ($val >= 1) {
 			return 0;
 		}
-		$expPercent = max(0, min(1, pow(1-$val,15)));
+		$expPercent = max(0, min(1, pow(1-$val,13)));
 		return $expPercent;
 	}
 	

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -884,22 +884,28 @@ class AbstractSmrPort {
 	}
 	
 	public function getIdealPrice($goodID, $transactionType, $numGoods, $relations) {
-//		echo 'Good:'.$goodID.',Dist::'.$dist.',Type:'.$transactionType.',NumGoods:'.$numGoods.',Relations:'.$relations.',';
-		if($relations>1000)
-			$relations=1000;
+		$relations = min(1000, $relations);  // no effect for higher relations
 		$good = $this->getGood($goodID);
-		$base = $good['BasePrice'];
+		$base = $good['BasePrice'] * $numGoods;
 		$maxSupply = $good['Max'];
 		$supply = $this->getGoodAmount($goodID);
 		$dist = $this->getGoodDistance($goodID);
 	
-//		$relations_factor_buy = 2-(($relations + 500) / 1500);
-//		$relations_factor_sell = ($relations + 500) / 1500;
-		if($transactionType == 'Sell')
-			$idealPrice = round($numGoods * $base * 0.6 * (pow($dist + .5, 1.8)) * (2.5-($supply / $maxSupply)) * (($relations + 350) / 8415) );
-		else if($transactionType == 'Buy')
-			$idealPrice = round($numGoods * $base * 0.7 * pow($dist, 1.84) * (2.5-($supply / $maxSupply)) * (2-($relations + 50) / 850) * (($relations + 350) / 1500) / 38.56 * (1 + (10 - $this->getLevel()) / 50));
-		return $idealPrice;
+		$distFactor = pow($dist, 1.3);
+		if ($transactionType == 'Sell') {
+			// Trader sells
+			$supplyFactor = 1 + ($supply / $maxSupply);
+			$relationsFactor = 1 + 2 * ($relations / 1000);
+			$scale = 0.08;
+		} else if($transactionType == 'Buy') {
+			// Trader buys
+			$supplyFactor = 2 - ($supply / $maxSupply);
+			$relationsFactor = 3 - 2 * ($relations / 1000);
+			$scale = 0.03;
+		} else {
+			throw new Exception('Unknown transaction type');
+		}
+		return round($base * $scale * $distFactor * $supplyFactor * $relationsFactor);
 	}
 	
 	public function getOfferPrice($idealPrice, $relations, $transactionType) {

--- a/templates/Default/engine/Default/shop_goods_trade.php
+++ b/templates/Default/engine/Default/shop_goods_trade.php
@@ -7,7 +7,6 @@ $TradeCalcInfo = [
 	$Port->getGoodAmount($Good['ID']),
 	$Good['Max'],
 	$ThisPlayer->getRelation($Port->getRaceID()),
-	$Port->getLevel()
 ];
 
 if (isset($OfferToo)) { ?>
@@ -20,7 +19,7 @@ Note: In order to maximize your experience you have to bargain with the port own
 <form name="FORM" method="POST" action="<?php echo $BargainHREF; ?>">
 	<input type="number" name="bargain_price" value="<?php echo $BargainPrice; ?>" class="InputFields center" style="width:75;vertical-align:middle;">&nbsp;
 	<!-- all needed information to calculate the ideal price -->
-	<!-- Trade.Amount:Good.BasePrice:Good.Distance:Port.Good.Amount:Port.Good.Max:Relations:Port.Level -->
+	<!-- Trade.Amount:Good.BasePrice:Good.Distance:Port.Good.Amount:Port.Good.Max:Relations -->
 	<!-- (<?php echo join(':', $TradeCalcInfo); ?>)-->
 	<input type="submit" name="action" class="InputFields" value="Bargain (1)" />
 </form>


### PR DESCRIPTION
Modify the ideal price trade formulas in the following ways:

**DISTANCE**

Ideal price grows more slowly with distance (and scales the same
with distance for both buy & sell). This was needed because the
sell prices for jump routes (>10 sectors) were too lucrative.

**RELATIONS**

Reduce the penalty for having less than perfect relations. This
effect was way too severe for relations below zero.

BUGFIX: The price to buy goods is now correctly scaled with relations.
Previously, this was mostly backwards -- you'd get a cheaper price
the worse your relations were (due to a perhaps accidental quadratic
term in the equation). This makes low-relations purchases cost more.

**PORT LEVEL**

Remove the port level factor in the buying formula. This was an
unnecessary complication that needlessly punished trading at lower
level ports (which was already discouraged due to not having high
tier goods). It was also never a factor in the selling formula.

**SUPPLY**

Flip effect of demand on the sell price so that it consistently
follows the law of supply and demand (buy price decreases with supply
and sell price increases with demand).

NOTE: This has a fairly major implication for gameplay dynamics, since
it will no longer be the best strategy to drain a route. Instead, you
will be rewarded by keeping demand high, and perhaps trading more than
just one route to maximize profit.

------------------

Also gain slightly more experience trading at lower relations.

Soften the very top-sided function that limits experience gain
to only very close to max relations. This will allow, for example,
newbies to see experience gain sooner.
