### PR TITLE
Add required HTML5 attribute to some input fields

### DIFF
--- a/htdocs/login_create.php
+++ b/htdocs/login_create.php
@@ -40,19 +40,19 @@ require_once('config.inc');
 					<table border='0' cellspacing='0' cellpadding='1'>
 					<tr>
 						<td width='27%'>User name:</td>
-						<td width='73%'><input type='text' name='login' size='20' maxlength='32' class="InputFields"></td>
+						<td width='73%'><input required type='text' name='login' size='20' maxlength='32' class="InputFields"></td>
 					</tr>
 					<tr>
 						<td width='27%'>Password:</td>
-						<td width='73%'><input type='password' name='password' size='20' maxlength='32' class="InputFields"></td>
+						<td width='73%'><input required type='password' name='password' size='20' maxlength='32' class="InputFields"></td>
 					</tr>
 					<tr>
 						<td width='27%'>Verify Password:</td>
-						<td width='73%'><input type='password' name='pass_verify' size='20' maxlength='32' class="InputFields"></td>
+						<td width='73%'><input required type='password' name='pass_verify' size='20' maxlength='32' class="InputFields"></td>
 					</tr>
 					<tr>
 						<td width='27%'>E-Mail Address:</td>
-						<td width='73%'><input type='email' name='email' size='50' maxlength='128' class="InputFields"></td>
+						<td width='73%'><input required type='email' name='email' size='50' maxlength='128' class="InputFields"></td>
 					</tr>
 					<tr>
 						<td width='27%'>Local Time:</td>
@@ -75,7 +75,7 @@ require_once('config.inc');
 					</table>
 
 					<div style='font-size:80%;'>
-						<input type='checkbox' name='agreement' value='checkbox'>
+						<input required type='checkbox' name='agreement' value='checkbox'>
 						I have read and accept the
 						<a href='https://wiki.smrealms.de/rules' target="_blank" style='font-weight:bold;'>Terms of Use</a>.
 					</div>

--- a/htdocs/resend_password.php
+++ b/htdocs/resend_password.php
@@ -34,7 +34,7 @@
 										<table class="center" border="0">
 											<tr>
 												<th class="right">Email:</th>
-												<td><input type="email" name="email" class="InputFields"></td>
+												<td><input required type="email" name="email" class="InputFields"></td>
 											</tr>
 										</table>
 										<p><input type="submit" value="Resend my password" class="InputFields"></p>

--- a/htdocs/reset_password.php
+++ b/htdocs/reset_password.php
@@ -33,19 +33,19 @@
 											<table class="center" border="0">
 												<tr>
 														<th class="right">Username:</th>
-														<td><input name="login" type="text" class="InputFields" value="<?php echo isset($_REQUEST['login']) ? htmlspecialchars($_REQUEST['login']) : ''; ?>" /></td>
+														<td><input required name="login" type="text" class="InputFields" value="<?php echo isset($_REQUEST['login']) ? htmlspecialchars($_REQUEST['login']) : ''; ?>" /></td>
 												</tr>
 												<tr>
 														<th class="right">Password Reset Code:</th>
-														<td><input name="password_reset" type="text" class="InputFields" value="<?php echo isset($_REQUEST['resetcode']) ? htmlspecialchars($_REQUEST['resetcode']) : ''; ?>" /></td>
+														<td><input required name="password_reset" type="text" class="InputFields" value="<?php echo isset($_REQUEST['resetcode']) ? htmlspecialchars($_REQUEST['resetcode']) : ''; ?>" /></td>
 												</tr>
 												<tr>
 														<th class="right">New Password:</th>
-														<td><input name="password" type="password" class="InputFields" /></td>
+														<td><input required name="password" type="password" class="InputFields" /></td>
 												</tr>
 												<tr>
 														<th class="right">Verify New Password:</th>
-														<td><input name="pass_verify" type="password" class="InputFields" /></td>
+														<td><input required name="pass_verify" type="password" class="InputFields" /></td>
 												</tr>
 											</table>
 											<p><input type="submit" value="Reset my password" class="InputFields" /></p>

--- a/templates/Default/admin/Default/1.6/GameDetails.inc
+++ b/templates/Default/admin/Default/1.6/GameDetails.inc
@@ -2,7 +2,7 @@
 	<table class="standard">
 	<tr>
 		<td class="right">Game Name</td>
-		<td><input type="text" size="32" name="game_name" value="<?php echo $Game['name']; ?>"></td>
+		<td><input required type="text" size="32" name="game_name" value="<?php echo $Game['name']; ?>"></td>
 	</tr>
 	<tr>
 		<td class="right">Game Description</td>
@@ -10,23 +10,23 @@
 	</tr>
 	<tr>
 		<td class="right">Game Speed</td>
