### PR TITLE
Add img dimensions to President icon

### DIFF
--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -443,7 +443,7 @@ abstract class AbstractSmrPlayer {
 	public function getLevelName() {
 		$level_name = Globals::getLevelRequirements()[$this->getLevelID()]['Name'];
 		if ($this->isPresident()) {
-			$level_name = '<img src="images/council_president.png" title="' . Globals::getRaceName($this->getRaceID()) . ' President" />&nbsp;' . $level_name;
+			$level_name = '<img src="images/council_president.png" title="' . Globals::getRaceName($this->getRaceID()) . ' President" height="12" width="16" />&nbsp;' . $level_name;
 		}
 		return $level_name;
 	}


### PR DESCRIPTION
Specifying the image dimensions allows the browser to allocate
space for the image before the image is downloaded. This prevents
other page elements from being shifted after the image is loaded
(which makes the page flicker and look like it's jumping around).

This is certainly worth a small amount of additional text being
served.