### PR TITLE
Add rounding functions that return integer types

### DIFF
--- a/engine/Default/bar_buy_drink_processing.php
+++ b/engine/Default/bar_buy_drink_processing.php
@@ -73,7 +73,7 @@ $player->actionTaken('BuyDrink', array(
 //see if the player blacksout or not
 if (isset($num_drinks) && $num_drinks > 15) {
 	$percent = mt_rand(1, 25);
-	$lostCredits = round($player->getCredits() * $percent / 100);
+	$lostCredits = IRound($player->getCredits() * $percent / 100);
 
 	$message .= '<span class="red">You decide you need to go to the restroom.  So you stand up and try to start walking but immediately collapse!<br />About 10 minutes later you wake up and find yourself missing ' . number_format($lostCredits) . ' credits</span><br />';
 

--- a/engine/Default/cargo_dump_processing.php
+++ b/engine/Default/cargo_dump_processing.php
@@ -46,7 +46,7 @@ if ($player->getExperience() > 0) {
 
 	// Don't lose more exp than you have
 	$lost_xp = min($player->getExperience(),
-	               round(SmrPort::getBaseExperience($amount, $good_distance)));
+	               IRound(SmrPort::getBaseExperience($amount, $good_distance)));
 	$player->decreaseExperience($lost_xp);
 	$player->increaseHOF($lost_xp, array('Trade', 'Experience', 'Jettisoned'), HOF_PUBLIC);
 
@@ -55,7 +55,7 @@ if ($player->getExperience() > 0) {
 	$account->log(LOG_TYPE_TRADING, 'Dumps ' . $amount . ' of ' . $good_name . ' and loses ' . $lost_xp . ' experience', $player->getSectorID());
 } else {
 	// No experience to lose, so damage the ship
-	$damage = ceil($amount / 5);
+	$damage = ICeil($amount / 5);
 
 	// Don't allow ship to be destroyed dumping cargo
 	if ($ship->getArmour() <= $damage) {

--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -98,7 +98,7 @@ if ($transaction == 'Steal' ||
 	$base_xp = SmrPort::getBaseExperience($amount, $port->getGoodDistance($good_id));
 
 	// if offered equals ideal we get a problem (division by zero)
-	$gained_exp = round($port->calculateExperiencePercent($ideal_price, $offered_price, $bargain_price, $transaction) * $base_xp);
+	$gained_exp = IRound($port->calculateExperiencePercent($ideal_price, $offered_price, $bargain_price, $transaction) * $base_xp);
 
 	if ($transaction == 'Buy') {
 		$msg_transaction = 'bought';

--- a/engine/Default/shop_hardware_processing.php
+++ b/engine/Default/shop_hardware_processing.php
@@ -45,7 +45,7 @@ else if ($action == 'Sell') {
 		create_error('You can\'t sell more ' . $hardware_name . ' than you have aboard your ship!');
 	}
 
-	$player->increaseCredits(round($cost * CDS_REFUND_PERCENT) * $amount);
+	$player->increaseCredits(IRound($cost * CDS_REFUND_PERCENT) * $amount);
 	$ship->decreaseCDs($amount, true); // 2nd arg avoids under attack warning
 }
 else {

--- a/engine/Default/shop_ship_processing.php
+++ b/engine/Default/shop_ship_processing.php
@@ -30,7 +30,7 @@ if ($player->getCredits() < $cost) {
 }
 
 // adapt turns
-$player->setTurns(round($player->getTurns() * $newShip['Speed'] / $ship->getSpeed())); //Don't times by game speed as getSpeed doesn't include it meaning ratio will be the same but less work.
+$player->setTurns(IRound($player->getTurns() * $newShip['Speed'] / $ship->getSpeed())); //Don't times by game speed as getSpeed doesn't include it meaning ratio will be the same but less work.
 
 // take the money from the user
 if ($cost > 0) {

--- a/engine/Default/shop_weapon_processing.php
+++ b/engine/Default/shop_weapon_processing.php
@@ -46,7 +46,7 @@ if (!isset($var['OrderID'])) {
 } else {
 	// mhh we wanna sell our weapon
 	// give the money to the user
-	$player->increaseCredits(floor($weapon->getCost() * WEAPON_REFUND_PERCENT));
+	$player->increaseCredits(IFloor($weapon->getCost() * WEAPON_REFUND_PERCENT));
 
 	// take weapon
 	$ship->removeWeapon($var['OrderID']);

--- a/htdocs/config.inc
+++ b/htdocs/config.inc
@@ -144,6 +144,27 @@ function dumpMemDiff($msg) {
 	ob_start();
 }
 
+/**
+ * Wrapper around the floor() builtin for returning an integer type.
+ */
+function IFloor(float $val) : int {
+	return (int)floor($val);
+}
+
+/**
+ * Wrapper around the ceil() builtin for returning an integer type.
+ */
+function ICeil(float $val) : int {
+	return (int)ceil($val);
+}
+
+/**
+ * Wrapper around the round() builtin for returning an integer type.
+ */
+function IRound(float $val) : int {
+	return (int)round($val);
+}
+
 // Defines all constants
 require_once('config.php');
 

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -4,7 +4,7 @@ error_reporting(E_ALL);
 
 // Must use define so that the time is evaluated at runtime, not compile time.
 define('MICRO_TIME', microtime(true));
-define('TIME', intval(MICRO_TIME));
+define('TIME', IFloor(MICRO_TIME));
 
 // Repository paths
 const ROOT = __DIR__ . '/../';

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -433,8 +433,8 @@ abstract class AbstractSmrAccount {
 		return $this->individualScores[$gameID];
 	}
 
-	public function getRank() {
-		$rank = ceil(pow($this->getScore(),self::USER_RANKINGS_TOTAL_SCORE_POW)/self::USER_RANKINGS_RANK_BOUNDARY);
+	public function getRank() : int {
+		$rank = ICeil(pow($this->getScore(),self::USER_RANKINGS_TOTAL_SCORE_POW)/self::USER_RANKINGS_RANK_BOUNDARY);
 		if($rank<1)
 			$rank=1;
 		if($rank > $this->maxRankAchieved)

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -327,10 +327,14 @@ abstract class AbstractSmrPlayer {
 		return $this->experience;
 	}
 
-	public function getNextLevelPercentAcquired() {
+	/**
+	 * Returns the percent progress towards the next level.
+	 * This value is rounded because it is used primarily in HTML img widths.
+	 */
+	public function getNextLevelPercentAcquired() : int {
 		if ($this->getNextLevelExperience() == $this->getThisLevelExperience())
 			return 100;
-		return max(0, min(100, round(($this->getExperience() - $this->getThisLevelExperience()) / ($this->getNextLevelExperience() - $this->getThisLevelExperience()) * 100)));
+		return max(0, min(100, IRound(($this->getExperience() - $this->getThisLevelExperience()) / ($this->getNextLevelExperience() - $this->getThisLevelExperience()) * 100)));
 	}
 
 	public function getNextLevelPercentRemaining() {
@@ -922,7 +926,7 @@ abstract class AbstractSmrPlayer {
 		if ($take < 0 || $takeNewbie < 0) {
 			throw new Exception('Trying to take negative turns.');
 		}
-		$take = ceil($take);
+		$take = ICeil($take);
 		// Only take up to as many newbie turns as we have remaining
 		$takeNewbie = min($this->getNewbieTurns(), $takeNewbie);
 
@@ -937,11 +941,11 @@ abstract class AbstractSmrPlayer {
 		$this->updateLastCPLAction();
 	}
 
-	public function giveTurns($give, $giveNewbie = 0) {
+	public function giveTurns(int $give, $giveNewbie = 0) {
 		if ($give < 0 || $giveNewbie < 0) {
 			throw new Exception('Trying to give negative turns.');
 		}
-		$this->setTurns($this->getTurns() + floor($give));
+		$this->setTurns($this->getTurns() + $give);
 		$this->setNewbieTurns($this->getNewbieTurns() + $giveNewbie);
 	}
 

--- a/lib/Default/AbstractSmrShip.class.php
+++ b/lib/Default/AbstractSmrShip.class.php
@@ -95,7 +95,7 @@ abstract class AbstractSmrShip {
 			$ship['MaxHardware'][$db2->getInt('hardware_type_id')] = $db2->getInt('max_amount');
 		}
 
-		$ship['BaseMR'] = round(
+		$ship['BaseMR'] = IRound(
 								700 -
 								(
 									(
@@ -224,28 +224,28 @@ abstract class AbstractSmrShip {
 			return $this->getDefenseRating();
 	}
 
-	public function getAttackRating() {
-		return round(($this->getTotalShieldDamage() + $this->getTotalArmourDamage() + $this->getCDs() * 2) / 40);
+	public function getAttackRating() : int {
+		return IRound(($this->getTotalShieldDamage() + $this->getTotalArmourDamage() + $this->getCDs() * 2) / 40);
 	}
 
-	public function getAttackRatingWithMaxCDs() {
-		return round(($this->getTotalShieldDamage() + $this->getTotalArmourDamage() + $this->getMaxCDs() * .7) / 40);
+	public function getAttackRatingWithMaxCDs() : int {
+		return IRound(($this->getTotalShieldDamage() + $this->getTotalArmourDamage() + $this->getMaxCDs() * .7) / 40);
 	}
 
-	public function getDefenseRating() {
-		return round((($this->getShields() + $this->getArmour()) / 100) + (($this->getCDs() * 3) / 100));
+	public function getDefenseRating() : int {
+		return IRound((($this->getShields() + $this->getArmour()) / 100) + (($this->getCDs() * 3) / 100));
 	}
 
-	public function getMaxDefenseRating() {
-		return round((($this->getMaxShields() + $this->getMaxArmour()) / 100) + (($this->getMaxCDs() * 3) / 100));
+	public function getMaxDefenseRating() : int {
+		return IRound((($this->getMaxShields() + $this->getMaxArmour()) / 100) + (($this->getMaxCDs() * 3) / 100));
 	}
 
-	public function getShieldLow() { return floor($this->getShields() / 100) * 100; }
-	public function getShieldHigh() { return $this->getShieldLow() + 100; }
-	public function getArmourLow() { return floor($this->getArmour() / 100) * 100; }
-	public function getArmourHigh() { return $this->getArmourLow() + 100; }
-	public function getCDsLow() { return floor($this->getCDs() / 100) * 100; }
-	public function getCDsHigh() { return $this->getCDsLow() + 100; }
+	public function getShieldLow() : int { return IFloor($this->getShields() / 100) * 100; }
+	public function getShieldHigh() : int { return $this->getShieldLow() + 100; }
+	public function getArmourLow() : int { return IFloor($this->getArmour() / 100) * 100; }
+	public function getArmourHigh() : int { return $this->getArmourLow() + 100; }
+	public function getCDsLow() : int { return IFloor($this->getCDs() / 100) * 100; }
+	public function getCDsHigh() : int { return $this->getCDsLow() + 100; }
 
 
 
@@ -462,7 +462,7 @@ abstract class AbstractSmrShip {
 
 	public function getCostToUpgrade($upgradeShipID) {
 		$upgadeBaseShip = AbstractSmrShip::getBaseShip(Globals::getGameType($this->getGameID()), $upgradeShipID);
-		return $upgadeBaseShip['Cost'] - floor($this->getCost() * SHIP_REFUND_PERCENT);
+		return $upgadeBaseShip['Cost'] - IFloor($this->getCost() * SHIP_REFUND_PERCENT);
 	}
 
 	public function getCostToUpgradeAndUNO($upgradeShipID) {
@@ -889,7 +889,7 @@ abstract class AbstractSmrShip {
 			$results['Drones'] =& $thisCDs->shootPlayer($thisPlayer, $targetPlayers[array_rand($targetPlayers)]);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}
-		$thisPlayer->increaseExperience(round($results['TotalDamage'] * self::EXP_PER_DAMAGE_PLAYER));
+		$thisPlayer->increaseExperience(IRound($results['TotalDamage'] * self::EXP_PER_DAMAGE_PLAYER));
 		$thisPlayer->increaseHOF($results['TotalDamage'], array('Combat', 'Player', 'Damage Done'), HOF_PUBLIC);
 		$thisPlayer->increaseHOF(1, array('Combat', 'Player', 'Shots'), HOF_PUBLIC);
 		return $results;
@@ -928,7 +928,7 @@ abstract class AbstractSmrShip {
 			$thisPlayer->increaseHOF($results['Drones']['ActualDamage']['SDs'], array('Combat', 'Forces', 'Scout Drones', 'Damage Done'), HOF_PUBLIC);
 			$thisPlayer->increaseHOF($results['Drones']['ActualDamage']['NumMines'] + $results['Drones']['ActualDamage']['NumCDs'] + $results['Drones']['ActualDamage']['NumSDs'], array('Combat', 'Forces', 'Killed'), HOF_PUBLIC);
 		}
-		$thisPlayer->increaseExperience(round($results['TotalDamage'] * self::EXP_PER_DAMAGE_FORCE));
+		$thisPlayer->increaseExperience(IRound($results['TotalDamage'] * self::EXP_PER_DAMAGE_FORCE));
 		$thisPlayer->increaseHOF($results['TotalDamage'], array('Combat', 'Forces', 'Damage Done'), HOF_PUBLIC);
 		$thisPlayer->increaseHOF(1, array('Combat', 'Forces', 'Shots'), HOF_PUBLIC);
 		return $results;
@@ -952,7 +952,7 @@ abstract class AbstractSmrShip {
 			$results['Drones'] =& $thisCDs->shootPort($thisPlayer, $port);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}
-		$thisPlayer->increaseExperience(round($results['TotalDamage'] * self::EXP_PER_DAMAGE_PORT));
+		$thisPlayer->increaseExperience(IRound($results['TotalDamage'] * self::EXP_PER_DAMAGE_PORT));
 		$thisPlayer->increaseHOF($results['TotalDamage'], array('Combat', 'Port', 'Damage Done'), HOF_PUBLIC);
 //		$thisPlayer->increaseHOF(1,array('Combat','Port','Shots')); //in SmrPortt::attackedBy()
 
@@ -989,7 +989,7 @@ abstract class AbstractSmrShip {
 			$results['Drones'] =& $thisCDs->shootPlanet($thisPlayer, $planet, $delayed);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}
-		$thisPlayer->increaseExperience(round($results['TotalDamage'] * self::EXP_PER_DAMAGE_PLANET));
+		$thisPlayer->increaseExperience(IRound($results['TotalDamage'] * self::EXP_PER_DAMAGE_PLANET));
 		$thisPlayer->increaseHOF($results['TotalDamage'], array('Combat', 'Planet', 'Damage Done'), HOF_PUBLIC);
 //		$thisPlayer->increaseHOF(1,array('Combat','Planet','Shots')); //in SmrPlanet::attackedBy()
 		return $results;
@@ -1056,7 +1056,7 @@ abstract class AbstractSmrShip {
 	}
 
 	protected function doCDDamage($damage) {
-		$actualDamage = min($this->getCDs(), floor($damage / CD_ARMOUR));
+		$actualDamage = min($this->getCDs(), IFloor($damage / CD_ARMOUR));
 		$this->decreaseCDs($actualDamage);
 		return $actualDamage * CD_ARMOUR;
 	}
@@ -1067,8 +1067,8 @@ abstract class AbstractSmrShip {
 		return $actualDamage;
 	}
 
-	public function getMR() {
-		return round(
+	public function getMR() : int {
+		return IRound(
 						700 -
 						(
 							(

--- a/lib/Default/SmrCombatDrones.class.php
+++ b/lib/Default/SmrCombatDrones.class.php
@@ -130,15 +130,15 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 		if (!$this->canShootForces()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		$damage =& $this->getModifiedDamage();
-		$damage['Launched'] = ceil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstForces($weaponPlayer, $forces) / 100);
+		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstForces($weaponPlayer, $forces) / 100);
 		$damage['Kamikaze'] = 0;
 		if ($weaponPlayer->isCombatDronesKamikazeOnMines()) { // If kamikaze then damage is same as MINE_ARMOUR
 			$damage['Kamikaze'] = min($damage['Launched'], $forces->getMines());
 			$damage['Launched'] -= $damage['Kamikaze'];
 		}
-		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
-		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
+		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
+		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
+		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
 		
 		$damage['Launched'] += $damage['Kamikaze'];
 		$damage['MaxDamage'] += $damage['Kamikaze'] * MINE_ARMOUR;
@@ -152,10 +152,10 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 		if (!$this->canShootPorts()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		$damage =& $this->getModifiedDamage();
-		$damage['Launched'] = ceil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPort($weaponPlayer, $port) / 100);
-		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
-		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
+		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPort($weaponPlayer, $port) / 100);
+		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
+		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
+		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
 		
 		return $damage;
 	}
@@ -164,11 +164,11 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 		if (!$this->canShootPlanets()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		$damage =& $this->getModifiedDamage();
-		$damage['Launched'] = ceil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPlanet($weaponPlayer, $planet) / 100);
+		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPlanet($weaponPlayer, $planet) / 100);
 		$planetMod = self::PLANET_DAMAGE_MOD;
-		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage'] * $planetMod);
-		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield'] * $planetMod);
-		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour'] * $planetMod);
+		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage'] * $planetMod);
+		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield'] * $planetMod);
+		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour'] * $planetMod);
 		
 		return $damage;
 	}
@@ -184,10 +184,10 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			$damage['Shield'] *= DCS_PLAYER_DAMAGE_DECIMAL_PERCENT;
 			$damage['Armour'] *= DCS_PLAYER_DAMAGE_DECIMAL_PERCENT;
 		}
-		$damage['Launched'] = ceil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPlayer($weaponPlayer, $targetPlayer) / 100);
-		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
-		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
+		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPlayer($weaponPlayer, $targetPlayer) / 100);
+		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
+		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
+		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
 		return $damage;
 	}
 	
@@ -204,10 +204,10 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			$damage['Armour'] *= DCS_FORCE_DAMAGE_DECIMAL_PERCENT;
 		}
 		
-		$damage['Launched'] = ceil($this->getNumberOfCDs() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer) / 100);
-		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
-		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
+		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer) / 100);
+		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
+		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
+		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
 		return $damage;
 	}
 	
@@ -223,10 +223,10 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			$damage['Shield'] *= DCS_PORT_DAMAGE_DECIMAL_PERCENT;
 			$damage['Armour'] *= DCS_PORT_DAMAGE_DECIMAL_PERCENT;
 		}
-		$damage['Launched'] = ceil($this->getNumberOfCDs() * $this->getModifiedPortAccuracyAgainstPlayer($port, $targetPlayer) / 100);
-		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
-		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
+		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedPortAccuracyAgainstPlayer($port, $targetPlayer) / 100);
+		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
+		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
+		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
 		return $damage;
 	}
 	
@@ -242,10 +242,10 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			$damage['Shield'] *= DCS_PLANET_DAMAGE_DECIMAL_PERCENT;
 			$damage['Armour'] *= DCS_PLANET_DAMAGE_DECIMAL_PERCENT;
 		}
-		$damage['Launched'] = ceil($this->getNumberOfCDs() * $this->getModifiedPlanetAccuracyAgainstPlayer($planet, $targetPlayer) / 100);
-		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
-		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
+		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedPlanetAccuracyAgainstPlayer($planet, $targetPlayer) / 100);
+		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
+		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
+		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
 		return $damage;
 	}
 	

--- a/lib/Default/SmrForce.class.php
+++ b/lib/Default/SmrForce.class.php
@@ -522,19 +522,19 @@ class SmrForce {
 	}
 
 	protected function doMinesDamage($damage) {
-		$actualDamage = min($this->getMines(), floor($damage / MINE_ARMOUR));
+		$actualDamage = min($this->getMines(), IFloor($damage / MINE_ARMOUR));
 		$this->takeMines($actualDamage);
 		return $actualDamage * MINE_ARMOUR;
 	}
 
 	protected function doCDDamage($damage) {
-		$actualDamage = min($this->getCDs(), floor($damage / CD_ARMOUR));
+		$actualDamage = min($this->getCDs(), IFloor($damage / CD_ARMOUR));
 		$this->takeCDs($actualDamage);
 		return $actualDamage * CD_ARMOUR;
 	}
 
 	protected function doSDDamage($damage) {
-		$actualDamage = min($this->getSDs(), floor($damage / SD_ARMOUR));
+		$actualDamage = min($this->getSDs(), IFloor($damage / SD_ARMOUR));
 		$this->takeSDs($actualDamage);
 		return $actualDamage * SD_ARMOUR;
 	}

--- a/lib/Default/SmrMines.class.php
+++ b/lib/Default/SmrMines.class.php
@@ -96,20 +96,20 @@ class SmrMines extends AbstractSmrCombatWeapon {
 		}
 		$damage =& $this->getModifiedDamage();
 		if ($targetPlayer->getShip()->isFederal()) { // do less damage to fed ships 
-			$damage['MaxDamage'] = round($damage['MaxDamage'] * self::FED_SHIP_DAMAGE_MODIFIER);
-			$damage['Shield'] = round($damage['Shield'] * self::FED_SHIP_DAMAGE_MODIFIER);
-			$damage['Armour'] = round($damage['Armour'] * self::FED_SHIP_DAMAGE_MODIFIER);
+			$damage['MaxDamage'] = IRound($damage['MaxDamage'] * self::FED_SHIP_DAMAGE_MODIFIER);
+			$damage['Shield'] = IRound($damage['Shield'] * self::FED_SHIP_DAMAGE_MODIFIER);
+			$damage['Armour'] = IRound($damage['Armour'] * self::FED_SHIP_DAMAGE_MODIFIER);
 		} 
 		
 		if ($targetPlayer->getShip()->hasDCS()) { // do less damage to DCS (Drone Scrambler) 
-			$damage['MaxDamage'] = round($damage['MaxDamage'] * self::DCS_DAMAGE_MODIFIER);
-			$damage['Shield'] = round($damage['Shield'] * self::DCS_DAMAGE_MODIFIER);
-			$damage['Armour'] = round($damage['Armour'] * self::DCS_DAMAGE_MODIFIER);		
+			$damage['MaxDamage'] = IRound($damage['MaxDamage'] * self::DCS_DAMAGE_MODIFIER);
+			$damage['Shield'] = IRound($damage['Shield'] * self::DCS_DAMAGE_MODIFIER);
+			$damage['Armour'] = IRound($damage['Armour'] * self::DCS_DAMAGE_MODIFIER);
 		}
-		$damage['Launched'] = ceil($this->getNumberOfMines() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer, $minesAreAttacker) / 100);
-		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
-		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
+		$damage['Launched'] = ICeil($this->getNumberOfMines() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer, $minesAreAttacker) / 100);
+		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
+		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
+		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
 		return $damage;
 	}
 	
@@ -133,7 +133,7 @@ class SmrMines extends AbstractSmrCombatWeapon {
 	protected function &doForceDamageToPlayer(array &$return, SmrForce $forces, AbstractSmrPlayer $targetPlayer, $minesAreAttacker = false) {
 		$return['WeaponDamage'] =& $this->getModifiedForceDamageAgainstPlayer($forces, $targetPlayer, $minesAreAttacker);
 		$return['ActualDamage'] =& $targetPlayer->getShip()->doMinesDamage($return['WeaponDamage']);
-		$return['ActualDamage']['Launched'] = ceil($return['WeaponDamage']['Launched'] * $return['ActualDamage']['TotalDamage'] / $return['WeaponDamage']['MaxDamage']);
+		$return['ActualDamage']['Launched'] = ICeil($return['WeaponDamage']['Launched'] * $return['ActualDamage']['TotalDamage'] / $return['WeaponDamage']['MaxDamage']);
 
 		if ($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] =& $targetPlayer->killPlayerByForces($forces);

--- a/lib/Default/SmrPlanet.class.php
+++ b/lib/Default/SmrPlanet.class.php
@@ -196,8 +196,8 @@ class SmrPlanet {
 		}
 	}
 
-	public function getBondTime() {
-		return round(BOND_TIME / $this->getGame()->getGameSpeed());
+	public function getBondTime() : int {
+		return IRound(BOND_TIME / $this->getGame()->getGameSpeed());
 	}
 
 	public function bond() {
@@ -940,9 +940,9 @@ class SmrPlanet {
 	}
 
 	// Amount of time (in seconds) to build the next building of this type
-	public function getConstructionTime($constructionID) {
+	public function getConstructionTime($constructionID) : int {
 		$baseTime = $this->getStructureTypes($constructionID)->baseTime();
-		$constructionTime = ceil($baseTime * $this->getCompletionModifier($constructionID) / $this->getGame()->getGameSpeed());
+		$constructionTime = ICeil($baseTime * $this->getCompletionModifier($constructionID) / $this->getGame()->getGameSpeed());
 		return $constructionTime;
 	}
 	
@@ -1229,7 +1229,7 @@ class SmrPlanet {
 
 			}
 			else { // hit drones behind shields - we should only use this reduced damage branch if we cannot hit shields.
-				$cdDamage = $this->doCDDamage(floor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT), $delayed);
+				$cdDamage = $this->doCDDamage(IFloor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT), $delayed);
 			}
 		}
 
@@ -1255,7 +1255,7 @@ class SmrPlanet {
 	}
 
 	protected function doCDDamage($damage, $delayed) {
-		$actualDamage = min($this->getCDs(true), floor($damage / CD_ARMOUR));
+		$actualDamage = min($this->getCDs(true), IFloor($damage / CD_ARMOUR));
 		$this->decreaseCDs($actualDamage, $delayed);
 		return $actualDamage * CD_ARMOUR;
 	}

--- a/lib/Default/SmrScoutDrones.class.php
+++ b/lib/Default/SmrScoutDrones.class.php
@@ -81,10 +81,10 @@ class SmrScoutDrones extends AbstractSmrCombatWeapon {
 			return $return;
 		}
 		$damage =& $this->getModifiedDamage();
-		$damage['Launched'] = ceil($this->getNumberOfSDs() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer) / 100);
-		$damage['MaxDamage'] = ceil($damage['Launched'] * $damage['MaxDamage']);
-		$damage['Shield'] = ceil($damage['Launched'] * $damage['Shield']);
-		$damage['Armour'] = ceil($damage['Launched'] * $damage['Armour']);
+		$damage['Launched'] = ICeil($this->getNumberOfSDs() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer) / 100);
+		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
+		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
+		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
 		return $damage;
 	}
 	

--- a/lib/Default/SmrSession.class.php
+++ b/lib/Default/SmrSession.class.php
@@ -178,7 +178,7 @@ class SmrSession {
 			$loadDelay = isset(self::URL_LOAD_DELAY[$currentPage]) ? self::URL_LOAD_DELAY[$currentPage] : 0;
 			$initialTimeBetweenLoads = microtime(true) - $var['PreviousRequestTime'];
 			while (($timeBetweenLoads = microtime(true) - $var['PreviousRequestTime']) < $loadDelay) {
-				$sleepTime = round(($loadDelay - $timeBetweenLoads) * 1000000);
+				$sleepTime = IRound(($loadDelay - $timeBetweenLoads) * 1000000);
 			//	echo 'Sleeping for: ' . $sleepTime . 'us';
 				usleep($sleepTime);
 			}

--- a/lib/Default/SmrWeapon.class.php
+++ b/lib/Default/SmrWeapon.class.php
@@ -209,9 +209,9 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 		$damage =& $this->getModifiedDamage();
 		
 		$planetMod = self::PLANET_DAMAGE_MOD;
-		$damage['MaxDamage'] = ceil($damage['MaxDamage'] * $planetMod);
-		$damage['Shield'] = ceil($damage['Shield'] * $planetMod);
-		$damage['Armour'] = ceil($damage['Armour'] * $planetMod);
+		$damage['MaxDamage'] = ICeil($damage['MaxDamage'] * $planetMod);
+		$damage['Shield'] = ICeil($damage['Shield'] * $planetMod);
+		$damage['Armour'] = ICeil($damage['Armour'] * $planetMod);
 		
 		return $damage;
 	}

--- a/tools/npc/chess.php
+++ b/tools/npc/chess.php
@@ -48,7 +48,7 @@ try {
 	while(true) {
 		//Redefine MICRO_TIME and TIME, the rest of the game expects them to be the single point in time that the script is executing, with it being redefined for each page load - unfortunately NPCs are one consistent script so we have to do a hack and redefine it (or change every instance of the TIME constant).
 		runkit_constant_redefine('MICRO_TIME', microtime(true));
-		runkit_constant_redefine('TIME', intval(MICRO_TIME));
+		runkit_constant_redefine('TIME', IFloor(MICRO_TIME));
 
 		foreach (ChessGame::getNPCMoveGames(true) as $chessGame) {
 			debug('Looking at game: ' . $chessGame->getChessGameID());

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -362,7 +362,7 @@ function processContainer($container) {
 	debug('Executing container', $container);
  	//Redefine MICRO_TIME and TIME, the rest of the game expects them to be the single point in time that the script is executing, with it being redefined for each page load - unfortunately NPCs are one consistent script so we have to do a hack and redefine it (or change every instance of the TIME constant.
 	uopz_redefine('MICRO_TIME', microtime(true));
-	uopz_redefine('TIME', intval(MICRO_TIME));
+	uopz_redefine('TIME', IFloor(MICRO_TIME));
 	resetContainer($container);
 	do_voodoo();
 }


### PR DESCRIPTION
The functions `round`, `floor`, and `ceil` return a float type, even
though the returned value is a whole number. With strict types enabled,
we can not pass the result of one of these functions as an argument
that is type-hinted as an integer.

We add wrappers for these functions: `IRound`, `IFloor`, and `ICeil`,
which cast the return value as an int type.

NOTE: While `intval` is another method of converting to int types, we
want to avoid it, where possible, since it casts _any_ type to an int.
If we know the input is a float, then we should use `IFloor` instead.