### PR TITLE
Add user IP address to the bug report

### DIFF
--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -23,8 +23,9 @@ function logException(Throwable $e) {
 
 	$message .=
 		'$var: ' . var_export($var, true) . $delim .
+		'User IP: ' . getIpAddress() . "\n" .
 		'USING_AJAX: ' . (defined('USING_AJAX') ? var_export(USING_AJAX, true) : 'undefined') . "\n" .
-		'URL: ' . (defined('URL') ? var_export(URL, true) : 'undefined');
+		'URL: ' . (defined('URL') ? URL : 'undefined');
 
 	try {
 		if (function_exists('release_lock')) {
@@ -112,6 +113,19 @@ function setupMailer() {
 		$mail->Host = SMTP_HOSTNAME;
 	}
 	return $mail;
+}
+
+function getIpAddress() {
+	foreach (['HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED', 'REMOTE_ADDR'] as $key) {
+		if (array_key_exists($key, $_SERVER) === true) {
+			foreach (explode(',', $_SERVER[$key]) as $ip) {
+				if (filter_var($ip, FILTER_VALIDATE_IP) !== false) {
+					return $ip;
+				}
+			}
+		}
+	}
+	return 'unknown';
 }
 
 function dumpMemDiff($msg) {

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -385,18 +385,6 @@ function pluralise($word, $count = 0) {
 	return $word . 's';
 }
 
-function getIpAddress() {
-    foreach (array('HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED', 'REMOTE_ADDR') as $key) {
-        if (array_key_exists($key, $_SERVER) === true) {
-            foreach (explode(',', $_SERVER[$key]) as $ip) {
-                if (filter_var($ip, FILTER_VALIDATE_IP) !== false) {
-                    return $ip;
-                }
-            }
-        }
-    }
-}
-
 /**
  * This function is a hack around the old style http forward mechanism.
  * It is also responsible for setting most of the global variables


### PR DESCRIPTION
This information is helpful for debugging anonymous bug reports
(i.e. automatic reports that are triggered before logging in).

Added a fallback to the `getIpAddress` function in case none of
the expected `$_SERVER` keys are available. In this case it will
display "unknown".