### PR TITLE
Fix weapon Show/Hide ajax

### DIFF
--- a/engine/Default/toggle_processing.php
+++ b/engine/Default/toggle_processing.php
@@ -1,13 +1,14 @@
 <?php
 if($var['toggle']=='WeaponHiding') {
 	$player->setDisplayWeapons(!$player->isDisplayWeapons());
+	// If this is called by ajax, we don't want to do any forwarding
+	if (USING_AJAX) {
+		exit;
+	}
 }
 else if($var['toggle']=='AJAX') {
 	$account->setUseAJAX(!$account->isUseAJAX());
 }
-if(!USING_AJAX) {
-	$container = create_container('skeleton.php');
-	if(isset($var['referrer'])) $container['body'] = $var['referrer'];
-	else $container['body'] = 'current_sector.php';
-	forward($container);
-}
+
+$body = $var['referrer'] ?? 'current_sector.php';
+forward(create_container('skeleton.php', $body));

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -1390,9 +1390,10 @@ abstract class AbstractSmrPlayer {
 		return Globals::getAllianceRosterHREF($this->getAllianceID());
 	}
 
-	public function getToggleWeaponHidingHREF() {
+	public function getToggleWeaponHidingHREF($ajax=false) {
 		$container = create_container('skeleton.php','toggle_processing.php');
 		$container['toggle'] = 'WeaponHiding';
+		$container['AJAX'] = $ajax;
 		return SmrSession::getNewHREF($container);
 	}
 }

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -549,11 +549,16 @@ class SmrPlayer extends AbstractSmrPlayer {
 		return $this->displayWeapons;
 	}
 
+	/**
+	 * Should weapons be displayed in the right panel?
+	 * This updates the player database directly because it is used with AJAX,
+	 * which does not acquire a sector lock.
+	 */
 	function setDisplayWeapons($bool) {
 		if($this->displayWeapons == $bool)
 			return;
 		$this->displayWeapons=$bool;
-		$this->hasChanged=true;
+		$this->db->query('UPDATE player SET display_weapons=' . $this->db->escapeBoolean($this->displayWeapons) . ' WHERE ' . $this->SQL);
 	}
 
 	function isForceDropMessages() {
@@ -1185,7 +1190,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 				', bank='.$this->db->escapeNumber($this->bank).
 				', zoom='.$this->db->escapeString($this->zoom).
 				', display_missions='.$this->db->escapeBoolean($this->displayMissions).
-				', display_weapons='.$this->db->escapeBoolean($this->displayWeapons).
 				', force_drop_messages='.$this->db->escapeBoolean($this->forceDropMessages).
 				', group_scout_messages='.$this->db->escapeString($this->groupScoutMessages).
 				', ignore_globals='.$this->db->escapeBoolean($this->ignoreGlobals).

--- a/templates/Default/engine/Default/includes/RightPanelShip.inc
+++ b/templates/Default/engine/Default/includes/RightPanelShip.inc
@@ -76,7 +76,7 @@ if(isset($GameID)) { ?>
 	Empty : <?php echo $ThisShip->getEmptyHolds(); ?><br /><br />
 	<a href="<?php echo $WeaponReorderLink; ?>"><span class="bold">Weapons</span></a>&nbsp;<a href="weapon_list.php" target="_blank"><img src="images/silk/help.png" width="16" height="16" alt="Weapon List" title="Weapon List"/></a><br /><?php
 	if($ThisShip->hasWeapons()) { ?>
-		<div class="wep_drop1" id="hide-show" onclick="toggleWepD('<?php echo $ThisPlayer->getToggleWeaponHidingHREF(); ?>');">
+		<div class="wep_drop1" id="hide-show" onclick="toggleWepD('<?php echo $ThisPlayer->getToggleWeaponHidingHREF(true); ?>');">
 			<a href="<?php echo $ThisPlayer->getToggleWeaponHidingHREF(); ?>" onclick="this.href='javascript:void(0)';">
 				Show/Hide (<?php echo $ThisShip->getNumWeapons(); ?>)<br />
 			</a>


### PR DESCRIPTION
* Clicking the Show/Hide link no longer stops automatic ajax updates.
* Multiple clicks of Show/Hide on the same page are now respected.

Add `'AJAX'=>true` to the container used for the JavaScript-only
Show/Hide link so that when we run toggle_processing.php,
`USING_AJAX=true`.

Since the Show/Hide HTML changes are performed exclusively in JS,
the only purpose of the call to toggle_processing.php is to update
the `display_weapons` setting for the SmrPlayer. Therefore, we will
do an early exit in toggle_processing.php (when triggered with ajax)
so that the remainder of `do_voodoo` (i.e. template display and
SmrSession updating) does not get run.

The only somewhat backwards aspect of this fix is that we had to make
SmrPlayer::setDisplayWeapons update the `player` database table
directly. This is because ajax triggers, as designed here, do not
acquire a sector lock. (This is partly due to a degeneracy of the
USING_AJAX constant, which disables both SmrSession updates and
sector locks, because normal ajax auto updates don't need either.)
However, we don't want to update the entire `player` row without
a sector lock, since this could clobber other changes to this player,
so we are forced to do a direct update of the `display_weapons` table
column.