### PR TITLE
Fix voting links in new web browsers

### DIFF
--- a/htdocs/js/smr15.js
+++ b/htdocs/js/smr15.js
@@ -1,9 +1,12 @@
 (function() {
 "use strict";
 
-	window.voteSite = function(url,snUrl) {
-		window.open(url);
-		window.location=snUrl;
+	window.voteSite = function(snUrl) {
+		// Must not redirect the current page until after the external vote
+		// site URL has been opened in a new tab. Use setTimeout to do this.
+		setTimeout(function() {
+			window.location = snUrl;
+		}, 0);
 	};
 
 	function doCalc(type, number, totalDest) {

--- a/lib/Default/VoteSite.class.inc
+++ b/lib/Default/VoteSite.class.inc
@@ -20,9 +20,9 @@ class VoteSite {
 			3 => array(
 				'img_default' => 'twg.png',
 				'img_star' => 'twg_vote.png',
-				'url_base' => 'http://topwebgames.com/in.aspx?ID=136&alwaysreward=1',
+				'url_base' => 'http://topwebgames.com/in.aspx?ID=136',
 				'url_func' => function($baseUrl, $accountId, $gameId, $linkId) {
-					$query = array('account' => $accountId, 'game' => $gameId, 'link' => $linkId);
+					$query = array('account' => $accountId, 'game' => $gameId, 'link' => $linkId, 'alwaysreward' => 1);
 					return $baseUrl . '&' . http_build_query($query);
 				},
 			),
@@ -109,10 +109,17 @@ class VoteSite {
 	}
 
 	/**
+	 * Returns true if account can currently receive free turns at this site.
+	 */
+	private function freeTurnsReady($accountID, $gameID) {
+		return $this->givesFreeTurns() && $gameID != 0 && $this->getTimeUntilFreeTurns($accountID) <= 0;
+	}
+
+	/**
 	 * Returns the image to display for this voting site.
 	 */
 	public function getLinkImg($accountID, $gameID) {
-		if ($this->givesFreeTurns() && $gameID != 0 && $this->getTimeUntilFreeTurns($accountID) <= 0) {
+		if ($this->freeTurnsReady($accountID, $gameID)) {
 			return $this->data['img_star'];
 		} else {
 			return $this->data['img_default'];
@@ -124,15 +131,26 @@ class VoteSite {
 	 */
 	public function getLinkUrl($accountID, $gameID) {
 		$baseUrl = $this->data['url_base'];
-		if ($this->givesFreeTurns() && $gameID != 0 && $this->getTimeUntilFreeTurns($accountID) <= 0) {
+		if ($this->freeTurnsReady($accountID, $gameID)) {
+			return $this->data['url_func']($baseUrl, $accountID, $gameID, $this->linkID);
+		} else {
+			return $baseUrl;
+		}
+	}
+
+	/**
+	 * Returns the SN to redirect the current page to if free turns are
+	 * available; otherwise, returns false.
+	 */
+	public function getSN($accountID, $gameID) {
+		if ($this->freeTurnsReady($accountID, $gameID)) {
+			// This page will prepare the account for the voting callback.
 			$container = create_container('vote_link.php');
 			$container['link_id'] = $this->linkID;
 			$container['can_get_turns'] = true;
-			$internalUrl = SmrSession::getNewHREF($container, true);
-			$externalUrl = $this->data['url_func']($baseUrl, $accountID, $gameID, $this->linkID);
-			return 'javascript:voteSite("' . $externalUrl . '","' . $internalUrl . '")';
+			return SmrSession::getNewHREF($container, true);
 		} else {
-			return $baseUrl;
+			return false;
 		}
 	}
 

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -827,6 +827,7 @@ function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account, $v
 		$voteSites[] = array(
 			'img' => $site->getLinkImg($account->getAccountID(), SmrSession::getGameID()),
 			'url' => $site->getLinkUrl($account->getAccountID(), SmrSession::getGameID()),
+			'sn' => $site->getSN($account->getAccountID(), SmrSession::getGameID()),
 		);
 	}
 	$template->assign('VoteSites', $voteSites);

--- a/templates/Default/engine/Default/includes/VoteLinks.inc
+++ b/templates/Default/engine/Default/includes/VoteLinks.inc
@@ -4,7 +4,7 @@ if (SmrSession::hasGame()) { ?>
 } ?>
 <span id="vote_links"><?php
 	foreach ($VoteSites as $VoteSite) { ?>
-		<a href='<?php echo htmlspecialchars($VoteSite['url']); ?>' target="_blank">
+		<a href='<?php echo htmlspecialchars($VoteSite['url']); ?>' target="_blank" <?php if ($VoteSite['sn']) { ?> data-sn="<?php echo $VoteSite['sn']; ?>" onclick="voteSite(this.dataset.sn)" <?php } ?>>
 			<img class="vote_site" src="images/game_sites/<?php echo $VoteSite['img']; ?>" alt="" width="98" height="41" />
 		</a><?php
 	} ?>


### PR DESCRIPTION
Due to a security fix in Chrome 76 and Firefox 70, it is no longer
possible to execute javascript in a new tab. Therefore, we can no
longer call one of our js functions in a link that opens a new tab.

For example, the following will now open a blank page and then fail
to load "a" because `voteSite` is not defined in that tab's context:

```
  <a href="javascript:voteSite(a,b)" target="_blank">
```

See https://bugs.chromium.org/p/chromium/issues/detail?id=992244

The fix to our voting links is to use a normal href link for the
external site (with `target="_blank"`), and then add an `onclick`
event to redirect the current page (if necessary, i.e. if free
turns are available):

```
  <a href="a" onclick="window.location='b'" target="_blank">
```

The real `onclick` event is only slightly more complicated than this.
We need to update the `window.location` _after_ we have opened the
external URL in a new tab. Therefore, the guts of `onclick` must be
wrapped in a `setTimeout`.

We change `VoteSite::getLinkUrl` to only return the external URL
and add `VoteSite::getSN`, which returns the internal SN or false.

Additional changes:
* Refactored the logic deciding whether or not free turns can be
  awarded into a private function `VoteSite::freeTurnsReady`.
* Moved the `alwaysreward=1` query param for TWG into the URL used
  when free turns are available (since it does nothing otherwise).