### PR TITLE
add trap to catch accuracy 100 or greater

### DIFF
--- a/lib/Default/SmrWeapon.class.php
+++ b/lib/Default/SmrWeapon.class.php
@@ -108,6 +108,12 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	 * Given $weaponAccuracy as a percent, decide if the weapon hits.
 	 */
 	protected function checkHit(AbstractSmrPlayer $player, $weaponAccuracy) : bool {
+		// Skip weighting factor for absolute hits/misses.
+		if ($weaponAccuracy >= 100) {
+			return true;
+		} elseif ($weaponAccuracy <= 0) {
+			return false;
+		}
 		return $this->getWeightedRandomForPlayer($player)->flipWeightedCoin($weaponAccuracy);
 	}
 	

--- a/lib/Default/WeightedRandom.class.php
+++ b/lib/Default/WeightedRandom.class.php
@@ -88,6 +88,10 @@ class WeightedRandom {
 	 * reduce that chance by the current weighting, and then check the result.
 	 */
 	public function flipWeightedCoin($successChance) : bool {
+		// The weighting update formulas below only work in the range [0, 100].
+		$successChance = min(100, max(0, $successChance));
+
+		// Check if the event was successful.
 		$success = mt_rand(1, 100) + $this->weighting <= $successChance;
 
 		// Now update the weighting (the extra factor is needed to achieve the


### PR DESCRIPTION
when firing at 100 or greater accuracy there is no need for a weighted random roll.  the shot is already guaranteed to hit.  simply reporting the hit saves resources and should prevent the weight from being adjusted the wrong way.