### PR TITLE
map_warps.php: fix HTML structure

### DIFF
--- a/htdocs/map_warps.php
+++ b/htdocs/map_warps.php
@@ -51,17 +51,21 @@ try {
 ?>
 
 <!DOCTYPE html>
-<meta charset="utf-8">
+<html>
+	<head>
+		<title><?php echo PAGE_TITLE . ": " . SmrGame::getGame($gameID)->getName(); ?></title>
+		<meta charset="utf-8">
+		<style>
+		body { background-image: url("images/stars2.png"); }
+		</style>
+	</head>
 
-<style>
-body { background-image: url("images/stars2.png"); }
-</style>
-
-<body></body>
-
-<script src="https://d3js.org/d3.v5.min.js"></script>
-<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-<script>
-	const graph = <?php echo $data; ?>;
-</script>
-<script src="js/map_warps.js"></script>
+	<body>
+		<script src="https://d3js.org/d3.v5.min.js"></script>
+		<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+		<script>
+			const graph = <?php echo $data; ?>;
+		</script>
+		<script src="js/map_warps.js"></script>
+	</body>
+</html>


### PR DESCRIPTION
Add low-level tags (html, head, etc.) and place content elements
in the appropriate places (e.g. the `<script>` tags were outside of
`<body>`, which was invalid).

Also add a sensible title to the page.