### PR TITLE
smr.inc: fix types in number_colour_format

### DIFF
--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -918,8 +918,8 @@ function number_colour_format($number, $justSign = false) {
 		$formatted .= '>';
 	if ($justSign === false) {
 		$decimalPlaces = 0;
-		if (($pos = strpos($number, '.')) !== false)
-			$decimalPlaces = strlen(substr($number, $pos + 1));
+		if (($pos = strpos((string)$number, '.')) !== false)
+			$decimalPlaces = strlen(substr((string)$number, $pos + 1));
 		$formatted .= number_format(abs($number), $decimalPlaces);
 	}
 	$formatted .= '</span>';


### PR DESCRIPTION
The `strpos` and `substr` methods expect a string as input, even
though `number_colour_format` will typically be passed a float|int.