### PR TITLE
Improve social login processing

### DIFF
--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -12,7 +12,7 @@ try {
 
 	if (!SmrSession::hasAccount()) {
 		if (isset($_REQUEST['loginType'])) {
-			$socialLogin = new SocialLogin($_REQUEST['loginType']);
+			$socialLogin = SocialLogin::get($_REQUEST['loginType'])->login();
 			if (!$socialLogin->isValid()) {
 				$msg = 'Error validating login.';
 				header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -4,9 +4,6 @@ try {
 	require_once('config.inc');
 	require_once(LIB . 'Default/smr.inc');
 
-	$db = new SmrMySqlDatabase();
-	$db2 = new SmrMySqlDatabase();
-
 	// ********************************
 	// *
 	// * C r e a t e   S e s s i o n
@@ -93,6 +90,7 @@ try {
 		session_destroy();
 	}
 
+	$db = new SmrMySqlDatabase();
 	$db->query('SELECT * FROM game_disable');
 	if ($db->nextRecord()) {
 		// allow admins to access it
@@ -192,13 +190,12 @@ try {
 
 
 	//get rid of expired messages
-	$db2->query('UPDATE message SET receiver_delete = \'TRUE\', sender_delete = \'TRUE\', expire_time = 0 WHERE expire_time < ' . $db->escapeNumber(TIME) . ' AND expire_time != 0');
+	$db->query('UPDATE message SET receiver_delete = \'TRUE\', sender_delete = \'TRUE\', expire_time = 0 WHERE expire_time < ' . $db->escapeNumber(TIME) . ' AND expire_time != 0');
 	// Mark message as read if it was sent to self as a mass mail.
-	$db2->query('UPDATE message SET msg_read = \'TRUE\' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' AND account_id = sender_id AND message_type_id IN (' . $db->escapeArray(array(MSG_ALLIANCE, MSG_GLOBAL, MSG_POLITICAL)) . ');');
+	$db->query('UPDATE message SET msg_read = \'TRUE\' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' AND account_id = sender_id AND message_type_id IN (' . $db->escapeArray(array(MSG_ALLIANCE, MSG_GLOBAL, MSG_POLITICAL)) . ');');
 	//check to see if we need to remove player_has_unread
-	$db2 = new SmrMySqlDatabase();
-	$db2->query('DELETE FROM player_has_unread_messages WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
-	$db2->query('
+	$db->query('DELETE FROM player_has_unread_messages WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+	$db->query('
 		INSERT INTO player_has_unread_messages (game_id, account_id, message_type_id)
 		SELECT game_id, account_id, message_type_id FROM message WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' AND msg_read = ' . $db->escapeBoolean(false) . ' AND receiver_delete = ' . $db->escapeBoolean(false)
 	);

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -28,16 +28,7 @@ try {
 					session_start();
 				}
 				$_SESSION['socialLogin'] = $socialLogin;
-				$template = new Template();
-				$template->assign('SocialLogin', $socialLogin);
-				// Pre-populate the login field if an account with this email exists.
-				// (Also disable creating a new account because they would just get
-				// an "Email already registered" error anyway.)
-				$account = SmrAccount::getAccountByEmail($socialLogin->getEmail());
-				if (!is_null($account)) {
-					$template->assign('MatchingLogin', $account->getLogin());
-				}
-				$template->display('socialRegister.inc');
+				header('Location: /login_social_create.php');
 				exit;
 			}
 		}

--- a/htdocs/login_social_create.php
+++ b/htdocs/login_social_create.php
@@ -1,0 +1,31 @@
+<?php
+
+try {
+	require_once('config.inc');
+
+	if (session_status() === PHP_SESSION_NONE) {
+		session_start();
+	}
+	if (!isset($_SESSION['socialLogin'])) {
+		$msg = 'Authentication data not found!';
+		header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
+		exit;
+	}
+	$socialLogin = $_SESSION['socialLogin'];
+
+	$template = new Template();
+	$template->assign('SocialLogin', $socialLogin);
+
+	// Pre-populate the login field if an account with this email exists.
+	// (Also disable creating a new account because they would just get
+	// an "Email already registered" error anyway.)
+	$account = SmrAccount::getAccountByEmail($socialLogin->getEmail());
+	if (!is_null($account)) {
+		$template->assign('MatchingLogin', $account->getLogin());
+	}
+
+	$template->display('socialRegister.inc');
+
+} catch (Throwable $e) {
+	handleException($e);
+}

--- a/htdocs/login_social_processing.php
+++ b/htdocs/login_social_processing.php
@@ -12,15 +12,7 @@ try {
 		// immediately forwards to the social login URL after it is generated.
 
 		require_once('config.inc');
-		if ($type == 'facebook') {
-			$url = SocialLogin::getFacebookLoginUrl();
-		} elseif ($type == 'twitter') {
-			$url = SocialLogin::getTwitterLoginUrl();
-		} else {
-			throw new Exception('Unknown social login type: ' . $type);
-		}
-
-		header('Location: ' . $url);
+		header('Location: ' . SocialLogin::getLoginUrl($type));
 		exit;
 	}
 

--- a/htdocs/login_social_processing.php
+++ b/htdocs/login_social_processing.php
@@ -12,7 +12,7 @@ try {
 		// immediately forwards to the social login URL after it is generated.
 
 		require_once('config.inc');
-		header('Location: ' . SocialLogin::getLoginUrl($type));
+		header('Location: ' . SocialLogin::get($type)->getLoginUrl());
 		exit;
 	}
 

--- a/lib/Default/SocialLogin.class.php
+++ b/lib/Default/SocialLogin.class.php
@@ -42,7 +42,20 @@ class SocialLogin {
 		return URL . '/login_processing.php?loginType=' . $loginType;
 	}
 
-	public static function getFacebookLoginUrl() {
+	/**
+	 * Returns the URL to authenticate with the social platform.
+	 */
+	public static function getLoginUrl($loginType) {
+		if ($loginType == self::FACEBOOK) {
+			return SocialLogin::getFacebookLoginUrl();
+		} elseif ($loginType == self::TWITTER) {
+			return SocialLogin::getTwitterLoginUrl();
+		} else {
+			throw new Exception('Unknown social login type: ' . $loginType);
+		}
+	}
+
+	private static function getFacebookLoginUrl() {
 		if (empty(FACEBOOK_APP_ID)) {
 			// No facebook app specified. Continuing would throw an exception.
 			return;
@@ -52,7 +65,7 @@ class SocialLogin {
 		return $helper->GetLoginUrl(self::getRedirectUrl(self::FACEBOOK), $permissions);
 	}
 
-	public static function getTwitterLoginUrl() {
+	private static function getTwitterLoginUrl() {
 		if (empty(TWITTER_CONSUMER_KEY)) {
 			// No twitter app specified. Continuing would throw an exception.
 			return;

--- a/lib/Default/SocialLogin.class.php
+++ b/lib/Default/SocialLogin.class.php
@@ -1,129 +1,81 @@
 <?php
 
-class SocialLogin {
-	// Define `loginType` constants to avoid string typos
-	const FACEBOOK = 'Facebook';
-	const TWITTER = 'Twitter';
+/**
+ * Defines the methods to be implemented by each social login platform.
+ */
+abstract class SocialLogin {
 
-	private $valid = false;
-	private $loginType = null;
 	private $userID = null;
 	private $email = null;
-	private static $facebook = null;
+	private $valid = false;
 
-	private static function getFacebookObj() {
-		if (session_status() === PHP_SESSION_NONE) {
-			session_start();
+	/**
+	 * Provides the canonical name of the platform to use in string comparison.
+	 */
+	abstract public static function getLoginType() : string;
+
+	/**
+	 * Returns a SocialLogin class of the given derived type.
+	 */
+	public static function get(string $loginType) : SocialLogin {
+		if ($loginType === SocialLogins\Facebook::getLoginType()) {
+			return new SocialLogins\Facebook();
+		} elseif ($loginType === SocialLogins\Twitter::getLoginType()) {
+			return new SocialLogins\Twitter();
+		} else {
+			throw new Exception('Unknown social login type: ' . $loginType);
 		}
-		if (self::$facebook == null) {
-			self::$facebook = new Facebook\Facebook([
-				'app_id' => FACEBOOK_APP_ID,
-				'app_secret' => FACEBOOK_APP_SECRET,
-				'default_graph_version' => 'v2.12'
-			]);
-		}
-		return self::$facebook;
 	}
 
-	private static function getTwitterObj($token = null) {
-		return new Abraham\TwitterOAuth\TwitterOAuth(
-			TWITTER_CONSUMER_KEY,
-			TWITTER_CONSUMER_SECRET,
-			is_null($token) ? null : $token['oauth_token'],
-			is_null($token) ? null : $token['oauth_token_secret']
-		);
+	public function __construct() {
+		// All social logins use a session for authentication
+		if (session_status() === PHP_SESSION_NONE) {
+			if (!session_start()) {
+				throw new Exception('Failed to start social login session');
+			}
+		}
+	}
+
+	/**
+	 * After a successful authentication, set credentials.
+	 */
+	protected function setCredentials(?string $userID, ?string $email) : void {
+		$this->userID = $userID;
+		$this->email = $email;
+		$this->valid = !empty($userID);
 	}
 
 	/**
 	 * Returns the URL that the social platform will redirect to
 	 * after authentication.
 	 */
-	private static function getRedirectUrl($loginType) {
-		return URL . '/login_processing.php?loginType=' . $loginType;
+	protected function getRedirectUrl() : string {
+		return URL . '/login_processing.php?loginType=' . $this->getLoginType();
 	}
 
 	/**
 	 * Returns the URL to authenticate with the social platform.
 	 */
-	public static function getLoginUrl($loginType) {
-		if ($loginType == self::FACEBOOK) {
-			return SocialLogin::getFacebookLoginUrl();
-		} elseif ($loginType == self::TWITTER) {
-			return SocialLogin::getTwitterLoginUrl();
-		} else {
-			throw new Exception('Unknown social login type: ' . $loginType);
-		}
-	}
+	abstract public function getLoginUrl() : string;
 
-	private static function getFacebookLoginUrl() {
-		if (empty(FACEBOOK_APP_ID)) {
-			// No facebook app specified. Continuing would throw an exception.
-			return;
-		}
-		$helper = self::getFacebookObj()->getRedirectLoginHelper();
-		$permissions = ['email'];
-		return $helper->GetLoginUrl(self::getRedirectUrl(self::FACEBOOK), $permissions);
-	}
+	/**
+	 * Authenticates with the social platform.
+	 */
+	abstract public function login() : SocialLogin;
 
-	private static function getTwitterLoginUrl() {
-		if (empty(TWITTER_CONSUMER_KEY)) {
-			// No twitter app specified. Continuing would throw an exception.
-			return;
-		}
-		if (session_status() === PHP_SESSION_NONE) {
-			session_start();
-		}
-		$auth = self::getTwitterObj();
-		$params = ['oauth_callback' => self::getRedirectUrl(self::TWITTER)];
-		$_SESSION['TwitterToken'] = $auth->oauth('oauth/request_token', $params);
-		// 'authenticate' asks for permission only once ('authorize' is every time)
-		return $auth->url('oauth/authenticate', $_SESSION['TwitterToken']);
-	}
-
-	public function __construct($loginType) {
-		$this->loginType = $loginType;
-
-		if ($loginType == self::FACEBOOK) {
-			$helper = self::getFacebookObj()->getRedirectLoginHelper();
-			$accessToken = $helper->getAccessToken(self::getRedirectUrl($loginType));
-			$response = self::getFacebookObj()->get('/me?fields=email', $accessToken);
-			$userInfo = $response->getGraphUser();
-			$this->userID = $userInfo->getId();
-			$this->email = $userInfo->getEmail();
-			$this->valid = true;
-		} else if ($loginType == self::TWITTER) {
-			if (session_status() === PHP_SESSION_NONE) {
-				session_start();
-			}
-			if ($_SESSION['TwitterToken']['oauth_token'] != $_REQUEST['oauth_token']) {
-				create_error('Unexpected token received from Twitter');
-			}
-			$helper = self::getTwitterObj($_SESSION['TwitterToken']);
-			$accessToken = $helper->oauth('oauth/access_token',
-			                              ['oauth_verifier' => $_REQUEST['oauth_verifier']]);
-			$auth = self::getTwitterObj($accessToken);
-			$userInfo = $auth->get('account/verify_credentials', ['include_email' => 'true']);
-			if ($auth->getLastHttpCode() == 200) {
-				$this->userID = $userInfo->id_str;
-				$this->email = $userInfo->email;
-				$this->valid = true;
-			}
-		}
-	}
-
-	public function isValid() {
+	/**
+	 * Returns true if the authentication was successful.
+	 */
+	public function isValid() : bool {
 		return $this->valid;
 	}
 
-	public function getLoginType() {
-		return $this->loginType;
-	}
-
-	public function getUserID() {
+	public function getUserID() : ?string {
 		return $this->userID;
 	}
 
-	public function getEmail() {
+	public function getEmail() : ?string {
 		return $this->email;
 	}
+
 }

--- a/lib/Default/SocialLogins/Facebook.class.php
+++ b/lib/Default/SocialLogins/Facebook.class.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SocialLogins;
+
+class Facebook extends \SocialLogin {
+
+	private static $facebook = null;
+
+	public static function getLoginType() : string {
+		return 'Facebook';
+	}
+
+	private static function getFacebookObj() : \Facebook\Facebook {
+		if (is_null(self::$facebook)) {
+			self::$facebook = new \Facebook\Facebook([
+				'app_id' => FACEBOOK_APP_ID,
+				'app_secret' => FACEBOOK_APP_SECRET,
+				'default_graph_version' => 'v2.12'
+			]);
+		}
+		return self::$facebook;
+	}
+
+	public function getLoginUrl() : string {
+		if (empty(FACEBOOK_APP_ID)) {
+			// No facebook app specified. Continuing would throw an exception.
+			return URL;
+		}
+		$helper = self::getFacebookObj()->getRedirectLoginHelper();
+		$permissions = ['email'];
+		return $helper->GetLoginUrl($this->getRedirectUrl(), $permissions);
+	}
+
+	public function login() : \SocialLogin {
+		$helper = self::getFacebookObj()->getRedirectLoginHelper();
+		$accessToken = $helper->getAccessToken($this->getRedirectUrl());
+		$response = self::getFacebookObj()->get('/me?fields=email', $accessToken);
+		$userInfo = $response->getGraphUser();
+		$this->setCredentials($userInfo->getId(), $userInfo->getEmail());
+		return $this;
+	}
+
+}

--- a/lib/Default/SocialLogins/Twitter.class.php
+++ b/lib/Default/SocialLogins/Twitter.class.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SocialLogins;
+
+class Twitter extends \SocialLogin {
+
+	public static function getLoginType() : string {
+		return 'Twitter';
+	}
+
+	private static function getTwitterObj(?array $token = null) : \Abraham\TwitterOAuth\TwitterOAuth {
+		return new \Abraham\TwitterOAuth\TwitterOAuth(
+			TWITTER_CONSUMER_KEY,
+			TWITTER_CONSUMER_SECRET,
+			$token['oauth_token'] ?? null,
+			$token['oauth_token_secret'] ?? null
+		);
+	}
+
+	public function getLoginUrl() : string {
+		if (empty(TWITTER_CONSUMER_KEY)) {
+			// No twitter app specified. Continuing would throw an exception.
+			return URL;
+		}
+		$auth = self::getTwitterObj();
+		$params = ['oauth_callback' => $this->getRedirectUrl()];
+		$_SESSION['TwitterToken'] = $auth->oauth('oauth/request_token', $params);
+		// 'authenticate' asks for permission only once ('authorize' is every time)
+		return $auth->url('oauth/authenticate', $_SESSION['TwitterToken']);
+	}
+
+	public function login() : \SocialLogin {
+		if ($_SESSION['TwitterToken']['oauth_token'] != $_REQUEST['oauth_token']) {
+			throw new \Exception('Unexpected token received from Twitter');
+		}
+		$helper = self::getTwitterObj($_SESSION['TwitterToken']);
+		$accessToken = $helper->oauth('oauth/access_token',
+		                              ['oauth_verifier' => $_REQUEST['oauth_verifier']]);
+		$auth = self::getTwitterObj($accessToken);
+		$userInfo = $auth->get('account/verify_credentials', ['include_email' => 'true']);
+		if ($auth->getLastHttpCode() == 200) {
+			$this->setCredentials($userInfo->id_str, $userInfo->email);
+		}
+		return $this;
+	}
+
+}

--- a/lib/autoload.inc
+++ b/lib/autoload.inc
@@ -29,6 +29,7 @@ function get_game_dir() {
  * Try to avoid calling this before `$overrideGameID` is set!
  */
 function get_class_loc($className) {
+	$className = str_replace("\\", DIRECTORY_SEPARATOR, $className);
 	$classFile = LIB . get_game_dir() . $className . '.class.php';
 	if (!is_file($classFile)) {
 		// Fallback to Default directory

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -120,10 +120,10 @@
 						<span style="font-size: 14px;">Or register &amp; login with:</span>
 						<br />
 						<span>
-							<a class="btn-social" href="login_social_processing.php?type=<?php echo SocialLogin::FACEBOOK; ?>">
+							<a class="btn-social" href="login_social_processing.php?type=<?php echo SocialLogins\Facebook::getLoginType(); ?>">
 								<img alt="Facebook" src="images/login/facebook.svg" width="32" height="32">
 							</a>
-							<a class="btn-social" href="login_social_processing.php?type=<?php echo SocialLogin::TWITTER; ?>">
+							<a class="btn-social" href="login_social_processing.php?type=<?php echo SocialLogins\Twitter::getLoginType(); ?>">
 								<img alt="Twitter" src="images/login/twitter.svg" width="32" height="32">
 							</a>
 						</span>

--- a/templates/Default/login.inc
+++ b/templates/Default/login.inc
@@ -120,10 +120,10 @@
 						<span style="font-size: 14px;">Or register &amp; login with:</span>
 						<br />
 						<span>
-							<a class="btn-social" href="login_social_processing.php?type=facebook">
+							<a class="btn-social" href="login_social_processing.php?type=<?php echo SocialLogin::FACEBOOK; ?>">
 								<img alt="Facebook" src="images/login/facebook.svg" width="32" height="32">
 							</a>
-							<a class="btn-social" href="login_social_processing.php?type=twitter">
+							<a class="btn-social" href="login_social_processing.php?type=<?php echo SocialLogin::TWITTER; ?>">
 								<img alt="Twitter" src="images/login/twitter.svg" width="32" height="32">
 							</a>
 						</span>


### PR DESCRIPTION
* Add a separate page for displaying account creation via social login. This is necessary so that the display is not part of the processing page, which may have been contributing to errors from invalidated social credentials (e.g. if you refresh the page after you are prompted to create an SMR account).
* Clean up SocialLogin interface by abstracting the class and utilizing a new `SocialLogins` namespace for the derived classes.

Note: The autoloader function needed to be generalized to handle namespaces (which will be in a subdirectory with the same name as the namespace).