### PR TITLE
Stay on Local Map when dropping single forces

### DIFF
--- a/engine/Default/forces_drop_processing.php
+++ b/engine/Default/forces_drop_processing.php
@@ -223,4 +223,10 @@ $account->log(LOG_TYPE_FORCES, $change_combat_drones.' combat drones, '.$change_
 $forces->updateExpire();
 $forces->update(); // Needs to be in db to show up on CS instantly when querying sector forces
 
-forward(create_container('skeleton.php', 'current_sector.php'));
+// If we dropped forces from the Local Map, stay on that page
+if (isset($var['referrer']) && $var['referrer'] == 'map_local.php') {
+	$body = $var['referrer'];
+} else {
+	$body = 'current_sector.php';
+}
+forward(create_container('skeleton.php', $body));

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -532,7 +532,7 @@ function do_voodoo() {
 	if($account->getCssLink()!=null) {
 		$template->assign('ExtraCSSLink',$account->getCssLink());
 	}
-	doSkeletonAssigns($template,$player,$ship,$sector,$db,$account);
+	doSkeletonAssigns($template,$player,$ship,$sector,$db,$account,$var);
 
 	// Set ajax refresh time
 	$ajaxRefresh = $var['AllowAjax'] ?? true; // hack for bar_gambling_processing.php
@@ -640,7 +640,7 @@ function doTickerAssigns($template, $player, $db) {
 	}
 }
 
-function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account) {
+function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account, $var) {
 	$template->assign('CSSLink', $account->getCssUrl());
 	$template->assign('CSSColourLink', $account->getCssColourUrl());
 
@@ -801,12 +801,14 @@ function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account) {
 			$container = create_container('forces_drop_processing.php');
 			$container['owner_id'] = $player->getAccountID();
 			$container['drop_mines'] = 1;
+			$container['referrer'] = $var['body'];
 			$template->assign('DropMineLink',SmrSession::getNewHREF($container));
 		}
 		if ($ship->hasCDs()) {
 			$container = create_container('forces_drop_processing.php');
 			$container['owner_id'] = $player->getAccountID();
 			$container['drop_combat_drones'] = 1;
+			$container['referrer'] = $var['body'];
 			$template->assign('DropCDLink',SmrSession::getNewHREF($container));
 		}
 
@@ -814,6 +816,7 @@ function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account) {
 			$container = create_container('forces_drop_processing.php');
 			$container['owner_id'] = $player->getAccountID();
 			$container['drop_scout_drones'] = 1;
+			$container['referrer'] = $var['body'];
 			$template->assign('DropSDLink',SmrSession::getNewHREF($container));
 		}
 


### PR DESCRIPTION
Previously, dropping a single force using the "[x]" links on the
right panel would always take you to the Current Sector page.

However, if you are on the Local Map, it is likely that you want
to stay on the Local Map, and so we now do that in order to avoid
unnecessary clicking and page switching.

This may have some impact on gameplay, since the old behavior
does combine two actions together in a relevant way (e.g. dropping
a single mine and then going to the Current Sector page to attack).
We will want to monitor the community feedback from this change
before deploying it to the live server.