### PR TITLE
SmrPort: stolen goods bugfix

### DIFF
--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -126,7 +126,7 @@ if ($transaction == 'Steal' ||
 		$ship->increaseCargo($good_id, $amount);
 		$player->increaseHOF($amount, array('Trade', 'Goods', 'Stolen'), HOF_ALLIANCE);
 		$player->increaseHOF($gained_exp, array('Trade', 'Experience', 'Stealing'), HOF_PUBLIC);
-		$port->buyGoods($portGood, $amount, $ideal_price, $bargain_price, $gained_exp);
+		$port->stealGoods($portGood, $amount);
 	}
 
 	$player->increaseHOF($gained_exp, array('Trade', 'Experience', 'Total'), HOF_PUBLIC);

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -397,7 +397,7 @@ class AbstractSmrPort {
 	}
 	
 	protected function stealGoods(array $good, $goodsTraded) {
-		$this->decreaseGood($good, $goodsTraded, true);
+		$this->decreaseGood($good, $goodsTraded, false);
 	}
 	
 	public function checkForUpgrade() {

--- a/lib/Default/AbstractSmrPort.class.inc
+++ b/lib/Default/AbstractSmrPort.class.inc
@@ -396,6 +396,10 @@ class AbstractSmrPort {
 		$this->tradeGoods($good, $goodsTraded, $exp);
 	}
 	
+	protected function stealGoods(array $good, $goodsTraded) {
+		$this->decreaseGood($good, $goodsTraded, true);
+	}
+	
 	public function checkForUpgrade() {
 		if ($this->isCachedVersion())
 			throw new Exception('Cannot upgrade a cached port!');


### PR DESCRIPTION
Stolen goods has been working towards a port level increase.  Added a separate function for stealing goods to the port class so that theft bypasses port upgrade calls.