### PR TITLE
Improve types from database queries

### DIFF
--- a/admin/Default/account_edit.php
+++ b/admin/Default/account_edit.php
@@ -46,7 +46,7 @@ if ($action == "Search") {
 									   'hof_name LIKE ' . $db->escapeString($var['hofname']) . ' OR ' .
 									   'validation_code LIKE ' . $db->escapeString($var['val_code']));
 	if ($db->nextRecord()) {
-		$curr_account = SmrAccount::getAccount($db->getField('account_id'));
+		$curr_account = SmrAccount::getAccount($db->getInt('account_id'));
 	} else {
 		SmrSession::updateVar('errorMsg', 'No matching accounts were found!');
 	}

--- a/admin/Default/admin_message_send.php
+++ b/admin/Default/admin_message_send.php
@@ -25,7 +25,7 @@ if (empty($gameID)) {
 		$gamePlayers = array();
 		$db->query('SELECT account_id,player_id,player_name FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY player_name');
 		while ($db->nextRecord()) {
-			$gamePlayers[] = array('AccountID' => $db->getField('account_id'), 'PlayerID' => $db->getField('player_id'), 'Name' => $db->getField('player_name'));
+			$gamePlayers[] = array('AccountID' => $db->getInt('account_id'), 'PlayerID' => $db->getInt('player_id'), 'Name' => $db->getField('player_name'));
 		}
 		$template->assign('GamePlayers', $gamePlayers);
 	}

--- a/admin/Default/admin_message_send_processing.php
+++ b/admin/Default/admin_message_send_processing.php
@@ -29,7 +29,7 @@ if (isset($_REQUEST['account_id']) || $game_id == 20000) {
 		//send to all players in games that haven't ended yet
 		$db->query('SELECT game_id,account_id FROM player JOIN game USING(game_id) WHERE end_time > ' . $db->escapeNumber(TIME));
 		while ($db->nextRecord()) {
-			SmrPlayer::sendMessageFromAdmin($db->getField('game_id'), $db->getField('account_id'), $message, $expire);
+			SmrPlayer::sendMessageFromAdmin($db->getInt('game_id'), $db->getInt('account_id'), $message, $expire);
 		}
 	}
 	$msg = '<span class="green">SUCCESS: </span>Your message has been sent.';

--- a/admin/Default/album_moderate_processing.php
+++ b/admin/Default/album_moderate_processing.php
@@ -11,7 +11,7 @@ if ($var['task'] == 'reset_image') {
 	$db->lockTable('album_has_comments');
 	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($account_id));
 	if ($db->nextRecord())
-		$comment_id = $db->getField('MAX(comment_id)') + 1;
+		$comment_id = $db->getInt('MAX(comment_id)') + 1;
 	else
 		$comment_id = 1;
 

--- a/admin/Default/anon_acc_view.php
+++ b/admin/Default/anon_acc_view.php
@@ -23,7 +23,7 @@ if ($haveIDs) {
 		$rows[] = [
 			'player_name' => $db->getField('player_name'),
 			'transaction' => $db->getField('transaction'),
-			'amount' => $db->getField('amount'),
+			'amount' => $db->getInt('amount'),
 		];
 	}
 	$template->assign('Rows', $rows);

--- a/admin/Default/box_view.php
+++ b/admin/Default/box_view.php
@@ -65,7 +65,7 @@ if (!isset($var['box_type_id'])) {
 				$messages[$messageID]['GameName'] = SmrGame::getGame($gameID)->getDisplayName();
 			}
 
-			$messages[$messageID]['SendTime'] = date(DATE_FULL_SHORT, $db->getField('send_time'));
+			$messages[$messageID]['SendTime'] = date(DATE_FULL_SHORT, $db->getInt('send_time'));
 			$messages[$messageID]['Message'] = bbifyMessage(htmliseMessage($db->getField('message_text')));
 		}
 		$template->assign('Messages', $messages);

--- a/admin/Default/changelog_add_processing.php
+++ b/admin/Default/changelog_add_processing.php
@@ -20,7 +20,7 @@ $db->query('SELECT MAX(changelog_id)
 			WHERE version_id = ' . $db->escapeNumber($var['version_id'])
 		   );
 if ($db->nextRecord()) {
-	$changelog_id = $db->getField('MAX(changelog_id)') + 1;
+	$changelog_id = $db->getInt('MAX(changelog_id)') + 1;
 } else {
 	$changelog_id = 1;
 }

