### PR TITLE
Improve error reporting and NPCs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,11 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 COPY composer.json .
 RUN composer install --no-interaction
 
-# Use the production php.ini unless PHP_DEBUG=1 (defaults to 0)
+# Set the baseline php.ini version based on the value of PHP_DEBUG
 ARG PHP_DEBUG=0
-RUN [ "$PHP_DEBUG" = "1" ] && echo "Using development php.ini" || \
-	{ echo "Using production php.ini" && \
-	  tar -xOvf /usr/src/php.tar.xz php-$PHP_VERSION/php.ini-production > /usr/local/etc/php/php.ini; \
-	}
+RUN MODE=$([ "$PHP_DEBUG" == "0" ] && echo "production" || echo "development") && \
+	echo "Using $MODE php.ini" && \
+	tar -xOvf /usr/src/php.tar.xz php-$PHP_VERSION/php.ini-$MODE > /usr/local/etc/php/php.ini
 
 COPY --from=builder /smr .
 RUN rm -rf /var/www/html/ && ln -s "$(pwd)/htdocs" /var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,7 @@ services:
             - "traefik.enable=false"
         depends_on:
             - mysql
+            - smtp
         volumes:
             - ./config:/smr/config
 

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -40,13 +40,20 @@ function logException(Throwable $e) {
 		}
 	}
 
-	if (defined('NPC_SCRIPT')) {
-		echo 'Script: ' . SCRIPT_ID . $delim . $message . "\n\n";
-		return;
+	if (defined('SCRIPT_ID')) {
+		$message = 'Script: ' . SCRIPT_ID . $delim . $message . "\n\n";
 	}
 
 	// Unconditionally send error message to the log
 	error_log($message);
+
+	if (defined('NPC_SCRIPT')) {
+		echo $message;
+		// In debug mode, we normally exit, but NPCs must cleanup after an error
+		if (ENABLE_DEBUG) {
+			return;
+		}
+	}
 
 	if (ENABLE_DEBUG) {
 		// Display error message on the page and then exit

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -1,6 +1,8 @@
 <?php
 ini_set('date.timezone', 'UTC');
+error_reporting(E_ALL);
 
+// Must use define so that the time is evaluated at runtime, not compile time.
 define('MICRO_TIME', microtime(true));
 define('TIME', intval(MICRO_TIME));
 
@@ -17,11 +19,6 @@ const TEMPLATES_DIR = ROOT . 'templates/';
 
 // Define server-specific constants
 require_once(CONFIG . 'config.specific.php');
-
-if (ENABLE_DEBUG) {
-	// Warn about everything when in debug mode
-	error_reporting(E_ALL);
-}
 
 if (ENABLE_BETA && !ENABLE_DEBUG) {
 	// Everything raises an exception in beta mode (for e-mail notifications).

--- a/lib/Default/SmrSession.class.php
+++ b/lib/Default/SmrSession.class.php
@@ -163,7 +163,9 @@ class SmrSession {
 				self::$session_id = md5(uniqid(mt_rand()));
 				self::$db->query('SELECT 1 FROM active_session WHERE session_id = ' . self::$db->escapeString(self::$session_id) . ' LIMIT 1');
 			} while (self::$db->nextRecord()); //Make sure we haven't somehow clashed with someone else's session.
-			setcookie('session_id', self::$session_id);
+			if (!defined('NPC_SCRIPT')) {
+				setcookie('session_id', self::$session_id);
+			}
 		}
 
 		// try to get current session

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -77,10 +77,6 @@ const SHIP_UPGRADE_PATH = array(
 
 
 try {
-	// Initialize the SmrSession before any output to avoid a warning about
-	// setcookie sending headers after output has started.
-	SmrSession::init();
-
 	$db = new SmrMySqlDatabase();
 	debug('Script started');
 
@@ -382,6 +378,7 @@ function releaseNPC() {
 	} else {
 		debug('Failed to release NPC: ' . $login);
 	}
+	SmrSession::destroy();
 }
 
 function exitNPC() {
@@ -432,6 +429,7 @@ function changeNPCLogin() {
 
 	// Update session info for this chosen NPC
 	$account = SmrAccount::getAccount($npc['account_id']);
+	SmrSession::init();
 	SmrSession::setAccount($account);
 	SmrSession::updateGame($npc['game_id']);
 

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -32,6 +32,10 @@ require_once(CONFIG . 'npc/config.specific.php');
 require_once(get_file_loc('smr.inc'));
 require_once(get_file_loc('shop_goods.inc'));
 
+// Raise exceptions for all types of errors for improved error reporting
+// and to attempt to shut down the NPCs cleanly on errors.
+set_error_handler("exception_error_handler");
+
 const SHIP_UPGRADE_PATH = array(
 	RACE_ALSKANT => array(
 		SHIP_TYPE_TRADE_MASTER,


### PR DESCRIPTION
* Switch to the development php.ini instead of using the default php ini values when `PHP_DEBUG=1`.
* Use `E_ALL` for all modes (debug, beta, live).
* npc.php: 
  - Try to convert all error events into exceptions so that we can shut down NPCs cleanly.
  - Fix some issues with NPC error messages, and allow errors to be logged in-game an by e-mail.