### PR TITLE
Add an Admin Tool to manage NPCs

### DIFF
--- a/admin/Default/npc_manage.php
+++ b/admin/Default/npc_manage.php
@@ -1,0 +1,60 @@
+<?php
+
+$template->assign('PageTopic', 'Manage NPCs');
+
+$selectedGameID = SmrSession::getRequestVar('selected_game_id');
+
+$container = create_container('skeleton.php', 'npc_manage.php');
+$template->assign('SelectGameHREF', SmrSession::getNewHREF($container));
+
+$games = [];
+$db->query('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(TIME) . ' AND enabled = ' . $db->escapeBoolean(true) . ' ORDER BY game_id DESC');
+while ($db->nextRecord()) {
+	$gameID = $db->getInt('game_id');
+	if (!isset($selectedGameID)) {
+		$selectedGameID = $gameID;
+	}
+	$games[] = [
+		'Name' => SmrGame::getGame($gameID)->getDisplayName(),
+		'ID' => $gameID,
+		'Selected' => $gameID == $selectedGameID,
+	];
+}
+$template->assign('Games', $games);
+$template->assign('SelectedGameID', $selectedGameID);
+
+$container = create_container('skeleton.php', 'npc_manage_processing.php');
+$container['selected_game_id'] = $selectedGameID;
+$template->assign('AddAccountHREF', SmrSession::getNewHREF($container));
+
+$npcs = [];
+$db->query('SELECT * FROM npc_logins JOIN account USING(login)');
+while ($db->nextRecord()) {
+	$accountID = $db->getInt('account_id');
+	$login = $db->getField('login');
+
+	$container['login'] = $login;
+	$container['accountID'] = $accountID;
+
+	$npcs[$accountID] = [
+		'login' => $login,
+		'default_player_name' => $db->getField('player_name'),
+		'default_alliance' => $db->getField('alliance_name'),
+		'active' => $db->getBoolean('active'),
+		'working' => $db->getBoolean('working'),
+		'href' => SmrSession::getNewHREF($container),
+	];
+}
+
+// Set the login name for the next NPC to create
+$nextNpcID = count($npcs) + 1;
+$template->assign('NextLogin', 'npc' . $nextNpcID);
+
+// Get the existing NPC players for the selected game
+$db->query('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($selectedGameID) . ' AND npc=' . $db->escapeBoolean(true));
+while ($db->nextRecord()) {
+	$accountID = $db->getInt('account_id');
+	$npcs[$accountID]['player'] = SmrPlayer::getPlayer($accountID, $selectedGameID, false, $db);
+}
+
+$template->assign('Npcs', $npcs);

--- a/admin/Default/npc_manage_processing.php
+++ b/admin/Default/npc_manage_processing.php
@@ -1,0 +1,49 @@
+<?php
+
+// Change active status of an NPC
+if (isset($_POST['active-submit'])) {
+	// Toggle the activity of this NPC
+	$active = isset($_POST['active']);
+	$db->query('UPDATE npc_logins SET active=' . $db->escapeBoolean($active) . ' WHERE login=' . $db->escapeString($var['login']));
+}
+
+// Create a new NPC player in a selected game
+if (isset($_POST['create_npc_player'])) {
+	$accountID = $var['accountID'];
+	$gameID = $var['selected_game_id'];
+	$playerName = $_POST['player_name'];
+	$raceID = $_POST['race_id'];
+	$npcPlayer = SmrPlayer::createPlayer($accountID, $gameID, $playerName, $raceID, false, true);
+
+	$npcPlayer->getShip()->setHardwareToMax();
+	$npcPlayer->giveStartingTurns();
+
+	// Give a random alignment
+	$npcPlayer->setAlignment(rand(-300, 300));
+
+	$allianceName = $_POST['player_alliance'];
+	$alliance = SmrAlliance::getAllianceByName($allianceName, $gameID);
+	if (is_null($alliance)) {
+		$alliance = SmrAlliance::createAlliance($gameID, $allianceName, '*', false);
+		$alliance->setLeaderID($npcPlayer->getAccountID());
+		$alliance->update();
+		$alliance->createDefaultRoles();
+	}
+	$npcPlayer->joinAlliance($alliance->getAllianceID());
+
+	// Update because we may not have a lock
+	$npcPlayer->update();
+	$npcPlayer->getShip()->update();
+}
+
+// Add a new NPC account
+if (isset($_POST['add_npc_account'])) {
+	$login = $_POST['npc_login'];
+	$npcAccount = SmrAccount::createAccount($login, '', 'NPC@smrealms.de', 0, 0);
+	$npcAccount->setValidated(true);
+	$db->query('INSERT INTO npc_logins (login, player_name, alliance_name) VALUES(' . $db->escapeString($login) . ',' . $db->escapeString($_POST['default_player_name']) . ',' . $db->escapeString($_POST['default_alliance']) . ')');
+}
+
+$container = create_container('skeleton.php', 'npc_manage.php');
+transfer('selected_game_id');
+forward($container);

--- a/engine/Default/alliance_create_processing.php
+++ b/engine/Default/alliance_create_processing.php
@@ -36,12 +36,11 @@ if ($name != $filteredName) {
 $alliance = SmrAlliance::createAlliance($player->getGameID(), $name, $password, $recruit);
 $alliance->setAllianceDescription($description);
 $alliance->setLeaderID($player->getAccountID());
+$alliance->createDefaultRoles($perms);
 $alliance->update();
 
 // assign the player to the created alliance
-$player->setAllianceID($alliance->getAllianceID());
+$player->joinAlliance($alliance->getAllianceID());
 $player->update();
-
-$alliance->createDefaultRoles($perms);
 
 forward(create_container('skeleton.php', 'alliance_roster.php'));

--- a/engine/Default/alliance_leadership_processing.php
+++ b/engine/Default/alliance_leadership_processing.php
@@ -3,9 +3,11 @@ $leader_id = $_REQUEST['leader_id'];
 if (!is_numeric($leader_id)) {
 	create_error('Leader ID must be a number.');
 }
-$db->query('UPDATE alliance SET leader_id = ' . $db->escapeNumber($leader_id) . '
-			WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-			AND game_id = ' . $db->escapeNumber($player->getGameID()));
+
+$alliance = $player->getAlliance();
+$alliance->setLeaderID($leader_id);
+$alliance->update();
+
 $db->query('UPDATE player_has_alliance_role SET role_id = 2 WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
 $db->query('UPDATE player_has_alliance_role SET role_id = 1 WHERE account_id = ' . $db->escapeNumber($leader_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
 

--- a/engine/Default/alliance_leadership_processing.php
+++ b/engine/Default/alliance_leadership_processing.php
@@ -8,8 +8,8 @@ $alliance = $player->getAlliance();
 $alliance->setLeaderID($leader_id);
 $alliance->update();
 
-$db->query('UPDATE player_has_alliance_role SET role_id = 2 WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
-$db->query('UPDATE player_has_alliance_role SET role_id = 1 WHERE account_id = ' . $db->escapeNumber($leader_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
+$db->query('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ' WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
+$db->query('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ' WHERE account_id = ' . $db->escapeNumber($leader_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
 
 // Notify the new leader
 $playerMessage = 'You are now the leader of [alliance=' . $player->getAllianceID() . ']!';

--- a/engine/Default/alliance_roles_processing.php
+++ b/engine/Default/alliance_roles_processing.php
@@ -7,7 +7,7 @@ $positiveBalance = isset($_REQUEST['positive']);
 $changePass = isset($_REQUEST['changePW']);
 $removeMember = isset($_REQUEST['removeMember']);
 $changeMOD = isset($_REQUEST['changeMoD']);
-$changeRoles = isset($_REQUEST['changeRoles']) || (isset($var['role_id']) && $var['role_id'] == 1); //Leader can always change roles.
+$changeRoles = isset($_REQUEST['changeRoles']) || (isset($var['role_id']) && $var['role_id'] == ALLIANCE_ROLE_LEADER); //Leader can always change roles.
 $planetAccess = isset($_REQUEST['planets']);
 $mbMessages = isset($_REQUEST['mbMessages']);
 $exemptWith = isset($_REQUEST['exemptWithdrawals']);
@@ -52,9 +52,9 @@ if (!isset($var['role_id'])) {
 } else {
 	// if no role is given we delete that entry
 	if (empty($_REQUEST['role'])) {
-		if ($var['role_id'] == 1) {
+		if ($var['role_id'] == ALLIANCE_ROLE_LEADER) {
 			create_error('You cannot delete the leader role.');
-		} else if ($var['role_id'] == 2) {
+		} else if ($var['role_id'] == ALLIANCE_ROLE_NEW_MEMBER) {
 			create_error('You cannot delete the new member role.');
 		}
 		$db->query('DELETE FROM alliance_has_roles

--- a/engine/Default/beta_func_processing.php
+++ b/engine/Default/beta_func_processing.php
@@ -26,7 +26,7 @@ if ($var['func'] == 'Map') {
 	
 	//now adapt turns
 	$player->setTurns($player->getTurns() * ($speed / $ship->getSpeed()));
-	setHardwareToMax($ship);
+	$ship->setHardwareToMax();
 } elseif ($var['func'] == 'Weapon') {
 	$weapon_id = $_REQUEST['weapon_id'];
 	$amount = $_REQUEST['amount'];
@@ -34,7 +34,7 @@ if ($var['func'] == 'Map') {
 		$ship->addWeapon($weapon_id);
 	}
 } elseif ($var['func'] == 'Uno') {
-	setHardwareToMax($ship);
+	$ship->setHardwareToMax();
 } elseif ($var['func'] == 'Warp') {
 	$sector_to = trim($_REQUEST['sector_to']);
 	if (!is_numeric($sector_to)) {
@@ -100,14 +100,3 @@ if ($var['func'] == 'Map') {
 
 $container = create_container('skeleton.php', $var['body']);
 forward($container);
-
-/**
- * Set all hardware to its maximum value for this ship.
- */
-function setHardwareToMax($ship) {
-	$maxHardware = $ship->getMaxHardware();
-	foreach ($maxHardware as $key => $max) {
-		$ship->setHardware($key, $max);
-	}
-	$ship->removeUnderAttack();
-}

--- a/engine/Default/course_plot_nearest_processing.php
+++ b/engine/Default/course_plot_nearest_processing.php
@@ -21,7 +21,5 @@ if ($sector->hasX($realX, $player))
 
 $path = Plotter::findReversiblePathToX($realX, $sector, true, $player, $player);
 
-// Forward to do common processing of path
-$container = create_container('skeleton.php', 'course_plot_result.php');
-$container['Distance'] = serialize($path);
-forward($container);
+// common processing
+require('course_plot_processing.inc');

--- a/engine/Default/course_plot_processing.inc
+++ b/engine/Default/course_plot_processing.inc
@@ -1,0 +1,22 @@
+<?php
+// NOTE: This file is included by "Conventional" and "Plot To Nearest" pages.
+
+// Throw start sector away (it's useless for the route),
+// but save the full path in case we end up needing to display it.
+$fullPath = implode(' - ', $path->getPath());
+$startSectorID = $path->removeStart();
+
+if ($player->getSectorID() == $startSectorID) {
+	$player->setPlottedCourse($path);
+
+	if (!$player->isLandedOnPlanet()) {
+		// If the course can immediately be followed, display it on the current sector page
+		$container = create_container('skeleton.php', 'current_sector.php');
+		forward($container);
+	}
+}
+
+$container = create_container('skeleton.php', 'course_plot_result.php');
+$container['Path'] = $path;
+$container['FullPath'] = $fullPath;
+forward($container);

--- a/engine/Default/course_plot_processing.php
+++ b/engine/Default/course_plot_processing.php
@@ -36,7 +36,5 @@ $account->log(LOG_TYPE_MOVEMENT, 'Player plots to ' . $target . '.', $player->ge
 
 $path = Plotter::findReversiblePathToX(SmrSector::getSector($player->getGameID(), $target), SmrSector::getSector($player->getGameID(), $start), true);
 
-// Forward to do common processing of path
-$container = create_container('skeleton.php', 'course_plot_result.php');
-$container['Distance'] = serialize($path);
-forward($container);
+// common processing
+require('course_plot_processing.inc');

--- a/engine/Default/course_plot_result.php
+++ b/engine/Default/course_plot_result.php
@@ -1,22 +1,7 @@
 <?php
-// Load the Distance object to do the common processing
-// for both "Conventional" and "Plot To Nearest".
-$path = unserialize($var['Distance']);
 
-// Throw start sector away (it's useless for the route),
-// but save the full path in case we end up needing to display it.
-$fullPath = implode(' - ', $path->getPath());
-$startSectorID = $path->removeStart();
-
-if ($player->getSectorID() == $startSectorID) {
-	$player->setPlottedCourse($path);
-
-	if (!$player->isLandedOnPlanet()) {
-		// If the course can immediately be followed, display it on the current sector page
-		$container = create_container('skeleton.php', 'current_sector.php');
-		forward($container);
-	}
-}
+$path = $var['Path'];
+$fullPath = $var['FullPath'];
 
 $template->assign('PageTopic', 'Plot A Course');
 Menu::navigation($template, $player);

--- a/engine/Default/game_join_processing.php
+++ b/engine/Default/game_join_processing.php
@@ -93,7 +93,7 @@ $player = SmrPlayer::createPlayer($account->getAccountID(), $gameID, $player_nam
 
 // Put the Newbie Help Leader into the Newbie Help Alliance
 if ($account->getAccountID() == ACCOUNT_ID_NHL) {
-	$player->setAllianceID(NHA_ID);
+	$player->joinAlliance(NHA_ID);
 }
 
 $player->setNewbieTurns($startingNewbieTurns);

--- a/engine/Default/game_join_processing.php
+++ b/engine/Default/game_join_processing.php
@@ -40,23 +40,12 @@ if (empty($race_id) || $race_id == RACE_NEUTRAL) {
 $gameID = $var['game_id'];
 $game = SmrGame::getGame($gameID);
 
-// Escape html elements so the name displays correctly
-$player_name = htmlentities($player_name);
-
-$db->query('SELECT 1 FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND player_name = ' . $db->escapeString($player_name) . ' LIMIT 1');
-if ($db->nextRecord() > 0) {
-	create_error('The player name already exists.');
-}
-
 // does it cost SMR Credits to join this game?
 $creditsNeeded = $game->getCreditsNeeded();
 if ($account->getTotalSmrCredits() < $creditsNeeded) {
 	create_error('You do not have enough SMR credits to join this game!');
 }
 $account->decreaseTotalSmrCredits($creditsNeeded);
-
-// put him in a sector with a hq
-$home_sector_id = SmrPlayer::getHome($gameID, $race_id);
 
 // for newbie and beginner another ship, more shields and armour
 $isNewbie = !$account->isVeteran();
@@ -99,34 +88,20 @@ if ($isNewbie) {
 	$amount_armour = 50;
 }
 
-//// newbie leaders need to put into there alliances
-if ($account->getAccountID() == ACCOUNT_ID_NHL) {
-	$alliance_id = NHA_ID;
-} else {
-	$alliance_id = 0;
-}
-
-$db->lockTable('player');
-
-// get last registered player id in that game and increase by one.
-$db->query('SELECT MAX(player_id) FROM player WHERE game_id = ' . $db->escapeNumber($gameID));
-if ($db->nextRecord()) {
-	$player_id = $db->getInt('MAX(player_id)') + 1;
-} else {
-	$player_id = 1;
-}
-
 // insert into player table.
-$db->query('INSERT INTO player (account_id, game_id, player_id, player_name, race_id, ship_type_id, alliance_id, sector_id, last_cpl_action, last_active, newbie_turns, npc, newbie_status)
-			VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber($player_id) . ', ' . $db->escapeString($player_name) . ', ' . $db->escapeNumber($race_id) . ', ' . $db->escapeNumber($ship_id) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($home_sector_id) . ', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($startingNewbieTurns) . ',' . $db->escapeBoolean(defined('NPC_SCRIPT')) . ',' . $db->escapeBoolean($isNewbie) . ')');
+$player = SmrPlayer::createPlayer($account->getAccountID(), $gameID, $player_name, $race_id, $isNewbie, defined('NPC_SCRIPT'));
 
-$db->unlock();
+// Put the Newbie Help Leader into the Newbie Help Alliance
+if ($account->getAccountID() == ACCOUNT_ID_NHL) {
+	$player->setAllianceID(NHA_ID);
+}
 
-$player = SmrPlayer::getPlayer($account->getAccountID(), $gameID);
+$player->setNewbieTurns($startingNewbieTurns);
 $player->giveStartingTurns();
 $player->setCredits($game->getStartingCredits());
 
 // Equip the ship
+$player->setShipTypeID($ship_id);
 $ship = $player->getShip();
 $ship->setShields($amount_shields, true);
 $ship->setArmour($amount_armour, true);

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -347,6 +347,8 @@ const ALLIANCE_VS_PORTS = -3;
 /*
  * Miscellaneous definitions
  */
+const ALLIANCE_ROLE_LEADER = 1;
+const ALLIANCE_ROLE_NEW_MEMBER = 2;
 
 const STARTING_NEWBIE_TURNS_NEWBIE = 750;
 const STARTING_NEWBIE_TURNS_VET = 250;

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -50,7 +50,7 @@ try {
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
-	if (strpos($login, 'NPC') === 0) {
+	if (stripos($login, 'NPC') === 0) {
 		$msg = 'Login names cannot begin with "NPC".';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -457,7 +457,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function getPlayerName() {
-		return $this->playerName . ($this->isNPC() ? ' <span class="npcColour">[NPC]</span>' : '');
+		return $this->playerName;
 	}
 
 	public function setPlayerName($name) {

--- a/lib/Default/AbstractSmrPlayer.class.inc
+++ b/lib/Default/AbstractSmrPlayer.class.inc
@@ -531,7 +531,7 @@ abstract class AbstractSmrPlayer {
 		return $this->getAllianceID() != 0;
 	}
 
-	public function setAllianceID($ID) {
+	protected function setAllianceID($ID) {
 		if ($this->allianceID == $ID)
 			return;
 		$this->allianceID = $ID;

--- a/lib/Default/AbstractSmrShip.class.inc
+++ b/lib/Default/AbstractSmrShip.class.inc
@@ -176,6 +176,16 @@ abstract class AbstractSmrShip {
 			}
 	}
 
+	/**
+	 * Set all hardware to its maximum value for this ship.
+	 */
+	public function setHardwareToMax() {
+		foreach ($this->getMaxHardware() as $key => $max) {
+			$this->setHardware($key, $max);
+		}
+		$this->removeUnderAttack();
+	}
+
 	public function getPowerUsed() {
 		$power = 0;
 		if ($this->getNumWeapons() > 0)

--- a/lib/Default/AdminPermissions.class.inc
+++ b/lib/Default/AdminPermissions.class.inc
@@ -36,6 +36,7 @@ class AdminPermissions {
 		34 => ['Manage Galactic Post Editors', 'manage_post_editors.php', 5],
 		35 => ['Manage Draft Leaders', 'manage_draft_leaders.php', 5],
 		36 => ['Display Admin Tag', '', 2],
+		37 => ['Manage NPCs', 'npc_manage.php', 5],
 	];
 
 	private const PERMISSION_CATEGORIES = [

--- a/lib/Default/RouteGenerator.class.inc
+++ b/lib/Default/RouteGenerator.class.inc
@@ -283,38 +283,6 @@ class OneWayRoute extends Route {
 		$this->buyPortRace = $_buyPortRace;
 	}
 
-	public function setSellSectorId($value) {
-		$this->sellSectorId = $value;
-	}
-
-	public function setBuySectorId($value) {
-		$this->buySectorId = $value;
-	}
-
-	public function setSellPortRace($value) {
-		$this->sellPortRace = $value;
-	}
-
-	public function setBuyPortRace($value) {
-		$this->buyPortRace = $value;
-	}
-
-	public function setSellDi($value) {
-		$this->sellDi = $value;
-	}
-
-	public function setBuyDi($value) {
-		$this->buyDi = $value;
-	}
-
-	public function setDistance(Distance &$value) {
-		$this->distance =& $value;
-	}
-
-	public function setGoodId($value) {
-		$this->goodId = $value;
-	}
-
 	public function getSellSectorId() {
 		return $this->sellSectorId;
 	}
@@ -413,17 +381,9 @@ class MultiplePortRoute extends Route {
 	private $forwardRoute;
 	private $returnRoute;
 
-	public function __construct(Route &$_forwardRoute, Route &$_returnRoute) {
+	public function __construct(OneWayRoute &$_forwardRoute, OneWayRoute &$_returnRoute) {
 		$this->forwardRoute =& $_forwardRoute;
 		$this->returnRoute =& $_returnRoute;
-	}
-
-	public function setForwardRoute(Route &$r) {
-		$this->forwardRoute =& $r;
-	}
-
-	public function setReturnRoute(Route &$r) {
-		$this->returnRoute =& $r;
 	}
 
 	public function &getForwardRoute() {

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -85,6 +85,32 @@ class SmrAlliance {
 	}
 
 	/**
+	 * Create an alliance and return the new object.
+	 */
+	public static function createAlliance($gameID, $name, $password, $recruit) {
+		$db = new SmrMySqlDatabase();
+
+		// check if the alliance name already exists
+		$db->query('SELECT 1 FROM alliance WHERE alliance_name = ' . $db->escapeString($name) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' LIMIT 1');
+		if ($db->getNumRows() > 0) {
+			create_error('That alliance name already exists!');
+		}
+
+		// get the next alliance id (ignoring reserved ID's)
+		$db->query('SELECT max(alliance_id) FROM alliance WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND (alliance_id < ' . $db->escapeNumber(NHA_ID) . ' OR alliance_id > ' . $db->escapeNumber(NHA_ID + 7) . ') LIMIT 1');
+		$db->nextRecord();
+		$allianceID = $db->getInt('max(alliance_id)') + 1;
+		if ($allianceID >= NHA_ID && $allianceID <= NHA_ID + 7) {
+			$allianceID = NHA_ID + 8;
+		}
+
+		// actually create the alliance here
+		$db->query('INSERT INTO alliance (alliance_id, game_id, alliance_name, alliance_password, recruiting) VALUES(' . $db->escapeNumber($allianceID) . ', ' . $db->escapeNumber($gameID) . ', ' . $db->escapeString($name) . ', ' . $db->escapeString($password) . ', ' . $db->escapeBoolean($recruit) . ')');
+
+		return self::getAlliance($allianceID, $gameID);
+	}
+
+	/**
 	 * Returns true if the alliance ID is associated with allianceless players.
 	 */
 	public function isNone() {

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -52,6 +52,16 @@ class SmrAlliance {
 		return $return;
 	}
 
+	public static function getAllianceByName($name, $gameID, $forceUpdate = false) {
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT alliance_id FROM alliance WHERE alliance_name = ' . $db->escapeString($name) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' LIMIT 1');
+		if ($db->nextRecord()) {
+			return self::getAlliance($db->getInt('alliance_id'), $gameID, $forceUpdate);
+		} else {
+			return null;
+		}
+	}
+
 	protected function __construct($allianceID, $gameID) {
 		$this->db = new SmrMySqlDatabase();
 

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -468,7 +468,7 @@ class SmrAlliance {
 		$opLeader = TRUE;
 		$viewBonds = TRUE;
 		$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
-			'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', 1, \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+			'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ', \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 
 		switch ($newMemberPermission) {
 			case 'full':
@@ -502,10 +502,8 @@ class SmrAlliance {
 			break;
 		}
 		$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
-					'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', 2, \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+					'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ', \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 
-		// Set the leader permissions
-		$db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber($this->getLeaderID()) . ', 1,' . $db->escapeNumber($this->getAllianceID()) . ')');
 	}
 
 }

--- a/lib/Default/SmrAlliance.class.inc
+++ b/lib/Default/SmrAlliance.class.inc
@@ -130,6 +130,10 @@ class SmrAlliance {
 		return SmrPlayer::getPlayer($this->getLeaderID(), $this->getGameID());
 	}
 
+	public function setLeaderID($leaderID) {
+		$this->leaderID = $leaderID;
+	}
+
 	public function getDiscordServer() {
 		return $this->discordServer;
 	}

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -181,6 +181,42 @@ class SmrPlayer extends AbstractSmrPlayer {
 		}
 	}
 
+	/**
+	 * Insert a new player into the database. Returns the new player object.
+	 */
+	public static function createPlayer($accountID, $gameID, $playerName, $raceID, $isNewbie, $npc=false) {
+		// Put the player in a sector with an HQ
+		$startSectorID = self::getHome($gameID, $raceID);
+
+		$db = new SmrMySqlDatabase();
+		$db->lockTable('player');
+
+		// Escape html elements so the name displays correctly
+		$playerName = htmlentities($playerName);
+
+		// Player names must be unique within each game
+		$db->query('SELECT 1 FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND player_name = ' . $db->escapeString($playerName) . ' LIMIT 1');
+		if ($db->nextRecord() > 0) {
+			$db->unlock();
+			create_error('The player name already exists.');
+		}
+
+		// get last registered player id in that game and increase by one.
+		$db->query('SELECT MAX(player_id) FROM player WHERE game_id = ' . $db->escapeNumber($gameID));
+		if ($db->nextRecord()) {
+			$playerID = $db->getInt('MAX(player_id)') + 1;
+		} else {
+			$playerID = 1;
+		}
+
+		$db->query('INSERT INTO player (account_id, game_id, player_id, player_name, race_id, sector_id, last_cpl_action, last_active, npc, newbie_status)
+					VALUES(' . $db->escapeNumber($accountID) . ', ' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber($playerID) . ', ' . $db->escapeString($playerName) . ', ' . $db->escapeNumber($raceID) . ', ' . $db->escapeNumber($startSectorID) . ', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ',' . $db->escapeBoolean($npc) . ',' . $db->escapeBoolean($isNewbie) . ')');
+
+		$db->unlock();
+
+		return SmrPlayer::getPlayer($accountID, $gameID);
+	}
+
 	// Get array of players whose info can be accessed by this player.
 	// Skips players who are not in the same alliance as this player.
 	public function getSharingPlayers($forceUpdate = false) {

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -326,6 +326,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 		}
 	}
 
+	/**
+	 * Join an alliance (used for both Leader and New Member roles)
+	 */
 	public function joinAlliance($allianceID) {
 		$this->setAllianceID($allianceID);
 		$alliance = $this->getAlliance();
@@ -337,9 +340,13 @@ class SmrPlayer extends AbstractSmrPlayer {
 			} catch (AccountNotFoundException $e) {
 				if ($alliance->getLeaderID() != ACCOUNT_ID_NHL) throw $e;
 			}
-		}
 
-		$this->db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getAccountID()) . ', 2,' . $this->db->escapeNumber($alliance->getAllianceID()) . ')');
+			$roleID = ALLIANCE_ROLE_NEW_MEMBER;
+		} else {
+			$roleID = ALLIANCE_ROLE_LEADER;
+		}
+		$this->db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($roleID) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
+
 		$this->actionTaken('JoinAlliance', array('Alliance' => $alliance));
 
 		// Joining an alliance cancels all open invitations

--- a/templates/Default/admin/Default/npc_manage.php
+++ b/templates/Default/admin/Default/npc_manage.php
@@ -1,0 +1,67 @@
+<form method="POST" action="<?php echo $SelectGameHREF; ?>">
+	<select id="InputFields" name="selected_game_id" onchange="this.form.submit()"><?php
+		foreach ($Games as $Game) { ?>
+			<option <?php if ($Game['Selected']) { ?>selected<?php } ?> value="<?php echo $Game['ID']; ?>"><?php echo $Game['Name']; ?></option><?php
+		} ?>
+	</select>&nbsp;
+	<input type="submit" name="action" value="Select" />
+</form>
+
+<?php
+if (isset($SelectedGameID)) { ?>
+	<br />
+	<table class="standard">
+		<tr>
+			<th>Login</th>
+			<th>Active</th>
+			<th>Player Name</th>
+			<th>Race</th>
+			<th>Alliance</th>
+			<th>Status</th>
+		</tr><?php
+		foreach ($Npcs as $accountID => $npc) { ?>
+			<tr>
+				<td><?php echo $npc['login']; ?></td>
+				<td class="center">
+					<form method="POST" action="<?php echo $npc['href']; ?>">
+						<input name="active" type="checkbox" <?php if ($npc['active']) { ?>checked<?php } ?> onclick="this.form.submit()" />
+						<input type="hidden" name="active-submit" />
+					</form>
+				</td><?php
+				if (!isset($npc['player'])) {
+					// The form wrapping only these columns is invalid HTML, but it works for now... ?>
+					<form method="POST" action="<?php echo $npc['href']; ?>">
+						<td><input required name="player_name" value="<?php echo $npc['default_player_name']; ?>" /></td>
+						<td>
+							<select name="race_id" class="InputFields"><?php
+								foreach (Globals::getRaces() as $raceID => $race) {
+									if ($raceID == RACE_NEUTRAL) {
+										continue;
+									} ?>
+									<option value="<?php echo $raceID; ?>"><?php echo $race['Race Name']; ?></option><?php
+								} ?>
+							</select>
+						</td>
+						<td><input name="player_alliance" value="<?php echo $npc['default_alliance']; ?>" /></td>
+						<td><input type="submit" name="create_npc_player" value="Create" /></td>
+					</form><?php
+				} else { ?>
+					<td><?php echo $npc['player']->getDisplayName(); ?></td>
+					<td><?php echo Globals::getRaceName($npc['player']->getRaceID()); ?></td>
+					<td><?php echo $npc['player']->getAllianceName(); ?></td>
+					<td class="center"><?php echo $npc['working'] ? 'Working' : 'Idle'; ?></td><?php
+				} ?>
+			</tr><?php
+		} ?>
+	</table><?php
+} ?>
+
+<br /><br />
+<h2>Add New NPC Login</h2>
+<form method="POST" action="<?php echo $AddAccountHREF; ?>">
+	<input type="hidden" name="npc_login" value="<?php echo $NextLogin; ?>" />
+	Login: <?php echo $NextLogin; ?><br />
+	Default Player Name: <input required name="default_player_name" /><br />
+	Default Alliance: <input required name="default_alliance" /><br />
+	<input type="submit" name="add_npc_account" />
+</form>

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -128,6 +128,10 @@ function NPCStuff() {
 			debug('Getting player for account id: ' . SmrSession::getAccountID());
 			//We have to reload player on each loop
 			$player = SmrPlayer::getPlayer(SmrSession::getAccountID(), SmrSession::getGameID(), true);
+			// Sanity check to be certain we actually have an NPC
+			if (!$player->isNPC()) {
+				throw new Exception('Player is not an NPC!');
+			}
 			$player->updateTurns();
 
 			if ($actions == 0) {

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -614,6 +614,9 @@ function &findRoutes($player) {
 	$db = new SmrMySqlDatabase();
 	$db->query('SELECT routes FROM route_cache WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND max_ports=' . $db->escapeNumber($maxNumberOfPorts) . ' AND goods_allowed=' . $db->escapeObject($tradeGoods) . ' AND races_allowed=' . $db->escapeObject($tradeRaces) . ' AND start_sector_id=' . $db->escapeNumber($startSectorID) . ' AND end_sector_id=' . $db->escapeNumber($endSectorID) . ' AND routes_for_port=' . $db->escapeNumber($routesForPort) . ' AND max_distance=' . $db->escapeNumber($maxDistance));
 	if ($db->nextRecord()) {
+		// The "MultiPortRoute" class cannot be autoloaded because it is not
+		// in its own file.
+		require_once(get_file_loc('RouteGenerator.class.inc'));
 		$routes = unserialize(gzuncompress($db->getField('routes')));
 		debug('Using Cached Routes: #' . count($routes));
 		return $routes;

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -118,6 +118,10 @@ function NPCStuff() {
 	$actions = -1;
 
 	while (true) {
+		// Clear the $_REQUEST global, in case we had set it, to avoid
+		// contaminating subsequent page processing.
+		$_REQUEST = [];
+
 		$actions++;
 		try {
 			$TRADE_ROUTE =& $GLOBALS['TRADE_ROUTE'];
@@ -476,7 +480,10 @@ function canWeUNO(AbstractSmrPlayer $player, $oppurtunisticOnly) {
 
 function doUNO($hardwareID, $amount) {
 	debug('Buying ' . $amount . ' units of "' . Globals::getHardwareName($hardwareID) . '"');
-	$_REQUEST['amount'] = $amount;
+	$_REQUEST = [
+		'amount' => $amount,
+		'action' => 'Buy',
+	];
 	return create_container('shop_hardware_processing.php', '', array('hardware_id'=>$hardwareID));
 }
 
@@ -496,6 +503,7 @@ function tradeGoods($goodID, AbstractSmrPlayer $player, SmrPort $port) {
 	$idealPrice = $port->getIdealPrice($goodID, $transaction, $amount, $relations);
 	$offeredPrice = $port->getOfferPrice($idealPrice, $relations, $transaction);
 
+	$_REQUEST = ['action' => $transaction];
 	return create_container('shop_goods_processing.php', '', array('offered_price'=>$offeredPrice, 'ideal_price'=>$idealPrice, 'amount'=>$amount, 'good_id'=>$goodID, 'bargain_price'=>$offeredPrice));
 }
 


### PR DESCRIPTION
This admin tool replaces some of the logic in the `npc.php` script to create NPC accounts/players/alliances. It also allows us to add new NPC slots and to set their active status, which previously could only be done directly inside the database. The name and alliance specified in `npc_logins` are now only default values -- these can be changed at creation time (so that, e.g., you don't need to create an entirely new NPC account just to have a different NPC name).

Some engine pages needed to be refactored into class methods (`SmrAlliance::createAlliance` and `SmrPlayer::createPlayer`) and several other methods needed to be added.

See commit messages for complete details.

![image](https://user-images.githubusercontent.com/846186/59947630-915b7600-9422-11e9-9e23-941202242592.png)
