### PR TITLE
alliance_stat_processing.php: fix PHP warning

### DIFF
--- a/engine/Default/alliance_stat_processing.php
+++ b/engine/Default/alliance_stat_processing.php
@@ -25,7 +25,8 @@ if (isset($_REQUEST['url'])) {
 	$url = trim($_REQUEST['url']);
 }
 
-if(preg_match('/"/',$url)) {
+// Prevent XSS attacks
+if (isset($url) && preg_match('/"/',$url)) {
 	create_error('You cannot use a " in the image link!');
 }
 


### PR DESCRIPTION
If a player has permission to change some alliance info, but *not*
`change_mod` permission, then this will result in the following
warning:

Undefined variable: url in /smr/engine/Default/alliance_stat_processing.php on line 28

Fix this by first checking that `isset($url)` before using it.