### PR TITLE
Increase exp earned per damage to ports/planets

### DIFF
--- a/lib/Default/AbstractSmrShip.class.inc
+++ b/lib/Default/AbstractSmrShip.class.inc
@@ -5,6 +5,12 @@ abstract class AbstractSmrShip {
 
 	const SHIP_CLASS_RAIDER = 3;
 
+	// Player exp gained for each point of damage done
+	const EXP_PER_DAMAGE_PLAYER = 0.25;
+	const EXP_PER_DAMAGE_PLANET = 0.5;
+	const EXP_PER_DAMAGE_PORT   = 0.1;
+	const EXP_PER_DAMAGE_FORCE  = 0.05;
+
 	protected $player;
 
 	protected $gameID;
@@ -858,7 +864,7 @@ abstract class AbstractSmrShip {
 			$results['Drones'] =& $thisCDs->shootPlayer($thisPlayer, $targetPlayers[array_rand($targetPlayers)]);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}
-		$thisPlayer->increaseExperience(round($results['TotalDamage']/4)); // 1/4 weapon damage to exp.
+		$thisPlayer->increaseExperience(round($results['TotalDamage'] * self::EXP_PER_DAMAGE_PLAYER));
 		$thisPlayer->increaseHOF($results['TotalDamage'],array('Combat','Player','Damage Done'), HOF_PUBLIC);
 		$thisPlayer->increaseHOF(1,array('Combat','Player','Shots'), HOF_PUBLIC);
 		return $results;
@@ -897,7 +903,7 @@ abstract class AbstractSmrShip {
 			$thisPlayer->increaseHOF($results['Drones']['ActualDamage']['SDs'],array('Combat','Forces','Scout Drones','Damage Done'), HOF_PUBLIC);
 			$thisPlayer->increaseHOF($results['Drones']['ActualDamage']['NumMines']+$results['Drones']['ActualDamage']['NumCDs']+$results['Drones']['ActualDamage']['NumSDs'],array('Combat','Forces','Killed'), HOF_PUBLIC);
 		}
-		$thisPlayer->increaseExperience(round($results['TotalDamage']/20)); // 1/20 weapon damage to exp.
+		$thisPlayer->increaseExperience(round($results['TotalDamage'] * self::EXP_PER_DAMAGE_FORCE));
 		$thisPlayer->increaseHOF($results['TotalDamage'],array('Combat','Forces','Damage Done'), HOF_PUBLIC);
 		$thisPlayer->increaseHOF(1,array('Combat','Forces','Shots'), HOF_PUBLIC);
 		return $results;
@@ -921,7 +927,7 @@ abstract class AbstractSmrShip {
 			$results['Drones'] =& $thisCDs->shootPort($thisPlayer, $port);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}
-		$thisPlayer->increaseExperience(round($results['TotalDamage']/20)); // 1/20 weapon damage to exp.
+		$thisPlayer->increaseExperience(round($results['TotalDamage'] * self::EXP_PER_DAMAGE_PORT));
 		$thisPlayer->increaseHOF($results['TotalDamage'],array('Combat','Port','Damage Done'), HOF_PUBLIC);
 //		$thisPlayer->increaseHOF(1,array('Combat','Port','Shots')); //in SmrPortt::attackedBy()
 
@@ -958,7 +964,7 @@ abstract class AbstractSmrShip {
 			$results['Drones'] =& $thisCDs->shootPlanet($thisPlayer, $planet, $delayed);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}
-		$thisPlayer->increaseExperience(round($results['TotalDamage']/20)); // 1/20 weapon damage to exp.
+		$thisPlayer->increaseExperience(round($results['TotalDamage'] * self::EXP_PER_DAMAGE_PLANET));
 		$thisPlayer->increaseHOF($results['TotalDamage'],array('Combat','Planet','Damage Done'), HOF_PUBLIC);
 //		$thisPlayer->increaseHOF(1,array('Combat','Planet','Shots')); //in SmrPlanet::attackedBy()
 		return $results;


### PR DESCRIPTION
Previous exp/damage ratios:

* vs players: 1/4
* vs ports/planets/forces: 1/20

New exp/damage ratios:

* vs players: 1/4 (unchanged)
* vs ports: 1/10 (2x higher)
* vs planets: 1/2 (10x higher)
* vs forces: 1/20 (unchanged)

Ports were increased by 2x because the exp was aggressively low.
There is not too much risk, so it should not be heavily rewarded,
but even at the increased level, it is 1/2 the exp you would make
trading a 1x route in an IST.

Planets were increased by 5x*2x = 10x. The 5x comes from the fact
that weapons do 1/5 their normal damage to planets (e.g. a HHG does
60 shield damage instead of 300), and the 2x is to bring it in line
with the change to ports. This is likely still too low.

The following exp will be earned from damage done (spread out across
all attackers).
- Level 9 port: 1040 -> 2080 exp
- Level 1 port: 210 -> 520 exp
- Level 45 planet (Terran): 425 -> 4250 exp
- Level 33 planet (Dwarf): 305 -> 3050 exp

NOTE: Force exp is unchanged since each mine has 20 armour (i.e.
destroying 50 mines is already 1000 damage).