### PR TITLE
Prevent overwriting planet mounted weapons

### DIFF
--- a/engine/Default/planet_defense_weapon_processing.php
+++ b/engine/Default/planet_defense_weapon_processing.php
@@ -6,13 +6,17 @@ if (!$player->isLandedOnPlanet()) {
 $planet = $player->getSectorPlanet();
 
 if (isset($_REQUEST['transfer'])) {
+	$planetOrderID = $_REQUEST['transfer'];
+	if ($planet->hasMountedWeapon($planetOrderID)) {
+		create_error('The planet already has a weapon mounted there!');
+	}
 	// transfer weapon to planet
-	if (!isset($_REQUEST['ship_order' . $_REQUEST['transfer']])) {
+	if (!isset($_REQUEST['ship_order' . $planetOrderID])) {
 		create_error('You must select a weapon to transfer!');
 	}
-	$shipOrderID = $_REQUEST['ship_order' . $_REQUEST['transfer']];
+	$shipOrderID = $_REQUEST['ship_order' . $planetOrderID];
 	$weaponTypeID = $ship->getWeapons()[$shipOrderID]->getWeaponTypeID();
-	$planet->addMountedWeapon($weaponTypeID, $_REQUEST['transfer']);
+	$planet->addMountedWeapon($weaponTypeID, $planetOrderID);
 	$ship->removeWeapon($shipOrderID);
 } elseif (isset($_REQUEST['destroy'])) {
 	// Destroy the weapon on the planet

--- a/lib/Default/SmrPlanet.class.php
+++ b/lib/Default/SmrPlanet.class.php
@@ -531,48 +531,37 @@ class SmrPlanet {
 		$this->hasChangedWeapons[$orderID] = true;
 	}
 
-	public function moveMountedWeaponUp($orderID) {
+	private function swapMountedWeapons($orderID1, $orderID2) {
 		$this->getMountedWeapons(); // Make sure array is initialized
+		if (isset($this->mountedWeapons[$orderID1])) {
+			$saveWeapon = $this->mountedWeapons[$orderID1];
+		}
+		if (isset($this->mountedWeapons[$orderID2])) {
+			$this->mountedWeapons[$orderID1] = $this->mountedWeapons[$orderID2];
+		} else {
+			unset($this->mountedWeapons[$orderID1]);
+		}
+		if (isset($saveWeapon)) {
+			$this->mountedWeapons[$orderID2] = $saveWeapon;
+		} else {
+			unset($this->mountedWeapons[$orderID2]);
+		}
+		$this->hasChangedWeapons[$orderID1] = true;
+		$this->hasChangedWeapons[$orderID2] = true;
+	}
+
+	public function moveMountedWeaponUp($orderID) {
 		if ($orderID == 0) {
 			throw new Exception('Cannot move this weapon up!');
 		}
-		if (isset($this->mountedWeapons[$orderID - 1])) {
-			$previousWeapon = $this->mountedWeapons[$orderID - 1];
-		}
-		if (isset($this->mountedWeapons[$orderID])) {
-			$this->mountedWeapons[$orderID - 1] = $this->mountedWeapons[$orderID];
-		} else {
-			unset($this->mountedWeapons[$orderID - 1]);
-		}
-		if (isset($previousWeapon)) {
-			$this->mountedWeapons[$orderID] = $previousWeapon;
-		} else {
-			unset($this->mountedWeapons[$orderID]);
-		}
-		$this->hasChangedWeapons[$orderID] = true;
-		$this->hasChangedWeapons[$orderID - 1] = true;
+		$this->swapMountedWeapons($orderID - 1, $orderID);
 	}
 
 	public function moveMountedWeaponDown($orderID) {
-		$this->getMountedWeapons(); // Make sure array is initialized
 		if ($orderID == $this->getMaxMountedWeapons() - 1) {
 			throw new Exception('Cannot move this weapon down!');
 		}
-		if (isset($this->mountedWeapons[$orderID + 1])) {
-			$nextWeapon = $this->mountedWeapons[$orderID + 1];
-		}
-		if (isset($this->mountedWeapons[$orderID])) {
-			$this->mountedWeapons[$orderID + 1] = $this->mountedWeapons[$orderID];
-		} else {
-			unset($this->mountedWeapons[$orderID + 1]);
-		}
-		if (isset($nextWeapon)) {
-			$this->mountedWeapons[$orderID] = $nextWeapon;
-		} else {
-			unset($this->mountedWeapons[$orderID]);
-		}
-		$this->hasChangedWeapons[$orderID] = true;
-		$this->hasChangedWeapons[$orderID + 1] = true;
+		$this->swapMountedWeapons($orderID + 1, $orderID);
 	}
 
 

--- a/lib/Default/SmrPlanet.class.php
+++ b/lib/Default/SmrPlanet.class.php
@@ -514,6 +514,11 @@ class SmrPlanet {
 		return $this->mountedWeapons;
 	}
 
+	public function hasMountedWeapon($orderID) {
+		$this->getMountedWeapons(); // Make sure array is initialized
+		return isset($this->mountedWeapons[$orderID]);
+	}
+
 	public function addMountedWeapon($weaponTypeID, $orderID) {
 		$this->getMountedWeapons(); // Make sure array is initialized
 		$this->mountedWeapons[$orderID] = SmrWeapon::getWeapon($weaponTypeID);


### PR DESCRIPTION
When adding a mounted weapon, it is possible that a weapon has been
added to the selected slot in the time between when the "Defense" page
was rendered and when the "Transfer" button was clicked.

To mitigate this (rare) scenario, the processing script will now raise
an error if the selected slot is already occupied.

Also refactor the common logic from moveMountedWeapon{Up,Down} into a
new function swapMountedWeapons.
