### PR TITLE
Uni Gen: add port good selection

### DIFF
--- a/admin/Default/1.6/universe_create_planets.php
+++ b/admin/Default/1.6/universe_create_planets.php
@@ -24,9 +24,6 @@ foreach ($galaxy->getSectors() as $galSector) {
 $template->assign('Galaxy', $galaxy);
 $template->assign('NumberOfPlanets', $numberOfPlanets);
 
-$numberOfNpcPlanets = (isset($planet_info['NPC']) ? $planet_info['NPC'] : 0);
-$template->assign('NumberOfNpcPlanets', $numberOfNpcPlanets);
-
 // Form to make planet changes
 $container = create_container('1.6/universe_create_save_processing.php',
                               '1.6/universe_create_sectors.php', $var);

--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -197,32 +197,40 @@ elseif ($submit == 'Edit Sector') {
 			}
 		}
 	}
-	
-//	elseif ($_POST['plan_type'] == 'NPC') {
-//		$GAL_PLANETS[$this_sec]['Inhabitable'] = 1;
-//		$GAL_PLANETS[$this_sec]['Owner'] = 0;
-//		$GAL_PLANETS[$this_sec]['Owner Type'] = 'NPC';
-//	}
 	else {
 		$editSector->removePlanet();
 	}
+
 	//update port
 	if ($_POST['port_level'] > 0) {
-		if(!$editSector->hasPort()) {
+		if (!$editSector->hasPort()) {
 			$port = $editSector->createPort();
-		}
-		else {
+		} else {
 			$port = $editSector->getPort();
 		}
-		if ($port->getLevel()!=$_POST['port_level']) {
+		$port->setRaceID($_POST['port_race']);
+		if ($port->getLevel() != $_POST['port_level']) {
 			$port->upgradeToLevel($_POST['port_level']);
 			$port->setCreditsToDefault();
+		} elseif (isset($_POST['select_goods'])) {
+			// Only set the goods manually if the level hasn't changed
+			$goods = [];
+			foreach (array_keys(Globals::getGoods()) as $goodID) {
+				$trans = $_POST['good'.$goodID];
+				if ($trans != 'None') {
+					$goods[$goodID] = $trans;
+				}
+			}
+			if (!$port->setPortGoods($goods)) {
+				create_error('Invalid goods specified for this port level!');
+			}
 		}
-		$port->setRaceID($_POST['port_race']);
 		$port->update();
-	} else $editSector->removePort();
+	} else {
+		$editSector->removePort();
+	}
+
 	//update locations
-	
 	$locationsToAdd = array();
 	$locationsToKeep = array();
 	for($x=0;$x<UNI_GEN_LOCATION_SLOTS;$x++) {

--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -114,7 +114,6 @@ elseif ($submit == 'Create Planets') {
 			$galSector->removePlanet();
 		}
 	}
-//	$numberOfNpcPlanets = $_POST['NPC'];
 
 	foreach (array_keys(SmrPlanetType::PLANET_TYPES) as $planetTypeID) {
 		$numberOfPlanets = $_POST['type' . $planetTypeID];

--- a/admin/Default/1.6/universe_create_sector_details.php
+++ b/admin/Default/1.6/universe_create_sector_details.php
@@ -6,12 +6,13 @@ $template->assign('EditSector', $editSector);
 
 $container = $var;
 $container['url'] = '1.6/universe_create_save_processing.php';
-$container['body'] = '1.6/universe_create_sectors.php';
+$container['body'] = '1.6/universe_create_sector_details.php';
 $template->assign('EditHREF', SmrSession::getNewHREF($container));
 
 $selectedPlanetType = 0;
 if ($editSector->hasPlanet()) {
 	$selectedPlanetType = $editSector->getPlanet()->getTypeID();
+	$template->assign('Planet', $editSector->getPlanet());
 }
 $template->assign('SelectedPlanetType', $selectedPlanetType);
 
@@ -20,6 +21,7 @@ $selectedPortRaceID = null;
 if ($editSector->hasPort()) {
 	$selectedPortLevel = $editSector->getPort()->getLevel();
 	$selectedPortRaceID = $editSector->getPort()->getRaceID();
+	$template->assign('Port', $editSector->getPort());
 }
 $template->assign('SelectedPortLevel', $selectedPortLevel);
 $template->assign('SelectedPortRaceID', $selectedPortRaceID);
@@ -42,3 +44,7 @@ $template->assign('WarpSectorID', $warpSectorID);
 $container = $var;
 $container['body'] = '1.6/universe_create_sectors.php';
 $template->assign('CancelHREF', SmrSession::getNewHREF($container));
+
+if (isset($var['message'])) {
+	$template->assign('Message', $var['message']);
+}

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -460,16 +460,54 @@ class AbstractSmrPort {
 	}
 
 	/**
+	 * Manually set port goods.
+	 * Input must be an array of good_id => transaction.
+	 * Only modifies goods that need to change.
+	 * Returns false on invalid input.
+	 */
+	public function setPortGoods(array $goods) {
+		// Validate the input list of goods to make sure we have the correct
+		// number of each good class for this port level.
+		$givenClasses = [];
+		foreach (array_keys($goods) as $goodID) {
+			$givenClasses[] = Globals::getGood($goodID)['Class'];
+		}
+		$expectedClasses = [1, 1]; // Level 1 has 2 extra Class 1 goods
+		foreach (range(1, $this->getLevel()) as $level) {
+			$expectedClasses[] = $this->getGoodClassAtLevel($level);
+		}
+		if ($givenClasses != $expectedClasses) {
+			return false;
+		}
+
+		// Remove goods not specified or that have the wrong transaction
+		foreach ($this->getAllGoodIDs() as $goodID) {
+			if (!isset($goods[$goodID]) || !$this->hasGood($goodID, $goods[$goodID])) {
+				$this->removePortGood($goodID);
+			}
+		}
+		// Add goods
+		foreach ($goods as $goodID => $trans) {
+			$this->addPortGood($goodID, $trans);
+		}
+		return true;
+	}
+
+	/**
 	 * Add good with given ID to the port, with transaction $type
 	 * as either "Buy" or "Sell", meaning the player buys or sells.
+	 * If the port already has this transaction, do nothing.
+	 *
 	 * NOTE: make sure to adjust the port level appropriately if
 	 * calling this function directly.
 	 */
 	public function addPortGood($goodID,$type) {
 		if($this->isCachedVersion())
 			throw new Exception('Cannot update a cached port!');
-		if(!is_numeric($goodID))
-			return false;
+		if ($this->hasGood($goodID, $type)) {
+			return;
+		}
+
 		$this->goodIDs['All'][] = $goodID;
 		$this->goodIDs[$type][] = $goodID;
 		// sort ID arrays, since the good ID might not be the largest
@@ -484,12 +522,17 @@ class AbstractSmrPort {
 
 	/**
 	 * Remove good with given ID from the port.
+	 * If the port does not have this good, do nothing.
+	 *
 	 * NOTE: make sure to adjust the port level appropriately if
 	 * calling this function directly.
 	 */
 	public function removePortGood($goodID) {
 		if($this->isCachedVersion())
 			throw new Exception('Cannot update a cached port!');
+		if (!$this->hasGood($goodID)) {
+			return;
+		}
 		if (($key = array_search($goodID, $this->goodIDs['All'])) !== false) {
 			array_splice($this->goodIDs['All'], $key, 1);
 		}

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -406,49 +406,52 @@ class AbstractSmrPort {
 			$this->doDowngrade();
 		}
 	}
-	
+
+	/**
+	 * Returns the good class associated with the given level.
+	 * If no level specified, will use the current port level.
+	 * This is useful for determining what trade goods to add/remove.
+	 */
+	protected function getGoodClassAtLevel($level=false) {
+		if ($level === false) {
+			$level = $this->getLevel();
+		}
+		if ($level <= 2) {
+			return 1;
+		} elseif ($level <= 6) {
+			return 2;
+		} else {
+			return 3;
+		}
+	}
+
 	protected function selectAndAddGood($goodClass) {
 		$GOODS = Globals::getGoods();
 		shuffle($GOODS);
-		do {
-			if(count($GOODS) == 0) return false;
-			$newGood = array_shift($GOODS);
-		} while( $this->hasGood($newGood['ID']) || $newGood['Class'] != $goodClass );
-		
-		$transactionType = mt_rand(1,2) == 1 ? 'Buy' : 'Sell';
-		$this->addPortGood($newGood['ID'],$transactionType);
-		return $newGood;
+		foreach ($GOODS as $good) {
+			if (!$this->hasGood($good['ID']) && $good['Class'] == $goodClass) {
+				$transactionType = rand(1,2) == 1 ? 'Buy' : 'Sell';
+				$this->addPortGood($good['ID'], $transactionType);
+				return $good;
+			}
+		}
+		throw new Exception('Failed to add a good!');
 	}
 	
 	protected function doUpgrade() {
-		switch($this->getLevel()) {
-			case 0:
-				for($i=0;$i<3;++$i) { // Add 3 goods for upgrading to level 1
-					if( $this->selectAndAddGood(1) === false ) break;
-				}
-			break;
-			
-			case 1:
-				$this->selectAndAddGood(1);
-			break;
-			
-			case 2:
-			case 3:
-			case 4:
-			case 5:
-				$this->selectAndAddGood(2);
-			break;
-			
-			case 6:
-			case 7:
-			case 8:
-				$this->selectAndAddGood(3);
-			break;
-			
-			default: // We don't want to add goods.
-			break;
+		if ($this->isCachedVersion()) {
+			throw new Exception('Cannot upgrade a cached port!');
 		}
+
 		$this->increaseLevel(1);
+		$goodClass = $this->getGoodClassAtLevel();
+		$this->selectAndAddGood($goodClass);
+
+		if ($this->getLevel() == 1) {
+			// Add 2 extra goods when upgrading to level 1 (i.e. in Uni Gen)
+			$this->selectAndAddGood($goodClass);
+			$this->selectAndAddGood($goodClass);
+		}
 	}
 	
 	public function getUpgradeRequirement() {
@@ -532,39 +535,17 @@ class AbstractSmrPort {
 		if($this->isCachedVersion())
 			throw new Exception('Cannot downgrade a cached port!');
 
-		switch($this->level) {
-			case 1:
-				// Replace one class 1 good with another
-				$this->selectAndRemoveGood(1);
-				$newGood = $this->selectAndAddGood(1);
-				// Set new good to 0 supply
-				// (since other goods are set to 0 when port is destroyed)
-				$this->setGoodAmount($newGood['ID'], 0);
-			break;
-			
-			case 2:
-				$this->selectAndRemoveGood(1);
-			break;
-			
-			case 3:
-			case 4:
-			case 5:
-			case 6:
-				$this->selectAndRemoveGood(2);
-			break;
-			
-			case 7:
-			case 8:
-			case 9:
-				$this->selectAndRemoveGood(3);
-			break;
+		$goodClass = $this->getGoodClassAtLevel();
+		$this->selectAndRemoveGood($goodClass);
 
-			default: // We don't want to add goods.
-			break;
-		}
-
-		// Don't make the port level 0
-		if ($this->level > 1) {
+		if ($this->getLevel() == 1) {
+			// For level 1 ports, we don't want to have fewer goods
+			$newGood = $this->selectAndAddGood($goodClass);
+			// Set new good to 0 supply
+			// (since other goods are set to 0 when port is destroyed)
+			$this->setGoodAmount($newGood['ID'], 0);
+		} else {
+			// Don't make the port level 0
 			$this->decreaseLevel(1);
 		}
 		$this->setUpgrade(0);

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -997,6 +997,10 @@ class SmrPlanet {
 		return $this->inhabitableTime<= TIME;
 	}
 
+	public function getInhabitableTime() {
+		return $this->inhabitableTime;
+	}
+
 	public function isClaimed() {
 		return $this->ownerID>0;
 	}

--- a/templates/Default/admin/Default/1.6/universe_create_planets.php
+++ b/templates/Default/admin/Default/1.6/universe_create_planets.php
@@ -10,13 +10,9 @@ Working on Galaxy : <?php echo $Galaxy->getName(); ?> (<?php echo $Galaxy->getGa
 		foreach ($AllowedTypes as $ID => $Name) { ?>
 			<tr>
 				<td class="right"><?php echo $Name; ?></td>
-				<td><input type="number" value="<?php echo $NumberOfPlanets[$ID]; ?>" size="5" name="type<?php echo $ID; ?>"></td>
+				<td><input class="center" type="number" value="<?php echo $NumberOfPlanets[$ID]; ?>" size="5" name="type<?php echo $ID; ?>"></td>
 			</tr><?php
 		} ?>
-		<tr>
-			<td class="right">NPC - Won't work</td>
-			<td><input type="number" value="<?php echo $NumberOfNpcPlanets; ?>" size="5" name="NPC"></td>
-		</tr>
 		<tr>
 			<td colspan="2" class="center">
 				<input type="submit" name="submit" value="Create Planets"><br /><br /><a href="<?php echo $CancelHREF; ?>" class="submitStyle">Cancel</a>

--- a/templates/Default/admin/Default/1.6/universe_create_sector_details.php
+++ b/templates/Default/admin/Default/1.6/universe_create_sector_details.php
@@ -1,35 +1,73 @@
+<a href="<?php echo $CancelHREF; ?>">&lt;&lt; Back</a><br /><br />
 <form method="POST" action="<?php echo $EditHREF; ?>">
+	<h2>Planet</h2><br />
+	<b>Type: </b>
+	<select name="plan_type" class="InputFields">
+		<option value="0">No Planet</option><?php
+		foreach (array_keys(SmrPlanetType::PLANET_TYPES) as $type) { ?>
+			<option value="<?php echo $type; ?>" <?php echo ($type == $SelectedPlanetType ? 'selected' : ''); ?>><?php echo SmrPlanetType::getTypeInfo($type)->name(); ?></option><?php
+		} ?>
+	</select><br /><?php
+	if ($SelectedPlanetType) { ?>
+		<b>Habitable: </b><?php echo date(DATE_FULL_SHORT, $Planet->getInhabitableTime()); ?><br /><?php
+	} ?>
+	<br />
+
+	<h2>Port</h2>
+	<select name="port_level" class="InputFields">
+		<option value="0">No Port</option><?php
+		for ($i=1; $i<=SmrPort::MAX_LEVEL; $i++) { ?>
+			<option value="<?php echo $i; ?>" <?php echo ($i == $SelectedPortLevel ? 'selected' : ''); ?>>Level <?php echo $i; ?></option><?php
+		} ?>
+	</select>&nbsp;
+
+	<select name="port_race" class="InputFields"><?php
+		foreach (Globals::getRaces() as $race) { ?>
+		<option value="<?php echo $race['Race ID']; ?>" <?php echo ($race['Race ID'] == $SelectedPortRaceID ? 'selected' : ''); ?>><?php echo $race['Race Name']; ?></option><?php
+	} ?>
+	</select>
+	<br />
+
+  <?php
+	if ($SelectedPortLevel) { ?>
+		<br /><span class="bold red">WARNING: </span>Ports should only have (Level + 2) number of goods.
+		These options will be ignored if you are changing the port level.
+		<input type="hidden" name="select_goods" value="1" />
+		<table class="nobord">
+			<tr><?php
+				foreach ([1, 2, 3] as $class) { ?>
+					<td class="top">
+					<table class="nobord"><?php
+						foreach (Globals::getGoods() as $good) {
+							if ($good['Class'] == $class) { ?>
+								<tr>
+								<td>
+									<img class="bottom" src="<?php echo $good['ImageLink']; ?>">&nbsp;
+									<select name="good<?php echo $good['ID']; ?>" class="InputFields">
+										<option value="None">--</option><?php
+										foreach (['Buy', 'Sell'] as $trans) { ?>
+											<option <?php if ($Port->hasGood($good['ID'], $trans)) { ?> selected <?php } ?> value="<?php echo $trans; ?>"><?php echo $trans; ?></option><?php
+										} ?>
+									</select>
+								</td>
+								</tr><?php
+							}
+						} ?>
+					</table></td><?php
+				} ?>
+			</tr>
+		</table><?php
+	} ?>
+	<br />
+
+	<h2>Locations</h2>
 	<table class="shrink">
 		<tr>
 			<td class="center noWrap">
-				Planet Type:
-				<select name="plan_type">
-					<option value="0">No Planet</option><?php
-					foreach (array_keys(SmrPlanetType::PLANET_TYPES) as $type) { ?>
-						<option value="<?php echo $type; ?>" <?php echo ($type == $SelectedPlanetType ? 'selected' : ''); ?>><?php echo SmrPlanetType::getTypeInfo($type)->name(); ?></option><?php
-					} ?>
-				</select>
-				<br /><br />
-
-				Port:
-				<select name="port_level">
-					<option value="0">No Port</option><?php
-					for ($i=1; $i<=SmrPort::MAX_LEVEL; $i++) { ?>
-						<option value="<?php echo $i; ?>" <?php echo ($i == $SelectedPortLevel ? 'selected' : ''); ?>>Level <?php echo $i; ?></option><?php
-					} ?>
-				</select>
-
-				<select name="port_race"><?php
-					foreach (Globals::getRaces() as $race) { ?>
-						<option value="<?php echo $race['Race ID']; ?>" <?php echo ($race['Race ID'] == $SelectedPortRaceID ? 'selected' : ''); ?>><?php echo $race['Race Name']; ?></option><?php
-					} ?>
-				</select>
-				<br /><br />
-
 				<?php
 				for ($i=0; $i<UNI_GEN_LOCATION_SLOTS; $i++) { ?>
-					Location <?php echo ($i + 1); ?>:
-					<select name="loc_type<?php echo $i; ?>">
+					<b><?php echo ($i + 1); ?>. </b>
+					<select name="loc_type<?php echo $i; ?>" class="InputFields">
 						<option value="0">No Location</option><?php
 						foreach (SmrLocation::getAllLocations() as $id => $location) { ?>
 							<option value="<?php echo $id ?>" <?php echo ($id == $SectorLocationIDs[$i] ? 'selected' : ''); ?>><?php echo $location->getName(); ?></option><?php
@@ -50,5 +88,9 @@
 
 	<input type="submit" name="submit" value="Edit Sector">
 	<br /><br />
-	<a href="<?php echo $CancelHREF; ?>" class="submitStyle">Cancel</a>
 </form>
+
+<?php
+if (isset($Message)) {
+	echo $Message;
+} ?>

--- a/templates/Default/admin/Default/1.6/universe_create_sectors.php
+++ b/templates/Default/admin/Default/1.6/universe_create_sectors.php
@@ -1,6 +1,6 @@
 <table class="center standard">
 	<tr>
-		<th>ID</th>
+		<th>Galaxy ID</th>
 		<th>Name</th>
 		<th>Type</th>
 		<th>Size</th>
@@ -48,13 +48,13 @@
 		<td>
 			<form method="POST" action="<?php echo $SubmitChangesHREF; ?>">
 				Connection %<br />
-				<input type="number" name="connect" value="<?php echo $RequestedConnectivity; ?>" size="3"><br />
+				<input type="number" name="connect" value="<?php echo $RequestedConnectivity; ?>" size="3" class="center" /><br />
 				<input type="submit" name="submit" value="Redo Connections">
 			</form>
 			<br />
 			<form method="POST" action="<?php echo $SubmitChangesHREF; ?>">
 				Sector ID<br />
-				<input type="number" size="5" name="sector_edit"><br />
+				<input type="number" size="5" name="sector_edit" class="center" /><br />
 				<input type="submit" value="Modify Sector" name="submit">
 			</form>
 		</td>


### PR DESCRIPTION
Revamped the "Edit Sector" page in the Uni Gen. Additional information about planets will be specified, and you can now select specific port goods if you want to.

Also includes other minor tweaks to the Uni Gen display and a refactoring / addition of some methods to `SmrPort`.

![image](https://user-images.githubusercontent.com/846186/56843056-0bbbaf80-6851-11e9-9136-643a99d9a96c.png)