--- a/admin/Default/comp_share.php
+++ b/admin/Default/comp_share.php
@@ -27,7 +27,7 @@ while ($db->nextRecord()) {
 	//how many are they linked to?
 	$rows = count($accountIDs);
 
-	$currTabAccId = $db->getField('account_id');
+	$currTabAccId = $db->getInt('account_id');
 
 	//if this account was listed with another we can skip it.
 	if (isset($used[$currTabAccId])) {
@@ -69,7 +69,7 @@ while ($db->nextRecord()) {
 			$email = $db2->getField('email');
 			$valid = $db2->getBoolean('validated') ? 'Valid' : 'Invalid';
 			$common_ip = $db2->getField('common_ip');
-			$last_login = date(DATE_FULL_SHORT, $db2->getField('last_login'));
+			$last_login = date(DATE_FULL_SHORT, $db2->getInt('last_login'));
 
 			$db2->query('SELECT * FROM account_is_closed WHERE account_id = ' . $db2->escapeNumber($currLinkAccId));
 			$isDisabled = $db2->nextRecord();

--- a/admin/Default/game_delete_processing.php
+++ b/admin/Default/game_delete_processing.php
@@ -77,9 +77,9 @@ if ($action == 'Yes') {
 		$db->query('SELECT * FROM alliance_vs_alliance WHERE game_id = '.$db->escapeNumber($game_id));
 		while ($db->nextRecord()) {
 
-			$alliance_1 = $db->getField('alliance_id_1');
-			$alliance_2 = $db->getField('alliance_id_2');
-			$kills = $db->getField('kills');
+			$alliance_1 = $db->getInt('alliance_id_1');
+			$alliance_2 = $db->getInt('alliance_id_2');
+			$kills = $db->getInt('kills');
 			$history_db_sql[] = 'INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) ' .
 								'VALUES ('.$game_id.', '.$alliance_1.', '.$alliance_2.', '.$kills.')';
 
@@ -120,7 +120,7 @@ if ($action == 'Yes') {
 		while ($db->nextRecord()) {
 
 			// get info we want
-			$time = $db->getField('time');
+			$time = $db->getInt('time');
 			$msg = $db->getField('news_message');
 
 			// insert into history db
@@ -139,19 +139,19 @@ if ($action == 'Yes') {
 		while ($db->nextRecord()) {
 
 			// get info we want
-			$sector = $db->getField('sector_id');
-			$owner = $db->getField('owner_id');
+			$sector = $db->getInt('sector_id');
+			$owner = $db->getInt('owner_id');
 
 			$db2->query('SELECT * FROM planet_has_building WHERE game_id = '.$game_id.' AND sector_id = '.$sector.' AND construction_id = 1');
-			if ($db2->nextRecord()) $gens = $db2->getField('amount');
+			if ($db2->nextRecord()) $gens = $db2->getInt('amount');
 			else $gens = 0;
 
 			$db2->query('SELECT * FROM planet_has_building WHERE game_id = '.$game_id.' AND sector_id = '.$sector.' AND construction_id = 2');
-			if ($db2->nextRecord()) $hangs = $db2->getField('amount');
+			if ($db2->nextRecord()) $hangs = $db2->getInt('amount');
 			else $hangs = 0;
 
 			$db2->query('SELECT * FROM planet_has_building WHERE game_id = '.$game_id.' AND sector_id = '.$sector.' AND construction_id = 3');
-			if ($db2->nextRecord()) $turs = $db2->getField('amount');
+			if ($db2->nextRecord()) $turs = $db2->getInt('amount');
 			else $turs = 0;
 
 			// insert into history db
@@ -174,23 +174,23 @@ if ($action == 'Yes') {
 		while ($db->nextRecord()) {
 
 			// get info we want
-			$acc_id = $db->getField('account_id');
+			$acc_id = $db->getInt('account_id');
 			$name = stripslashes($db->getField('player_name'));
-			$id = $db->getField('player_id');
-			$exp = $db->getField('experience');
-			$ship = $db->getField('ship_type_id');
-			$race = $db->getField('race_id');
-			$align = $db->getField('alignment');
-			$alli = $db->getField('alliance_id');
-			$kills = $db->getField('kills');
-			$deaths = $db->getField('deaths');
+			$id = $db->getInt('player_id');
+			$exp = $db->getInt('experience');
+			$ship = $db->getInt('ship_type_id');
+			$race = $db->getInt('race_id');
+			$align = $db->getInt('alignment');
+			$alli = $db->getInt('alliance_id');
+			$kills = $db->getInt('kills');
+			$deaths = $db->getInt('deaths');
 
 			$amount = 0;
 			$smrCredits = 0;
 			$db2->query('SELECT sum(amount) as bounty_am, sum(smr_credits) as bounty_cred FROM bounty WHERE game_id = '.$game_id.' AND account_id = '.$acc_id.' AND claimer_id = 0');
 			if ($db2->nextRecord()) {
-				if (is_int($db2->getField('bounty_am'))) $amount = $db2->getField('bounty_am');
-				if (is_int($db2->getField('bounty_cred'))) $smrCredits = $db2->getField('bounty_cred');
+				if (is_int($db2->getField('bounty_am'))) $amount = $db2->getInt('bounty_am');
+				if (is_int($db2->getField('bounty_cred'))) $smrCredits = $db2->getInt('bounty_cred');
 
 			}
 
@@ -233,17 +233,17 @@ if ($action == 'Yes') {
 		while ($db->nextRecord()) {
 
 			// get info we want
-			$sector = $db->getField('sector_id');
-			$kills = $db->getField('battles');
-			$gal_id = $db->getField('galaxy_id');
+			$sector = $db->getInt('sector_id');
+			$kills = $db->getInt('battles');
+			$gal_id = $db->getInt('galaxy_id');
 
 			$db2->query('SELECT sum(mines) as sum_mines, sum(combat_drones) as cds, sum(scout_drones) as sds FROM sector_has_forces ' .
 						'WHERE sector_id = '.$sector.' AND game_id = '.$game_id.' GROUP BY sector_id');
 			if ($db2->nextRecord()) {
 
-				$mines = $db2->getField('sum_mines');
-				$cds = $db2->getField('cds');
-				$sds = $db2->getField('sds');
+				$mines = $db2->getInt('sum_mines');
+				$cds = $db2->getInt('cds');
+				$sds = $db2->getInt('sds');
 				if (!is_numeric($mines)) $mines = 0;
 				if (!is_numeric($cds)) $cds = 0;
 				if (!is_numeric($sds)) $sds = 0;

--- a/admin/Default/ip_view_results.php
+++ b/admin/Default/ip_view_results.php
@@ -27,7 +27,7 @@ if ($type == 'comp_share') {
 	$ip_array = array();
 	//make sure we have enough but not too mant to reduce lag
 	while ($db->nextRecord()) {
-		$id = $db->getField('account_id');
+		$id = $db->getInt('account_id');
 		$ip = $db->getField('ip');
 		$host = $db->getField('host');
 		$ip_array[] = array('ip' => $ip, 'id' => $id, 'host' => $host);
@@ -112,7 +112,7 @@ if ($type == 'comp_share') {
 	while ($db->nextRecord()) {
 		$rows[] = [
 			'ip' => $db->getField('ip'),
-			'date' => date(DATE_FULL_SHORT, $db->getField('time')),
+			'date' => date(DATE_FULL_SHORT, $db->getInt('time')),
 			'host' => $db->getField('host'),
 		];
 	}
@@ -196,8 +196,8 @@ if ($type == 'comp_share') {
 
 	$rows = [];
 	while ($db->nextRecord()) {
-		$id = $db->getField('account_id');
-		$time = $db->getField('time');
+		$id = $db->getInt('account_id');
+		$time = $db->getInt('time');
 		$ip = $db->getField('ip');
 		$host = $db->getField('host');
 

--- a/admin/Default/location_edit.php
+++ b/admin/Default/location_edit.php
@@ -37,7 +37,7 @@ if (isset($var['location_type_id'])) {
 	$db->query('SELECT * FROM hardware_type');
 	$hardware = array();
 	while ($db->nextRecord()) {
-		$hardware[$db->getField('hardware_type_id')] = array('ID' => $db->getField('hardware_type_id'),
+		$hardware[$db->getInt('hardware_type_id')] = array('ID' => $db->getInt('hardware_type_id'),
 														'Name' => $db->getField('hardware_name'));
 	}
 	$template->assign('AllHardware', $hardware);

--- a/admin/Default/log_anonymous_account.php
+++ b/admin/Default/log_anonymous_account.php
@@ -19,7 +19,7 @@ while ($db->nextRecord()) {
 	$anon_logs[$db->getInt('game_id')][$db->getInt('anon_id')][] = [
 		'login' => $db->getField('login'),
 		'amount' => number_format($db->getInt('amount')),
-		'date' => date(DATE_FULL_SHORT, $db->getField('time')),
+		'date' => date(DATE_FULL_SHORT, $db->getInt('time')),
 		'type' => $transaction,
 		'color' => $transaction == 'payment' ? 'tomato' : 'green',
 	];

--- a/admin/Default/newsletter_send.php
+++ b/admin/Default/newsletter_send.php
@@ -9,7 +9,7 @@ $processingContainer = create_container('newsletter_send_processing.php');
 $db = new SmrMySqlDatabase();
 $db->query('SELECT newsletter_id, newsletter_html, newsletter_text FROM newsletter ORDER BY newsletter_id DESC LIMIT 1');
 if ($db->nextRecord()) {
-	$id = $db->getField('newsletter_id');
+	$id = $db->getInt('newsletter_id');
 	$template->assign('NewsletterId', $id);
 	$template->assign('DefaultSubject', 'Space Merchant Realms Newsletter #' . $id);
 

--- a/admin/Default/newsletter_send_processing.php
+++ b/admin/Default/newsletter_send_processing.php
@@ -59,7 +59,7 @@ if ($_REQUEST['to_email'] == '*') {
 
 	while ($db->nextRecord()) {
 		// get account data
-		$account_id = $db->getField('account_id');
+		$account_id = $db->getInt('account_id');
 		$to_email = $db->getField('email');
 		$to_name = $db->getField('login');
 

--- a/admin/Default/notify_view.php
+++ b/admin/Default/notify_view.php
@@ -9,7 +9,7 @@ $template->assign('DeleteHREF', SmrSession::getNewHREF($container));
 $db->query('SELECT * FROM message_notify');
 $messages = [];
 while ($db->nextRecord()) {
-	$gameID = $db->getField('game_id');
+	$gameID = $db->getInt('game_id');
 	$sender = getMessagePlayer($db->getInt('from_id'), $gameID);
 	$receiver = getMessagePlayer($db->getInt('to_id'), $gameID);
 
@@ -49,8 +49,8 @@ while ($db->nextRecord()) {
 		'senderLink' => $senderLink,
 		'receiverLink' => $receiverLink,
 		'gameName' => $gameName,
-		'sentDate' => date(DATE_FULL_SHORT, $db->getField('sent_time')),
-		'reportDate' => date(DATE_FULL_SHORT, $db->getField('notify_time')),
+		'sentDate' => date(DATE_FULL_SHORT, $db->getInt('sent_time')),
+		'reportDate' => date(DATE_FULL_SHORT, $db->getInt('notify_time')),
 		'text' => bbifyMessage($db->getField('text')),
 	];
 }

--- a/admin/Default/vote_create.php
+++ b/admin/Default/vote_create.php
@@ -7,7 +7,7 @@ $template->assign('VoteFormHREF', SmrSession::getNewHREF(create_container('vote_
 $voting = array();
 $db->query('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(TIME));
 while ($db->nextRecord()) {
-	$voteID = $db->getField('vote_id');
+	$voteID = $db->getInt('vote_id');
 	$voting[$voteID]['ID'] = $voteID;
 	$voting[$voteID]['Question'] = $db->getField('question');
 }

--- a/engine/Default/album_edit_processing.php
+++ b/engine/Default/album_edit_processing.php
@@ -112,7 +112,7 @@ if (!empty($comment)) {
 
 	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($account->getAccountID()));
 	if ($db->nextRecord()) {
-		$comment_id = $db->getField('MAX(comment_id)') + 1;
+		$comment_id = $db->getInt('MAX(comment_id)') + 1;
 	} else {
 		$comment_id = 1;
 	}

--- a/engine/Default/alliance_forces.php
+++ b/engine/Default/alliance_forces.php
@@ -45,6 +45,6 @@ ORDER BY sector_id ASC');
 
 $forces = array();
 while ($db->nextRecord()) {
-	$forces[] = SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'), false, $db);
+	$forces[] = SmrForce::getForce($player->getGameID(), $db->getInt('sector_id'), $db->getInt('owner_id'), false, $db);
 }
 $template->assign('Forces', $forces);

--- a/engine/Default/alliance_list.php
+++ b/engine/Default/alliance_list.php
@@ -27,7 +27,7 @@ ORDER BY alliance_name ASC'
 
 $alliances = array();
 while ($db->nextRecord()) {
-	if ($db->getField('alliance_id') != $player->getAllianceID()) {
+	if ($db->getInt('alliance_id') != $player->getAllianceID()) {
 		$container['body'] = 'alliance_roster.php';
 	} else {
 		$container['body'] = 'alliance_mod.php';

--- a/engine/Default/alliance_roles.php
+++ b/engine/Default/alliance_roles.php
@@ -15,7 +15,7 @@ ORDER BY role_id
 ');
 $allianceRoles = array();
 while ($db->nextRecord()) {
-	$roleID = $db->getField('role_id');
+	$roleID = $db->getInt('role_id');
 	$allianceRoles[$roleID]['RoleID'] = $roleID;
 	$allianceRoles[$roleID]['Name'] = $db->getField('role');
 	$allianceRoles[$roleID]['EditingRole'] = isset($var['role_id']) && $var['role_id'] == $roleID;

--- a/engine/Default/bank_alliance_processing.php
+++ b/engine/Default/bank_alliance_processing.php
@@ -78,7 +78,7 @@ if ($action == 'Deposit') {
 						AND transaction = \'Payment\'
 						AND exempt = 0
 						AND time > ' . $db->escapeNumber(TIME - 86400));
-		if ($db->nextRecord() && !is_null($db->getField('total'))) {
+		if ($db->nextRecord() && !is_null($db->getInt('total'))) {
 			$total = $db->getInt('total');
 		} else {
 			$total = 0;

--- a/engine/Default/bank_anon_detail.php
+++ b/engine/Default/bank_anon_detail.php
@@ -37,7 +37,7 @@ if (isset($var['maxValue'])
 				AND anon_id=' . $db->escapeNumber($account_num)
 				);
 	if ($db->nextRecord()) {
-		$maxValue = $db->getField('MAX(transaction_id)');
+		$maxValue = $db->getInt('MAX(transaction_id)');
 	} else {
 		$maxValue = 5;
 	}

--- a/engine/Default/bank_anon_detail_processing.php
+++ b/engine/Default/bank_anon_detail_processing.php
@@ -36,11 +36,11 @@ if ($action == 'Deposit') {
 else {
 	$db->query('SELECT * FROM anon_bank WHERE anon_id = ' . $db->escapeNumber($account_num) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	$db->nextRecord();
-	if ($db->getField('amount') < $amount)
+	if ($db->getInt('amount') < $amount)
 		create_error('You don\'t have that much money on your account!');
 	$db->query('SELECT transaction_id FROM anon_bank_transactions WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num) . ' ORDER BY transaction_id DESC LIMIT 1');
 	if ($db->nextRecord()) {
-		$trans_id = $db->getField('transaction_id') + 1;
+		$trans_id = $db->getInt('transaction_id') + 1;
 	}
 	else {
 		$trans_id = 1;

--- a/engine/Default/bank_report.php
+++ b/engine/Default/bank_report.php
@@ -14,7 +14,7 @@ if (!$db->getNumRows()) {
 $trans = array();
 while ($db->nextRecord()) {
 	$transType = ($db->getField('transaction') == 'Payment') ? WITHDRAW : DEPOSIT;
-	$payeeId = ($db->getField('exempt')) ? 0 : $db->getInt('payee_id');
+	$payeeId = ($db->getInt('exempt')) ? 0 : $db->getInt('payee_id');
 	// initialize payee if necessary
 	if (!isset($trans[$payeeId])) {
 		$trans[$payeeId] = array(WITHDRAW => 0, DEPOSIT => 0);
@@ -31,7 +31,7 @@ arsort($totals, SORT_NUMERIC);
 $db->query('SELECT * FROM player WHERE account_id IN (' . $db->escapeArray($playerIDs) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY player_name');
 $players[0] = 'Alliance Funds';
 while ($db->nextRecord()) {
-	$players[$db->getField('account_id')] = $db->getField('player_name');
+	$players[$db->getInt('account_id')] = $db->getField('player_name');
 }
 
 //format it this way so its easy to send to the alliance MB if requested.

--- a/engine/Default/bank_report_processing.php
+++ b/engine/Default/bank_report_processing.php
@@ -16,7 +16,7 @@ if ($db->nextRecord()) {
 	// There is no "Bank Statement" thread yet
 	$db->query('SELECT thread_id FROM alliance_thread_topic WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' ORDER BY thread_id DESC LIMIT 1');
 	if ($db->nextRecord()) {
-		$thread_id = $db->getField('thread_id') + 1;
+		$thread_id = $db->getInt('thread_id') + 1;
 	} else {
 		$thread_id = 1;
 	}

--- a/engine/Default/beta_func_processing.php
+++ b/engine/Default/beta_func_processing.php
@@ -9,7 +9,7 @@ if ($var['func'] == 'Map') {
 	// add port infos
 	$db->query('SELECT * FROM port WHERE game_id = ' . $db->escapeNumber($game_id));
 	while ($db->nextRecord()) {
-		$port = SmrPort::getPort($game_id, $db->getField('sector_id'), false, $db);
+		$port = SmrPort::getPort($game_id, $db->getInt('sector_id'), false, $db);
 		$port->addCachePort($account_id);
 	}
 

--- a/engine/Default/combat_log_list.php
+++ b/engine/Default/combat_log_list.php
@@ -119,7 +119,7 @@ if ($db->getNumRows() > 0) {
 
 	while ($db->nextRecord()) {
 		$sectorID = $db->getInt('sector_id');
-		$logs[$db->getField('log_id')] = array(
+		$logs[$db->getInt('log_id')] = array(
 			'Attacker' => getParticipantName($db->getInt('attacker_id'), $sectorID),
 			'Defender' => getParticipantName($db->getInt('defender_id'), $sectorID),
 			'Time' => $db->getInt('timestamp'),

--- a/engine/Default/combat_log_viewer.php
+++ b/engine/Default/combat_log_viewer.php
@@ -11,8 +11,8 @@ $db->query('SELECT timestamp,sector_id,result,type FROM combat_logs WHERE log_id
 if (!$db->nextRecord()) {
 	create_error('Combat log not found');
 }
-$template->assign('CombatLogSector', $db->getField('sector_id'));
-$template->assign('CombatLogTimestamp', date(DATE_FULL_SHORT, $db->getField('timestamp')));
+$template->assign('CombatLogSector', $db->getInt('sector_id'));
+$template->assign('CombatLogTimestamp', date(DATE_FULL_SHORT, $db->getInt('timestamp')));
 $results = unserialize(gzuncompress($db->getField('result')));
 $template->assign('CombatResultsType', $db->getField('type'));
 $template->assign('CombatResults', $results);

--- a/engine/Default/configure_hardware.php
+++ b/engine/Default/configure_hardware.php
@@ -20,7 +20,7 @@ if ($ship->hasIllusion()) {
 	$ships = array();
 	$db->query('SELECT ship_type_id,ship_name FROM ship_type ORDER BY ship_name');
 	while ($db->nextRecord()) {
-		$ships[$db->getField('ship_type_id')] = $db->getField('ship_name');
+		$ships[$db->getInt('ship_type_id')] = $db->getField('ship_name');
 	}
 	$template->assign('IllusionShips', $ships);
 	$container['action'] = 'Disable Illusion';

--- a/engine/Default/council_vote.php
+++ b/engine/Default/council_vote.php
@@ -13,7 +13,7 @@ $db->query('SELECT * FROM player_votes_relation
 				AND game_id = ' . $db->escapeNumber($player->getGameID()));
 $votedForRace = -1;
 if ($db->nextRecord()) {
-	$votedForRace = $db->getField('race_id_2');
+	$votedForRace = $db->getInt('race_id_2');
 	$votedFor = $db->getField('action');
 }
 
@@ -43,7 +43,7 @@ if ($db->getNumRows() > 0) {
 	$db2 = new SmrMySqlDatabase();
 
 	while ($db->nextRecord()) {
-		$otherRaceID = $db->getField('race_id_2');
+		$otherRaceID = $db->getInt('race_id_2');
 		$container = create_container('council_vote_processing.php', '', array('race_id' => $otherRaceID));
 
 		// get 'yes' votes
@@ -77,7 +77,7 @@ if ($db->getNumRows() > 0) {
 		$voteTreaties[$otherRaceID] = array(
 			'HREF' => SmrSession::getNewHREF($container),
 			'Type' => $db->getField('type'),
-			'EndTime' => $db->getField('end_time'),
+			'EndTime' => $db->getInt('end_time'),
 			'For' => $votedFor == 'YES',
 			'Against' => $votedFor == 'NO',
 			'NoVotes' => $noVotes,

--- a/engine/Default/current_players.php
+++ b/engine/Default/current_players.php
@@ -7,7 +7,7 @@ $db->query('SELECT count(*) count FROM active_session
 				game_id = ' . $db->escapeNumber($player->getGameID()));
 $count_real_last_active = 0;
 if ($db->nextRecord()) {
-	$count_real_last_active = $db->getField('count');
+	$count_real_last_active = $db->getInt('count');
 }
 if (SmrSession::$last_accessed < TIME - 600) {
 	++$count_real_last_active;

--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -30,7 +30,7 @@ $unvisited = array();
 
 $db->query('SELECT sector_id FROM player_visited_sector WHERE sector_id IN (' . $db->escapeArray($links) . ') AND account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
 while ($db->nextRecord()) {
-	$unvisited[$db->getField('sector_id')] = TRUE;
+	$unvisited[$db->getInt('sector_id')] = TRUE;
 }
 
 foreach ($links as $key => $linkArray) {
@@ -147,7 +147,7 @@ function checkForForceRefreshMessage(&$msg) {
 			$forceRefreshMessage = '';
 			$db->query('SELECT refresh_at FROM sector_has_forces WHERE refresh_at >= ' . $db->escapeNumber(TIME) . ' AND sector_id = ' . $db->escapeNumber($player->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND refresher = ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY refresh_at DESC LIMIT 1');
 			if ($db->nextRecord()) {
-				$remainingTime = $db->getField('refresh_at') - TIME;
+				$remainingTime = $db->getInt('refresh_at') - TIME;
 				$forceRefreshMessage = '<span class="green">REFRESH</span>: All forces will be refreshed in ' . $remainingTime . ' seconds.';
 				$db->query('REPLACE INTO sector_message (game_id, account_id, message) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', \'[Force Check]\')');
 			}
@@ -167,7 +167,7 @@ function checkForAttackMessage(&$msg) {
 		if (!$template->hasTemplateVar('AttackResults')) {
 			$db->query('SELECT sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($msg) . ' LIMIT 1');
 			if ($db->nextRecord()) {
-				if ($player->getSectorID() == $db->getField('sector_id')) {
+				if ($player->getSectorID() == $db->getInt('sector_id')) {
 					$results = unserialize(gzuncompress($db->getField('result')));
 					$template->assign('AttackResultsType', $db->getField('type'));
 					$template->assign('AttackResults', $results);

--- a/engine/Default/donation.php
+++ b/engine/Default/donation.php
@@ -3,5 +3,5 @@
 $template->assign('PageTopic', 'Donations');
 $db->query('SELECT SUM(amount) as total_donation FROM account_donated WHERE time > ' . $db->escapeNumber(TIME) . ' - (86400 * 90)');
 if ($db->nextRecord()) {
-	$template->assign('TotalDonation', $db->getField('total_donation'));
+	$template->assign('TotalDonation', $db->getInt('total_donation'));
 }

--- a/engine/Default/feature_request_comments.php
+++ b/engine/Default/feature_request_comments.php
@@ -26,15 +26,15 @@ if ($db->getNumRows() > 0) {
 
 	$featureRequestComments = array();
 	while ($db->nextRecord()) {
-		$commentID = $db->getField('comment_id');
+		$commentID = $db->getInt('comment_id');
 		$featureRequestComments[$commentID] = array(
 								'CommentID' => $commentID,
 								'Message' => $db->getField('text'),
-								'Time' => date(DATE_FULL_SHORT, $db->getField('posting_time')),
+								'Time' => date(DATE_FULL_SHORT, $db->getInt('posting_time')),
 								'Anonymous' => $db->getBoolean('anonymous')
 		);
 		if ($featureModerator || !$db->getBoolean('anonymous')) {
-			$featureRequestComments[$commentID]['PosterAccount'] = SmrAccount::getAccount($db->getField('poster_id'));
+			$featureRequestComments[$commentID]['PosterAccount'] = SmrAccount::getAccount($db->getInt('poster_id'));
 		}
 	}
 	$template->assign('Comments', $featureRequestComments);

--- a/engine/Default/forces_list.php
+++ b/engine/Default/forces_list.php
@@ -11,6 +11,6 @@ $db->query('SELECT *
 
 $forces = array();
 while ($db->nextRecord()) {
-	$forces[] = SmrForce::getForce($player->getGameID(), $db->getField('sector_id'), $db->getField('owner_id'), false, $db);
+	$forces[] = SmrForce::getForce($player->getGameID(), $db->getInt('sector_id'), $db->getInt('owner_id'), false, $db);
 }
 $template->assign('Forces', $forces);

--- a/engine/Default/galactic_post.php
+++ b/engine/Default/galactic_post.php
@@ -23,7 +23,7 @@ while ($db->nextRecord()) {
 
 	$db2->query('SELECT count(*) FROM galactic_post_paper_content WHERE paper_id = ' . $db2->escapeNumber($paper_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	$db2->nextRecord();
-	$numArticles = $db2->getField('count(*)');
+	$numArticles = $db2->getInt('count(*)');
 	$hasEnoughArticles = $numArticles > 2 && $numArticles < 9;
 
 	$paper = [

--- a/engine/Default/galactic_post_current.php
+++ b/engine/Default/galactic_post_current.php
@@ -2,7 +2,7 @@
 
 $db->query('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY online_since DESC LIMIT 1');
 if ($db->nextRecord()) {
-	$paper_id = $db->getField('paper_id');
+	$paper_id = $db->getInt('paper_id');
 } else {
 	$paper_id = null;
 }

--- a/engine/Default/galactic_post_make_paper_processing.php
+++ b/engine/Default/galactic_post_make_paper_processing.php
@@ -2,7 +2,7 @@
 
 $db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY paper_id DESC');
 if ($db->nextRecord()) {
-	$num = $db->getField('paper_id') + 1;
+	$num = $db->getInt('paper_id') + 1;
 } else {
 	$num = 1;
 }

--- a/engine/Default/galactic_post_paper_edit.php
+++ b/engine/Default/galactic_post_paper_edit.php
@@ -12,7 +12,7 @@ $db->query('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article
 $articles = [];
 while ($db->nextRecord()) {
 	$container = create_container('galactic_post_paper_edit_processing.php');
-	$container['article_id'] = $db->getField('article_id');
+	$container['article_id'] = $db->getInt('article_id');
 	transfer('id');
 	$articles[] = [
 		'title' => bbifyMessage($db->getField('title')),

--- a/engine/Default/galactic_post_past.php
+++ b/engine/Default/galactic_post_past.php
@@ -31,7 +31,7 @@ while ($db->nextRecord()) {
 	$container['back'] = true;
 
 	$pastEditions[] = array('title' => $db->getField('title'),
-	                        'online_since' => $db->getField('online_since'),
+	                        'online_since' => $db->getInt('online_since'),
 	                        'href' => SmrSession::getNewHREF($container));
 }
 $template->assign('PastEditions', $pastEditions);

--- a/engine/Default/galactic_post_view_article.php
+++ b/engine/Default/galactic_post_view_article.php
@@ -15,9 +15,9 @@ $articles = [];
 $db->query('SELECT * FROM galactic_post_article WHERE article_id NOT IN (SELECT article_id FROM galactic_post_paper_content) AND game_id = ' . $db->escapeNumber($player->getGameID()));
 while ($db->nextRecord()) {
 	$title = stripslashes($db->getField('title'));
-	$writer = SmrPlayer::getPlayer($db->getField('writer_id'), $player->getGameID());
+	$writer = SmrPlayer::getPlayer($db->getInt('writer_id'), $player->getGameID());
 	$container = create_container('skeleton.php', 'galactic_post_view_article.php');
-	$container['id'] = $db->getField('article_id');
+	$container['id'] = $db->getInt('article_id');
 	$articles[] = [
 		'title' => $title,
 		'writer' => $writer->getPlayerName(),
@@ -53,7 +53,7 @@ if (isset($var['id'])) {
 	$papers = [];
 	$db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
 	while ($db->nextRecord()) {
-		$container['paper_id'] = $db->getField('paper_id');
+		$container['paper_id'] = $db->getInt('paper_id');
 		$papers[] = [
 			'title' => $db->getField('title'),
 			'addHREF' => SmrSession::getNewHREF($container),

--- a/engine/Default/galactic_post_write_article_processing.php
+++ b/engine/Default/galactic_post_write_article_processing.php
@@ -32,7 +32,7 @@ if (isset($var['id'])) {
 
 	$db->query('SELECT MAX(article_id) article_id FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' LIMIT 1');
 	$db->nextRecord();
-	$num = $db->getField('article_id') + 1;
+	$num = $db->getInt('article_id') + 1;
 	$db->query('INSERT INTO galactic_post_article (game_id, article_id, writer_id, title, text, last_modified) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($num) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($title) . ' , ' . $db->escapeString($message) . ' , ' . $db->escapeNumber(TIME) . ')');
 	$db->query('UPDATE galactic_post_writer SET last_wrote = ' . $db->escapeNumber(TIME) . ' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 	forward(create_container('skeleton.php', 'galactic_post_read.php'));

--- a/engine/Default/game_join.php
+++ b/engine/Default/game_join.php
@@ -40,7 +40,7 @@ $db->query('SELECT location_name, location_type_id
 			ORDER BY location_type_id');
 $races = array();
 while ($db->nextRecord()) {
-	$curr_race_id = $db->getField('location_type_id') - 101;
+	$curr_race_id = $db->getInt('location_type_id') - 101;
 	if (in_array($curr_race_id, $only)) {
 		continue;
 	}

--- a/engine/Default/game_play.php
+++ b/engine/Default/game_play.php
@@ -26,12 +26,12 @@ $db->query('SELECT end_time, game_id, game_name, game_speed, game_type
 			ORDER BY start_time DESC');
 if ($db->getNumRows() > 0) {
 	while ($db->nextRecord()) {
-		$game_id = $db->getField('game_id');
+		$game_id = $db->getInt('game_id');
 		$games['Play'][$game_id]['ID'] = $game_id;
 		$games['Play'][$game_id]['Name'] = $db->getField('game_name');
 		$games['Play'][$game_id]['Type'] = SmrGame::GAME_TYPES[$db->getInt('game_type')];
 		$games['Play'][$game_id]['EndDate'] = date(DATE_FULL_SHORT_SPLIT, $db->getInt('end_time'));
-		$games['Play'][$game_id]['Speed'] = $db->getField('game_speed');
+		$games['Play'][$game_id]['Speed'] = $db->getFloat('game_speed');
 
 		$container = create_container('game_play_processing.php');
 		$container['game_id'] = $game_id;
@@ -52,7 +52,7 @@ if ($db->getNumRows() > 0) {
 					WHERE last_cpl_action >= ' . $db->escapeNumber(TIME - 600) . '
 						AND game_id = '.$db->escapeNumber($game_id));
 		$db2->nextRecord();
-		$games['Play'][$game_id]['NumberPlaying'] = $db2->getField('num_playing');
+		$games['Play'][$game_id]['NumberPlaying'] = $db2->getInt('num_playing');
 
 		// create a container that will hold next url and additional variables.
 
@@ -94,7 +94,7 @@ if ($db->getNumRows() > 0) {
 	$games['Join'] = array();
 	// iterate over the resultset
 	while ($db->nextRecord()) {
-		$game_id = $db->getField('game_id');
+		$game_id = $db->getInt('game_id');
 		$game = SmrGame::getGame($game_id);
 		$games['Join'][$game_id] = [
 			'ID' => $game_id,
@@ -126,12 +126,12 @@ $db->query('SELECT start_time, end_time, game_name, game_speed, game_id ' .
 		'FROM game WHERE enabled = \'TRUE\' AND end_time < ' . $db->escapeNumber(TIME) . ' ORDER BY game_id DESC');
 if ($db->getNumRows()) {
 	while ($db->nextRecord()) {
-		$game_id = $db->getField('game_id');
+		$game_id = $db->getInt('game_id');
 		$games['Previous'][$game_id]['ID'] = $game_id;
 		$games['Previous'][$game_id]['Name'] = $db->getField('game_name');
 		$games['Previous'][$game_id]['StartDate'] = date(DATE_DATE_SHORT, $db->getInt('start_time'));
 		$games['Previous'][$game_id]['EndDate'] = date(DATE_DATE_SHORT, $db->getInt('end_time'));
-		$games['Previous'][$game_id]['Speed'] = $db->getField('game_speed');
+		$games['Previous'][$game_id]['Speed'] = $db->getFloat('game_speed');
 		// create a container that will hold next url and additional variables.
 		$container = create_container('skeleton.php');
 		$container['game_id'] = $container['GameID'] = $game_id;
@@ -153,13 +153,13 @@ foreach (Globals::getHistoryDatabases() as $databaseClassName => $oldColumn) {
 						FROM game ORDER BY game_id DESC');
 	if ($historyDB->getNumRows()) {
 		while ($historyDB->nextRecord()) {
-			$game_id = $historyDB->getField('game_id');
+			$game_id = $historyDB->getInt('game_id');
 			$index = $databaseClassName . $game_id;
 			$games['Previous'][$index]['ID'] = $game_id;
 			$games['Previous'][$index]['Name'] = $historyDB->getField('game_name');
-			$games['Previous'][$index]['StartDate'] = date(DATE_DATE_SHORT, $historyDB->getField('start_date'));
-			$games['Previous'][$index]['EndDate'] = date(DATE_DATE_SHORT, $historyDB->getField('end_date'));
-			$games['Previous'][$index]['Speed'] = $historyDB->getField('speed');
+			$games['Previous'][$index]['StartDate'] = date(DATE_DATE_SHORT, $historyDB->getInt('start_date'));
+			$games['Previous'][$index]['EndDate'] = date(DATE_DATE_SHORT, $historyDB->getInt('end_date'));
+			$games['Previous'][$index]['Speed'] = $historyDB->getFloat('speed');
 			// create a container that will hold next url and additional variables.
 			$container = create_container('skeleton.php');
 			$container['view_game_id'] = $game_id;
@@ -193,24 +193,24 @@ if ($db->getNumRows() > 0) {
 	$votedFor = array();
 	$db2->query('SELECT * FROM voting_results WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 	while ($db2->nextRecord()) {
-		$votedFor[$db2->getField('vote_id')] = $db2->getField('option_id');
+		$votedFor[$db2->getInt('vote_id')] = $db2->getInt('option_id');
 	}
 	$voting = array();
 	while ($db->nextRecord()) {
-		$voteID = $db->getField('vote_id');
+		$voteID = $db->getInt('vote_id');
 		$voting[$voteID]['ID'] = $voteID;
 		$container = create_container('vote_processing.php', 'game_play.php');
 		$container['vote_id'] = $voteID;
 		$voting[$voteID]['HREF'] = SmrSession::getNewHREF($container);
 		$voting[$voteID]['Question'] = $db->getField('question');
-		$voting[$voteID]['TimeRemaining'] = format_time($db->getField('end') - TIME, true);
+		$voting[$voteID]['TimeRemaining'] = format_time($db->getInt('end') - TIME, true);
 		$voting[$voteID]['Options'] = array();
 		$db2->query('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = ' . $db->escapeNumber($db->getInt('vote_id')) . ' GROUP BY option_id');
 		while ($db2->nextRecord()) {
-			$voting[$voteID]['Options'][$db2->getField('option_id')]['ID'] = $db2->getField('option_id');
-			$voting[$voteID]['Options'][$db2->getField('option_id')]['Text'] = $db2->getField('text');
-			$voting[$voteID]['Options'][$db2->getField('option_id')]['Chosen'] = isset($votedFor[$db->getField('vote_id')]) && $votedFor[$voteID] == $db2->getField('option_id');
-			$voting[$voteID]['Options'][$db2->getField('option_id')]['Votes'] = $db2->getField('count(account_id)');
+			$voting[$voteID]['Options'][$db2->getInt('option_id')]['ID'] = $db2->getInt('option_id');
+			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Text'] = $db2->getField('text');
+			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Chosen'] = isset($votedFor[$db->getInt('vote_id')]) && $votedFor[$voteID] == $db2->getInt('option_id');
+			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Votes'] = $db2->getInt('count(account_id)');
 		}
 	}
 	$template->assign('Voting', $voting);

--- a/engine/Default/game_stats.php
+++ b/engine/Default/game_stats.php
@@ -10,16 +10,16 @@ $template->assign('PageTopic', 'Game Stats: ' . $statsGame->getName() . ' (' . $
 
 $db->query('SELECT count(*) total_players, MAX(experience) max_exp, MAX(alignment) max_align, MIN(alignment) min_alignment, MAX(kills) max_kills FROM player WHERE game_id = ' . $gameID . ' ORDER BY experience DESC');
 if ($db->nextRecord()) {
-	$template->assign('TotalPlayers', $db->getField('total_players'));
-	$template->assign('HighestExp', $db->getField('max_exp'));
-	$template->assign('HighestAlign', $db->getField('max_align'));
-	$template->assign('LowestAlign', $db->getField('min_alignment'));
-	$template->assign('HighestKills', $db->getField('max_kills'));
+	$template->assign('TotalPlayers', $db->getInt('total_players'));
+	$template->assign('HighestExp', $db->getInt('max_exp'));
+	$template->assign('HighestAlign', $db->getInt('max_align'));
+	$template->assign('LowestAlign', $db->getInt('min_alignment'));
+	$template->assign('HighestKills', $db->getInt('max_kills'));
 }
 	
 $db->query('SELECT count(*) num_alliance FROM alliance WHERE game_id = ' . $gameID);
 if ($db->nextRecord()) {
-	$template->assign('TotalAlliances', $db->getField('num_alliance'));
+	$template->assign('TotalAlliances', $db->getInt('num_alliance'));
 }
 
 $db->query('SELECT * FROM player WHERE game_id = ' . $gameID . ' ORDER BY experience DESC LIMIT 10');

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -61,11 +61,11 @@ else {
 	}
 	$rows = [];
 	while ($db->nextRecord()) {
-		$accountID = $db->getField('account_id');
+		$accountID = $db->getInt('account_id');
 		if ($accountID == $account->getAccountID()) {
 			$foundMe = true;
 		}
-		$amount = applyHofVisibilityMask($db->getField('amount'), $vis, $game_id, $accountID);
+		$amount = applyHofVisibilityMask($db->getFloat('amount'), $vis, $game_id, $accountID);
 		$rows[] = displayHOFRow($rank++, $accountID, $amount);
 	}
 	if (!$foundMe) {

--- a/engine/Default/help.inc
+++ b/engine/Default/help.inc
@@ -27,7 +27,7 @@ function echo_nav($topic_id) {
 
 		echo ('<th width="32">');
 		if ($db2->nextRecord()) {
-			$previous_topic_id = $db2->getField('topic_id');
+			$previous_topic_id = $db2->getInt('topic_id');
 			$previous_topic = stripslashes($db2->getField('topic'));
 			echo ('<a href="/manual.php?'.$previous_topic_id.'"><img src="/images/help/previous.jpg" width="32" height="32" border="0"></a>');
 		} else
@@ -61,8 +61,8 @@ function echo_nav($topic_id) {
 			$seenParentIDs[] = $curr_parent_topic_id;
 			$db3->query('SELECT * FROM manual WHERE topic_id = '.$db3->escapeNumber($parent_topic_id));
 			$db3->nextRecord();
-			$curr_order_id = $db3->getField('order_id');
-			$curr_parent_topic_id = $db3->getField('parent_topic_id');
+			$curr_order_id = $db3->getInt('order_id');
+			$curr_parent_topic_id = $db3->getInt('parent_topic_id');
 
 			$db2->query('SELECT * FROM manual WHERE parent_topic_id = '.$db2->escapeNumber($parent_topic_id).' AND order_id = '.$db2->escapeNumber($curr_order_id + 1));
 		}

--- a/engine/Default/history_games.php
+++ b/engine/Default/history_games.php
@@ -14,10 +14,10 @@ $db->query('SELECT start_date, type, end_date, game_name, speed, game_id ' .
            'FROM game WHERE game_id = ' . $db->escapeNumber($game_id));
 $db->nextRecord();
 $template->assign('GameName', $game_name);
-$template->assign('Start', date(DATE_DATE_SHORT, $db->getField('start_date')));
-$template->assign('End', date(DATE_DATE_SHORT, $db->getField('end_date')));
+$template->assign('Start', date(DATE_DATE_SHORT, $db->getInt('start_date')));
+$template->assign('End', date(DATE_DATE_SHORT, $db->getInt('end_date')));
 $template->assign('Type', $db->getField('type'));
-$template->assign('Speed', $db->getField('speed'));
+$template->assign('Speed', $db->getFloat('speed'));
 
 $db->query('SELECT count(*), max(experience), max(alignment), min(alignment), max(kills) FROM player WHERE game_id = ' . $db->escapeNumber($game_id));
 if ($db->nextRecord()) {
@@ -35,7 +35,7 @@ $playerExp = [];
 $db->query('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY experience DESC LIMIT 10');
 while ($db->nextRecord()) {
 	$playerExp[] = [
-		'exp' => $db->getField('experience'),
+		'exp' => $db->getInt('experience'),
 		'name' => stripslashes($db->getField('player_name')),
 	];
 }
@@ -45,7 +45,7 @@ $playerKills = [];
 $db->query('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY kills DESC LIMIT 10');
 while ($db->nextRecord()) {
 	$playerKills[] = [
-		'kills' => $db->getField('kills'),
+		'kills' => $db->getInt('kills'),
 		'name' => stripslashes($db->getField('player_name')),
 	];
 }
@@ -62,10 +62,10 @@ $db->query('SELECT SUM(experience) as exp, alliance_name, alliance_id
 			WHERE game_id = '.$db->escapeNumber($game_id) . ' GROUP BY alliance_id ORDER BY exp DESC LIMIT 10');
 while ($db->nextRecord()) {
 	$alliance = stripslashes($db->getField('alliance_name'));
-	$id = $db->getField('alliance_id');
+	$id = $db->getInt('alliance_id');
 	$container['alliance_id'] = $id;
 	$allianceExp[] = [
-		'exp' => $db->getField('exp'),
+		'exp' => $db->getInt('exp'),
 		'link' => create_link($container, $alliance),
 	];
 }
@@ -75,10 +75,10 @@ $allianceKills = [];
 $db->query('SELECT kills, alliance_name, alliance_id FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY kills DESC LIMIT 10');
 while ($db->nextRecord()) {
 	$alliance = stripslashes($db->getField('alliance_name'));
-	$id = $db->getField('alliance_id');
+	$id = $db->getInt('alliance_id');
 	$container['alliance_id'] = $id;
 	$allianceKills[] = [
-		'kills' => $db->getField('kills'),
+		'kills' => $db->getInt('kills'),
 		'link' => create_link($container, $alliance),
 	];
 }

--- a/engine/Default/history_games_news.php
+++ b/engine/Default/history_games_news.php
@@ -23,7 +23,7 @@ $db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($var['view_
 $rows = [];
 while ($db->nextRecord()) {
 	$rows[] = [
-		'time' => date(DATE_FULL_SHORT, $db->getField('time')),
+		'time' => date(DATE_FULL_SHORT, $db->getInt('time')),
 		'news' => $db->getField('message'),
 	];
 }

--- a/engine/Default/message_blacklist_add.php
+++ b/engine/Default/message_blacklist_add.php
@@ -18,7 +18,7 @@ if (isset($var['account_id'])) {
 		$container['msg'] = '<span class="red bold">ERROR: </span>Player does not exist.';
 		forward($container);
 	}
-	$blacklisted_id = $db->getField('account_id');
+	$blacklisted_id = $db->getInt('account_id');
 }
 
 $db->query('SELECT account_id FROM message_blacklist WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND blacklisted_id=' . $db->escapeNumber($blacklisted_id) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' LIMIT 1');

--- a/engine/Default/message_notify_processing.php
+++ b/engine/Default/message_notify_processing.php
@@ -11,7 +11,7 @@ if (empty($var['message_id'])) {
 // get next id
 $db->query('SELECT max(notify_id) FROM message_notify WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY notify_id DESC');
 if ($db->nextRecord()) {
-	$notify_id = $db->getField('max(notify_id)') + 1;
+	$notify_id = $db->getInt('max(notify_id)') + 1;
 } else {
 	$notify_id = 1;
 }
@@ -27,6 +27,6 @@ if (!$db->nextRecord()) {
 // insert
 $db->query('INSERT INTO message_notify
 			(notify_id, game_id, from_id, to_id, text, sent_time, notify_time)
-			VALUES ('.$notify_id . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->getField('sender_id') . ', ' . $db->getField('account_id') . ', ' . $db->escapeString($db->getField('message_text')) . ', ' . $var['sent_time'] . ', ' . $var['notified_time'] . ')');
+			VALUES ('.$notify_id . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->getInt('sender_id') . ', ' . $db->getInt('account_id') . ', ' . $db->escapeString($db->getField('message_text')) . ', ' . $var['sent_time'] . ', ' . $var['notified_time'] . ')');
 
 forward(create_container('skeleton.php', 'message_view.php'));

--- a/engine/Default/message_send_processing.php
+++ b/engine/Default/message_send_processing.php
@@ -23,7 +23,7 @@ if (isset($var['alliance_id'])) {
 				AND alliance_id = ' . $var['alliance_id'] . '
 				AND account_id != ' . $db->escapeNumber($player->getAccountID())); //No limit in case they are over limit - ie NHA
 	while ($db->nextRecord()) {
-		$player->sendMessage($db->getField('account_id'), MSG_ALLIANCE, $message, false);
+		$player->sendMessage($db->getInt('account_id'), MSG_ALLIANCE, $message, false);
 	}
 	$player->sendMessage($player->getAccountID(), MSG_ALLIANCE, $message, true, false);
 }

--- a/engine/Default/message_view.php
+++ b/engine/Default/message_view.php
@@ -38,7 +38,7 @@ if (!isset ($var['folder_id'])) {
 						AND message_type_id = ' . $db2->escapeNumber($message_type_id) . '
 						AND receiver_delete = ' . $db2->escapeBoolean(false));
 		if ($db2->nextRecord()) {
-			$messageBox['MessageCount'] = $db2->getField('message_count');
+			$messageBox['MessageCount'] = $db2->getInt('message_count');
 		}
 
 		$container = create_container('skeleton.php', 'message_view.php');
@@ -59,7 +59,7 @@ if (!isset ($var['folder_id'])) {
 					AND message_type_id = ' . $db->escapeNumber(MSG_PLAYER) . '
 					AND sender_delete = ' . $db->escapeBoolean(false));
 	if ($db->nextRecord()) {
-		$messageBox['MessageCount'] = $db->getField('count');
+		$messageBox['MessageCount'] = $db->getInt('count');
 	}
 	$messageBox['Name'] = 'Sent Messages';
 	$messageBox['HasUnread'] = false;
@@ -96,11 +96,11 @@ if (!isset ($var['folder_id'])) {
 					FROM message ' . $whereClause . '
 						AND msg_read = ' . $db->escapeBoolean(false));
 		$db->nextRecord();
-		$messageBox['UnreadMessages'] = $db->getField('count');
+		$messageBox['UnreadMessages'] = $db->getInt('count');
 	}
 	$db->query('SELECT count(*) as count FROM message ' . $whereClause);
 	$db->nextRecord();
-	$messageBox['TotalMessages'] = $db->getField('count');
+	$messageBox['TotalMessages'] = $db->getInt('count');
 	$messageBox['Type'] = $var['folder_id'];
 
 	$page = 0;
@@ -161,7 +161,7 @@ if (!isset ($var['folder_id'])) {
 		displayScouts($messageBox, $player);
 	} else {
 		while ($db->nextRecord()) {
-			displayMessage($messageBox, $db->getField('message_id'), $db->getField('account_id'), $db->getField('sender_id'), $db->getField('message_text'), $db->getField('send_time'), $db->getField('msg_read'), $var['folder_id']);
+			displayMessage($messageBox, $db->getInt('message_id'), $db->getInt('account_id'), $db->getInt('sender_id'), $db->getField('message_text'), $db->getInt('send_time'), $db->getBoolean('msg_read'), $var['folder_id']);
 		}
 	}
 	if (!USING_AJAX) {
@@ -185,11 +185,11 @@ function displayScouts(&$messageBox, $player) {
 					ORDER BY last DESC');
 
 	while ($db->nextRecord()) {
-		$senderName = get_colored_text($db->getField('alignment'), stripslashes($db->getField('sender')) . ' (' . $db->getField('player_id') . ')');
+		$senderName = get_colored_text($db->getInt('alignment'), stripslashes($db->getField('sender')) . ' (' . $db->getInt('player_id') . ')');
 		$totalUnread = $db->getInt('total_unread');
-		$message = 'Your forces have spotted ' . $senderName . ' passing your forces ' . $db->getField('number') . ' ' . pluralise('time', $db->getField('number'));
+		$message = 'Your forces have spotted ' . $senderName . ' passing your forces ' . $db->getInt('number') . ' ' . pluralise('time', $db->getInt('number'));
 		$message .= ($totalUnread > 0) ? ' (' . $totalUnread . ' unread).' : '.';
-		displayGrouped($messageBox, $senderName, $db->getField('player_id'), $db->getField('sender_id'), $message, $db->getField('first'), $db->getField('last'), $totalUnread > 0);
+		displayGrouped($messageBox, $senderName, $db->getInt('player_id'), $db->getInt('sender_id'), $message, $db->getInt('first'), $db->getInt('last'), $totalUnread > 0);
 	}
 
 	// Now display individual messages in each group
@@ -205,7 +205,7 @@ function displayScouts(&$messageBox, $player) {
 		$groupBox =& $messageBox['GroupedMessages'][$db->getInt('sender_id')];
 		// Limit the number of messages in each group
 		if (!isset($groupBox['Messages']) || count($groupBox['Messages']) < MESSAGE_SCOUT_GROUP_LIMIT) {
-			displayMessage($groupBox, $db->getField('message_id'), $db->getField('account_id'), $db->getField('sender_id'), stripslashes($db->getField('message_text')), $db->getField('send_time'), $db->getField('msg_read'), MSG_SCOUT);
+			displayMessage($groupBox, $db->getInt('message_id'), $db->getInt('account_id'), $db->getInt('sender_id'), stripslashes($db->getField('message_text')), $db->getInt('send_time'), $db->getBoolean('msg_read'), MSG_SCOUT);
 		}
 	}
 
@@ -241,7 +241,7 @@ function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $me
 	$message = array();
 	$message['ID'] = $message_id;
 	$message['Text'] = $message_text;
-	$message['Unread'] = $msg_read == 'FALSE';
+	$message['Unread'] = !$msg_read;
 	$message['SendTime'] = date(DATE_FULL_SHORT, $send_time);
 
 	$sender = getMessagePlayer($sender_id, $player->getGameID(), $type);

--- a/engine/Default/news_read_advanced.php
+++ b/engine/Default/news_read_advanced.php
@@ -33,7 +33,7 @@ $db->query('SELECT alliance_id, alliance_name
 $newsAlliances = array();
 $newsAlliances[0] = array('ID' => 0, 'Name' => 'None');
 while ($db->nextRecord()) {
-	$newsAlliances[$db->getField('alliance_id')] = array('ID' => $db->getField('alliance_id'), 'Name' => $db->getField('alliance_name'));
+	$newsAlliances[$db->getInt('alliance_id')] = array('ID' => $db->getInt('alliance_id'), 'Name' => $db->getField('alliance_name'));
 }
 $template->assign('NewsAlliances', $newsAlliances);
 

--- a/engine/Default/rankings_alliance_vs_alliance.php
+++ b/engine/Default/rankings_alliance_vs_alliance.php
@@ -14,7 +14,7 @@ $detailsAllianceID = SmrSession::getRequestVar('alliance_id', $player->getAllian
 $activeAlliances = [];
 $db->query('SELECT alliance_id FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_deaths > 0 OR alliance_kills > 0) ORDER BY alliance_kills DESC, alliance_name');
 while ($db->nextRecord()) {
-	$activeAlliances[] = $db->getField('alliance_id');
+	$activeAlliances[] = $db->getInt('alliance_id');
 }
 $template->assign('ActiveAlliances', $activeAlliances);
 
@@ -100,7 +100,7 @@ $db->query('SELECT * FROM alliance_vs_alliance
 			WHERE alliance_id_1 = '.$db->escapeNumber($var['alliance_id']) . '
 				AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC');
 while ($db->nextRecord()) {
-	$id = $db->getField('alliance_id_2');
+	$id = $db->getInt('alliance_id_2');
 	if ($id > 0) {
 		$killer_alliance = SmrAlliance::getAlliance($id, $player->getGameID());
 		$alliance_name = $killer_alliance->getAllianceName();
@@ -122,7 +122,7 @@ $db->query('SELECT * FROM alliance_vs_alliance
 			WHERE alliance_id_2 = '.$db->escapeNumber($var['alliance_id']) . '
 				AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC');
 while ($db->nextRecord()) {
-	$id = $db->getField('alliance_id_1');
+	$id = $db->getInt('alliance_id_1');
 	if ($id > 0) {
 		$killer_alliance = SmrAlliance::getAlliance($id, $player->getGameID());
 		$alliance_name = $killer_alliance->getAllianceName();
@@ -134,7 +134,7 @@ while ($db->nextRecord()) {
 
 	$deaths[] = [
 		'Name' => $alliance_name,
-		'Deaths' => $db->getField('kills'),
+		'Deaths' => $db->getInt('kills'),
 	];
 }
 $template->assign('Deaths', $deaths);

--- a/engine/Default/rankings_race.php
+++ b/engine/Default/rankings_race.php
@@ -16,7 +16,7 @@ while ($db->nextRecord()) {
 
 	$ranks[] = [
 		'style' => $style,
-		'race_id' => $db->getField('race_id'),
+		'race_id' => $db->getInt('race_id'),
 		'exp_sum' => $db->getInt('exp_sum'),
 		'exp_avg' => round($db->getInt('exp_sum') / $db->getInt('num_players')),
 		'num_players' => $db->getInt('num_players'),

--- a/engine/Default/rankings_race_death.php
+++ b/engine/Default/rankings_race_death.php
@@ -16,7 +16,7 @@ while ($db->nextRecord()) {
 
 	$ranks[] = [
 		'style' => $style,
-		'race_id' => $db->getField('race_id'),
+		'race_id' => $db->getInt('race_id'),
 		'death_sum' => $db->getInt('death_sum'),
 	];
 }

--- a/engine/Default/rankings_race_kills.php
+++ b/engine/Default/rankings_race_kills.php
@@ -16,7 +16,7 @@ while ($db->nextRecord()) {
 
 	$ranks[] = [
 		'style' => $style,
-		'race_id' => $db->getField('race_id'),
+		'race_id' => $db->getInt('race_id'),
 		'kill_sum' => $db->getInt('kill_sum'),
 	];
 }

--- a/engine/Default/rankings_sector_kill.php
+++ b/engine/Default/rankings_sector_kill.php
@@ -10,7 +10,7 @@ $rank = 1;
 $topTen = [];
 while ($db->nextRecord()) {
 	// get current player
-	$sectorID = $db->getField('sector_id');
+	$sectorID = $db->getInt('sector_id');
 	$topTen[$rank++] = SmrSector::getSector($player->getGameID(), $sectorID, false, $db);
 }
 $template->assign('TopTen', $topTen);
@@ -30,7 +30,7 @@ if ($min_rank < 0) {
 
 $db->query('SELECT max(sector_id) FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
 if ($db->nextRecord()) {
-	$total_sector = $db->getField('max(sector_id)');
+	$total_sector = $db->getInt('max(sector_id)');
 }
 
 if ($max_rank > $total_sector) {
@@ -51,7 +51,7 @@ $rank = $min_rank;
 $topCustom = [];
 while ($db->nextRecord()) {
 	// get current player
-	$sectorID = $db->getField('sector_id');
+	$sectorID = $db->getInt('sector_id');
 	$topCustom[$rank++] = SmrSector::getSector($player->getGameID(), $sectorID, false, $db);
 }
 $template->assign('TopCustom', $topCustom);

--- a/engine/Default/trader_status.php
+++ b/engine/Default/trader_status.php
@@ -55,7 +55,7 @@ $template->assign('NoteDeleteHREF', SmrSession::getNewHREF($container));
 $notes = [];
 $db->query('SELECT * FROM player_has_notes WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND account_id=' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY note_id DESC');
 while ($db->nextRecord()) {
-	$notes[$db->getField('note_id')] = $db->getField('note');
+	$notes[$db->getInt('note_id')] = $db->getField('note');
 }
 $template->assign('Notes', $notes);
 

--- a/engine/Default/vote.php
+++ b/engine/Default/vote.php
@@ -11,21 +11,21 @@ if ($db->getNumRows() > 0) {
 	}
 	$voting = array();
 	while ($db->nextRecord()) {
-		$voteID = $db->getField('vote_id');
+		$voteID = $db->getInt('vote_id');
 		$voting[$voteID]['ID'] = $voteID;
 		$container = create_container('vote.php', 'vote_processing.php');
 		$container['vote_id'] = $voteID;
 		$voting[$voteID]['HREF'] = SmrSession::getNewHREF($container);
 		$voting[$voteID]['Question'] = $db->getField('question');
-		if ($db->getField('end') > TIME) {
-			$voting[$voteID]['TimeRemaining'] = format_time($db->getField('end') - TIME, true);
+		if ($db->getInt('end') > TIME) {
+			$voting[$voteID]['TimeRemaining'] = format_time($db->getInt('end') - TIME, true);
 		}
 		$voting[$voteID]['Options'] = array();
 		$db2->query('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = ' . $db2->escapeNumber($db->getInt('vote_id')) . ' GROUP BY option_id');
 		while ($db2->nextRecord()) {
 			$voting[$voteID]['Options'][$db2->getInt('option_id')]['ID'] = $db2->getInt('option_id');
 			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Text'] = $db2->getField('text');
-			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Chosen'] = isset($votedFor[$db->getField('vote_id')]) && $votedFor[$voteID] == $db2->getInt('option_id');
+			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Chosen'] = isset($votedFor[$db->getInt('vote_id')]) && $votedFor[$voteID] == $db2->getInt('option_id');
 			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Votes'] = $db2->getInt('count(account_id)');
 		}
 	}

--- a/htdocs/album/album_comment.php
+++ b/htdocs/album/album_comment.php
@@ -54,7 +54,7 @@ try {
 
 	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($album_id));
 	if ($db->nextRecord())
-		$comment_id = $db->getField('MAX(comment_id)') + 1;
+		$comment_id = $db->getInt('MAX(comment_id)') + 1;
 	else
 		$comment_id = 1;
 

--- a/htdocs/album/index.php
+++ b/htdocs/album/index.php
@@ -57,13 +57,13 @@ try {
 					ORDER BY hof_name');
 			
 			if ($db2->nextRecord())
-				album_entry($db2->getField('album_id'));
+				album_entry($db2->getInt('album_id'));
 			else {
 				// get all id's and build array
 				$album_ids = array();
 		
 				while ($db->nextRecord())
-					$album_ids[] = $db->getField('album_id');
+					$album_ids[] = $db->getInt('album_id');
 		
 				// double check if we have id's
 				if (count($album_ids) > 0)
@@ -75,7 +75,7 @@ try {
 		}
 		elseif ($db->getNumRows() == 1) {
 			if ($db->nextRecord())
-				album_entry($db->getField('album_id'));
+				album_entry($db->getInt('album_id'));
 			else
 				main_page();
 		}

--- a/lib/Album/album_functions.php
+++ b/lib/Album/album_functions.php
@@ -32,8 +32,8 @@ function main_page() {
 				LIMIT 5');
 	if ($db->getNumRows()) {
 		while ($db->nextRecord()) {
-			$page_views = $db->getField('page_views');
-			$nick = get_album_nick($db->getField('account_id'));
+			$page_views = $db->getInt('page_views');
+			$nick = get_album_nick($db->getInt('account_id'));
 
 			echo('<a href="?nick=' . urlencode($nick) . '">' . $nick . '</a> (' . $page_views . ')<br />');
 		}
@@ -48,8 +48,8 @@ function main_page() {
 				LIMIT 5');
 	if ($db->getNumRows()) {
 		while ($db->nextRecord()) {
-			$created = $db->getField('created');
-			$nick = get_album_nick($db->getField('account_id'));
+			$created = $db->getInt('created');
+			$nick = get_album_nick($db->getInt('account_id'));
 
 			echo('<span style="font-size:85%;"><b>[' . date(defined('DATE_FULL_SHORT') ?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $created) . ']</b> Picture of <a href="?nick=' . urlencode($nick) . '">' . $nick . '</a> added</span><br />');
 		}
@@ -85,8 +85,8 @@ function album_entry($album_id) {
 		$month = $db->getField('month');
 		$year = $db->getField('year');
 		$other = nl2br(stripslashes($db->getField('other')));
-		$page_views = $db->getField('page_views');
-		$disabled = $db->getField('disabled') == 'TRUE';
+		$page_views = $db->getInt('page_views');
+		$disabled = $db->getBoolean('disabled');
 	}
 	else {
 		echo('<h1>Error</h1>');
@@ -191,8 +191,8 @@ function album_entry($album_id) {
 				FROM album_has_comments
 				WHERE album_id = '.$db->escapeNumber($album_id));
 	while ($db->nextRecord()) {
-		$time = $db->getField('time');
-		$postee = get_album_nick($db->getField('post_id'));
+		$time = $db->getInt('time');
+		$postee = get_album_nick($db->getInt('post_id'));
 		$msg = stripslashes($db->getField('msg'));
 
 		echo('<span style="font-size:85%;">[' . date(defined('DATE_FULL_SHORT') ?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $time) . '] &lt;' . $postee . '&gt; ' . $msg . '</span><br />');

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -100,7 +100,7 @@ abstract class AbstractSmrAccount {
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT account_id FROM account WHERE login = '.$db->escapeString($login).' LIMIT 1');
 		if($db->nextRecord())
-			return self::getAccount($db->getField('account_id'),$forceUpdate);
+			return self::getAccount($db->getInt('account_id'), $forceUpdate);
 		$return = null;
 		return $return;
 	}
@@ -121,7 +121,7 @@ abstract class AbstractSmrAccount {
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT account_id FROM account where discord_id = '.$db->escapeString($id).' LIMIT 1');
 		if ($db->nextRecord()) {
-			return self::getAccount($db->getField('account_id'), $forceUpdate);
+			return self::getAccount($db->getInt('account_id'), $forceUpdate);
 		} else {
 			return null;
 		}
@@ -132,7 +132,7 @@ abstract class AbstractSmrAccount {
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT account_id FROM account WHERE irc_nick = '.$db->escapeString($nick).' LIMIT 1');
 		if ($db->nextRecord()) {
-			return self::getAccount($db->getField('account_id'), $forceUpdate);
+			return self::getAccount($db->getInt('account_id'), $forceUpdate);
 		} else {
 			return null;
 		}
@@ -305,7 +305,7 @@ abstract class AbstractSmrAccount {
 
 		$this->db->query('SELECT time,ip FROM account_has_ip WHERE '.$this->SQL.' ORDER BY time ASC');
 		if ($this->db->getNumRows() > 50 && $this->db->nextRecord()) {
-			$delete_time = $this->db->getField('time');
+			$delete_time = $this->db->getInt('time');
 			$delete_ip = $this->db->getField('ip');
 
 			$this->db->query('DELETE FROM account_has_ip
@@ -379,7 +379,7 @@ abstract class AbstractSmrAccount {
 					}
 					$hof =& $hof[$type];
 				}
-				$hof = $this->db->getField('amount');
+				$hof = $this->db->getFloat('amount');
 			}
 		}
 	}

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -1341,7 +1341,7 @@ abstract class AbstractSmrPlayer {
 			$this->visitedSectors = array();
 			$this->db->query('SELECT sector_id FROM player_visited_sector WHERE ' . $this->SQL);
 			while ($this->db->nextRecord())
-				$this->visitedSectors[$this->db->getField('sector_id')] = false;
+				$this->visitedSectors[$this->db->getInt('sector_id')] = false;
 		}
 		return !isset($this->visitedSectors[$sectorID]);
 	}

--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -1280,7 +1280,7 @@ class AbstractSmrPort {
 		$attackers = array();
 		$this->db->query('SELECT account_id,level FROM player_attacks_port WHERE ' . $this->SQL . ' AND time > ' . $this->db->escapeNumber(TIME - self::TIME_TO_CREDIT_RAID));
 		while ($this->db->nextRecord()) {
-			$attackers[] = SmrPlayer::getPlayer($this->db->getField('account_id'), $this->getGameID());
+			$attackers[] = SmrPlayer::getPlayer($this->db->getInt('account_id'), $this->getGameID());
 		}
 		return $attackers;
 	}

--- a/lib/Default/AbstractSmrShip.class.php
+++ b/lib/Default/AbstractSmrShip.class.php
@@ -46,14 +46,14 @@ abstract class AbstractSmrShip {
 		$ship = array();
 		$ship['Type'] = 'Ship';
 		$ship['Name'] = $db->getField('ship_name');
-		$ship['ShipTypeID'] = $db->getField('ship_type_id');
+		$ship['ShipTypeID'] = $db->getInt('ship_type_id');
 		$ship['ShipClassID'] = $db->getInt('ship_class_id');
-		$ship['RaceID'] = $db->getField('race_id');
-		$ship['Hardpoint'] = $db->getField('hardpoint');
-		$ship['Speed'] = $db->getField('speed');
-		$ship['Cost'] = $db->getField('cost');
-		$ship['AlignRestriction'] = $db->getField('buyer_restriction');
-		$ship['Level'] = $db->getField('lvl_needed');
+		$ship['RaceID'] = $db->getInt('race_id');
+		$ship['Hardpoint'] = $db->getInt('hardpoint');
+		$ship['Speed'] = $db->getInt('speed');
+		$ship['Cost'] = $db->getInt('cost');
+		$ship['AlignRestriction'] = $db->getInt('buyer_restriction');
+		$ship['Level'] = $db->getInt('lvl_needed');
 
 		$maxPower = 0;
 		switch ($ship['Hardpoint']) {
@@ -92,7 +92,7 @@ abstract class AbstractSmrShip {
 
 		while ($db2->nextRecord()) {
 			// adding hardware to array
-			$ship['MaxHardware'][$db2->getField('hardware_type_id')] = $db2->getField('max_amount');
+			$ship['MaxHardware'][$db2->getInt('hardware_type_id')] = $db2->getInt('max_amount');
 		}
 
 		$ship['BaseMR'] = round(

--- a/lib/Default/Globals.class.php
+++ b/lib/Default/Globals.class.php
@@ -44,7 +44,7 @@ class Globals {
 			self::$db->query('SELECT account_id FROM hidden_players');
 			self::$HIDDEN_PLAYERS = array(0); //stop errors
 			while (self::$db->nextRecord()) {
-				self::$HIDDEN_PLAYERS[] = self::$db->getField('account_id');
+				self::$HIDDEN_PLAYERS[] = self::$db->getInt('account_id');
 			}
 		}
 		return self::$HIDDEN_PLAYERS;
@@ -136,14 +136,14 @@ class Globals {
 			// determine user level
 			self::$db->query('SELECT * FROM good ORDER BY good_id');
 			while (self::$db->nextRecord()) {
-				self::$GOODS[self::$db->getField('good_id')] = array(
+				self::$GOODS[self::$db->getInt('good_id')] = array(
 																'Type' => 'Good',
 																'ID' => self::$db->getInt('good_id'),
 																'Name' => self::$db->getField('good_name'),
 																'Max' => self::$db->getInt('max_amount'),
 																'BasePrice' => self::$db->getInt('base_price'),
 																'Class' => self::$db->getInt('good_class'),
-																'ImageLink' => 'images/port/' . self::$db->getField('good_id') . '.png',
+																'ImageLink' => 'images/port/' . self::$db->getInt('good_id') . '.png',
 																'AlignRestriction' => self::$db->getInt('align_restriction')
 															);
 			}
@@ -168,7 +168,7 @@ class Globals {
 			// determine user level
 			self::$db->query('SELECT * FROM hardware_type ORDER BY hardware_type_id');
 			while (self::$db->nextRecord()) {
-				self::$HARDWARE_TYPES[self::$db->getField('hardware_type_id')] = array(
+				self::$HARDWARE_TYPES[self::$db->getInt('hardware_type_id')] = array(
 																			'Type' => 'Hardware',
 																			'ID' => self::$db->getInt('hardware_type_id'),
 																			'Name' => self::$db->getField('hardware_name'),

--- a/lib/Default/SmrGalaxy.class.php
+++ b/lib/Default/SmrGalaxy.class.php
@@ -27,7 +27,7 @@ class SmrGalaxy {
 			$db->query('SELECT * FROM game_galaxy WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY galaxy_id ASC');
 			$galaxies = array();
 			while ($db->nextRecord()) {
-				$galaxyID = $db->getField('galaxy_id');
+				$galaxyID = $db->getInt('galaxy_id');
 				$galaxies[$galaxyID] = self::getGalaxy($gameID, $galaxyID, $forceUpdate, $db);
 			}
 			self::$CACHE_GAME_GALAXIES[$gameID] = $galaxies;

--- a/lib/Default/SmrPlayer.class.php
+++ b/lib/Default/SmrPlayer.class.php
@@ -107,7 +107,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$db->query('SELECT * FROM player WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(true) . ' AND account_id NOT IN (' . $db->escapeArray(Globals::getHiddenPlayers()) . ') ORDER BY last_cpl_action DESC');
 			$players = array();
 			while ($db->nextRecord()) {
-				$accountID = $db->getField('account_id');
+				$accountID = $db->getInt('account_id');
 				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $db);
 			}
 			self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID] = $players;
@@ -698,7 +698,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$this->db->query('SELECT gadget_id,equipped,cooldown,lasts_until FROM player_has_gadget WHERE ' . $this->SQL);
 			$this->gadgets = array();
 			while ($this->db->nextRecord())
-				$this->gadgets[$this->db->getField('gadget_id')] = array('Equipped' => $this->db->getField('equipped'), 'Cooldown' => $this->db->getField('cooldown'), 'Expires' => $this->db->getField('lasts_until'));
+				$this->gadgets[$this->db->getInt('gadget_id')] = array('Equipped' => $this->db->getField('equipped'), 'Cooldown' => $this->db->getInt('cooldown'), 'Expires' => $this->db->getInt('lasts_until'));
 		}
 	}
 
@@ -1273,7 +1273,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 					}
 					$hof =& $hof[$type];
 				}
-				$hof = $this->db->getField('amount');
+				$hof = $this->db->getFloat('amount');
 			}
 			self::getHOFVis();
 		}
@@ -1296,7 +1296,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$this->bounties = array();
 			$this->db->query('SELECT * FROM bounty WHERE ' . $this->SQL);
 			while ($this->db->nextRecord()) {
-				$this->bounties[$this->db->getField('bounty_id')] = array(
+				$this->bounties[$this->db->getInt('bounty_id')] = array(
 							'Amount' => $this->db->getInt('amount'),
 							'SmrCredits' => $this->db->getInt('smr_credits'),
 							'Type' => $this->db->getField('type'),

--- a/lib/Default/SmrSector.class.php
+++ b/lib/Default/SmrSector.class.php
@@ -113,16 +113,16 @@ class SmrSector {
 			$this->battles = $db->getInt('battles');
 
 			$this->links = array();
-			if ($db->getField('link_up')) {
+			if ($db->getInt('link_up')) {
 				$this->links['Up'] = $db->getInt('link_up');
 			}
-			if ($db->getField('link_down')) {
+			if ($db->getInt('link_down')) {
 				$this->links['Down'] = $db->getInt('link_down');
 			}
-			if ($db->getField('link_left')) {
+			if ($db->getInt('link_left')) {
 				$this->links['Left'] = $db->getInt('link_left');
 			}
-			if ($db->getField('link_right')) {
+			if ($db->getInt('link_right')) {
 				$this->links['Right'] = $db->getInt('link_right');
 			}
 			$this->warp = $db->getInt('warp');

--- a/lib/Default/VoteSite.class.php
+++ b/lib/Default/VoteSite.class.php
@@ -96,7 +96,7 @@ class VoteSite {
 			$db->query('SELECT link_id, timeout FROM vote_links WHERE account_id=' . $db->escapeNumber($accountID) . ' AND link_id IN (' . join(',', $activeLinkIDs) . ') LIMIT ' . $db->escapeNumber(count($activeLinkIDs)));
 			while ($db->nextRecord()) {
 				// 'timeout' is the last time the player claimed free turns (or 0, if unclaimed)
-				$WAIT_TIMES[$db->getInt('link_id')] = ($db->getField('timeout') + TIME_BETWEEN_VOTING) - TIME;
+				$WAIT_TIMES[$db->getInt('link_id')] = ($db->getInt('timeout') + TIME_BETWEEN_VOTING) - TIME;
 			}
 			// If not in the vote_link database, this site is eligible now.
 			foreach ($activeLinkIDs as $linkID) {

--- a/lib/Default/WeightedRandom.class.php
+++ b/lib/Default/WeightedRandom.class.php
@@ -57,7 +57,7 @@ class WeightedRandom {
 		$this->db = new SmrMySqlDatabase();
 		$this->db->query('SELECT weighting FROM weighted_random WHERE game_id = ' . $this->db->escapeNumber($gameID) . ' AND account_id = ' . $this->db->escapeNumber($accountID) . ' AND type = ' . $this->db->escapeString($type) . ' AND type_id = ' . $this->db->escapeNumber($typeID) . ' LIMIT 1');
 		if ($this->db->nextRecord()) {
-			$this->weighting = $this->db->getField('weighting');
+			$this->weighting = $this->db->getInt('weighting');
 		} else {
 			$this->weighting = 0;
 		}

--- a/lib/Default/bar.functions.inc
+++ b/lib/Default/bar.functions.inc
@@ -11,13 +11,13 @@ function checkForLottoWinner($gameID) {
 		//we need to pick a winner
 		$db->query('SELECT * FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND time > 0 ORDER BY rand() LIMIT 1');
 		if ($db->nextRecord()) {
-			$winner_id = $db->getField('account_id');
+			$winner_id = $db->getInt('account_id');
 		}
 
 		// Any unclaimed prizes get merged into this prize
 		$db->query('SELECT SUM(prize) FROM player_has_ticket WHERE time = 0 AND game_id = ' . $db->escapeNumber($gameID));
 		if ($db->nextRecord()) {
-			$lottoInfo['Prize'] += $db->getField('SUM(prize)');
+			$lottoInfo['Prize'] += $db->getInt('SUM(prize)');
 		}
 
 		// Delete all tickets and re-insert the winning ticket
@@ -51,9 +51,9 @@ function getLottoInfo($gameID) {
 	$db->query('SELECT count(*) as num, min(time) as time FROM player_has_ticket
 				WHERE game_id = '.$db->escapeNumber($gameID) . ' AND time > 0');
 	$db->nextRecord();
-	if ($db->getField('num') > 0) {
-		$amount += $db->getField('num') * 1000000 * .9;
-		$firstBuy = $db->getField('time');
+	if ($db->getInt('num') > 0) {
+		$amount += $db->getInt('num') * 1000000 * .9;
+		$firstBuy = $db->getInt('time');
 	}
 	//find the time remaining in this jackpot. (which is 2 days from the first purchased ticket)
 	return array('Prize' => $amount, 'TimeRemaining' => $firstBuy + TIME_LOTTO - TIME);

--- a/lib/Default/council.inc
+++ b/lib/Default/council.inc
@@ -27,7 +27,7 @@ function modifyRelations($race_id_1) {
 						AND race_id_2 = ' . $db2->escapeNumber($race_id_2) . '
 						AND game_id = ' . $db2->escapeNumber($player->getGameID()));
 		if ($db2->nextRecord())
-			$relation = $db2->getField('relation') + $relation_modifier;
+			$relation = $db2->getInt('relation') + $relation_modifier;
 
 		if ($relation < MIN_GLOBAL_RELATIONS) {
 			$relation = MIN_GLOBAL_RELATIONS;

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -91,7 +91,7 @@ function getHofRank($view, $viewType, $accountID, $gameID) {
 	$realAmount = 0;
 	if ($db->nextRecord()) {
 		if ($db->getField('amount') != null) {
-			$realAmount = $db->getField('amount');
+			$realAmount = $db->getFloat('amount');
 		}
 	}
 	$rank['Amount'] = applyHofVisibilityMask($realAmount, $vis, $gameID, $accountID);

--- a/lib/Default/news.functions.inc
+++ b/lib/Default/news.functions.inc
@@ -22,7 +22,7 @@ function doBreakingNewsAssign($gameID, Template $template) {
 	$db = new SmrMySqlDatabase();
 	$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type = \'breaking\' AND time > ' . $db->escapeNumber(TIME - TIME_FOR_BREAKING_NEWS) . ' ORDER BY time DESC LIMIT 1');
 	if ($db->nextRecord()) {
-		$template->assign('BreakingNews', array('Time' => $db->getField('time'), 'Message' => bbifyMessage($db->getField('news_message'))));
+		$template->assign('BreakingNews', array('Time' => $db->getInt('time'), 'Message' => bbifyMessage($db->getField('news_message'))));
 	}
 }
 
@@ -32,6 +32,6 @@ function doLottoNewsAssign($gameID, Template $template) {
 	$db = new SmrMySqlDatabase();
 	$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type = \'lotto\' ORDER BY time DESC LIMIT 1');
 	if ($db->nextRecord()) {
-		 $template->assign('LottoNews', array('Time' => $db->getField('time'), 'Message' => bbifyMessage($db->getField('news_message'))));
+		 $template->assign('LottoNews', array('Time' => $db->getInt('time'), 'Message' => bbifyMessage($db->getField('news_message'))));
 	}
 }

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -601,7 +601,7 @@ function doTickerAssigns($template, $player, $db) {
 			//get recent news (5 mins)
 			$db->query('SELECT time,news_message FROM news WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND time >= ' . $max . ' ORDER BY time DESC LIMIT 4');
 			while ($db->nextRecord()) {
-				$ticker[] = array('Time' => date(DATE_FULL_SHORT, $db->getField('time')),
+				$ticker[] = array('Time' => date(DATE_FULL_SHORT, $db->getInt('time')),
 								'Message'=>$db->getField('news_message'));
 			}
 		}
@@ -615,7 +615,7 @@ function doTickerAssigns($template, $player, $db) {
 						ORDER BY send_time DESC
 						LIMIT 4');
 			while ($db->nextRecord()) {
-				$ticker[] = array('Time' => date(DATE_FULL_SHORT, $db->getField('send_time')),
+				$ticker[] = array('Time' => date(DATE_FULL_SHORT, $db->getInt('send_time')),
 								'Message'=>$db->getField('message_text'));
 			}
 		}

--- a/tools/chat_helpers/channel_msg_forces.php
+++ b/tools/chat_helpers/channel_msg_forces.php
@@ -55,8 +55,8 @@ function shared_channel_msg_forces($player, $option) {
 	}
 
 	if ($db->nextRecord()) {
-		$sectorId = $db->getField('sector');
-		$expire = $db->getField('expire_time');
+		$sectorId = $db->getInt('sector');
+		$expire = $db->getInt('expire_time');
 
 		return array('Forces in sector ' . $sectorId . ' will expire in ' . format_time($expire - time()));
 	} else {

--- a/tools/chat_helpers/channel_msg_money.php
+++ b/tools/chat_helpers/channel_msg_money.php
@@ -14,22 +14,22 @@ function shared_channel_msg_money($player) {
 	$db->query('SELECT alliance_account FROM alliance WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID());
 
 	if ($db->nextRecord()) {
-		$result[] = 'The alliance has ' . number_format($db->getField('alliance_account')) . ' credits in the bank account.';
+		$result[] = 'The alliance has ' . number_format($db->getInt('alliance_account')) . ' credits in the bank account.';
 	}
 
 	// get money on ships and personal bank accounts
 	$db->query('SELECT sum(credits) as total_onship, sum(bank) as total_onbank FROM player WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID());
 
 	if ($db->nextRecord()) {
-		$result[] = 'Alliance members carry a total of ' . number_format($db->getField('total_onship')) . ' credits with them';
-		$result[] = 'and keep a total of ' . number_format($db->getField('total_onbank')) . ' credits in their personal bank accounts.';
+		$result[] = 'Alliance members carry a total of ' . number_format($db->getInt('total_onship')) . ' credits with them';
+		$result[] = 'and keep a total of ' . number_format($db->getInt('total_onbank')) . ' credits in their personal bank accounts.';
 	}
 
 	// get money on planets
 	$db->query('SELECT SUM(credits) AS total_credits, SUM(bonds) AS total_bonds FROM planet WHERE game_id = ' . $player->getGameID() . ' AND owner_id IN (SELECT account_id FROM player WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID() . ')');
 	if ($db->nextRecord()) {
-		$result[] = 'There is a total of ' . number_format($db->getField('total_credits')) . ' credits on the planets';
-		$result[] = 'and ' . number_format($db->getField('total_bonds')) . ' credits in bonds.';
+		$result[] = 'There is a total of ' . number_format($db->getInt('total_credits')) . ' credits on the planets';
+		$result[] = 'and ' . number_format($db->getInt('total_bonds')) . ' credits in bonds.';
 	}
 
 	return $result;

--- a/tools/chat_helpers/channel_msg_op_info.php
+++ b/tools/chat_helpers/channel_msg_op_info.php
@@ -9,7 +9,7 @@ function shared_channel_msg_op_info($player) {
 	}
 
 	// check if the op has already started
-	$opTime = $db->getField('time');
+	$opTime = $db->getInt('time');
 	if ($opTime < time()) {
 		return array('The op started ' . format_time(time() - $opTime, true) . ' ago!');
 	}

--- a/tools/irc/channel.php
+++ b/tools/irc/channel.php
@@ -19,9 +19,9 @@ function channel_join($fp, $rdata)
 
 		if ($db->nextRecord()) {
 			// existing nick?
-			$seen_id = $db->getField('seen_id');
+			$seen_id = $db->getInt('seen_id');
 
-			$seen_count = $db->getField('seen_count');
+			$seen_count = $db->getInt('seen_count');
 			$seen_by = $db->getField('seen_by');
 
 			if ($seen_count > 1) {
@@ -83,7 +83,7 @@ function channel_part($fp, $rdata)
 		// exiting nick?
 		if ($db->nextRecord()) {
 
-			$seen_id = $db->getField('seen_id');
+			$seen_id = $db->getInt('seen_id');
 
 			$db->query('UPDATE irc_seen SET signed_off = ' . time() . ' WHERE seen_id = ' . $seen_id);
 

--- a/tools/irc/channel_msg.php
+++ b/tools/irc/channel_msg.php
@@ -165,12 +165,12 @@ function channel_msg_seen($fp, $rdata)
 			$seennick = $db->getField('nick');
 			$seenuser = $db->getField('user');
 			$seenhost = $db->getField('host');
-			$signed_on = $db->getField('signed_on');
-			$signed_off = $db->getField('signed_off');
+			$signed_on = $db->getInt('signed_on');
+			$signed_off = $db->getInt('signed_off');
 
 			if ($signed_off > 0) {
 
-				$seen_id = $db->getField('seen_id');
+				$seen_id = $db->getInt('seen_id');
 
 				// remember who did the !seen command
 				$db->query('UPDATE irc_seen

--- a/tools/irc/notice.php
+++ b/tools/irc/notice.php
@@ -16,7 +16,7 @@ function notice_nickserv_registered_user($fp, $rdata)
 
 		$db->query('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick));
 		while ($db->nextRecord()) {
-			$seen_id = $db->getField('seen_id');
+			$seen_id = $db->getInt('seen_id');
 
 			$db2->query('UPDATE irc_seen SET
 						registered_nick = ' . $db->escapeString($registeredNick) . '

--- a/tools/irc/server.php
+++ b/tools/irc/server.php
@@ -39,7 +39,7 @@ function server_msg_307($fp, $rdata)
 
 		$db->query('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick));
 		while ($db->nextRecord()) {
-			$seen_id = $db->getField('seen_id');
+			$seen_id = $db->getInt('seen_id');
 
 			$db2->query('UPDATE irc_seen SET ' .
 						'registered = 1 ' .
@@ -70,7 +70,7 @@ function server_msg_318($fp, $rdata)
 
 		$db->query('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND registered IS NULL');
 		while ($db->nextRecord()) {
-			$seen_id = $db->getField('seen_id');
+			$seen_id = $db->getInt('seen_id');
 
 			$db2->query('UPDATE irc_seen SET ' .
 						'registered = 0 ' .
@@ -133,7 +133,7 @@ function server_msg_352($fp, $rdata)
 
 		if ($db->nextRecord()) {
 			// exiting nick?
-			$seen_id = $db->getField('seen_id');
+			$seen_id = $db->getInt('seen_id');
 
 			$db->query('UPDATE irc_seen SET ' .
 					   'signed_on = ' . time() . ', ' .
@@ -175,7 +175,7 @@ function server_msg_401($fp, $rdata)
 		// get the user in question
 		$db->query('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND signed_off = 0');
 		if ($db->nextRecord()) {
-			$seen_id = $db->getField('seen_id');
+			$seen_id = $db->getInt('seen_id');
 
 			// maybe he left without us noticing, so we fix this now
 			$db->query('UPDATE irc_seen SET ' .

--- a/tools/irc/user.php
+++ b/tools/irc/user.php
@@ -78,7 +78,7 @@ function user_nick($fp, $rdata)
 
 			if ($db->nextRecord()) {
 				// exiting nick?
-				$seen_id = $db->getField('seen_id');
+				$seen_id = $db->getInt('seen_id');
 
 				$db->query('UPDATE irc_seen SET ' .
 						   'signed_on = ' . time() . ', ' .


### PR DESCRIPTION
Many of the errors caused by turning on type-strictness in #795 were
the result of getting content from the database as a string and then
using it like an int, float, or boolean.

We can use the `get{Int,Float,Boolean}` methods of MySqlDatabase
instead of `getField` (which returns a string) to improve the type-
correctness of our database query results.

Not every change made here is necessary to avoid an exception, but it
does make sense to try to be consistent about our data types.