### PR TITLE
forces_drop_processing.php: don't error on empty

### DIFF
--- a/engine/Default/forces_drop_processing.php
+++ b/engine/Default/forces_drop_processing.php
@@ -15,7 +15,11 @@ if ($sector->hasLocation()) {
 function getInputAmount($name) {
 	global $var;
 	$value = $var[$name] ?? ($_REQUEST[$name] ?? 0);
-	// Any non-numeric value is bypassing the HTML5 input type
+	// Empty strings are a valid HTML5 "number" input type value
+	if (empty($value)) {
+		$value = 0;
+	}
+	// Any other non-numeric value is bypassing the HTML5 input type validator
 	if (!is_numeric($value)) {
 		throw new Exception('Expected numeric value for ' . $name . ', got ' . $value);
 	}


### PR DESCRIPTION
This fixes an error that players would get when they leave an input
field on the forces_drop.php page blank.

In 4452a2dba9f, this script was modified to simplify the checks on
the input fields with the addition of the "number" HTML5 input types.
However, empty strings are valid HTML5 "number" type values, and this
was not accounted for in the PHP validation logic.

Add in an explicit check to set the value to "0" if the input value
is the empty string.