### PR TITLE
Use ajax to update Uni Gen sector walls

### DIFF
--- a/admin/Default/1.6/universe_create_sectors.php
+++ b/admin/Default/1.6/universe_create_sectors.php
@@ -43,21 +43,25 @@ else if (!isset($var['conn'])) {
 }
 $template->assign('RequestedConnectivity', $var['conn']);
 
-$container = $var;
+$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
+transfer('game_id');
+transfer('gal_on');
 $template->assign('JumpGalaxyHREF', SmrSession::getNewHref($container));
 
 $container['url'] = '1.6/universe_create_save_processing.php';
-$container['body'] = '1.6/universe_create_sectors.php';
 $template->assign('SubmitChangesHREF', SmrSession::getNewHref($container));
 
 $container['submit'] = 'Toggle Link';
 $template->assign('ToggleLink', $container);
 
-$container = $var;
-$container['body'] = '1.6/universe_create_sector_details.php';
+$container = create_container('skeleton.php', '1.6/universe_create_sector_details.php');
+transfer('game_id');
+transfer('gal_on');
 $template->assign('UniGen', $container);
 
-$container = $var;
+$container = create_container('skeleton.php');
+transfer('game_id');
+transfer('gal_on');
 $container['body'] = '1.6/universe_create_locations.php';
 $template->assign('ModifyLocationsHREF', SmrSession::getNewHREF($container));
 

--- a/admin/Default/1.6/universe_create_sectors.php
+++ b/admin/Default/1.6/universe_create_sectors.php
@@ -52,6 +52,7 @@ $container['url'] = '1.6/universe_create_save_processing.php';
 $template->assign('SubmitChangesHREF', SmrSession::getNewHref($container));
 
 $container['submit'] = 'Toggle Link';
+$container['AJAX'] = true;
 $template->assign('ToggleLink', $container);
 
 $container = create_container('skeleton.php', '1.6/universe_create_sector_details.php');

--- a/htdocs/js/ajax.js
+++ b/htdocs/js/ajax.js
@@ -193,6 +193,13 @@ var exec = function(s) {
 		});
 	});
 
