### PR TITLE
npc.php: don't use a hard-coded game ID

### DIFF
--- a/config/npc/config.specific.sample.php
+++ b/config/npc/config.specific.sample.php
@@ -1,6 +1,5 @@
 <?php
 
-const NPC_GAME_ID = 1;
 const NPC_LOG_TO_DATABASE = true; // insert debug messages into db
 
 const NPC_LOW_TURNS = 75;

--- a/lib/Default/ChessGame.class.inc
+++ b/lib/Default/ChessGame.class.inc
@@ -12,6 +12,7 @@ class ChessGame {
 	private $db;
 
 	private $chessGameID;
+	private $gameID;
 	private $startDate;
 	private $endDate;
 	private $gameType;
@@ -75,6 +76,7 @@ class ChessGame {
 						WHERE chess_game_id=' . $this->db->escapeNumber($chessGameID) . ' LIMIT 1;');
 		if($this->db->nextRecord()) {
 			$this->chessGameID = $chessGameID;
+			$this->gameID = $this->db->getInt('game_id');
 			$this->startDate = $this->db->getInt('start_time');
 			$this->endDate = $this->db->getInt('end_time');
 			$this->whiteID = $this->db->getInt('white_id');
@@ -726,8 +728,7 @@ class ChessGame {
 	}
 
 	public function getGameID() {
-		return SmrSession::getGameID();
-//		return $this->gameID;
+		return $this->gameID;
 	}
 
 	public function getWhitePlayer() {

--- a/lib/Default/ChessGame.class.inc
+++ b/lib/Default/ChessGame.class.inc
@@ -297,46 +297,46 @@ class ChessGame {
 		return $board;
 	}
 
-	public static function getStandardGame($gameID, AbstractSmrPlayer $whitePlayer, AbstractSmrPlayer $blackPlayer) {
+	public static function getStandardGame($chessGameID, AbstractSmrPlayer $whitePlayer, AbstractSmrPlayer $blackPlayer) {
 		$white = $whitePlayer->getAccountID();
 		$black = $blackPlayer->getAccountID();
 		return array
 			(
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::ROOK, 0, 0),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::KNIGHT, 1, 0),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::BISHOP, 2, 0),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::QUEEN, 3, 0),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::KING, 4, 0),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::BISHOP, 5, 0),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::KNIGHT, 6, 0),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::ROOK, 7, 0),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::ROOK, 0, 0),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::KNIGHT, 1, 0),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::BISHOP, 2, 0),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::QUEEN, 3, 0),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::KING, 4, 0),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::BISHOP, 5, 0),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::KNIGHT, 6, 0),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::ROOK, 7, 0),
 
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 0, 1),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 1, 1),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 2, 1),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 3, 1),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 4, 1),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 5, 1),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 6, 1),
-				new ChessPiece($gameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 7, 1),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 0, 1),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 1, 1),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 2, 1),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 3, 1),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 4, 1),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 5, 1),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 6, 1),
+				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 7, 1),
 
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 0, 6),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 1, 6),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 2, 6),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 3, 6),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 4, 6),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 5, 6),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 6, 6),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 7, 6),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 0, 6),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 1, 6),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 2, 6),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 3, 6),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 4, 6),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 5, 6),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 6, 6),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 7, 6),
 
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::ROOK, 0, 7),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::KNIGHT, 1, 7),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::BISHOP, 2, 7),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::QUEEN, 3, 7),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::KING, 4, 7),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::BISHOP, 5, 7),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::KNIGHT, 6, 7),
-				new ChessPiece($gameID, $white, self::PLAYER_WHITE, ChessPiece::ROOK, 7, 7),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::ROOK, 0, 7),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::KNIGHT, 1, 7),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::BISHOP, 2, 7),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::QUEEN, 3, 7),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::KING, 4, 7),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::BISHOP, 5, 7),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::KNIGHT, 6, 7),
+				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::ROOK, 7, 7),
 			);
 	}
 
