### PR TITLE
SmrPort: fix "Levels Raided" HoF credit

### DIFF
--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -1278,7 +1278,7 @@ class AbstractSmrPort {
 	protected function &getAttackersToCredit() {
 		//get all players involved for HoF
 		$attackers = array();
-		$this->db->query('SELECT account_id,level FROM player_attacks_port WHERE ' . $this->SQL . ' AND time > ' . $this->db->escapeNumber(TIME - self::TIME_TO_CREDIT_RAID));
+		$this->db->query('SELECT account_id FROM player_attacks_port WHERE ' . $this->SQL . ' AND time > ' . $this->db->escapeNumber(TIME - self::TIME_TO_CREDIT_RAID));
 		while ($this->db->nextRecord()) {
 			$attackers[] = SmrPlayer::getPlayer($this->db->getInt('account_id'), $this->getGameID());
 		}
@@ -1289,7 +1289,7 @@ class AbstractSmrPort {
 		//get all players involved for HoF
 		$attackers = $this->getAttackersToCredit();
 		foreach ($attackers as $attacker) {
-			$attacker->increaseHOF($this->db->getInt('level'), array('Combat', 'Port', 'Levels Raided'), HOF_PUBLIC);
+			$attacker->increaseHOF($this->level, array('Combat', 'Port', 'Levels Raided'), HOF_PUBLIC);
 			$attacker->increaseHOF(1, array('Combat', 'Port', 'Total Raided'), HOF_PUBLIC);
 		}
 	}


### PR DESCRIPTION
When razing was added back in 2013 (38e4b44aab), the refactoring of
the attacker list into `getAttackersToCredit` left a dangling database
reference in `creditCurrentAttackersForKill`, causing the following
notice (new in PHP 7.4) to be emitted:

Notice: Trying to access array offset on value of type null

As a result, the "Levels Raided" Hall of Fame category was not being
populated.

The simplest fix is to use the current level of the port, rather than
the level the port was at the last time each player attacked it (as it
is stored in the `player_attacks_port` table). Regardless of which way
the stats are awarded, the impact should be completely negligible.