### PR TITLE
Finalize transition to templates

### DIFF
--- a/engine/Default/skeleton.php
+++ b/engine/Default/skeleton.php
@@ -1,7 +1,0 @@
-<?php
-
-
-$PHP_OUTPUT='';
-
-require_once(get_file_loc($var['body']));
-$template->assign('PHP_OUTPUT',$PHP_OUTPUT);

--- a/lib/Default/Template.class.inc
+++ b/lib/Default/Template.class.inc
@@ -125,11 +125,8 @@ class Template {
 		elseif (file_exists(TEMPLATES_DIR . 'Default/' . $templateName)) {
 			return TEMPLATES_DIR . 'Default/' . $templateName;
 		}
-		elseif (file_exists($templateDir . 'default.inc')) {
-			return $templateDir.'default.inc';
-		}
 		else {
-			return TEMPLATES_DIR.'Default/default.inc';//return $file_name;
+			throw new Exception('No template found for ' . $templateName);
 		}
 	}
 	

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -489,16 +489,11 @@ function do_voodoo() {
 		require(get_file_loc($var['url']));
 	}
 	if($var['body']) {
-		$PHP_OUTPUT = '';
 		if ($var['body']=='error.php') { // infinite includes for error pages
 			require(get_file_loc($var['body']));
-		}
-		else {
+		} else {
 			require_once(get_file_loc($var['body']));
 		}
-
-		if($PHP_OUTPUT!='')
-			$template->assign('PHP_OUTPUT',$PHP_OUTPUT);
 	}
 
 	if (SmrSession::hasGame()) {

--- a/templates/Default/default.inc
+++ b/templates/Default/default.inc
@@ -1,3 +1,0 @@
-<?php
-	echo $PHP_OUTPUT;
-?>


### PR DESCRIPTION
We have _at long last_ (really... it's taken forever) converted all
pages to templates. Therefore, we can finally remove the extra
processing of `$PHP_OUTPUT`!

If a template file is not found, it will raise an exception.

Closes #30.