### PR TITLE
Chess matches will now end with each game

### DIFF
--- a/db/patches/V1_6_63_20__chess_game_id.sql
+++ b/db/patches/V1_6_63_20__chess_game_id.sql
@@ -1,0 +1,2 @@
+-- Add `game_id` column to the `chess_game` table.
+ALTER TABLE chess_game ADD COLUMN game_id int(10) unsigned NOT NULL DEFAULT '0';

--- a/engine/Default/chess.php
+++ b/engine/Default/chess.php
@@ -10,7 +10,7 @@ foreach($chessGames as $chessGame) {
 }
 
 $players = array();
-$db->query('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) LEFT OUTER JOIN npc_logins USING(login) WHERE working IS NULL AND validated = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
+$db->query('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) WHERE npc = ' . $db->escapeBoolean(false) . ' AND validated = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
 while ($db->nextRecord()) {
 	$players[$db->getInt('player_id')] = $db->getField('player_name');
 }
@@ -18,7 +18,7 @@ $template->assign('PlayerList',$players);
 
 if(ENABLE_NPCS_CHESS) {
 	$npcs = array();
-	$db->query('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) JOIN npc_logins USING(login) WHERE validated = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
+	$db->query('SELECT player_id, player.player_name FROM player WHERE npc = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
 	while ($db->nextRecord()) {
 		$npcs[$db->getInt('player_id')] = $db->getField('player_name');
 	}

--- a/engine/Default/chess.php
+++ b/engine/Default/chess.php
@@ -1,7 +1,8 @@
 <?php
 
-$chessGames = ChessGame::getOngoingAccountGames($player->getAccountID());
+$chessGames = ChessGame::getOngoingPlayerGames($player);
 $template->assign('ChessGames', $chessGames);
+$template->assign('PageTopic', 'Casino');
 
 $playersChallenged = array($player->getAccountID() => true);
 foreach($chessGames as $chessGame) {

--- a/lib/Default/ChessGame.class.inc
+++ b/lib/Default/ChessGame.class.inc
@@ -41,9 +41,9 @@ class ChessGame {
 		return $games;
 	}
 
-	public static function &getOngoingAccountGames($accountID) {
+	public static function &getOngoingPlayerGames(AbstractSmrPlayer $player) {
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT chess_game_id FROM chess_game WHERE (black_id = ' . $db->escapeNumber($accountID) . ' OR white_id = ' . $db->escapeNumber($accountID) . ') AND (end_time > ' . TIME . ' OR end_time IS NULL);');
+		$db->query('SELECT chess_game_id FROM chess_game WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND (black_id = ' . $db->escapeNumber($player->getAccountID()) . ' OR white_id = ' . $db->escapeNumber($player->getAccountID()) . ') AND (end_time > ' . TIME . ' OR end_time IS NULL);');
 		$games = array();
 		while($db->nextRecord()) {
 			$games[] = self::getChessGame($db->getInt('chess_game_id'));
@@ -277,28 +277,6 @@ class ChessGame {
 		return $fen;
 	}
 
-	//TODO: this hasn't been fully translated to PHP yet, if it ever should be?
-//	public function getMessages() {
-//		if($this->messages == null) {
-//			$df = new SimpleDateFormat('yyyy-MM-dd HH:mm:ss');
-//			$this->db->query('SELECT * FROM chess_game_messages WHERE chess_game_id = ' . $this->db->escapeNumber($this->chessGameID) . ' ORDER BY message_id;');
-//			$this->messages = array();
-//			while($this->db->nextRecord()) {
-//				$this->messages[] = $df->format(new Date($this->db->getInt('sent_time'))) . ' ' . $this->db->getField('sender') . ': ' . $this->db->getField('message');
-//			}
-//		}
-//		return $this->messages;
-//	}
-
-//	public function addMessage($accountID, $message) {
-//		$this->getMessages();
-//		$this->db->query('INSERT INTO chess_game_messages' .
-//				'(chess_game_id,sender,sent_time,message)' .
-//				'values' .
-//				'(' . $this->db->escapeNumber($gameID) . ',' . $this->db->escapeNumber($accountID) . ',' . $this->db->escapeNumber(TIME) . ',' . $this->db->escapeString($message) . ');');
-//		$this->messages[] = $message;
-//	}
-
 	public static function &parsePieces(array &$pieces) {
 		$board = array();
 		$row = array();
@@ -317,7 +295,7 @@ class ChessGame {
 		return $board;
 	}
 
-	public static function getStandardGame($gameID, AbstractSmrPlayer &$whitePlayer, AbstractSmrPlayer &$blackPlayer) {
+	public static function getStandardGame($gameID, AbstractSmrPlayer $whitePlayer, AbstractSmrPlayer $blackPlayer) {
 		$white = $whitePlayer->getAccountID();
 		$black = $blackPlayer->getAccountID();
 		return array
@@ -360,23 +338,23 @@ class ChessGame {
 			);
 	}
 
-	public static function insertNewGame($startDate, $endDate, AbstractSmrPlayer &$whitePlayer, AbstractSmrPlayer &$blackPlayer) {
+	public static function insertNewGame($startDate, $endDate, AbstractSmrPlayer $whitePlayer, AbstractSmrPlayer $blackPlayer) {
 		if($startDate == null) {
 			throw new Exception('Start date cannot be null.');
 		}
 
 		$db = new SmrMySqlDatabase();
 		$db->query('INSERT INTO chess_game' .
-				'(start_time,end_time,white_id,black_id)' .
+				'(start_time,end_time,white_id,black_id,game_id)' .
 				'values' .
-				'(' . $db->escapeNumber($startDate) . ',' . ($endDate == null ? 'NULL' : $db->escapeNumber($endDate)) . ',' . $db->escapeNumber($whitePlayer->getAccountID()) . ',' . $db->escapeNumber($blackPlayer->getAccountID()) . ');');
+				'(' . $db->escapeNumber($startDate) . ',' . ($endDate == null ? 'NULL' : $db->escapeNumber($endDate)) . ',' . $db->escapeNumber($whitePlayer->getAccountID()) . ',' . $db->escapeNumber($blackPlayer->getAccountID()) . ',' . $db->escapeNumber($whitePlayer->getGameID()) . ');');
 		$chessGameID = $db->getInsertID();
 
 		self::insertPieces($chessGameID, $whitePlayer, $blackPlayer);
 		return $chessGameID;
 	}
 
-	private static function insertPieces($chessGameID, AbstractSmrPlayer &$whitePlayer, AbstractSmrPlayer &$blackPlayer) {
+	private static function insertPieces($chessGameID, AbstractSmrPlayer $whitePlayer, AbstractSmrPlayer $blackPlayer) {
 		$db = new SmrMySqlDatabase();
 		$pieces = self::getStandardGame($chessGameID, $whitePlayer, $blackPlayer);
 		foreach($pieces as $p) {
@@ -752,28 +730,16 @@ class ChessGame {
 //		return $this->gameID;
 	}
 
-	public function &getWhitePlayer() {
-		try {
-			return SmrPlayer::getPlayer($this->whiteID, $this->getGameID());
-		}
-		catch(Exception $e) {
-			$null = null;
-			return $null;
-		}
+	public function getWhitePlayer() {
+		return SmrPlayer::getPlayer($this->whiteID, $this->getGameID());
 	}
 
 	public function getWhiteID() {
 		return $this->whiteID;
 	}
 
-	public function &getBlackPlayer() {
-		try {
-			return SmrPlayer::getPlayer($this->blackID, $this->getGameID());
-		}
-		catch(Exception $e) {
-			$null = null;
-			return $null;
-		}
+	public function getBlackPlayer() {
+		return SmrPlayer::getPlayer($this->blackID, $this->getGameID());
 	}
 
 	public function getBlackID() {
@@ -789,14 +755,8 @@ class ChessGame {
 		}
 	}
 
-	public function &getColourPlayer($colour) {
-		try {
-			return SmrPlayer::getPlayer($this->getColourID($colour), $this->getGameID());
-		}
-		catch(Exception $e) {
-			$null = null;
-			return $null;
-		}
+	public function getColourPlayer($colour) {
+		return SmrPlayer::getPlayer($this->getColourID($colour), $this->getGameID());
 	}
 
 	public function getColourForAccountID($accountID) {
@@ -848,25 +808,19 @@ class ChessGame {
 		return count($this->getMoves()) % 2 == 0 ? $this->whiteID : $this->blackID;
 	}
 
-	public function &getCurrentTurnPlayer() {
-		try {
-			return SmrPlayer::getPlayer($this->getCurrentTurnAccountID(), $this->getGameID());
-		}
-		catch(Exception $e) {
-			$null = null;
-			return $null;
-		}
+	public function getCurrentTurnPlayer() {
+		return SmrPlayer::getPlayer($this->getCurrentTurnAccountID(), $this->getGameID());
 	}
 
-	public function &getCurrentTurnAccount() {
+	public function getCurrentTurnAccount() {
 		return SmrAccount::getAccount($this->getCurrentTurnAccountID());
 	}
 
-	public function &getWhiteAccount() {
+	public function getWhiteAccount() {
 		return SmrAccount::getAccount($this->getWhiteID());
 	}
 
-	public function &getBlackAccount() {
+	public function getBlackAccount() {
 		return SmrAccount::getAccount($this->getBlackID());
 	}
 

--- a/templates/Default/engine/Default/chess.php
+++ b/templates/Default/engine/Default/chess.php
@@ -1,46 +1,33 @@
+<p style="width: 60%">Challenge other traders to a round of <i>Faster Than Knight</i>,
+a game of chess played over the super-photonic transponder aboard your ship.</p>
+
 <?php
-if(isset($CreateGameMessage)) {
-	echo $CreateGameMessage;
-} ?>
-<table class="standard ajax" id="GameList">
-	<tr>
-		<th>Players</th>
-		<th>Current Turn</th>
-		<th></th>
-	</tr><?php
-	foreach($ChessGames as $ChessGame) { ?>
+if (!empty($ChessGames)) { ?>
+	<table class="standard ajax" id="GameList">
 		<tr>
-			<td><?php
-				$WhitePlayer = $ChessGame->getWhitePlayer();
-				$BlackPlayer = $ChessGame->getBlackPlayer();
-				if($WhitePlayer == null) {
-					?>Unknown<?php
-				}
-				else {
-					echo $WhitePlayer->getLinkedDisplayName(false);
-				} ?> vs <?php 
-				if($BlackPlayer == null) {
-					?>Unknown<?php
-				}
-				else {
-					echo $BlackPlayer->getLinkedDisplayName(false);
-				} ?>
-			</td>
-			<td><?php
-				$CurrentTurnPlayer = $ChessGame->getCurrentTurnPlayer();
-				if($CurrentTurnPlayer == null) {
-					?>Unknown<?php
-				}
-				else {
-					echo $CurrentTurnPlayer->getLinkedDisplayName(false);
-				} ?>
-			</td>
-			<td>
-				<div class="buttonA"><a class="buttonA" href="<?php echo $ChessGame->getPlayGameHREF(); ?>">Play</a></div>
-			</td>
+			<th>Players</th>
+			<th>Current Turn</th>
+			<th></th>
 		</tr><?php
-	} ?>
-</table><?php
+		foreach($ChessGames as $ChessGame) { ?>
+			<tr>
+				<td>
+					<?php echo $ChessGame->getWhitePlayer()->getLinkedDisplayName(false); ?>
+					vs
+					<?php echo $ChessGame->getBlackPlayer()->getLinkedDisplayName(false); ?>
+				</td>
+				<td>
+					<?php echo $ChessGame->getCurrentTurnPlayer()->getLinkedDisplayName(false); ?>
+				</td>
+				<td>
+					<div class="buttonA"><a class="buttonA" href="<?php echo $ChessGame->getPlayGameHREF(); ?>">Play</a></div>
+				</td>
+			</tr><?php
+		} ?>
+	</table>
+	<small>NOTE: Chess matches do not carry over between games.</small>
+	<br /><br /><?php
+}
 
 if(count($PlayerList) > 0) { ?>
 	<form action="<?php echo Globals::getChessCreateHREF(); ?>" method="POST">
@@ -49,7 +36,7 @@ if(count($PlayerList) > 0) { ?>
 			foreach($PlayerList as $PlayerID => $PlayerName) {
 				?><option value="<?php echo $PlayerID; ?>"><?php echo $PlayerName; ?></option><?php
 			} ?>
-		</select><input type="submit"/>
+		</select>&nbsp;<input type="submit"/>
 	</form><?php
 }
 else { ?>
@@ -64,7 +51,7 @@ if(isset($NPCList)) {
 				foreach($NPCList as $PlayerID => $PlayerName) {
 					?><option value="<?php echo $PlayerID; ?>"><?php echo $PlayerName; ?></option><?php
 				} ?>
-			</select><input type="submit"/>
+			</select>&nbsp;<input type="submit"/>
 		</form><?php
 	}
 	else { ?>


### PR DESCRIPTION
Having chess matches span multiple games caused two major problems:

1. It was a sneaky way to keep track of who a player is from game
   to game, circumventing the anonymity that everyone assumed they
   had.

2. If one player in a match doesn't join a subsequent game, then
   we can get any number of Exceptions due to trying to access
   methods on a player that is `null`.

The simplest solution to these problems is to have matches end when
the game ends.

To implement this, we need to make a few changes:

* Add a `game_id` column to the `chess_game` table.
  (Since we can't know what game_id past chess games were associated
  with, they will be assigned `game_id=0`.)

* Replace the `ChessGame` method `getOngoingAccountGames` with
  `getOngoingPlayerGames`, which is restricted to matches in the
  current game.

* Let the `ChessGame` methods `get<X>Player` raise an Exception
  if the SmrPlayer isn't found, rather than returning null.
  (There should be no more valid cases where the player isn't found.)

Since it is no longer possible for a player to be `null`, we can
remove those conditionals in the chess.php template. We can also
clean up some of the `ChessGame` methods so that they don't use
references.

Also added some flavor text to the "Casino" page.

![image](https://user-images.githubusercontent.com/846186/58678723-9773a080-8315-11e9-8d92-7661a05da839.png)
