### PR TITLE
Improve Smr{Port,Planet}::checkForDowngrade

### DIFF
--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -568,16 +568,20 @@ class AbstractSmrPort {
 		$this->db->query('DELETE FROM port_has_goods WHERE ' . $this->SQL . ' AND good_id=' . $this->db->escapeNumber($goodID) . ';');
 		$this->db->query('DELETE FROM route_cache WHERE game_id=' . $this->db->escapeNumber($this->getGameID()));
 	}
-	
-	public function checkForDowngrade($damageDone) {
-		$downgrades = 0;
-		for (;$damageDone > self::DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE; $damageDone -= self::DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE) {
+
+	/**
+	 * Returns the number of port level downgrades due to damage taken.
+	 */
+	public function checkForDowngrade($damage) : int {
+		$numDowngrades = 0;
+		$numChances = floor($damage / self::DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE);
+		for ($i = 0; $i < $numChances; $i++) {
 			if (mt_rand(1, 100) <= self::CHANCE_TO_DOWNGRADE && $this->level > 1) {
-				++$downgrades;
+				++$numDowngrades;
 				$this->doDowngrade();
 			}
 		}
-		return $downgrades;
+		return $numDowngrades;
 	}
 	
 	protected function selectAndRemoveGood($goodClass) {

--- a/lib/Default/SmrPlanet.class.php
+++ b/lib/Default/SmrPlanet.class.php
@@ -1170,12 +1170,16 @@ class SmrPlanet {
 		return $results;
 	}
 
-	public function &checkForDowngrade($damage) {
-		$results = '';
+	/**
+	 * Returns an array of structure losses due to damage taken.
+	 */
+	public function checkForDowngrade($damage) : array {
+		$results = [];
 		// For every 70 damage there is a 15% chance of destroying a structure.
 		// Which structure is destroyed depends on the ratio of buildings and
 		// the time it takes to build them.
-		for ($i = 0; $damage > self::DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE; $damage -= self::DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE) {
+		$numChances = floor($damage / self::DAMAGE_NEEDED_FOR_DOWNGRADE_CHANCE);
+		for ($i = 0; $i < $numChances; $i++) {
 			// Stop if the planet has no more buildlings
 			if ($this->getLevel() == 0) {
 				break;
@@ -1189,7 +1193,11 @@ class SmrPlanet {
 				$destroyID = getWeightedRandom($chanceFactors);
 				$this->destroyBuilding($destroyID, 1);
 				$this->checkForExcessDefense();
-				$results .= 'This team destroys <span class="red">1</span> ' . $this->getStructureTypes($destroyID)->name() . '.<br />';
+				if (isset($results[$destroyID])) {
+					$results[$destroyID] += 1;
+				} else {
+					$results[$destroyID] = 1;
+				}
 			}
 		}
 		return $results;

--- a/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc
@@ -131,6 +131,6 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 }
 $TotalDamage = $TraderTeamCombatResults['TotalDamage']; ?>
 This fleet <?php if($TotalDamage > 0){ ?>hits for a total of <span class="red"><?php echo $TotalDamage ?></span> damage in this round of combat<?php } else{ ?>does no damage this round. You call that a fleet? They need a better recruiter<?php } ?>.<br /><?php
-if($TraderTeamCombatResults['Downgrades']) {
-	echo $TraderTeamCombatResults['Downgrades'];
+foreach ($TraderTeamCombatResults['Downgrades'] as $structureID => $numDestroyed) { ?>
+	This team destroys <span class="red"><?php echo $numDestroyed; ?> </span><?php echo pluralise($TargetPlanet->getStructureTypes($structureID)->name(), $numDestroyed); ?>.<br /><?php
 } ?>


### PR DESCRIPTION
* Determine the number of downgrade chances up front to simplify the
  looping condition.

* For SmrPlanet, return an array instead of an HTML string so that
  we can report total structure losses. (E.g., instead of repeating
  "This team destroys 1 generator" 3 times, it will simply say
  "This team destroys 3 generators" once.)

![image](https://user-images.githubusercontent.com/846186/66960432-498bda80-f021-11e9-898b-0b5d530d9b0e.png)
