### PR TITLE
Globals: remove getGameName method

### DIFF
--- a/admin/Default/box_view.php
+++ b/admin/Default/box_view.php
@@ -62,7 +62,7 @@ if (!isset($var['box_type_id'])) {
 			} elseif (!$validGame) {
 				$messages[$messageID]['GameName'] = 'Game no longer exists';
 			} else {
-				$messages[$messageID]['GameName'] = Globals::getGameName($gameID);
+				$messages[$messageID]['GameName'] = SmrGame::getGame($gameID)->getDisplayName();
 			}
 
 			$messages[$messageID]['SendTime'] = date(DATE_FULL_SHORT, $db->getField('send_time'));

--- a/admin/Default/notify_view.php
+++ b/admin/Default/notify_view.php
@@ -41,7 +41,7 @@ while ($db->nextRecord()) {
 	if (!Globals::isValidGame($gameID)) {
 		$gameName = 'Game no longer exists';
 	} else {
-		$gameName = Globals::getGameName($gameID);
+		$gameName = SmrGame::getGame($gameID)->getDisplayName();
 	}
 
 	$messages[] = [

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -7,7 +7,7 @@ if (empty($game_id)) {
 	$topic = 'All Time Hall of Fame';
 }
 else {
-	$topic = Globals::getGameName($game_id) . ' Hall of Fame';
+	$topic = 'Hall of Fame: ' . SmrGame::getGame($game_id)->getDisplayName();
 }
 $template->assign('PageTopic', $topic);
 

--- a/engine/Default/hall_of_fame_player_detail.php
+++ b/engine/Default/hall_of_fame_player_detail.php
@@ -17,7 +17,7 @@ if (isset($var['game_id'])) {
 	} catch (PlayerNotFoundException $e) {
 		create_error('That player has not yet joined this game.');
 	}
-	$template->assign('PageTopic', $hofPlayer->getPlayerName() . '\'s Personal Hall of Fame For ' . Globals::getGameName($var['game_id']));
+	$template->assign('PageTopic', $hofPlayer->getPlayerName() . '\'s Personal Hall of Fame: ' . SmrGame::getGame($game_id)->getDisplayName());
 } else {
 	$hofName = SmrAccount::getAccount($account_id)->getHofName();
 	$template->assign('PageTopic', $hofName . '\'s All Time Personal Hall of Fame');

--- a/engine/Default/smr_file_create.php
+++ b/engine/Default/smr_file_create.php
@@ -107,7 +107,7 @@ foreach (SmrLocation::getAllLocations() as $location) {
 $file .= '[Metadata]
 FileVersion=' . SMR_FILE_VERSION . '
 [Game]
-Name='.inify(Globals::getGameName($gameID)) . '
+Name='.inify(SmrGame::getGame($gameID)->getName()) . '
 [Galaxies]
 ';
 $galaxies = SmrGalaxy::getGameGalaxies($gameID);
@@ -175,7 +175,7 @@ header('Expires: 0');
 header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 header('Cache-Control: private', false);
 header('Content-Type: application/force-download');
-header('Content-Disposition: attachment; filename="' . Globals::getGameName($gameID) . '.smr"');
+header('Content-Disposition: attachment; filename="' . SmrGame::getGame($gameID)->getName() . '.smr"');
 header('Content-Transfer-Encoding: binary');
 header('Content-Length: ' . $size);
 

--- a/lib/Default/Globals.class.inc
+++ b/lib/Default/Globals.class.inc
@@ -206,10 +206,6 @@ class Globals {
 		return 0;
 	}
 
-	public static function getGameName($gameID) {
-		return SmrGame::getGame($gameID)->getName();
-	}
-
 	public static function isFeatureRequestOpen() {
 		if (self::$FEATURE_REQUEST_OPEN == null) {
 			self::initialiseDatabase();

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -646,7 +646,7 @@ function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account, $v
 
 
 	if (SmrSession::hasGame()) {
-		$template->assign('GameName', Globals::getGameName(SmrSession::getGameID()));
+		$template->assign('GameName', SmrGame::getGame(SmrSession::getGameID())->getName());
 		$template->assign('GameID', SmrSession::getGameID());
 
 		$template->assign('PlotCourseLink', Globals::getPlotCourseHREF());


### PR DESCRIPTION
Replace this with explicit calls to methods of `SmrGame`. In some
cases we switch to using the "Display Name", which includes the
game ID.

![image](https://user-images.githubusercontent.com/846186/59741469-ee3b0e80-921f-11e9-8f42-dc2536226145.png)

![image](https://user-images.githubusercontent.com/846186/59741484-f8f5a380-921f-11e9-8a69-dcc8cf13c3a4.png)
