### PR TITLE
Fix chess ajax triggers

### DIFF
--- a/engine/Default/chess_move_processing.php
+++ b/engine/Default/chess_move_processing.php
@@ -1,7 +1,9 @@
 <?php
 
+$container = create_container('skeleton.php', 'chess_play.php');
+transfer('ChessGameID');
+
 $chessGame = ChessGame::getChessGame($var['ChessGameID']);
-$template->assign('ChessGame',$chessGame);
 if(is_numeric($_REQUEST['x']) && is_numeric($_REQUEST['y']) && is_numeric($_REQUEST['toX']) && is_numeric($_REQUEST['toY'])) {
 	$x = $_REQUEST['x'];
 	$y = $_REQUEST['y'];
@@ -16,39 +18,28 @@ if(is_numeric($_REQUEST['x']) && is_numeric($_REQUEST['y']) && is_numeric($_REQU
 						//Success
 					break;
 					case 1:
-						$template->assign('MoveMessage', 'You have just checkmated your opponent, congratulations!');
+						$container['MoveMessage'] = 'You have just checkmated your opponent, congratulations!';
 					break;
 					case 2:
-						$template->assign('MoveMessage', 'There is no piece in that square.');
+						$container['MoveMessage'] = 'There is no piece in that square.';
 					break;
 					case 3:
-						$template->assign('MoveMessage', 'You cannot end your turn in check.');
+						$container['MoveMessage'] = 'You cannot end your turn in check.';
 					break;
 					case 4:
-						$template->assign('MoveMessage', 'It is not your turn to move.');
+						$container['MoveMessage'] = 'It is not your turn to move.';
 					break;
 					case 5:
-						$template->assign('MoveMessage', 'The game is over.');
+						$container['MoveMessage'] = 'The game is over.';
 					break;
 				}
 			}
-			else {
-//				this.logger.error('Player tried to move from an empty tile: username = ' + username + ', x = ' + xIn + ', y = ' + yIn + ', toX = ' + toXIn + ', toY = ' + toYIn);
-			}
+		} else {
+			$container['MoveMessage'] = 'It is not your turn to move.';
 		}
-		else {
-//			this.logger.error('Player tried to move in an ended game');
-			$template->assign('MoveMessage', 'It is not your turn to move.');
-		}
+	} else {
+		$container['MoveMessage'] = 'This game is over.';
 	}
-	else {
-		$template->assign('MoveMessage', 'This game is over.');
-//		this.logger.error('Player tried to move when it was not their turn: x = ' + xIn + ', y = ' + yIn + ', toX = ' + toXIn + ', toY = ' + toYIn);
-	}
-}
-else {
-//	this.logger.error('Player supplied an invalid number: x = ' + xIn + ', y = ' + yIn + ', toX = ' + toXIn + ', toY = ' + toYIn);
 }
 
-$var = SmrSession::retrieveVar(SmrSession::$lastSN);
-do_voodoo();
+forward($container);

--- a/engine/Default/chess_play.php
+++ b/engine/Default/chess_play.php
@@ -1,4 +1,5 @@
 <?php
 
+$template->assign('MoveMessage', $var['MoveMessage'] ?? '');
 $template->assign('ChessGame',ChessGame::getChessGame($var['ChessGameID']));
 $template->assign('ChessMoveHREF',SmrSession::getNewHREF(create_container('chess_move_processing.php','',array('AJAX' => true, 'ChessGameID' => $var['ChessGameID']))));

--- a/htdocs/js/ajax.js
+++ b/htdocs/js/ajax.js
@@ -38,8 +38,8 @@ var exec = function(s) {
 		}
 	};
 
