### PR TITLE
SmrSession: add account setter/getter methods

### DIFF
--- a/htdocs/album/album_comment.php
+++ b/htdocs/album/album_comment.php
@@ -10,8 +10,9 @@ try {
 	require_once(LIB . 'Default/smr.inc');
 	require_once(LIB . 'Album/album_functions.php');
 
-	if (SmrSession::$account_id == 0)
+	if (!SmrSession::hasAccount()) {
 		create_error_offline('You need to logged in to post comments!');
+	}
 
 	if (!isset($_GET['album_id']) || empty($_GET['album_id']))
 		create_error_offline('Which picture do you want comment?');
@@ -24,7 +25,7 @@ try {
 	if ($album_id < 1)
 		create_error_offline('Picture ID has to be positive!');
 
-	$account = SmrAccount::getAccount(SmrSession::$account_id);
+	$account = SmrSession::getAccount();
 
 	if (isset($_GET['action']) && $_GET['action'] == 'Moderate') {
 		if(!$account->hasPermission(PERMISSION_MODERATE_PHOTO_ALBUM))

--- a/htdocs/loader.php
+++ b/htdocs/loader.php
@@ -50,7 +50,7 @@ try {
 	//echo '<pre>';echo_r($session);echo'</pre>';
 	//exit;
 	// do we have a session?
-	if (SmrSession::$account_id == 0) {
+	if (!SmrSession::hasAccount()) {
 		header('Location: /login.php');
 		exit;
 	}
@@ -94,7 +94,7 @@ try {
 
 	require_once(get_file_loc('smr.inc'));
 
-	$account = SmrAccount::getAccount(SmrSession::$account_id);
+	$account = SmrSession::getAccount();
 	// get reason for disabled user
 	if(($disabled = $account->isDisabled())!==false) {
 		// save session (incase we forward)

--- a/htdocs/login.php
+++ b/htdocs/login.php
@@ -12,9 +12,9 @@ try {
 	// ********************************
 	
 	
-	if (SmrSession::$account_id > 0) {
+	if (SmrSession::hasAccount()) {
 		// creates a new user account object
-		$account = SmrAccount::getAccount(SmrSession::$account_id);
+		$account = SmrSession::getAccount();
 	
 		// update last login column
 		$account->updateLastLogin();

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -4,7 +4,7 @@ try {
 	require_once('config.inc');
 	require_once(LIB . 'Default/smr.inc');
 
-	if (SmrSession::$account_id > 0) {
+	if (SmrSession::hasAccount()) {
 		$msg = 'You\'re already logged in! Creating multis is against the rules!';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
@@ -165,7 +165,7 @@ try {
 	}
 
 	// register session
-	SmrSession::$account_id = $account->getAccountID();
+	SmrSession::setAccount($account);
 
 	// save ip
 	$account->updateIP();
@@ -185,7 +185,7 @@ try {
 
 		// remember when we sent validation code
 		$db->query('INSERT INTO notification (notification_type, account_id, time) ' .
-		           'VALUES(\'validation_code\', '.$db->escapeNumber(SmrSession::$account_id).', ' . $db->escapeNumber(TIME) . ')');
+		           'VALUES(\'validation_code\', '.$db->escapeNumber($account->getAccountID()).', ' . $db->escapeNumber(TIME) . ')');
 	}
 
 	$container = create_container('login_processing.php');

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -13,7 +13,7 @@ try {
 	// *
 	// ********************************
 
-	if (SmrSession::$account_id == 0) {
+	if (!SmrSession::hasAccount()) {
 		if(isset($_REQUEST['loginType'])) {
 			$socialLogin = new SocialLogin($_REQUEST['loginType']);
 			if(!$socialLogin->isValid()) {
@@ -24,7 +24,7 @@ try {
 			$account = SmrAccount::getAccountBySocialLogin($socialLogin);
 			if (!is_null($account)) {
 				// register session and continue to login
-				SmrSession::$account_id = $account->getAccountID();
+				SmrSession::setAccount($account);
 			} else {
 				// Let them create an account or link to existing
 				if (session_status() === PHP_SESSION_NONE) {
@@ -57,7 +57,7 @@ try {
 
 			$account = SmrAccount::getAccountByName($login);
 			if (is_object($account) && $account->checkPassword($password)) {
-				SmrSession::$account_id = $account->getAccountID();
+				SmrSession::setAccount($account);
 			}
 			else {
 				$msg = 'Password is incorrect!';
@@ -78,7 +78,7 @@ try {
 	// ********************************
 
 	// get this user from db
-	$account = SmrAccount::getAccount(SmrSession::$account_id);
+	$account = SmrSession::getAccount();
 
 	// If linking a social login to an existing account
 	if(isset($_REQUEST['social'])) {

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -18,11 +18,9 @@ try {
 	
 	
 	// do we have a session?
-	if (SmrSession::$account_id == 0 || !SmrSession::hasGame()) {
-	
+	if (!SmrSession::hasAccount() || !SmrSession::hasGame()) {
 		header('Location: /login.php');
 		exit;
-	
 	}
 	
 	if(isset($_REQUEST['sector_id'])) {
@@ -53,10 +51,8 @@ try {
 		}
 	}
 	
-	$player = SmrPlayer::getPlayer(SmrSession::$account_id, SmrSession::getGameID());
-	
-	// create account object
-	$account = $player->getAccount();
+	$account = SmrSession::getAccount();
+	$player = SmrPlayer::getPlayer($account->getAccountID(), SmrSession::getGameID());
 	
 	// Create a session to store temporary display options
 	// Garbage collect here often, since the page is slow anyways (see map_local.php)

--- a/htdocs/map_warps.php
+++ b/htdocs/map_warps.php
@@ -3,12 +3,12 @@ try {
 	require_once('config.inc');
 
 	$gameID = $_GET['game'];
-	if (SmrSession::$account_id == 0 || !Globals::isValidGame($gameID)) {
+	if (!SmrSession::hasAccount() || !Globals::isValidGame($gameID)) {
 		header('Location: /login.php');
 		exit;
 	}
 
-	$account = SmrAccount::getAccount(SmrSession::$account_id);
+	$account = SmrSession::getAccount();
 	if (!SmrGame::getGame($gameID)->isEnabled() && !$account->hasPermission(PERMISSION_UNI_GEN)) {
 		header('location: /error.php?msg=You do not have permission to view this map!');
 		exit;

--- a/lib/Album/album_functions.php
+++ b/lib/Album/album_functions.php
@@ -66,11 +66,12 @@ function album_entry($album_id) {
 	// list of all first letter nicks
 	create_link_list();
 
-	if (SmrSession::$account_id != 0 && $album_id != SmrSession::$account_id)
+	if (SmrSession::hasAccount() && $album_id != SmrSession::getAccountID()) {
 		$db->query('UPDATE album
 				SET page_views = page_views + 1
 				WHERE account_id = '.$db->escapeNumber($album_id).' AND
 					approved = \'YES\'');
+	}
 
 	$db->query('SELECT *
 				FROM album
@@ -197,17 +198,17 @@ function album_entry($album_id) {
 		echo('<span style="font-size:85%;">[' . date(defined('DATE_FULL_SHORT')?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $time) . '] &lt;'.$postee.'&gt; '.$msg.'</span><br />');
 	}
 
-	if (SmrSession::$account_id > 0) {
+	if (SmrSession::hasAccount()) {
 		echo('<form action="album_comment.php">');
 		echo('<input type="hidden" name="album_id" value="'.$album_id.'">');
 		echo('<table>');
 		echo('<tr>');
-		echo('<td style="color:green; font-size:70%;">Nick:<br /><input type="text" size="10" name="nick" value="' . htmlspecialchars(get_album_nick(SmrSession::$account_id)) . '" class="InputFields" readonly></td>');
+		echo('<td style="color:green; font-size:70%;">Nick:<br /><input type="text" size="10" name="nick" value="' . htmlspecialchars(get_album_nick(SmrSession::getAccountID())) . '" class="InputFields" readonly></td>');
 		echo('<td style="color:green; font-size:70%;">Comment:<br /><input type="text" size="50" name="comment" class="InputFields"></td>');
 		echo('<td style="color:green; font-size:70%;"><br /><input type="submit" value="Send" class="InputFields"></td>');
 		$db->query('SELECT *
 					FROM account_has_permission
-					WHERE account_id = '.$db->escapeNumber(SmrSession::$account_id).' AND
+					WHERE account_id = '.$db->escapeNumber(SmrSession::getAccountID()).' AND
 						permission_id = '.$db->escapeNumber(PERMISSION_MODERATE_PHOTO_ALBUM));
 		if ($db->nextRecord())
 			echo('<td style="color:green; font-size:70%;"><br /><input type="submit" name="action" value="Moderate" class="InputFields"></td>');

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -136,7 +136,7 @@ class SmrSession {
 	private static $generate;
 	private static $SN;
 	private static $lastSN;
-	public static $account_id;
+	private static $account_id;
 	public static $last_accessed;
 
 	protected static $previousAjaxReturns;
@@ -260,6 +260,25 @@ class SmrSession {
 	 */
 	public static function hasGame() {
 		return self::$game_id != 0;
+	}
+
+	public static function hasAccount() {
+		return self::$account_id > 0;
+	}
+
+	public static function getAccountID() {
+		return self::$account_id;
+	}
+
+	public static function getAccount() {
+		return SmrAccount::getAccount(self::$account_id);
+	}
+
+	/**
+	 * Sets the `account_id` attribute of this session.
+	 */
+	public static function setAccount(AbstractSmrAccount $account) {
+		self::$account_id = $account->getAccountID();
 	}
 
 	/**

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -414,7 +414,7 @@ function do_voodoo() {
 //	ob_clean();
 
 	// create account object
-	$account = SmrAccount::getAccount(SmrSession::$account_id);
+	$account = SmrSession::getAccount();
 
 	if(!defined('DATE_DATE_SHORT')) define('DATE_DATE_SHORT',$account->getShortDateFormat());
 	if(!defined('DATE_TIME_SHORT')) define('DATE_TIME_SHORT',$account->getShortTimeFormat());
@@ -440,7 +440,7 @@ function do_voodoo() {
 		}
 		// We need to acquire locks BEFORE getting the player information
 		// Otherwise we could be working on stale information
-		$db->query('SELECT sector_id FROM player WHERE account_id=' . $db->escapeNumber(SmrSession::$account_id) . ' AND game_id=' . $db->escapeNumber(SmrSession::getGameID()) . ' LIMIT 1');
+		$db->query('SELECT sector_id FROM player WHERE account_id=' . $db->escapeNumber($account->getAccountID()) . ' AND game_id=' . $db->escapeNumber(SmrSession::getGameID()) . ' LIMIT 1');
 		$db->nextRecord();
 		$sector_id = $db->getInt('sector_id');
 
@@ -456,7 +456,7 @@ function do_voodoo() {
 				SmrSession::fetchVarInfo();
 				if (!($var = SmrSession::retrieveVar())) {
 					if (ENABLE_DEBUG) {
-						$db->query('INSERT INTO debug VALUES (\'SPAM\',' . $db->escapeNumber(SmrSession::$account_id) . ',0,0)');
+						$db->query('INSERT INTO debug VALUES (\'SPAM\',' . $db->escapeNumber($account->getAccountID()) . ',0,0)');
 					}
 					create_error('Please do not spam click!');
 				}
@@ -464,7 +464,7 @@ function do_voodoo() {
 		}
 
 		// Now that they've acquire a lock we can move on
-		$player = SmrPlayer::getPlayer(SmrSession::$account_id, SmrSession::getGameID());
+		$player = SmrPlayer::getPlayer($account->getAccountID(), SmrSession::getGameID());
 
 		if($player->isDead() && $var['url'] != 'death_processing.php' && !isset($var['override_death'])) {
 			forward(create_container('death_processing.php'));
@@ -561,7 +561,7 @@ function acquire_lock($sector) {
 		return true;
 
 	// Insert ourselves into the queue.
-	$db->query('INSERT INTO locks_queue (game_id,account_id,sector_id,timestamp) VALUES(' . $db->escapeNumber(SmrSession::getGameID()) . ',' . $db->escapeNumber(SmrSession::$account_id) . ',' . $db->escapeNumber($sector) . ',' . $db->escapeNumber(TIME) . ')');
+	$db->query('INSERT INTO locks_queue (game_id,account_id,sector_id,timestamp) VALUES(' . $db->escapeNumber(SmrSession::getGameID()) . ',' . $db->escapeNumber(SmrSession::getAccountID()) . ',' . $db->escapeNumber($sector) . ',' . $db->escapeNumber(TIME) . ')');
 	$lock = $db->getInsertID();
 
 	for($i=0;$i<250;++$i) {
@@ -575,7 +575,7 @@ function acquire_lock($sector) {
 			//usleep(100000 + mt_rand(0,50000));
 
 			// We can only have one lock in the queue, anything more means someone is screwing around
-			$db->query('SELECT COUNT(*) FROM locks_queue WHERE account_id=' . $db->escapeNumber(SmrSession::$account_id) . ' AND sector_id=' . $db->escapeNumber($sector) . ' AND timestamp > ' . $db->escapeNumber(TIME - LOCK_DURATION));
+			$db->query('SELECT COUNT(*) FROM locks_queue WHERE account_id=' . $db->escapeNumber(SmrSession::getAccountID()) . ' AND sector_id=' . $db->escapeNumber($sector) . ' AND timestamp > ' . $db->escapeNumber(TIME - LOCK_DURATION));
 			if($db->nextRecord() && $db->getInt('COUNT(*)') > 1) {
 				release_lock();
 				$locksFailed[$sector] = true;
@@ -683,11 +683,11 @@ function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account, $v
 		$template->assign('CurrentHallOfFameLink',SmrSession::getNewHREF($container));
 	}
 
-	if (SmrSession::$account_id > 0) {
+	if (SmrSession::hasAccount()) {
 		$container = create_container('skeleton.php', 'hall_of_fame_new.php');
 		$template->assign('HallOfFameLink',SmrSession::getNewHREF($container));
 
-		$template->assign('AccountID',SmrSession::$account_id);
+		$template->assign('AccountID', SmrSession::getAccountID());
 		$template->assign('PlayGameLink',SmrSession::getNewHREF(create_container('game_play_preprocessing.php')));
 
 		$template->assign('LogoutLink',SmrSession::getNewHREF(create_container('logoff.php')));

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -127,9 +127,9 @@ function NPCStuff() {
 
 			SmrSession::updateGame(NPC_GAME_ID);
 
-			debug('Getting player for account id: '.SmrSession::$account_id);
+			debug('Getting player for account id: '.SmrSession::getAccountID());
 			//We have to reload player on each loop
-			$player = SmrPlayer::getPlayer(SmrSession::$account_id, SmrSession::getGameID(), true);
+			$player = SmrPlayer::getPlayer(SmrSession::getAccountID(), SmrSession::getGameID(), true);
 			$player->updateTurns();
 
 			if($actions==0) {
@@ -457,7 +457,7 @@ function changeNPCLogin() {
 	}
 
 	$GLOBALS['account'] =& $account;
-	SmrSession::$account_id = $account->getAccountID();
+	SmrSession::setAccount($account);
 	$underAttack = false;
 
 	//Auto-create player if need be.


### PR DESCRIPTION
Make the `account_id` attribute private and replace direct calls
to it with the setter/getter methods.

This makes it more explicit when and how we are setting the account.