### PR TITLE
npc.php: add NPC_MAX_ACTIONS

### DIFF
--- a/config/npc/config.specific.sample.php
+++ b/config/npc/config.specific.sample.php
@@ -2,6 +2,7 @@
 
 const NPC_LOG_TO_DATABASE = true; // insert debug messages into db
 
+const NPC_MAX_ACTIONS = 2500; // About a half hour worth of actions
 const NPC_LOW_TURNS = 75;
 const NPC_LOW_NEWBIE_TURNS = 10;
 const MINUMUM_RESERVE_CREDITS = 100000;

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -113,6 +113,13 @@ function NPCStuff() {
 		$_REQUEST = [];
 
 		$actions++;
+
+		// Avoid infinite loops by restricting the number of actions
+		if ($actions > NPC_MAX_ACTIONS) {
+			debug('Reached maximum number of actions: ' . NPC_MAX_ACTIONS);
+			changeNPCLogin();
+		}
+
 		try {
 			$TRADE_ROUTE =& $GLOBALS['TRADE_ROUTE'];
 			debug('Action #' . $actions);


### PR DESCRIPTION
To avoid an infinite loop, set an upper limit for the number of
actions an NPC can take in a single execution.

The sample limit is set to 2500 actions, which corresponds to about
a half hour of actions.