### PR TITLE
Notify IRC users about discordbot

### DIFF
--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -54,7 +54,8 @@ const MAX_IMAGE_HEIGHT = 30;
 
 const MULTI_CHECKING_COOKIE_VERSION = 'v3';
 
-const WIKI_URL = 'http://wiki.smrealms.de';
+const WIKI_URL = 'https://wiki.smrealms.de';
+const DISCORD_URL = 'https://discord.me/smrealms';
 
 /*
  * Localisations

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -33,7 +33,7 @@
 
 				<!-- header menu -->
 				<ul id="main_menu">
-					<li><a href="https://discord.me/smrealms" target="discord">Discord</a></li>
+					<li><a href="<?php echo DISCORD_URL; ?>" target="discord">Discord</a></li>
 					<li><a href="<?php echo WIKI_URL; ?>" target="manu">Game&nbsp;Guide</a></li>
 					<li><a href="https://smrcnn.smrealms.de" target="board">Forums</a></li>
 					<li><a href="<?php echo WIKI_URL; ?>/tutorials#video-tutorials" target="vid">Video&nbsp;Tutorials</a></li>

--- a/tools/irc/channel.php
+++ b/tools/irc/channel.php
@@ -12,22 +12,13 @@ function channel_join($fp, $rdata)
 
 		echo_r('[JOIN] ' . $nick . '!' . $user . '@' . $host . ' joined ' . $channel);
 
-//		if ($nick == 'MrSpock' && $user == 'mrspock')
-//			fputs($fp, 'PRIVMSG ' . $channel . ' :The creator! The God! He\'s among us! Praise him!' . EOL);
-		if ($nick == 'Holti' && $user == 'Holti')
-			fputs($fp, 'PRIVMSG ' . $channel . ' :' . chr(1) . 'ACTION hands ' . $nick . ' a ' . chr(3) . '4@' . chr(3) . '3' . chr(2) . '}' . chr(2) . '-,`--' . chr(1) . EOL);
-		if ($nick == 'kiNky' && $user == 'cicika')
-			fputs($fp, 'PRIVMSG ' . $channel . ' :' . chr(1) . 'ACTION hands ' . $nick . ' a ' . chr(3) . '4@' . chr(3) . '3' . chr(2) . '}' . chr(2) . '-,`--' . chr(1) . EOL);
-		if ($nick == 'River' && $user == 'Serenity')
-			fputs($fp, 'PRIVMSG ' . $channel . ' :' . chr(1) . 'ACTION hands ' . $nick . ' a ' . chr(3) . '8@' . chr(3) . '3' . chr(2) . '}' . chr(2) . '-,`--' . chr(1) . EOL);
-
 		$db = new SmrMySqlDatabase();
 
 		// check if we have seen this user before
 		$db->query('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND channel = ' . $db->escapeString($channel));
 
 		if ($db->nextRecord()) {
-			// exiting nick?
+			// existing nick?
 			$seen_id = $db->getField('seen_id');
 
 			$seen_count = $db->getField('seen_count');
@@ -52,6 +43,10 @@ function channel_join($fp, $rdata)
 		} else {
 			// new nick?
 			$db->query('INSERT INTO irc_seen (nick, user, host, channel, signed_on) VALUES(' . $db->escapeString($nick) . ', ' . $db->escapeString($user) . ', ' . $db->escapeString($host) . ', ' . $db->escapeString($channel) . ', ' . time() . ')');
+
+			if ($nick != IRC_BOT_NICK) {
+				fputs($fp, 'PRIVMSG ' . $channel . ' :Welcome, ' . $nick . '! Most players are using Discord (' . DISCORD_URL . ') instead of IRC, but the two platforms are linked by discordbot. Anything you say here will be relayed to the Discord channel and vice versa.' . EOL);
+			}
 		}
 
 		// check if player joined alliance chat


### PR DESCRIPTION
Since IRC is usually empty these days, players join and don't see
anyone and then quickly leave. This notification is sent whenever
a new player joins IRC to help explain where everyone is and how
to communicate with them.

Also removed a few custom join notifications for specific people.
![image](https://user-images.githubusercontent.com/846186/58437139-7133d380-807d-11e9-97e7-7fbe894af72a.png)

To avoid being spammy, this is only displayed for people that Caretaker has not seen before.