### PR TITLE
SmrPlayer: simplify turns interface

### DIFF
--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -938,45 +938,40 @@ abstract class AbstractSmrPlayer {
 //		round(DEFAULT_MAX_TURNS * Globals::getGameSpeed($this->getGameID()));
 	}
 
-	public function setTurns($turns,$newNoob = false,$updateLastActive = false) {
-		if($this->turns == $turns && ($this->newbieTurns == $newNoob || $newNoob==false) && !$updateLastActive)
+	public function setTurns($turns) {
+		if ($this->turns == $turns) {
 			return;
-
+		}
 		// Make sure turns are in range [0, MaxTurns]
 		$this->turns = max(0, min($turns, $this->getMaxTurns()));
-
-		if($newNoob !== false)
-			$this->newbieTurns = $newNoob;
-		if ($this->newbieTurns < 0)
-			$this->newbieTurns = 0;
-
-		$this->hasChanged=true;
-		if($updateLastActive === true) {
-			$this->setLastActive(TIME);
-			$this->updateLastCPLAction();
-		}
+		$this->hasChanged = true;
 	}
 
-	public function takeTurns($take, $noob = 0, $updateLastActive = true) {
-		if($take < 0 || $noob < 0)
+	public function takeTurns($take, $takeNewbie=0) {
+		if ($take < 0 || $takeNewbie < 0) {
 			throw new Exception('Trying to take negative turns.');
+		}
 		$take = ceil($take);
-		$new_turns = $this->getTurns() - $take;
-		$newbiesTaken = min($this->getNewbieTurns(),$noob);
-		$new_noob = $this->getNewbieTurns() - $noob;
+		// Only take up to as many newbie turns as we have remaining
+		$takeNewbie = min($this->getNewbieTurns(), $takeNewbie);
 
-		$this->setTurns($new_turns, $new_noob, $updateLastActive);
+		$this->setTurns($this->getTurns() - $take);
+		$this->setNewbieTurns($this->getNewbieTurns() - $takeNewbie);
 		$this->increaseHOF($take,array('Movement','Turns Used','Since Last Death'), HOF_ALLIANCE);
 		$this->increaseHOF($take,array('Movement','Turns Used','Total'), HOF_ALLIANCE);
-		$this->increaseHOF($newbiesTaken,array('Movement','Turns Used','Newbie'), HOF_ALLIANCE);
+		$this->increaseHOF($takeNewbie, array('Movement','Turns Used','Newbie'), HOF_ALLIANCE);
+
+		// Player has taken an action
+		$this->setLastActive(TIME);
+		$this->updateLastCPLAction();
 	}
 
-	public function giveTurns($give, $noob = 0,$updateLastActive = false) {
-		if($give < 0 || $noob < 0)
+	public function giveTurns($give, $giveNewbie=0) {
+		if ($give < 0 || $giveNewbie < 0) {
 			throw new Exception('Trying to give negative turns.');
-		$give = floor($give);
-
-		$this->setTurns($this->getTurns() + $give, $this->getNewbieTurns() + $noob, $updateLastActive);
+		}
+		$this->setTurns($this->getTurns() + floor($give));
+		$this->setNewbieTurns($this->getNewbieTurns() + $giveNewbie);
 	}
 
 	public function getLastActive() {

--- a/lib/Default/DummyPlayer.class.inc
+++ b/lib/Default/DummyPlayer.class.inc
@@ -77,8 +77,7 @@ class DummyPlayer extends AbstractSmrPlayer {
 		// speed for pod
 		$new_speed = 7;
 
-		// adapt turns
-//		$this->setTurns(round($this->turns / $old_speed * $new_speed),100);
+		// don't adapt turns
 
 		$this->setSectorID(1);
 		$this->increaseDeaths(1);

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -864,7 +864,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 		// Update turns due to ship change
 		$new_speed = $this->getShip()->getSpeed();
-		$this->setTurns(round($this->turns / $old_speed * $new_speed),100);
+		$this->setTurns(round($this->turns / $old_speed * $new_speed));
+		$this->setNewbieTurns(100);
 	}
 
 	static public function getHome($gameID, $raceID) {


### PR DESCRIPTION
* Use existing `setNewbieTurns` method instead of complicating the
  `setTurns` method with newbie turn logic.

* Remove the `updateLastActive` argument from all the turns methods.
  Taking turns will always update the "last active" time, and giving
  turns will never do this (and so we move the code that sets it out
  of `setTurns` and into `takeTurns`).