### PR TITLE
Uni Gen: specifiable starting political relations

### DIFF
--- a/admin/Default/1.6/game_create.php
+++ b/admin/Default/1.6/game_create.php
@@ -26,6 +26,7 @@ $defaultGame = [
 	'allianceMaxVets' => 15,
 	'startCredits' => 100000,
 	'ignoreStats' => false,
+	'relations' => MIN_GLOBAL_RELATIONS,
 ];
 $template->assign('Game', $defaultGame);
 $template->assign('SubmitValue', 'Create Game');

--- a/admin/Default/1.6/game_create_processing.php
+++ b/admin/Default/1.6/game_create_processing.php
@@ -35,25 +35,11 @@ $game->setGameSpeed($_REQUEST['game_speed']);
 $game->setIgnoreStats($_REQUEST['ignore_stats'] == 'Yes');
 $game->setStartingCredits($_REQUEST['starting_credits']);
 $game->setCreditsNeeded($_REQUEST['creds_needed']);
+$game->setStartingRelations($_REQUEST['relations']);
 
 // Start game disabled by default
 $game->setEnabled(false);
 $game->save();
-
-//insert race relations
-foreach (Globals::getRaces() as $race) {
-	foreach (Globals::getRaces() as $race2) {
-		if ($race['Race ID'] == $race2['Race ID']) {
-			$amount = MAX_GLOBAL_RELATIONS;
-		} elseif ($race['Race ID'] == RACE_NEUTRAL || $race2['Race ID'] == RACE_NEUTRAL) {
-			$amount = 0; //0 relats with neutral
-		} else {
-			$amount = MIN_GLOBAL_RELATIONS;
-		}
-		$db->query('REPLACE INTO race_has_relation (game_id, race_id_1, race_id_2, relation)
-						VALUES (' . $db->escapeNumber($game->getGameID()) . ',' . $db->escapeNumber($race['Race ID']) . ',' . $db->escapeNumber($race2['Race ID']) . ',' . $db->escapeNumber($amount) . ')');
-		}
-	}
 
 createNHA($game->getGameID()); //do the alliances/message stuff
 

--- a/admin/Default/1.6/game_edit.php
+++ b/admin/Default/1.6/game_edit.php
@@ -4,6 +4,9 @@ $template->assign('PageTopic', 'Edit Game Details');
 
 $gameID = SmrSession::getRequestVar('game_id');
 
+// Use Alskant-Creonti as a proxy for the starting political relations
+$relations = Globals::getRaceRelations($gameID, RACE_ALSKANT)[RACE_CREONTI];
+
 $game = SmrGame::getGame($gameID);
 $gameArray = [
 	'name' => $game->getName(),
@@ -21,6 +24,7 @@ $gameArray = [
 	'allianceMaxVets' => $game->getAllianceMaxVets(),
 	'startCredits' => $game->getStartingCredits(),
 	'ignoreStats' => $game->isIgnoreStats(),
+	'relations' => $relations,
 ];
 $template->assign('Game', $gameArray);
 

--- a/admin/Default/1.6/game_edit_processing.php
+++ b/admin/Default/1.6/game_edit_processing.php
@@ -22,6 +22,9 @@ $game->setGameSpeed($_REQUEST['game_speed']);
 $game->setIgnoreStats($_REQUEST['ignore_stats'] == 'Yes');
 $game->setStartingCredits($_REQUEST['starting_credits']);
 $game->setCreditsNeeded($_REQUEST['creds_needed']);
+if (!$game->hasStarted()) {
+	$game->setStartingRelations($_REQUEST['relations']);
+}
 $game->save();
 
 $container = create_container('skeleton.php', '1.6/universe_create_sectors.php');

--- a/lib/Default/SmrGame.class.inc
+++ b/lib/Default/SmrGame.class.inc
@@ -378,4 +378,28 @@ class SmrGame {
 	public function getDisplayName() {
 		return $this->getName() . " (" . $this->getGameID() . ")";
 	}
+
+	/**
+	 * Set the starting political relations between races.
+	 */
+	public function setStartingRelations($relations) {
+		if ($relations < MIN_GLOBAL_RELATIONS || $relations > MAX_GLOBAL_RELATIONS) {
+			throw new Exception('Invalid relations: ' . $relations);
+		}
+		foreach (Globals::getRaces() as $race1) {
+			foreach (Globals::getRaces() as $race2) {
+				if ($race1['Race ID'] == $race2['Race ID']) {
+					// Max relations for a race with itself
+					$amount = MAX_GLOBAL_RELATIONS;
+				} elseif ($race1['Race ID'] == RACE_NEUTRAL || $race2['Race ID'] == RACE_NEUTRAL) {
+					$amount = 0; //0 relations with neutral
+				} else {
+					$amount = $relations;
+				}
+				$this->db->query('REPLACE INTO race_has_relation (game_id, race_id_1, race_id_2, relation)
+				                  VALUES (' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber($race1['Race ID']) . ',' . $this->db->escapeNumber($race2['Race ID']) . ',' . $this->db->escapeNumber($amount) . ')');
+			}
+		}
+	}
+
 }

--- a/templates/Default/admin/Default/1.6/GameDetails.inc
+++ b/templates/Default/admin/Default/1.6/GameDetails.inc
@@ -69,6 +69,13 @@
 		</td>
 	</tr>
 	<tr>
+		<td class="right">Starting Relations</td>
+		<td>
+			<input required type="number" name="relations" min="<?php echo MIN_GLOBAL_RELATIONS; ?>" max="<?php echo MAX_GLOBAL_RELATIONS; ?>" class="InputFields" value="<?php echo $Game['relations']; ?>">
+			Only updated if game hasn't started yet
+		</td>
+	</tr>
+	<tr>
 		<td class="center" colspan="2"><input type="submit" value="<?php echo $SubmitValue; ?>" name="submit"></td>
 	</tr>
 	</table>


### PR DESCRIPTION
Admins can now specify the starting political relations between races.
This can be modified as well, but only until the game has started.

Added a new method `SmrGame::setStartingRelations` to avoid code
duplication between game create/edit.

![image](https://user-images.githubusercontent.com/846186/64992524-e9224580-d888-11e9-963f-d9755db93bc7.png)
