### PR TITLE
Fix unescaped HTML special characters in HoF names

### DIFF
--- a/admin/Default/album_approve.php
+++ b/admin/Default/album_approve.php
@@ -4,7 +4,7 @@ function get_album_nick($album_id) {
 	if ($album_id == 0)
 		return 'System';
 
-	return SmrAccount::getAccount($album_id)->getHofName();
+	return SmrAccount::getAccount($album_id)->getHofDisplayName();
 }
 
 $template->assign('PageTopic', 'Approve Album Entries');

--- a/engine/Default/album_edit.php
+++ b/engine/Default/album_edit.php
@@ -19,7 +19,7 @@ if ($db->nextRecord()) {
 	} elseif ($db->getBoolean('disabled')) {
 		$albumEntry['Status'] = ('<span class="red">Disabled</span>');
 	} elseif ($approved == 'YES') {
-		$albumEntry['Status'] = ('<a href="album/?' . $account->getHofName() . '" class="dgreen">Online</a>');
+		$albumEntry['Status'] = ('<a href="album/?nick=' . urlencode($account->getHofName()) . '" class="dgreen">Online</a>');
 	}
 		
 	if (is_readable(UPLOAD . $account->getAccountID())) {

--- a/engine/Default/chat_sharing.php
+++ b/engine/Default/chat_sharing.php
@@ -19,7 +19,7 @@ while ($db->nextRecord()) {
 	$shareFrom[$fromAccountId] = array(
 		'Player ID'   => $otherPlayer == null ? '-' : $otherPlayer->getPlayerID(),
 		'Player Name' => $otherPlayer == null ?
-		                 '<b>Account</b>: ' . SmrAccount::getAccount($fromAccountId)->getHofName() :
+		                 '<b>Account</b>: ' . SmrAccount::getAccount($fromAccountId)->getHofDisplayName() :
 		                 $otherPlayer->getPlayerName(),
 		'All Games'   => $gameId == 0 ? '<span class="green">YES</span>' : '<span class="red">NO</span>',
 		'Game ID'     => $gameId,
@@ -40,7 +40,7 @@ while ($db->nextRecord()) {
 	$shareTo[$toAccountId] = array(
 		'Player ID'   => $otherPlayer == null ? '-' : $otherPlayer->getPlayerID(),
 		'Player Name' => $otherPlayer == null ?
-		                 '<b>Account</b>: ' . SmrAccount::getAccount($toAccountId)->getHofName() :
+		                 '<b>Account</b>: ' . SmrAccount::getAccount($toAccountId)->getHofDisplayName() :
 		                 $otherPlayer->getPlayerName(),
 		'All Games'   => $gameId == 0 ? '<span class="green">YES</span>' : '<span class="red">NO</span>',
 		'Game ID'     => $gameId,

--- a/engine/Default/hall_of_fame_player_detail.php
+++ b/engine/Default/hall_of_fame_player_detail.php
@@ -19,7 +19,7 @@ if (isset($var['game_id'])) {
 	}
 	$template->assign('PageTopic', $hofPlayer->getPlayerName() . '\'s Personal Hall of Fame: ' . SmrGame::getGame($game_id)->getDisplayName());
 } else {
-	$hofName = SmrAccount::getAccount($account_id)->getHofName();
+	$hofName = SmrAccount::getAccount($account_id)->getHofDisplayName();
 	$template->assign('PageTopic', $hofName . '\'s All Time Personal Hall of Fame');
 }
 

--- a/engine/Default/preferences.php
+++ b/engine/Default/preferences.php
@@ -12,16 +12,8 @@ $template->assign('PreferencesConfirmFormHREF', SmrSession::getNewHREF(create_co
 $template->assign('ChatSharingHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'chat_sharing.php')));
 
 $transferAccounts = array();
-//if(SmrSession::hasGame()) {
-//	$db->query('SELECT account_id,player_name,player_id FROM player WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY player_name');
-//	while ($db->nextRecord()) {
-//		$transferAccounts[$db->getField('account_id')] = $db->getField('player_name') .' ('. $db->getField('player_id').')';
-//	}
-//}
-//else {
-	$db->query('SELECT account_id,hof_name FROM account WHERE validated = ' . $db->escapeBoolean(true) . ' ORDER BY hof_name');
-	while ($db->nextRecord()) {
-		$transferAccounts[$db->getField('account_id')] = $db->getField('hof_name');
-	}
-//}
+$db->query('SELECT account_id,hof_name FROM account WHERE validated = ' . $db->escapeBoolean(true) . ' ORDER BY hof_name');
+while ($db->nextRecord()) {
+	$transferAccounts[$db->getInt('account_id')] = htmlspecialchars($db->getField('hof_name'));
+}
 $template->assign('TransferAccounts', $transferAccounts);

--- a/engine/Default/preferences_confirm.php
+++ b/engine/Default/preferences_confirm.php
@@ -19,7 +19,7 @@ if ($amount > $account->getSmrCredits()) {
 
 $template->assign('PageTopic', 'Confirmation');
 $template->assign('Amount', $amount);
-$template->assign('HofName', SmrAccount::getAccount($account_id)->getHofName());
+$template->assign('HofName', SmrAccount::getAccount($account_id)->getHofDisplayName());
 
 $container = create_container('preferences_processing.php');
 $container['account_id'] = $account_id;

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -741,12 +741,21 @@ abstract class AbstractSmrAccount {
 		return CSS_COLOUR_URLS[$this->getTemplate()][$this->getColourScheme()];
 	}
 
-	public function getHofName($linked=false) {
+	/**
+	 * The Hall Of Fame name is not html-escaped in the database, so to display
+	 * it correctly we must escape html entities.
+	 */
+	public function getHofDisplayName($linked=false) {
+		$hofDisplayName = htmlspecialchars($this->getHofName());
 		if ($linked) {
-			return '<a href="' . $this->getPersonalHofHREF() . '">' . $this->hofName . '</a>';
+			return '<a href="' . $this->getPersonalHofHREF() . '">' . $hofDisplayName . '</a>';
 		} else {
-			return $this->hofName;
+			return $hofDisplayName;
 		}
+	}
+
+	public function getHofName() {
+		return $this->hofName;
 	}
 
 	public function setHofName($name) {

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -138,7 +138,7 @@ function displayHOFRow($rank, $accountID, $amount) {
 	if (isset($hofPlayer) && is_object($hofPlayer)) {
 		$return .= ('<td ' . $bold . '>' . create_link($container, $hofPlayer->getPlayerName()) . '</td>');
 	} else if (isset($hofAccount) && is_object($hofAccount)) {
-		$return .= ('<td ' . $bold . '>' . create_link($container, $hofAccount->getHofName()) . '</td>');
+		$return .= ('<td ' . $bold . '>' . create_link($container, $hofAccount->getHofDisplayName()) . '</td>');
 	} else {
 		$return .= ('<td ' . $bold . '>Unknown</td>');
 	}

--- a/templates/Default/admin/Default/account_edit.php
+++ b/templates/Default/admin/Default/account_edit.php
@@ -44,7 +44,7 @@
 			<td class="right bold">HoF Name:</td>
 			<td><?php
 				if (isset($EditingAccount)) {
-					echo $EditingAccount->getHofName();
+					echo $EditingAccount->getHofDisplayName();
 				} else { ?>
 					<input type="text" name="hofname" class="InputFields" size="20"><?php
 				} ?>

--- a/templates/Default/engine/Default/album_edit.php
+++ b/templates/Default/engine/Default/album_edit.php
@@ -11,7 +11,7 @@ Your image will be posted under your <i>Hall Of Fame</i> nick!<br />
 	<table>
 		<tr>
 			<td class="right bold">Nick:</td>
-			<td><?php echo $ThisAccount->getHofName(); ?></td>
+			<td><?php echo $ThisAccount->getHofDisplayName(); ?></td>
 		</tr>
 		
 		<tr>

--- a/templates/Default/engine/Default/alliance_pick.php
+++ b/templates/Default/engine/Default/alliance_pick.php
@@ -57,7 +57,7 @@ if (count($PickPlayers) > 0) { ?>
 					<?php echo $PickPlayer['Player']->getRaceName(); ?>
 				</td>
 				<td>
-					<?php echo $PickPlayer['Player']->getAccount()->getHofName(true); ?>
+					<?php echo $PickPlayer['Player']->getAccount()->getHofDisplayName(true); ?>
 				</td>
 				<td>
 					<?php echo $PickPlayer['Player']->getAccount()->getScore(); ?>
@@ -90,7 +90,7 @@ if (count($History) > 0) { ?>
 				<td><?php echo date(DATE_FULL_SHORT, $Pick['Time']); ?></td>
 				<td><?php echo $Pick['Player']->getPlayerName(); ?></td>
 				<td><?php echo $Pick['Player']->getRaceName(); ?></td>
-				<td><?php echo $Pick['Player']->getAccount()->getHofName(true); ?></td>
+				<td><?php echo $Pick['Player']->getAccount()->getHofDisplayName(true); ?></td>
 				<td><?php echo $Pick['Player']->getAccount()->getScore(); ?></td>
 			</tr><?php
 		} ?>

--- a/templates/Default/engine/Default/feature_request_comments.php
+++ b/templates/Default/engine/Default/feature_request_comments.php
@@ -12,7 +12,7 @@ if (isset($Comments)) { ?>
 				if ($Comment['Anonymous']) {
 					?>Anonymous<?php
 				} else {
-					echo $Comment['PosterAccount']->getHofName();
+					echo $Comment['PosterAccount']->getHofDisplayName();
 				}
 				if ($FeatureModerator) {
 					?> - <?php echo $Comment['PosterAccount']->getLogin(); ?>&nbsp;(<?php echo $Comment['PosterAccount']->getAccountID(); ?>)</td><?php

--- a/templates/Default/engine/Default/includes/HallOfFame.inc
+++ b/templates/Default/engine/Default/includes/HallOfFame.inc
@@ -1,5 +1,5 @@
 <div class="center">
-	Welcome to the Hall of Fame, <?php echo $ThisAccount->getHofName(); ?>!<br />
+	Welcome to the Hall of Fame, <?php echo $ThisAccount->getHofDisplayName(); ?>!<br />
 	The Hall of Fame is a comprehensive list of player accomplishments.
 	Here you can view how players rank in many different aspects of the game.<?php
 	if (isset($PersonalHofHREF)) { ?>

--- a/templates/Default/engine/Default/preferences.php
+++ b/templates/Default/engine/Default/preferences.php
@@ -172,7 +172,7 @@ if (isset($GameID)) { ?>
 
 		<tr>
 			<td>Hall of Fame Name:</td>
-			<td><input type="text" name="HoF_name" value="<?php echo htmlspecialchars($ThisAccount->getHofName()); ?>" class="InputFields" size="50" /></td>
+			<td><input type="text" name="HoF_name" value="<?php echo $ThisAccount->getHofDisplayName(); ?>" class="InputFields" size="50" /></td>
 		</tr>
 		
 		<tr>
@@ -419,8 +419,8 @@ if (isset($GameID)) { ?>
 			<td>
 				<input type="number" name="amount" class="InputFields center" style="width:50px;" /> credits to <?php if (!isset($GameID)) { ?>the account with HoF name of <?php } ?>
 				<select name="account_id" class="InputFields"><?php
-					foreach ($TransferAccounts as $AccID => $AccOrPlayerName) {
-						?><option value="<?php echo $AccID; ?>"><?php echo $AccOrPlayerName; ?></option><?php
+					foreach ($TransferAccounts as $AccID => $HofDisplayName) {
+						?><option value="<?php echo $AccID; ?>"><?php echo $HofDisplayName; ?></option><?php
 					} ?>
 				</select>
 			</td>


### PR DESCRIPTION
Add a new function `SmrAccount::getHofDisplayName`, which returns the
HoF name in a form that is suitable for display (i.e. all HTML special
characters are escaped). The existing `SmrAccount::getHofName` returns
only the raw HoF name.

Most notably, there are some HoF names that use the `&`, which when
displayed unescaped causes DOMDocument to issue a warning.

Also fixed the link to the user's album page on the "Edit Photo" page.
It was missing the `nick` query string param added in 9e11f611990a5f5.
It is also now url-encoded.