### PR TITLE
Update to PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - '7.3'
+  - '7.4'
 git:
   depth: false
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN rm -rf node_modules
 
 #---------------------------
 
-FROM php:7.3-apache
+FROM php:7.4-apache
 RUN apt-get update \
 	&& apt-get install -y zip unzip \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "require": {
         "abraham/twitteroauth": "^1.0",
         "ext-curl": "*",
-        "ext-json": "^1.0.0",
+        "ext-json": "*",
         "ext-mysqli": "*",
         "facebook/graph-sdk": "^5.5.0",
         "google/recaptcha": "^1.1",
-        "php": "^7.3",
-        "phpmailer/phpmailer": "^6.0",
+        "php": "^7.4",
+        "phpmailer/phpmailer": "^6.1",
         "vanilla/nbbc": "^2.0"
     }
 }

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,10 +1,12 @@
-FROM php:7.3-cli-alpine as builder
+FROM php:7.4-cli-alpine as builder
 
 # Install phpDox - https://github.com/theseer/phpdox
+# - dependency: gcrypt (missing prereq for libxslt-dev)
 # - dependency: XSL
 # - dependency: git (for composer and git enricher)
 
 RUN apk upgrade --update && apk add --no-cache \
+    libgcrypt-dev \
     libxslt-dev \
     git \
     && docker-php-ext-install xsl

--- a/tools/discord/Dockerfile
+++ b/tools/discord/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli-alpine
+FROM php:7.4-cli-alpine
 
 RUN docker-php-ext-install mysqli
 

--- a/tools/discord/composer.json
+++ b/tools/discord/composer.json
@@ -4,7 +4,7 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "php": "~7.3",
+        "php": "^7.4",
         "team-reflex/discord-php": "*"
     }
 }

--- a/tools/irc/Dockerfile
+++ b/tools/irc/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli-alpine
+FROM php:7.4-cli-alpine
 
 RUN docker-php-ext-install mysqli
 

--- a/tools/irc/composer.json
+++ b/tools/irc/composer.json
@@ -4,6 +4,6 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "php": "~7.3"
+        "php": "^7.4"
     }
 }

--- a/tools/npc/Dockerfile
+++ b/tools/npc/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli-alpine
+FROM php:7.4-cli-alpine
 
 RUN docker-php-ext-install mysqli
 
@@ -8,7 +8,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 # Install an extension for redefining constants
 # (The .build-deps package group is needed to run `pecl install`)
 RUN apk add --no-cache --virtual .build-deps pcre-dev ${PHPIZE_DEPS} \
-	&& pecl install uopz-6.0.1 \
+	&& pecl install uopz-6.1.1 \
 	&& docker-php-ext-enable uopz \
 	&& apk del .build-deps
 

--- a/tools/npc/composer.json
+++ b/tools/npc/composer.json
@@ -4,6 +4,6 @@
     "license": "AGPL-3.0",
     "require": {
         "ext-mysqli": "*",
-        "php": "~7.3"
+        "php": "^7.4"
     }
 }


### PR DESCRIPTION
- Use "*" for ext-json dependency in composer.json since this extension
  comes packaged with PHP and has switched to a versioning scheme that
  mirrors the PHP version number.

- Update phpmailer minimum version in composer.json to 6.1.0, which
  is the first version that tests against PHP 7.4.

- Install gcrypt package in docs/Dockerfile because the new XSL package
  has incorrectly omitted it as a dependency. Otherwise, it has build
  errors:
    ld: cannot find -lgcrypt
    ld: cannot find -lgpg-error

- Change version constraint operator in discord/irc/npc composer.json
  files from "~" to "^" as per 5e903dadacdfeceba46.

- Update uopz from 6.0.1 -> 6.1.1, which adds PHP 7.4 support.