### PR TITLE
Fix invalid array access in combat reports

### DIFF
--- a/templates/Default/engine/Default/includes/ForceTraderTeamCombatResults.inc
+++ b/templates/Default/engine/Default/includes/ForceTraderTeamCombatResults.inc
@@ -14,12 +14,9 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 					$ActualDamage =& $WeaponResults['ActualDamage'];
 					$WeaponDamage =& $WeaponResults['WeaponDamage'];
 					$TargetPlayer =& $WeaponResults['TargetPlayer'];
-					$DamageTypes = 0;
-					if($ActualDamage['NumMines'] > 0){ $DamageTypes = $DamageTypes+1; }
-					if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-					if($ActualDamage['NumSDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 					echo $ShootingPlayer->getDisplayName() ?> fires their <?php echo $ShootingWeapon->getName() ?> at<?php if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?> the debris that was once<?php } ?> the forces<?php
-					if(!$ActualDamage['TargetAlreadyDead']) {
+					if (!$ShotHit || !$ActualDamage['TargetAlreadyDead']) {
 						if(!$ShotHit) {
 							?> and misses<?php
 						} else if($ActualDamage['TotalDamage'] == 0) {
@@ -32,6 +29,11 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 							}
 						} else {
 							?> destroying <?php
+							$DamageTypes = 0;
+							if($ActualDamage['NumMines'] > 0){ $DamageTypes = $DamageTypes+1; }
+							if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+							if($ActualDamage['NumSDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 							if($ActualDamage['NumMines'] > 0) {
 								?><span class="red"><?php echo number_format($ActualDamage['NumMines']) ?></span> mines<?php
 								$this->doDamageTypeReductionDisplay($DamageTypes);
@@ -46,7 +48,7 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 						}
 					} ?>.
 					<br />
-					<?php if($ActualDamage['KillingShot']) {
+					<?php if ($ShotHit && $ActualDamage['KillingShot']) {
 						?>Forces are <span class="red">DESTROYED!</span><br /><?php
 					}
 				}
@@ -56,10 +58,7 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 				$ActualDamage =& $Drones['ActualDamage'];
 				$WeaponDamage =& $Drones['WeaponDamage'];
 				$TargetPlayer =& $Drones['TargetPlayer'];
-				$DamageTypes = 0;
-				if($ActualDamage['NumMines'] > $WeaponDamage['Kamikaze']) { $DamageTypes = $DamageTypes+1; }
-				if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-				if($ActualDamage['NumSDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 				echo $ShootingPlayer->getDisplayName();
 				if($WeaponDamage['Launched'] == 0) {
 					?> fails to launch their combat drones<?php
@@ -76,6 +75,11 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 								?> but they cannot do any damage<?php
 							}
 						} else {
+							$DamageTypes = 0;
+							if($ActualDamage['NumMines'] > $WeaponDamage['Kamikaze']) { $DamageTypes = $DamageTypes+1; }
+							if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+							if($ActualDamage['NumSDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 							if($WeaponDamage['Kamikaze'] == 0) {
 								?> destroying <?php
 							} else {

--- a/templates/Default/engine/Default/includes/ForcesCombatResults.inc
+++ b/templates/Default/engine/Default/includes/ForcesCombatResults.inc
@@ -6,11 +6,7 @@ if(isset($ForcesCombatResults['Results']) && is_array($ForcesCombatResults['Resu
 		$ActualDamage =& $ForceResults['ActualDamage'];
 		$WeaponDamage =& $ForceResults['WeaponDamage'];
 		$TargetPlayer =& $ForceResults['TargetPlayer'];
-		$DamageTypes = 0;
-		if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
-		if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-		if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; } ?>
-		
+		?>
 		<span class="cds"><?php echo isset($ActualDamage['Launched']) ? $ActualDamage['Launched'] : $WeaponDamage['Launched']; ?></span><?php
 		if($ForceType == 'Mines') {
 			?> mines kamikaze themselves against <?php
@@ -22,7 +18,7 @@ if(isset($ForcesCombatResults['Results']) && is_array($ForcesCombatResults['Resu
 		
 		if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?> the debris that was once <?php }
 		echo $TargetPlayer->getDisplayName();
-		if(!$ActualDamage['TargetAlreadyDead']) {
+		if (!$ShotHit || !$ActualDamage['TargetAlreadyDead']) {
 			if(!$ShotHit) {
 				?> and misses<?php
 			} else if($ActualDamage['TotalDamage'] == 0) {
@@ -40,6 +36,11 @@ if(isset($ForcesCombatResults['Results']) && is_array($ForcesCombatResults['Resu
 			} else {
 				?> destroying <?php
 			}
+			$DamageTypes = 0;
+			if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
+			if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+			if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 			if($ActualDamage['Shield'] > 0) {
 				?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
 				$this->doDamageTypeReductionDisplay($DamageTypes);
@@ -53,7 +54,7 @@ if(isset($ForcesCombatResults['Results']) && is_array($ForcesCombatResults['Resu
 			}
 		} ?>.
 		<br /><?php
-		if($ActualDamage['KillingShot']) {
+		if ($ShotHit && $ActualDamage['KillingShot']) {
 			$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$ForceResults['KillResults'],'TargetPlayer'=>$TargetPlayer));
 		}
 	}

--- a/templates/Default/engine/Default/includes/PlanetCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PlanetCombatResults.inc
@@ -18,13 +18,9 @@ if(isset($PlanetCombatResults['Weapons']) && is_array($PlanetCombatResults['Weap
 		$ActualDamage =& $WeaponResults['ActualDamage'];
 		$WeaponDamage =& $WeaponResults['WeaponDamage'];
 		$TargetPlayer =& $WeaponResults['TargetPlayer'];
-		$DamageTypes = 0;
-		if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
-		if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-		if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
 		
 		echo $CombatPlanet->getDisplayName() ?> fires a <?php echo $ShootingWeapon->getName(); ?> at <?php if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?> the debris that was once <?php } echo $TargetPlayer->getDisplayName();
-		if(!$ActualDamage['TargetAlreadyDead']) {
+		if (!$ShotHit || !$ActualDamage['TargetAlreadyDead']) {
 			if(!$ShotHit) {
 				?> and misses<?php
 			}
@@ -46,6 +42,11 @@ if(isset($PlanetCombatResults['Weapons']) && is_array($PlanetCombatResults['Weap
 			}
 			else {
 				?> destroying <?php
+				$DamageTypes = 0;
+				if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
+				if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+				if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 				if($ActualDamage['Shield'] > 0) {
 					?><span class="shields"><?php echo number_format($ActualDamage['Shield']); ?></span> shields<?php
 					$this->doDamageTypeReductionDisplay($DamageTypes);
@@ -60,7 +61,7 @@ if(isset($PlanetCombatResults['Weapons']) && is_array($PlanetCombatResults['Weap
 			}
 		} ?>.
 		<br /><?php
-		if($ActualDamage['KillingShot']) {
+		if ($ShotHit && $ActualDamage['KillingShot']) {
 			$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPlayer'=>$TargetPlayer));
 		}
 	}

--- a/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc
@@ -22,13 +22,9 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 				$ActualDamage =& $WeaponResults['ActualDamage'];
 				$WeaponDamage =& $WeaponResults['WeaponDamage'];
 				$TargetPlanet =& $WeaponResults['TargetPlanet'];
-				$DamageTypes = 0;
-				if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
-				if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-				if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
 				
 				echo $ShootingPlayer->getDisplayName() ?> fires their <?php echo $ShootingWeapon->getName() ?> at <?php if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?>the debris that was once <?php } echo $TargetPlanet->getDisplayName();
-				if(!$ActualDamage['TargetAlreadyDead']) {
+				if (!$ShotHit || !$ActualDamage['TargetAlreadyDead']) {
 					if(!$ShotHit) {
 						?> and misses<?php
 					} else if($ActualDamage['TotalDamage'] == 0) {
@@ -45,6 +41,11 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 						}
 					} else {
 						?> destroying <?php
+						$DamageTypes = 0;
+						if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
+						if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+						if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 						if($ActualDamage['Shield'] > 0) {
 							?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
 							$this->doDamageTypeReductionDisplay($DamageTypes);
@@ -59,7 +60,7 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 					}
 				} ?>.
 				<br /><?php
-				if($ActualDamage['KillingShot']) {
+				if ($ShotHit && $ActualDamage['KillingShot']) {
 					$this->includeTemplate('includes/PlanetKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPlanet'=>$TargetPlanet));
 				}
 			}

--- a/templates/Default/engine/Default/includes/PortCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PortCombatResults.inc
@@ -17,13 +17,9 @@ if(isset($PortCombatResults['Weapons']) && is_array($PortCombatResults['Weapons'
 		$ActualDamage =& $WeaponResults['ActualDamage'];
 		$WeaponDamage =& $WeaponResults['WeaponDamage'];
 		$TargetPlayer =& $WeaponResults['TargetPlayer'];
-		$DamageTypes = 0;
-		if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
-		if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-		if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
 		
 		echo $CombatPort->getDisplayName() ?> fires an <?php echo $ShootingWeapon->getName() ?> at <?php if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?> the debris that was once <?php } echo $TargetPlayer->getDisplayName();
-		if(!$ActualDamage['TargetAlreadyDead']) {
+		if (!$ShotHit || !$ActualDamage['TargetAlreadyDead']) {
 			if(!$ShotHit) {
 				?> and misses<?php
 			} else if($ActualDamage['TotalDamage'] == 0) {
@@ -40,6 +36,11 @@ if(isset($PortCombatResults['Weapons']) && is_array($PortCombatResults['Weapons'
 				}
 			} else {
 				?> destroying <?php
+				$DamageTypes = 0;
+				if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
+				if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+				if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 				if($ActualDamage['Shield'] > 0) {
 					?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
 					$this->doDamageTypeReductionDisplay($DamageTypes);
@@ -53,8 +54,8 @@ if(isset($PortCombatResults['Weapons']) && is_array($PortCombatResults['Weapons'
 				}
 			}
 		} ?>.
-		<br />
-		<?php if($ActualDamage['KillingShot']) {
+		<br /><?php
+		if ($ShotHit && $ActualDamage['KillingShot']) {
 			$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPlayer'=>$TargetPlayer));
 		}
 	}
@@ -64,10 +65,6 @@ if(isset($PortCombatResults['Drones'])) {
 	$ActualDamage =& $Drones['ActualDamage'];
 	$WeaponDamage =& $Drones['WeaponDamage'];
 	$TargetPlayer =& $Drones['TargetPlayer'];
-	$DamageTypes = 0;
-	if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
-	if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-	if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
 	
 	echo $CombatPort->getDisplayName();
 	if($WeaponDamage['Launched'] == 0) {
@@ -89,6 +86,11 @@ if(isset($PortCombatResults['Drones'])) {
 				}
 			} else {
 				?> destroying <?php
+				$DamageTypes = 0;
+				if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
+				if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+				if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 				if($ActualDamage['Shield'] > 0) {
 					?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
 					$this->doDamageTypeReductionDisplay($DamageTypes);

--- a/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc
@@ -22,13 +22,9 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 				$ActualDamage =& $WeaponResults['ActualDamage'];
 				$WeaponDamage =& $WeaponResults['WeaponDamage'];
 				$TargetPort =& $WeaponResults['TargetPort'];
-				$DamageTypes = 0;
-				if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
-				if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-				if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
 				
 				echo $ShootingPlayer->getDisplayName() ?> fires their <?php echo $ShootingWeapon->getName() ?> at <?php if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?>the remnants of <?php } echo $TargetPort->getDisplayName();
-				if(!$ActualDamage['TargetAlreadyDead']) {
+				if (!$ShotHit || !$ActualDamage['TargetAlreadyDead']) {
 					if(!$ShotHit) {
 						?> and misses every critical system<?php
 					} else if($ActualDamage['TotalDamage'] == 0) {
@@ -45,6 +41,11 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 						}
 					} else {
 						?> destroying <?php
+						$DamageTypes = 0;
+						if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
+						if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+						if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 						if($ActualDamage['Shield'] > 0) {
 							?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
 							$this->doDamageTypeReductionDisplay($DamageTypes);
@@ -59,7 +60,7 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 					}
 				} ?>.
 				<br /><?php
-				if($ActualDamage['KillingShot']) {
+				if ($ShotHit && $ActualDamage['KillingShot']) {
 					$this->includeTemplate('includes/PortKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPort'=>$TargetPort,'ShootingPlayer'=>$ShootingPlayer));
 				}
 			}
@@ -69,10 +70,6 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 			$ActualDamage =& $Drones['ActualDamage'];
 			$WeaponDamage =& $Drones['WeaponDamage'];
 			$TargetPort =& $Drones['TargetPort'];
-			$DamageTypes = 0;
-			if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
-			if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-			if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
 			
 			echo $ShootingPlayer->getDisplayName();
 			if($WeaponDamage['Launched'] == 0) {
@@ -100,6 +97,11 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 						}
 					} else {
 						?> destroying <?php
+						$DamageTypes = 0;
+						if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
+						if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+						if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 						if($ActualDamage['Shield'] > 0) {
 							?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
 							$this->doDamageTypeReductionDisplay($DamageTypes);

--- a/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc
+++ b/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc
@@ -14,17 +14,13 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 					$ActualDamage =& $WeaponResults['ActualDamage'];
 					$WeaponDamage =& $WeaponResults['WeaponDamage'];
 					$TargetPlayer =& $WeaponResults['TargetPlayer'];
-					$DamageTypes = 0;
-					if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
-					if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
-					if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
 					
 					echo $ShootingPlayer->getDisplayName() ?> fires their <?php echo $ShootingWeapon->getName() ?> at <?php
 					if($ShotHit && $ActualDamage['TargetAlreadyDead']) {
 						?>the debris that was once <?php
 					}
 					echo $TargetPlayer->getDisplayName();
-					if(!$ActualDamage['TargetAlreadyDead']) {
+					if (!$ShotHit || !$ActualDamage['TargetAlreadyDead']) {
 						if(!$ShotHit) {
 							?> and misses<?php
 						} else if($ActualDamage['TotalDamage'] == 0) {
@@ -41,6 +37,11 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 							}
 						} else {
 							?> destroying <?php
+							$DamageTypes = 0;
+							if($ActualDamage['Shield'] > 0){ $DamageTypes = $DamageTypes+1; }
+							if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
+							if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
+
 							if($ActualDamage['Shield'] > 0) {
 								?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
 								$this->doDamageTypeReductionDisplay($DamageTypes);
@@ -55,7 +56,7 @@ if(is_array($TraderTeamCombatResults['Traders'])) {
 						}
 					} ?>.
 					<br /><?php
-					if($ActualDamage['KillingShot']) {
+					if ($ShotHit && $ActualDamage['KillingShot']) {
 						$this->includeTemplate('includes/TraderCombatKillMessage.inc',array('KillResults'=>$WeaponResults['KillResults'],'TargetPlayer'=>$TargetPlayer,'ShootingPlayer'=>$ShootingPlayer));
 					}
 				}


### PR DESCRIPTION
PHP 7.4 now warns when trying to index `null` like an array. We have
a lot of places (in the combat report code specifically) that relied
on this returning null without a warning.

Fixes the following warning:

> Notice: Trying to access array offset on value of type null