### PR TITLE
SmrPort: fix visibility of stealGoods method

### DIFF
--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -396,7 +396,7 @@ class AbstractSmrPort {
 		$this->tradeGoods($good, $goodsTraded, $exp);
 	}
 	
-	protected function stealGoods(array $good, $goodsTraded) {
+	public function stealGoods(array $good, $goodsTraded) {
 		$this->decreaseGood($good, $goodsTraded, false);
 	}
 	


### PR DESCRIPTION
The `SmrPort::stealGoods` method needs to be public, since it is used
in shop_goods_processing.php.

This bug was introduced in 508cb96bd0.