### PR TITLE
Optimize galaxy-wide database queries

### DIFF
--- a/admin/Default/1.6/universe_create_sectors.php
+++ b/admin/Default/1.6/universe_create_sectors.php
@@ -13,6 +13,13 @@ if (empty($galaxies)) {
 }
 
 $galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
+
+// Efficiently construct the caches before proceeding
+$galaxy->getSectors();
+$galaxy->getPorts();
+$galaxy->getLocations();
+$galaxy->getPlanets();
+
 $connectivity = round($galaxy->getConnectivity());
 $template->assign('ActualConnectivity', $connectivity);
 

--- a/engine/Default/bar_galmap_buy.php
+++ b/engine/Default/bar_galmap_buy.php
@@ -38,9 +38,7 @@ if (isset($var['process'])) {
 	//start section
 	
 	// add port infos
-	$db->query('SELECT * FROM port WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND sector_id >= ' . $db->escapeNumber($low));
-	while ($db->nextRecord()) {
-		$port = SmrPort::getPort($player->getGameID(), $db->getField('sector_id'), false, $db);
+	foreach ($galaxy->getPorts() as $port) {
 		$port->addCachePort($player->getAccountID());
 	}
 	

--- a/engine/Default/smr_file_create.php
+++ b/engine/Default/smr_file_create.php
@@ -122,6 +122,11 @@ foreach ($galaxies as $galaxy) {
 
 
 foreach ($galaxies as $galaxy) {
+	// Efficiently construct the caches before proceeding
+	$galaxy->getLocations();
+	$galaxy->getPlanets();
+	$galaxy->getForces();
+
 	foreach ($galaxy->getSectors() as $sector) {
 		$file .= '[Sector=' . $sector->getSectorID() . ']' . EOL;
 		

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -83,7 +83,13 @@ try {
 		}
 	}
 
-	$galaxy->getSectors(); //optimized call to cache all sectors first
+	// Efficiently construct the caches before proceeding
+	$galaxy->getSectors();
+	$galaxy->getLocations();
+	$galaxy->getPlanets();
+	$galaxy->getForces();
+	$galaxy->getPlayers();
+
 	if (isset($sectorID)) {
 		$template->assign('FocusSector', $sectorID);
 		$mapSectors = $galaxy->getMapSectors($sectorID);

--- a/lib/Default/AbstractSmrLocation.class.inc
+++ b/lib/Default/AbstractSmrLocation.class.inc
@@ -35,7 +35,25 @@ class AbstractSmrLocation {
 		}
 		return self::$CACHE_ALL_LOCATIONS;
 	}
-	
+
+	public static function getGalaxyLocations($gameID, $galaxyID, $forceUpdate = false) {
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT location_type.*, sector_id FROM sector LEFT JOIN location USING(game_id, sector_id) LEFT JOIN location_type USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$galaxyLocations = [];
+		while ($db->nextRecord()) {
+			$sectorID = $db->getInt('sector_id');
+			if (!$db->hasField('location_type_id')) {
+				self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] = [];
+			} else {
+				$locationTypeID = $db->getInt('location_type_id');
+				$location = self::getLocation($locationTypeID, $forceUpdate, $db);
+				self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID][$locationTypeID] = $location;
+				$galaxyLocations[$sectorID][$locationTypeID] = $location;
+			}
+		}
+		return $galaxyLocations;
+	}
+
 	public static function &getSectorLocations($gameID, $sectorID, $forceUpdate = false) {
 		if ($forceUpdate || !isset(self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID])) {
 			$db = new SmrMySqlDatabase();

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -68,6 +68,22 @@ class AbstractSmrPort {
 		self::$CACHE_CACHED_PORTS = array();
 	}
 
+	public static function getGalaxyPorts($gameID, $galaxyID, $forceUpdate = false) {
+		$db = new SmrMySqlDatabase();
+		// Use a left join so that we populate the cache for every sector
+		$db->query('SELECT port.*, sector_id FROM sector LEFT JOIN port USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$galaxyPorts = [];
+		while ($db->nextRecord()) {
+			$sectorID = $db->getInt('sector_id');
+			$port = self::getPort($gameID, $sectorID, $forceUpdate, $db);
+			// Only return those ports that exist
+			if ($port->exists()) {
+				$galaxyPorts[$sectorID] = $port;
+			}
+		}
+		return $galaxyPorts;
+	}
+
 	public static function &getPort($gameID, $sectorID, $forceUpdate = false, $db = null) {
 		if ($forceUpdate || !isset(self::$CACHE_PORTS[$gameID][$sectorID])) {
 			self::$CACHE_PORTS[$gameID][$sectorID] = new SmrPort($gameID, $sectorID, $db);
@@ -113,7 +129,7 @@ class AbstractSmrPort {
 		$this->SQL = 'sector_id = ' . $this->db->escapeNumber($sectorID) . ' AND game_id = ' . $this->db->escapeNumber($gameID);
 
 		if (isset($db)) {
-			$this->isNew = false;
+			$this->isNew = !$db->hasField('game_id');
 		} else {
 			$db = $this->db;
 			$db->query('SELECT * FROM port WHERE ' . $this->SQL . ' LIMIT 1');

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -83,6 +83,7 @@ class AbstractSmrPort {
 		$db->query('DELETE FROM port_has_goods WHERE ' . $SQL);
 		$db->query('DELETE FROM player_visited_port WHERE ' . $SQL);
 		$db->query('DELETE FROM player_attacks_port WHERE ' . $SQL);
+		$db->query('DELETE FROM port_info_cache WHERE ' . $SQL);
 		self::$CACHE_PORTS[$gameID][$sectorID] = null;
 		unset(self::$CACHE_PORTS[$gameID][$sectorID]);
 	}

--- a/lib/Default/MySqlDatabase.class.inc
+++ b/lib/Default/MySqlDatabase.class.inc
@@ -71,9 +71,11 @@ abstract class MySqlDatabase {
 		}
 		return false;
 	}
-	
-	
-	
+
+	public function hasField($name) {
+		return isset($this->dbRecord[$name]);
+	}
+
 	public function getField($name) {
 		return $this->dbRecord[$name];
 	}

--- a/lib/Default/SmrForce.class.inc
+++ b/lib/Default/SmrForce.class.inc
@@ -53,6 +53,24 @@ class SmrForce {
 		}
 	}
 
+	public static function getGalaxyForces($gameID, $galaxyID, $forceUpdate = false) {
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT sector_has_forces.*, sector_id FROM sector LEFT JOIN sector_has_forces USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$galaxyForces = [];
+		while ($db->nextRecord()) {
+			$sectorID = $db->getInt('sector_id');
+			if (!$db->hasField('owner_id')) {
+				self::$CACHE_SECTOR_FORCES[$gameID][$sectorID] = [];
+			} else {
+				$ownerID = $db->getInt('owner_id');
+				$force = self::getForce($gameID, $sectorID, $ownerID, $forceUpdate, $db);
+				self::$CACHE_SECTOR_FORCES[$gameID][$sectorID][$ownerID] = $force;
+				$galaxyForces[$sectorID][$ownerID] = $force;
+			}
+		}
+		return $galaxyForces;
+	}
+
 	public static function &getSectorForces($gameID, $sectorID, $forceUpdate = false) {
 		if ($forceUpdate || !isset(self::$CACHE_SECTOR_FORCES[$gameID][$sectorID])) {
 			self::tidyUpForces(SmrGalaxy::getGalaxyContaining($gameID, $sectorID));

--- a/lib/Default/SmrGalaxy.class.inc
+++ b/lib/Default/SmrGalaxy.class.inc
@@ -181,10 +181,33 @@ class SmrGalaxy {
 		return SmrSector::getGalaxySectors($this->getGameID(), $this->getGalaxyID());
 	}
 
+	public function getPorts() {
+		return SmrPort::getGalaxyPorts($this->getGameID(), $this->getGalaxyID());
+	}
+
+	public function getLocations() {
+		return SmrLocation::getGalaxyLocations($this->getGameID(), $this->getGalaxyID());
+	}
+
+	public function getPlanets() {
+		return SmrPlanet::getGalaxyPlanets($this->getGameID(), $this->getGalaxyID());
+	}
+
+	public function getForces() {
+		return SmrForce::getGalaxyForces($this->getGameID(), $this->getGalaxyID());
+	}
+
+	public function getPlayers() {
+		return SmrPlayer::getGalaxyPlayers($this->getGameID(), $this->getGalaxyID());
+	}
+
 	/**
 	 * Returns a 2D array of sectors in the galaxy.
 	 * If $centerSectorID is specified, it will be in the center of the array.
 	 * If $dist is also specified, only include sectors $dist away from center.
+	 *
+	 * NOTE: This routine queries sectors inefficiently. You may want to
+	 * construct the cache efficiently before calling this.
 	 */
 	public function getMapSectors($centerSectorID = false, $dist = false) {
 		if ($centerSectorID === false) {

--- a/lib/Default/SmrPlanet.class.inc
+++ b/lib/Default/SmrPlanet.class.inc
@@ -67,6 +67,20 @@ class SmrPlanet {
 		}
 	}
 
+	public static function getGalaxyPlanets($gameID, $galaxyID, $forceUpdate = false) {
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT planet.*, sector_id FROM sector LEFT JOIN planet USING (game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$galaxyPlanets = [];
+		while ($db->nextRecord()) {
+			$sectorID = $db->getInt('sector_id');
+			$planet = self::getPlanet($gameID, $sectorID, $forceUpdate, $db);
+			if ($planet->exists()) {
+				$galaxyPlanets[$sectorID] = $planet;
+			}
+		}
+		return $galaxyPlanets;
+	}
+
 	public static function &getPlanet($gameID, $sectorID, $forceUpdate = false, $db = null) {
 		if ($forceUpdate || !isset(self::$CACHE_PLANETS[$gameID][$sectorID])) {
 			self::$CACHE_PLANETS[$gameID][$sectorID] = new SmrPlanet($gameID, $sectorID, $db);
@@ -106,7 +120,7 @@ class SmrPlanet {
 		$this->SQL = 'game_id = ' . $this->db->escapeNumber($gameID) . ' AND sector_id = ' . $this->db->escapeNumber($sectorID);
 
 		if (isset($db)) {
-			$planetExists = true;
+			$planetExists = $db->hasField('planet_type_id');
 		} else {
 			$db = $this->db;
 			$db->query('SELECT * FROM planet WHERE ' . $this->SQL);

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -64,6 +64,24 @@ class SmrPlayer extends AbstractSmrPlayer {
 		return $players;
 	}
 
+	public static function getGalaxyPlayers($gameID, $galaxyID, $forceUpdate = false) {
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT player.*, sector_id FROM sector LEFT JOIN player USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$galaxyPlayers = [];
+		while ($db->nextRecord()) {
+			$sectorID = $db->getInt('sector_id');
+			if (!$db->hasField('account_id')) {
+				self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] = [];
+			} else {
+				$accountID = $db->getInt('account_id');
+				$player = self::getPlayer($accountID, $gameID, $forceUpdate, $db);
+				self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID][$accountID] = $player;
+				$galaxyPlayers[$sectorID][$accountID] = $player;
+			}
+		}
+		return $galaxyPlayers;
+	}
+
 	public static function &getSectorPlayers($gameID, $sectorID, $forceUpdate = false) {
 		if ($forceUpdate || !isset(self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID])) {
 			$db = new SmrMySqlDatabase();

--- a/templates/Default/engine/Default/includes/SectorMap.inc
+++ b/templates/Default/engine/Default/includes/SectorMap.inc
@@ -141,9 +141,8 @@
 				</td><?php
 			} ?>
 		</tr><?php
-		//A little hacky but clearing these caches for each row of gal map drastically reduces total memory usage, and these caches should never be needed after this point either.
-		SmrPort::clearCache();
-		SmrForce::clearCache();
-		SmrPlanet::clearCache();
+		// NOTE: We no longer clear the caches here because we pre-cache.
+		// If memory becomes an issue, we can implement a purge of the cache
+		// for sectors that we have already processed.
 	} ?>
 </table>


### PR DESCRIPTION
We have a lot of methods that get an entity for a given sector
by querying the database if it is the first time the entity has
been requested. If we're performing a separate query for each
sector in a galaxy, then the database communication overhead
becomes the dominant cost.

On these pages, we can mitigate this overhead cost by performing
a single query for the entire galaxy to cache all the entities
that will be needed later.

The caching infrastructure was already set up for the most part,
we just needed methods to operate on a galaxy.

Adds galaxy-wide static caching methods to the following classes:

* SmrForce
* SmrPlanet
* SmrPlayer
* SmrPort
* SmrLocation

These are a bit more complicated than `SmrSector::getGalaxySectors`
because they only conditionally exist, but the principle is the
same.

These new methods are then used to pre-cache for the following pages:

* Galaxy Map
* Universe Generator
* DL Sectors File

NOTE: We remove the cache clearing in SectorMap.inc, which will
significantly increase concurrent memory usage, but for now we'll
trade off memory for speed.