-	getURLParameter = function(paramName) {
-		var paramValue = false, href = location.href, paramDetail;
+	getURLParameter = function(paramName, href) {
+		var paramValue = false, paramDetail;
 		if ( href.indexOf("?") > -1 ) {
 			var i, paramListStr = href.substr(href.indexOf("?")), paramList = paramListStr.split("&");
 			for ( i = 0; i < paramList.length; i++ ) {
@@ -99,6 +99,7 @@ var exec = function(s) {
 		data.toX = e.data('x');
 		data.toY = e.data('y');
 		$.get(submitMoveHREF, data, function(data, textStatus, jqXHR) {
+				sn = getURLParameter('sn', submitMoveHREF);
 				highlightMoves();
 				updateRefresh(data, textStatus, jqXHR);
 			}, 'xml');
@@ -133,7 +134,7 @@ var exec = function(s) {
 			return;
 		}
 		refreshSpeed = _refreshSpeed;
-		sn = getURLParameter('sn');
+		sn = getURLParameter('sn', location.href);
 		if(sn===false) {
 			return;
 		}

--- a/htdocs/js/ajax.js
+++ b/htdocs/js/ajax.js
@@ -177,7 +177,7 @@ var exec = function(s) {
 		"use strict";
 		$('.wep1:visible').slideToggle(600);
 		$('.wep1:hidden').fadeToggle(600);
-		$.get(link);
+		$.get(link, {ajax: 1});
 	};
 
 	window.toggleScoutGroup = function(senderID) {

--- a/htdocs/js/ajax.js
+++ b/htdocs/js/ajax.js
@@ -4,7 +4,7 @@ var exec = function(s) {
 };
 (function() {
 	"use strict";
-	var bindOne, updateRefreshTimeout, refreshSpeed, ajaxRunning = true, refreshReady = true, disableStartAJAX=true, xmlHttpRefresh, sn, updateRefresh, updateRefreshRequest, stopAJAX, getURLParameter;
+	var bindOne, updateRefreshTimeout, refreshSpeed, ajaxRunning = true, refreshReady = true, disableStartAJAX=true, xmlHttpRefresh, sn, updateRefresh, updateRefreshRequest, stopAJAX;
 
 	bindOne = function(func, arg) {
 		return function() {
@@ -38,21 +38,17 @@ var exec = function(s) {
 		}
 	};
 
-	getURLParameter = function(paramName, href) {
-		var paramValue = false, paramDetail;
+	function getURLParameter(paramName, href) {
 		if ( href.indexOf("?") > -1 ) {
-			var i, paramListStr = href.substr(href.indexOf("?")), paramList = paramListStr.split("&");
-			for ( i = 0; i < paramList.length; i++ ) {
+			var paramList = href.substr(href.indexOf("?")).split("&");
+			for (var i = 0; i < paramList.length; i++) {
 				if (paramList[i].toUpperCase().indexOf(paramName.toUpperCase() + "=") > -1 ) {
-					paramDetail = paramList[i].split("=");
-					paramValue = paramDetail[1];
-					break;
+					return paramList[i].split("=")[1];
 				}
 			}
 		}
-		return paramValue;
-	};
-
+		return false;
+	}
 
 	updateRefresh = function(data) {
 		$('all > *', data).each(function(i, e) {

--- a/lib/Default/ChessGame.class.inc
+++ b/lib/Default/ChessGame.class.inc
@@ -185,16 +185,6 @@ class ChessGame {
 				$pieceTakenID = $this->db->getField('piece_taken') == null ? null : $this->db->getInt('piece_taken');
 				$this->moves[] = $this->createMove($this->db->getInt('piece_id'), $this->db->getInt('start_x'), $this->db->getInt('start_y'), $this->db->getInt('end_x'), $this->db->getInt('end_y'), $pieceTakenID, $this->db->getField('checked'), $this->db->getInt('move_id') % 2 == 1 ? self::PLAYER_WHITE : self::PLAYER_BLACK, $this->db->getField('castling'), $this->db->getBoolean('en_passant'), $this->db->getInt('promote_piece_id'));
 				$mate = $this->db->getField('checked') == 'MATE';
-				$this->lastMove = array(
-						'From' => array(
-							'X' => $this->db->getInt('start_x'),
-							'Y' => $this->db->getInt('start_y')
-						),
-						'To' => array(
-							'X' => $this->db->getInt('end_x'),
-							'Y' => $this->db->getInt('end_y')
-						)
-					);
 			}
 			if(!$mate && $this->hasEnded()) {
 				if($this->getWinner() != 0) {
@@ -397,7 +387,13 @@ class ChessGame {
 		}
 	}
 
-	public function createMove($pieceID, $startX, $startY, $endX, $endY, $pieceTaken, $checking, $playerColour, $castling, $enPassant, $promotionPieceID) {
+	private function createMove($pieceID, $startX, $startY, $endX, $endY, $pieceTaken, $checking, $playerColour, $castling, $enPassant, $promotionPieceID) {
+		// This move will be set as the most recent move
+		$this->lastMove = [
+			'From' => ['X' => $startX, 'Y' => $startY],
+			'To'   => ['X' => $endX,   'Y' => $endY],
+		];
+
 		$otherPlayerColour = self::getOtherColour($playerColour);
 		if($pieceID == ChessPiece::KING) {
 			$this->hasMoved[$playerColour][ChessPiece::KING] = true;

--- a/lib/Default/ChessGame.class.inc
+++ b/lib/Default/ChessGame.class.inc
@@ -818,7 +818,7 @@ class ChessGame {
 	}
 
 	public function hasEnded() {
-		return $this->endDate != 0 && $this->endDate < TIME;
+		return $this->endDate != 0 && $this->endDate <= TIME;
 	}
 
 	public function getWinner() {
@@ -827,6 +827,7 @@ class ChessGame {
 
 	public function setWinner($accountID) {
 		$this->winner = $accountID;
+		$this->endDate = TIME;
 		$this->db->query('UPDATE chess_game
 						SET end_time=' . $this->db->escapeNumber(TIME) . ', winner_id=' . $this->db->escapeNumber($this->winner) . '
 						WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ';');

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -424,7 +424,7 @@ class SmrSession {
 	}
 
 	public static function getNewHREF($container, $forceFullURL=false) {
-		$sn = self::addLink($container) . (isset($container['AJAX']) && $container['AJAX'] == true ? '&amp;ajax=1':'');
+		$sn = self::addLink($container);
 		if($forceFullURL===true||stripos($_SERVER['REQUEST_URI'],'loader.php')===false)
 			return '/loader.php?sn=' . $sn;
 		else

--- a/lib/Default/Template.class.inc
+++ b/lib/Default/Template.class.inc
@@ -61,7 +61,7 @@ class Template {
 
 		$ajaxEnabled = ($this->data['AJAX_ENABLE_REFRESH'] ?? false) !== false;
 		if ($ajaxEnabled) {
-			$ajaxXml =& $this->convertHtmlToAjaxXml($output,USING_AJAX);
+			$ajaxXml =& $this->convertHtmlToAjaxXml($output, $outputXml);
 			if ($outputXml) {
 				/* Left out for size: <?xml version="1.0" encoding="ISO-8859-1"?>*/
 				$ajaxXml='<all>'.$ajaxXml.'</all>';

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -549,7 +549,7 @@ function do_voodoo() {
 	}
 	$template->assign('AJAX_ENABLE_REFRESH', $ajaxRefresh);
 
-	$template->display($var['url'], USING_AJAX);
+	$template->display($var['url'], USING_AJAX || AJAX_CONTAINER);
 
 	SmrSession::update();
 

--- a/templates/Default/engine/Default/chess_play.php
+++ b/templates/Default/engine/Default/chess_play.php
@@ -47,7 +47,7 @@
 		</td>
 	</tr>
 	<tr>
-		<td></td>
+		<td id="chessMsg" class="ajax"><p><?php echo $MoveMessage; ?></p></td>
 		<td id="chessButtons" class="ajax"><?php
 			if(!$ChessGame->hasEnded() && $ChessGame->getColourForAccountID($ThisPlayer->getAccountID())) {
 				?><div class="buttonA"><a class="buttonA" href="<?php echo $ChessGame->getResignHREF(); ?>"><?php if(count($ChessGame->getMoves()) < 2) { ?>Cancel Game<?php } else { ?>Resign<?php } ?></a></div><?php
@@ -71,11 +71,8 @@
 				}
 			}
 		}
-	}
-	if(isset($MoveMessage)) {
-		$this->addJavascriptAlert($MoveMessage);
 	} ?>
-	var submitMoveHREF = '<?php echo $ChessMoveHREF; ?>',
+	var submitMoveHREF = <?php echo $this->addJavascriptForAjax('submitMoveHREF', $ChessMoveHREF); ?>,
 		availableMoves = <?php echo $this->addJavascriptForAjax('availableMoves', $AvailableMoves); ?>;<?php
 	$LastMove = $ChessGame->getLastMove();
 	if($LastMove != null) {


### PR DESCRIPTION
Chess moves now have a more standard processing procedure, using containers and forwarding as we would normally expect.

The ajax updating infrastructure has been slightly modified to make this happen correctly, notably by disentangling how we set `AJAX_CONTAINER` and `USING_AJAX`. Roughly, they now mean:
* `AJAX_CONTAINER`: a page that will be accessed by ajax submitting a link (with possible XML returns)
* `USING_AJAX`: an ajax trigger or auto-update that should not require a sector lock

These variables will likely need to be documented and/or renamed for clarity, but I think there is more to do to simplify this infrastructure before that is done.

Also fixed a few bugs in ChessGame.class.inc that were causing ajax triggers (once working correctly) to update the content in unexpected ways.

See commit messages for details.