-		<td><input type="number" size="6" name="game_speed" step=".05" value="<?php echo $Game['speed']; ?>"></td>
+		<td><input required type="number" size="6" name="game_speed" step=".05" value="<?php echo $Game['speed']; ?>"></td>
 	</tr>
 	<tr>
 		<td class="right">Max Turns</td>
-		<td><input type="number" size="6" name="max_turns" step="5" value="<?php echo $Game['maxTurns']; ?>"></td>
+		<td><input required type="number" size="6" name="max_turns" step="5" value="<?php echo $Game['maxTurns']; ?>"></td>
 	</tr>
 	<tr>
 		<td class="right">Starting Turn Hours</td>
-		<td><input type="number" size="6" name="start_turns" value="<?php echo $Game['startTurnHours']; ?>"></td>
+		<td><input required type="number" size="6" name="start_turns" value="<?php echo $Game['startTurnHours']; ?>"></td>
 	</tr>
 	<tr>
 		<td class="right">Max Players</td>
-		<td><input type="number" size="6" name="max_players" value="<?php echo $Game['maxPlayers']; ?>"></td>
+		<td><input required type="number" size="6" name="max_players" value="<?php echo $Game['maxPlayers']; ?>"></td>
 	</tr>
 	<tr>
 		<td class="right">Join Date (DD/MM/YYYY)</td>
-		<td><input type="text" size="20" name="game_join" value="<?php echo $Game['joinDate']; ?>"></td>
+		<td><input required type="text" size="20" name="game_join" value="<?php echo $Game['joinDate']; ?>"></td>
 	</tr>
 	<tr>
 		<td class="right">Start Date (DD/MM/YYYY)</td>
@@ -34,7 +34,7 @@
 	</tr>
 	<tr>
 		<td class="right">End Date (DD/MM/YYYY)</td>
-		<td><input type="text" size="20" name="game_end" value="<?php echo $Game['endDate']; ?>"></td></tr>
+		<td><input required type="text" size="20" name="game_end" value="<?php echo $Game['endDate']; ?>"></td></tr>
 	<tr>
 		<td class="right">SMR Credits Required</td>
 		<td><input type="number" size="5" name="creds_needed" value="<?php echo $Game['smrCredits']; ?>"></td>
@@ -51,15 +51,15 @@
 	</tr>
 	<tr>
 		<td class="right">Alliance Max Players</td>
-		<td><input type="number" size="6" name="alliance_max_players" value="<?php echo $Game['allianceMax']; ?>"></td>
+		<td><input required type="number" size="6" name="alliance_max_players" value="<?php echo $Game['allianceMax']; ?>"></td>
 	</tr>
 	<tr>
 		<td class="right">Alliance Max Vets</td>
-		<td><input type="number" size="6" name="alliance_max_vets" value="<?php echo $Game['allianceMaxVets']; ?>"></td>
+		<td><input required type="number" size="6" name="alliance_max_vets" value="<?php echo $Game['allianceMaxVets']; ?>"></td>
 	</tr>
 	<tr>
 		<td class="right">Starting Credits</td>
-		<td><input type="number" size="6" name="starting_credits" value="<?php echo $Game['startCredits']; ?>"></td>
+		<td><input required type="number" size="6" name="starting_credits" value="<?php echo $Game['startCredits']; ?>"></td>
 	</tr>
 	<tr>
 		<td class="right">Ignore Stats</td>

--- a/templates/Default/admin/Default/1.6/universe_create_galaxies.php
+++ b/templates/Default/admin/Default/1.6/universe_create_galaxies.php
@@ -19,9 +19,9 @@
 		for ($i=1;$i<=$NumGals;++$i) {
 			?><tr>
 				<td class="center"><?php echo $i; ?></td>
-				<td><input type="text" value="<?php if (isset($DefaultNames[$i])) { echo htmlspecialchars($DefaultNames[$i]); } ?>" name="gal<?php echo $i; ?>"></td>
-				<td><input class="center" type="number" min="1" max="100" value="15" name="width<?php echo $i; ?>"></td>
-				<td><input class="center" type="number" min="1" max="100" value="15" name="height<?php echo $i; ?>"></td>
+				<td><input required type="text" value="<?php if (isset($DefaultNames[$i])) { echo htmlspecialchars($DefaultNames[$i]); } ?>" name="gal<?php echo $i; ?>"></td>
+				<td><input required class="center" type="number" min="1" max="100" value="15" name="width<?php echo $i; ?>"></td>
+				<td><input required class="center" type="number" min="1" max="100" value="15" name="height<?php echo $i; ?>"></td>
 				<td>
 					<select name="type<?php echo $i; ?>" class="InputFields"><?php
 					foreach($GalaxyTypes as $GalaxyType) {
@@ -29,7 +29,7 @@
 					} ?>
 					</select>
 				</td>
-				<td class="center"><input size="3" type="text" value="120" name="forces<?php echo $i; ?>"></td>
+				<td class="center"><input required size="3" type="text" value="120" name="forces<?php echo $i; ?>"></td>
 			</tr><?php
 		} ?>
 		<tr><td class="center" colspan="6"><input type="submit" value="Create Galaxies" name="submit"></td>

