### PR TITLE
login.inc: add optional Google Analytics tracking

### DIFF
--- a/config/config.specific.sample.php
+++ b/config/config.specific.sample.php
@@ -13,6 +13,8 @@ const FACEBOOK_APP_SECRET = '';
 const TWITTER_CONSUMER_KEY = '';
 const TWITTER_CONSUMER_SECRET = '';
 
+const GOOGLE_ANALYTICS_ID = '';
+
 const ENABLE_NPCS_CHESS = false;
 
 // Set to empty string if using a local mailserver.

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -3,6 +3,17 @@
 	<head>
 		<title><?php echo PAGE_TITLE; ?></title>
 		<link rel="stylesheet" href="css/login.css" />
+		<?php
+		// Include Google Analytics global site tag if we have one
+		if (!empty(GOOGLE_ANALYTICS_ID)) { ?>
+			<script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo GOOGLE_ANALYTICS_ID; ?>"></script>
+			<script>
+				window.dataLayer = window.dataLayer || [];
+				function gtag() { dataLayer.push(arguments); }
+				gtag('js', new Date());
+				gtag('config', '<?php echo GOOGLE_ANALYTICS_ID; ?>');
+			</script><?php
+		} ?>
 		<!--[if IE]>
 		<style>
 		input.inputbox {


### PR DESCRIPTION
Uses the global config variable `GOOGLE_ANALYTICS_ID`.

Currently we're only tracking the login page (since it is useful to
know where we receive traffic from). Internal tracking is less
important, but it can easily be added later.

Closes #137.