### PR TITLE
Gameplay changes to relations

### DIFF
--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -73,6 +73,7 @@ if ($_REQUEST['action'] == 'Steal') {
 		$newCredits = max(5000, $player->getCredits() - $fine);
 		$player->setCredits($newCredits);
 		$player->decreaseAlignment(5);
+		$player->decreaseRelationsByTrade($amount, $port->getRaceID());
 
 		$fineMessage = '<span class="red">A Federation patrol caught you loading stolen goods onto your ship!<br />The stolen goods have been confiscated and you have been fined ' . number_format($fine) . ' credits.</span><br /><br />';
 		$container = create_container('skeleton.php', 'shop_goods.php');

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -1334,11 +1334,9 @@ class AbstractSmrPort {
 		$killer->increaseCurrentBountyAmount('HQ', $return['KillerBounty']);
 		$killer->increaseHOF($return['KillerBounty'], array('Combat', 'Port', 'Bounties', 'Gained'), HOF_PUBLIC);
 		
-		if ($this->getRaceID() != RACE_NEUTRAL) {
-			$return['KillerRelations'] = 45;
-			$killer->decreaseRelations($return['KillerRelations'], $this->getRaceID());
-			$killer->increaseHOF($return['KillerRelations'], array('Combat', 'Port', 'Relation', 'Loss'), HOF_PUBLIC);
-		}
+		$return['KillerRelations'] = 45;
+		$killer->decreaseRelations($return['KillerRelations'], $this->getRaceID());
+		$killer->increaseHOF($return['KillerRelations'], array('Combat', 'Port', 'Relation', 'Loss'), HOF_PUBLIC);
 		
 		return $return;
 	}

--- a/lib/Default/SmrPlayer.class.inc
+++ b/lib/Default/SmrPlayer.class.inc
@@ -610,10 +610,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 	 * of the port given by $raceID.
 	 */
 	public function increaseRelationsByTrade($numGoods, $raceID) {
-		// No relations increase for neutral ports (unless Alskant)
-		if ($raceID == RACE_NEUTRAL && $this->getRaceID() != RACE_ALSKANT) {
-			return;
-		}
 		$relations = ceil(min($numGoods, 300) / 30);
 		//Cap relations to a max of 1 after 500 have been reached
 		if ($this->getPureRelation($raceID) + $relations >= 500) {

--- a/lib/Default/shop_goods.inc
+++ b/lib/Default/shop_goods.inc
@@ -26,19 +26,14 @@ function check_bargain_number($amount, $ideal_price, $offered_price, $bargain_pr
 
 	if (isset($var['overall_number_of_bargains'])) {
 		// lose relations for bad bargain
-		if ($port->getRaceID() != RACE_NEUTRAL || $player->getRaceID() == RACE_ALSKANT) {
-			$player->decreaseRelationsByTrade($amount, $port->getRaceID());
-		}
+		$player->decreaseRelationsByTrade($amount, $port->getRaceID());
 		$player->increaseHOF(1, array('Trade', 'Results', 'Fail'), HOF_PUBLIC);
 		// transfer values
 		transfer('overall_number_of_bargains');
 
 		// does we have enough of it?
 		if ($container['number_of_bargains'] > $container['overall_number_of_bargains']) {
-			// change relation for non neutral ports
-			if ($port->getRaceID() != RACE_NEUTRAL || $player->getRaceID() == RACE_ALSKANT) {
-				$player->decreaseRelationsByTrade($amount, $port->getRaceID());
-			}
+			$player->decreaseRelationsByTrade($amount, $port->getRaceID());
 			$player->increaseHOF(1, array('Trade', 'Results', 'Epic Fail'), HOF_PUBLIC);
 			create_error('You don\'t want to accept my offer? I\'m sick of you! Get out of here!');
 		}


### PR DESCRIPTION
* All races will now gain/lose relations when trading with Neutral ports, not just Alskant.
* Raiding a Neutral port will now decrease Neutral relations, just like with all other port races.
* Getting caught stealing will now decrease relations the same amount as a bad bargain. (Note: Successful stealing no longer increases relations thanks to the bugfix in #765.)