### PR TITLE
Slightly decrease structure damage in planet busts

### DIFF
--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -7,8 +7,8 @@ require_once('SmrPlanetType.class.inc');
 class SmrPlanet {
 	protected static $CACHE_PLANETS = array();
 
-	const DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE = 70;
-	const CHANCE_TO_DOWNGRADE = 15;
+	const DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE = 100;
+	const CHANCE_TO_DOWNGRADE = 15;  // percent
 	const TIME_TO_CREDIT_BUST = 10800; // 3 hours
 	const TIME_ATTACK_NEWS_COOLDOWN = 3600; // 1 hour
 	const MAX_STOCKPILE = 600;


### PR DESCRIPTION
With a 15% chance every 70 damage (the previous algorithm), you
would destroy the following number of structures in a max level
planet bust on average:

Terran - 18 structures (6 levels)
Dwarf - 13 structures (4.33 levels)

This is a bit too much, especially considering how long it takes
to build structures when near the max planet level.

Increasing the damage threshold from 70 -> 100 achieves a less
severe result:

Terran - 13 structures (4.33 levels)
Dwarf - 9 structures (3 levels)

This might still be too high, but it is a step in the right
direction, and will be a good place to evaluate further.