### PR TITLE
npc.php: fix handling of illegal goods in plotToFed

### DIFF
--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -532,20 +532,19 @@ function plotToSector($player, $sectorID) {
 function plotToFed($player, $plotToHQ = false) {
 	debug('Plotting To Fed', $plotToHQ);
 
-	if ($plotToHQ === false && $player->getSector()->offersFederalProtection()) {
-		if (!$player->hasNewbieTurns() && !$player->hasFederalProtection() && $player->getShip()->hasIllegalGoods()) { //We have illegals and no newbie turns, dump the illegals to get fed protection.
-			debug('Dumping illegals');
-			processContainer(dumpCargo($player));
-		}
+	// Always drop illegal goods before heading to fed space
+	if ($player->getShip()->hasIllegalGoods()) {
+		debug('Dumping illegal goods');
+		processContainer(dumpCargo($player));
+	}
+
+	$fedLocID = $player->getRaceID() + ($plotToHQ ? LOCATION_GROUP_RACIAL_HQS : LOCATION_GROUP_RACIAL_BEACONS);
+	if ($player->getSector()->hasLocation($fedLocID)) {
 		debug('Plotted to fed whilst in fed, switch NPC and wait for turns');
 		changeNPCLogin();
 		return true;
 	}
-	if ($plotToHQ === true) {
-		return plotToNearest($player, SmrLocation::getLocation($player->getRaceID() + LOCATION_GROUP_RACIAL_HQS));
-	}
-	return plotToNearest($player, SmrLocation::getLocation($player->getRaceID() + LOCATION_GROUP_RACIAL_BEACONS));
-//	return plotToNearest($player,$plotToHQ===true?'HQ':'Fed');
+	return plotToNearest($player, SmrLocation::getLocation($fedLocID));
 }
 
 function plotToNearest(AbstractSmrPlayer $player, $realX) {


### PR DESCRIPTION
This function was only dumping illegal goods when it was in a sector
that offered federal protection. Since dumping cargo is not allowed
in Fed sectors, this was causing an error, leaving NPCs unprotected
with illegal goods on board.

To fix this problem, we dump illegal goods before we plot to Fed.
For simplicity and safety, we do this unconditionally (regardless of
the reason the NPC is going to Fed).

If the NPC tries to plot to Fed with illegal goods on board while in
a Fed sector already, then this error will still occur, and I don't
think that it's worth coding a workaround into the AI. We can always
simply delete the NPC cargo if we must (NPCs don't necessarily need
to follow the rules the way players do).