### PR TITLE
Add ability to decline and abandon missions

### DIFF
--- a/engine/Default/mission_abandon_processing.php
+++ b/engine/Default/mission_abandon_processing.php
@@ -1,0 +1,5 @@
+<?php
+
+$player->deleteMission($var['MissionID']);
+
+forward(create_container('skeleton.php', 'current_sector.php'));

--- a/engine/Default/mission_decline_processing.php
+++ b/engine/Default/mission_decline_processing.php
@@ -1,0 +1,5 @@
+<?php
+
+$player->declineMission($var['MissionID']);
+
+forward(create_container('skeleton.php', 'current_sector.php'));

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -37,7 +37,6 @@ abstract class AbstractSmrPlayer {
 	protected $bounties;
 	protected $turns;
 	protected $lastCPLAction;
-	protected $completedMissions;
 	protected $missions;
 
 	protected $visitedSectors;
@@ -999,18 +998,6 @@ abstract class AbstractSmrPlayer {
 		$this->setLastCPLAction(TIME);
 	}
 
-
-	function getCompletedMissions() {
-		if(!isset($this->completedMissions)) {
-			//Get Player missions
-			$this->db->query('SELECT mission_id FROM player_completed_mission WHERE ' . $this->SQL);
-			$this->completedMissions = array();
-			while ($this->db->nextRecord())
-				$this->completedMissions[$this->db->getField('mission_id')] = $this->db->getField('mission_id');
-		}
-		return $this->completedMissions;
-	}
-
 	public function getMissions() {
 		if(!isset($this->missions)) {
 			$this->db->query('SELECT * FROM player_has_mission WHERE ' . $this->SQL);
@@ -1073,6 +1060,10 @@ abstract class AbstractSmrPlayer {
 
 	private function setupMissionStep($missionID) {
 		$mission =& $this->missions[$missionID];
+		if ($mission['On Step'] >= count(MISSIONS[$missionID]['Steps'])) {
+			// Nothing to do if this mission is already completed
+			return;
+		}
 		$step = MISSIONS[$missionID]['Steps'][$mission['On Step']];
 		if(isset($step['PickSector'])) {
 			$realX = Plotter::getX($step['PickSector']['Type'], $step['PickSector']['X'], $this->getGameID());
@@ -1087,7 +1078,16 @@ abstract class AbstractSmrPlayer {
 		}
 	}
 
-	function addMission($missionID) {
+	/**
+	 * Declining a mission will permanently hide it from the player
+	 * by adding it in its completed state.
+	 */
+	public function declineMission($missionID) {
+		$finishedStep = count(MISSIONS[$missionID]['Steps']);
+		$this->addMission($missionID, $finishedStep);
+	}
+
+	public function addMission($missionID, $step=0) {
 		$this->getMissions();
 
 		if(isset($this->missions[$missionID]))
@@ -1095,7 +1095,7 @@ abstract class AbstractSmrPlayer {
 		$sector = 0;
 
 		$mission = array(
-			'On Step' => 0,
+			'On Step' => $step,
 			'Progress' => 0,
 			'Unread' => true,
 			'Expires' => (TIME + 86400),

--- a/lib/Default/Globals.class.inc
+++ b/lib/Default/Globals.class.inc
@@ -500,14 +500,6 @@ class Globals {
 		return SmrSession::getNewHREF(create_container('skeleton.php', 'buy_ship_name.php'));
 	}
 
-	public static function getAcceptMissionHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_accept_processing.php', array('MissionID'=>$missionID)));
-	}
-
-	public static function getClaimMissionRewardHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_claim_processing.php', array('MissionID'=>$missionID)));
-	}
-
 	public static function getSectorBBLink($sectorID) {
 		return '[sector=' . $sectorID . ']';
 	}

--- a/lib/Default/Mission.class.inc
+++ b/lib/Default/Mission.class.inc
@@ -1,0 +1,21 @@
+<?php
+
+class Mission {
+
+	public static function getAcceptHREF($missionID) {
+		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_accept_processing.php', ['MissionID' => $missionID]));
+	}
+
+	public static function getDeclineHREF($missionID) {
+		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_decline_processing.php', ['MissionID' => $missionID]));
+	}
+
+	public static function getAbandonHREF($missionID) {
+		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_abandon_processing.php', ['MissionID' => $missionID]));
+	}
+
+	public static function getClaimRewardHREF($missionID) {
+		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_claim_processing.php', ['MissionID' => $missionID]));
+	}
+
+}

--- a/templates/Default/engine/Default/includes/Missions.inc
+++ b/templates/Default/engine/Default/includes/Missions.inc
@@ -9,7 +9,10 @@ if(count($AvailableMissions) > 0) {
 	foreach($AvailableMissions as $MissionID => $AvailableMission) { ?>
 		<span class="green">New Mission: </span><?php
 		echo bbifyMessage($AvailableMission['Steps'][0]['Text']); ?><br/><br/>
-		<div class="buttonA"><a href="<?php echo Globals::getAcceptMissionHREF($MissionID); ?>" class="buttonA">Accept</a></div><br/><?php
+		<div class="buttonA">
+			<a href="<?php echo Mission::getAcceptHREF($MissionID); ?>" class="buttonA">Accept</a>&nbsp;
+			<a href="<?php echo Mission::getDeclineHREF($MissionID); ?>" class="buttonA">Decline</a>
+		</div><br/><?php
 	}
 }
 
@@ -23,11 +26,14 @@ if(count($Missions) > 0) {
 		}
 		if($Mission['Task']['Step'] == 'Claim') { ?>
 			<span class="green">Claim Reward: </span>
-			<div class="buttonA"><a href="<?php echo Globals::getClaimMissionRewardHREF($MissionID); ?>" class="buttonA">Claim Reward</a></div><br/><?php
+			<div class="buttonA"><a href="<?php echo Mission::getClaimRewardHREF($MissionID); ?>" class="buttonA">Claim Reward</a></div><br/><?php
 		}
 		else { ?>
 			<span class="green">Current Task: </span><?php
-			echo bbifyMessage($Mission['Task']['Task']); ?><br/><?php
+			echo bbifyMessage($Mission['Task']['Task']); ?><br/>
+			<div class="buttonA">
+				<p><a class="buttonA" href="<?php echo Mission::getAbandonHREF($MissionID); ?>">Abandon Mission</a></p>
+			</div><?php
 		}
 	}
 }


### PR DESCRIPTION
When you can accept a mission, you now also have the option
to decline it, which will prevent it from displaying again.

Once you have accepted a mission, you can now also abandon
it at any time, which will allow you to restart it later.

Use a new `Mission` class to hold the HREF methods:
* getAcceptHREF (from Globals::getAcceptMissionHREF)
* getClaimRewardHREF (from Globals::getClaimMissionRewardHREF)
* getDeclineHREF (new)
* getAbandonHREF (new)

Add method `SmrPlayer::declineMission`, which uses a new "step"
argument to `addMission` to reuse that code to effectively add
the mission in its completed state.

Also remove the `SmrPlayer::getCompletedMissions` method because
it is unused and non-functional (it queries a non-existent table
`player_completed_mission`).

![image](https://user-images.githubusercontent.com/846186/58376257-619c7980-7f1b-11e9-88ad-573f03b0bf1c.png)

![image](https://user-images.githubusercontent.com/846186/58376265-7547e000-7f1b-11e9-998c-33c2990b2ef3.png)
