### PR TITLE
Add combat log links to Current Sector display

### DIFF
--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -162,6 +162,7 @@ function checkForAttackMessage(&$msg) {
 	$contains = 0;
 	$msg = str_replace('[ATTACK_RESULTS]','',$msg,$contains);
 	if($contains>0) {
+		// $msg now contains only the log_id, if there is one
 		SmrSession::updateVar('AttackMessage','[ATTACK_RESULTS]'.$msg);
 		if(!$template->hasTemplateVar('AttackResults')) {
 			$db->query('SELECT sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($msg) . ' LIMIT 1');
@@ -170,6 +171,7 @@ function checkForAttackMessage(&$msg) {
 					$results = unserialize(gzuncompress($db->getField('result')));
 					$template->assign('AttackResultsType',$db->getField('type'));
 					$template->assign('AttackResults',$results);
+					$template->assign('AttackLogLink', linkCombatLog($msg));
 				}
 			}
 		}

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -13,6 +13,12 @@ function parseBoolean($check) {
 	return (bool)$check;
 }
 
+function linkCombatLog($logID) {
+	$container = create_container('combat_log_viewer_verify.php');
+	$container['log_id'] = $logID;
+	return '<a href="' . SmrSession::getNewHREF($container) . '"><img src="images/notify.gif" width="14" height="11" border="0" title="View the combat log" /></a>';
+}
+
 function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagContent) {
 	global $overrideGameID, $disableBBLinks, $player, $account, $var;
 	try {
@@ -22,9 +28,7 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
 					return true;
 				}
-				$container = create_container('combat_log_viewer_verify.php');
-				$container['log_id'] = $logID;
-				return '<a href="' . SmrSession::getNewHREF($container) . '"><img src="images/notify.gif" width="14" height="11" border="0" title="View the combat log" /></a>';
+				return linkCombatLog($logID);
 			break;
 			case 'player':
 				$playerID = $default;

--- a/templates/Default/engine/Default/includes/PlanetCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PlanetCombatResults.inc
@@ -8,7 +8,7 @@ if($MinimalDisplay) {
 	}
 	else {
 		?> does no damage this round<?php
-	} ?>.<?php
+	} ?>. <?php echo $AttackLogLink;
 	return;
 }
 if(isset($PlanetCombatResults['Weapons']) && is_array($PlanetCombatResults['Weapons'])) {

--- a/templates/Default/engine/Default/includes/PortCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PortCombatResults.inc
@@ -8,7 +8,7 @@ if($MinimalDisplay) {
 	}
 	else {
 		?> does no damage this round<?php
-	} ?>.<?php
+	} ?>. <?php echo $AttackLogLink;
 	return;
 }
 if(isset($PortCombatResults['Weapons']) && is_array($PortCombatResults['Weapons'])) {


### PR DESCRIPTION
The combat summary display on the Current Sector page (for allies
contributing to the combat) will now include a link to the combat
log report.

This affects both Port Raids and Planet Busts.

![image](https://user-images.githubusercontent.com/846186/55455645-435c7200-5599-11e9-8ecc-fa23788f2215.png)
