### PR TITLE
docker-compose.yml: set mysql charset to utf8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,8 +97,9 @@ services:
         # The mysql:5.7+ docker default sql mode uses STRICT_TRANS_TABLES,
         # which is incompatible with the way the SMR database is used.
         # Therefore, we override CMD to omit this sql mode.
-        command: ["mysqld", "--sql-mode=NO_ENGINE_SUBSTITUTION"]
-
+        command: ["mysqld", "--sql-mode=NO_ENGINE_SUBSTITUTION",
+                  "--character-set-server=utf8",
+                  "--collation-server=utf8_general_ci"]
 
     pma:
         image: phpmyadmin/phpmyadmin

--- a/lib/Default/MySqlDatabase.class.inc
+++ b/lib/Default/MySqlDatabase.class.inc
@@ -18,6 +18,13 @@ abstract class MySqlDatabase {
 				$this->error('Connection failed: ' . self::$dbConn->connect_error);
 			}
 			self::$selectedDbName = $dbName;
+
+			// Default server charset should be set correctly. Using the default
+			// avoids the additional query involved in `set_charset`.
+			$charset = self::$dbConn->character_set_name();
+			if ($charset != 'utf8') {
+				$this->error('Unexpected charset: ' . $charset);
+			}
 		}
 
 		// Do we need to switch databases (e.g. for compatability db access)?


### PR DESCRIPTION
Fixes the following PHP Warning:

```
DOMDocument::loadHTML(): Input is not proper UTF-8
```

The charset for the `smr_live` database is currently set to `latin1`,
since it was created before UTF-8 was standard in MySQL. This caused
any UTF-8 characters to be encoded in the database in what looked to
be gibberish, even though querying and displaying those characters in
HTML worked correctly (since the mysql server and client were using a
consistent encoding).

We want the characters to be stored in UTF-8 in the database, so we
need the charset to be `utf8` for both server and client. By setting
the charset when the mysql server starts up, the client will default
to the server's charset, which avoids an additional query that would
be incurred by using

```php
self::$dbConn->set_charset('utf8')
```

in the SmrMySqlDatabase constructor. Instead, we will simply demand
that the client charset is the one we expect to be using (utf8), and
throw an exception otherwise.

NOTES:

1. The live server charset was likely changed to "utf8" manually in
   2011, but that setting was lost some time before 2015 (perhaps due
   to a mysql server update). There are some gibberish non-utf8 chars
   in the database as a result, but not in any places we care about.

2. To get a "true" UTF-8 encoding, we will eventually need to switch
   to the `utf8mb4` charset and the `utf8mb4_unicode_ci` collation.