### PR TITLE
Fix Galaxy Map showing traders on planets

### DIFF
--- a/lib/Default/SmrPlayer.class.php
+++ b/lib/Default/SmrPlayer.class.php
@@ -64,9 +64,14 @@ class SmrPlayer extends AbstractSmrPlayer {
 		return $players;
 	}
 
+	/**
+	 * Returns the same players as getSectorPlayers (e.g. not on planets),
+	 * but for an entire galaxy rather than a single sector. This is useful
+	 * for reducing the number of queries in galaxy-wide processing.
+	 */
 	public static function getGalaxyPlayers($gameID, $galaxyID, $forceUpdate = false) {
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT player.*, sector_id FROM sector LEFT JOIN player USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$db->query('SELECT player.*, sector_id FROM sector LEFT JOIN player USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(false) . ' AND (last_cpl_action > ' . $db->escapeNumber(TIME - TIME_BEFORE_INACTIVE) . ' OR newbie_turns = 0) AND galaxy_id = ' . $db->escapeNumber($galaxyID));
 		$galaxyPlayers = [];
 		while ($db->nextRecord()) {
 			$sectorID = $db->getInt('sector_id');


### PR DESCRIPTION
Significant optimizations were made to the Galaxy Map in 8379956c5,
including a new function `SmrPlayer::getGalaxyPlayers`, which used a
single database query to cache the results for all subsequent calls
to `SmrPlayer::getSectorPlayers` (to avoid making a separate database
query for each sector in the galaxy).

The optimization is fine in principle, but `getGalaxyPlayers` was
caching the wrong results because the query was not identical to the
one in `getSectorPlayers`. Most importantly, it didn't exclude players
on planets, and so the Galaxy Map was incorrectly displaying them
(even enemy players, which had serious gameplay implications).

The fix is simply to make sure the queries between the two functions
in SmrPlayer are consistent.