--- a/templates/Default/engine/Default/alliance_create.php
+++ b/templates/Default/engine/Default/alliance_create.php
@@ -2,7 +2,7 @@
 	<table cellspacing="0" cellpadding="0" class="nobord nohpad">
 		<tr>
 			<td class="top">Name:</td>
-			<td><input type="text" name="name" size="30"></td>
+			<td><input required type="text" name="name" size="30"></td>
 		</tr>
 		<tr>
 			<td class="top">Description:</td>

--- a/templates/Default/engine/Default/game_join.php
+++ b/templates/Default/engine/Default/game_join.php
@@ -109,7 +109,7 @@ if (!isset($JoinGameFormHref)) { ?>
 				<table>
 					<tr>
 						<td class="right"><b>Name:</b>&nbsp;</td>
-						<td><input type="text" name="player_name" maxlength="32" class="InputFields" /></td>
+						<td><input required type="text" name="player_name" maxlength="32" class="InputFields" /></td>
 						<td rowspan="4" class="standard"><img id="race_image" name="race_image" src="images/race/race1.gif" alt="Please select a race."></td>
 					</tr>
 					<tr>

--- a/templates/Default/engine/Default/planet_ownership.php
+++ b/templates/Default/engine/Default/planet_ownership.php
@@ -34,7 +34,7 @@ else {
 		<br />
 
 		<form method="POST" action="<?php echo $ProcessingHREF; ?>">
-			<input type="text" name="name" value="<?php echo htmlspecialchars($Planet->getName()); ?>" class="InputFields" />&nbsp;&nbsp;&nbsp;
+			<input required type="text" name="name" value="<?php echo htmlspecialchars($Planet->getName()); ?>" class="InputFields" />&nbsp;&nbsp;&nbsp;
 			<input type="submit" name="action" value="Rename" class="InputFields" />
 		</form><?php
 	}

--- a/templates/Default/socialRegister.inc
+++ b/templates/Default/socialRegister.inc
@@ -28,11 +28,11 @@
 					<table border="0" cellspacing="0" cellpadding="1">
 						<tr>
 							<td width="27%">User name:</td>
-							<td width="73%"><input type="text" name="login" size="20" maxlength="32" class="InputFields" value="<?php if (isset($MatchingLogin)) { echo $MatchingLogin; } ?>"></td>
+							<td width="73%"><input required type="text" name="login" size="20" maxlength="32" class="InputFields" value="<?php if (isset($MatchingLogin)) { echo $MatchingLogin; } ?>"></td>
 						</tr>
 						<tr>
 							<td width="27%">Password:</td>
-							<td width="73%"><input type="password" name="password" size="20" maxlength="32" class="InputFields"></td>
+							<td width="73%"><input required type="password" name="password" size="20" maxlength="32" class="InputFields"></td>
 						</tr>
 					</table>
 					<p><input type="submit" name="link_login" value="Link Login"></p>
@@ -54,7 +54,7 @@
 						<table border="0" cellspacing="0" cellpadding="1">
 							<tr>
 								<td width="27%">User name:</td>
-								<td width="73%"><input type="text" name="login" size="20" maxlength="32" class="InputFields"></td>
+								<td width="73%"><input required type="text" name="login" size="20" maxlength="32" class="InputFields"></td>
 							</tr>
 						<tr>
 							<td width="27%">Password (Optional):</td>
@@ -95,7 +95,7 @@
 						</table>
 
 						<div style='font-size:80%;'>
-							<input type='checkbox' name='agreement' value='checkbox'>
+							<input required type='checkbox' name='agreement' value='checkbox'>
 							I have read and accept the
 							<a href='https://wiki.smrealms.de/rules' target="_blank" style='font-weight:bold;'>Terms of Use</a>.
 						</div>


### PR DESCRIPTION
The `required` attribute is a less destructive way of telling a
user that a form field cannot be left blank than redirecting to an
error page (which usually results in losing any form fields already
filled in and having to navigate back to the page).

It can easily be circumvented (by falsifying form data or by not
having an HTML5-compatible browser), so the checks on these fields
in the PHP need to remain.

However, it is still very useful, so I suspect I'll be adding it
more systematically throughout the code later.

![image](https://user-images.githubusercontent.com/846186/58679690-7d3bc180-8319-11e9-9e9b-5e51dc59dd7e.png)