@@ -676,7 +676,7 @@ class ChessGame {
 				$this->db->query('INSERT INTO chess_game_moves
 								(chess_game_id,piece_id,start_x,start_y,end_x,end_y,checked,piece_taken,castling,en_passant,promote_piece_id)
 								VALUES
-								(' . $this->db->escapeNumber($p->gameID) . ',' . $this->db->escapeNumber($pieceID) . ',' . $this->db->escapeNumber($x) . ',' . $this->db->escapeNumber($y) . ',' . $this->db->escapeNumber($toX) . ',' . $this->db->escapeNumber($toY) . ',' . $this->db->escapeString($checking, true, true) . ',' . ($moveInfo['PieceTaken'] == null ? 'NULL' : $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID)) . ',' . $this->db->escapeString($moveInfo['Castling']['Type'], true, true) . ',' . $this->db->escapeBoolean($moveInfo['EnPassant']) . ',' . ($moveInfo['PawnPromotion'] == false ? 'NULL' : $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceID'])) . ');');
+								(' . $this->db->escapeNumber($p->chessGameID) . ',' . $this->db->escapeNumber($pieceID) . ',' . $this->db->escapeNumber($x) . ',' . $this->db->escapeNumber($y) . ',' . $this->db->escapeNumber($toX) . ',' . $this->db->escapeNumber($toY) . ',' . $this->db->escapeString($checking, true, true) . ',' . ($moveInfo['PieceTaken'] == null ? 'NULL' : $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID)) . ',' . $this->db->escapeString($moveInfo['Castling']['Type'], true, true) . ',' . $this->db->escapeBoolean($moveInfo['EnPassant']) . ',' . ($moveInfo['PawnPromotion'] == false ? 'NULL' : $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceID'])) . ');');
 
 
 				$currentPlayer->increaseHOF(1, array($chessType,'Moves','Total Taken'), HOF_PUBLIC);

--- a/lib/Default/ChessPiece.class.inc
+++ b/lib/Default/ChessPiece.class.inc
@@ -8,7 +8,7 @@ class ChessPiece {
 	const KNIGHT = 5;
 	const PAWN = 6;
 
-	public $gameID;
+	public $chessGameID;
 	public $accountID;
 	public $colour;
 	public $pieceID;
@@ -16,8 +16,8 @@ class ChessPiece {
 	private $x;
 	private $y;
 	
-	public function __construct($gameID, $accountID, $colour, $pieceID, $x, $y, $pieceNo = -1) {
-		$this->gameID = $gameID;
+	public function __construct($chessGameID, $accountID, $colour, $pieceID, $x, $y, $pieceNo = -1) {
+		$this->chessGameID = $chessGameID;
 		$this->accountID = $accountID;
 		$this->colour = $colour;
 		$this->pieceID = $pieceID;

--- a/tools/npc/chess.php
+++ b/tools/npc/chess.php
@@ -44,7 +44,6 @@ try {
 	writeToEngine('setoption name Hash value ' . UCI_HASH_SIZE_MB, false);
 	writeToEngine('isready');
 	writeToEngine('ucinewgame', false);
-	SmrSession::updateGame(NPC_GAME_ID);
 
 	while(true) {
 		//Redefine MICRO_TIME and TIME, the rest of the game expects them to be the single point in time that the script is executing, with it being redefined for each page load - unfortunately NPCs are one consistent script so we have to do a hack and redefine it (or change every instance of the TIME constant).

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -80,13 +80,9 @@ try {
 	$db = new SmrMySqlDatabase();
 	debug('Script started');
 
-	define('SCRIPT_ID', $db->getInsertID());
-	$db->query('UPDATE npc_logs SET script_id=' . SCRIPT_ID . ' WHERE log_id=' . SCRIPT_ID);
-
 	$NPC_LOGINS_USED = array('');
 
 	// Make sure NPC's have been set up in the database
-	$db = new SmrMySqlDatabase();
 	$db->query('SELECT 1 FROM npc_logins LIMIT 1');
 	if (!$db->nextRecord()) {
 		debug('No NPCs have been created yet!');
@@ -341,6 +337,12 @@ function debug($message, $debugObject = null) {
 	echo date('Y-m-d H:i:s - ') . $message . ($debugObject !== null ?EOL.var_export($debugObject, true) : '') . EOL;
 	if (NPC_LOG_TO_DATABASE) {
 		$db->query('INSERT INTO npc_logs (script_id, npc_id, time, message, debug_info, var) VALUES (' . (defined('SCRIPT_ID') ?SCRIPT_ID:0) . ', ' . (is_object($player) ? $player->getAccountID() : 0) . ',NOW(),' . $db->escapeString($message) . ',' . $db->escapeString(var_export($debugObject, true)) . ',' . $db->escapeString(var_export($var, true)) . ')');
+
+		// On the first call to debug, we need to update the script_id retroactively
+		if (!defined('SCRIPT_ID')) {
+			define('SCRIPT_ID', $db->getInsertID());
+			$db->query('UPDATE npc_logs SET script_id=' . SCRIPT_ID . ' WHERE log_id=' . SCRIPT_ID);
+		}
 	}
 }
 


### PR DESCRIPTION
Put active NPCs to work for all enabled games instead of hard-coding
the `NPC_GAME_ID` in the NPC configuration file (which needed to be
manually updated each game). This is the simplest way to avoid manual
intervention for NPCs with each new game.

This new scheme uses the SmrSession to track which NPC is working,
rather than using globals in npc.php.

NOTE: This scheme may not work correctly if multiple games are active,
one of which is a non-Default game (because it may autoload the wrong
version of libraries).
