### PR TITLE
Refactor: Add game_play_preprocessing.php

### DIFF
--- a/engine/Default/game_play_preprocessing.php
+++ b/engine/Default/game_play_preprocessing.php
@@ -1,0 +1,11 @@
+<?php
+
+// Reset the game ID if necessary
+if (SmrSession::hasGame()) {
+	$account->log(LOG_TYPE_GAME_ENTERING, 'Player left game ' . SmrSession::getGameID());
+	SmrSession::updateGame(0);
+}
+
+SmrSession::clearLinks();
+
+forward(create_container('skeleton.php', 'game_play.php', $var));

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -409,18 +409,6 @@ function do_voodoo() {
 	if (!defined('DATE_FULL_SHORT')) define('DATE_FULL_SHORT', DATE_DATE_SHORT . ' ' . DATE_TIME_SHORT);
 	if (!defined('DATE_FULL_SHORT_SPLIT')) define('DATE_FULL_SHORT_SPLIT', DATE_DATE_SHORT . '\<b\r /\>' . DATE_TIME_SHORT);
 
-	if ($var['url'] == 'game_play_preprocessing.php') { // Would rather not have these here but if we go through the initialisation based on game id when leaving a classic game it breaks.
-		SmrSession::clearLinks();
-		if (SmrSession::hasGame()) {
-			$account->log(LOG_TYPE_GAME_ENTERING, 'Player left game ' . SmrSession::getGameID());
-		}
-
-		// reset game id
-		SmrSession::updateGame(0);
-
-		forward(create_container('skeleton.php', 'game_play.php', $var));
-	}
-
 	// initialize objects we usually need, like player, ship
 	if (SmrSession::hasGame()) {
 		if (SmrGame::getGame(SmrSession::getGameID())->hasEnded()) {


### PR DESCRIPTION
Remove a special case for preprocessing the "Play Game" page in the
`do_voodoo` function. This was only needed for the "Classic" version
of the engine (v1.2), which no longer exists. Now it uses forwarding
like all other pages.