### PR TITLE
Various Hall of Fame fixes

### DIFF
--- a/engine/Default/game_join.php
+++ b/engine/Default/game_join.php
@@ -17,8 +17,9 @@ if ($game->getTotalPlayers() >= $game->getMaxPlayers()) {
 //if (TIME < $game['StartDate'])
 //	create_error('You want to join a game that hasn\'t started yet?');
 
-if (TIME > $game->getEndDate())
+if ($game->hasEnded()) {
 	create_error('You want to join a game that is already over?');
+}
 
 $template->assign('PageTopic', 'Join Game: ' . $game->getDisplayName());
 $template->assign('Game', $game);

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -39,7 +39,7 @@ if(!isset($var['view'])) {
 	$template->assign('Categories', $categories);
 }
 else {
-	$gameIDSql = ' AND game_id '.(isset($game_id) ? '= ' . $db->escapeNumber($game_id) : 'IN (SELECT game_id FROM game WHERE ignore_stats = '.$db->escapeBoolean(false).')');
+	$gameIDSql = ' AND game_id '.(isset($game_id) ? '= ' . $db->escapeNumber($game_id) : 'IN (SELECT game_id FROM game WHERE end_date < '.TIME.' AND ignore_stats = '.$db->escapeBoolean(false).')');
 
 	$vis = HOF_PUBLIC;
 	$rank=1;

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -66,18 +66,8 @@ else {
 		$accountID = $db->getField('account_id');
 		if($accountID == $account->getAccountID()) {
 			$foundMe = true;
-			$amount = $db->getField('amount');
 		}
-		else if($vis==HOF_PUBLIC) {
-			$amount = $db->getField('amount');
-		}
-		else if($vis==HOF_ALLIANCE) {
-			$rankInfo = getHofRank($var['view'], $viewType, $db->getField('account_id'), $game_id);
-			$amount = $rankInfo['Amount'];
-		}
-		else {
-			$amount = '-';
-		}
+		$amount = applyHofVisibilityMask($db->getField('amount'), $vis, $game_id, $accountID);
 		$rows[] = displayHOFRow($rank++, $accountID, $amount);
 	}
 	if(!$foundMe) {

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -48,10 +48,10 @@ else {
 	$viewType[] = $var['view'];
 	if($var['view'] == DONATION_NAME)
 		$db->query('SELECT account_id, SUM(amount) as amount FROM account_donated
-					GROUP BY account_id ORDER BY amount DESC LIMIT 25');
+					GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
 	else if($var['view'] == USER_SCORE_NAME) {
 		$statements = SmrAccount::getUserScoreCaseStatement($db);
-		$query = 'SELECT account_id, '.$statements['CASE'].' amount FROM (SELECT account_id, type, SUM(amount) amount FROM player_hof WHERE type IN ('.$statements['IN'].')'.$gameIDSql.' GROUP BY account_id,type) x GROUP BY account_id ORDER BY amount DESC LIMIT 25';
+		$query = 'SELECT account_id, '.$statements['CASE'].' amount FROM (SELECT account_id, type, SUM(amount) amount FROM player_hof WHERE type IN ('.$statements['IN'].')'.$gameIDSql.' GROUP BY account_id,type) x GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25';
 		$db->query($query);
 	}
 	else {
@@ -59,7 +59,7 @@ else {
 		if($db->nextRecord()) {
 			$vis = $db->getField('visibility');
 		}
-		$db->query('SELECT account_id,SUM(amount) amount FROM player_hof WHERE type='.$db->escapeArray($viewType,false,true,':',false).$gameIDSql.' GROUP BY account_id ORDER BY amount DESC LIMIT 25');
+		$db->query('SELECT account_id,SUM(amount) amount FROM player_hof WHERE type='.$db->escapeArray($viewType,false,true,':',false).$gameIDSql.' GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
 	}
 	$rows = [];
 	while($db->nextRecord()) {

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -35,7 +35,7 @@ while($db->nextRecord()) {
 $template->assign('Breadcrumb', buildBreadcrumb($var,$hofTypes,isset($game_id)?'Current HoF':'Global HoF'));
 
 if(!isset($var['view'])) {
-	$categories = getHofCategories($hofTypes, $game_id);
+	$categories = getHofCategories($hofTypes, $game_id, $account->getAccountID());
 	$template->assign('Categories', $categories);
 }
 else {

--- a/engine/Default/hall_of_fame_player_detail.php
+++ b/engine/Default/hall_of_fame_player_detail.php
@@ -47,7 +47,7 @@ while($db->nextRecord()) {
 $template->assign('Breadcrumb', buildBreadcrumb($var, $hofTypes, 'Personal HoF'));
 
 if(!isset($var['view'])) {
-	$categories = getHofCategories($hofTypes, $game_id);
+	$categories = getHofCategories($hofTypes, $game_id, $account_id);
 	$template->assign('Categories', $categories);
 }
 else {

--- a/engine/Default/hall_of_fame_player_detail.php
+++ b/engine/Default/hall_of_fame_player_detail.php
@@ -18,7 +18,8 @@ if(isset($var['game_id'])) {
 	$template->assign('PageTopic',$hofPlayer->getPlayerName().'\'s Personal Hall of Fame For '.Globals::getGameName($var['game_id']));
 }
 else {
-	$template->assign('PageTopic',$account->getHofName().'\'s All Time Personal Hall of Fame');
+	$hofName = SmrAccount::getAccount($account_id)->getHofName();
+	$template->assign('PageTopic', $hofName.'\'s All Time Personal Hall of Fame');
 }
 
 $allowedVisibities = array(HOF_PUBLIC);

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -1278,7 +1278,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function sameAlliance(AbstractSmrPlayer $otherPlayer = null) {
-		return $otherPlayer != null && ($this->equals($otherPlayer) || ($this->hasAlliance() && $this->getAllianceID()==$otherPlayer->getAllianceID()));
+		return $this->equals($otherPlayer) || (!is_null($otherPlayer) && $this->getGameID() == $otherPlayer->getGameID() && $this->hasAlliance() && $this->getAllianceID() == $otherPlayer->getAllianceID());
 	}
 
 	public function sharedForceAlliance(AbstractSmrPlayer $otherPlayer = null) {

--- a/lib/Default/SmrGame.class.inc
+++ b/lib/Default/SmrGame.class.inc
@@ -198,6 +198,10 @@ class SmrGame {
 		$this->hasChanged=true;
 	}
 
+	public function hasEnded() {
+		return $this->getEndDate() < TIME;
+	}
+
 	public function getEndDate() {
 		return $this->endDate;
 	}

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -178,7 +178,7 @@ function buildBreadcrumb(&$var,&$hofTypes,$hofName) {
 			else {
 				$typeList[] = $type;
 			}
-			$viewing .= ' -&gt; ';
+			$viewing .= ' &rarr; ';
 			$container = $var;
 			$container['type'] = $typeList;
 			unset($container['view']);
@@ -188,7 +188,7 @@ function buildBreadcrumb(&$var,&$hofTypes,$hofName) {
 		}
 	}
 	if(isset($var['view'])) {
-		$viewing .= ' -&gt; ';
+		$viewing .= ' &rarr; ';
 		if(is_array($hofTypes[$var['view']])) {
 			$typeList[] = $var['view'];
 			$var['type'] = $typeList;

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -45,9 +45,30 @@ function getHofCategories($hofTypes, $game_id, $account_id) {
 	return $categories;
 }
 
+/**
+ * Conditionally hide displayed HoF stat.
+ *
+ * Hide the amount for:
+ * - alliance stats in live games for players not in your alliance
+ * - private stats for players who are not the current player
+ */
+function applyHofVisibilityMask($amount, $vis, $gameID, $accountID) {
+	global $account, $player;
+	if (($vis == HOF_PRIVATE && $account->getAccountID() != $accountID) ||
+	    ($vis == HOF_ALLIANCE && isset($gameID) &&
+	     !SmrGame::getGame($gameID)->hasEnded() &&
+	     !SmrPlayer::getPlayer($accountID, $gameID)->sameAlliance($player)))
+	{
+		return '-';
+	} else {
+		return $amount;
+	}
+}
+
 function getHofRank($view,$viewType,$accountID,$gameID) {
-	global $account,$player;
+	global $account;
 	$db = new SmrMySqlDatabase();
+	// If no game specified, show total amount from completed games only
 	$gameIDSql = ' AND game_id '.(isset($gameID) ? '= ' . $db->escapeNumber($gameID) : 'IN (SELECT game_id FROM game WHERE end_date < '.TIME.' AND ignore_stats = '.$db->escapeBoolean(false).')');
 
 	$vis = HOF_PUBLIC;
@@ -69,29 +90,13 @@ function getHofRank($view,$viewType,$accountID,$gameID) {
 		$db->query('SELECT SUM(amount) amount FROM player_hof WHERE type='.$db->escapeArray($viewType,false,true,':',false) .' AND account_id='.$db->escapeNumber($accountID).$gameIDSql.' GROUP BY account_id LIMIT 1');
 	}
 
-	// What we will show for the amount:
-	// * Live game:
-	//  - Ally: real amount
-	//  - Enemy: "-"
-	// * Ended game:
-	//  - All players: real amount
-	// * No game specified (All Time HoF):
-	//  - All players: total amount from completed games
 	$realAmount = 0;
 	if($db->nextRecord()) {
 		if($db->getField('amount')!=null) {
 			$realAmount = $db->getField('amount');
 		}
 	}
-	if ($vis == HOF_PRIVATE || $vis == HOF_ALLIANCE && isset($gameID) &&
-	    !SmrGame::getGame($gameID)->hasEnded() &&
-	    !SmrPlayer::getPlayer($accountID, $gameID)->sameAlliance($player))
-	{
-		// Hide the amount in live games for players not in your alliance
-		$rank['Amount'] = '-';
-	} else {
-		$rank['Amount'] = $realAmount;
-	}
+	$rank['Amount'] = applyHofVisibilityMask($realAmount, $vis, $gameID, $accountID);
 
 	if($view == DONATION_NAME) {
 		$db->query('SELECT COUNT(account_id) rank FROM (SELECT account_id FROM account_donated GROUP BY account_id HAVING SUM(amount)>' . $db->escapeNumber($rank['Amount']) . ') x');

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -146,11 +146,8 @@ function displayHOFRow($rank,$accountID,$amount) {
 
 	if (isset($var['game_id'])) {
 		$container['game_id'] = $var['game_id'];
-		$container['sending_page'] = 'personal_current_hof';
 	}
-	else {
-		$container['sending_page'] = 'personal_hof';
-	}
+
 	if(isset($hofPlayer) && is_object($hofPlayer)) {
 		$return.=('<td '.$bold.'>'.create_link($container, $hofPlayer->getPlayerName()) .'</td>');
 	}

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -70,9 +70,12 @@ function getHofRank($view,$viewType,$accountID,$gameID) {
 	}
 
 	// What we will show for the amount:
-	// * Game specified:
+	// * Live game:
 	//  - Ally: real amount
 	//  - Enemy: "-"
+	// * Ended game:
+	//  - Ally: real amount
+	//  - Enemy: real amount
 	// * No game specified (All Time HoF):
 	//  - Current player: real total amount
 	//  - Other Player: total amount from completed games
@@ -84,12 +87,12 @@ function getHofRank($view,$viewType,$accountID,$gameID) {
 	}
 	if($vis==HOF_PUBLIC || $account->getAccountID()==$accountID) {
 		$rank['Amount'] = $realAmount;
-	}
-	else if($vis==HOF_ALLIANCE&&$account->getAccountID()!=$accountID) {
+	} else if ($vis == HOF_ALLIANCE) {
 		if (isset($gameID)) {
 			$hofPlayer = SmrPlayer::getPlayer($accountID, $gameID);
-			// Only show the real amount if player is in your alliance.
-			if ($hofPlayer->sameAlliance($player)) {
+			$hofGame = SmrGame::getGame($gameID);
+			// Show the real amount if player is in your alliance or game has ended.
+			if ($hofPlayer->sameAlliance($player) || $hofGame->hasEnded()) {
 				$rank['Amount'] = $realAmount;
 			} else {
 				$rank['Amount'] = '-';

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -1,7 +1,7 @@
 <?php
 
-function getHofCategories($hofTypes, $game_id) {
-	global $account, $var;
+function getHofCategories($hofTypes, $game_id, $account_id) {
+	global $var;
 	$categories = [];
 	foreach ($hofTypes as $type => $value) {
 		// Make each category a link to view the subcategory page
@@ -24,7 +24,7 @@ function getHofCategories($hofTypes, $game_id) {
 				$container['view'] = $subType;
 				$rankType = $container['type'];
 				$rankType[] = $subType;
-				$rank = getHofRank($subType, $rankType, $account->getAccountID(), $game_id);
+				$rank = getHofRank($subType, $rankType, $account_id, $game_id);
 				$rankMsg = '';
 				if ($rank['Rank'] != 0) {
 					$rankMsg = ' (#' . $rank['Rank'] .')';
@@ -33,7 +33,7 @@ function getHofCategories($hofTypes, $game_id) {
 			}
 		} else {
 			unset($container['view']);
-			$rank = getHofRank($type, $container['type'], $account->getAccountID(), $game_id);
+			$rank = getHofRank($type, $container['type'], $account_id, $game_id);
 			$subcategories[] = create_submit_link($container, 'View (#' . $rank['Rank'] .')');
 		}
 

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -48,7 +48,7 @@ function getHofCategories($hofTypes, $game_id, $account_id) {
 function getHofRank($view,$viewType,$accountID,$gameID) {
 	global $account,$player;
 	$db = new SmrMySqlDatabase();
-	$gameIDSql = ' AND game_id '.(isset($gameID) ? '= ' . $db->escapeNumber($gameID) : 'IN (SELECT game_id FROM game WHERE ignore_stats = '.$db->escapeBoolean(false).')');
+	$gameIDSql = ' AND game_id '.(isset($gameID) ? '= ' . $db->escapeNumber($gameID) : 'IN (SELECT game_id FROM game WHERE end_date < '.TIME.' AND ignore_stats = '.$db->escapeBoolean(false).')');
 
 	$vis = HOF_PUBLIC;
 	$rank = array('Amount'=>0,'Rank'=>0);
@@ -74,38 +74,23 @@ function getHofRank($view,$viewType,$accountID,$gameID) {
 	//  - Ally: real amount
 	//  - Enemy: "-"
 	// * Ended game:
-	//  - Ally: real amount
-	//  - Enemy: real amount
+	//  - All players: real amount
 	// * No game specified (All Time HoF):
-	//  - Current player: real total amount
-	//  - Other Player: total amount from completed games
+	//  - All players: total amount from completed games
 	$realAmount = 0;
 	if($db->nextRecord()) {
 		if($db->getField('amount')!=null) {
 			$realAmount = $db->getField('amount');
 		}
 	}
-	if($vis==HOF_PUBLIC || $account->getAccountID()==$accountID) {
+	if ($vis == HOF_PRIVATE || $vis == HOF_ALLIANCE && isset($gameID) &&
+	    !SmrGame::getGame($gameID)->hasEnded() &&
+	    !SmrPlayer::getPlayer($accountID, $gameID)->sameAlliance($player))
+	{
+		// Hide the amount in live games for players not in your alliance
+		$rank['Amount'] = '-';
+	} else {
 		$rank['Amount'] = $realAmount;
-	} else if ($vis == HOF_ALLIANCE) {
-		if (isset($gameID)) {
-			$hofPlayer = SmrPlayer::getPlayer($accountID, $gameID);
-			$hofGame = SmrGame::getGame($gameID);
-			// Show the real amount if player is in your alliance or game has ended.
-			if ($hofPlayer->sameAlliance($player) || $hofGame->hasEnded()) {
-				$rank['Amount'] = $realAmount;
-			} else {
-				$rank['Amount'] = '-';
-			}
-		} else {
-			$rank['Amount'] = 0; //default
-			$db->query('SELECT SUM(amount) amount FROM player_hof WHERE type='.$db->escapeArray($viewType,false,true,':',false) .' AND account_id='.$accountID.' AND game_id IN (SELECT game_id FROM game WHERE end_date < '.TIME.' AND ignore_stats = '.$db->escapeBoolean(false).') GROUP BY account_id LIMIT 1');
-			if($db->nextRecord()) {
-				if($db->getField('amount')!=null) {
-					$rank['Amount'] = $db->getField('amount');
-				}
-			}
-		}
 	}
 
 	if($view == DONATION_NAME) {

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -435,7 +435,7 @@ function do_voodoo() {
 
 	// initialize objects we usually need, like player, ship
 	if (SmrSession::hasGame()) {
-		if (SmrGame::getGame(SmrSession::getGameID())->getEndDate() < TIME) {
+		if (SmrGame::getGame(SmrSession::getGameID())->hasEnded()) {
 			forward(create_container('game_play_preprocessing.php', '', array('errorMsg' => 'The game has ended.')));
 		}
 		// We need to acquire locks BEFORE getting the player information

--- a/templates/Default/admin/Default/game_delete_confirm.php
+++ b/templates/Default/admin/Default/game_delete_confirm.php
@@ -1,6 +1,6 @@
 Are you sure you want to delete the game <i><?php echo $Game->getDisplayName(); ?></i>?<br />
 <?php
-if ($Game->getEndDate() > TIME) { ?>
+if (!$Game->hasEnded()) { ?>
 	<span class="red"><b>WARNING!</b> This game hasn't ended yet!</span><br /><?php
 } ?>
 <br />


### PR DESCRIPTION
* Lots of visual / performance / code improvements
* Fixed two bugs when viewing "Personal HoF" for other players:
  1. It will display that player's ranks in the categories list instead of yours.
  2. It will correctly display that player's name in the page topic instead of yours.
* Fix `SmrPlayer::sameAlliance` to check the game ID.
* Stop hiding HOF_ALLIANCE stats after a game has ended.
* Prevent rows from jumping around on ajax updates by secondary sorting on `account_id`.
* The All-Time HoF now excludes live games from all categories (not just HOF_ALLIANCE stats).