### PR TITLE
Add FileVersion metadata to SMR file

### DIFF
--- a/admin/Default/1.6/upload_smr_file_processing.php
+++ b/admin/Default/1.6/upload_smr_file_processing.php
@@ -6,18 +6,23 @@ if ($_FILES['smr_file']['error'] == UPLOAD_ERR_OK) {
 	create_error('Failed to upload SMR file!');
 }
 
-// We only care about the [Galaxies] and [Sector=X] sections, and the earlier
+// We only care about the sections after [Metadata], and the earlier
 // sections have invalid INI key characters (e.g. Creonti "Big Daddy", Salvene
 // Supply & Plunder). For this reason, we simply remove the offending sections
 // instead of trying to encode all the special characters: ?{}|&~![()^"
 //
 // NOTE: these special characters are allowed in the ini-values, but only if
 // we use the "raw" scanner. We need this because of the "Location=" values.
-$ini_substr = strstr($ini_str, "[Galaxies]");
+$ini_substr = strstr($ini_str, "[Metadata]");
 if ($ini_substr === false) {
-	create_error('Could not find [Galaxies] section in SMR file');
+	create_error('Could not find [Metadata] section in SMR file');
 }
 $data = parse_ini_string($ini_substr, true, INI_SCANNER_RAW);
+
+$version = $data['Metadata']['FileVersion'];
+if ($version !== SMR_FILE_VERSION) {
+	create_error('Uploaded v' . $version . ' is incompatible with server expecting v' . SMR_FILE_VERSION);
+}
 
 // Create the galaxies
 foreach ($data['Galaxies'] as $galID => $details) {

--- a/engine/Default/smr_file_create.php
+++ b/engine/Default/smr_file_create.php
@@ -9,7 +9,11 @@ if (isset($var['AdminCreateGameID']) && $var['AdminCreateGameID'] !== false)
 else
 	$adminCreate = false;
 
-$file = ';SMR1.6 Sectors File v 1.04
+// NOTE: If the format of this file is changed in an incompatible way,
+// make sure to update the SMR_FILE_VERSION!
+
+$file = '; SMR Sectors File v' . SMR_FILE_VERSION . '
+; Created on ' . date(DEFAULT_DATE_FULL_SHORT) . '
 [Races]
 ; Name = ID' . EOL;
 foreach (Globals::getRaces() as $race) {
@@ -99,7 +103,10 @@ foreach (SmrLocation::getAllLocations() as $location) {
 	$file .= EOL;
 }
 
-$file .= '[Game]
+// Everything below here must be valid INI syntax (safe to parse)
+$file .= '[Metadata]
+FileVersion=' . SMR_FILE_VERSION . '
+[Game]
 Name='.inify(Globals::getGameName($gameID)) . '
 [Galaxies]
 ';

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -393,6 +393,8 @@ const CDS_REFUND_PERCENT = .5;
 
 const EOL = "\n";
 
+const SMR_FILE_VERSION = '1.05';
+
 // These CSS URLs must be hard-coded here so that grunt-cache-bust
 // can replace them with the hashed filenames.
 const CSS_URLS = array(


### PR DESCRIPTION
To make sure that we don't inadvertently use an incompatible SMR
file when we're loading a game from file in the Uni Gen, we add a
file version to the metadata that we can check against.

Also add the date the file was created (in a comment) for reference.