+	window.ajaxLink = function(link) {
+		$.get(link, {ajax: 1}, function(data) {
+				sn = getURLParameter('sn', link);
+				updateRefresh(data);
+			}, 'xml');
+	}
+
 	window.toggleWepD = function(link) {
 		"use strict";
 		$('.wep1:visible').slideToggle(600);

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -108,12 +108,12 @@ class SmrSession {
 			'permission_manage.php' => self::ALWAYS_AVAILABLE,
 			'word_filter.php' => self::ALWAYS_AVAILABLE,
 			//Uni gen
-			'universe_create_locations.php' => self::ALWAYS_AVAILABLE,
-			'universe_create_planets.php' => self::ALWAYS_AVAILABLE,
-			'universe_create_ports.php' => self::ALWAYS_AVAILABLE,
-			'universe_create_sector_details.php' => self::ALWAYS_AVAILABLE,
-			'universe_create_sectors.php' => self::ALWAYS_AVAILABLE,
-			'universe_create_warps.php' => self::ALWAYS_AVAILABLE
+			'1.6/universe_create_locations.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_planets.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_ports.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_sector_details.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_sectors.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_warps.php' => self::ALWAYS_AVAILABLE,
 		);
 
 	private const URL_LOAD_DELAY = array(

--- a/lib/Default/SmrSession.class.inc
+++ b/lib/Default/SmrSession.class.inc
@@ -1,7 +1,9 @@
 <?php
 
-if (!defined('USING_AJAX'))
+if (!defined('USING_AJAX')) {
 	define('USING_AJAX', false);
+}
+
 class SmrSession {
 	const ALWAYS_AVAILABLE = 999999;
 	const TIME_BEFORE_EXPIRY = 3600;
@@ -310,9 +312,10 @@ class SmrSession {
 	}
 
 	private static function updateSN() {
-		if (!USING_AJAX)
+		if (!USING_AJAX) {
 			self::$db->query('UPDATE active_session SET last_sn=' . self::$db->escapeString(self::$SN) .
 				' WHERE session_id=' . self::$db->escapeString(self::$session_id) . ' LIMIT 1');
+		}
 	}
 
 	public static function destroy() {
@@ -384,8 +387,9 @@ class SmrSession {
 		}
 
 		self::$var[$sn] = $container;
-		if (!$lock && !USING_AJAX)
+		if (!$lock && !USING_AJAX) {
 			self::update();
+		}
 		return $sn;
 	}
 
@@ -406,7 +410,7 @@ class SmrSession {
 		self::$commonIDs = array();
 	}
 
-	public static function addLink($container, $sn = false) { // Container['ID'] MUST be unique to a specific action, if there will be two different outcomes from containers given the same ID then problems will likely arise.
+	protected static function addLink($container, $sn = false) { // Container['ID'] MUST be unique to a specific action, if there will be two different outcomes from containers given the same ID then problems will likely arise.
 		if (!isset($container['Expires'])) {
 			$container['Expires'] = 0; // Lasts forever
 		}
@@ -447,15 +451,17 @@ class SmrSession {
 		unset($commonContainer['RemainingPageLoads']);
 		unset($commonContainer['PreviousRequestTime']);
 		unset($commonContainer['CommonID']);
+		// NOTE: This ID will change if the order of elements in the container
+		// changes. If this causes unnecessary SN changes, sort the container!
 		return md5(serialize($commonContainer));
 	}
 
 	public static function getNewHREF($container, $forceFullURL = false) {
 		$sn = self::addLink($container);
-		if ($forceFullURL === true || stripos($_SERVER['REQUEST_URI'], 'loader.php') === false)
+		if ($forceFullURL === true || stripos($_SERVER['REQUEST_URI'], 'loader.php') === false) {
 			return '/loader.php?sn=' . $sn;
-		else
-			return '?sn=' . $sn;
+		}
+		return '?sn=' . $sn;
 	}
 
 	public static function addAjaxReturns($element, $contents) {
@@ -464,8 +470,9 @@ class SmrSession {
 	}
 
 	public static function saveAjaxReturns() {
-		if (empty(self::$ajaxReturns))
+		if (empty(self::$ajaxReturns)) {
 			return;
+		}
 		$compressed = gzcompress(serialize(self::$ajaxReturns));
 		self::$db->query('UPDATE active_session SET ajax_returns=' . self::$db->escapeBinary($compressed) .
 				' WHERE session_id=' . self::$db->escapeString(self::$session_id) . ' LIMIT 1');

--- a/templates/Default/admin/Default/1.6/universe_create_sectors.php
+++ b/templates/Default/admin/Default/1.6/universe_create_sectors.php
@@ -13,7 +13,7 @@
 		<td><?php echo $Galaxy->getGalaxyType(); ?></td>
 		<td><?php echo $Galaxy->getWidth(); ?> x <?php echo $Galaxy->getHeight(); ?></td>
 		<td><?php echo $Galaxy->getMaxForceTime() / 3600; ?> hours</td>
-		<td><?php echo $ActualConnectivity; ?>%</td>
+		<td id="conn" class="ajax"><?php echo $ActualConnectivity; ?>%</td>
 	</tr>
 </table>
 <br />

--- a/templates/Default/engine/Default/includes/SectorMap.inc
+++ b/templates/Default/engine/Default/includes/SectorMap.inc
@@ -28,7 +28,7 @@
 							foreach ($MovementTypes as $MovementType) {
 								if (isset($ToggleLink)) {
 									$ToggleLink['dir'] = $MovementType; ?>
-									<a href="<?php echo SmrSession::getNewHREF($ToggleLink); ?>" class="lm<?php echo $MovementType; ?>"><?php
+									<a onclick="ajaxLink('<?php echo SmrSession::getNewHREF($ToggleLink); ?>')" class="lm<?php echo $MovementType; ?>"><?php
 								} ?>
 								<div class="lm<?php echo $MovementType; ?> <?php if ($Sector->getLink($MovementType)) { ?>con<?php } else { ?>wall<?php } ?>"></div><?php
 								if (isset($ToggleLink)) { ?>


### PR DESCRIPTION
Galaxy maps are very large, and the process of manually adjusting
sector connections was slowed down by the fact that adding/removing
a wall reset the page display to the top left.

By using ajax, the process is much faster because the position on the
page remains unchanged. It also reduces bandwidth because only a small
amount of data on the page is modified, and so we don't need to serve
the entire page each time.

Also made some additional bugfixes to `1.6/universe_create_sectors.php` and
`SmrSession.class.inc` that needed to be addressed to support this change.