### PR TITLE
Remove unnecessary SmrGame wrappers in Globals

### DIFF
--- a/engine/Default/council_embassy_processing.php
+++ b/engine/Default/council_embassy_processing.php
@@ -6,7 +6,7 @@ if(!$player->isPresident()) {
 
 $race_id = $var['race_id'];
 $type = strtoupper($_REQUEST['action']);
-$time = TIME + TIME_FOR_COUNCIL_VOTE;// / Globals::getGameSpeed($player->getGameID());
+$time = TIME + TIME_FOR_COUNCIL_VOTE;
 
 $db->query('SELECT count(*) FROM race_has_voting
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '

--- a/engine/Default/shop_ship.php
+++ b/engine/Default/shop_ship.php
@@ -18,7 +18,7 @@ $template->assign('ShipsSoldHREF',$shipsSoldHREF);
 
 if (isset($var['ship_id'])) {
 	$compareShip = $shipsSold[$var['ship_id']];
-	$compareShip['RealSpeed'] = $compareShip['Speed'] * Globals::getGameSpeed($player->getGameID());
+	$compareShip['RealSpeed'] = $compareShip['Speed'] * $player->getGame()->getGameSpeed();
 	$compareShip['Turns'] = round($player->getTurns()*$compareShip['Speed']/$ship->getSpeed());
 
 	$container = create_container('shop_ship_processing.php');

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -934,8 +934,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function getMaxTurns() {
-		return Globals::getGameMaxTurns($this->getGameID());
-//		round(DEFAULT_MAX_TURNS * Globals::getGameSpeed($this->getGameID()));
+		return $this->getGame()->getMaxTurns();
 	}
 
 	public function setTurns($turns) {

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -187,7 +187,7 @@ class AbstractSmrPort {
 		}
 
 		$goodClass = Globals::getGood($goodID)['Class'];
-		$refreshPerHour = self::BASE_REFRESH_PER_HOUR[$goodClass] * Globals::getGameSpeed($this->getGameID());
+		$refreshPerHour = self::BASE_REFRESH_PER_HOUR[$goodClass] * $this->getGame()->getGameSpeed();
 		$refreshPerSec = $refreshPerHour / 3600;
 		$amountToAdd = floor($secondsSinceLastUpdate * $refreshPerSec);
 
@@ -761,7 +761,11 @@ class AbstractSmrPort {
 	public function getGameID() {
 		return $this->gameID;
 	}
-	
+
+	public function getGame() {
+		return SmrGame::getGame($this->gameID);
+	}
+
 	public function getSectorID() {
 		return $this->sectorID;
 	}

--- a/lib/Default/AbstractSmrShip.class.inc
+++ b/lib/Default/AbstractSmrShip.class.inc
@@ -428,6 +428,10 @@ abstract class AbstractSmrShip {
 		return $this->gameID;
 	}
 
+	public function getGame() {
+		return SmrGame::getGame($this->gameID);
+	}
+
 	public function getShipTypeID() {
 		return $this->baseShip['ShipTypeID'];
 	}
@@ -468,12 +472,18 @@ abstract class AbstractSmrShip {
 		return $this->getCostToUNOAgainstShip($this->getShipTypeID());
 	}
 
+	/**
+	 * Returns the base ship speed (unmodified by the game speed).
+	 */
 	public function getSpeed() {
 		return $this->baseShip['Speed'];
 	}
 
+	/**
+	 * Returns the ship speed modified by the game speed.
+	 */
 	public function getRealSpeed() {
-		return $this->baseShip['Speed'] * Globals::getGameSpeed($this->getGameID());
+		return $this->getSpeed() * $this->getGame()->getGameSpeed();
 	}
 
 	public function getHardware($hardwareTypeID = false) {

--- a/lib/Default/Globals.class.inc
+++ b/lib/Default/Globals.class.inc
@@ -188,14 +188,6 @@ class Globals {
 		}
 	}
 
-	public static function getGameDescription($gameID) {
-		return SmrGame::getGame($gameID)->getDescription();
-	}
-
-	public static function getGameSpeed($gameID) {
-		return SmrGame::getGame($gameID)->getGameSpeed();
-	}
-
 	public static function getGameType($gameID) {
 		if(self::isValidGame($gameID)) {
 			return SmrGame::getGame($gameID)->getGameType();
@@ -205,34 +197,6 @@ class Globals {
 
 	public static function getGameName($gameID) {
 		return SmrGame::getGame($gameID)->getName();
-	}
-
-	public static function getGameMaxTurns($gameID) {
-		return SmrGame::getGame($gameID)->getMaxTurns();
-	}
-
-	public static function getGameMaxPlayers($gameID) {
-		return SmrGame::getGame($gameID)->getMaxPlayers();
-	}
-
-	public static function getGameCreditsRequired($gameID) {
-		return SmrGame::getGame($gameID)->getCreditsNeeded();
-	}
-
-	public static function getGameIgnoreStats($gameID) {
-		return SmrGame::getGame($gameID)->isIgnoreStats();
-	}
-
-	public static function getAllianceMaxPlayers($gameID) {
-		return SmrGame::getGame($gameID)->getAllianceMaxPlayers();
-	}
-
-	public static function getAllianceMaxVets($gameID) {
-		return SmrGame::getGame($gameID)->getAllianceMaxVets();
-	}
-
-	public static function getStartingCredits($gameID) {
-		return SmrGame::getGame($gameID)->getStartingCredits();
 	}
 
 	public static function isFeatureRequestOpen() {

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -110,6 +110,10 @@ class SmrAlliance {
 		return $this->gameID;
 	}
 
+	public function getGame() {
+		return SmrGame::getGame($this->gameID);
+	}
+
 	public function hasDisbanded() {
 		return !$this->hasLeader();
 	}
@@ -280,11 +284,11 @@ class SmrAlliance {
 		if($player->getAllianceJoinable() > TIME) {
 			return 'You cannot join another alliance for '.format_time($player->getAllianceJoinable()-TIME).'.';
 		}
-		if($this->getNumMembers()<Globals::getAllianceMaxPlayers($this->getGameID())) {
+		if ($this->getNumMembers() < $this->getGame()->getAllianceMaxPlayers()) {
 			if ($player->hasNewbieStatus()) {
 				return true;
 			}
-			$maxVets = Globals::getAllianceMaxVets($this->getGameID());
+			$maxVets = $this->getGame()->getAllianceMaxVets();
 			if($this->getNumMembers()<$maxVets) {
 				return true;
 			}

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -183,7 +183,7 @@ class SmrPlanet {
 	}
 
 	public function getBondTime() {
-		return round(BOND_TIME / Globals::getGameSpeed($this->getGameID()));
+		return round(BOND_TIME / $this->getGame()->getGameSpeed());
 	}
 
 	public function bond() {
@@ -201,6 +201,10 @@ class SmrPlanet {
 
 	public function getGameID() {
 		return $this->gameID;
+	}
+
+	public function getGame() {
+		return SmrGame::getGame($this->gameID);
 	}
 
 	public function getSectorID() {
@@ -929,7 +933,7 @@ class SmrPlanet {
 	// Amount of time (in seconds) to build the next building of this type
 	function getConstructionTime($constructionID) {
 		$baseTime = $this->getStructureTypes($constructionID)->baseTime();
-		$constructionTime = ceil($baseTime * $this->getCompletionModifier($constructionID) / Globals::getGameSpeed($this->getGameID()));
+		$constructionTime = ceil($baseTime * $this->getCompletionModifier($constructionID) / $this->getGame()->getGameSpeed());
 		return $constructionTime;
 	}
 	

--- a/tools/irc/channel_msg_sd.php
+++ b/tools/irc/channel_msg_sd.php
@@ -112,7 +112,7 @@ function channel_msg_sd_list($fp, $rdata, $account, $player)
 
 		echo_r('[SD_LIST] by ' . $nick . ' in ' . $channel);
 
-		$refresh_per_hour = 250 * Globals::getGameSpeed($player->getGameID());
+		$refresh_per_hour = 250 * $player->getGame()->getGameSpeed();
 		$refresh_per_sec = $refresh_per_hour / 3600;
 
 		fputs($fp, 'PRIVMSG ' . $channel . ' :The following supply/demand list has been recorded:' . EOL);


### PR DESCRIPTION
Remove the following Globals methods:
* getGameDescription
* getGameSpeed
* getGameMaxTurns
* getGameMaxPlayers
* getGameCreditsRequired
* getGameIgnoreStats
* getAllianceMaxPlayers
* getAllianceMaxVets
* getStartingCredits

Some of these were unused. For those that were used in some places,
we can easily replace them with calling the methods directly on an
SmrGame instance that we can access.

We did need to add the following methods to more easily access an
SmrGame instance in some classes:
* SmrPlanet::getGame
* SmrAlliance::getGame
* SmrShip::getGame
* SmrPort::getGame

Also some minor refactoring of game_join_processing.php.