### PR TITLE
Initialize Weapons index in combat results array

### DIFF
--- a/lib/Default/AbstractSmrShip.class.inc
+++ b/lib/Default/AbstractSmrShip.class.inc
@@ -848,7 +848,7 @@ abstract class AbstractSmrShip {
 
 	public function &shootPlayers(array $targetPlayers) {
 		$thisPlayer = $this->getPlayer();
-		$results = array('Player' => $thisPlayer, 'TotalDamage' => 0);
+		$results = array('Player' => $thisPlayer, 'TotalDamage' => 0, 'Weapons' => []);
 		if($thisPlayer->isDead()) {
 			$results['DeadBeforeShot'] = true;
 			return $results;
@@ -872,7 +872,7 @@ abstract class AbstractSmrShip {
 
 	public function &shootForces(SmrForce $forces) {
 		$thisPlayer = $this->getPlayer();
-		$results = array('Player' => $thisPlayer, 'TotalDamage' => 0);
+		$results = array('Player' => $thisPlayer, 'TotalDamage' => 0, 'Weapons' => []);
 		if($thisPlayer->isDead()) {
 			$results['DeadBeforeShot'] = true;
 			return $results;
@@ -911,7 +911,7 @@ abstract class AbstractSmrShip {
 
 	public function &shootPort(SmrPort $port) {
 		$thisPlayer = $this->getPlayer();
-		$results = array('Player' => $thisPlayer, 'TotalDamage' => 0);
+		$results = array('Player' => $thisPlayer, 'TotalDamage' => 0, 'Weapons' => []);
 		if($thisPlayer->isDead()) {
 			$results['DeadBeforeShot'] = true;
 			return $results;
@@ -948,7 +948,7 @@ abstract class AbstractSmrShip {
 
 	public function &shootPlanet(SmrPlanet $planet, $delayed) {
 		$thisPlayer = $this->getPlayer();
-		$results = array('Player' => $thisPlayer, 'TotalDamage' => 0);
+		$results = array('Player' => $thisPlayer, 'TotalDamage' => 0, 'Weapons' => []);
 		if($thisPlayer->isDead()) {
 			$results['DeadBeforeShot'] = true;
 			return $results;


### PR DESCRIPTION
In player vs. player combat, if a team with more than 1 player had
a player with no weapons, then when checking if assists should be
awarded, we would get a warning when trying to iterate over the
'Weapons' index of the results array. This was because this index
was not initialized, and thus undefined if the player had no weapons.

We could fix this by skipping the check if 'Weapons' was not set,
but it is more robust to initialize 'Weapons' as an empty array.