### PR TITLE
Remove dangling-ifs

### DIFF
--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -22,10 +22,11 @@ if ($submit == 'Create Galaxies') {
 }
 else if ($submit == 'Redo Connections') {
 	$galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
-	if (!$galaxy->setConnectivity($_REQUEST['connect']))
+	if (!$galaxy->setConnectivity($_REQUEST['connect'])) {
 		$var['message'] = '<span class="red">Error</span> : Regenerating connections failed.';
-	else
+	} else {
 		$var['message'] = '<span class="green">Success</span> : Regenerated connectivity with ' . $_REQUEST['connect'] . '% target.';
+	}
 	SmrSector::saveSectors();
 }
 elseif ($submit == 'Toggle Link') {
@@ -228,10 +229,11 @@ elseif ($submit == 'Edit Sector') {
 	for ($x = 0; $x < UNI_GEN_LOCATION_SLOTS; $x++) {
 		if ($_POST['loc_type' . $x] != 0) {
 			$locationToAdd = SmrLocation::getLocation($_POST['loc_type' . $x]);
-			if ($editSector->hasLocation($locationToAdd->getTypeID()))
+			if ($editSector->hasLocation($locationToAdd->getTypeID())) {
 				$locationsToKeep[] = $locationToAdd;
-			else
+			} else {
 				$locationsToAdd[] = $locationToAdd;
+			}
 		}
 	}
 	$editSector->removeAllLocations();
@@ -274,8 +276,9 @@ function checkSectorAllowedForLoc(SmrSector $sector, SmrLocation $location) {
 }
 
 function addLocationToSector(SmrLocation $location, SmrSector $sector) {
-	if ($sector->hasLocation($location->getTypeID()))
+	if ($sector->hasLocation($location->getTypeID())) {
 		return false;
+	}
 
 	$sector->addLocation($location); //insert the location
 	if ($location->isHQ()) {
@@ -283,13 +286,15 @@ function addLocationToSector(SmrLocation $location, SmrSector $sector) {
 		//Racial/Fed
 		foreach ($location->getLinkedLocations() as $linkedLocation) {
 			$sector->addLocation($linkedLocation);
-			if ($linkedLocation->isFed())
+			if ($linkedLocation->isFed()) {
 				$fedBeacon = $linkedLocation;
+			}
 		}
 			
 		//add Beacons to all surrounding areas (up to 2 sectors out)
-		if (!$sector->offersFederalProtection())
+		if (!$sector->offersFederalProtection()) {
 			$sector->addLocation($fedBeacon); //add beacon to this sector
+		}
 		$visitedSectors = array();
 		$links = array('Up', 'Right', 'Down', 'Left');
 		$fedSectors = array($sector);
@@ -299,8 +304,9 @@ function addLocationToSector(SmrLocation $location, SmrSector $sector) {
 				foreach ($links as $link) {
 					if ($fedSector->hasLink($link) && !isset($visitedSectors[$fedSector->getLink($link)])) {
 						$linkSector = $sector->getLinkSector($link);
-						if (!$linkSector->offersFederalProtection())
+						if (!$linkSector->offersFederalProtection()) {
 							$linkSector->addLocation($fedBeacon); //add beacon to this sector
+						}
 						$tempFedSectors[] = $linkSector;
 						$visitedSectors[$fedSector->getLink($link)] = true;
 					}

--- a/admin/Default/1.6/universe_create_save_processing.php
+++ b/admin/Default/1.6/universe_create_save_processing.php
@@ -19,8 +19,7 @@ if ($submit == 'Create Galaxies') {
 	}
 	SmrSector::saveSectors();
 	$var['message'] = '<span class="green">Success</span> : Succesfully created galaxies.';
-}
-else if ($submit == 'Redo Connections') {
+} else if ($submit == 'Redo Connections') {
 	$galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
 	if (!$galaxy->setConnectivity($_REQUEST['connect'])) {
 		$var['message'] = '<span class="red">Error</span> : Regenerating connections failed.';
@@ -28,13 +27,11 @@ else if ($submit == 'Redo Connections') {
 		$var['message'] = '<span class="green">Success</span> : Regenerated connectivity with ' . $_REQUEST['connect'] . '% target.';
 	}
 	SmrSector::saveSectors();
-}
-elseif ($submit == 'Toggle Link') {
+} elseif ($submit == 'Toggle Link') {
 	$linkSector = SmrSector::getSector($var['game_id'], $var['sector_id']);
 	$linkSector->toggleLink($var['dir']);
 	SmrSector::saveSectors();
-}
-elseif ($submit == 'Create Locations') {
+} elseif ($submit == 'Create Locations') {
 	$galSectors = SmrSector::getGalaxySectors($var['game_id'], $var['gal_on']);
 	foreach ($galSectors as $galSector) {
 		$galSector->removeAllLocations();
@@ -54,8 +51,7 @@ elseif ($submit == 'Create Locations') {
 		}
 	}
 	$var['message'] = '<span class="green">Success</span> : Succesfully added locations.';
-}
-elseif ($submit == 'Create Warps') {
+} elseif ($submit == 'Create Warps') {
 	//get all warp info from all gals, some need to be removed, some need to be added
 	$galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
 	$galSectors = $galaxy->getSectors();
@@ -95,8 +91,7 @@ elseif ($submit == 'Create Warps') {
 	}
 	SmrSector::saveSectors();
 	$var['message'] = '<span class="green">Success</span> : Succesfully added warps.';
-}
-elseif ($submit == 'Create Planets') {
+} elseif ($submit == 'Create Planets') {
 	$galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
 	$galSectors = $galaxy->getSectors();
 	foreach ($galSectors as $galSector) {
@@ -170,27 +165,23 @@ elseif ($submit == 'Create Ports') {
 		}
 		SmrPort::savePorts();
 		$var['message'] = '<span class="green">Success</span> : Succesfully added ports.';
-	}
-	else {
+	} else {
 		$var['message'] = '<span class="red">Error: Your port race distribution must equal 100!</span>';
 	}
-}
-elseif ($submit == 'Edit Sector') {
+} elseif ($submit == 'Edit Sector') {
 	$editSector = SmrSector::getSector($var['game_id'], $var['sector_id']);
 
 	//update planet
 	if ($_POST['plan_type'] != '0') {
 		if (!$editSector->hasPlanet()) {
 			$editSector->createPlanet($_POST['plan_type']);
-		}
-		else {
+		} else {
 			$type = $editSector->getPlanet()->getTypeID();
 			if ($_POST['plan_type'] != $type) {
 				$editSector->getPlanet()->setTypeID($_POST['plan_type']);
 			}
 		}
-	}
-	else {
+	} else {
 		$editSector->removePlanet();
 	}
 
@@ -267,8 +258,7 @@ forward($container);
 function checkSectorAllowedForLoc(SmrSector $sector, SmrLocation $location) {
 	if (!$location->isHQ()) {
 		return (count($sector->getLocations()) < 4 && !$sector->offersFederalProtection());
-	}
-	else {
+	} else {
 		//HQs are here
 		//find a sector where there are no locations yet
 		return !$sector->hasLocation();

--- a/admin/Default/album_approve.php
+++ b/admin/Default/album_approve.php
@@ -1,8 +1,9 @@
 <?php declare(strict_types=1);
 
 function get_album_nick($album_id) {
-	if ($album_id == 0)
+	if ($album_id == 0) {
 		return 'System';
+	}
 
 	return SmrAccount::getAccount($album_id)->getHofDisplayName();
 }
@@ -59,12 +60,15 @@ if ($db->nextRecord()) {
 	$nick = get_album_nick($album_id);
 	$template->assign('Nick', $nick);
 
-	if (!empty($day) && !empty($month) && !empty($year))
+	if (!empty($day) && !empty($month) && !empty($year)) {
 		$birthdate = $month . ' / ' . $day . ' / ' . $year;
-	if (empty($birthdate) && !empty($year))
+	}
+	if (empty($birthdate) && !empty($year)) {
 		$birthdate = 'Year ' . $year;
-	if (empty($birthdate))
+	}
+	if (empty($birthdate)) {
 		$birthdate = 'N/A';
+	}
 	$template->assign('Birthdate', $birthdate);
 
 	// get the time that passed since the entry was last changed

--- a/admin/Default/album_moderate.php
+++ b/admin/Default/album_moderate.php
@@ -36,12 +36,15 @@ else {
 		create_error('This User doesn\'t have an album entry or it needs to be approved first!');
 	}
 
-	if (!empty($day) && !empty($month) && !empty($year))
+	if (!empty($day) && !empty($month) && !empty($year)) {
 		$birthdate = $month . ' / ' . $day . ' / ' . $year;
-	if (empty($birthdate) && !empty($year))
+	}
+	if (empty($birthdate) && !empty($year)) {
 		$birthdate = 'Year ' . $year;
-	if (empty($birthdate))
+	}
+	if (empty($birthdate)) {
 		$birthdate = 'N/A';
+	}
 
 	$entry = [
 		'disabled' => $disabled,

--- a/admin/Default/album_moderate.php
+++ b/admin/Default/album_moderate.php
@@ -19,8 +19,7 @@ if (empty($account_id)) {
 		$approved[$accountId] = get_album_nick($accountId);
 	}
 	$template->assign('Approved', $approved);
-}
-else {
+} else {
 	// check if the given account really has an entry
 	$db->query('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account_id) . ' AND Approved = \'YES\'');
 	if ($db->nextRecord()) {

--- a/admin/Default/album_moderate_processing.php
+++ b/admin/Default/album_moderate_processing.php
@@ -51,8 +51,7 @@ if ($var['task'] == 'reset_image') {
 					WHERE album_id = '.$db->escapeNumber($account_id) . ' AND
 						  comment_id IN ('.$db->escapeArray($comment_ids) . ')');
 	}
-}
-else {
+} else {
 	create_error('No action chosen!');
 }
 

--- a/admin/Default/album_moderate_processing.php
+++ b/admin/Default/album_moderate_processing.php
@@ -10,10 +10,11 @@ if ($var['task'] == 'reset_image') {
 
 	$db->lockTable('album_has_comments');
 	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($account_id));
-	if ($db->nextRecord())
+	if ($db->nextRecord()) {
 		$comment_id = $db->getInt('MAX(comment_id)') + 1;
-	else
+	} else {
 		$comment_id = 1;
+	}
 
 	$db->query('INSERT INTO album_has_comments
 				(album_id, comment_id, time, post_id, msg)
@@ -31,17 +32,17 @@ if ($var['task'] == 'reset_image') {
 		$mail->send();
 	}
 
-} else if ($var['task'] == 'reset_location')
+} else if ($var['task'] == 'reset_location') {
 	$db->query('UPDATE album SET location = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
-else if ($var['task'] == 'reset_email')
+} else if ($var['task'] == 'reset_email') {
 	$db->query('UPDATE album SET email = \'\' WHERE account_id =' . $db->escapeNumber($account_id));
-else if ($var['task'] == 'reset_website')
+} else if ($var['task'] == 'reset_website') {
 	$db->query('UPDATE album SET website = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
-else if ($var['task'] == 'reset_birthdate')
+} else if ($var['task'] == 'reset_birthdate') {
 	$db->query('UPDATE album SET day = 0, month = 0, year = 0 WHERE account_id = ' . $db->escapeNumber($account_id));
-else if ($var['task'] == 'reset_other')
+} else if ($var['task'] == 'reset_other') {
 	$db->query('UPDATE album SET other = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
-else if ($var['task'] == 'delete_comment') {
+} else if ($var['task'] == 'delete_comment') {
 	$comment_ids = $_REQUEST['comment_ids'];
 	// we just ignore if nothing was set
 	if (count($comment_ids) > 0) {

--- a/admin/Default/box_delete_processing.php
+++ b/admin/Default/box_delete_processing.php
@@ -1,15 +1,18 @@
 <?php declare(strict_types=1);
 $action = $_REQUEST['action'];
 if ($action == 'Marked Messages') {
-	if (!isset($_REQUEST['message_id']))
+	if (!isset($_REQUEST['message_id'])) {
 		create_error('You must choose the messages you want to delete.');
+	}
 
-	foreach ($_REQUEST['message_id'] as $id)
+	foreach ($_REQUEST['message_id'] as $id) {
 		$db->query('DELETE FROM message_boxes WHERE message_id = ' . $db->escapeNumber($id));
+	}
 }
 else if ($action == 'All Messages') {
-	if (!isset($var['box_type_id']))
+	if (!isset($var['box_type_id'])) {
 		create_error('No box selected.');
+	}
 	$db->query('DELETE FROM message_boxes WHERE box_type_id = ' . $db->escapeNumber($var['box_type_id']));
 }
 forward(create_container('skeleton.php', 'box_view.php'));

--- a/admin/Default/box_delete_processing.php
+++ b/admin/Default/box_delete_processing.php
@@ -8,8 +8,7 @@ if ($action == 'Marked Messages') {
 	foreach ($_REQUEST['message_id'] as $id) {
 		$db->query('DELETE FROM message_boxes WHERE message_id = ' . $db->escapeNumber($id));
 	}
-}
-else if ($action == 'All Messages') {
+} else if ($action == 'All Messages') {
 	if (!isset($var['box_type_id'])) {
 		create_error('No box selected.');
 	}

--- a/admin/Default/location_edit.php
+++ b/admin/Default/location_edit.php
@@ -5,21 +5,30 @@ $template->assign('ViewAllLocationsLink', SmrSession::getNewHREF(create_containe
 if (isset($var['location_type_id'])) {
 	$location = SmrLocation::getLocation($var['location_type_id']);
 	if (isset($_REQUEST['save'])) {
-		if ($_REQUEST['add_ship_id'] != 0)
+		if ($_REQUEST['add_ship_id'] != 0) {
 			$location->addShipSold($_REQUEST['add_ship_id']);
-		if ($_REQUEST['add_weapon_id'] != 0)
+		}
+		if ($_REQUEST['add_weapon_id'] != 0) {
 			$location->addWeaponSold($_REQUEST['add_weapon_id']);
-		if ($_REQUEST['add_hardware_id'] != 0)
+		}
+		if ($_REQUEST['add_hardware_id'] != 0) {
 			$location->addHardwareSold($_REQUEST['add_hardware_id']);
-		if (isset($_REQUEST['remove_ships']) && is_array($_REQUEST['remove_ships']))
-			foreach ($_REQUEST['remove_ships'] as $shipTypeID)
+		}
+		if (isset($_REQUEST['remove_ships']) && is_array($_REQUEST['remove_ships'])) {
+			foreach ($_REQUEST['remove_ships'] as $shipTypeID) {
 				$location->removeShipSold($shipTypeID);
-		if (isset($_REQUEST['remove_weapons']) && is_array($_REQUEST['remove_weapons']))
-			foreach ($_REQUEST['remove_weapons'] as $weaponTypeID)
+			}
+		}
+		if (isset($_REQUEST['remove_weapons']) && is_array($_REQUEST['remove_weapons'])) {
+			foreach ($_REQUEST['remove_weapons'] as $weaponTypeID) {
 				$location->removeWeaponSold($weaponTypeID);
-		if (isset($_REQUEST['remove_hardware']) && is_array($_REQUEST['remove_hardware']))
-			foreach ($_REQUEST['remove_hardware'] as $hardwareTypeID)
+			}
+		}
+		if (isset($_REQUEST['remove_hardware']) && is_array($_REQUEST['remove_hardware'])) {
+			foreach ($_REQUEST['remove_hardware'] as $hardwareTypeID) {
 				$location->removeHardwareSold($hardwareTypeID);
+			}
+		}
 
 		$location->setFed(isset($_REQUEST['fed']));
 		$location->setBar(isset($_REQUEST['bar']));

--- a/admin/Default/location_edit.php
+++ b/admin/Default/location_edit.php
@@ -50,7 +50,6 @@ if (isset($var['location_type_id'])) {
 														'Name' => $db->getField('hardware_name'));
 	}
 	$template->assign('AllHardware', $hardware);
-}
-else {
+} else {
 	$template->assign('Locations', SmrLocation::getAllLocations());
 }

--- a/admin/Default/log_console.php
+++ b/admin/Default/log_console.php
@@ -19,15 +19,17 @@ if ($db->getNumRows()) {
 								'Notes' => '');
 
 		$db2->query('SELECT notes FROM log_has_notes WHERE account_id = ' . $db2->escapeNumber($accountID));
-		if ($db2->nextRecord())
+		if ($db2->nextRecord()) {
 			$loggedAccounts[$accountID]['Notes'] = nl2br($db2->getField('notes'));
+		}
 	}
 
 	// put hidden fields in for log type to have all fields selected on next page.
 	$logTypes = array();
 	$db->query('SELECT log_type_id FROM log_type');
-	while ($db->nextRecord())
+	while ($db->nextRecord()) {
 		$logTypes[] = $db->getInt('log_type_id');
+	}
 	$template->assign('LogTypes', $logTypes);
 
 	$template->assign('LogConsoleFormHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'log_console_detail.php')));

--- a/admin/Default/notify_reply_processing.php
+++ b/admin/Default/notify_reply_processing.php
@@ -30,7 +30,9 @@ if (isset($offenderReply) && $offenderReply != '') {
 		$offenderAccount->addPoints($_REQUEST['offenderBanPoints'], $account, 7, $suspicion);
 	}
 }
-if (isset($_REQUEST['offendedReply'])) $offendedReply = $_REQUEST['offendedReply'];
+if (isset($_REQUEST['offendedReply'])) {
+	$offendedReply = $_REQUEST['offendedReply'];
+}
 
 if (isset($offendedReply) && $offendedReply != '') {
 	//next message

--- a/admin/Default/notify_reply_processing.php
+++ b/admin/Default/notify_reply_processing.php
@@ -7,12 +7,14 @@ if ($_REQUEST['action'] == 'Preview messages') {
 	transfer('offended');
 	transfer('game_id');
 	transfer('sender_id');
-	if (!empty($offenderReply))
+	if (!empty($offenderReply)) {
 		$container['PreviewOffender'] = $offenderReply;
+	}
 	$container['OffenderBanPoints'] = $_REQUEST['offenderBanPoints'];
 
-	if (!empty($offendedReply))
+	if (!empty($offendedReply)) {
 		$container['PreviewOffended'] = $offendedReply;
+	}
 	$container['OffendedBanPoints'] = $_REQUEST['offendedBanPoints'];
 	forward($container);
 }

--- a/admin/Default/vote_create_processing.php
+++ b/admin/Default/vote_create_processing.php
@@ -28,8 +28,7 @@ if ($_REQUEST['action'] == 'Create Vote') {
 	
 	// put the msg into the database
 	$db->query('INSERT INTO voting (question, end) VALUES(' . $db->escapeString($question) . ',' . $db->escapeNumber($end) . ')');
-}
-else if ($_REQUEST['action'] == 'Add Option') {
+} else if ($_REQUEST['action'] == 'Add Option') {
 	if (empty($option)) {
 		create_error('You have to specify an option message.');
 	}

--- a/admin/Default/vote_create_processing.php
+++ b/admin/Default/vote_create_processing.php
@@ -15,24 +15,30 @@ if ($_REQUEST['action'] == 'Preview Option') {
 }
 
 if ($_REQUEST['action'] == 'Create Vote') {
-	if (empty($question))
+	if (empty($question)) {
 		create_error('You have to specify a vote message.');
-	if (empty($_REQUEST['days']))
+	}
+	if (empty($_REQUEST['days'])) {
 		create_error('You have to specify the amount of time to run the vote for.');
-	if (!is_numeric($_REQUEST['days']))
+	}
+	if (!is_numeric($_REQUEST['days'])) {
 		create_error('The vote runtime must be a number.');
+	}
 	$end = TIME + 86400 * $_REQUEST['days'];
 	
 	// put the msg into the database
 	$db->query('INSERT INTO voting (question, end) VALUES(' . $db->escapeString($question) . ',' . $db->escapeNumber($end) . ')');
 }
 else if ($_REQUEST['action'] == 'Add Option') {
-	if (empty($option))
+	if (empty($option)) {
 		create_error('You have to specify an option message.');
-	if (empty($_REQUEST['vote']))
+	}
+	if (empty($_REQUEST['vote'])) {
 		create_error('You have to select a vote to add the option to.');
-	if (!is_numeric($_REQUEST['vote']))
+	}
+	if (!is_numeric($_REQUEST['vote'])) {
 		create_error('Vote ID must be a number.');
+	}
 	
 	// put the msg into the database
 	$db->query('INSERT INTO voting_options (vote_id, text) VALUES(' . $db->escapeNumber($_REQUEST['vote']) . ',' . $db->escapeString($option) . ')');

--- a/engine/Default/bank_anon_detail_processing.php
+++ b/engine/Default/bank_anon_detail_processing.php
@@ -36,8 +36,9 @@ if ($action == 'Deposit') {
 else {
 	$db->query('SELECT * FROM anon_bank WHERE anon_id = ' . $db->escapeNumber($account_num) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	$db->nextRecord();
-	if ($db->getInt('amount') < $amount)
+	if ($db->getInt('amount') < $amount) {
 		create_error('You don\'t have that much money on your account!');
+	}
 	$db->query('SELECT transaction_id FROM anon_bank_transactions WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num) . ' ORDER BY transaction_id DESC LIMIT 1');
 	if ($db->nextRecord()) {
 		$trans_id = $db->getInt('transaction_id') + 1;

--- a/engine/Default/bank_anon_detail_processing.php
+++ b/engine/Default/bank_anon_detail_processing.php
@@ -21,8 +21,7 @@ if ($action == 'Deposit') {
 	$db->query('SELECT transaction_id FROM anon_bank_transactions WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num) . ' ORDER BY transaction_id DESC LIMIT 1');
 	if ($db->nextRecord()) {
 		$trans_id = $db->getInt('transaction_id') + 1;
-	}
-	else {
+	} else {
 		$trans_id = 1;
 	}
 	$db->query('INSERT INTO anon_bank_transactions (account_id, game_id, anon_id, transaction_id, transaction, amount, time) ' .
@@ -32,8 +31,7 @@ if ($action == 'Deposit') {
 
 	// log action
 	$account->log(LOG_TYPE_BANK, 'Deposits ' . $amount . ' credits in anonymous account #' . $account_num, $player->getSectorID());
-}
-else {
+} else {
 	$db->query('SELECT * FROM anon_bank WHERE anon_id = ' . $db->escapeNumber($account_num) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	$db->nextRecord();
 	if ($db->getInt('amount') < $amount) {
@@ -42,8 +40,7 @@ else {
 	$db->query('SELECT transaction_id FROM anon_bank_transactions WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num) . ' ORDER BY transaction_id DESC LIMIT 1');
 	if ($db->nextRecord()) {
 		$trans_id = $db->getInt('transaction_id') + 1;
-	}
-	else {
+	} else {
 		$trans_id = 1;
 	}
 	$db->query('INSERT INTO anon_bank_transactions (account_id, game_id, anon_id, transaction_id, transaction, amount, time)

--- a/engine/Default/course_plot_nearest_processing.php
+++ b/engine/Default/course_plot_nearest_processing.php
@@ -4,8 +4,9 @@ if (isset($var['RealX'])) {
 	$realX = $var['RealX'];
 }
 else {
-	if (!isset($_REQUEST['xtype']) || !isset($_REQUEST['X']))
+	if (!isset($_REQUEST['xtype']) || !isset($_REQUEST['X'])) {
 		create_error('You have to select what you would like to find.');
+	}
 	$xType = $_REQUEST['xtype'];
 	$X = $_REQUEST['X'];
 	$realX = Plotter::getX($xType, $X, $player->getGameID(), $player);
@@ -16,8 +17,9 @@ else {
 	$account->log(LOG_TYPE_MOVEMENT, 'Player plots to nearest ' . $xType . ': ' . $X . '.', $player->getSectorID());
 }
 
-if ($sector->hasX($realX, $player))
+if ($sector->hasX($realX, $player)) {
 	create_error('Current sector has what you\'re looking for!');
+}
 
 $path = Plotter::findReversiblePathToX($realX, $sector, true, $player, $player);
 

--- a/engine/Default/course_plot_nearest_processing.php
+++ b/engine/Default/course_plot_nearest_processing.php
@@ -2,8 +2,7 @@
 
 if (isset($var['RealX'])) {
 	$realX = $var['RealX'];
-}
-else {
+} else {
 	if (!isset($_REQUEST['xtype']) || !isset($_REQUEST['X'])) {
 		create_error('You have to select what you would like to find.');
 	}

--- a/engine/Default/course_plot_processing.php
+++ b/engine/Default/course_plot_processing.php
@@ -6,18 +6,20 @@ if (isset($var['to'])) $target = $var['to'];
 else $target = trim($_POST['to']);
 
 // perform some basic checks on both numbers
-if (empty($start) || empty($target))
+if (empty($start) || empty($target)) {
 	create_error('Where do you want to go today?');
+}
 
-
-if (!is_numeric($start) || !is_numeric($target))
+if (!is_numeric($start) || !is_numeric($target)) {
 	create_error('Please enter only numbers!');
+}
 
 $start = abs(str_replace('.', '', $start));
 $target = abs(str_replace('.', '', $target));
 
-if ($start == $target)
+if ($start == $target) {
 	create_error('Hmmmm...if ' . $start . '=' . $target . ' then that means...YOU\'RE ALREADY THERE! *cough*you\'re real smart*cough*');
+}
 
 try {
 	$startSector = SmrSector::getSector($player->getGameID(), $start);

--- a/engine/Default/course_plot_processing.php
+++ b/engine/Default/course_plot_processing.php
@@ -1,9 +1,15 @@
 <?php declare(strict_types=1);
 
-if (isset($var['from'])) $start = $var['from'];
-else $start = trim($_POST['from']);
-if (isset($var['to'])) $target = $var['to'];
-else $target = trim($_POST['to']);
+if (isset($var['from'])) {
+	$start = $var['from'];
+} else {
+	$start = trim($_POST['from']);
+}
+if (isset($var['to'])) {
+	$target = $var['to'];
+} else {
+	$target = trim($_POST['to']);
+}
 
 // perform some basic checks on both numbers
 if (empty($start) || empty($target)) {

--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -80,18 +80,20 @@ $protectionMessage = '';
 if ($player->getNewbieTurns()) {
 	if ($player->getNewbieTurns() < 25) {
 		$protectionMessage = '<span class="blue">PROTECTION</span>: You are almost out of <span class="green">NEWBIE</span> protection.';
-	}
-	else
+	} else {
 		$protectionMessage = '<span class="blue">PROTECTION</span>: You are under <span class="green">NEWBIE</span> protection.';
+	}
 }
 elseif ($player->hasFederalProtection()) {
 	$protectionMessage = '<span class="blue">PROTECTION</span>: You are under <span class="blue">FEDERAL</span> protection.';
 }
-elseif ($sector->offersFederalProtection())
+elseif ($sector->offersFederalProtection()) {
 	$protectionMessage = '<span class="blue">PROTECTION</span>: You are <span class="red">NOT</span> under protection.';
+}
 
-if (!empty($protectionMessage))
+if (!empty($protectionMessage)) {
 	$template->assign('ProtectionMessage', $protectionMessage);
+}
 
 //enableProtectionDependantRefresh($template,$player);
 

--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -35,9 +35,13 @@ while ($db->nextRecord()) {
 
 foreach ($links as $key => $linkArray) {
 	if ($linkArray['ID'] > 0 && $linkArray['ID'] != $player->getSectorID()) {
-		if ($player->getLastSectorID() == $linkArray['ID']) $class = 'lastVisited';
-		else if (isset($unvisited[$linkArray['ID']])) $class = 'unvisited';
-		else $class = 'visited';
+		if ($player->getLastSectorID() == $linkArray['ID']) {
+			$class = 'lastVisited';
+		} else if (isset($unvisited[$linkArray['ID']])) {
+			$class = 'unvisited';
+		} else {
+			$class = 'visited';
+		}
 		$links[$key]['Class'] = $class;
 	}
 }
@@ -83,11 +87,9 @@ if ($player->getNewbieTurns()) {
 	} else {
 		$protectionMessage = '<span class="blue">PROTECTION</span>: You are under <span class="green">NEWBIE</span> protection.';
 	}
-}
-elseif ($player->hasFederalProtection()) {
+} elseif ($player->hasFederalProtection()) {
 	$protectionMessage = '<span class="blue">PROTECTION</span>: You are under <span class="blue">FEDERAL</span> protection.';
-}
-elseif ($sector->offersFederalProtection()) {
+} elseif ($sector->offersFederalProtection()) {
 	$protectionMessage = '<span class="blue">PROTECTION</span>: You are <span class="red">NOT</span> under protection.';
 }
 
@@ -117,7 +119,9 @@ if (isset($var['msg'])) {
 }
 
 //error msgs take precedence
-if (isset($var['errorMsg'])) $template->assign('ErrorMessage', $var['errorMsg']);
+if (isset($var['errorMsg'])) {
+	$template->assign('ErrorMessage', $var['errorMsg']);
+}
 
 // *******************************************
 // *
@@ -152,8 +156,9 @@ function checkForForceRefreshMessage(&$msg) {
 				$remainingTime = $db->getInt('refresh_at') - TIME;
 				$forceRefreshMessage = '<span class="green">REFRESH</span>: All forces will be refreshed in ' . $remainingTime . ' seconds.';
 				$db->query('REPLACE INTO sector_message (game_id, account_id, message) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', \'[Force Check]\')');
+			} else {
+				$forceRefreshMessage = '<span class="green">REFRESH</span>: All forces have finished refreshing.';
 			}
-			else $forceRefreshMessage = '<span class="green">REFRESH</span>: All forces have finished refreshing.';
 			$template->assign('ForceRefreshMessage', $forceRefreshMessage);
 		}
 	}

--- a/engine/Default/feature_request_vote_processing.php
+++ b/engine/Default/feature_request_vote_processing.php
@@ -15,8 +15,7 @@ if ($_REQUEST['action'] == 'Vote') {
 	}
 
 	forward(create_container('skeleton.php', 'feature_request.php'));
-}
-else if ($_REQUEST['action'] == 'Set Status') {
+} else if ($_REQUEST['action'] == 'Set Status') {
 	if (empty($_REQUEST['status'])) {
 		create_error('You have to select a status to set');
 	}

--- a/engine/Default/feature_request_vote_processing.php
+++ b/engine/Default/feature_request_vote_processing.php
@@ -10,8 +10,9 @@ if ($_REQUEST['action'] == 'Vote') {
 		}
 		$db->query(substr($query, 0, -1));
 	}
-	if (!empty($_REQUEST['favourite']) && is_numeric($_REQUEST['favourite']))
+	if (!empty($_REQUEST['favourite']) && is_numeric($_REQUEST['favourite'])) {
 		$db->query('REPLACE INTO account_votes_for_feature VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($_REQUEST['favourite']) . ',\'FAVOURITE\')');
+	}
 
 	forward(create_container('skeleton.php', 'feature_request.php'));
 }
@@ -20,10 +21,12 @@ else if ($_REQUEST['action'] == 'Set Status') {
 		create_error('You have to select a status to set');
 	}
 	$status = $_REQUEST['status'];
-	if (empty($_REQUEST['set_status_ids']))
+	if (empty($_REQUEST['set_status_ids'])) {
 		create_error('You have to select a feature');
-	if (!$account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST))
+	}
+	if (!$account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST)) {
 		create_error('You do not have permission to do that');
+	}
 
 	$db->query('UPDATE feature_request fr SET status = ' . $db->escapeString($status) . '
 			, fav = (

--- a/engine/Default/forces_attack_processing.php
+++ b/engine/Default/forces_attack_processing.php
@@ -3,16 +3,21 @@
 $forces = SmrForce::getForce($player->getGameID(), $player->getSectorID(), $var['owner_id']);
 $forceOwner = $forces->getOwner();
 
-if ($player->hasNewbieTurns())
+if ($player->hasNewbieTurns()) {
 	create_error('You are under newbie protection!');
-if ($player->hasFederalProtection())
+}
+if ($player->hasFederalProtection()) {
 	create_error('You are under federal protection.');
-if ($player->isLandedOnPlanet())
+}
+if ($player->isLandedOnPlanet()) {
 	create_error('You cannot attack forces whilst on a planet!');
-if (!$player->canFight())
+}
+if (!$player->canFight()) {
 	create_error('You are not allowed to fight!');
-if ($player->forceNAPAlliance($forceOwner))
+}
+if ($player->forceNAPAlliance($forceOwner)) {
 	create_error('You cannot attack allied forces!');
+}
 
 // The attack is processed slightly differently if the attacker bumped into mines
 // when moving into sector
@@ -25,15 +30,19 @@ if ($var['action'] == 'attack') {
 }
 
 if ($bump) {
-	if (!$forces->hasMines())
+	if (!$forces->hasMines()) {
 		create_error('No mines in sector!');
+	}
 } else {
-	if (!$forces->exists())
+	if (!$forces->exists()) {
 		create_error('These forces no longer exist.');
-	if ($player->getTurns() < $forces->getAttackTurnCost($ship))
+	}
+	if ($player->getTurns() < $forces->getAttackTurnCost($ship)) {
 		create_error('You do not have enough turns to attack these forces!');
-	if (!$ship->hasWeapons() && !$ship->hasCDs())
+	}
+	if (!$ship->hasWeapons() && !$ship->hasCDs()) {
 		create_error('You cannot attack without weapons!');
+	}
 }
 
 // take the turns
@@ -103,10 +112,11 @@ if ($sendMessage) {
 $container = create_container('skeleton.php', 'forces_attack.php');
 
 // If their target is dead there is no continue attack button
-if ($forces->exists())
+if ($forces->exists()) {
 	$container['owner_id'] = $forces->getOwnerID();
-else
+} else {
 	$container['owner_id'] = 0;
+}
 
 // If they died on the shot they get to see the results
 if ($player->isDead()) {

--- a/engine/Default/forces_drop_processing.php
+++ b/engine/Default/forces_drop_processing.php
@@ -129,8 +129,7 @@ if ($change_combat_drones != 0) {
 	if ($change_combat_drones > 0) {
 		$ship->decreaseCDs($change_combat_drones, true);
 		$forces->addCDs($change_combat_drones);
-	}
-	else {
+	} else {
 		$ship->increaseCDs(-$change_combat_drones, true);
 		$forces->takeCDs(-$change_combat_drones);
 	}
@@ -140,8 +139,7 @@ if ($change_scout_drones != 0) {
 	if ($change_scout_drones > 0) {
 		$ship->decreaseSDs($change_scout_drones);
 		$forces->addSDs($change_scout_drones);
-	}
-	else {
+	} else {
 		$ship->increaseSDs(-$change_scout_drones);
 		$forces->takeSDs(-$change_scout_drones);
 	}
@@ -155,8 +153,7 @@ if ($change_mines != 0) {
 			$ship->decloak();
 			$player->giveTurns(1);
 		}
-	}
-	else {
+	} else {
 		$ship->increaseMines(-$change_mines);
 		$forces->takeMines(-$change_mines);
 	}
@@ -191,8 +188,7 @@ if ($forces->getOwnerID() != $player->getAccountID() && $forces->getOwner()->isF
 			$scout_drones_message = 'added ';
 		}
 		$scout_drones_message .= $change_scout_drones . ' scout drone';
-	}
-	elseif ($change_scout_drones < 0) {
+	} elseif ($change_scout_drones < 0) {
 		$scout_drones_message = '';
 		if ((isset($combat_drones_message) && $change_combat_drones > 0) || (!isset($combat_drones_message) && $change_mines >= 0)) {
 			$scout_drones_message = 'removed ';

--- a/engine/Default/forces_drop_processing.php
+++ b/engine/Default/forces_drop_processing.php
@@ -165,61 +165,71 @@ if ($change_mines != 0) {
 // message to send out
 if ($forces->getOwnerID() != $player->getAccountID() && $forces->getOwner()->isForceDropMessages()) {
 	$mines_message = '';
-	if ($change_mines > 0)
+	if ($change_mines > 0) {
 		$mines_message = 'added ' . $change_mines . ' mine';
-	elseif ($change_mines < 0)
+	} elseif ($change_mines < 0) {
 		$mines_message = 'removed ' . abs($change_mines) . ' mine';
+	}
 	//add s to mine if necesary
-	if (abs($change_mines) > 1)
+	if (abs($change_mines) > 1) {
 		$mines_message .= 's';
+	}
 
-	if ($change_combat_drones > 0)
+	if ($change_combat_drones > 0) {
 		$combat_drones_message = ($change_mines <= 0 ? 'added ' : '') . $change_combat_drones . ' combat drone';
-	elseif ($change_combat_drones < 0)
+	} elseif ($change_combat_drones < 0) {
 		$combat_drones_message = ($change_mines >= 0 ? 'removed ' : '') . abs($change_combat_drones) . ' combat drone';
+	}
 	//add s to drone if necesary
-	if (abs($change_combat_drones) > 1)
+	if (abs($change_combat_drones) > 1) {
 		$combat_drones_message .= 's';
+	}
 
 	if ($change_scout_drones > 0) {
 		$scout_drones_message = '';
-		if ((isset($combat_drones_message) && $change_combat_drones < 0) || (!isset($combat_drones_message) && $change_mines <= 0))
+		if ((isset($combat_drones_message) && $change_combat_drones < 0) || (!isset($combat_drones_message) && $change_mines <= 0)) {
 			$scout_drones_message = 'added ';
+		}
 		$scout_drones_message .= $change_scout_drones . ' scout drone';
 	}
 	elseif ($change_scout_drones < 0) {
 		$scout_drones_message = '';
-		if ((isset($combat_drones_message) && $change_combat_drones > 0) || (!isset($combat_drones_message) && $change_mines >= 0))
+		if ((isset($combat_drones_message) && $change_combat_drones > 0) || (!isset($combat_drones_message) && $change_mines >= 0)) {
 			$scout_drones_message = 'removed ';
+		}
 		$scout_drones_message .= abs($change_scout_drones) . ' scout drone';
 	}
 	//add s to drone if necesary
-	if (abs($change_scout_drones) > 1)
+	if (abs($change_scout_drones) > 1) {
 		$scout_drones_message .= 's';
+	}
 
 	// now compile it together
 	$message = $player->getPlayerName() . ' has ' . $mines_message;
 
-	if (!empty($mines_message) && isset($combat_drones_message) && !isset($scout_drones_message))
+	if (!empty($mines_message) && isset($combat_drones_message) && !isset($scout_drones_message)) {
 		$message .= ' and ' . $combat_drones_message;
-	elseif (!empty($mines_message) && isset($combat_drones_message))
+	} elseif (!empty($mines_message) && isset($combat_drones_message)) {
 		$message .= ', ' . $combat_drones_message;
-	elseif (empty($mines_message) && isset($combat_drones_message))
+	} elseif (empty($mines_message) && isset($combat_drones_message)) {
 		$message .= $combat_drones_message;
+	}
 
-	if (!empty($mines_message) && isset($combat_drones_message) && isset($scout_drones_message))
+	if (!empty($mines_message) && isset($combat_drones_message) && isset($scout_drones_message)) {
 		$message .= ', and ' . $scout_drones_message;
-	elseif ((!empty($mines_message) || isset($combat_drones_message)) && isset($scout_drones_message))
+	} elseif ((!empty($mines_message) || isset($combat_drones_message)) && isset($scout_drones_message)) {
 		$message .= ' and ' . $scout_drones_message;
-	elseif (empty($mines_message) && !isset($combat_drones_message) && isset($scout_drones_message))
+	} elseif (empty($mines_message) && !isset($combat_drones_message) && isset($scout_drones_message)) {
 		$message .= $scout_drones_message;
+	}
 
-	if ($change_mines >= 0 && $change_combat_drones >= 0 && $change_scout_drones >= 0)
+	if ($change_mines >= 0 && $change_combat_drones >= 0 && $change_scout_drones >= 0) {
 		$message .= ' to';
-	elseif ($change_mines <= 0 && $change_combat_drones <= 0 && $change_scout_drones <= 0)
+	} elseif ($change_mines <= 0 && $change_combat_drones <= 0 && $change_scout_drones <= 0) {
 		$message .= ' from';
-	else
+	} else {
 		$message .= ' from/to';
+	}
 
 	$message .= ' your stack in sector ' . Globals::getSectorBBLink($forces->getSectorID());
 

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -44,10 +44,10 @@ else {
 	$foundMe = false;
 	$viewType = $var['type'];
 	$viewType[] = $var['view'];
-	if ($var['view'] == DONATION_NAME)
+	if ($var['view'] == DONATION_NAME) {
 		$db->query('SELECT account_id, SUM(amount) as amount FROM account_donated
 					GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
-	else if ($var['view'] == USER_SCORE_NAME) {
+	} else if ($var['view'] == USER_SCORE_NAME) {
 		$statements = SmrAccount::getUserScoreCaseStatement($db);
 		$query = 'SELECT account_id, ' . $statements['CASE'] . ' amount FROM (SELECT account_id, type, SUM(amount) amount FROM player_hof WHERE type IN (' . $statements['IN'] . ')' . $gameIDSql . ' GROUP BY account_id,type) x GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25';
 		$db->query($query);

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -1,18 +1,21 @@
 <?php declare(strict_types=1);
 require_once(get_file_loc('hof.functions.inc'));
 $game_id = null;
-if (isset($var['game_id'])) $game_id = $var['game_id'];
+if (isset($var['game_id'])) {
+	$game_id = $var['game_id'];
+}
 
 if (empty($game_id)) {
 	$topic = 'All Time Hall of Fame';
-}
-else {
+} else {
 	$topic = 'Hall of Fame: ' . SmrGame::getGame($game_id)->getDisplayName();
 }
 $template->assign('PageTopic', $topic);
 
 $container = create_container('skeleton.php', 'hall_of_fame_player_detail.php');
-if (isset($game_id)) $container['game_id'] = $game_id;
+if (isset($game_id)) {
+	$container['game_id'] = $game_id;
+}
 $template->assign('PersonalHofHREF', SmrSession::getNewHREF($container));
 
 $db->query('SELECT type FROM hof_visibility WHERE visibility != ' . $db->escapeString(HOF_PRIVATE) . ' ORDER BY type');
@@ -35,8 +38,7 @@ $template->assign('Breadcrumb', buildBreadcrumb($var, $hofTypes, isset($game_id)
 if (!isset($var['view'])) {
 	$categories = getHofCategories($hofTypes, $game_id, $account->getAccountID());
 	$template->assign('Categories', $categories);
-}
-else {
+} else {
 	$gameIDSql = ' AND game_id ' . (isset($game_id) ? '= ' . $db->escapeNumber($game_id) : 'IN (SELECT game_id FROM game WHERE end_time < ' . TIME . ' AND ignore_stats = ' . $db->escapeBoolean(false) . ')');
 
 	$vis = HOF_PUBLIC;
@@ -51,8 +53,7 @@ else {
 		$statements = SmrAccount::getUserScoreCaseStatement($db);
 		$query = 'SELECT account_id, ' . $statements['CASE'] . ' amount FROM (SELECT account_id, type, SUM(amount) amount FROM player_hof WHERE type IN (' . $statements['IN'] . ')' . $gameIDSql . ' GROUP BY account_id,type) x GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25';
 		$db->query($query);
-	}
-	else {
+	} else {
 		$db->query('SELECT visibility FROM hof_visibility WHERE type = ' . $db->escapeArray($viewType, false, true, ':', false) . ' LIMIT 1');
 		if ($db->nextRecord()) {
 			$vis = $db->getField('visibility');

--- a/engine/Default/message_delete_processing.php
+++ b/engine/Default/message_delete_processing.php
@@ -19,8 +19,7 @@ if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'Marked Messages') {
 			while ($db->nextRecord()) {
 				$message_id_list[] = $db->getInt('message_id');
 			}
-		}
-		else {
+		} else {
 			$message_id_list[] = $id;
 		}
 	}
@@ -29,20 +28,17 @@ if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'Marked Messages') {
 	} else {
 		$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . ' WHERE message_id IN (' . $db->escapeArray($message_id_list) . ')');
 	}
-}
-else {
+} else {
 	if ($var['folder_id'] == MSG_SCOUT) {
 		$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . '
 					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 						AND message_type_id = '.$db->escapeNumber($var['folder_id']) . '
 						AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	}
-	else if ($var['folder_id'] == MSG_SENT) {
+	} else if ($var['folder_id'] == MSG_SENT) {
 		$db->query('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . '
 					WHERE sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
 						AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	}
-	else {
+	} else {
 		$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . '
 					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '

--- a/engine/Default/message_delete_processing.php
+++ b/engine/Default/message_delete_processing.php
@@ -24,10 +24,11 @@ if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'Marked Messages') {
 			$message_id_list[] = $id;
 		}
 	}
-	if ($var['folder_id'] == MSG_SENT)
+	if ($var['folder_id'] == MSG_SENT) {
 		$db->query('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . ' WHERE message_id IN (' . $db->escapeArray($message_id_list) . ')');
-	else
+	} else {
 		$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . ' WHERE message_id IN (' . $db->escapeArray($message_id_list) . ')');
+	}
 }
 else {
 	if ($var['folder_id'] == MSG_SCOUT) {

--- a/engine/Default/message_send_processing.php
+++ b/engine/Default/message_send_processing.php
@@ -4,18 +4,20 @@ $message = htmlentities(trim($_REQUEST['message']), ENT_COMPAT, 'utf-8');
 
 if ($_REQUEST['action'] == 'Preview message') {
 	$container = create_container('skeleton.php');
-	if (isset($var['alliance_id']))
+	if (isset($var['alliance_id'])) {
 		$container['body'] = 'alliance_broadcast.php';
-	else
+	} else {
 		$container['body'] = 'message_send.php';
+	}
 	transfer('receiver');
 	transfer('alliance_id');
 	$container['preview'] = $message;
 	forward($container);
 }
 
-if (empty($message))
+if (empty($message)) {
 	create_error('You have to enter a message to send!');
+}
 
 if (isset($var['alliance_id'])) {
 	$db->query('SELECT account_id FROM player

--- a/engine/Default/message_send_processing.php
+++ b/engine/Default/message_send_processing.php
@@ -28,11 +28,9 @@ if (isset($var['alliance_id'])) {
 		$player->sendMessage($db->getInt('account_id'), MSG_ALLIANCE, $message, false);
 	}
 	$player->sendMessage($player->getAccountID(), MSG_ALLIANCE, $message, true, false);
-}
-else if (!empty($var['receiver'])) {
+} else if (!empty($var['receiver'])) {
 	$player->sendMessage($var['receiver'], MSG_PLAYER, $message);
-}
-else {
+} else {
 	$player->sendGlobalMessage($message);
 }
 

--- a/engine/Default/planet_attack_processing.php
+++ b/engine/Default/planet_attack_processing.php
@@ -1,23 +1,31 @@
 <?php declare(strict_types=1);
 
-if ($player->hasNewbieTurns())
+if ($player->hasNewbieTurns()) {
 	create_error('You are under newbie protection!');
-if ($player->hasFederalProtection())
+}
+if ($player->hasFederalProtection()) {
 	create_error('You are under federal protection!');
-if ($player->isLandedOnPlanet())
+}
+if ($player->isLandedOnPlanet()) {
 	create_error('You cannot attack planets whilst on a planet!');
-if ($player->getTurns() < 3)
+}
+if ($player->getTurns() < 3) {
 	create_error('You do not have enough turns to attack this planet!');
-if (!$ship->hasWeapons() && !$ship->hasCDs())
+}
+if (!$ship->hasWeapons() && !$ship->hasCDs()) {
 	create_error('What are you going to do? Insult it to death?');
-if (!$player->canFight())
+}
+if (!$player->canFight()) {
 	create_error('You are not allowed to fight!');
+}
 
 $planet = $player->getSectorPlanet();
-if (!$planet->exists())
+if (!$planet->exists()) {
 	create_error('This planet does not exist.');
-if (!$planet->isClaimed())
+}
+if (!$planet->isClaimed()) {
 	create_error('This planet is not claimed.');
+}
 
 $planetOwner = $planet->getOwner();
 
@@ -88,8 +96,9 @@ if ($planetOwner->hasAlliance()) {
 
 // Update sector messages for attackers
 foreach ($attackers as $attacker) {
-	if (!$player->equals($attacker))
+	if (!$player->equals($attacker)) {
 		$db->query('REPLACE INTO sector_message VALUES(' . $attacker->getAccountID() . ',' . $attacker->getGameID() . ',' . $db->escapeString('[ATTACK_RESULTS]' . $logId) . ')');
+	}
 }
 
 $container = create_container('skeleton.php', 'planet_attack.php');

--- a/engine/Default/planet_defense_processing.php
+++ b/engine/Default/planet_defense_processing.php
@@ -1,17 +1,21 @@
 <?php declare(strict_types=1);
-if (!$player->isLandedOnPlanet())
+if (!$player->isLandedOnPlanet()) {
 	create_error('You are not on a planet!');
+}
 $amount = trim($_REQUEST['amount']);
-if (!is_numeric($amount))
+if (!is_numeric($amount)) {
 	create_error('Numbers only please');
-	
+}
+
 // only whole numbers allowed
 $amount = round($amount);
 
-if ($amount <= 0)
+if ($amount <= 0) {
 	create_error('You must actually enter an amount > 0!');
-if ($player->getNewbieTurns() > 0)
+}
+if ($player->getNewbieTurns() > 0) {
 	create_error('You can\'t drop defenses under newbie protection!');
+}
 // get a planet from the sector where the player is in
 $planet = $player->getSectorPlanet();
 
@@ -21,12 +25,14 @@ $action = $_REQUEST['action'];
 if ($action == 'Ship') {
 	if ($type_id == HARDWARE_SHIELDS) {
 		// do we want transfer more than we have?
-		if ($amount > $planet->getShields())
+		if ($amount > $planet->getShields()) {
 			create_error('You can\'t take more shields from planet than are on it!');
+		}
 
 		// do we want to transfer more than we can carry?
-		if ($amount > $ship->getMaxShields() - $ship->getShields())
+		if ($amount > $ship->getMaxShields() - $ship->getShields()) {
 			create_error('You can\'t take more shields than you can carry!');
+		}
 
 		// now transfer
 		$planet->decreaseShields($amount);
@@ -35,12 +41,14 @@ if ($action == 'Ship') {
 	}
 	else if ($type_id == HARDWARE_COMBAT) {
 		// do we want transfer more than we have?
-		if ($amount > $planet->getCDs())
+		if ($amount > $planet->getCDs()) {
 			create_error('You can\'t take more drones from planet than are on it!');
+		}
 
 		// do we want to transfer more than we can carry?
-		if ($amount > $ship->getMaxCDs() - $ship->getCDs())
+		if ($amount > $ship->getMaxCDs() - $ship->getCDs()) {
 			create_error('You can\'t take more drones than you can carry!');
+		}
 
 		// now transfer
 		$planet->decreaseCDs($amount);
@@ -49,12 +57,14 @@ if ($action == 'Ship') {
 	}
 	else if ($type_id == HARDWARE_ARMOUR) {
 		// do we want transfer more than we have?
-		if ($amount > $planet->getArmour())
+		if ($amount > $planet->getArmour()) {
 			create_error('You can\'t take more armour from planet than are on it!');
+		}
 
 		// do we want to transfer more than we can carry?
-		if ($amount > $ship->getMaxArmour() - $ship->getArmour())
+		if ($amount > $ship->getMaxArmour() - $ship->getArmour()) {
 			create_error('You can\'t take more armour than you can carry!');
+		}
 
 		// now transfer
 		$planet->decreaseArmour($amount);
@@ -67,12 +77,14 @@ elseif ($action == 'Planet') {
 	// does the user wants to transfer shields?
 	if ($type_id == HARDWARE_SHIELDS) {
 		// do we want transfer more than we have?
-		if ($amount > $ship->getShields())
+		if ($amount > $ship->getShields()) {
 			create_error('You can\'t transfer more shields than you carry!');
+		}
 
 		// do we want to transfer more than the planet can hold?
-		if ($amount + $planet->getShields() > $planet->getMaxShields())
+		if ($amount + $planet->getShields() > $planet->getMaxShields()) {
 			create_error('The planet can\'t hold more than ' . $planet->getMaxShields() . ' shields!');
+		}
 
 		// now transfer
 		$planet->increaseShields($amount);
@@ -82,12 +94,14 @@ elseif ($action == 'Planet') {
 	}
 	else if ($type_id == HARDWARE_COMBAT) {
 		// do we want transfer more than we have?
-		if ($amount > $ship->getCDs())
+		if ($amount > $ship->getCDs()) {
 			create_error('You can\'t transfer more combat drones than you carry!');
+		}
 
 		// do we want to transfer more than we can carry?
-		if ($amount + $planet->getCDs() > $planet->getMaxCDs())
+		if ($amount + $planet->getCDs() > $planet->getMaxCDs()) {
 			create_error('The planet can\'t hold more than ' . $planet->getMaxCDs() . ' drones!');
+		}
 
 		// now transfer
 		$planet->increaseCDs($amount);
@@ -97,12 +111,14 @@ elseif ($action == 'Planet') {
 	// does the user wish to transfare armour?
 	else if ($type_id == HARDWARE_ARMOUR) {
 		// do we want transfer more than we have?
-		if ($amount >= $ship->getArmour())
+		if ($amount >= $ship->getArmour()) {
 			create_error('You can\'t transfer more armour than what you carry minus one!');
+		}
 
 		// do we want to transfer more than we can carry?
-		if ($amount + $planet->getArmour() > $planet->getMaxArmour())
+		if ($amount + $planet->getArmour() > $planet->getMaxArmour()) {
 			create_error('The planet can\'t hold more than ' . $planet->getMaxArmour() . ' armour!');
+		}
 
 		// now transfer
 		$planet->increaseArmour($amount);
@@ -111,8 +127,9 @@ elseif ($action == 'Planet') {
 	}
 	
 }
-else
+else {
 	create_error('You must choose if you want to transfer to planet or to the ship!');
+}
 
 $ship->removeUnderAttack();
 

--- a/engine/Default/planet_defense_processing.php
+++ b/engine/Default/planet_defense_processing.php
@@ -38,8 +38,7 @@ if ($action == 'Ship') {
 		$planet->decreaseShields($amount);
 		$ship->increaseShields($amount);
 		$account->log(LOG_TYPE_PLANETS, 'Player takes ' . $amount . ' shields from planet.', $player->getSectorID());
-	}
-	else if ($type_id == HARDWARE_COMBAT) {
+	} else if ($type_id == HARDWARE_COMBAT) {
 		// do we want transfer more than we have?
 		if ($amount > $planet->getCDs()) {
 			create_error('You can\'t take more drones from planet than are on it!');
@@ -54,8 +53,7 @@ if ($action == 'Ship') {
 		$planet->decreaseCDs($amount);
 		$ship->increaseCDs($amount);
 		$account->log(LOG_TYPE_PLANETS, 'Player takes ' . $amount . ' drones from planet.', $player->getSectorID());
-	}
-	else if ($type_id == HARDWARE_ARMOUR) {
+	} else if ($type_id == HARDWARE_ARMOUR) {
 		// do we want transfer more than we have?
 		if ($amount > $planet->getArmour()) {
 			create_error('You can\'t take more armour from planet than are on it!');
@@ -72,8 +70,7 @@ if ($action == 'Ship') {
 		$account->log(LOG_TYPE_PLANETS, 'Player takes ' . $amount . ' armour from planet.', $player->getSectorID());
 	}
 	
-}
-elseif ($action == 'Planet') {
+} elseif ($action == 'Planet') {
 	// does the user wants to transfer shields?
 	if ($type_id == HARDWARE_SHIELDS) {
 		// do we want transfer more than we have?
@@ -91,8 +88,7 @@ elseif ($action == 'Planet') {
 		$ship->decreaseShields($amount);
 		$account->log(LOG_TYPE_PLANETS, 'Player puts ' . $amount . ' shields on planet.', $player->getSectorID());
 	// does the user wants to transfer drones?
-	}
-	else if ($type_id == HARDWARE_COMBAT) {
+	} else if ($type_id == HARDWARE_COMBAT) {
 		// do we want transfer more than we have?
 		if ($amount > $ship->getCDs()) {
 			create_error('You can\'t transfer more combat drones than you carry!');
@@ -126,8 +122,7 @@ elseif ($action == 'Planet') {
 		$account->log(LOG_TYPE_PLANETS, 'Player puts ' . $amount . ' armour on planet.', $player->getSectorID());
 	}
 	
-}
-else {
+} else {
 	create_error('You must choose if you want to transfer to planet or to the ship!');
 }
 

--- a/engine/Default/planet_financial_processing.php
+++ b/engine/Default/planet_financial_processing.php
@@ -1,33 +1,38 @@
 <?php declare(strict_types=1);
-if (!$player->isLandedOnPlanet())
+if (!$player->isLandedOnPlanet()) {
 	create_error('You are not on a planet!');
+}
 $planet = $player->getSectorPlanet();
 $action = $_REQUEST['action'];
 
 // Player has requested a planetary fund transaction
 if ($action == 'Deposit' || $action == 'Withdraw') {
 	$amount = $_REQUEST['amount'];
-	if (!is_numeric($amount))
+	if (!is_numeric($amount)) {
 		create_error('Numbers only please!');
+	}
 
 	// only whole numbers allowed
 	$amount = floor($amount);
 
 	// no negative amounts are allowed
-	if ($amount <= 0)
+	if ($amount <= 0) {
 		create_error('You must actually enter an amount > 0!');
+	}
 
 	if ($action == 'Deposit') {
-		if ($player->getCredits() < $amount)
+		if ($player->getCredits() < $amount) {
 			create_error('You don\'t own that much money!');
+		}
 
 		$player->decreaseCredits($amount);
 		$planet->increaseCredits($amount);
 		$account->log(LOG_TYPE_BANK, 'Player puts ' . $amount . ' credits on planet', $player->getSectorID());
 	}
 	elseif ($action == 'Withdraw') {
-		if ($planet->getCredits() < $amount)
+		if ($planet->getCredits() < $amount) {
 			create_error('There are not enough credits in the planetary account!');
+		}
 
 		$player->increaseCredits($amount);
 		$planet->decreaseCredits($amount);

--- a/engine/Default/planet_financial_processing.php
+++ b/engine/Default/planet_financial_processing.php
@@ -28,8 +28,7 @@ if ($action == 'Deposit' || $action == 'Withdraw') {
 		$player->decreaseCredits($amount);
 		$planet->increaseCredits($amount);
 		$account->log(LOG_TYPE_BANK, 'Player puts ' . $amount . ' credits on planet', $player->getSectorID());
-	}
-	elseif ($action == 'Withdraw') {
+	} elseif ($action == 'Withdraw') {
 		if ($planet->getCredits() < $amount) {
 			create_error('There are not enough credits in the planetary account!');
 		}

--- a/engine/Default/planet_ownership_processing.php
+++ b/engine/Default/planet_ownership_processing.php
@@ -1,14 +1,16 @@
 <?php declare(strict_types=1);
-if (!$player->isLandedOnPlanet())
+if (!$player->isLandedOnPlanet()) {
 	create_error('You are not on a planet!');
+}
 // get a planet from the sector where the player is in
 $planet = $player->getSectorPlanet();
 $action = $_REQUEST['action'];
 $password = isset($_REQUEST['password']) ? $_REQUEST['password'] : '';
 
 if ($action == 'Take Ownership') {
-	if ($planet->hasOwner() && $planet->getPassword() != $password)
+	if ($planet->hasOwner() && $planet->getPassword() != $password) {
 		create_error('You are not allowed to take ownership!');
+	}
 
 	// delete all previous ownerships
 	$db->query('UPDATE planet SET owner_id = 0, password = NULL

--- a/engine/Default/planet_ownership_processing.php
+++ b/engine/Default/planet_ownership_processing.php
@@ -22,8 +22,7 @@ if ($action == 'Take Ownership') {
 	$planet->removePassword();
 	$planet->update();
 	$account->log(LOG_TYPE_PLANETS, 'Player takes ownership of planet.', $player->getSectorID());
-}
-else if ($action == 'Rename') {
+} else if ($action == 'Rename') {
 	$name = trim($_REQUEST['name']);
 	if (empty($name)) {
 		create_error('You cannot leave your planet nameless!');
@@ -33,8 +32,7 @@ else if ($action == 'Rename') {
 	$planet->update();
 	$account->log(LOG_TYPE_PLANETS, 'Player renames planet to ' . $name . '.', $player->getSectorID());
 
-}
-else if ($action == 'Set Password') {
+} else if ($action == 'Set Password') {
 	// set password
 	$planet->setPassword($password);
 	$planet->update();

--- a/engine/Default/planet_stockpile_processing.php
+++ b/engine/Default/planet_stockpile_processing.php
@@ -34,8 +34,7 @@ if ($action == 'Ship') {
 	$account->log(LOG_TYPE_PLANETS, 'Player takes ' . $amount . ' ' . Globals::getGoodName($var['good_id']) . ' from planet.', $player->getSectorID());
 
 // transfer to planet
-}
-elseif ($action == 'Planet') {
+} elseif ($action == 'Planet') {
 	// do we want transfer more than we have?
 	if ($amount > $ship->getCargo($var['good_id'])) {
 		create_error('You can\'t store more than you carry!');

--- a/engine/Default/planet_stockpile_processing.php
+++ b/engine/Default/planet_stockpile_processing.php
@@ -1,14 +1,16 @@
 <?php declare(strict_types=1);
-if (!$player->isLandedOnPlanet())
+if (!$player->isLandedOnPlanet()) {
 	create_error('You are not on a planet!');
+}
 $amount = $_REQUEST['amount'];
-if (!is_numeric($amount))
+if (!is_numeric($amount)) {
 	create_error('Numbers only please');
-	
+}
 $amount = floor($amount);
 
-if ($amount <= 0)
+if ($amount <= 0) {
 	create_error('You must actually enter an amount > 0!');
+}
 
 // get a planet from the sector where the player is in
 $planet = $player->getSectorPlanet();
@@ -17,12 +19,14 @@ $action = $_REQUEST['action'];
 if ($action == 'Ship') {
 
 	// do we want transfer more than we have?
-	if ($amount > $planet->getStockpile($var['good_id']))
+	if ($amount > $planet->getStockpile($var['good_id'])) {
 		create_error('You can\'t take more than on planet!');
+	}
 
 	// do we want to transfer more than we can carry?
-	if ($amount > $ship->getEmptyHolds())
+	if ($amount > $ship->getEmptyHolds()) {
 		create_error('You can\'t take more than you can carry!');
+	}
 
 	// now transfer
 	$planet->decreaseStockpile($var['good_id'], $amount);
@@ -33,12 +37,14 @@ if ($action == 'Ship') {
 }
 elseif ($action == 'Planet') {
 	// do we want transfer more than we have?
-	if ($amount > $ship->getCargo($var['good_id']))
+	if ($amount > $ship->getCargo($var['good_id'])) {
 		create_error('You can\'t store more than you carry!');
+	}
 
 	// do we want to transfer more than the planet can hold?
-	if ($amount > $planet->getRemainingStockpile($var['good_id']))
+	if ($amount > $planet->getRemainingStockpile($var['good_id'])) {
 		create_error('This planet cannot store more than ' . SmrPlanet::MAX_STOCKPILE . ' of each good!');
+	}
 
 	// now transfer
 	$planet->increaseStockpile($var['good_id'], $amount);

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -3,8 +3,7 @@
 $container = create_container('skeleton.php');
 if (SmrSession::hasGame()) {
 	$container['body'] = 'current_sector.php';
-}
-else {
+} else {
 	$container['body'] = 'game_play.php';
 }
 $action = $_REQUEST['action'];
@@ -17,8 +16,7 @@ if ($action == 'Save and resend validation code') {
 	// overwrite container
 	$container['body'] = 'validate.php';
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your email address, you will now need to revalidate with the code sent to the new email address.';
-}
-elseif ($action == 'Change Password') {
+} elseif ($action == 'Change Password') {
 	$new_password = $_REQUEST['new_password'];
 	$old_password = $_REQUEST['old_password'];
 	$retype_password = $_REQUEST['retype_password'];
@@ -41,8 +39,7 @@ elseif ($action == 'Change Password') {
 
 	$account->setPassword($new_password);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your password.';
-}
-elseif ($action == 'Change Name') {
+} elseif ($action == 'Change Name') {
 	$HoF_name = trim($_REQUEST['HoF_name']);
 
 	$limited_char = 0;
@@ -67,18 +64,20 @@ elseif ($action == 'Change Name') {
 	}
 
 	//disallow blank names
-	if (empty($HoF_name) || $HoF_name == '') create_error('You Hall of Fame name must contain characters!');
+	if (empty($HoF_name) || $HoF_name == '') {
+		create_error('You Hall of Fame name must contain characters!');
+	}
 
 	//no duplicates
 	$db->query('SELECT * FROM account WHERE hof_name = ' . $db->escapeString($HoF_name) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
-	if ($db->nextRecord()) create_error('Someone is already using that name!');
+	if ($db->nextRecord()) {
+		create_error('Someone is already using that name!');
+	}
 
 	// set the HoF name in account stat
 	$account->setHofName($HoF_name);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your hall of fame name.';
-}
-
-elseif ($action == 'Change Discord ID') {
+} elseif ($action == 'Change Discord ID') {
 	$discordId = trim($_REQUEST['discord_id']);
 
 	if (empty($discordId)) {
@@ -88,14 +87,14 @@ elseif ($action == 'Change Discord ID') {
 	} else {
 		// no duplicates
 		$db->query('SELECT * FROM account WHERE discord_id =' . $db->escapeString($discordId) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
-		if ($db->nextRecord()) create_error('Someone is already using that Discord User ID!');
+		if ($db->nextRecord()) {
+			create_error('Someone is already using that Discord User ID!');
+		}
 
 		$account->setDiscordId($discordId);
 		$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your Discord User ID.';
 	}
-}
-
-elseif ($action == 'Change IRC Nick') {
+} elseif ($action == 'Change IRC Nick') {
 	$ircNick = trim($_REQUEST['irc_nick']);
 
 	for ($i = 0; $i < strlen($ircNick); $i++) {
@@ -113,7 +112,9 @@ elseif ($action == 'Change IRC Nick') {
 
 		// no duplicates
 		$db->query('SELECT * FROM account WHERE irc_nick = ' . $db->escapeString($ircNick) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
-		if ($db->nextRecord()) create_error('Someone is already using that nick!');
+		if ($db->nextRecord()) {
+			create_error('Someone is already using that nick!');
+		}
 
 		// save irc nick in db and set message
 		$account->setIrcNick($ircNick);
@@ -121,8 +122,7 @@ elseif ($action == 'Change IRC Nick') {
 
 	}
 
-}
-elseif ($action == 'Yes') {
+} elseif ($action == 'Yes') {
 	$account_id = $var['account_id'];
 	$amount = $var['amount'];
 
@@ -134,8 +134,7 @@ elseif ($action == 'Yes') {
 	// add to him
 	$his_account->increaseSmrCredits($amount);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have sent SMR credits.';
-}
-elseif ($action == 'Change Timezone') {
+} elseif ($action == 'Change Timezone') {
 	$timez = $_REQUEST['timez'];
 	if (!is_numeric($timez)) {
 		create_error('Numbers only please');
@@ -143,25 +142,20 @@ elseif ($action == 'Change Timezone') {
 
 	$db->query('UPDATE account SET offset = ' . $db->escapeNumber($timez) . ' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your time offset.';
-}
-elseif ($action == 'Change Date Formats') {
+} elseif ($action == 'Change Date Formats') {
 	$account->setShortDateFormat($_REQUEST['dateformat']);
 	$account->setShortTimeFormat($_REQUEST['timeformat']);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your date formats.';
-}
-elseif ($action == 'Change Images') {
+} elseif ($action == 'Change Images') {
 	$account->setDisplayShipImages($_REQUEST['images']);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your ship images preferences.';
-}
-elseif ($action == 'Change Centering') {
+} elseif ($action == 'Change Centering') {
 	$account->setCenterGalaxyMapOnPlayer($_REQUEST['centergalmap'] == 'Yes');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your centering galaxy map preferences.';
-}
-else if ($action == 'Change Size' && is_numeric($_REQUEST['fontsize']) && $_REQUEST['fontsize'] >= 50) {
+} else if ($action == 'Change Size' && is_numeric($_REQUEST['fontsize']) && $_REQUEST['fontsize'] >= 50) {
 	$account->setFontSize($_REQUEST['fontsize']);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your font size.';
-}
-else if ($action == 'Change CSS Options') {
+} else if ($action == 'Change CSS Options') {
 	$account->setCssLink($_REQUEST['csslink']);
 	if ($_REQUEST['template'] == 'None') {
 		$account->setDefaultCSSEnabled(false);
@@ -172,24 +166,20 @@ else if ($action == 'Change CSS Options') {
 		$account->setColourScheme($cssColourScheme);
 	}
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your CSS options.';
-}
-else if ($action == 'Change Kamikaze Setting') {
+} else if ($action == 'Change Kamikaze Setting') {
 	$player->setCombatDronesKamikazeOnMines($_REQUEST['kamikaze'] == 'Yes');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your combat drones options.';
-}
-else if ($action == 'Change Message Setting') {
+} else if ($action == 'Change Message Setting') {
 	$player->setForceDropMessages($_REQUEST['forceDropMessages'] == 'Yes');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your message options.';
-}
-else if ($action == 'Save Hotkeys') {
+} else if ($action == 'Save Hotkeys') {
 	foreach (AbstractSmrAccount::getDefaultHotkeys() as $hotkey => $binding) {
 		if (isset($_REQUEST[$hotkey])) {
 			$account->setHotkey($hotkey, explode(' ', $_REQUEST[$hotkey]));
 		}
 	}
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have saved your hotkeys.';
-}
-else if (strpos(trim($action), 'Alter Player') === 0) {
+} else if (strpos(trim($action), 'Alter Player') === 0) {
 	// trim input now
 	$player_name = trim($_POST['PlayerName']);
 
@@ -247,8 +237,7 @@ else if (strpos(trim($action), 'Alter Player') === 0) {
 	$news = 'Please be advised that ' . $old_name . ' has changed their name to ' . $player->getBBLink();
 	$db->query('INSERT INTO news (time, news_message, game_id, type) VALUES (' . $db->escapeNumber(TIME) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($player->getGameID()) . ', \'admin\')');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your player name.';
-}
-else if ($action == 'Update Colours') {
+} else if ($action == 'Update Colours') {
 	$friendlyColour = $_REQUEST['friendly_color'];
 	$neutralColour = $_REQUEST['neutral_color'];
 	$enemyColour = $_REQUEST['enemy_color'];

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -23,17 +23,21 @@ elseif ($action == 'Change Password') {
 	$old_password = $_REQUEST['old_password'];
 	$retype_password = $_REQUEST['retype_password'];
 
-	if (empty($new_password))
+	if (empty($new_password)) {
 		create_error('You must enter a non empty password!');
+	}
 
-	if (!$account->checkPassword($old_password))
+	if (!$account->checkPassword($old_password)) {
 		create_error('Your current password is wrong!');
+	}
 
-	if ($new_password != $retype_password)
+	if ($new_password != $retype_password) {
 		create_error('The passwords you entered don\'t match!');
+	}
 
-	if ($new_password == $account->getLogin())
+	if ($new_password == $account->getLogin()) {
 		create_error('Your chosen password is invalid!');
+	}
 
 	$account->setPassword($new_password);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your password.';
@@ -44,8 +48,9 @@ elseif ($action == 'Change Name') {
 	$limited_char = 0;
 	for ($i = 0; $i < strlen($HoF_name); $i++) {
 		// disallow certain ascii chars
-		if (ord($HoF_name[$i]) < 32 || ord($HoF_name[$i]) > 127)
+		if (ord($HoF_name[$i]) < 32 || ord($HoF_name[$i]) > 127) {
 			create_error('Your Hall Of Fame name contains invalid characters!');
+		}
 
 		// numbers 48..57
 		// Letters 65..90
@@ -57,9 +62,9 @@ elseif ($action == 'Change Name') {
 		}
 	}
 
-	if ($limited_char > 4)
+	if ($limited_char > 4) {
 		create_error('You cannot use a name with more than 4 special characters.');
-
+	}
 
 	//disallow blank names
 	if (empty($HoF_name) || $HoF_name == '') create_error('You Hall of Fame name must contain characters!');
@@ -95,8 +100,9 @@ elseif ($action == 'Change IRC Nick') {
 
 	for ($i = 0; $i < strlen($ircNick); $i++) {
 		// disallow certain ascii chars (and whitespace!)
-		if (ord($ircNick[$i]) < 33 || ord($ircNick[$i]) > 127)
+		if (ord($ircNick[$i]) < 33 || ord($ircNick[$i]) > 127) {
 			create_error('Your IRC Nick contains invalid characters!');
+		}
 	}
 
 	// here you can delete your registered irc nick
@@ -131,8 +137,9 @@ elseif ($action == 'Yes') {
 }
 elseif ($action == 'Change Timezone') {
 	$timez = $_REQUEST['timez'];
-	if (!is_numeric($timez))
+	if (!is_numeric($timez)) {
 		create_error('Numbers only please');
+	}
 
 	$db->query('UPDATE account SET offset = ' . $db->escapeNumber($timez) . ' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your time offset.';
@@ -193,8 +200,9 @@ else if (strpos(trim($action), 'Alter Player') === 0) {
 	$limited_char = 0;
 	for ($i = 0; $i < strlen($player_name); $i++) {
 		// disallow certain ascii chars
-		if (ord($player_name[$i]) < 32 || ord($player_name[$i]) > 127)
+		if (ord($player_name[$i]) < 32 || ord($player_name[$i]) > 127) {
 			create_error('The player name contains invalid characters!');
+		}
 
 		// numbers 48..57
 		// Letters 65..90
@@ -206,11 +214,13 @@ else if (strpos(trim($action), 'Alter Player') === 0) {
 		}
 	}
 
-	if ($limited_char > 4)
+	if ($limited_char > 4) {
 		create_error('You cannot use a name with more than 4 special characters.');
+	}
 
-	if (empty($player_name))
+	if (empty($player_name)) {
 		create_error('You must enter a player name!');
+	}
 
 	// Escape html elements so the name displays correctly
 	$player_name = htmlentities($player_name);

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -4,8 +4,11 @@ if (!$player->getGame()->hasStarted()) {
 	create_error('You cannot move until the game has started!');
 }
 
-if (isset($_REQUEST['target'])) $target = trim($_REQUEST['target']);
-else $target = $var['target'];
+if (isset($_REQUEST['target'])) {
+	$target = trim($_REQUEST['target']);
+} else {
+	$target = $var['target'];
+}
 
 //allow hidden players (admins that don't play) to move without pinging, hitting mines, losing turns
 if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
@@ -86,8 +89,7 @@ if ($misjump > 0) { // we missed the sector
 	}
 	$player->setSectorID($misjumpSector);
 	unset($distances);
-}
-else { // we hit it. exactly
+} else { // we hit it. exactly
 	$player->setSectorID($targetSector->getSectorID());
 }
 $player->takeTurns($turnsToJump, $turnsToJump);
@@ -124,8 +126,7 @@ if ($mineOwnerID) {
 		$container = create_container('skeleton.php', 'current_sector.php');
 		$container['msg'] = 'You have just flown past a sprinkle of mines.<br />Because of your newbie status you have been spared from the harsh reality of the forces.';
 		forward($container);
-	}
-	else {
+	} else {
 		$container = create_container('forces_attack_processing.php');
 		$container['action'] = 'bump';
 		$container['owner_id'] = $mineOwnerID;

--- a/engine/Default/sector_jump_processing.php
+++ b/engine/Default/sector_jump_processing.php
@@ -20,18 +20,22 @@ if (isset($_POST['action']) && $_POST['action'] == 'No') {
 }
 
 // you can't move while on planet
-if ($player->isLandedOnPlanet())
+if ($player->isLandedOnPlanet()) {
 	create_error('You are on a planet! You must launch first!');
+}
 
 // if no 'target' is given we forward to plot
-if (empty($target))
+if (empty($target)) {
 	create_error('Where do you want to go today?');
+}
 
-if (!is_numeric($target))
+if (!is_numeric($target)) {
 	create_error('Please enter only numbers!');
-	
-if ($player->getSectorID() == $target)
+}
+
+if ($player->getSectorID() == $target) {
 	create_error('Hmmmm...if ' . $player->getSectorID() . '=' . $target . ' then that means...YOU\'RE ALREADY THERE! *cough*you\'re real smart*cough*');
+}
 
 if (!SmrSector::sectorExists($player->getGameID(), $target)) {
 	create_error('The target sector doesn\'t exist!');
@@ -60,8 +64,9 @@ $turnsToJump = $jumpInfo['turn_cost'];
 $maxMisjump = $jumpInfo['max_misjump'];
 
 // check for turns
-if ($player->getTurns() < $turnsToJump)
+if ($player->getTurns() < $turnsToJump) {
 	create_error('You don\'t have enough turns for that jump!');
+}
 
 // send scout msg
 $sector->leavingSector($player, MOVEMENT_JUMP);
@@ -76,8 +81,9 @@ if ($misjump > 0) { // we missed the sector
 	}
 		
 	$misjumpSector = array_rand($distances[$misjump]);
-	if ($misjumpSector == null)
+	if ($misjumpSector == null) {
 		throw new Exception('Misjump sector is null, distances: ' . var_export($distances, true));
+	}
 	$player->setSectorID($misjumpSector);
 	unset($distances);
 }

--- a/engine/Default/sector_scan.php
+++ b/engine/Default/sector_scan.php
@@ -18,20 +18,22 @@ $enemy_vessel = 0;
 // iterate over all forces in the target sector
 foreach ($scanSector->getForces() as $scanSectorForces) {
 	// decide if it's a friendly or enemy stack
-	if ($player->sameAlliance($scanSectorForces->getOwner()))
+	if ($player->sameAlliance($scanSectorForces->getOwner())) {
 		$friendly_forces += $scanSectorForces->getMines() * 3 + $scanSectorForces->getCDs() * 2 + $scanSectorForces->getSDs();
-	else
+	} else {
 		$enemy_forces += $scanSectorForces->getMines() * 3 + $scanSectorForces->getCDs() * 2 + $scanSectorForces->getSDs();
+	}
 }
 
 foreach ($scanSector->getOtherTraders($player) as $scanSectorPlayer) {
 	$scanSectorShip = $scanSectorPlayer->getShip();
 
 	// he's a friend if he's in our alliance (and we are not in a 0 alliance
-	if ($player->traderMAPAlliance($scanSectorPlayer))
+	if ($player->traderMAPAlliance($scanSectorPlayer)) {
 		$friendly_vessel += $scanSectorShip->getAttackRating();
-	else
+	} else {
 		$enemy_vessel += $scanSectorShip->getDefenseRating() * 10;
+	}
 }
 
 $template->assign('FriendlyVessel', $friendly_vessel);
@@ -40,10 +42,11 @@ $template->assign('EnemyVessel', $enemy_vessel);
 $template->assign('EnemyForces', $enemy_forces);
 
 // is it a warp or a normal move?
-if ($sector->getWarp() == $var['target_sector'])
+if ($sector->getWarp() == $var['target_sector']) {
 	$turns = TURNS_PER_WARP;
-else
+} else {
 	$turns = TURNS_PER_SECTOR;
+}
 
 $template->assign('ScanSector', $scanSector);
 $template->assign('Turns', $turns);

--- a/engine/Default/shop_goods.php
+++ b/engine/Default/shop_goods.php
@@ -6,8 +6,9 @@ require_once(LIB . 'Default/shop_goods.inc');
 $port = $player->getSectorPort();
 
 $tradeable = checkPortTradeable($port, $player);
-if ($tradeable !== true)
+if ($tradeable !== true) {
 	create_error($tradeable);
+}
 
 // topic
 $template->assign('PageTopic', 'Port In Sector #' . $player->getSectorID());
@@ -28,12 +29,15 @@ elseif ($player->getLastPort() != $player->getSectorID()) {
 	// test if we are searched, but only if we hadn't a previous trade here
 
 	$base_chance = 15;
-	if ($port->hasGood(GOODS_SLAVES))
+	if ($port->hasGood(GOODS_SLAVES)) {
 		$base_chance -= 4;
-	if ($port->hasGood(GOODS_WEAPONS))
+	}
+	if ($port->hasGood(GOODS_WEAPONS)) {
 		$base_chance -= 4;
-	if ($port->hasGood(GOODS_NARCOTICS))
+	}
+	if ($port->hasGood(GOODS_NARCOTICS)) {
 		$base_chance -= 4;
+	}
 
 	if ($ship->isUnderground()) {
 		$base_chance -= 4;
@@ -64,8 +68,9 @@ elseif ($player->getLastPort() != $player->getSectorID()) {
 					// because credits is 0 it will take money from bank
 					$player->decreaseBank(min($fine, $player->getBank()));
 					// leave insurance
-					if ($player->getBank() < 5000)
+					if ($player->getBank() < 5000) {
 						$player->setBank(5000);
+					}
 				}
 			}
 			else {

--- a/engine/Default/shop_goods.php
+++ b/engine/Default/shop_goods.php
@@ -24,8 +24,7 @@ $searchedByFeds = false;
 //The player is sent here after trading and sees this if his offer is accepted.
 if (!empty($var['trade_msg'])) {
 	$template->assign('TradeMsg', $var['trade_msg']);
-}
-elseif ($player->getLastPort() != $player->getSectorID()) {
+} elseif ($player->getLastPort() != $player->getSectorID()) {
 	// test if we are searched, but only if we hadn't a previous trade here
 
 	$base_chance = 15;
@@ -72,8 +71,7 @@ elseif ($player->getLastPort() != $player->getSectorID()) {
 						$player->setBank(5000);
 					}
 				}
-			}
-			else {
+			} else {
 				$player->decreaseCredits($fine);
 			}
 
@@ -85,8 +83,7 @@ elseif ($player->getLastPort() != $player->getSectorID()) {
 			$ship->setCargo(GOODS_NARCOTICS, 0);
 			$account->log(LOG_TYPE_TRADING, 'Player gets caught with illegals', $player->getSectorID());
 
-		}
-		else {
+		} else {
 			$template->assign('IllegalsFound', false);
 			$player->increaseHOF(1, array('Trade', 'Search', 'Times Found Innocent'), HOF_PUBLIC);
 			$player->increaseAlignment(1);

--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -5,46 +5,55 @@ require_once(LIB . 'Default/shop_goods.inc');
 $amount = get_amount();
 $bargain_price = get_bargain_price();
 
-if (!is_numeric($amount) || !is_numeric($bargain_price))
+if (!is_numeric($amount) || !is_numeric($bargain_price)) {
 	create_error('Numbers only please!');
+}
 // get good name, id, ...
 $good_id = $var['good_id'];
 $good_name = Globals::getGoodName($good_id);
 
 // do we have enough turns?
-if ($player->getTurns() == 0)
+if ($player->getTurns() == 0) {
 	create_error('You don\'t have enough turns to trade.');
+}
 
 // get rid of those bugs when we die...there is no port at the home sector
-if (!$sector->hasPort())
+if (!$sector->hasPort()) {
 	create_error('I can\'t see a port in this sector. Can you?');
+}
 $port = $sector->getPort();
 
 // check if the player has the right relations to trade at the current port
-if ($player->getRelation($port->getRaceID()) < RELATIONS_WAR)
+if ($player->getRelation($port->getRaceID()) < RELATIONS_WAR) {
 	create_error('This port refuses to trade with you because you are at <span class="big bold red">WAR!</span>');
+}
 
 // does the port actually buy or sell this good?
 $transaction = $port->getGoodTransaction($good_id);
-if (empty($transaction))
+if (empty($transaction)) {
 	create_error('I don\'t trade in that good.');
+}
 
 $portGood = $port->getGood($good_id);
 // check if there are enough left at port
-if ($port->getGoodAmount($good_id) < $amount)
+if ($port->getGoodAmount($good_id) < $amount) {
 	create_error('I\'m short of ' . $good_name . '. So I\'m not going to sell you ' . $amount . ' pcs.');
+}
 
 // does we have what we are going to sell?
-if ($transaction == 'Sell' && $amount > $ship->getCargo($good_id))
+if ($transaction == 'Sell' && $amount > $ship->getCargo($good_id)) {
 	create_error('Scanning your ships indicates you don\'t have ' . $amount . ' pcs. of ' . $good_name . '!');
+}
 
 // check if we have enough room for the thing we are going to buy
-if ($transaction == 'Buy' && $amount > $ship->getEmptyHolds())
+if ($transaction == 'Buy' && $amount > $ship->getEmptyHolds()) {
 	create_error('Scanning your ships indicates you don\'t have enough free cargo bays!');
+}
 
 // check if the guy has enough money
-if ($transaction == 'Buy' && $player->getCredits() < $bargain_price)
+if ($transaction == 'Buy' && $player->getCredits() < $bargain_price) {
 	create_error('You don\'t have enough credits!');
+}
 
 // get relations for us (global + personal)
 $relations = $player->getRelation($port->getRaceID());
@@ -56,8 +65,9 @@ if (!isset($var['offered_price'])) SmrSession::updateVar('offered_price', $port-
 $offered_price = $var['offered_price'];
 
 // nothing should happen here but just to avoid / by 0
-if ($ideal_price == 0 || $offered_price == 0)
+if ($ideal_price == 0 || $offered_price == 0) {
 	create_error('Port calculation error...buy more goods.');
+}
 
 if ($_REQUEST['action'] == 'Steal') {
 	if (!$ship->isUnderground()) {
@@ -152,10 +162,11 @@ if ($transaction == 'Steal' ||
 
 	$container['trade_msg'] = $tradeMessage;
 
-	if ($ship->getEmptyHolds() == 0)
+	if ($ship->getEmptyHolds() == 0) {
 		$container['body'] = 'current_sector.php';
-	else
+	} else {
 		$container['body'] = 'shop_goods.php';
+	}
 
 }
 else {
@@ -173,8 +184,9 @@ else {
 }
 
 // only take turns if they bargained
-if (!isset($container['number_of_bargains']) || $container['number_of_bargains'] != 1)
+if (!isset($container['number_of_bargains']) || $container['number_of_bargains'] != 1) {
 	$player->takeTurns(TURNS_PER_TRADE, TURNS_PER_TRADE);
+}
 
 // go to next page
 forward($container);

--- a/engine/Default/shop_goods_processing.php
+++ b/engine/Default/shop_goods_processing.php
@@ -58,10 +58,14 @@ if ($transaction == 'Buy' && $player->getCredits() < $bargain_price) {
 // get relations for us (global + personal)
 $relations = $player->getRelation($port->getRaceID());
 
-if (!isset($var['ideal_price'])) SmrSession::updateVar('ideal_price', $port->getIdealPrice($good_id, $transaction, $amount, $relations));
+if (!isset($var['ideal_price'])) {
+	SmrSession::updateVar('ideal_price', $port->getIdealPrice($good_id, $transaction, $amount, $relations));
+}
 $ideal_price = $var['ideal_price'];
 
-if (!isset($var['offered_price'])) SmrSession::updateVar('offered_price', $port->getOfferPrice($ideal_price, $relations, $transaction));
+if (!isset($var['offered_price'])) {
+	SmrSession::updateVar('offered_price', $port->getOfferPrice($ideal_price, $relations, $transaction));
+}
 $offered_price = $var['offered_price'];
 
 // nothing should happen here but just to avoid / by 0
@@ -120,8 +124,7 @@ if ($transaction == 'Steal' ||
 		$player->increaseHOF($bargain_price, array('Trade', 'Money', 'Buying'), HOF_PUBLIC);
 		$port->buyGoods($portGood, $amount, $ideal_price, $bargain_price, $gained_exp);
 		$player->increaseRelationsByTrade($amount, $port->getRaceID());
-	}
-	elseif ($transaction == 'Sell') {
+	} elseif ($transaction == 'Sell') {
 		$msg_transaction = 'sold';
 		$ship->decreaseCargo($good_id, $amount);
 		$player->increaseCredits($bargain_price);
@@ -131,8 +134,7 @@ if ($transaction == 'Steal' ||
 		$player->increaseHOF($bargain_price, array('Trade', 'Money', 'Selling'), HOF_PUBLIC);
 		$port->sellGoods($portGood, $amount, $ideal_price, $bargain_price, $gained_exp);
 		$player->increaseRelationsByTrade($amount, $port->getRaceID());
-	}
-	elseif ($transaction == 'Steal') {
+	} elseif ($transaction == 'Steal') {
 		$msg_transaction = 'stolen';
 		$ship->increaseCargo($good_id, $amount);
 		$player->increaseHOF($amount, array('Trade', 'Goods', 'Stolen'), HOF_ALLIANCE);
@@ -168,8 +170,7 @@ if ($transaction == 'Steal' ||
 		$container['body'] = 'shop_goods.php';
 	}
 
-}
-else {
+} else {
 	// does the trader try to outsmart us?
 	$container = create_container('skeleton.php', 'shop_goods_trade.php');
 	transfer('ideal_price');

--- a/engine/Default/shop_hardware_processing.php
+++ b/engine/Default/shop_hardware_processing.php
@@ -1,8 +1,9 @@
 <?php declare(strict_types=1);
 $action = $_REQUEST['action'];
 $amount = $_REQUEST['amount'];
-if (!is_numeric($amount))
+if (!is_numeric($amount)) {
 	create_error('Numbers only please');
+}
 
 // only whole numbers allowed
 $amount = floor($amount);
@@ -12,8 +13,9 @@ $hardware_name = Globals::getHardwareName($hardware_id);
 $cost = Globals::getHardwareCost($hardware_id);
 
 // no negative amounts are allowed
-if ($amount <= 0)
+if ($amount <= 0) {
 	create_error('You must actually enter an amount greater than zero!');
+}
 
 if ($action == 'Buy') {
 	// do we have enough cash?

--- a/engine/Default/smr_file_create.php
+++ b/engine/Default/smr_file_create.php
@@ -4,15 +4,17 @@
 // code is read-only. This will help reduce sector lag and possible abuse.
 release_lock();
 
-if (isset($var['AdminCreateGameID']) && $var['AdminCreateGameID'] !== false)
+if (isset($var['AdminCreateGameID']) && $var['AdminCreateGameID'] !== false) {
 	$gameID = $var['AdminCreateGameID'];
-else
+} else {
 	$gameID = $player->getGameID();
+}
 
-if (isset($var['AdminCreateGameID']) && $var['AdminCreateGameID'] !== false)
+if (isset($var['AdminCreateGameID']) && $var['AdminCreateGameID'] !== false) {
 	$adminCreate = true;
-else
+} else {
 	$adminCreate = false;
+}
 
 // NOTE: If the format of this file is changed in an incompatible way,
 // make sure to update the SMR_FILE_VERSION!
@@ -103,8 +105,9 @@ foreach (SmrLocation::getAllLocations() as $location) {
 	if ($location->isFed()) {
 		$locSells .= 'Fed=,';
 	}
-	if ($locSells != '')
+	if ($locSells != '') {
 		$file .= substr($locSells, 0, -1);
+	}
 	$file .= EOL;
 }
 
@@ -130,19 +133,22 @@ foreach ($galaxies as $galaxy) {
 	foreach ($galaxy->getSectors() as $sector) {
 		$file .= '[Sector=' . $sector->getSectorID() . ']' . EOL;
 		
-		if (!$sector->isVisited($player) && $adminCreate === false)
+		if (!$sector->isVisited($player) && $adminCreate === false) {
 			continue;
+		}
 		
 		foreach ($sector->getLinks() as $linkName => $link) {
 			$file .= $linkName . '=' . $link . EOL;
 		}
-		if ($sector->hasWarp())
+		if ($sector->hasWarp()) {
 			$file .= 'Warp=' . $sector->getWarp() . EOL;
+		}
 		if (($adminCreate !== false && $sector->hasPort()) || is_object($player) && $sector->hasCachedPort($player)) {
-			if ($adminCreate !== false)
+			if ($adminCreate !== false) {
 				$port = $sector->getPort();
-			else
+			} else {
 				$port = $sector->getCachedPort($player);
+			}
 			$file .= 'Port Level=' . $port->getLevel() . EOL;
 			$file .= 'Port Race=' . $port->getRaceID() . EOL;
 			if (!empty($port->getSoldGoodIDs())) {

--- a/engine/Default/trader_attack_processing.php
+++ b/engine/Default/trader_attack_processing.php
@@ -1,30 +1,36 @@
 <?php declare(strict_types=1);
 
-if ($player->hasNewbieTurns())
+if ($player->hasNewbieTurns()) {
 	create_error('You are under newbie protection.');
-if ($player->hasFederalProtection())
+}
+if ($player->hasFederalProtection()) {
 	create_error('You are under federal protection.');
-if ($player->isLandedOnPlanet())
+}
+if ($player->isLandedOnPlanet()) {
 	create_error('You cannot attack whilst on a planet!');
-if ($player->getTurns() < 3)
+}
+if ($player->getTurns() < 3) {
 	create_error('You have insufficient turns to perform that action.');
-if (!$player->canFight())
+}
+if (!$player->canFight()) {
 	create_error('You are not allowed to fight!');
+}
 
 $targetPlayer = SmrPlayer::getPlayer($var['target'], $player->getGameID());
 
-	if ($player->traderNAPAlliance($targetPlayer))
+	if ($player->traderNAPAlliance($targetPlayer)) {
 		create_error('Your alliance does not allow you to attack this trader.');
-	else if ($targetPlayer->isDead())
+	} else if ($targetPlayer->isDead()) {
 		create_error('Target is already dead.');
-	else if ($targetPlayer->getSectorID() != $player->getSectorID())
+	} else if ($targetPlayer->getSectorID() != $player->getSectorID()) {
 		create_error('Target is no longer in this sector.');
-	else if ($targetPlayer->hasNewbieTurns())
+	} else if ($targetPlayer->hasNewbieTurns()) {
 		create_error('Target is under newbie protection.');
-	else if ($targetPlayer->isLandedOnPlanet())
+	} else if ($targetPlayer->isLandedOnPlanet()) {
 		create_error('Target is protected by planetary shields.');
-	else if ($targetPlayer->hasFederalProtection())
+	} else if ($targetPlayer->hasFederalProtection()) {
 		create_error('Target is under federal protection.');
+	}
 
 $fightingPlayers = $sector->getFightingTraders($player, $targetPlayer);
 
@@ -76,10 +82,11 @@ unserialize($serializedResults); //because of references we have to undo this.
 $container = create_container('skeleton.php', 'trader_attack.php');
 
 // If their target is dead there is no continue attack button
-if (!$targetPlayer->isDead())
+if (!$targetPlayer->isDead()) {
 	$container['target'] = $var['target'];
-else
+} else {
 	$container['target'] = 0;
+}
 
 // If they died on the shot they get to see the results
 if ($player->isDead()) {

--- a/engine/Default/weapon_reorder.php
+++ b/engine/Default/weapon_reorder.php
@@ -11,6 +11,7 @@ if (isset($var['Down']) && is_numeric($var['Down'])) {
 }
 
 if (isset($var['Form'])) {
-	if (isset($_REQUEST['weapon_reorder']) && is_array($_REQUEST['weapon_reorder']))
+	if (isset($_REQUEST['weapon_reorder']) && is_array($_REQUEST['weapon_reorder'])) {
 		$ship->setWeaponLocations($_REQUEST['weapon_reorder']);
+	}
 }

--- a/htdocs/album/album_comment.php
+++ b/htdocs/album/album_comment.php
@@ -71,7 +71,6 @@ try {
 
 	header('Location: /album/?' . get_album_nick($album_id));
 	exit;
-}
-catch (Throwable $e) {
+} catch (Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/album/album_comment.php
+++ b/htdocs/album/album_comment.php
@@ -14,22 +14,26 @@ try {
 		create_error_offline('You need to logged in to post comments!');
 	}
 
-	if (!isset($_GET['album_id']) || empty($_GET['album_id']))
+	if (!isset($_GET['album_id']) || empty($_GET['album_id'])) {
 		create_error_offline('Which picture do you want comment?');
-	else
+	} else {
 		$album_id = $_GET['album_id'];
+	}
 
-	if (!is_numeric($album_id))
+	if (!is_numeric($album_id)) {
 		create_error_offline('Picture ID has to be numeric!');
+	}
 
-	if ($album_id < 1)
+	if ($album_id < 1) {
 		create_error_offline('Picture ID has to be positive!');
+	}
 
 	$account = SmrSession::getAccount();
 
 	if (isset($_GET['action']) && $_GET['action'] == 'Moderate') {
-		if (!$account->hasPermission(PERMISSION_MODERATE_PHOTO_ALBUM))
+		if (!$account->hasPermission(PERMISSION_MODERATE_PHOTO_ALBUM)) {
 			create_error_offline('You do not have permission to do that!');
+		}
 		$container = create_container('skeleton.php', 'album_moderate.php');
 		$container['account_id'] = $album_id;
 
@@ -38,10 +42,11 @@ try {
 
 	$db = new SmrMySqlDatabase();
 
-	if (!isset($_GET['comment']) || empty($_GET['comment']))
+	if (!isset($_GET['comment']) || empty($_GET['comment'])) {
 		create_error_offline('Please enter a comment.');
-	else
+	} else {
 		$comment = $_GET['comment'];
+	}
 
 	// get current time
 	$curr_time = TIME;
@@ -53,10 +58,11 @@ try {
 	$db->lockTable('album_has_comments');
 
 	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($album_id));
-	if ($db->nextRecord())
+	if ($db->nextRecord()) {
 		$comment_id = $db->getInt('MAX(comment_id)') + 1;
-	else
+	} else {
 		$comment_id = 1;
+	}
 
 	$db->query('INSERT INTO album_has_comments
 				(album_id, comment_id, time, post_id, msg)

--- a/htdocs/album/index.php
+++ b/htdocs/album/index.php
@@ -56,34 +56,37 @@ try {
 						  approved = \'YES\'
 					ORDER BY hof_name');
 			
-			if ($db2->nextRecord())
+			if ($db2->nextRecord()) {
 				album_entry($db2->getInt('album_id'));
-			else {
+			} else {
 				// get all id's and build array
 				$album_ids = array();
 		
-				while ($db->nextRecord())
+				while ($db->nextRecord()) {
 					$album_ids[] = $db->getInt('album_id');
+				}
 		
 				// double check if we have id's
-				if (count($album_ids) > 0)
+				if (count($album_ids) > 0) {
 					search_result($album_ids);
-				else
+				} else {
 					main_page();
+				}
 			}
 	
 		}
 		elseif ($db->getNumRows() == 1) {
-			if ($db->nextRecord())
+			if ($db->nextRecord()) {
 				album_entry($db->getInt('album_id'));
-			else
+			} else {
 				main_page();
-		}
-		else
+			}
+		} else {
 			main_page();
-	}
-	else
+		}
+	} else {
 		main_page();
+	}
 }
 catch (Throwable $e) {
 	handleException($e);

--- a/htdocs/album/index.php
+++ b/htdocs/album/index.php
@@ -74,8 +74,7 @@ try {
 				}
 			}
 	
-		}
-		elseif ($db->getNumRows() == 1) {
+		} elseif ($db->getNumRows() == 1) {
 			if ($db->nextRecord()) {
 				album_entry($db->getInt('album_id'));
 			} else {
@@ -87,8 +86,7 @@ try {
 	} else {
 		main_page();
 	}
-}
-catch (Throwable $e) {
+} catch (Throwable $e) {
 	handleException($e);
 }
 ?>

--- a/htdocs/loader.php
+++ b/htdocs/loader.php
@@ -74,9 +74,15 @@ try {
 	// Must not call `get_file_loc` until after we have set $overrideGameID
 	// (unless we're exiting immediately with an error, as above).
 	$overrideGameID = 0;
-	if (isset($var['game_id']) && is_numeric($var['game_id'])) $overrideGameID = $var['game_id'];
-	if ($overrideGameID == 0 && isset($var['GameID']) && is_numeric($var['GameID'])) $overrideGameID = $var['GameID'];
-	if ($overrideGameID == 0) $overrideGameID = SmrSession::getGameID();
+	if (isset($var['game_id']) && is_numeric($var['game_id'])) {
+		$overrideGameID = $var['game_id'];
+	}
+	if ($overrideGameID == 0 && isset($var['GameID']) && is_numeric($var['GameID'])) {
+		$overrideGameID = $var['GameID'];
+	}
+	if ($overrideGameID == 0) {
+		$overrideGameID = SmrSession::getGameID();
+	}
 
 	require_once(get_file_loc('smr.inc'));
 
@@ -92,22 +98,19 @@ try {
 			} else {
 				forward(create_container('skeleton.php', 'invalid_email.php'));
 			}
-		}
-		else if ($disabled['Reason'] == CLOSE_ACCOUNT_BY_REQUEST_REASON) {
+		} else if ($disabled['Reason'] == CLOSE_ACCOUNT_BY_REQUEST_REASON) {
 			if (isset($var['do_reopen_account'])) {
 				// The user has requested to reopen their account
 				$account->unbanAccount($account);
 			} else {
 				forward(create_container('skeleton.php', 'reopen_account.php'));
 			}
-		}
-		else {
+		} else {
 			forward(create_container('disabled.php'));
 		}
 	}
 	
 	do_voodoo();
-}
-catch (Throwable $e) {
+} catch (Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/loader.php
+++ b/htdocs/loader.php
@@ -54,9 +54,9 @@ try {
 		if (!USING_AJAX) {
 			require_once(get_file_loc('smr.inc'));
 			create_error('Your browser lost the SN. Try to reload the page!');
-		}
-		else
+		} else {
 			exit;
+		}
 	}
 	
 	// do we have such a container object in the db?
@@ -64,9 +64,9 @@ try {
 		if (!USING_AJAX) {
 			require_once(get_file_loc('smr.inc'));
 			create_error('Please avoid using the back button!');
-		}
-		else
+		} else {
 			exit;
+		}
 	}
 	
 	// Determine where to load game scripts from (in case we need a special

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -31,8 +31,7 @@ try {
 				header('Location: /login_social_create.php');
 				exit;
 			}
-		}
-		else {
+		} else {
 			$login = (isset($_REQUEST['login']) ? $_REQUEST['login'] : (isset($var['login']) ? $var['login'] : ''));
 			$password = (isset($_REQUEST['password']) ? $_REQUEST['password'] : (isset($var['password']) ? $var['password'] : ''));
 
@@ -46,8 +45,7 @@ try {
 			$account = SmrAccount::getAccountByName($login);
 			if (is_object($account) && $account->checkPassword($password)) {
 				SmrSession::setAccount($account);
-			}
-			else {
+			} else {
 				$msg = 'Password is incorrect!';
 				header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 				exit;
@@ -142,39 +140,56 @@ try {
 			//convert to array
 			$old = explode('-', $db->getField('array'));
 			//get rid of old version cookie since it isn't optimal.
-			if ($old[0] != MULTI_CHECKING_COOKIE_VERSION) $old = array();
-		} else $old = array();
+			if ($old[0] != MULTI_CHECKING_COOKIE_VERSION) {
+				$old = array();
+			}
+		} else {
+			$old = array();
+		}
 		$old[0] = MULTI_CHECKING_COOKIE_VERSION;
-		if (!in_array($account->getAccountID(), $old)) $old[] = $account->getAccountID();
-	}
-	else {
+		if (!in_array($account->getAccountID(), $old)) {
+			$old[] = $account->getAccountID();
+		}
+	} else {
 
 		//we have a cookie so we see if we add to it etc
 		//break cookie into array
 		$cookie = explode('-', $_COOKIE['Session_Info']);
 		//check for current version
-		if ($cookie[0] != MULTI_CHECKING_COOKIE_VERSION) $cookie = array();
+		if ($cookie[0] != MULTI_CHECKING_COOKIE_VERSION) {
+			$cookie = array();
+		}
 		$cookie[0] = MULTI_CHECKING_COOKIE_VERSION;
 		//add this acc to the cookie if it isn't there
-		if (!in_array($account->getAccountID(), $cookie)) $cookie[] = $account->getAccountID();
+		if (!in_array($account->getAccountID(), $cookie)) {
+			$cookie[] = $account->getAccountID();
+		}
 
 		$db->query('SELECT * FROM multi_checking_cookie WHERE account_id = ' . $account->getAccountID());
 		if ($db->nextRecord()) {
 			//convert to array
 			$old = explode('-', $db->getField('array'));
-			if ($old[0] != MULTI_CHECKING_COOKIE_VERSION) $old = array();
-		} else $old = array();
+			if ($old[0] != MULTI_CHECKING_COOKIE_VERSION) {
+				$old = array();
+			}
+		} else {
+			$old = array();
+		}
 		$old[0] = MULTI_CHECKING_COOKIE_VERSION;
 		//merge arrays...but keys are all different so we go through each value
 		foreach ($cookie as $value) {
-			if (!in_array($value, $old)) $old[] = $value;
+			if (!in_array($value, $old)) {
+				$old[] = $value;
+			}
 		}
 	}
 	$use = (count($old) <= 2) ? 'FALSE' : 'TRUE';
 	//check that each value is legit and add it to db string
 	$new = MULTI_CHECKING_COOKIE_VERSION;
 	foreach ($old as $accID) {
-		if (is_numeric($accID)) $new .= '-' . $accID;
+		if (is_numeric($accID)) {
+			$new .= '-' . $accID;
+		}
 	}
 	$db->query('REPLACE INTO multi_checking_cookie (account_id, array, `use`) VALUES (' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($new) . ', ' . $db->escapeString($use) . ')');
 	//now we update their cookie with the newest info
@@ -194,7 +209,6 @@ try {
 
 	header('Location: ' . $href);
 	exit;
-}
-catch (Throwable $e) {
+} catch (Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/login_processing.php
+++ b/htdocs/login_processing.php
@@ -166,8 +166,9 @@ try {
 		} else $old = array();
 		$old[0] = MULTI_CHECKING_COOKIE_VERSION;
 		//merge arrays...but keys are all different so we go through each value
-		foreach ($cookie as $value)
+		foreach ($cookie as $value) {
 			if (!in_array($value, $old)) $old[] = $value;
+		}
 	}
 	$use = (count($old) <= 2) ? 'FALSE' : 'TRUE';
 	//check that each value is legit and add it to db string

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -35,8 +35,7 @@ try {
 			header('location: /error.php?msg=Invalid sector ID');
 			exit;
 		}
-	}
-	else if (isset($_REQUEST['galaxy_id'])) {
+	} else if (isset($_REQUEST['galaxy_id'])) {
 		$galaxyID = $_REQUEST['galaxy_id'];
 		if (!is_numeric($galaxyID)) {
 			header('location: /error.php?msg=Galaxy ID was not a number.');
@@ -44,8 +43,7 @@ try {
 		}
 		try {
 			$galaxy = SmrGalaxy::getGalaxy(SmrSession::getGameID(), $galaxyID);
-		}
-		catch (Exception $e) {
+		} catch (Exception $e) {
 			header('location: /error.php?msg=Invalid galaxy ID');
 			exit;
 		}
@@ -117,7 +115,6 @@ try {
 	$template->assign('AJAX_ENABLE_REFRESH', false);
 
 	$template->display('GalaxyMap.inc');
-}
-catch (Throwable $e) {
+} catch (Throwable $e) {
 	handleException($e);
 }

--- a/htdocs/map_galaxy.php
+++ b/htdocs/map_galaxy.php
@@ -99,8 +99,9 @@ try {
 
 	$template->assign('Title', 'Galaxy Map');
 
-	if ($account->getCssLink() != null)
+	if ($account->getCssLink() != null) {
 		$template->assign('ExtraCSSLink', $account->getCssLink());
+	}
 	$template->assign('CSSLink', $account->getCssUrl());
 	$template->assign('CSSColourLink', $account->getCssColourUrl());
 	$template->assign('FontSize', $account->getFontSize() - 20);

--- a/lib/Album/album_functions.php
+++ b/lib/Album/album_functions.php
@@ -54,8 +54,9 @@ function main_page() {
 			echo('<span style="font-size:85%;"><b>[' . date(defined('DATE_FULL_SHORT') ?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $created) . ']</b> Picture of <a href="?nick=' . urlencode($nick) . '">' . $nick . '</a> added</span><br />');
 		}
 	}
-	else
+	else {
 		echo('<span style="font-size:85%;">no entries</span>');
+	}
 	echo('</p>');
 }
 
@@ -139,46 +140,55 @@ function album_entry($album_id) {
 	echo('<tr>');
 	echo('<td colspan="2" class="center" valign="middle">');
 
-	if ($disabled == false)
+	if ($disabled == false) {
 		echo('<img src="../upload/' . $album_id . '">');
-	else
+	} else {
 		echo('<img src="../images/album/disabled.jpg">');
+	}
 
 	echo('</td>');
 	echo('</tr>');
 
-	if (empty($location))
+	if (empty($location)) {
 		$location = 'N/A';
+	}
 	echo('<tr>');
 	echo('<td class="right bold" width="10%">Location:</td><td>' . $location . '</td>');
 	echo('</tr>');
 
-	if (empty($email))
+	if (empty($email)) {
 		$email = 'N/A';
+	}
 	echo('<tr>');
 	echo('<td class="right bold" width="10%">E-mail:</td><td>' . $email . '</td>');
 	echo('</tr>');
 
-	if (empty($website))
+	if (empty($website)) {
 		$website = 'N/A';
-	else
+	}
+	else {
 		$website = '<a href="' . $website . '" target="_new">' . $website . '</a>';
+	}
 	echo('<tr>');
 	echo('<td class="right bold" width="10%">Website:</td><td>' . $website . '</td>');
 	echo('</tr>');
 
 	echo('<tr>');
-	if (!empty($day) && !empty($month) && !empty($year))
+	if (!empty($day) && !empty($month) && !empty($year)) {
 		$birthdate = $month . ' / ' . $day . ' / ' . $year;
-	if (empty($birthdate) && !empty($year))
+	}
+	if (empty($birthdate) && !empty($year)) {
 		$birthdate = 'Year ' . $year;
-	if (empty($birthdate))
+	}
+	if (empty($birthdate)) {
 		$birthdate = 'N/A';
+	}
 	echo('<td class="right bold" width="10%">Birthdate:</td><td>' . $birthdate . '</td>');
 	echo('</tr>');
 
-	if (empty($other))
+	if (empty($other)) {
 		$other = 'N/A';
+	}
 	echo('<tr>');
 	echo('<td class="right bold" valign="top" width="10%">Other&nbsp;Info:</td><td>' . $other . '</td>');
 	echo('</tr>');
@@ -210,15 +220,17 @@ function album_entry($album_id) {
 					FROM account_has_permission
 					WHERE account_id = '.$db->escapeNumber(SmrSession::getAccountID()) . ' AND
 						permission_id = '.$db->escapeNumber(PERMISSION_MODERATE_PHOTO_ALBUM));
-		if ($db->nextRecord())
+		if ($db->nextRecord()) {
 			echo('<td style="color:green; font-size:70%;"><br /><input type="submit" name="action" value="Moderate" class="InputFields"></td>');
+		}
 
 		echo('</tr>');
 		echo('</table>');
 		echo('</form>');
 	}
-	else
+	else {
 		echo('<p>Please <a href="/login.php?return_page=/album/?nick=' . urlencode($nick) . '"><u>login</u></a> if you want comment on this picture!</p>');
+	}
 
 	echo('</td>');
 	echo('</tr>');
@@ -288,8 +300,9 @@ function create_link_list() {
 
 
 function get_album_nick($album_id) {
-	if ($album_id == 0)
+	if ($album_id == 0) {
 		return 'System';
+	}
 
 	return SmrAccount::getAccount($album_id)->getHofName();
 }

--- a/lib/Album/album_functions.php
+++ b/lib/Album/album_functions.php
@@ -53,8 +53,7 @@ function main_page() {
 
 			echo('<span style="font-size:85%;"><b>[' . date(defined('DATE_FULL_SHORT') ?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $created) . ']</b> Picture of <a href="?nick=' . urlencode($nick) . '">' . $nick . '</a> added</span><br />');
 		}
-	}
-	else {
+	} else {
 		echo('<span style="font-size:85%;">no entries</span>');
 	}
 	echo('</p>');
@@ -88,8 +87,7 @@ function album_entry($album_id) {
 		$other = nl2br(stripslashes($db->getField('other')));
 		$page_views = $db->getInt('page_views');
 		$disabled = $db->getBoolean('disabled');
-	}
-	else {
+	} else {
 		echo('<h1>Error</h1>');
 		echo('This user doesn\'t have an entry in our album!');
 		return;
@@ -165,8 +163,7 @@ function album_entry($album_id) {
 
 	if (empty($website)) {
 		$website = 'N/A';
-	}
-	else {
+	} else {
 		$website = '<a href="' . $website . '" target="_new">' . $website . '</a>';
 	}
 	echo('<tr>');
@@ -227,8 +224,7 @@ function album_entry($album_id) {
 		echo('</tr>');
 		echo('</table>');
 		echo('</form>');
-	}
-	else {
+	} else {
 		echo('<p>Please <a href="/login.php?return_page=/album/?nick=' . urlencode($nick) . '"><u>login</u></a> if you want comment on this picture!</p>');
 	}
 

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -99,8 +99,9 @@ abstract class AbstractSmrAccount {
 		if (empty($login)) { return null; }
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT account_id FROM account WHERE login = '.$db->escapeString($login).' LIMIT 1');
-		if($db->nextRecord())
+		if($db->nextRecord()) {
 			return self::getAccount($db->getInt('account_id'), $forceUpdate);
+		}
 		$return = null;
 		return $return;
 	}
@@ -235,8 +236,9 @@ abstract class AbstractSmrAccount {
 			$this->template			= $row['template'];
 			$this->colourScheme		= $row['colour_scheme'];
 
-			if(empty($this->hofName))
+			if(empty($this->hofName)) {
 				$this->hofName=$this->login;
+			}
 		}
 		else {
 			throw new AccountNotFoundException('Account ID '.$accountID.' does not exist!');
@@ -324,8 +326,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function updateLastLogin() {
-		if($this->last_login == TIME)
+		if($this->last_login == TIME) {
 			return;
+		}
 		$this->last_login = TIME;
 		$this->hasChanged = true;
 		$this->update();
@@ -336,8 +339,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setLoggingEnabled($bool) {
-		if($this->logging==$bool)
+		if($this->logging==$bool) {
 			return;
+		}
 		$this->logging=$bool;
 		$this->hasChanged = true;
 		$this->update();
@@ -386,12 +390,14 @@ abstract class AbstractSmrAccount {
 
 	public function getHOF(array $typeList = null) {
 		$this->getHOFData();
-		if($typeList==null)
+		if($typeList==null) {
 			return $this->HOF;
+		}
 		$hof=$this->HOF;
 		foreach($typeList as $type) {
-			if(!isset($hof[$type]))
+			if(!isset($hof[$type])) {
 				return 0;
+			}
 			$hof = $hof[$type];
 		}
 		return $hof;
@@ -399,10 +405,11 @@ abstract class AbstractSmrAccount {
 
 	public function getRankName() {
 		$rankings = Globals::getUserRanking();
-		if(isset($rankings[$this->getRank()]))
+		if(isset($rankings[$this->getRank()])) {
 			return $rankings[$this->getRank()];
-		else
+		} else {
 			return end($rankings);
+		}
 	}
 
 	public function getScore() {
@@ -418,15 +425,17 @@ abstract class AbstractSmrAccount {
 
 	public function getIndividualScores(SmrPlayer $player = null) {
 		$gameID=0;
-		if($player!=null)
+		if($player!=null) {
 			$gameID = $player->getGameID();
+		}
 		if(!isset($this->individualScores[$gameID])) {
 			$this->individualScores[$gameID] = array();
 			foreach(self::USER_RANKINGS_SCORE as $statScore) {
-				if($player==null)
+				if($player==null) {
 					$stat = $this->getHOF($statScore[0]);
-				else
+				} else {
 					$stat = $player->getHOF($statScore[0]);
+				}
 				$this->individualScores[$gameID][]=array('Stat'=>$statScore[0],'Score'=>pow($stat*$statScore[1],self::USER_RANKINGS_EACH_STAT_POW)*$statScore[2]);
 			}
 		}
@@ -435,16 +444,19 @@ abstract class AbstractSmrAccount {
 
 	public function getRank() : int {
 		$rank = ICeil(pow($this->getScore(),self::USER_RANKINGS_TOTAL_SCORE_POW)/self::USER_RANKINGS_RANK_BOUNDARY);
-		if($rank<1)
+		if($rank<1) {
 			$rank=1;
-		if($rank > $this->maxRankAchieved)
+		}
+		if($rank > $this->maxRankAchieved) {
 			$this->updateMaxRankAchieved($rank);
+		}
 		return $rank;
 	}
 
 	protected function updateMaxRankAchieved($rank) {
-		if($rank <= $this->maxRankAchieved)
+		if($rank <= $this->maxRankAchieved) {
 			throw new Exception('Trying to set max rank achieved to a lower value: ' . $rank);
+		}
 		$delta = $rank - $this->maxRankAchieved;
 		if($this->hasReferrer()) {
 			$this->getReferrer()->increaseSmrRewardCredits($delta * CREDITS_PER_DOLLAR);
@@ -491,12 +503,15 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function decreaseTotalSmrCredits($totalCredits) {
-		if($totalCredits==0)
+		if($totalCredits==0) {
 			return;
-		if($totalCredits<0)
+		}
+		if($totalCredits<0) {
 			throw new Exception('You cannot use negative total credits');
-		if($totalCredits>$this->getTotalSmrCredits())
+		}
+		if($totalCredits>$this->getTotalSmrCredits()) {
 			throw new Exception('You do not have that many credits in total to use');
+		}
 
 		$rewardCredits=$this->rewardCredits;
 		$credits=$this->credits;
@@ -505,10 +520,11 @@ abstract class AbstractSmrAccount {
 			$credits+=$rewardCredits;
 			$rewardCredits=0;
 		}
-		if($this->credits==0 && $this->rewardCredits==0)
+		if($this->credits==0 && $this->rewardCredits==0) {
 			$this->db->query('REPLACE INTO account_has_credits (account_id, credits_left, reward_credits) VALUES('.$this->db->escapeNumber($this->getAccountID()).', '.$this->db->escapeNumber($credits).','.$this->db->escapeNumber($rewardCredits).')');
-		else
+		} else {
 			$this->db->query('UPDATE account_has_credits SET credits_left='.$this->db->escapeNumber($credits).', reward_credits='.$this->db->escapeNumber($rewardCredits).' WHERE '.$this->SQL.' LIMIT 1');
+		}
 		$this->credits=$credits;
 		$this->rewardCredits=$rewardCredits;
 	}
@@ -524,48 +540,59 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setSmrCredits($credits) {
-		if($this->getSmrCredits()==$credits)
+		if($this->getSmrCredits()==$credits) {
 			return;
-		if($this->credits==0 && $this->rewardCredits==0)
+		}
+		if($this->credits==0 && $this->rewardCredits==0) {
 			$this->db->query('REPLACE INTO account_has_credits (account_id, credits_left) VALUES('.$this->db->escapeNumber($this->getAccountID()).', '.$this->db->escapeNumber($credits).')');
-		else
+		} else {
 			$this->db->query('UPDATE account_has_credits SET credits_left='.$this->db->escapeNumber($credits).' WHERE '.$this->SQL.' LIMIT 1');
+		}
 		$this->credits=$credits;
 	}
 
 	public function increaseSmrCredits($credits) {
-		if($credits==0)
+		if($credits==0) {
 			return;
-		if($credits<0)
+		}
+		if($credits<0) {
 			throw new Exception('You cannot gain negative credits');
+		}
 		$this->setSmrCredits($this->getSmrCredits()+$credits);
 	}
 
 	public function decreaseSmrCredits($credits) {
-		if($credits==0)
+		if($credits==0) {
 			return;
-		if($credits<0)
+		}
+		if($credits<0) {
 			throw new Exception('You cannot use negative credits');
-		if($credits>$this->getSmrCredits())
+		}
+		if($credits>$this->getSmrCredits()) {
 			throw new Exception('You cannot use more credits than you have');
+		}
 		$this->setSmrCredits($this->getSmrCredits()-$credits);
 	}
 
 	public function setSmrRewardCredits($credits) {
-		if($this->getSmrRewardCredits()==$credits)
+		if($this->getSmrRewardCredits()==$credits) {
 			return;
-		if($this->credits==0 && $this->rewardCredits==0)
+		}
+		if($this->credits==0 && $this->rewardCredits==0) {
 			$this->db->query('REPLACE INTO account_has_credits (account_id, reward_credits) VALUES('.$this->db->escapeNumber($this->getAccountID()).', '.$this->db->escapeNumber($credits).')');
-		else
+		} else {
 			$this->db->query('UPDATE account_has_credits SET reward_credits='.$this->db->escapeNumber($credits).' WHERE '.$this->SQL.' LIMIT 1');
+		}
 		$this->rewardCredits=$credits;
 	}
 
 	public function increaseSmrRewardCredits($credits) {
-		if($credits==0)
+		if($credits==0) {
 			return;
-		if($credits<0)
+		}
+		if($credits<0) {
 			throw new Exception('You cannot gain negative reward credits');
+		}
 		$this->setSmrRewardCredits($this->getSmrRewardCredits()+$credits);
 	}
 
@@ -601,8 +628,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function hasOldAccountID($dbName=false) {
-		if($dbName===false)
+		if($dbName===false) {
 			return count($this->getOldAccountIDs())!=0;
+		}
 		return $this->getOldAccountID($dbName)!=0;
 	}
 
@@ -681,8 +709,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setFontSize($size) {
-		if($this->fontSize==$size)
+		if($this->fontSize==$size) {
 			return;
+		}
 		$this->fontSize = $size;
 		$this->hasChanged = true;
 		$this->update();
@@ -695,8 +724,9 @@ abstract class AbstractSmrAccount {
 
 	// sets the extra CSS file linked in preferences
 	public function setCssLink($link) {
-		if($this->cssLink==$link)
+		if($this->cssLink==$link) {
 			return;
+		}
 		$this->cssLink = $link;
 		$this->hasChanged = true;
 		$this->update();
@@ -707,10 +737,12 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setTemplate($template) {
-		if($this->template==$template)
+		if($this->template==$template) {
 			return;
-		if(!in_array($template,array_keys(Globals::getAvailableTemplates())))
+		}
+		if(!in_array($template,array_keys(Globals::getAvailableTemplates()))) {
 			throw new Exception('Template not allowed: '.$template);
+		}
 		$this->db->query('UPDATE account SET template = ' . $this->db->escapeString($template) . ' WHERE '.$this->SQL.' LIMIT 1');
 		$this->template = $template;
 		$colourSchemes = Globals::getAvailableColourSchemes($template);
@@ -722,10 +754,12 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setColourScheme($colourScheme) {
-		if($this->colourScheme==$colourScheme)
+		if($this->colourScheme==$colourScheme) {
 			return;
-		if(!in_array($colourScheme,array_keys(Globals::getAvailableColourSchemes($this->getTemplate()))))
+		}
+		if(!in_array($colourScheme,array_keys(Globals::getAvailableColourSchemes($this->getTemplate())))) {
 			throw new Exception('Colour scheme not allowed: '.$colourScheme);
+		}
 		$this->colourScheme = $colourScheme;
 		$this->hasChanged = true;
 		$this->update();
@@ -759,8 +793,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setHofName($name) {
-		if($this->hofName==$name)
+		if($this->hofName==$name) {
 			return;
+		}
 		$this->hofName = $name;
 		$this->hasChanged = true;
 		$this->update();
@@ -771,8 +806,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setIrcNick($nick) {
-		if($this->ircNick==$nick)
+		if($this->ircNick==$nick) {
 			return;
+		}
 		$this->ircNick = $nick;
 		$this->hasChanged = true;
 		$this->update();
@@ -800,8 +836,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setShortDateFormat($format) {
-		if($this->dateShort==$format)
+		if($this->dateShort==$format) {
 			return;
+		}
 		$this->dateShort = $format;
 		$this->hasChanged = true;
 		$this->update();
@@ -812,8 +849,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setShortTimeFormat($format) {
-		if($this->timeShort==$format)
+		if($this->timeShort==$format) {
 			return;
+		}
 		$this->timeShort = $format;
 		$this->hasChanged = true;
 		$this->update();
@@ -824,16 +862,18 @@ abstract class AbstractSmrAccount {
 	}
 
 	protected function setValidationCode($code) {
-		if($this->validation_code == $code)
+		if($this->validation_code == $code) {
 			return;
+		}
 		$this->validation_code=$code;
 		$this->hasChanged=true;
 		$this->update();
 	}
 
 	public function setValidated($bool) {
-		if($this->validated == $bool)
+		if($this->validated == $bool) {
 			return;
+		}
 		$this->validated = $bool;
 		$this->hasChanged = true;
 		$this->update();
@@ -906,8 +946,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	protected function setPasswordReset($passwordReset) {
-		if($this->passwordReset == $passwordReset)
+		if($this->passwordReset == $passwordReset) {
 			return;
+		}
 		$this->passwordReset=$passwordReset;
 		$this->hasChanged=true;
 		$this->update();
@@ -918,8 +959,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setDisplayShipImages($yesNo) {
-		if($this->images == $yesNo)
+		if($this->images == $yesNo) {
 			return;
+		}
 		$this->images = $yesNo;
 		$this->hasChanged = true;
 		$this->update();
@@ -930,8 +972,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setUseAJAX($bool) {
-		if($this->useAJAX == $bool)
+		if($this->useAJAX == $bool) {
 			return;
+		}
 		$this->useAJAX=$bool;
 		$this->hasChanged=true;
 		$this->update();
@@ -942,8 +985,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setDefaultCSSEnabled($bool) {
-		if($this->defaultCSSEnabled == $bool)
+		if($this->defaultCSSEnabled == $bool) {
 			return;
+		}
 		$this->defaultCSSEnabled=$bool;
 		$this->hasChanged=true;
 		$this->update();
@@ -962,8 +1006,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setHotkey($hotkeyType,$binding) {
-		if($this->getHotkeys($hotkeyType) == $binding)
+		if($this->getHotkeys($hotkeyType) == $binding) {
 			return;
+		}
 		$this->hotkeys[$hotkeyType] = $binding;
 		$this->hasChanged=true;
 		$this->update();
@@ -978,26 +1023,31 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setMessageNotifications($messageTypeID,$num) {
-		if($this->getMessageNotifications($messageTypeID) == $num)
+		if($this->getMessageNotifications($messageTypeID) == $num) {
 			return;
+		}
 		$this->messageNotifications[$messageTypeID]=$num;
 		$this->hasChanged=true;
 		$this->update();
 	}
 
 	public function increaseMessageNotifications($messageTypeID,$num) {
-		if($num==0)
+		if($num==0) {
 			return;
-		if($num<0)
+		}
+		if($num<0) {
 			throw new Exception('You cannot increase by a negative amount');
+		}
 		$this->setMessageNotifications($messageTypeID, $this->getMessageNotifications($messageTypeID) + $num);
 	}
 
 	public function decreaseMessageNotifications($messageTypeID,$num) {
-		if($num==0)
+		if($num==0) {
 			return;
-		if($num<0)
+		}
+		if($num<0) {
 			throw new Exception('You cannot decrease by a negative amount');
+		}
 		$this->setMessageNotifications($messageTypeID, $this->getMessageNotifications($messageTypeID) - $num);
 	}
 
@@ -1006,8 +1056,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setCenterGalaxyMapOnPlayer($bool) {
-		if($this->centerGalaxyMapOnPlayer == $bool)
+		if($this->centerGalaxyMapOnPlayer == $bool) {
 			return;
+		}
 		$this->centerGalaxyMapOnPlayer=$bool;
 		$this->hasChanged=true;
 		$this->update();
@@ -1022,8 +1073,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setMailBanned($time) {
-		if($this->mailBanned == $time)
+		if($this->mailBanned == $time) {
 			return;
+		}
 		$this->mailBanned=$time;
 		$this->hasChanged=true;
 	}
@@ -1077,48 +1129,52 @@ abstract class AbstractSmrAccount {
 
 	public function setPoints($numPoints,$lastUpdate=false) {
 		$numPoints = max($numPoints,0);
-		if($this->getPoints()==$numPoints)
+		if($this->getPoints()==$numPoints) {
 			return;
-		if ($this->points==0)
+		}
+		if ($this->points==0) {
 			$this->db->query('INSERT INTO account_has_points (account_id, points, last_update) VALUES ('.$this->db->escapeNumber($this->getAccountID()).', '.$this->db->escapeNumber($numPoints).', '.$this->db->escapeNumber($lastUpdate?$lastUpdate:TIME).')');
-		else if($numPoints<=0)
+		} else if($numPoints<=0) {
 			$this->db->query('DELETE FROM account_has_points WHERE '.$this->SQL.' LIMIT 1');
-		else
+		} else {
 			$this->db->query('UPDATE account_has_points SET points = '.$this->db->escapeNumber($numPoints).($lastUpdate ? ', last_update = '.$this->db->escapeNumber(TIME) : '').' WHERE '.$this->SQL.' LIMIT 1');
+		}
 		$this->points=$numPoints;
 	}
 
 	public function removePoints($numPoints,$lastUpdate=false) {
-		if($numPoints>0)
+		if($numPoints>0) {
 			$this->setPoints($this->getPoints()-$numPoints,$lastUpdate);
+		}
 	}
 
 	public function addPoints($numPoints,SmrAccount $admin,$reasonID,$suspicion) {
 		//do we have points
 		$this->setPoints($this->getPoints() + $numPoints,TIME);
 		$totalPoints = $this->getPoints();
-		if ($totalPoints < 10)
+		if ($totalPoints < 10) {
 			return false;//leave scripts its only a warning
-		elseif ($totalPoints < 20)
+		} elseif ($totalPoints < 20) {
 			$days = 2;
-		elseif ($totalPoints < 30)
+		} elseif ($totalPoints < 30) {
 			$days = 4;
-		elseif ($totalPoints < 50)
+		} elseif ($totalPoints < 50) {
 			$days = 7;
-		elseif ($totalPoints < 75)
+		} elseif ($totalPoints < 75) {
 			$days = 15 ;
-		elseif ($totalPoints < 100)
+		} elseif ($totalPoints < 100) {
 			$days = 30;
-		elseif ($totalPoints < 125)
+		} elseif ($totalPoints < 125) {
 			$days = 60;
-		elseif ($totalPoints < 150)
+		} elseif ($totalPoints < 150) {
 			$days = 120;
-		elseif ($totalPoints < 175)
+		} elseif ($totalPoints < 175) {
 			$days = 240;
-		elseif ($totalPoints < 200)
+		} elseif ($totalPoints < 200) {
 			$days = 480;
-		else
+		} else {
 			$days = 0; //Forever/indefinite
+		}
 
 		if($days==0) {
 			$expireTime = 0;
@@ -1178,26 +1234,30 @@ abstract class AbstractSmrAccount {
 			$player->update();
 		}
 		$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account closed by ' . $admin->getLogin() . '.');
-		if($removeExceptions!==false)
+		if($removeExceptions!==false) {
 			$this->db->query('DELETE FROM account_exceptions WHERE ' . $this->SQL);
+		}
 	}
 
 	public function unbanAccount(SmrAccount $admin = null,$currException=false) {
 		$adminID = 0;
-		if($admin!==null)
+		if($admin!==null) {
 			$adminID = $admin->getAccountID();
+		}
 		$this->db->query('DELETE FROM account_is_closed WHERE ' . $this->SQL . ' LIMIT 1');
 		$this->db->query('INSERT INTO account_has_closing_history
 						(account_id, time, admin_id, action)
 						VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber(TIME) . ', ' . $this->db->escapeNumber($adminID) . ', ' . $this->db->escapeString('Opened') . ')');
 		$this->db->query('UPDATE player SET last_turn_update = GREATEST(' . $this->db->escapeNumber(TIME) . ', last_turn_update) WHERE ' . $this->SQL);
-		if($admin!==null)
+		if($admin!==null) {
 			$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account reopened by ' . $admin->getLogin() . '.');
-		else
+		} else {
 			$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account automatically reopened.');
-		if($currException!==false)
+		}
+		if($currException!==false) {
 			$this->db->query('REPLACE INTO account_exceptions (account_id, reason)
 							VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeString($currException) . ')');
+		}
 	}
 
 	public function getToggleAJAXHREF() {

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -10,23 +10,23 @@ abstract class AbstractSmrAccount {
 	protected const USER_RANKINGS_SCORE = array(
 		// [Stat, a, b]
 		// Used as: pow(Stat * a, USER_RANKINGS_EACH_STAT_POW) * b
-		array(array('Trade','Experience','Total'),.1,0.5),
-		array(array('Trade','Money','Profit'),0.00005,0.5),
-		array(array('Killing','Kills'),1000,1)
+		array(array('Trade', 'Experience', 'Total'), .1, 0.5),
+		array(array('Trade', 'Money', 'Profit'), 0.00005, 0.5),
+		array(array('Killing', 'Kills'), 1000, 1)
 		);
 
 	protected static $CACHE_ACCOUNTS = array();
 	protected const DEFAULT_HOTKEYS = array(
-		'MoveUp' => array('w','up'),
-		'ScanUp' => array('shift+w','shift+up'),
-		'MoveLeft' => array('a','left'),
-		'ScanLeft' => array('shift+a','shift+left'),
-		'MoveRight' => array('d','right'),
-		'ScanRight' => array('shift+d','shift+right'),
-		'MoveDown' => array('s','down'),
-		'ScanDown' => array('shift+s','shift+down'),
-		'MoveWarp' => array('e','0'),
-		'ScanWarp' => array('shift+e','shift+0'),
+		'MoveUp' => array('w', 'up'),
+		'ScanUp' => array('shift+w', 'shift+up'),
+		'MoveLeft' => array('a', 'left'),
+		'ScanLeft' => array('shift+a', 'shift+left'),
+		'MoveRight' => array('d', 'right'),
+		'ScanRight' => array('shift+d', 'shift+right'),
+		'MoveDown' => array('s', 'down'),
+		'ScanDown' => array('shift+s', 'shift+down'),
+		'MoveWarp' => array('e', '0'),
+		'ScanWarp' => array('shift+e', 'shift+0'),
 		'ScanCurrent' => array('shift+1'),
 		'CurrentSector' => array('1'),
 		'LocalMap' => array('2'),
@@ -67,7 +67,7 @@ abstract class AbstractSmrAccount {
 	protected $oldAccountIDs = array();
 	protected $maxRankAchieved;
 	protected $referrerID;
-	protected $credits;       // SMR credits
+	protected $credits; // SMR credits
 	protected $rewardCredits; // SMR reward credits
 	protected $dateShort;
 	protected $timeShort;
@@ -88,8 +88,8 @@ abstract class AbstractSmrAccount {
 		return self::DEFAULT_HOTKEYS;
 	}
 
-	public static function getAccount($accountID,$forceUpdate = false) {
-		if($forceUpdate || !isset(self::$CACHE_ACCOUNTS[$accountID])) {
+	public static function getAccount($accountID, $forceUpdate = false) {
+		if ($forceUpdate || !isset(self::$CACHE_ACCOUNTS[$accountID])) {
 			self::$CACHE_ACCOUNTS[$accountID] = new SmrAccount($accountID);
 		}
 		return self::$CACHE_ACCOUNTS[$accountID];
@@ -98,18 +98,18 @@ abstract class AbstractSmrAccount {
 	public static function getAccountByName($login, $forceUpdate = false) {
 		if (empty($login)) { return null; }
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT account_id FROM account WHERE login = '.$db->escapeString($login).' LIMIT 1');
-		if($db->nextRecord()) {
+		$db->query('SELECT account_id FROM account WHERE login = ' . $db->escapeString($login) . ' LIMIT 1');
+		if ($db->nextRecord()) {
 			return self::getAccount($db->getInt('account_id'), $forceUpdate);
 		}
 		$return = null;
 		return $return;
 	}
 
-	public static function getAccountByEmail($email, $forceUpdate=false) {
+	public static function getAccountByEmail($email, $forceUpdate = false) {
 		if (empty($email)) { return null; }
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT account_id FROM account WHERE email = '.$db->escapeString($email).' LIMIT 1');
+		$db->query('SELECT account_id FROM account WHERE email = ' . $db->escapeString($email) . ' LIMIT 1');
 		if ($db->nextRecord()) {
 			return self::getAccount($db->getInt('account_id'), $forceUpdate);
 		} else {
@@ -117,10 +117,10 @@ abstract class AbstractSmrAccount {
 		}
 	}
 
-	public static function getAccountByDiscordId($id, $forceUpdate=false) {
+	public static function getAccountByDiscordId($id, $forceUpdate = false) {
 		if (empty($id)) { return null; }
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT account_id FROM account where discord_id = '.$db->escapeString($id).' LIMIT 1');
+		$db->query('SELECT account_id FROM account where discord_id = ' . $db->escapeString($id) . ' LIMIT 1');
 		if ($db->nextRecord()) {
 			return self::getAccount($db->getInt('account_id'), $forceUpdate);
 		} else {
@@ -131,7 +131,7 @@ abstract class AbstractSmrAccount {
 	public static function getAccountByIrcNick($nick, $forceUpdate = false) {
 		if (empty($nick)) { return null; }
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT account_id FROM account WHERE irc_nick = '.$db->escapeString($nick).' LIMIT 1');
+		$db->query('SELECT account_id FROM account WHERE irc_nick = ' . $db->escapeString($nick) . ' LIMIT 1');
 		if ($db->nextRecord()) {
 			return self::getAccount($db->getInt('account_id'), $forceUpdate);
 		} else {
@@ -139,12 +139,12 @@ abstract class AbstractSmrAccount {
 		}
 	}
 
-	public static function getAccountBySocialLogin(SocialLogin $social, $forceUpdate=false) {
+	public static function getAccountBySocialLogin(SocialLogin $social, $forceUpdate = false) {
 		if (!$social->isValid()) { return null; }
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT account_id FROM account JOIN account_auth USING(account_id)
-		            WHERE login_type = '.$db->escapeString($social->getLoginType()).'
-		              AND auth_key = '.$db->escapeString($social->getUserID()).' LIMIT 1');
+		            WHERE login_type = '.$db->escapeString($social->getLoginType()) . '
+		              AND auth_key = '.$db->escapeString($social->getUserID()) . ' LIMIT 1');
 		if ($db->nextRecord()) {
 			return self::getAccount($db->getInt('account_id'), $forceUpdate);
 		} else {
@@ -153,7 +153,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public static function createAccount($login, $password, $email, $timez, $referral) {
-		if($referral!=0) {
+		if ($referral != 0) {
 			// Will throw if referral account doesn't exist
 			SmrAccount::getAccount($referral);
 		}
@@ -161,60 +161,60 @@ abstract class AbstractSmrAccount {
 		$passwordHash = password_hash($password, PASSWORD_DEFAULT);
 		$db->query('INSERT INTO account (login, password, email, validation_code, last_login, offset,referral_id,hof_name) VALUES(' .
 			$db->escapeString($login) . ', ' . $db->escapeString($passwordHash) . ', ' . $db->escapeString($email) . ', ' .
-			$db->escapeString(random_string(10)) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($timez) . ',' . $db->escapeNumber($referral).','.$db->escapeString($login).')');
+			$db->escapeString(random_string(10)) . ',' . $db->escapeNumber(TIME) . ',' . $db->escapeNumber($timez) . ',' . $db->escapeNumber($referral) . ',' . $db->escapeString($login) . ')');
 		return self::getAccountByName($login);
 	}
 
 	public static function getUserScoreCaseStatement($db) {
 		$userRankingTypes = array();
 		$case = 'FLOOR(SUM(CASE type ';
-		foreach(self::USER_RANKINGS_SCORE as $userRankingScore) {
-			$userRankingType = $db->escapeArray($userRankingScore[0],false,false,':',false);
+		foreach (self::USER_RANKINGS_SCORE as $userRankingScore) {
+			$userRankingType = $db->escapeArray($userRankingScore[0], false, false, ':', false);
 			$userRankingTypes[] = $userRankingType;
-			$case.= ' WHEN '.$db->escapeString($userRankingType).' THEN POW(amount*'.$userRankingScore[1].','.SmrAccount::USER_RANKINGS_EACH_STAT_POW.')*'.$userRankingScore[2];
+			$case .= ' WHEN ' . $db->escapeString($userRankingType) . ' THEN POW(amount*' . $userRankingScore[1] . ',' . SmrAccount::USER_RANKINGS_EACH_STAT_POW . ')*' . $userRankingScore[2];
 		}
 		$case .= ' END))';
-		return array('CASE'=>$case,'IN'=>$db->escapeArray($userRankingTypes));
+		return array('CASE'=>$case, 'IN'=>$db->escapeArray($userRankingTypes));
 	}
 
 	protected function __construct($accountID) {
 		$this->db = new SmrMySqlDatabase();
 		$this->SQL = 'account_id = ' . $this->db->escapeNumber($accountID);
-		$this->db->query('SELECT * FROM account WHERE '.$this->SQL.' LIMIT 1');
+		$this->db->query('SELECT * FROM account WHERE ' . $this->SQL . ' LIMIT 1');
 
 		if ($this->db->nextRecord()) {
 			$row = $this->db->getRow();
-			$this->account_id		= $row['account_id'];
+			$this->account_id = $row['account_id'];
 
 			$this->login			= $row['login'];
-			$this->passwordHash		= $row['password'];
+			$this->passwordHash = $row['password'];
 			$this->email			= $row['email'];
-			$this->validated		= $this->db->getBoolean('validated');
+			$this->validated = $this->db->getBoolean('validated');
 
-			$this->last_login		= $row['last_login'];
-			$this->validation_code 	= $row['validation_code'];
-			$this->veteranForced	= $this->db->getBoolean('veteran');
-			$this->logging			= $this->db->getBoolean('logging');
+			$this->last_login = $row['last_login'];
+			$this->validation_code = $row['validation_code'];
+			$this->veteranForced = $this->db->getBoolean('veteran');
+			$this->logging = $this->db->getBoolean('logging');
 			$this->offset			= $row['offset'];
 			$this->images			= $row['images'];
-			$this->fontSize			= $row['fontsize'];
+			$this->fontSize = $row['fontsize'];
 
-			$this->passwordReset	= $row['password_reset'];
-			$this->useAJAX			= $this->db->getBoolean('use_ajax');
-			$this->mailBanned		= (int)$row['mail_banned'];
+			$this->passwordReset = $row['password_reset'];
+			$this->useAJAX = $this->db->getBoolean('use_ajax');
+			$this->mailBanned = (int)$row['mail_banned'];
 			
-			$this->friendlyColour 	= $row['friendly_colour'];
-			$this->neutralColour 	= $row['neutral_colour'];
-			$this->enemyColour 		= $row['enemy_colour'];
+			$this->friendlyColour = $row['friendly_colour'];
+			$this->neutralColour = $row['neutral_colour'];
+			$this->enemyColour = $row['enemy_colour'];
 
-			$this->cssLink			= $row['css_link'];
-			$this->defaultCSSEnabled	= $this->db->getBoolean('default_css_enabled');
-			$this->centerGalaxyMapOnPlayer	= $this->db->getBoolean('center_galaxy_map_on_player');
+			$this->cssLink = $row['css_link'];
+			$this->defaultCSSEnabled = $this->db->getBoolean('default_css_enabled');
+			$this->centerGalaxyMapOnPlayer = $this->db->getBoolean('center_galaxy_map_on_player');
 
 			$this->messageNotifications = $this->db->getObject('message_notifications');
 			$this->hotkeys = $this->db->getObject('hotkeys');
-			foreach(self::DEFAULT_HOTKEYS as $hotkey => $binding) {
-				if(!isset($this->hotkeys[$hotkey])) {
+			foreach (self::DEFAULT_HOTKEYS as $hotkey => $binding) {
+				if (!isset($this->hotkeys[$hotkey])) {
 					$this->hotkeys[$hotkey] = $binding;
 				}
 			}
@@ -223,8 +223,8 @@ abstract class AbstractSmrAccount {
 				$this->oldAccountIDs[$databaseName] = $row[$oldColumn];
 			}
 
-			$this->referrerID		= $row['referral_id'];
-			$this->maxRankAchieved	= $row['max_rank_achieved'];
+			$this->referrerID = $row['referral_id'];
+			$this->maxRankAchieved = $row['max_rank_achieved'];
 
 			$this->hofName			= $row['hof_name'];
 			$this->discordId		= $row['discord_id'];
@@ -234,20 +234,20 @@ abstract class AbstractSmrAccount {
 			$this->timeShort		= $row['time_short'];
 
 			$this->template			= $row['template'];
-			$this->colourScheme		= $row['colour_scheme'];
+			$this->colourScheme = $row['colour_scheme'];
 
-			if(empty($this->hofName)) {
-				$this->hofName=$this->login;
+			if (empty($this->hofName)) {
+				$this->hofName = $this->login;
 			}
 		}
 		else {
-			throw new AccountNotFoundException('Account ID '.$accountID.' does not exist!');
+			throw new AccountNotFoundException('Account ID ' . $accountID . ' does not exist!');
 		}
 	}
 
 	public function isDisabled() {
 		$this->db->query('SELECT * FROM account_is_closed JOIN closing_reason USING(reason_id) ' .
-			'WHERE '.$this->SQL.' LIMIT 1');
+			'WHERE ' . $this->SQL . ' LIMIT 1');
 		if ($this->db->nextRecord()) {
 			// get the expire time
 			$expireTime = $this->db->getInt('expires');
@@ -262,71 +262,72 @@ abstract class AbstractSmrAccount {
 				'Reason' => $this->db->getField('reason'),
 				'ReasonID' => $this->db->getInt('reason_id')
 			);
-		}
-		else {
+		} else {
 			return false;
 		}
 	}
 
 	public function update() {
-		$this->db->query('UPDATE account SET email = '.$this->db->escapeString($this->email).
-			', validation_code = '.$this->db->escapeString($this->validation_code).
-			', validated = '.$this->db->escapeBoolean($this->validated).
-			', password = '.$this->db->escapeString($this->passwordHash).
-			', images = '.$this->db->escapeString($this->images).
-			', password_reset = '.$this->db->escapeString($this->passwordReset).
-			', use_ajax='.$this->db->escapeBoolean($this->useAJAX).
-			', mail_banned='.$this->db->escapeNumber($this->mailBanned).
-			', max_rank_achieved='.$this->db->escapeNumber($this->maxRankAchieved).
-			', default_css_enabled='.$this->db->escapeBoolean($this->defaultCSSEnabled).
-			', center_galaxy_map_on_player='.$this->db->escapeBoolean($this->centerGalaxyMapOnPlayer).
-			', message_notifications='.$this->db->escapeObject($this->messageNotifications).
-			', hotkeys='.$this->db->escapeObject($this->hotkeys).
-			', last_login = '.$this->db->escapeNumber($this->last_login).
-			', logging = '.$this->db->escapeBoolean($this->logging).
-			', time_short = ' . $this->db->escapeString($this->timeShort).
-			', date_short = ' . $this->db->escapeString($this->dateShort).
-			', discord_id = ' . $this->db->escapeString($this->discordId, true, true).
-			', irc_nick = ' . $this->db->escapeString($this->ircNick, true, true).
-			', hof_name = ' . $this->db->escapeString($this->hofName).
-			', colour_scheme = ' . $this->db->escapeString($this->colourScheme).
-			', fontsize = ' . $this->db->escapeNumber($this->fontSize).
-			', css_link = ' . $this->db->escapeString($this->cssLink,true,true).
-			', friendly_colour = ' . $this->db->escapeString($this->friendlyColour, true, true).
-			', neutral_colour = ' . $this->db->escapeString($this->neutralColour, true, true).
-			', enemy_colour = ' . $this->db->escapeString($this->enemyColour, true, true).
-			' WHERE '.$this->SQL.' LIMIT 1');
+		$this->db->query('UPDATE account SET email = ' . $this->db->escapeString($this->email) .
+			', validation_code = ' . $this->db->escapeString($this->validation_code) .
+			', validated = ' . $this->db->escapeBoolean($this->validated) .
+			', password = ' . $this->db->escapeString($this->passwordHash) .
+			', images = ' . $this->db->escapeString($this->images) .
+			', password_reset = ' . $this->db->escapeString($this->passwordReset) .
+			', use_ajax=' . $this->db->escapeBoolean($this->useAJAX) .
+			', mail_banned=' . $this->db->escapeNumber($this->mailBanned) .
+			', max_rank_achieved=' . $this->db->escapeNumber($this->maxRankAchieved) .
+			', default_css_enabled=' . $this->db->escapeBoolean($this->defaultCSSEnabled) .
+			', center_galaxy_map_on_player=' . $this->db->escapeBoolean($this->centerGalaxyMapOnPlayer) .
+			', message_notifications=' . $this->db->escapeObject($this->messageNotifications) .
+			', hotkeys=' . $this->db->escapeObject($this->hotkeys) .
+			', last_login = ' . $this->db->escapeNumber($this->last_login) .
+			', logging = ' . $this->db->escapeBoolean($this->logging) .
+			', time_short = ' . $this->db->escapeString($this->timeShort) .
+			', date_short = ' . $this->db->escapeString($this->dateShort) .
+			', discord_id = ' . $this->db->escapeString($this->discordId, true, true) .
+			', irc_nick = ' . $this->db->escapeString($this->ircNick, true, true) .
+			', hof_name = ' . $this->db->escapeString($this->hofName) .
+			', colour_scheme = ' . $this->db->escapeString($this->colourScheme) .
+			', fontsize = ' . $this->db->escapeNumber($this->fontSize) .
+			', css_link = ' . $this->db->escapeString($this->cssLink, true, true) .
+			', friendly_colour = ' . $this->db->escapeString($this->friendlyColour, true, true) .
+			', neutral_colour = ' . $this->db->escapeString($this->neutralColour, true, true) .
+			', enemy_colour = ' . $this->db->escapeString($this->enemyColour, true, true) .
+			' WHERE ' . $this->SQL . ' LIMIT 1');
 		$this->hasChanged = false;
 	}
 
 	public function updateIP() {
 		$curr_ip = getIpAddress();
-		$this->log(LOG_TYPE_LOGIN, 'logged in from '.$curr_ip);
+		$this->log(LOG_TYPE_LOGIN, 'logged in from ' . $curr_ip);
 
 		// more than 50 elements in it?
 
-		$this->db->query('SELECT time,ip FROM account_has_ip WHERE '.$this->SQL.' ORDER BY time ASC');
+		$this->db->query('SELECT time,ip FROM account_has_ip WHERE ' . $this->SQL . ' ORDER BY time ASC');
 		if ($this->db->getNumRows() > 50 && $this->db->nextRecord()) {
 			$delete_time = $this->db->getInt('time');
 			$delete_ip = $this->db->getField('ip');
 
 			$this->db->query('DELETE FROM account_has_ip
-				WHERE '.$this->SQL.' AND
-				time = '.$this->db->escapeNumber($delete_time).' AND
+				WHERE '.$this->SQL . ' AND
+				time = '.$this->db->escapeNumber($delete_time) . ' AND
 				ip = '.$this->db->escapeString($delete_ip));
 		}
-		list($fi,$se,$th,$fo) = preg_split('/[.\s,]/', $curr_ip, 4);
+		list($fi, $se, $th, $fo) = preg_split('/[.\s,]/', $curr_ip, 4);
 		if ($curr_ip != 'unknown' && $curr_ip != 'unknown...' && $curr_ip != 'unknown, unknown') {
-			$curr_ip = $fi.'.'.$se.'.'.$th.'.'.$fo;
+			$curr_ip = $fi . '.' . $se . '.' . $th . '.' . $fo;
 			$host = gethostbyaddr($curr_ip);
-		} else $host = 'unknown';
+		} else {
+			$host = 'unknown';
+		}
 
 		// save...first make sure there isn't one for these keys (someone could double click and get error)
-		$this->db->query('REPLACE INTO account_has_ip (account_id, time, ip, host) VALUES ('.$this->db->escapeNumber($this->account_id).', '.$this->db->escapeNumber(TIME).', '.$this->db->escapeString($curr_ip).', '.$this->db->escapeString($host).')');
+		$this->db->query('REPLACE INTO account_has_ip (account_id, time, ip, host) VALUES (' . $this->db->escapeNumber($this->account_id) . ', ' . $this->db->escapeNumber(TIME) . ', ' . $this->db->escapeString($curr_ip) . ', ' . $this->db->escapeString($host) . ')');
 	}
 
 	public function updateLastLogin() {
-		if($this->last_login == TIME) {
+		if ($this->last_login == TIME) {
 			return;
 		}
 		$this->last_login = TIME;
@@ -339,10 +340,10 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setLoggingEnabled($bool) {
-		if($this->logging==$bool) {
+		if ($this->logging == $bool) {
 			return;
 		}
-		$this->logging=$bool;
+		$this->logging = $bool;
 		$this->hasChanged = true;
 		$this->update();
 	}
@@ -390,12 +391,12 @@ abstract class AbstractSmrAccount {
 
 	public function getHOF(array $typeList = null) {
 		$this->getHOFData();
-		if($typeList==null) {
+		if ($typeList == null) {
 			return $this->HOF;
 		}
-		$hof=$this->HOF;
-		foreach($typeList as $type) {
-			if(!isset($hof[$type])) {
+		$hof = $this->HOF;
+		foreach ($typeList as $type) {
+			if (!isset($hof[$type])) {
 				return 0;
 			}
 			$hof = $hof[$type];
@@ -405,7 +406,7 @@ abstract class AbstractSmrAccount {
 
 	public function getRankName() {
 		$rankings = Globals::getUserRanking();
-		if(isset($rankings[$this->getRank()])) {
+		if (isset($rankings[$this->getRank()])) {
 			return $rankings[$this->getRank()];
 		} else {
 			return end($rankings);
@@ -413,56 +414,56 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function getScore() {
-		if(!isset($this->score)) {
-			$score=0;
-			foreach($this->getIndividualScores() as $each) {
-				$score+=$each['Score'];
+		if (!isset($this->score)) {
+			$score = 0;
+			foreach ($this->getIndividualScores() as $each) {
+				$score += $each['Score'];
 			}
-			$this->score=round($score);
+			$this->score = round($score);
 		}
 		return $this->score;
 	}
 
 	public function getIndividualScores(SmrPlayer $player = null) {
-		$gameID=0;
-		if($player!=null) {
+		$gameID = 0;
+		if ($player != null) {
 			$gameID = $player->getGameID();
 		}
-		if(!isset($this->individualScores[$gameID])) {
+		if (!isset($this->individualScores[$gameID])) {
 			$this->individualScores[$gameID] = array();
-			foreach(self::USER_RANKINGS_SCORE as $statScore) {
-				if($player==null) {
+			foreach (self::USER_RANKINGS_SCORE as $statScore) {
+				if ($player == null) {
 					$stat = $this->getHOF($statScore[0]);
 				} else {
 					$stat = $player->getHOF($statScore[0]);
 				}
-				$this->individualScores[$gameID][]=array('Stat'=>$statScore[0],'Score'=>pow($stat*$statScore[1],self::USER_RANKINGS_EACH_STAT_POW)*$statScore[2]);
+				$this->individualScores[$gameID][] = array('Stat'=>$statScore[0], 'Score'=>pow($stat * $statScore[1], self::USER_RANKINGS_EACH_STAT_POW) * $statScore[2]);
 			}
 		}
 		return $this->individualScores[$gameID];
 	}
 
 	public function getRank() : int {
-		$rank = ICeil(pow($this->getScore(),self::USER_RANKINGS_TOTAL_SCORE_POW)/self::USER_RANKINGS_RANK_BOUNDARY);
-		if($rank<1) {
-			$rank=1;
+		$rank = ICeil(pow($this->getScore(), self::USER_RANKINGS_TOTAL_SCORE_POW) / self::USER_RANKINGS_RANK_BOUNDARY);
+		if ($rank < 1) {
+			$rank = 1;
 		}
-		if($rank > $this->maxRankAchieved) {
+		if ($rank > $this->maxRankAchieved) {
 			$this->updateMaxRankAchieved($rank);
 		}
 		return $rank;
 	}
 
 	protected function updateMaxRankAchieved($rank) {
-		if($rank <= $this->maxRankAchieved) {
+		if ($rank <= $this->maxRankAchieved) {
 			throw new Exception('Trying to set max rank achieved to a lower value: ' . $rank);
 		}
 		$delta = $rank - $this->maxRankAchieved;
-		if($this->hasReferrer()) {
+		if ($this->hasReferrer()) {
 			$this->getReferrer()->increaseSmrRewardCredits($delta * CREDITS_PER_DOLLAR);
 		}
-		$this->maxRankAchieved+=$delta;
-		$this->hasChanged=true;
+		$this->maxRankAchieved += $delta;
+		$this->hasChanged = true;
 		$this->update();
 	}
 
@@ -471,7 +472,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function hasReferrer() {
-		return $this->referrerID>0;
+		return $this->referrerID > 0;
 	}
 
 	public function getReferrer() {
@@ -482,15 +483,15 @@ abstract class AbstractSmrAccount {
 		if ($this->isLoggingEnabled()) {
 			$this->db->query('INSERT INTO account_has_logs ' .
 				'(account_id, microtime, log_type_id, message, sector_id) ' .
-				'VALUES('.$this->db->escapeNumber($this->account_id).', '. $this->db->escapeMicrotime(MICRO_TIME) . ', '.$this->db->escapeNumber($log_type_id).', ' . $this->db->escapeString($msg) . ', '.$this->db->escapeNumber($sector_id).')');
+				'VALUES(' . $this->db->escapeNumber($this->account_id) . ', ' . $this->db->escapeMicrotime(MICRO_TIME) . ', ' . $this->db->escapeNumber($log_type_id) . ', ' . $this->db->escapeString($msg) . ', ' . $this->db->escapeNumber($sector_id) . ')');
 		}
 	}
 
 	protected function getSmrCreditsData() {
-		if(!isset($this->credits)||!isset($this->rewardCredits)) {
+		if (!isset($this->credits) || !isset($this->rewardCredits)) {
 			$this->credits = 0;
 			$this->rewardCredits = 0;
-			$this->db->query('SELECT * FROM account_has_credits WHERE '.$this->SQL.' LIMIT 1');
+			$this->db->query('SELECT * FROM account_has_credits WHERE ' . $this->SQL . ' LIMIT 1');
 			if ($this->db->nextRecord()) {
 				$this->credits = $this->db->getInt('credits_left');
 				$this->rewardCredits = $this->db->getInt('reward_credits');
@@ -503,30 +504,30 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function decreaseTotalSmrCredits($totalCredits) {
-		if($totalCredits==0) {
+		if ($totalCredits == 0) {
 			return;
 		}
-		if($totalCredits<0) {
+		if ($totalCredits < 0) {
 			throw new Exception('You cannot use negative total credits');
 		}
-		if($totalCredits>$this->getTotalSmrCredits()) {
+		if ($totalCredits > $this->getTotalSmrCredits()) {
 			throw new Exception('You do not have that many credits in total to use');
 		}
 
-		$rewardCredits=$this->rewardCredits;
-		$credits=$this->credits;
-		$rewardCredits-=$totalCredits;
-		if($rewardCredits<0) {
-			$credits+=$rewardCredits;
-			$rewardCredits=0;
+		$rewardCredits = $this->rewardCredits;
+		$credits = $this->credits;
+		$rewardCredits -= $totalCredits;
+		if ($rewardCredits < 0) {
+			$credits += $rewardCredits;
+			$rewardCredits = 0;
 		}
-		if($this->credits==0 && $this->rewardCredits==0) {
-			$this->db->query('REPLACE INTO account_has_credits (account_id, credits_left, reward_credits) VALUES('.$this->db->escapeNumber($this->getAccountID()).', '.$this->db->escapeNumber($credits).','.$this->db->escapeNumber($rewardCredits).')');
+		if ($this->credits == 0 && $this->rewardCredits == 0) {
+			$this->db->query('REPLACE INTO account_has_credits (account_id, credits_left, reward_credits) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($credits) . ',' . $this->db->escapeNumber($rewardCredits) . ')');
 		} else {
-			$this->db->query('UPDATE account_has_credits SET credits_left='.$this->db->escapeNumber($credits).', reward_credits='.$this->db->escapeNumber($rewardCredits).' WHERE '.$this->SQL.' LIMIT 1');
+			$this->db->query('UPDATE account_has_credits SET credits_left=' . $this->db->escapeNumber($credits) . ', reward_credits=' . $this->db->escapeNumber($rewardCredits) . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		}
-		$this->credits=$credits;
-		$this->rewardCredits=$rewardCredits;
+		$this->credits = $credits;
+		$this->rewardCredits = $rewardCredits;
 	}
 
 	public function getSmrCredits() {
@@ -540,60 +541,60 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setSmrCredits($credits) {
-		if($this->getSmrCredits()==$credits) {
+		if ($this->getSmrCredits() == $credits) {
 			return;
 		}
-		if($this->credits==0 && $this->rewardCredits==0) {
-			$this->db->query('REPLACE INTO account_has_credits (account_id, credits_left) VALUES('.$this->db->escapeNumber($this->getAccountID()).', '.$this->db->escapeNumber($credits).')');
+		if ($this->credits == 0 && $this->rewardCredits == 0) {
+			$this->db->query('REPLACE INTO account_has_credits (account_id, credits_left) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($credits) . ')');
 		} else {
-			$this->db->query('UPDATE account_has_credits SET credits_left='.$this->db->escapeNumber($credits).' WHERE '.$this->SQL.' LIMIT 1');
+			$this->db->query('UPDATE account_has_credits SET credits_left=' . $this->db->escapeNumber($credits) . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		}
-		$this->credits=$credits;
+		$this->credits = $credits;
 	}
 
 	public function increaseSmrCredits($credits) {
-		if($credits==0) {
+		if ($credits == 0) {
 			return;
 		}
-		if($credits<0) {
+		if ($credits < 0) {
 			throw new Exception('You cannot gain negative credits');
 		}
-		$this->setSmrCredits($this->getSmrCredits()+$credits);
+		$this->setSmrCredits($this->getSmrCredits() + $credits);
 	}
 
 	public function decreaseSmrCredits($credits) {
-		if($credits==0) {
+		if ($credits == 0) {
 			return;
 		}
-		if($credits<0) {
+		if ($credits < 0) {
 			throw new Exception('You cannot use negative credits');
 		}
-		if($credits>$this->getSmrCredits()) {
+		if ($credits > $this->getSmrCredits()) {
 			throw new Exception('You cannot use more credits than you have');
 		}
-		$this->setSmrCredits($this->getSmrCredits()-$credits);
+		$this->setSmrCredits($this->getSmrCredits() - $credits);
 	}
 
 	public function setSmrRewardCredits($credits) {
-		if($this->getSmrRewardCredits()==$credits) {
+		if ($this->getSmrRewardCredits() == $credits) {
 			return;
 		}
-		if($this->credits==0 && $this->rewardCredits==0) {
-			$this->db->query('REPLACE INTO account_has_credits (account_id, reward_credits) VALUES('.$this->db->escapeNumber($this->getAccountID()).', '.$this->db->escapeNumber($credits).')');
+		if ($this->credits == 0 && $this->rewardCredits == 0) {
+			$this->db->query('REPLACE INTO account_has_credits (account_id, reward_credits) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($credits) . ')');
 		} else {
-			$this->db->query('UPDATE account_has_credits SET reward_credits='.$this->db->escapeNumber($credits).' WHERE '.$this->SQL.' LIMIT 1');
+			$this->db->query('UPDATE account_has_credits SET reward_credits=' . $this->db->escapeNumber($credits) . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		}
-		$this->rewardCredits=$credits;
+		$this->rewardCredits = $credits;
 	}
 
 	public function increaseSmrRewardCredits($credits) {
-		if($credits==0) {
+		if ($credits == 0) {
 			return;
 		}
-		if($credits<0) {
+		if ($credits < 0) {
 			throw new Exception('You cannot gain negative reward credits');
 		}
-		$this->setSmrRewardCredits($this->getSmrRewardCredits()+$credits);
+		$this->setSmrRewardCredits($this->getSmrRewardCredits() + $credits);
 	}
 
 	public function sendMessageToBox($boxTypeID, $message) {
@@ -601,7 +602,7 @@ abstract class AbstractSmrAccount {
 		self::doMessageSendingToBox($this->getAccountID(), $boxTypeID, $message);
 	}
 
-	public static function doMessageSendingToBox($senderID, $boxTypeID, $message, $gameID=0) {
+	public static function doMessageSendingToBox($senderID, $boxTypeID, $message, $gameID = 0) {
 		$db = new SmrMySqlDatabase();
 		// send him the message
 		$db->query('INSERT INTO message_boxes
@@ -624,14 +625,14 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function getOldAccountID($dbName) {
-		return isset($this->oldAccountIDs[$dbName])?$this->oldAccountIDs[$dbName]:0;
+		return isset($this->oldAccountIDs[$dbName]) ? $this->oldAccountIDs[$dbName] : 0;
 	}
 
-	public function hasOldAccountID($dbName=false) {
-		if($dbName===false) {
-			return count($this->getOldAccountIDs())!=0;
+	public function hasOldAccountID($dbName = false) {
+		if ($dbName === false) {
+			return count($this->getOldAccountIDs()) != 0;
 		}
-		return $this->getOldAccountID($dbName)!=0;
+		return $this->getOldAccountID($dbName) != 0;
 	}
 
 	public function getLogin() {
@@ -643,7 +644,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setEmail($email) {
-		if($this->email==$email) {
+		if ($this->email == $email) {
 			return;
 		}
 		$this->email = $email;
@@ -660,14 +661,14 @@ abstract class AbstractSmrAccount {
 
 		// check if the host got a MX or at least an A entry
 		if (!checkdnsrr($host, 'MX') && !checkdnsrr($host, 'A')) {
-			create_error('This is not a valid email address! The domain '.$host.' does not exist.');
+			create_error('This is not a valid email address! The domain ' . $host . ' does not exist.');
 		}
 
 		if (strstr($email, ' ')) {
 			create_error('The email is invalid! It cannot contain any spaces.');
 		}
 
-		$this->db->query('SELECT 1 FROM account WHERE email = '.$this->db->escapeString($email).' and account_id != ' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
+		$this->db->query('SELECT 1 FROM account WHERE email = ' . $this->db->escapeString($email) . ' and account_id != ' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
 		if ($this->db->getNumRows() > 0) {
 			create_error('This email address is already registered.');
 		}
@@ -678,12 +679,12 @@ abstract class AbstractSmrAccount {
 
 		// remember when we sent validation code
 		$this->db->query('REPLACE INTO notification (notification_type, account_id, time)
-				VALUES(\'validation_code\', '.$this->db->escapeNumber($this->getAccountID()).', ' . $this->db->escapeNumber(TIME) . ')');
+				VALUES(\'validation_code\', '.$this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber(TIME) . ')');
 
 		$emailMessage =
-			'You changed your email address registered with SMR and need to revalidate now!'.EOL.EOL.
-			'   Your new validation code is: '.$this->getValidationCode().EOL.EOL.
-			'The Space Merchant Realms server is on the web at '.URL;
+			'You changed your email address registered with SMR and need to revalidate now!' . EOL . EOL .
+			'   Your new validation code is: ' . $this->getValidationCode() . EOL . EOL .
+			'The Space Merchant Realms server is on the web at ' . URL;
 
 		$mail = setupMailer();
 		$mail->Subject = 'Your validation code!';
@@ -709,7 +710,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setFontSize($size) {
-		if($this->fontSize==$size) {
+		if ($this->fontSize == $size) {
 			return;
 		}
 		$this->fontSize = $size;
@@ -724,7 +725,7 @@ abstract class AbstractSmrAccount {
 
 	// sets the extra CSS file linked in preferences
 	public function setCssLink($link) {
-		if($this->cssLink==$link) {
+		if ($this->cssLink == $link) {
 			return;
 		}
 		$this->cssLink = $link;
@@ -737,13 +738,13 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setTemplate($template) {
-		if($this->template==$template) {
+		if ($this->template == $template) {
 			return;
 		}
-		if(!in_array($template,array_keys(Globals::getAvailableTemplates()))) {
-			throw new Exception('Template not allowed: '.$template);
+		if (!in_array($template, array_keys(Globals::getAvailableTemplates()))) {
+			throw new Exception('Template not allowed: ' . $template);
 		}
-		$this->db->query('UPDATE account SET template = ' . $this->db->escapeString($template) . ' WHERE '.$this->SQL.' LIMIT 1');
+		$this->db->query('UPDATE account SET template = ' . $this->db->escapeString($template) . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		$this->template = $template;
 		$colourSchemes = Globals::getAvailableColourSchemes($template);
 		$this->setColourScheme($colourSchemes[0]);
@@ -754,11 +755,11 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setColourScheme($colourScheme) {
-		if($this->colourScheme==$colourScheme) {
+		if ($this->colourScheme == $colourScheme) {
 			return;
 		}
-		if(!in_array($colourScheme,array_keys(Globals::getAvailableColourSchemes($this->getTemplate())))) {
-			throw new Exception('Colour scheme not allowed: '.$colourScheme);
+		if (!in_array($colourScheme, array_keys(Globals::getAvailableColourSchemes($this->getTemplate())))) {
+			throw new Exception('Colour scheme not allowed: ' . $colourScheme);
 		}
 		$this->colourScheme = $colourScheme;
 		$this->hasChanged = true;
@@ -779,7 +780,7 @@ abstract class AbstractSmrAccount {
 	 * The Hall Of Fame name is not html-escaped in the database, so to display
 	 * it correctly we must escape html entities.
 	 */
-	public function getHofDisplayName($linked=false) {
+	public function getHofDisplayName($linked = false) {
 		$hofDisplayName = htmlspecialchars($this->getHofName());
 		if ($linked) {
 			return '<a href="' . $this->getPersonalHofHREF() . '">' . $hofDisplayName . '</a>';
@@ -793,7 +794,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setHofName($name) {
-		if($this->hofName==$name) {
+		if ($this->hofName == $name) {
 			return;
 		}
 		$this->hofName = $name;
@@ -806,7 +807,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setIrcNick($nick) {
-		if($this->ircNick==$nick) {
+		if ($this->ircNick == $nick) {
 			return;
 		}
 		$this->ircNick = $nick;
@@ -828,7 +829,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function getReferralLink() {
-		return URL . '/login_create.php?ref='.$this->getAccountID();
+		return URL . '/login_create.php?ref=' . $this->getAccountID();
 	}
 
 	public function getShortDateFormat() {
@@ -836,7 +837,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setShortDateFormat($format) {
-		if($this->dateShort==$format) {
+		if ($this->dateShort == $format) {
 			return;
 		}
 		$this->dateShort = $format;
@@ -849,7 +850,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setShortTimeFormat($format) {
-		if($this->timeShort==$format) {
+		if ($this->timeShort == $format) {
 			return;
 		}
 		$this->timeShort = $format;
@@ -862,16 +863,16 @@ abstract class AbstractSmrAccount {
 	}
 
 	protected function setValidationCode($code) {
-		if($this->validation_code == $code) {
+		if ($this->validation_code == $code) {
 			return;
 		}
-		$this->validation_code=$code;
-		$this->hasChanged=true;
+		$this->validation_code = $code;
+		$this->hasChanged = true;
 		$this->update();
 	}
 
 	public function setValidated($bool) {
-		if($this->validated == $bool) {
+		if ($this->validated == $bool) {
 			return;
 		}
 		$this->validated = $bool;
@@ -884,7 +885,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function isLoggedIn() {
-		$this->db->query('SELECT 1 FROM active_session WHERE account_id = '.$this->db->escapeNumber($this->getAccountID()).' LIMIT 1');
+		$this->db->query('SELECT 1 FROM active_session WHERE account_id = ' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
 		return $this->db->nextRecord();
 	}
 
@@ -925,15 +926,15 @@ abstract class AbstractSmrAccount {
 		$this->update();
 	}
 
-	public function addAuthMethod($loginType,$authKey) {
-		$this->db->query('SELECT account_id FROM account_auth WHERE login_type='.$this->db->escapeString($loginType).' AND auth_key = '.$this->db->escapeString($authKey).';');
-		if($this->db->nextRecord()) {
-			if($this->db->getInt('account_id')!=$this->getAccountID()) {
+	public function addAuthMethod($loginType, $authKey) {
+		$this->db->query('SELECT account_id FROM account_auth WHERE login_type=' . $this->db->escapeString($loginType) . ' AND auth_key = ' . $this->db->escapeString($authKey) . ';');
+		if ($this->db->nextRecord()) {
+			if ($this->db->getInt('account_id') != $this->getAccountID()) {
 				throw new Exception('Another account already uses this form of auth.');
 			}
 			return true;
 		}
-		$this->db->query('INSERT INTO account_auth values ('.$this->db->escapeNumber($this->getAccountID()).','.$this->db->escapeString($loginType).','.$this->db->escapeString($authKey).');');
+		$this->db->query('INSERT INTO account_auth values (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeString($loginType) . ',' . $this->db->escapeString($authKey) . ');');
 		return true;
 	}
 
@@ -946,11 +947,11 @@ abstract class AbstractSmrAccount {
 	}
 
 	protected function setPasswordReset($passwordReset) {
-		if($this->passwordReset == $passwordReset) {
+		if ($this->passwordReset == $passwordReset) {
 			return;
 		}
-		$this->passwordReset=$passwordReset;
-		$this->hasChanged=true;
+		$this->passwordReset = $passwordReset;
+		$this->hasChanged = true;
 		$this->update();
 	}
 
@@ -959,7 +960,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setDisplayShipImages($yesNo) {
-		if($this->images == $yesNo) {
+		if ($this->images == $yesNo) {
 			return;
 		}
 		$this->images = $yesNo;
@@ -972,11 +973,11 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setUseAJAX($bool) {
-		if($this->useAJAX == $bool) {
+		if ($this->useAJAX == $bool) {
 			return;
 		}
-		$this->useAJAX=$bool;
-		$this->hasChanged=true;
+		$this->useAJAX = $bool;
+		$this->hasChanged = true;
 		$this->update();
 	}
 
@@ -985,67 +986,66 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setDefaultCSSEnabled($bool) {
-		if($this->defaultCSSEnabled == $bool) {
+		if ($this->defaultCSSEnabled == $bool) {
 			return;
 		}
-		$this->defaultCSSEnabled=$bool;
-		$this->hasChanged=true;
+		$this->defaultCSSEnabled = $bool;
+		$this->hasChanged = true;
 		$this->update();
 	}
 
 	public function getHotkeys($hotkeyType = false) {
-		if($hotkeyType!==false) {
-			if(isset($this->hotkeys[$hotkeyType])) {
+		if ($hotkeyType !== false) {
+			if (isset($this->hotkeys[$hotkeyType])) {
 				return $this->hotkeys[$hotkeyType];
-			}
-			else {
+			} else {
 				return array();
 			}
 		}
 		return $this->hotkeys;
 	}
 
-	public function setHotkey($hotkeyType,$binding) {
-		if($this->getHotkeys($hotkeyType) == $binding) {
+	public function setHotkey($hotkeyType, $binding) {
+		if ($this->getHotkeys($hotkeyType) == $binding) {
 			return;
 		}
 		$this->hotkeys[$hotkeyType] = $binding;
-		$this->hasChanged=true;
+		$this->hasChanged = true;
 		$this->update();
 	}
 
 	public function isReceivingMessageNotifications($messageTypeID) {
-		return isset($this->messageNotifications[$messageTypeID])?$this->messageNotifications[$messageTypeID]>0:false;
+		return isset($this->messageNotifications[$messageTypeID]) ? $this->messageNotifications[$messageTypeID] > 0 : false;
 	}
 
 	public function getMessageNotifications($messageTypeID) {
-		return isset($this->messageNotifications[$messageTypeID])?$this->messageNotifications[$messageTypeID]:0;
+		return isset($this->messageNotifications[$messageTypeID]) ? $this->messageNotifications[$messageTypeID] : 0;
 	}
 
-	public function setMessageNotifications($messageTypeID,$num) {
-		if($this->getMessageNotifications($messageTypeID) == $num) {
+	public function setMessageNotifications($messageTypeID, $num) {
+		if ($this->getMessageNotifications($messageTypeID) == $num) {
 			return;
 		}
-		$this->messageNotifications[$messageTypeID]=$num;
-		$this->hasChanged=true;
+		$this->messageNotifications[$messageTypeID] = $num;
+		$this->hasChanged = true;
 		$this->update();
 	}
 
-	public function increaseMessageNotifications($messageTypeID,$num) {
-		if($num==0) {
+	public function increaseMessageNotifications($messageTypeID, $num) {
+		if ($num == 0) {
 			return;
 		}
-		if($num<0) {
+		if ($num < 0) {
 			throw new Exception('You cannot increase by a negative amount');
 		}
 		$this->setMessageNotifications($messageTypeID, $this->getMessageNotifications($messageTypeID) + $num);
 	}
 
-	public function decreaseMessageNotifications($messageTypeID,$num) {
-		if($num==0) {
+	public function decreaseMessageNotifications($messageTypeID, $num) {
+		if ($num == 0) {
 			return;
 		}
-		if($num<0) {
+		if ($num < 0) {
 			throw new Exception('You cannot decrease by a negative amount');
 		}
 		$this->setMessageNotifications($messageTypeID, $this->getMessageNotifications($messageTypeID) - $num);
@@ -1056,11 +1056,11 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function setCenterGalaxyMapOnPlayer($bool) {
-		if($this->centerGalaxyMapOnPlayer == $bool) {
+		if ($this->centerGalaxyMapOnPlayer == $bool) {
 			return;
 		}
-		$this->centerGalaxyMapOnPlayer=$bool;
-		$this->hasChanged=true;
+		$this->centerGalaxyMapOnPlayer = $bool;
+		$this->hasChanged = true;
 		$this->update();
 	}
 
@@ -1069,27 +1069,27 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function isMailBanned() {
-		return $this->mailBanned>TIME;
+		return $this->mailBanned > TIME;
 	}
 
 	public function setMailBanned($time) {
-		if($this->mailBanned == $time) {
+		if ($this->mailBanned == $time) {
 			return;
 		}
-		$this->mailBanned=$time;
-		$this->hasChanged=true;
+		$this->mailBanned = $time;
+		$this->hasChanged = true;
 	}
 
 	public function increaseMailBanned($increaseTime) {
-		$time = max(TIME,$this->getMailBanned());
-		$this->setMailBanned($time+$increaseTime);
+		$time = max(TIME, $this->getMailBanned());
+		$this->setMailBanned($time + $increaseTime);
 	}
 	
 	public function getPermissions() {
-		if(!isset($this->permissions)) {
+		if (!isset($this->permissions)) {
 			$this->permissions = array();
 			$this->db->query('SELECT permission_id FROM account_has_permission WHERE ' . $this->SQL);
-			while($this->db->nextRecord()) {
+			while ($this->db->nextRecord()) {
 				$this->permissions[$this->db->getInt('permission_id')] = true;
 			}
 		}
@@ -1098,28 +1098,28 @@ abstract class AbstractSmrAccount {
 
 	public function hasPermission($permissionID = false) {
 		$permissions = $this->getPermissions();
-		if($permissionID === false) {
+		if ($permissionID === false) {
 			return count($permissions) > 0;
 		}
 		return isset($permissions[$permissionID]) ? $permissions[$permissionID] : false;
 	}
 
 	public function getPoints() {
-		if(!isset($this->points)) {
-			$this->points=0;
+		if (!isset($this->points)) {
+			$this->points = 0;
 			$this->db->lockTable('account_has_points');
-			$this->db->query('SELECT * FROM account_has_points WHERE '.$this->SQL.' LIMIT 1');
-			if($this->db->nextRecord()) {
-				$this->points=$this->db->getInt('points');
+			$this->db->query('SELECT * FROM account_has_points WHERE ' . $this->SQL . ' LIMIT 1');
+			if ($this->db->nextRecord()) {
+				$this->points = $this->db->getInt('points');
 				$lastUpdate = $this->db->getInt('last_update');
 				//we are gonna check for reducing points...
-				if($this->points>0 && $lastUpdate < TIME - (7 * 86400)) {
-					$removePoints=0;
-					while($lastUpdate < TIME - (7 * 86400)) {
+				if ($this->points > 0 && $lastUpdate < TIME - (7 * 86400)) {
+					$removePoints = 0;
+					while ($lastUpdate < TIME - (7 * 86400)) {
 						$removePoints++;
 						$lastUpdate += (7 * 86400);
 					}
-					$this->removePoints($removePoints,$lastUpdate);
+					$this->removePoints($removePoints, $lastUpdate);
 				}
 			}
 			$this->db->unlock();
@@ -1127,33 +1127,33 @@ abstract class AbstractSmrAccount {
 		return $this->points;
 	}
 
-	public function setPoints($numPoints,$lastUpdate=false) {
-		$numPoints = max($numPoints,0);
-		if($this->getPoints()==$numPoints) {
+	public function setPoints($numPoints, $lastUpdate = false) {
+		$numPoints = max($numPoints, 0);
+		if ($this->getPoints() == $numPoints) {
 			return;
 		}
-		if ($this->points==0) {
-			$this->db->query('INSERT INTO account_has_points (account_id, points, last_update) VALUES ('.$this->db->escapeNumber($this->getAccountID()).', '.$this->db->escapeNumber($numPoints).', '.$this->db->escapeNumber($lastUpdate?$lastUpdate:TIME).')');
-		} else if($numPoints<=0) {
-			$this->db->query('DELETE FROM account_has_points WHERE '.$this->SQL.' LIMIT 1');
+		if ($this->points == 0) {
+			$this->db->query('INSERT INTO account_has_points (account_id, points, last_update) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($numPoints) . ', ' . $this->db->escapeNumber($lastUpdate ? $lastUpdate : TIME) . ')');
+		} else if ($numPoints <= 0) {
+			$this->db->query('DELETE FROM account_has_points WHERE ' . $this->SQL . ' LIMIT 1');
 		} else {
-			$this->db->query('UPDATE account_has_points SET points = '.$this->db->escapeNumber($numPoints).($lastUpdate ? ', last_update = '.$this->db->escapeNumber(TIME) : '').' WHERE '.$this->SQL.' LIMIT 1');
+			$this->db->query('UPDATE account_has_points SET points = ' . $this->db->escapeNumber($numPoints) . ($lastUpdate ? ', last_update = ' . $this->db->escapeNumber(TIME) : '') . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		}
-		$this->points=$numPoints;
+		$this->points = $numPoints;
 	}
 
-	public function removePoints($numPoints,$lastUpdate=false) {
-		if($numPoints>0) {
-			$this->setPoints($this->getPoints()-$numPoints,$lastUpdate);
+	public function removePoints($numPoints, $lastUpdate = false) {
+		if ($numPoints > 0) {
+			$this->setPoints($this->getPoints() - $numPoints, $lastUpdate);
 		}
 	}
 
-	public function addPoints($numPoints,SmrAccount $admin,$reasonID,$suspicion) {
+	public function addPoints($numPoints, SmrAccount $admin, $reasonID, $suspicion) {
 		//do we have points
-		$this->setPoints($this->getPoints() + $numPoints,TIME);
+		$this->setPoints($this->getPoints() + $numPoints, TIME);
 		$totalPoints = $this->getPoints();
 		if ($totalPoints < 10) {
-			return false;//leave scripts its only a warning
+			return false; //leave scripts its only a warning
 		} elseif ($totalPoints < 20) {
 			$days = 2;
 		} elseif ($totalPoints < 30) {
@@ -1161,7 +1161,7 @@ abstract class AbstractSmrAccount {
 		} elseif ($totalPoints < 50) {
 			$days = 7;
 		} elseif ($totalPoints < 75) {
-			$days = 15 ;
+			$days = 15;
 		} elseif ($totalPoints < 100) {
 			$days = 30;
 		} elseif ($totalPoints < 125) {
@@ -1176,13 +1176,12 @@ abstract class AbstractSmrAccount {
 			$days = 0; //Forever/indefinite
 		}
 
-		if($days==0) {
+		if ($days == 0) {
 			$expireTime = 0;
-		}
-		else {
+		} else {
 			$expireTime = TIME + $days * 86400;
 		}
-		$this->banAccount($expireTime,$admin,$reasonID,$suspicion);
+		$this->banAccount($expireTime, $admin, $reasonID, $suspicion);
 
 		return $days;
 	}
@@ -1209,12 +1208,12 @@ abstract class AbstractSmrAccount {
 		$this->hasChanged = true;
 	}
 
-	public function banAccount($expireTime,SmrAccount $admin,$reasonID,$suspicion,$removeExceptions = false) {
+	public function banAccount($expireTime, SmrAccount $admin, $reasonID, $suspicion, $removeExceptions = false) {
 		$this->db->query('REPLACE INTO account_is_closed
 					(account_id, reason_id, suspicion, expires)
-					VALUES('.$this->db->escapeNumber($this->getAccountID()).', '.$this->db->escapeNumber($reasonID).', '.$this->db->escapeString($suspicion).', '.$this->db->escapeNumber($expireTime).')');
+					VALUES('.$this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($reasonID) . ', ' . $this->db->escapeString($suspicion) . ', ' . $this->db->escapeNumber($expireTime) . ')');
 		$this->db->lockTable('active_session');
-		$this->db->query('DELETE FROM active_session WHERE '.$this->SQL.' LIMIT 1');
+		$this->db->query('DELETE FROM active_session WHERE ' . $this->SQL . ' LIMIT 1');
 		$this->db->unlock();
 
 		$this->db->query('INSERT INTO account_has_closing_history
@@ -1234,14 +1233,14 @@ abstract class AbstractSmrAccount {
 			$player->update();
 		}
 		$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account closed by ' . $admin->getLogin() . '.');
-		if($removeExceptions!==false) {
+		if ($removeExceptions !== false) {
 			$this->db->query('DELETE FROM account_exceptions WHERE ' . $this->SQL);
 		}
 	}
 
-	public function unbanAccount(SmrAccount $admin = null,$currException=false) {
+	public function unbanAccount(SmrAccount $admin = null, $currException = false) {
 		$adminID = 0;
-		if($admin!==null) {
+		if ($admin !== null) {
 			$adminID = $admin->getAccountID();
 		}
 		$this->db->query('DELETE FROM account_is_closed WHERE ' . $this->SQL . ' LIMIT 1');
@@ -1249,12 +1248,12 @@ abstract class AbstractSmrAccount {
 						(account_id, time, admin_id, action)
 						VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber(TIME) . ', ' . $this->db->escapeNumber($adminID) . ', ' . $this->db->escapeString('Opened') . ')');
 		$this->db->query('UPDATE player SET last_turn_update = GREATEST(' . $this->db->escapeNumber(TIME) . ', last_turn_update) WHERE ' . $this->SQL);
-		if($admin!==null) {
+		if ($admin !== null) {
 			$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account reopened by ' . $admin->getLogin() . '.');
 		} else {
 			$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account automatically reopened.');
 		}
-		if($currException!==false) {
+		if ($currException !== false) {
 			$this->db->query('REPLACE INTO account_exceptions (account_id, reason)
 							VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeString($currException) . ')');
 		}
@@ -1262,14 +1261,14 @@ abstract class AbstractSmrAccount {
 
 	public function getToggleAJAXHREF() {
 		global $var;
-		return SmrSession::getNewHREF(create_container('skeleton.php','toggle_processing.php',array('toggle'=>'AJAX','referrer'=>$var['body'])));
+		return SmrSession::getNewHREF(create_container('skeleton.php', 'toggle_processing.php', array('toggle'=>'AJAX', 'referrer'=>$var['body'])));
 	}
 
 	public function getUserRankingHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php','rankings_view.php'));
+		return SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_view.php'));
 	}
 
 	public function getPersonalHofHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php','hall_of_fame_player_detail.php',array('account_id' => $this->getAccountID())));
+		return SmrSession::getNewHREF(create_container('skeleton.php', 'hall_of_fame_player_detail.php', array('account_id' => $this->getAccountID())));
 	}
 }

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -239,8 +239,7 @@ abstract class AbstractSmrAccount {
 			if (empty($this->hofName)) {
 				$this->hofName = $this->login;
 			}
-		}
-		else {
+		} else {
 			throw new AccountNotFoundException('Account ID ' . $accountID . ' does not exist!');
 		}
 	}

--- a/lib/Default/AbstractSmrCombatWeapon.class.php
+++ b/lib/Default/AbstractSmrCombatWeapon.class.php
@@ -87,8 +87,9 @@ abstract class AbstractSmrCombatWeapon {
 	protected function &doPlayerDamageToForce(array &$return, AbstractSmrPlayer $weaponPlayer, SmrForce $forces) {
 		$return['WeaponDamage'] =& $this->getModifiedDamageAgainstForces($weaponPlayer,$forces);
 		$return['ActualDamage'] =& $forces->doWeaponDamage($return['WeaponDamage']);
-		if($return['ActualDamage']['KillingShot'])
+		if($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] =& $forces->killForcesByPlayer($weaponPlayer);
+		}
 		return $return;
 	}
 	
@@ -96,24 +97,27 @@ abstract class AbstractSmrCombatWeapon {
 		$return['WeaponDamage'] =& $this->getModifiedDamageAgainstPlayer($weaponPlayer,$targetPlayer);
 		$return['ActualDamage'] =& $targetPlayer->getShip()->doWeaponDamage($return['WeaponDamage']);
 
-		if($return['ActualDamage']['KillingShot'])
+		if($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] =& $targetPlayer->killPlayerByPlayer($weaponPlayer);
+		}
 		return $return;
 	}
 	
 	protected function &doPlayerDamageToPort(array &$return, AbstractSmrPlayer $weaponPlayer, SmrPort $port) {
 		$return['WeaponDamage'] =& $this->getModifiedDamageAgainstPort($weaponPlayer,$port);
 		$return['ActualDamage'] =& $port->doWeaponDamage($return['WeaponDamage']);
-		if($return['ActualDamage']['KillingShot'])
+		if($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] =& $port->killPortByPlayer($weaponPlayer);
+		}
 		return $return;
 	}
 	
 	protected function &doPlayerDamageToPlanet(array &$return, AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet, $delayed) {
 		$return['WeaponDamage'] =& $this->getModifiedDamageAgainstPlanet($weaponPlayer,$planet);
 		$return['ActualDamage'] =& $planet->doWeaponDamage($return['WeaponDamage'],$delayed);
-		if($return['ActualDamage']['KillingShot'])
+		if($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] =& $planet->killPlanetByPlayer($weaponPlayer);
+		}
 		return $return;
 	}
 	
@@ -121,8 +125,9 @@ abstract class AbstractSmrCombatWeapon {
 		$return['WeaponDamage'] =& $this->getModifiedPortDamageAgainstPlayer($port,$targetPlayer);
 		$return['ActualDamage'] =& $targetPlayer->getShip()->doWeaponDamage($return['WeaponDamage']);
 
-		if($return['ActualDamage']['KillingShot'])
+		if($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] =& $targetPlayer->killPlayerByPort($port);
+		}
 		return $return;
 	}
 	
@@ -130,8 +135,9 @@ abstract class AbstractSmrCombatWeapon {
 		$return['WeaponDamage'] =& $this->getModifiedPlanetDamageAgainstPlayer($planet,$targetPlayer);
 		$return['ActualDamage'] =& $targetPlayer->getShip()->doWeaponDamage($return['WeaponDamage']);
 
-		if($return['ActualDamage']['KillingShot'])
+		if($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] =& $targetPlayer->killPlayerByPlanet($planet);
+		}
 		return $return;
 	}
 	
@@ -139,8 +145,9 @@ abstract class AbstractSmrCombatWeapon {
 		$return['WeaponDamage'] =& $this->getModifiedForceDamageAgainstPlayer($forces,$targetPlayer);
 		$return['ActualDamage'] =& $targetPlayer->getShip()->doWeaponDamage($return['WeaponDamage']);
 
-		if($return['ActualDamage']['KillingShot'])
+		if($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] =& $targetPlayer->killPlayerByForces($forces);
+		}
 		return $return;
 	}
 	

--- a/lib/Default/AbstractSmrLocation.class.php
+++ b/lib/Default/AbstractSmrLocation.class.php
@@ -174,8 +174,9 @@ class AbstractSmrLocation {
 	}
 	
 	public function setBank($bool) {
-		if ($this->bank === $bool)
+		if ($this->bank === $bool) {
 			return;
+		}
 		if ($bool === true) {
 			$this->db->query('INSERT INTO location_is_bank (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 			$this->bank = true;
@@ -195,8 +196,9 @@ class AbstractSmrLocation {
 	}
 	
 	public function setBar($bool) {
-		if ($this->bar === $bool)
+		if ($this->bar === $bool) {
 			return;
+		}
 		if ($bool === true) {
 			$this->db->query('INSERT IGNORE INTO location_is_bar (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 			$this->bar = true;
@@ -216,8 +218,9 @@ class AbstractSmrLocation {
 	}
 	
 	public function setHQ($bool) {
-		if ($this->HQ === $bool)
+		if ($this->HQ === $bool) {
 			return;
+		}
 		if ($bool === true) {
 			$this->db->query('INSERT IGNORE INTO location_is_hq (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 			$this->HQ = true;
@@ -237,8 +240,9 @@ class AbstractSmrLocation {
 	}
 	
 	public function setUG($bool) {
-		if ($this->UG === $bool)
+		if ($this->UG === $bool) {
 			return;
+		}
 		if ($bool === true) {
 			$this->db->query('INSERT INTO location_is_ug (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 			$this->UG = true;
@@ -269,18 +273,21 @@ class AbstractSmrLocation {
 	}
 	
 	public function addHardwareSold($hardwareTypeID) {
-		if ($this->isHardwareSold($hardwareTypeID))
+		if ($this->isHardwareSold($hardwareTypeID)) {
 			return;
+		}
 		$this->db->query('SELECT * FROM hardware_type WHERE hardware_type_id = ' . $this->db->escapeNumber($hardwareTypeID) . ' LIMIT 1');
-		if (!$this->db->nextRecord())
+		if (!$this->db->nextRecord()) {
 			throw new Exception('Invalid hardware type id given');
+		}
 		$this->db->query('INSERT INTO location_sells_hardware (location_type_id,hardware_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($hardwareTypeID) . ')');
 		$this->hardwareSold[$hardwareTypeID] = $this->db->getField('hardware_name');
 	}
 	
 	public function removeHardwareSold($hardwareTypeID) {
-		if (!$this->isHardwareSold($hardwareTypeID))
+		if (!$this->isHardwareSold($hardwareTypeID)) {
 			return;
+		}
 		$this->db->query('DELETE FROM location_sells_hardware WHERE ' . $this->SQL . ' AND hardware_type_id = ' . $this->db->escapeNumber($hardwareTypeID) . ' LIMIT 1');
 		unset($this->hardwareSold[$hardwareTypeID]);
 	}
@@ -298,24 +305,28 @@ class AbstractSmrLocation {
 	
 	public function isShipSold($shipTypeID = false) {
 		$ships = $this->getShipsSold();
-		if ($shipTypeID === false)
+		if ($shipTypeID === false) {
 			return count($ships) != 0;
+		}
 		return isset($ships[$shipTypeID]);
 	}
 	
 	public function addShipSold($shipTypeID) {
-		if ($this->isShipSold($shipTypeID))
+		if ($this->isShipSold($shipTypeID)) {
 			return;
+		}
 		$ship = AbstractSmrShip::getBaseShip(Globals::getGameType(SmrSession::getGameID()), $shipTypeID);
-		if ($ship === false)
+		if ($ship === false) {
 			throw new Exception('Invalid ship type id given');
+		}
 		$this->db->query('INSERT INTO location_sells_ships (location_type_id,ship_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($shipTypeID) . ')');
 		$this->shipsSold[$shipTypeID] = $ship;
 	}
 	
 	public function removeShipSold($shipTypeID) {
-		if (!$this->isShipSold($shipTypeID))
+		if (!$this->isShipSold($shipTypeID)) {
 			return;
+		}
 		$this->db->query('DELETE FROM location_sells_ships WHERE ' . $this->SQL . ' AND ship_type_id = ' . $this->db->escapeNumber($shipTypeID) . ' LIMIT 1');
 		unset($this->shipsSold[$shipTypeID]);
 	}
@@ -324,32 +335,37 @@ class AbstractSmrLocation {
 		if (!isset($this->weaponsSold)) {
 			$this->weaponsSold = array();
 			$this->db->query('SELECT * FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) WHERE ' . $this->SQL);
-			while ($this->db->nextRecord())
+			while ($this->db->nextRecord()) {
 				$this->weaponsSold[$this->db->getInt('weapon_type_id')] = SmrWeapon::getWeapon($this->db->getInt('weapon_type_id'), false, $this->db);
+			}
 		}
 		return $this->weaponsSold;
 	}
 	
 	public function isWeaponSold($weaponTypeID = false) {
 		$weapons = $this->getWeaponsSold();
-		if ($weaponTypeID === false)
+		if ($weaponTypeID === false) {
 			return count($weapons) != 0;
+		}
 		return isset($weapons[$weaponTypeID]);
 	}
 	
 	public function addWeaponSold($weaponTypeID) {
-		if ($this->isWeaponSold($weaponTypeID))
+		if ($this->isWeaponSold($weaponTypeID)) {
 			return;
+		}
 		$weapon = SmrWeapon::getWeapon($weaponTypeID);
-		if ($weapon === false)
+		if ($weapon === false) {
 			throw new Exception('Invalid weapon type id given');
+		}
 		$this->db->query('INSERT INTO location_sells_weapons (location_type_id,weapon_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($weaponTypeID) . ')');
 		$this->weaponsSold[$weaponTypeID] = $weapon;
 	}
 	
 	public function removeWeaponSold($weaponTypeID) {
-		if (!$this->isWeaponSold($weaponTypeID))
+		if (!$this->isWeaponSold($weaponTypeID)) {
 			return;
+		}
 		$this->db->query('DELETE FROM location_sells_weapons WHERE ' . $this->SQL . ' AND weapon_type_id = ' . $this->db->escapeNumber($weaponTypeID) . ' LIMIT 1');
 		unset($this->weaponsSold[$weaponTypeID]);
 	}

--- a/lib/Default/AbstractSmrLocation.class.php
+++ b/lib/Default/AbstractSmrLocation.class.php
@@ -98,8 +98,7 @@ class AbstractSmrLocation {
 			$this->name = $db->getField('location_name');
 			$this->processor = $db->getField('location_processor');
 			$this->image = $db->getField('location_image');
-		}
-		else {
+		} else {
 			throw new Exception('Cannot find location: ' . $locationTypeID);
 		}
 	}
@@ -158,8 +157,7 @@ class AbstractSmrLocation {
 		if ($bool === true) {
 			$this->db->query('INSERT IGNORE INTO location_is_fed (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 			$this->fed = true;
-		}
-		else if ($bool === false) {
+		} else if ($bool === false) {
 			$this->db->query('DELETE FROM location_is_fed WHERE ' . $this->SQL . ' LIMIT 1');
 			$this->fed = false;
 		}
@@ -180,8 +178,7 @@ class AbstractSmrLocation {
 		if ($bool === true) {
 			$this->db->query('INSERT INTO location_is_bank (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 			$this->bank = true;
-		}
-		else if ($bool === false) {
+		} else if ($bool === false) {
 			$this->db->query('DELETE FROM location_is_bank WHERE ' . $this->SQL . ' LIMIT 1');
 			$this->bank = false;
 		}
@@ -202,8 +199,7 @@ class AbstractSmrLocation {
 		if ($bool === true) {
 			$this->db->query('INSERT IGNORE INTO location_is_bar (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 			$this->bar = true;
-		}
-		else if ($bool === false) {
+		} else if ($bool === false) {
 			$this->db->query('DELETE FROM location_is_bar WHERE ' . $this->SQL . ' LIMIT 1');
 			$this->bar = false;
 		}
@@ -224,8 +220,7 @@ class AbstractSmrLocation {
 		if ($bool === true) {
 			$this->db->query('INSERT IGNORE INTO location_is_hq (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 			$this->HQ = true;
-		}
-		else if ($bool === false) {
+		} else if ($bool === false) {
 			$this->db->query('DELETE FROM location_is_hq WHERE ' . $this->SQL . ' LIMIT 1');
 			$this->HQ = false;
 		}
@@ -246,8 +241,7 @@ class AbstractSmrLocation {
 		if ($bool === true) {
 			$this->db->query('INSERT INTO location_is_ug (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 			$this->UG = true;
-		}
-		else if ($bool === false) {
+		} else if ($bool === false) {
 			$this->db->query('DELETE FROM location_is_ug WHERE ' . $this->SQL . ' LIMIT 1');
 			$this->UG = false;
 		}
@@ -376,8 +370,7 @@ class AbstractSmrLocation {
 			if ($this->getTypeID() == LOCATION_TYPE_FEDERAL_HQ) {
 				$linkedLocations[] = SmrLocation::getLocation(LOCATION_TYPE_FEDERAL_BEACON);
 				$linkedLocations[] = SmrLocation::getLocation(LOCATION_TYPE_FEDERAL_MINT);
-			}
-			else {
+			} else {
 				$raceID = $this->getRaceID();
 				$linkedLocations[] = SmrLocation::getLocation(LOCATION_GROUP_RACIAL_BEACONS + $raceID);
 				$linkedLocations[] = SmrLocation::getLocation(LOCATION_GROUP_RACIAL_SHIPS + $raceID);

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -76,8 +76,9 @@ abstract class AbstractSmrPlayer {
 		return $this->getNewbieTurns() > 0;
 	}
 	public function setNewbieTurns($newbieTurns) {
-		if ($this->newbieTurns == $newbieTurns)
+		if ($this->newbieTurns == $newbieTurns) {
 			return;
+		}
 		$this->newbieTurns = $newbieTurns;
 		$this->hasChanged = true;
 	}
@@ -87,8 +88,9 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setShipTypeID($shipID) {
-		if ($this->shipID == $shipID)
+		if ($this->shipID == $shipID) {
 			return;
+		}
 		$this->shipID = $shipID;
 		$this->hasChanged = true;
 	}
@@ -198,8 +200,9 @@ abstract class AbstractSmrPlayer {
 		}
 
 		$ship = $this->getShip();
-		if ($ship->hasIllegalGoods())
+		if ($ship->hasIllegalGoods()) {
 			return false;
+		}
 
 		if ($ship->getAttackRating() <= $this->getSafeAttackRating()) {
 			foreach ($sector->getFedRaceIDs() as $fedRaceID) {
@@ -240,8 +243,9 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setDead($bool) {
-		if ($this->dead == $bool)
+		if ($this->dead == $bool) {
 			return;
+		}
 		$this->dead = $bool;
 		$this->hasChanged = true;
 	}
@@ -251,14 +255,16 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function increaseKills($kills) {
-		if ($kills < 0)
+		if ($kills < 0) {
 			throw new Exception('Trying to increase negative kills.');
+		}
 		$this->setKills($this->kills + $kills);
 	}
 
 	public function setKills($kills) {
-		if ($this->kills == $kills)
+		if ($this->kills == $kills) {
 			return;
+		}
 		$this->kills = $kills;
 		$this->hasChanged = true;
 	}
@@ -268,14 +274,16 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function increaseDeaths($deaths) {
-		if ($deaths < 0)
+		if ($deaths < 0) {
 			throw new Exception('Trying to increase negative deaths.');
+		}
 		$this->setDeaths($this->getDeaths() + $deaths);
 	}
 
 	public function setDeaths($deaths) {
-		if ($this->deaths == $deaths)
+		if ($this->deaths == $deaths) {
 			return;
+		}
 		$this->deaths = $deaths;
 		$this->hasChanged = true;
 	}
@@ -297,24 +305,29 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function increaseAlignment($align) {
-		if ($align < 0)
+		if ($align < 0) {
 			throw new Exception('Trying to increase negative align.');
-		if ($align == 0)
+		}
+		if ($align == 0) {
 			return;
+		}
 		$align += $this->alignment;
 		$this->setAlignment($align);
 	}
 	public function decreaseAlignment($align) {
-		if ($align < 0)
+		if ($align < 0) {
 			throw new Exception('Trying to decrease negative align.');
-		if ($align == 0)
+		}
+		if ($align == 0) {
 			return;
+		}
 		$align = $this->alignment - $align;
 		$this->setAlignment($align);
 	}
 	public function setAlignment($align) {
-		if ($this->alignment == $align)
+		if ($this->alignment == $align) {
 			return;
+		}
 		$this->alignment = $align;
 		$this->hasChanged = true;
 	}
@@ -332,8 +345,9 @@ abstract class AbstractSmrPlayer {
 	 * This value is rounded because it is used primarily in HTML img widths.
 	 */
 	public function getNextLevelPercentAcquired() : int {
-		if ($this->getNextLevelExperience() == $this->getThisLevelExperience())
+		if ($this->getNextLevelExperience() == $this->getThisLevelExperience()) {
 			return 100;
+		}
 		return max(0, min(100, IRound(($this->getExperience() - $this->getThisLevelExperience()) / ($this->getNextLevelExperience() - $this->getThisLevelExperience()) * 100)));
 	}
 
@@ -343,8 +357,9 @@ abstract class AbstractSmrPlayer {
 
 	public function getNextLevelExperience() {
 		$LEVELS_REQUIREMENTS = Globals::getLevelRequirements();
-		if (!isset($LEVELS_REQUIREMENTS[$this->getLevelID() + 1]))
+		if (!isset($LEVELS_REQUIREMENTS[$this->getLevelID() + 1])) {
 			return $this->getThisLevelExperience(); //Return current level experience if on last level.
+		}
 		return $LEVELS_REQUIREMENTS[$this->getLevelID() + 1]['Requirement'];
 	}
 
@@ -354,12 +369,15 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setExperience($experience) {
-		if ($this->experience == $experience)
+		if ($this->experience == $experience) {
 			return;
-		if ($experience < MIN_EXPERIENCE)
+		}
+		if ($experience < MIN_EXPERIENCE) {
 			$experience = MIN_EXPERIENCE;
-		if ($experience > MAX_EXPERIENCE)
+		}
+		if ($experience > MAX_EXPERIENCE) {
 			$experience = MAX_EXPERIENCE;
+		}
 		$this->experience = $experience;
 		$this->hasChanged = true;
 
@@ -369,46 +387,57 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function increaseCredits($credits) {
-		if ($credits < 0)
+		if ($credits < 0) {
 			throw new Exception('Trying to increase negative credits.');
-		if ($credits == 0)
+		}
+		if ($credits == 0) {
 			return;
+		}
 		$credits += $this->credits;
 		$this->setCredits($credits);
 	}
 	public function decreaseCredits($credits) {
-		if ($credits < 0)
+		if ($credits < 0) {
 			throw new Exception('Trying to decrease negative credits.');
-		if ($credits == 0)
+		}
+		if ($credits == 0) {
 			return;
+		}
 		$credits = $this->credits - $credits;
 		$this->setCredits($credits);
 	}
 	public function setCredits($credits) {
-		if ($this->credits == $credits)
+		if ($this->credits == $credits) {
 			return;
-		if ($credits < 0)
+		}
+		if ($credits < 0) {
 			throw new Exception('Trying to set negative credits.');
-		if ($credits > MAX_MONEY)
+		}
+		if ($credits > MAX_MONEY) {
 			$credits = MAX_MONEY;
+		}
 		$this->credits = $credits;
 		$this->hasChanged = true;
 	}
 
 	public function increaseExperience($experience) {
-		if ($experience < 0)
+		if ($experience < 0) {
 			throw new Exception('Trying to increase negative experience.');
-		if ($experience == 0)
+		}
+		if ($experience == 0) {
 			return;
+		}
 		$newExperience = $this->experience + $experience;
 		$this->setExperience($newExperience);
 		$this->increaseHOF($experience, array('Experience', 'Total', 'Gain'), HOF_PUBLIC);
 	}
 	public function decreaseExperience($experience) {
-		if ($experience < 0)
+		if ($experience < 0) {
 			throw new Exception('Trying to decrease negative experience.');
-		if ($experience == 0)
+		}
+		if ($experience == 0) {
 			return;
+		}
 		$newExperience = $this->experience - $experience;
 		$this->setExperience($newExperience);
 		$this->decreaseHOF($experience, array('Experience', 'Total', 'Loss'), HOF_PUBLIC);
@@ -419,8 +448,9 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setLandedOnPlanet($bool) {
-		if ($this->landedOnPlanet == $bool)
+		if ($this->landedOnPlanet == $bool) {
 			return;
+		}
 		$this->landedOnPlanet = $bool;
 		$this->hasChanged = true;
 	}
@@ -512,8 +542,9 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setRaceID($raceID) {
-		if ($this->raceID == $raceID)
+		if ($this->raceID == $raceID) {
 			return;
+		}
 		$this->raceID = $raceID;
 		$this->hasChanged = true;
 	}
@@ -535,8 +566,9 @@ abstract class AbstractSmrPlayer {
 	}
 
 	protected function setAllianceID($ID) {
-		if ($this->allianceID == $ID)
+		if ($this->allianceID == $ID) {
 			return;
+		}
 		$this->allianceID = $ID;
 		if ($this->allianceID != 0) {
 			$status = $this->hasNewbieStatus() ? 'NEWBIE' : 'VETERAN';
@@ -582,8 +614,9 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setCombatDronesKamikazeOnMines($bool) {
-		if ($this->combatDronesKamikazeOnMines == $bool)
+		if ($this->combatDronesKamikazeOnMines == $bool) {
 			return;
+		}
 		$this->combatDronesKamikazeOnMines = $bool;
 		$this->hasChanged = true;
 	}
@@ -656,21 +689,24 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setMilitaryPayment($amount) {
-		if ($this->militaryPayment == $amount)
+		if ($this->militaryPayment == $amount) {
 			return;
+		}
 		$this->militaryPayment = $amount;
 		$this->hasChanged = true;
 	}
 
 	public function increaseMilitaryPayment($amount) {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to increase negative military payment.');
+		}
 		$this->setMilitaryPayment($this->getMilitaryPayment() + $amount);
 	}
 
 	public function decreaseMilitaryPayment($amount) {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to decrease negative military payment.');
+		}
 		$this->setMilitaryPayment($this->getMilitaryPayment() - $amount);
 	}
 
@@ -713,10 +749,11 @@ abstract class AbstractSmrPlayer {
 
 	protected function getNextBountyID() : int {
 		$keys = array_keys($this->getBounties());
-		if (count($keys) > 0)
+		if (count($keys) > 0) {
 			return max($keys) + 1;
-		else
+		} else {
 			return 0;
+		}
 	}
 
 	protected function setBounty(array $bounty) : void {
@@ -731,22 +768,25 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function increaseBountyAmount(int $bountyID, int $amount) : void {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to increase negative bounty.');
+		}
 		$this->setBountyAmount($this->getBountyAmount($bountyID) + $amount);
 	}
 
 	public function decreaseBountyAmount(int $bountyID, int $amount) : void {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to decrease negative bounty.');
+		}
 		$this->setBountyAmount($this->getBountyAmount($bountyID) + $amount);
 	}
 
 	public function getCurrentBounty(string $type) : array {
 		$bounties = $this->getBounties();
 		foreach ($bounties as $bounty) {
-			if ($bounty['Claimer'] == 0 && $bounty['Type'] == $type)
+			if ($bounty['Claimer'] == 0 && $bounty['Type'] == $type) {
 				return $bounty;
+			}
 		}
 		return $this->createBounty($type);
 	}
@@ -754,8 +794,9 @@ abstract class AbstractSmrPlayer {
 	public function hasCurrentBounty(string $type) : bool {
 		$bounties = $this->getBounties();
 		foreach ($bounties as $bounty) {
-			if ($bounty['Claimer'] == 0 && $bounty['Type'] == $type)
+			if ($bounty['Claimer'] == 0 && $bounty['Type'] == $type) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -767,21 +808,24 @@ abstract class AbstractSmrPlayer {
 
 	protected function setCurrentBountyAmount(string $type, int $amount) : void {
 		$bounty = $this->getCurrentBounty($type);
-		if ($bounty['Amount'] == $amount)
+		if ($bounty['Amount'] == $amount) {
 			return;
+		}
 		$bounty['Amount'] = $amount;
 		$this->setBounty($bounty);
 	}
 
 	public function increaseCurrentBountyAmount(string $type, int $amount) : void {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to increase negative current bounty.');
+		}
 		$this->setCurrentBountyAmount($type, $this->getCurrentBountyAmount($type) + $amount);
 	}
 
 	public function decreaseCurrentBountyAmount(string $type, int $amount) : void {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to decrease negative current bounty.');
+		}
 		$this->setCurrentBountyAmount($type, $this->getCurrentBountyAmount($type) - $amount);
 	}
 
@@ -792,21 +836,24 @@ abstract class AbstractSmrPlayer {
 
 	protected function setCurrentBountySmrCredits(string $type, int $credits) : void {
 		$bounty = $this->getCurrentBounty($type);
-		if ($bounty['SmrCredits'] == $credits)
+		if ($bounty['SmrCredits'] == $credits) {
 			return;
+		}
 		$bounty['SmrCredits'] = $credits;
 		$this->setBounty($bounty);
 	}
 
 	public function increaseCurrentBountySmrCredits(string $type, int $credits) : void {
-		if ($credits < 0)
+		if ($credits < 0) {
 			throw new Exception('Trying to increase negative current bounty.');
+		}
 		$this->setCurrentBountySmrCredits($type, $this->getCurrentBountySmrCredits($type) + $credits);
 	}
 
 	public function decreaseCurrentBountySmrCredits(string $type, int $credits) : void {
-		if ($credits < 0)
+		if ($credits < 0) {
 			throw new Exception('Trying to decrease negative current bounty.');
+		}
 		$this->setCurrentBountySmrCredits($type, $this->getCurrentBountySmrCredits($type) - $credits);
 	}
 
@@ -824,44 +871,53 @@ abstract class AbstractSmrPlayer {
 
 	public function getHOF(array $typeList = null) {
 		$this->getHOFData();
-		if ($typeList == null)
+		if ($typeList == null) {
 			return $this->HOF;
+		}
 		$hof = $this->HOF;
 		foreach ($typeList as $type) {
-			if (!isset($hof[$type]))
+			if (!isset($hof[$type])) {
 				return 0;
+			}
 			$hof = $hof[$type];
 		}
 		return $hof;
 	}
 
 	public function increaseHOF($amount, array $typeList, $visibility) {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to increase negative HOF: ' . implode(':', $typeList));
-		if ($amount == 0)
+		}
+		if ($amount == 0) {
 			return;
+		}
 		$this->setHOF($this->getHOF($typeList) + $amount, $typeList, $visibility);
 	}
 
 	public function decreaseHOF($amount, array $typeList, $visibility) {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to decrease negative HOF: ' . implode(':', $typeList));
-		if ($amount == 0)
+		}
+		if ($amount == 0) {
 			return;
+		}
 		$this->setHOF($this->getHOF($typeList) - $amount, $typeList, $visibility);
 	}
 
 	public function setHOF($amount, array $typeList, $visibility) {
-		if (is_array($this->getHOF($typeList)))
+		if (is_array($this->getHOF($typeList))) {
 			throw new Exception('Trying to overwrite a HOF type: ' . implode(':', $typeList));
+		}
 		if ($this->isNPC()) {
 			// Don't store HOF for NPCs.
 			return;
 		}
-		if ($this->getHOF($typeList) == $amount)
+		if ($this->getHOF($typeList) == $amount) {
 			return;
-		if ($amount < 0)
+		}
+		if ($amount < 0) {
 			$amount = 0;
+		}
 		$this->getHOF();
 
 		$hofType = implode(':', $typeList);
@@ -877,8 +933,9 @@ abstract class AbstractSmrPlayer {
 		$hofChanged =& $this->hasHOFChanged;
 		$new = false;
 		foreach ($typeList as $type) {
-			if (!isset($hofChanged[$type]))
+			if (!isset($hofChanged[$type])) {
 				$hofChanged[$type] = array();
+			}
 			if (!isset($hof[$type])) {
 				$hof[$type] = array();
 				$new = true;
@@ -888,8 +945,9 @@ abstract class AbstractSmrPlayer {
 		}
 		if ($hofChanged == null) {
 			$hofChanged = self::HOF_CHANGED;
-			if ($new)
+			if ($new) {
 				$hofChanged = self::HOF_NEW;
+			}
 		}
 		$hof = $amount;
 	}
@@ -954,8 +1012,9 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setLastActive($lastActive) {
-		if ($this->lastActive == $lastActive)
+		if ($this->lastActive == $lastActive) {
 			return;
+		}
 		$this->lastActive = $lastActive;
 		$this->hasChanged = true;
 	}
@@ -965,8 +1024,9 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setLastCPLAction($time) {
-		if ($this->lastCPLAction == $time)
+		if ($this->lastCPLAction == $time) {
 			return;
+		}
 		$this->lastCPLAction = $time;
 		$this->hasChanged = true;
 	}
@@ -1007,8 +1067,9 @@ abstract class AbstractSmrPlayer {
 
 	protected function getMission($missionID) {
 		$missions = $this->getMissions();
-		if (isset($missions[$missionID]))
+		if (isset($missions[$missionID])) {
 			return $missions[$missionID];
+		}
 		return false;
 	}
 
@@ -1067,8 +1128,9 @@ abstract class AbstractSmrPlayer {
 	public function addMission($missionID, $step = 0) {
 		$this->getMissions();
 
-		if (isset($this->missions[$missionID]))
+		if (isset($this->missions[$missionID])) {
 			return;
+		}
 		$sector = 0;
 
 		$mission = array(
@@ -1235,12 +1297,15 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function canSee(AbstractSmrPlayer $otherPlayer) {
-		if (!$otherPlayer->getShip()->isCloaked())
+		if (!$otherPlayer->getShip()->isCloaked()) {
 			return true;
-		if ($this->sameAlliance($otherPlayer))
+		}
+		if ($this->sameAlliance($otherPlayer)) {
 			return true;
-		if ($this->getExperience() >= $otherPlayer->getExperience())
+		}
+		if ($this->getExperience() >= $otherPlayer->getExperience()) {
 			return true;
+		}
 		return false;
 	}
 
@@ -1293,10 +1358,12 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function meetsAlignmentRestriction($restriction) {
-		if ($restriction < 0)
+		if ($restriction < 0) {
 			return $this->getAlignment() <= $restriction;
-		if ($restriction > 0)
+		}
+		if ($restriction > 0) {
 			return $this->getAlignment() >= $restriction;
+		}
 		return true;
 	}
 
@@ -1319,8 +1386,9 @@ abstract class AbstractSmrPlayer {
 		if (!isset($this->visitedSectors)) {
 			$this->visitedSectors = array();
 			$this->db->query('SELECT sector_id FROM player_visited_sector WHERE ' . $this->SQL);
-			while ($this->db->nextRecord())
+			while ($this->db->nextRecord()) {
 				$this->visitedSectors[$this->db->getInt('sector_id')] = false;
+			}
 		}
 		return !isset($this->visitedSectors[$sectorID]);
 	}

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -464,7 +464,9 @@ abstract class AbstractSmrPlayer {
 		if ($this->level === null) {
 			$LEVELS_REQUIREMENTS = Globals::getLevelRequirements();
 			foreach ($LEVELS_REQUIREMENTS as $level_id => $require) {
-				if ($this->getExperience() >= $require['Requirement']) continue;
+				if ($this->getExperience() >= $require['Requirement']) {
+					continue;
+				}
 				$this->level = $level_id - 1;
 				return $this->level;
 			}
@@ -585,8 +587,7 @@ abstract class AbstractSmrPlayer {
 	public function getAllianceDisplayName($linked = false, $includeAllianceID = false) {
 		if ($this->hasAlliance()) {
 			return $this->getAlliance()->getAllianceDisplayName($linked, $includeAllianceID);
-		}
-		else {
+		} else {
 			return 'No Alliance';
 		}
 	}
@@ -923,8 +924,7 @@ abstract class AbstractSmrPlayer {
 		$hofType = implode(':', $typeList);
 		if (!isset(self::$HOFVis[$hofType])) {
 			self::$hasHOFVisChanged[$hofType] = self::HOF_NEW;
-		}
-		else if (self::$HOFVis[$hofType] != $visibility) {
+		} else if (self::$HOFVis[$hofType] != $visibility) {
 			self::$hasHOFVisChanged[$hofType] = self::HOF_CHANGED;
 		}
 		self::$HOFVis[$hofType] = $visibility;
@@ -1159,8 +1159,7 @@ abstract class AbstractSmrPlayer {
 		if ($mission['On Step'] >= count(MISSIONS[$missionID]['Steps'])) {
 			// If we have completed this mission just use false to indicate no current task.
 			$currentStep = false;
-		}
-		else {
+		} else {
 			$currentStep = MISSIONS[$missionID]['Steps'][$mission['On Step']];
 			$currentStep['Text'] = str_replace(array('<Race>', '<Sector>', '<Starting Sector>', '<trader>'), array($this->getRaceID(), $mission['Sector'], $mission['Starting Sector'], $this->playerName), $currentStep['Text']);
 			if (isset($currentStep['Task'])) {
@@ -1168,8 +1167,7 @@ abstract class AbstractSmrPlayer {
 			}
 			if (isset($currentStep['Level'])) {
 				$currentStep['Level'] = str_replace('<Player Level>', $this->getLevelID(), $currentStep['Level']);
-			}
-			else {
+			} else {
 				$currentStep['Level'] = 0;
 			}
 		}

--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -153,8 +153,7 @@ class AbstractSmrPort {
 			$this->checkDefenses();
 			$this->getGoods();
 			$this->checkForUpgrade();
-		}
-		else {
+		} else {
 			$this->shields = 0;
 			$this->combatDrones = 0;
 			$this->armour = 0;
@@ -566,8 +565,7 @@ class AbstractSmrPort {
 		}
 		if (($key = array_search($goodID, $this->goodIDs['Buy'])) !== false) {
 			array_splice($this->goodIDs['Buy'], $key, 1);
-		}
-		elseif (($key = array_search($goodID, $this->goodIDs['Sell'])) !== false) {
+		} elseif (($key = array_search($goodID, $this->goodIDs['Sell'])) !== false) {
 			array_splice($this->goodIDs['Sell'], $key, 1);
 		}
 		
@@ -649,8 +647,7 @@ class AbstractSmrPort {
 			$newsMessage = '<span class="red bold">*MAYDAY* *MAYDAY*</span> A distress beacon has been activated by the port in sector ' . Globals::getSectorBBLink($this->getSectorID()) . '. It is under attack by ';
 			if ($trigger->hasAlliance()) {
 				$newsMessage .= 'members of ' . $trigger->getAllianceBBLink();
-			}
-			else {
+			} else {
 				$newsMessage .= $trigger->getBBLink();
 			}
 			
@@ -659,8 +656,7 @@ class AbstractSmrPort {
 
 			if ($trigger->hasAlliance()) {
 				$newsMessage .= 'bounties of <span class="creds">' . $bounty . '</span> credits for the deaths of any raiding members of ' . $trigger->getAllianceBBLink();
-			}
-			else {
+			} else {
 				$newsMessage .= 'a bounty of <span class="creds">' . $bounty . '</span> credits for the death of ' . $trigger->getBBLink();
 			}
 			$newsMessage .= ' prior to the destruction of the port, or until federal forces arrive to defend the port.';
@@ -1069,8 +1065,7 @@ class AbstractSmrPort {
 		if ($this->getCredits() > 0) {
 			$container = create_container('skeleton.php', 'port_payout_processing.php');
 			$container['PayoutType'] = 'Loot';
-		}
-		else {
+		} else {
 			$container = create_container('skeleton.php', 'current_sector.php');
 			$container['msg'] = 'This port has already been looted.';
 		}
@@ -1189,8 +1184,7 @@ class AbstractSmrPort {
 								', attack_started = ' . $this->db->escapeNumber($this->getAttackStarted()) .
 								', race_id = ' . $this->db->escapeNumber($this->getRaceID()) . '
 								WHERE ' . $this->SQL . ' LIMIT 1');
-			}
-			else {
+			} else {
 				$this->db->query('INSERT INTO port (game_id,sector_id,experience,shields,armour,combat_drones,level,credits,upgrade,reinforce_time,attack_started,race_id)
 								values
 								(' . $this->db->escapeNumber($this->getGameID()) .
@@ -1273,8 +1267,7 @@ class AbstractSmrPort {
 						$armourDamage = $this->doArmourDamage(min($damage['MaxDamage'], $damage['Armour']));
 					}
 				}
-			}
-			else { //hit drones behind shields
+			} else { //hit drones behind shields
 				$cdDamage = $this->doCDDamage(IFloor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT));
 			}
 		}
@@ -1370,8 +1363,11 @@ class AbstractSmrPort {
 		
 		// News Entry
 		$news = $this->getDisplayName() . ' has been successfully raided by ';
-		if ($killer->hasAlliance()) $news .= 'the members of <span class="yellow">' . $killer->getAllianceBBLink() . '</span>';
-		else $news .= $killer->getBBLink();
+		if ($killer->hasAlliance()) {
+			$news .= 'the members of <span class="yellow">' . $killer->getAllianceBBLink() . '</span>';
+		} else {
+			$news .= $killer->getBBLink();
+		}
 		$this->db->query('INSERT INTO news (game_id, time, news_message, type,killer_id,killer_alliance,dead_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(TIME) . ', ' . $this->db->escapeString($news) . ', \'REGULAR\',' . $this->db->escapeNumber($killer->getAccountID()) . ',' . $this->db->escapeNumber($killer->getAllianceID()) . ',' . $this->db->escapeNumber(ACCOUNT_ID_PORT) . ')');
 		// Killer gets a relations change and a bounty if port is taken
 		$return['KillerBounty'] = $killer->getExperience() * $this->getLevel();

--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -302,8 +302,9 @@ class AbstractSmrPort {
 				$x['TransactionType'] = 'Buy';
 			}
 			$di = Plotter::findDistanceToX($x, $this->getSector(), true);
-			if (is_object($di))
+			if (is_object($di)) {
 				$di = $di->getRelativeDistance();
+			}
 			$this->goodDistances[$goodID] = max(1, $di);
 		}
 		return $this->goodDistances[$goodID];
@@ -329,12 +330,14 @@ class AbstractSmrPort {
 	}
 	
 	private function setGoodAmount($goodID, $amount, $doUpdate = true) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
+		}
 		// The new amount must be between 0 and the max for this good
 		$amount = max(0, min($amount, $this->getGood($goodID)['Max']));
-		if ($this->getGoodAmount($goodID) == $amount)
+		if ($this->getGoodAmount($goodID) == $amount) {
 			return;
+		}
 		$this->goodAmounts[$goodID] = $amount;
 
 		if ($doUpdate) {
@@ -401,8 +404,9 @@ class AbstractSmrPort {
 	}
 	
 	public function checkForUpgrade() {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot upgrade a cached port!');
+		}
 		$upgrades = 0;
 		while ($this->upgrade >= $this->getUpgradeRequirement() && $this->level < 9) {
 			++$upgrades;
@@ -418,8 +422,9 @@ class AbstractSmrPort {
 	 * ports to a specific level.
 	 */
 	public function upgradeToLevel($level) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot upgrade a cached port!');
+		}
 		while ($this->getLevel() < $level) {
 			$this->doUpgrade();
 		}
@@ -523,8 +528,9 @@ class AbstractSmrPort {
 	 * calling this function directly.
 	 */
 	public function addPortGood($goodID, $type) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
+		}
 		if ($this->hasGood($goodID, $type)) {
 			return;
 		}
@@ -549,8 +555,9 @@ class AbstractSmrPort {
 	 * calling this function directly.
 	 */
 	public function removePortGood($goodID) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
+		}
 		if (!$this->hasGood($goodID)) {
 			return;
 		}
@@ -600,8 +607,9 @@ class AbstractSmrPort {
 	}
 
 	protected function doDowngrade() {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot downgrade a cached port!');
+		}
 
 		$goodClass = $this->getGoodClassAtLevel();
 		$this->selectAndRemoveGood($goodClass);
@@ -620,9 +628,10 @@ class AbstractSmrPort {
 	}
 	
 	public function attackedBy(AbstractSmrPlayer $trigger, array $attackers) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot attack a cached port!');
-			
+		}
+
 		$trigger->increaseHOF(1, array('Combat', 'Port', 'Number Of Triggers'), HOF_PUBLIC);
 		foreach ($attackers as $attacker) {
 			$attacker->increaseHOF(1, array('Combat', 'Port', 'Number Of Attacks'), HOF_PUBLIC);
@@ -665,34 +674,43 @@ class AbstractSmrPort {
 	}
 	
 	public function setShields($shields) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
-		if ($shields < 0)
+		}
+		if ($shields < 0) {
 			$shields = 0;
-		if ($this->shields == $shields)
+		}
+		if ($this->shields == $shields) {
 			return;
+		}
 		$this->shields = $shields;
 		$this->hasChanged = true;
 	}
 	
 	public function setArmour($armour) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
-		if ($armour < 0)
+		}
+		if ($armour < 0) {
 			$armour = 0;
-		if ($this->armour == $armour)
+		}
+		if ($this->armour == $armour) {
 			return;
+		}
 		$this->armour = $armour;
 		$this->hasChanged = true;
 	}
 	
 	public function setCDs($combatDrones) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
-		if ($combatDrones < 0)
+		}
+		if ($combatDrones < 0) {
 			$combatDrones = 0;
-		if ($this->combatDrones == $combatDrones)
+		}
+		if ($this->combatDrones == $combatDrones) {
 			return;
+		}
 		$this->combatDrones = $combatDrones;
 		$this->hasChanged = true;
 	}
@@ -702,84 +720,99 @@ class AbstractSmrPort {
 	}
 
 	public function setCredits($credits) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
-		if ($this->credits == $credits)
+		}
+		if ($this->credits == $credits) {
 			return;
+		}
 		$this->credits = $credits;
 		$this->hasChanged = true;
 	}
 	
 	public function decreaseCredits($credits) {
-		if ($credits < 0)
+		if ($credits < 0) {
 			throw new Exception('Cannot decrease negative credits.');
+		}
 		$this->setCredits($this->getCredits() - $credits);
 	}
 	
 	public function increaseCredits($credits) {
-		if ($credits < 0)
+		if ($credits < 0) {
 			throw new Exception('Cannot increase negative credits.');
+		}
 		$this->setCredits($this->getCredits() + $credits);
 	}
 	
 	public function setUpgrade($upgrade) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
+		}
 		if ($this->getLevel() == $this->getMaxLevel()) {
 			$upgrade = 0;
 		}
-		if ($this->upgrade == $upgrade)
+		if ($this->upgrade == $upgrade) {
 			return;
+		}
 		$this->upgrade = $upgrade;
 		$this->hasChanged = true;
 		$this->checkForUpgrade();
 	}
 	
 	public function decreaseUpgrade($upgrade) {
-		if ($upgrade < 0)
+		if ($upgrade < 0) {
 			throw new Exception('Cannot decrease negative upgrade.');
+		}
 		$this->setUpgrade($this->getUpgrade() - $upgrade);
 	}
 	
 	public function increaseUpgrade($upgrade) {
-		if ($upgrade < 0)
+		if ($upgrade < 0) {
 			throw new Exception('Cannot increase negative upgrade.');
+		}
 		$this->setUpgrade($this->getUpgrade() + $upgrade);
 	}
 	
 	public function setLevel($level) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
-		if ($this->level == $level)
+		}
+		if ($this->level == $level) {
 			return;
+		}
 		$this->level = $level;
 		$this->hasChanged = true;
 	}
 	
 	public function increaseLevel($level) {
-		if ($level < 0)
+		if ($level < 0) {
 			throw new Exception('Cannot increase negative level.');
+		}
 		$this->setLevel($this->getLevel() + $level);
 	}
 	
 	public function decreaseLevel($level) {
-		if ($level < 0)
+		if ($level < 0) {
 			throw new Exception('Cannot increase negative level.');
+		}
 		$this->setLevel($this->getLevel() - $level);
 	}
 	
 	public function setExperience($experience) {
-		if ($this->isCachedVersion())
+		if ($this->isCachedVersion()) {
 			throw new Exception('Cannot update a cached port!');
-		if ($this->experience == $experience)
+		}
+		if ($this->experience == $experience) {
 			return;
+		}
 		$this->experience = $experience;
 		$this->hasChanged = true;
 	}
 	
 	public function increaseExperience($experience) {
-		if ($experience < 0)
+		if ($experience < 0) {
 			throw new Exception('Cannot increase negative experience.');
+		}
 		$this->setExperience($this->getExperience() + $experience);
 	}
 	
@@ -804,8 +837,9 @@ class AbstractSmrPort {
 	}
 	
 	public function setRaceID($raceID) {
-		if ($this->raceID == $raceID)
+		if ($this->raceID == $raceID) {
 			return;
+		}
 		$this->raceID = $raceID;
 		$this->hasChanged = true;
 		$this->cacheIsValid = false;
@@ -883,8 +917,9 @@ class AbstractSmrPort {
 	}
 	
 	public function getReinforcePercent() {
-		if (!$this->isUnderAttack())
+		if (!$this->isUnderAttack()) {
 			return 0;
+		}
 		return min(1, max(0, ($this->getReinforceTime() - TIME) / ($this->getReinforceTime() - $this->getAttackStarted())));
 	}
 	
@@ -905,8 +940,9 @@ class AbstractSmrPort {
 	}
 	
 	private function setAttackStarted($time) {
-		if ($this->attackStarted == $time)
+		if ($this->attackStarted == $time) {
 			return;
+		}
 		$this->attackStarted = TIME;
 		$this->hasChanged = true;
 	}
@@ -966,13 +1002,12 @@ class AbstractSmrPort {
 		$relationsEffect = pow(1 + ($expRelations - 1000) / 10000, 1.2 - $expRelations / 1000);
 		$relationsEffect -= max(0, min(self::BARGAIN_LENIENCY_PERCENT, self::BARGAIN_LENIENCY_PERCENT * (2000 - $moneyRelations) / 1000)); //Gradual increase getting closer and closer to actual ideal price as relations increase to 2000 (will only be an increase of self::BARGAIN_LENIENCY_PERCENT percent extra cash)
 		 
-		 if ($transactionType == 'Buy')
-		 {
+		if ($transactionType == 'Buy') {
 			$relationsEffect = 2 - $relationsEffect;
 			return max($idealPrice, IFloor($idealPrice * $relationsEffect));
-		 }
-		 else
+		} else {
 			return min($idealPrice, ICeil($idealPrice * $relationsEffect));
+		}
 //		$range = .11 - .095;
 //		$rand = .095 + $range * mt_rand(0, 32767)/32767;
 //
@@ -1106,9 +1141,9 @@ class AbstractSmrPort {
 			if ($db->nextRecord()) {
 				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID] = unserialize(gzuncompress($db->getField('port_info')));
 				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID]->setCachedTime($db->getInt('visited'));
-			}
-			else
+			} else {
 				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID] = false;
+			}
 		}
 		return self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID];
 	}
@@ -1234,8 +1269,9 @@ class AbstractSmrPort {
 					$cdDamage = $this->doCDDamage(min($damage['MaxDamage'], $damage['Armour']));
 					$damage['Armour'] -= $cdDamage;
 					$damage['MaxDamage'] -= $cdDamage;
-					if (!$this->hasCDs() && ($cdDamage == 0 || $damage['Rollover']))
+					if (!$this->hasCDs() && ($cdDamage == 0 || $damage['Rollover'])) {
 						$armourDamage = $this->doArmourDamage(min($damage['MaxDamage'], $damage['Armour']));
+					}
 				}
 			}
 			else { //hit drones behind shields
@@ -1351,8 +1387,9 @@ class AbstractSmrPort {
 
 	public function hasX(/*Object*/ $x) {
 		if (is_array($x) && $x['Type'] == 'Good') { // instanceof Good) - No Good class yet, so array is the best we can do
-			if (isset($x['ID']))
+			if (isset($x['ID'])) {
 				return $this->hasGood($x['ID'], isset($x['TransactionType']) ? $x['TransactionType'] : false);
+			}
 		}
 		return false;
 	}

--- a/lib/Default/AbstractSmrShip.class.php
+++ b/lib/Default/AbstractSmrShip.class.php
@@ -273,8 +273,7 @@ abstract class AbstractSmrShip {
 		if ($replacement < 0) {
 			// Shift everything up by one and put the selected weapon at the bottom
 			array_push($this->weapons, array_shift($this->weapons));
-		}
-		else {
+		} else {
 			// Swap the selected weapon with the one above it
 			$temp = $this->weapons[$replacement];
 			$this->weapons[$replacement] = $this->weapons[$orderID];
@@ -288,8 +287,7 @@ abstract class AbstractSmrShip {
 		if ($replacement >= count($this->weapons)) {
 			// Shift everything down by one and put the selected weapon at the top
 			array_unshift($this->weapons, array_pop($this->weapons));
-		}
-		else {
+		} else {
 			// Swap the selected weapon with the one below it
 			$temp = $this->weapons[$replacement];
 			$this->weapons[$replacement] = $this->weapons[$orderID];
@@ -348,8 +346,7 @@ abstract class AbstractSmrShip {
 			$this->setArmour(150, true);
 			$this->setCargoHolds(40);
 			$this->setShipTypeID(SHIP_TYPE_NEWBIE_MERCHANT_VESSEL);
-		}
-		else {
+		} else {
 			$this->setShields(50, true);
 			$this->setArmour(50, true);
 			$this->setCargoHolds(5);

--- a/lib/Default/AbstractSmrShip.class.php
+++ b/lib/Default/AbstractSmrShip.class.php
@@ -34,10 +34,11 @@ abstract class AbstractSmrShip {
 			// determine ship
 			$db = new SmrMySqlDatabase();
 			$db->query('SELECT * FROM ship_type WHERE ship_type_id = ' . $db->escapeNumber($shipTypeID) . ' LIMIT 1'); //TODO add game type id
-			if ($db->nextRecord())
+			if ($db->nextRecord()) {
 				self::$CACHE_BASE_SHIPS[$gameTypeID][$shipTypeID] = self::buildBaseShip($db);
-			else
+			} else {
 				self::$CACHE_BASE_SHIPS[$gameTypeID][$shipTypeID] = false;
+			}
 		}
 		return self::$CACHE_BASE_SHIPS[$gameTypeID][$shipTypeID];
 	}
@@ -168,12 +169,13 @@ abstract class AbstractSmrShip {
 
 	public function checkForExcessHardware() {
 		//check hardware to see if anything needs to be removed
-		if (is_array($hardware = $this->getHardware()))
+		if (is_array($hardware = $this->getHardware())) {
 			foreach ($hardware as $hardwareTypeID => $amount) {
 				if ($amount > ($max = $this->getMaxHardware($hardwareTypeID))) {
 					$this->setHardware($hardwareTypeID, $max, true);
 				}
 			}
+		}
 	}
 
 	/**
@@ -188,9 +190,11 @@ abstract class AbstractSmrShip {
 
 	public function getPowerUsed() {
 		$power = 0;
-		if ($this->getNumWeapons() > 0)
-			foreach ($this->weapons as $weapon)
+		if ($this->getNumWeapons() > 0) {
+			foreach ($this->weapons as $weapon) {
 				$power += $weapon->getPowerLevel();
+			}
+		}
 		return $power;
 	}
 
@@ -211,17 +215,19 @@ abstract class AbstractSmrShip {
 	}
 
 	public function getDisplayAttackRating(AbstractSmrPlayer $player) {
-		if ($this->hasActiveIllusion())
+		if ($this->hasActiveIllusion()) {
 			return $this->getIllusionAttack();
-		else
+		} else {
 			return $this->getAttackRating();
+		}
 	}
 
 	public function getDisplayDefenseRating() {
-		if ($this->hasActiveIllusion())
+		if ($this->hasActiveIllusion()) {
 			return $this->getIllusionDefense();
-		else
+		} else {
 			return $this->getDefenseRating();
+		}
 	}
 
 	public function getAttackRating() : int {
@@ -363,10 +369,10 @@ abstract class AbstractSmrShip {
 
 
 	public function hasActiveIllusion() {
-		if (!$this->hasIllusion())
+		if (!$this->hasIllusion()) {
 			return false;
+		}
 		return $this->getIllusionShip() !== false;
-
 	}
 
 	public function hasIllusion() {
@@ -498,14 +504,16 @@ abstract class AbstractSmrShip {
 	}
 
 	public function getHardware($hardwareTypeID = false) {
-		if ($hardwareTypeID === false)
+		if ($hardwareTypeID === false) {
 			return $this->hardware;
+		}
 		return isset($this->hardware[$hardwareTypeID]) ? $this->hardware[$hardwareTypeID] : 0;
 	}
 
 	public function setHardware($hardwareTypeID, $amount) {
-		if ($this->getHardware($hardwareTypeID) == $amount)
+		if ($this->getHardware($hardwareTypeID) == $amount) {
 			return;
+		}
 		$this->hardware[$hardwareTypeID] = $amount;
 		$this->hasChangedHardware[$hardwareTypeID] = true;
 	}
@@ -515,14 +523,16 @@ abstract class AbstractSmrShip {
 	}
 
 	public function getOldHardware($hardwareTypeID = false) {
-		if ($hardwareTypeID === false)
+		if ($hardwareTypeID === false) {
 			return $this->oldHardware;
+		}
 		return isset($this->oldHardware[$hardwareTypeID]) ? $this->oldHardware[$hardwareTypeID] : 0;
 	}
 
 	public function setOldHardware($hardwareTypeID, $amount) {
-		if ($this->getOldHardware($hardwareTypeID) == $amount)
+		if ($this->getOldHardware($hardwareTypeID) == $amount) {
 			return;
+		}
 		$this->oldHardware[$hardwareTypeID] = $amount;
 		$this->hasChangedHardware[$hardwareTypeID] = true;
 	}
@@ -532,8 +542,9 @@ abstract class AbstractSmrShip {
 	}
 
 	public function getMaxHardware($hardwareTypeID = false) {
-		if ($hardwareTypeID === false)
+		if ($hardwareTypeID === false) {
 			return $this->baseShip['MaxHardware'];
+		}
 		return $this->baseShip['MaxHardware'][$hardwareTypeID];
 	}
 
@@ -542,8 +553,9 @@ abstract class AbstractSmrShip {
 	}
 
 	public function setShields($amount, $updateOldAmount = false) {
-		if ($updateOldAmount && !$this->hasLostShields())
+		if ($updateOldAmount && !$this->hasLostShields()) {
 			$this->setOldHardware(HARDWARE_SHIELDS, $amount);
+		}
 		$this->setHardware(HARDWARE_SHIELDS, $amount);
 	}
 
@@ -584,8 +596,9 @@ abstract class AbstractSmrShip {
 	}
 
 	public function setArmour($amount, $updateOldAmount = false) {
-		if ($updateOldAmount && !$this->hasLostArmour())
+		if ($updateOldAmount && !$this->hasLostArmour()) {
 			$this->setOldHardware(HARDWARE_ARMOUR, $amount);
+		}
 		$this->setHardware(HARDWARE_ARMOUR, $amount);
 	}
 
@@ -654,8 +667,9 @@ abstract class AbstractSmrShip {
 	}
 
 	public function setCDs($amount, $updateOldAmount = false) {
-		if ($updateOldAmount && !$this->hasLostCDs())
+		if ($updateOldAmount && !$this->hasLostCDs()) {
 			$this->setOldHardware(HARDWARE_COMBAT, $amount);
+		}
 		$this->setHardware(HARDWARE_COMBAT, $amount);
 	}
 
@@ -737,8 +751,9 @@ abstract class AbstractSmrShip {
 
 	public function getCargo($goodID = false) {
 		if ($goodID !== false) {
-			if (isset($this->cargo[$goodID]))
+			if (isset($this->cargo[$goodID])) {
 				return $this->cargo[$goodID];
+			}
 			$cargo = 0;
 			return $cargo;
 		}
@@ -746,16 +761,19 @@ abstract class AbstractSmrShip {
 	}
 
 	public function hasCargo($goodID = false) {
-		if ($goodID !== false)
+		if ($goodID !== false) {
 			return $this->getCargo($goodID) > 0;
-		if (is_array($cargo = $this->getCargo()))
+		}
+		if (is_array($cargo = $this->getCargo())) {
 			return array_sum($cargo) > 0;
+		}
 		return false;
 	}
 
 	public function setCargo($goodID, $amount) {
-		if ($this->getCargo($goodID) == $amount)
+		if ($this->getCargo($goodID) == $amount) {
 			return;
+		}
 		$this->cargo[$goodID] = $amount;
 		$this->hasChangedCargo = true;
 		// Sort cargo by goodID to make sure it shows up in the correct order
@@ -764,14 +782,16 @@ abstract class AbstractSmrShip {
 	}
 
 	public function decreaseCargo($goodID, $amount) {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to decrease negative cargo.');
+		}
 		$this->setCargo($goodID, $this->getCargo($goodID) - $amount);
 	}
 
 	public function increaseCargo($goodID, $amount) {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to increase negative cargo.');
+		}
 		$this->setCargo($goodID, $this->getCargo($goodID) + $amount);
 	}
 
@@ -801,8 +821,9 @@ abstract class AbstractSmrShip {
 		$this->setOldShields($this->getShields());
 		$this->setOldCDs($this->getCDs());
 		$this->setOldArmour($this->getArmour());
-		if (isset($var['UnderAttack']))
+		if (isset($var['UnderAttack'])) {
 			return $var['UnderAttack'];
+		}
 		if ($underAttack && !USING_AJAX) {
 			SmrSession::updateVar('UnderAttack', $underAttack); //Remember we are under attack for AJAX
 		}
@@ -881,8 +902,9 @@ abstract class AbstractSmrShip {
 		$results['DeadBeforeShot'] = false;
 		foreach ($this->weapons as $orderID => $weapon) {
 			$results['Weapons'][$orderID] =& $weapon->shootPlayer($thisPlayer, $targetPlayers[array_rand($targetPlayers)]);
-			if ($results['Weapons'][$orderID]['Hit'])
+			if ($results['Weapons'][$orderID]['Hit']) {
 				$results['TotalDamage'] += $results['Weapons'][$orderID]['ActualDamage']['TotalDamage'];
+			}
 		}
 		if ($this->hasCDs()) {
 			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs());
@@ -944,8 +966,9 @@ abstract class AbstractSmrShip {
 		$results['DeadBeforeShot'] = false;
 		foreach ($this->weapons as $orderID => $weapon) {
 			$results['Weapons'][$orderID] =& $weapon->shootPort($thisPlayer, $port);
-			if ($results['Weapons'][$orderID]['Hit'])
+			if ($results['Weapons'][$orderID]['Hit']) {
 				$results['TotalDamage'] += $results['Weapons'][$orderID]['ActualDamage']['TotalDamage'];
+			}
 		}
 		if ($this->hasCDs()) {
 			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs());
@@ -981,8 +1004,9 @@ abstract class AbstractSmrShip {
 		$results['DeadBeforeShot'] = false;
 		foreach ($this->weapons as $orderID => $weapon) {
 			$results['Weapons'][$orderID] =& $weapon->shootPlanet($thisPlayer, $planet, $delayed);
-			if ($results['Weapons'][$orderID]['Hit'])
+			if ($results['Weapons'][$orderID]['Hit']) {
 				$results['TotalDamage'] += $results['Weapons'][$orderID]['ActualDamage']['TotalDamage'];
+			}
 		}
 		if ($this->hasCDs()) {
 			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs());
@@ -1007,8 +1031,9 @@ abstract class AbstractSmrShip {
 				$cdDamage = $this->doCDDamage(min($damage['MaxDamage'], $damage['Armour']));
 				$damage['Armour'] -= $cdDamage;
 				$damage['MaxDamage'] -= $cdDamage;
-				if (!$this->hasCDs() && ($cdDamage == 0 || $damage['Rollover']))
+				if (!$this->hasCDs() && ($cdDamage == 0 || $damage['Rollover'])) {
 					$armourDamage = $this->doArmourDamage(min($damage['MaxDamage'], $damage['Armour']));
+				}
 			}
 		}
 		$return = array(

--- a/lib/Default/Menu.class.php
+++ b/lib/Default/Menu.class.php
@@ -22,8 +22,7 @@ class Menu {
 
 		if ($alliance_id) {
 			$in_alliance = ($alliance_id == $player->getAllianceID());
-		}
-		else {
+		} else {
 			$in_alliance = $player->hasAlliance();
 		}
 		if (!$in_alliance) {
@@ -36,8 +35,7 @@ class Menu {
 				$mbRead = $db->getBoolean('mb_read');
 				$modRead = $db->getBoolean('mod_read');
 				$planetLand = $db->getBoolean('planet_land');
-			}
-			else {
+			} else {
 				$mbRead = FALSE;
 				$modRead = FALSE;
 				$planetLand = FALSE;
@@ -366,8 +364,7 @@ function create_sub_menu($menu, $active_level1, $active_level2) {
 				}
 			}
 			$return .= ('</small></td>');
-		}
-		else {
+		} else {
 			// if it's not the first entry we have to put
 			// additional empty cell for the spacer
 			//if ($number > 0)

--- a/lib/Default/Menu.class.php
+++ b/lib/Default/Menu.class.php
@@ -247,9 +247,10 @@ class Menu {
 		$menu_items[] = create_link(create_container('skeleton.php', 'bank_personal.php'),
 														'Personal Account', 'nav');
 
-		if ($player->hasAlliance())
+		if ($player->hasAlliance()) {
 			$menu_items[] = create_link(create_container('skeleton.php', 'bank_alliance.php'),
 															'Alliance Account', 'nav');
+		}
 
 		$menu_items[] = create_link(create_container('skeleton.php', 'bank_anon.php'),
 														'Anonymous Account', 'nav');
@@ -272,12 +273,14 @@ class Menu {
 		$menu_items[] = create_link($container, 'Send Message', 'nav');
 
 		if ($player->getRaceID() == $race_id) {
-			if ($player->isOnCouncil())
+			if ($player->isOnCouncil()) {
 				$menu_items[] = create_link(create_container('skeleton.php', 'council_vote.php'),
 																'Voting Center', 'nav');
-			if ($player->isPresident())
+			}
+			if ($player->isPresident()) {
 				$menu_items[] = create_link(create_container('skeleton.php', 'council_embassy.php'),
 																'Embassy', 'nav');
+			}
 		}
 
 		create_menu($menu_items);
@@ -306,8 +309,9 @@ class Menu {
 	public static function navigation(Template $template, AbstractSmrPlayer $player) {
 		$menuItems = array();
 		$menuItems[] = array('Link'=>Globals::getPlotCourseHREF(), 'Text'=>'Plot A Course');
-		if (!$player->isLandedOnPlanet())
+		if (!$player->isLandedOnPlanet()) {
 			$menuItems[] = array('Link'=>Globals::getLocalMapHREF(), 'Text'=>'Local Map');
+		}
 		$menuItems[] = array('Link'=>'map_galaxy.php" target="gal_map', 'Text'=>'Galaxy Map');
 		$template->assign('MenuItems', $menuItems);
 	}
@@ -328,14 +332,16 @@ function create_sub_menu($menu, $active_level1, $active_level2) {
 	$return .= ('<tr>');
 	foreach ($menu as $number => $entry) {
 		// insert spacer
-		if ($number > 0)
+		if ($number > 0) {
 			$return .= ('<td>&nbsp;|&nbsp;</td>');
+		}
 
 		// if this is the active entry we mark it
-		if ($number == $active_level1)
+		if ($number == $active_level1) {
 			$active = ' class="bold"';
-		else
+		} else {
 			$active = '';
+		}
 
 		// echo entry itself
 		$return .= ('<td ' . $active . '> ' . $entry['entry'] . '</td>');
@@ -349,13 +355,15 @@ function create_sub_menu($menu, $active_level1, $active_level2) {
 		if (isset($entry['submenu']) && $number == $active_level1) {
 			$return .= ('<td><small>');
 			foreach ($entry['submenu'] as $sub_number => $sub_entry) {
-				if ($sub_number > 0)
+				if ($sub_number > 0) {
 					$return .= (' | ');
+				}
 
-				if ($sub_number == $active_level2)
+				if ($sub_number == $active_level2) {
 					$return .= ('<span class="bold">' . $sub_entry . '</span>');
-				else
+				} else {
 					$return .= ($sub_entry);
+				}
 			}
 			$return .= ('</small></td>');
 		}

--- a/lib/Default/MySqlDatabase.class.php
+++ b/lib/Default/MySqlDatabase.class.php
@@ -63,8 +63,9 @@ abstract class MySqlDatabase {
 	}
 	
 	public function nextRecord() {
-		if (!$this->dbResult)
+		if (!$this->dbResult) {
 			$this->error('No resource to get record from.');
+		}
 		
 		if ($this->dbRecord = $this->dbResult->fetch_assoc()) {
 			return true;
@@ -81,8 +82,9 @@ abstract class MySqlDatabase {
 	}
 	
 	public function getBoolean($name) {
-		if ($this->dbRecord[$name] == 'TRUE')
+		if ($this->dbRecord[$name] == 'TRUE') {
 			return true;
+		}
 //		if($this->dbRecord[$name] == 'FALSE')
 		return false;
 //		throw new Exception('Field is not a boolean');
@@ -116,8 +118,9 @@ abstract class MySqlDatabase {
 	
 	public function getObject($name, $compressed = false) {
 		$object = $this->getField($name);
-		if ($compressed === true)
+		if ($compressed === true) {
 			$object = gzuncompress($object);
+		}
 		return unserialize($object);
 	}
 	
@@ -159,38 +162,43 @@ abstract class MySqlDatabase {
 	
 	public function escape($escape, $autoQuotes = true, $quotes = true) {
 		if (is_bool($escape)) {
-			if ($autoQuotes)
+			if ($autoQuotes) {
 				return $this->escapeBoolean($escape);
-			else
+			} else {
 				return $this->escapeBoolean($escape, $quotes);
+			}
 		}
 		if (is_numeric($escape)) {
 			return $this->escapeNumber($escape);
 		}
 		if (is_string($escape)) {
-			if ($autoQuotes)
+			if ($autoQuotes) {
 				return $this->escapeString($escape);
-			else
+			} else {
 				return $this->escapeString($escape, $quotes);
+			}
 		}
 		if (is_array($escape)) {
 			return $this->escapeArray($escape, $autoQuotes, $quotes);
 		}
 		if (is_object($escape)) {
-			if ($autoQuotes)
+			if ($autoQuotes) {
 				return $this->escapeObject($escape);
-			else
+			} else {
 				return $this->escapeObject($escape, $quotes);
+			}
 		}
 	}
 	
 	public function escapeString($string, $quotes = true, $nullable = false) {
-		if ($nullable === true && ($string === null || $string === ''))
+		if ($nullable === true && ($string === null || $string === '')) {
 			return 'NULL';
-		if ($string === true)
+		}
+		if ($string === true) {
 			$string = 'TRUE';
-		else if ($string === false)
+		} else if ($string === false) {
 			$string = 'FALSE';
+		}
 		if (is_array($string)) {
 			$escapedString = '';
 			foreach ($string as $value) {
@@ -212,10 +220,11 @@ abstract class MySqlDatabase {
 		$string = '';
 		if ($escapeIndividually) {
 			foreach ($array as $value) {
-				if (is_array($value))
+				if (is_array($value)) {
 					$string .= $this->escapeArray($value, $autoQuotes, $quotes, $implodeString, $escapeIndividually) . $implodeString;
-				else
+				} else {
 					$string .= $this->escape($value, $autoQuotes, $quotes) . $implodeString;
+				}
 			}
 			$string = substr($string, 0, -1);
 		}
@@ -252,8 +261,9 @@ abstract class MySqlDatabase {
 	}
 	
 	public function escapeObject($object, $compress = false, $quotes = true, $nullable = false) {
-		if ($compress === true)
+		if ($compress === true) {
 			return $this->escapeBinary(gzcompress(serialize($object)));
+		}
 		return $this->escapeString(serialize($object), $quotes, $nullable);
 	}
 

--- a/lib/Default/MySqlDatabase.class.php
+++ b/lib/Default/MySqlDatabase.class.php
@@ -227,8 +227,7 @@ abstract class MySqlDatabase {
 				}
 			}
 			$string = substr($string, 0, -1);
-		}
-		else {
+		} else {
 			$string = $this->escape(implode($implodeString, $array), $autoQuotes, $quotes);
 		}
 		return $string;

--- a/lib/Default/Plotter.class.php
+++ b/lib/Default/Plotter.class.php
@@ -137,8 +137,7 @@ class Plotter {
 					$checkSector = SmrSector::getSector($gameID, $checkSectorID);
 					if ($x == 'Distance') {
 						$distances[$sectorsTravelled][$checkSector->getSectorID()] = $distance;
-					}
-					else if (($needsToHaveBeenExploredBy === null || $needsToHaveBeenExploredBy->hasVisitedSector($checkSector->getSectorID())) === true
+					} else if (($needsToHaveBeenExploredBy === null || $needsToHaveBeenExploredBy->hasVisitedSector($checkSector->getSectorID())) === true
 							&& $checkSector->hasX($x, $player) === true) {
 						if ($useFirst === true) {
 							return $distance;

--- a/lib/Default/Plotter.class.php
+++ b/lib/Default/Plotter.class.php
@@ -92,12 +92,14 @@ class Plotter {
 		$sectorsTravelled = 0;
 		$visitedSectors = array();
 		$visitedSectors[$checkSector->getSectorID()] = true;
-		if ($x == 'Distance')
+		if ($x == 'Distance') {
 			$distances[0][$checkSector->getSectorID()] = new Distance($gameID, $checkSector->getSectorID());
+		}
 
 		$distanceQ = array();
-		for ($i = 0; $i <= TURNS_WARP_SECTOR_EQUIVALENCE; $i++)
+		for ($i = 0; $i <= TURNS_WARP_SECTOR_EQUIVALENCE; $i++) {
 			$distanceQ[] = array();
+		}
 		//Warps first as a slight optimisation due to how visitedSectors is set.
 		if ($checkSector->hasWarp() === true) {
 			$d = new Distance($gameID, $checkSector->getSectorID());
@@ -115,8 +117,9 @@ class Plotter {
 		$maybeWarps = 0;
 		while ($maybeWarps <= TURNS_WARP_SECTOR_EQUIVALENCE) {
 			$sectorsTravelled++;
-			if ($sectorsTravelled > $distanceLimit)
+			if ($sectorsTravelled > $distanceLimit) {
 				return $distances;
+			}
 			if ($x == 'Distance') {
 				$distances[$sectorsTravelled] = array();
 			}
@@ -137,8 +140,9 @@ class Plotter {
 					}
 					else if (($needsToHaveBeenExploredBy === null || $needsToHaveBeenExploredBy->hasVisitedSector($checkSector->getSectorID())) === true
 							&& $checkSector->hasX($x, $player) === true) {
-						if ($useFirst === true)
+						if ($useFirst === true) {
 							return $distance;
+						}
 						$distances[$checkSector->getSectorID()] = $distance;
 					}
 					//Warps first as a slight optimisation due to how visitedSectors is set.

--- a/lib/Default/Routes/OneWayRoute.class.php
+++ b/lib/Default/Routes/OneWayRoute.class.php
@@ -82,10 +82,11 @@ class OneWayRoute extends Route {
 	}
 
 	public function getTurnsForRoute() : int {
-		if ($this->goodId === GOOD_NOTHING)
+		if ($this->goodId === GOOD_NOTHING) {
 			$tradeTurns = 0;
-		else
+		} else {
 			$tradeTurns = 2 * TURNS_PER_TRADE;
+		}
 		return $this->distance->getTurns() + $tradeTurns;
 	}
 

--- a/lib/Default/Routes/RouteGenerator.class.php
+++ b/lib/Default/Routes/RouteGenerator.class.php
@@ -50,8 +50,9 @@ class RouteGenerator {
 	private static function getContinueRoutes(int $maxNumPorts, int $startSectorId, Route $routeToContinue, array $forwardRoutes, array $routeLists, bool $lastGoodIsNothing) : void {
 		foreach ($forwardRoutes as $currentStepRoute) {
 			$currentStepBuySector = $currentStepRoute->getBuySectorId();
-			if ($lastGoodIsNothing && ($lastGoodIsNothing = GOOD_NOTHING === $currentStepRoute->getGoodID()))
+			if ($lastGoodIsNothing && ($lastGoodIsNothing = GOOD_NOTHING === $currentStepRoute->getGoodID())) {
 				continue; // Don't do two nothings in a row
+			}
 			if ($currentStepBuySector >= $startSectorId) { // Not already checked or back to start
 				if ($currentStepBuySector === $startSectorId) { // Route returns to start
 					$mpr = new MultiplePortRoute($routeToContinue, $currentStepRoute);
@@ -74,17 +75,21 @@ class RouteGenerator {
 				echo 'Error with Race ID: '.$sectors[$currentSectorId]->getPort()->getRaceID();
 				continue;
 			}
-			if($races[$raceID]===false)
+			if($races[$raceID]===false) {
 				continue;
+			}
 			$rl = array();
 			foreach ($d as $targetSectorId => $distance) {
-				if (!$races[$sectors[$targetSectorId]->getPort()->getRaceID()])
+				if (!$races[$sectors[$targetSectorId]->getPort()->getRaceID()]) {
 					continue;
-				if($routesForPort!==-1 && $currentSectorId !== $routesForPort && $targetSectorId !== $routesForPort)
+				}
+				if($routesForPort!==-1 && $currentSectorId !== $routesForPort && $targetSectorId !== $routesForPort) {
 					continue;
+				}
 
-				if ($goods[GOOD_NOTHING]===true)
+				if ($goods[GOOD_NOTHING]===true) {
 					$rl[] = new OneWayRoute($currentSectorId, $targetSectorId, $raceID, $sectors[$targetSectorId]->getPort()->getRaceID(), 0, 0, $distance, GOOD_NOTHING);
+				}
 
 				foreach (\Globals::getGoods() as $goodId => $value) {
 					if ($goods[$goodId]===true) {
@@ -103,13 +108,16 @@ class RouteGenerator {
 	public static function generateOneWayRoutes(array $sectors, array $distances, array $goods, array $races, int $routesForPort) : array {
 		self::initialize();
 		foreach ($distances as $currentSectorId => $d) {
-			if ($races[$sectors[$currentSectorId]->getPort()->getRaceID()]===false)
+			if ($races[$sectors[$currentSectorId]->getPort()->getRaceID()]===false) {
 				continue;
+			}
 			foreach ($d as $targetSectorId => $distance) {
-				if ($races[$sectors[$targetSectorId]->getPort()->getRaceID()]===false)
+				if ($races[$sectors[$targetSectorId]->getPort()->getRaceID()]===false) {
 					continue;
-				if($routesForPort!==-1 && $currentSectorId !== $routesForPort && $targetSectorId !== $routesForPort)
+				}
+				if($routesForPort!==-1 && $currentSectorId !== $routesForPort && $targetSectorId !== $routesForPort) {
 					continue;
+				}
 
 				foreach (\Globals::getGoods() as $goodId => $value) {
 					if ($goods[$goodId]===true) {
@@ -167,8 +175,9 @@ class RouteGenerator {
 			else {
 				foreach($routesByMulti as $key => $value) {
 					$i++;
-					if($i < $trimToBestXRoutes)
+					if($i < $trimToBestXRoutes) {
 						continue;
+					}
 					if($i === $trimToBestXRoutes) {
 						self::$dontAddWorseThan[self::EXP_ROUTE] = $multi;
 						continue;
@@ -191,8 +200,9 @@ class RouteGenerator {
 			else {
 				foreach($routesByMulti as $key => $value) {
 					$i++;
-					if($i < $trimToBestXRoutes)
+					if($i < $trimToBestXRoutes) {
 						continue;
+					}
 					if($i === $trimToBestXRoutes) {
 						self::$dontAddWorseThan[self::MONEY_ROUTE] = $multi;
 						continue;

--- a/lib/Default/Routes/RouteGenerator.class.php
+++ b/lib/Default/Routes/RouteGenerator.class.php
@@ -58,8 +58,7 @@ class RouteGenerator {
 					$mpr = new MultiplePortRoute($routeToContinue, $currentStepRoute);
 					self::addExpRoute($mpr);
 					self::addMoneyRoute($mpr);
-				}
-				else if ($maxNumPorts > 1 && !$routeToContinue->containsPort($currentStepBuySector)) {
+				} else if ($maxNumPorts > 1 && !$routeToContinue->containsPort($currentStepBuySector)) {
 					$mpr = new MultiplePortRoute($routeToContinue, $currentStepRoute);
 					self::getContinueRoutes($maxNumPorts - 1, $startSectorId, $mpr, $routeLists[$currentStepBuySector], $routeLists, $lastGoodIsNothing);
 				}
@@ -71,11 +70,11 @@ class RouteGenerator {
 		$routes = array();
 		foreach ($distances as $currentSectorId => $d) {
 			$raceID = $sectors[$currentSectorId]->getPort()->getRaceID();
-			if (isset($races[$raceID])===false) {
-				echo 'Error with Race ID: '.$sectors[$currentSectorId]->getPort()->getRaceID();
+			if (isset($races[$raceID]) === false) {
+				echo 'Error with Race ID: ' . $sectors[$currentSectorId]->getPort()->getRaceID();
 				continue;
 			}
-			if($races[$raceID]===false) {
+			if ($races[$raceID] === false) {
 				continue;
 			}
 			$rl = array();
@@ -83,16 +82,16 @@ class RouteGenerator {
 				if (!$races[$sectors[$targetSectorId]->getPort()->getRaceID()]) {
 					continue;
 				}
-				if($routesForPort!==-1 && $currentSectorId !== $routesForPort && $targetSectorId !== $routesForPort) {
+				if ($routesForPort !== -1 && $currentSectorId !== $routesForPort && $targetSectorId !== $routesForPort) {
 					continue;
 				}
 
-				if ($goods[GOOD_NOTHING]===true) {
+				if ($goods[GOOD_NOTHING] === true) {
 					$rl[] = new OneWayRoute($currentSectorId, $targetSectorId, $raceID, $sectors[$targetSectorId]->getPort()->getRaceID(), 0, 0, $distance, GOOD_NOTHING);
 				}
 
 				foreach (\Globals::getGoods() as $goodId => $value) {
-					if ($goods[$goodId]===true) {
+					if ($goods[$goodId] === true) {
 						if ($sectors[$currentSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_SELLS &&
 						    $sectors[$targetSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_BUYS) {
 							$rl[] = new OneWayRoute($currentSectorId, $targetSectorId, $raceID, $sectors[$targetSectorId]->getPort()->getRaceID(), $sectors[$currentSectorId]->getPort()->getGoodDistance($goodId), $sectors[$targetSectorId]->getPort()->getGoodDistance($goodId), $distance, $goodId);
@@ -108,19 +107,19 @@ class RouteGenerator {
 	public static function generateOneWayRoutes(array $sectors, array $distances, array $goods, array $races, int $routesForPort) : array {
 		self::initialize();
 		foreach ($distances as $currentSectorId => $d) {
-			if ($races[$sectors[$currentSectorId]->getPort()->getRaceID()]===false) {
+			if ($races[$sectors[$currentSectorId]->getPort()->getRaceID()] === false) {
 				continue;
 			}
 			foreach ($d as $targetSectorId => $distance) {
-				if ($races[$sectors[$targetSectorId]->getPort()->getRaceID()]===false) {
+				if ($races[$sectors[$targetSectorId]->getPort()->getRaceID()] === false) {
 					continue;
 				}
-				if($routesForPort!==-1 && $currentSectorId !== $routesForPort && $targetSectorId !== $routesForPort) {
+				if ($routesForPort !== -1 && $currentSectorId !== $routesForPort && $targetSectorId !== $routesForPort) {
 					continue;
 				}
 
 				foreach (\Globals::getGoods() as $goodId => $value) {
-					if ($goods[$goodId]===true) {
+					if ($goods[$goodId] === true) {
 						if ($sectors[$currentSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_SELLS &&
 						    $sectors[$targetSectorId]->getPort()->getGoodTransaction($goodId) === self::GOOD_BUYS) {
 							$owr = new OneWayRoute($currentSectorId, $targetSectorId, $sectors[$currentSectorId]->getPort()->getRaceID(), $sectors[$targetSectorId]->getPort()->getRaceID(), $sectors[$currentSectorId]->getPort()->getGoodDistance($goodId), $sectors[$targetSectorId]->getPort()->getGoodDistance($goodId), $distance, $goodId);
@@ -166,19 +165,19 @@ class RouteGenerator {
 		$i = 0;
 		krsort(self::$expRoutes, SORT_NUMERIC);
 		foreach (self::$expRoutes as $multi => $routesByMulti) {
-			if(count($routesByMulti)+$i < $trimToBestXRoutes) {
+			if (count($routesByMulti) + $i < $trimToBestXRoutes) {
 				$i += count($routesByMulti);
 			}
-			else if($i > $trimToBestXRoutes) {
+			else if ($i > $trimToBestXRoutes) {
 				unset(self::$expRoutes[$multi]);
 			}
 			else {
-				foreach($routesByMulti as $key => $value) {
+				foreach ($routesByMulti as $key => $value) {
 					$i++;
-					if($i < $trimToBestXRoutes) {
+					if ($i < $trimToBestXRoutes) {
 						continue;
 					}
-					if($i === $trimToBestXRoutes) {
+					if ($i === $trimToBestXRoutes) {
 						self::$dontAddWorseThan[self::EXP_ROUTE] = $multi;
 						continue;
 					}
@@ -190,20 +189,20 @@ class RouteGenerator {
 		$i = 0;
 		krsort(self::$moneyRoutes, SORT_NUMERIC);
 		foreach (self::$moneyRoutes as $multi => $routesByMulti) {
-			if(count($routesByMulti)+$i < $trimToBestXRoutes) {
+			if (count($routesByMulti) + $i < $trimToBestXRoutes) {
 				$i += count($routesByMulti);
 			}
-			else if($i > $trimToBestXRoutes) {
+			else if ($i > $trimToBestXRoutes) {
 				unset(self::$moneyRoutes[$multi]);
 				continue;
 			}
 			else {
-				foreach($routesByMulti as $key => $value) {
+				foreach ($routesByMulti as $key => $value) {
 					$i++;
-					if($i < $trimToBestXRoutes) {
+					if ($i < $trimToBestXRoutes) {
 						continue;
 					}
-					if($i === $trimToBestXRoutes) {
+					if ($i === $trimToBestXRoutes) {
 						self::$dontAddWorseThan[self::MONEY_ROUTE] = $multi;
 						continue;
 					}

--- a/lib/Default/SmrCombatDrones.class.php
+++ b/lib/Default/SmrCombatDrones.class.php
@@ -85,8 +85,9 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 		$weaponShip = $weaponPlayer->getShip();
 		$targetShip = $targetPlayer->getShip();
 		$mrDiff = $targetShip->getMR() - $weaponShip->getMR();
-		if ($mrDiff > 0)
+		if ($mrDiff > 0) {
 			$modifiedAccuracy -= $this->getBaseAccuracy() * ($mrDiff / MR_FACTOR) / 100;
+		}
 	
 		return max(0, min(100, $modifiedAccuracy));
 	}

--- a/lib/Default/SmrCombatDrones.class.php
+++ b/lib/Default/SmrCombatDrones.class.php
@@ -13,8 +13,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			$this->maxDamage = 2;
 			$this->shieldDamage = 2;
 			$this->armourDamage = 2;
-		}
-		else {
+		} else {
 			$this->maxDamage = 1;
 			$this->shieldDamage = 1;
 			$this->armourDamage = 1;
@@ -129,8 +128,10 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 	}
 	
 	public function &getModifiedDamageAgainstForces(AbstractSmrPlayer $weaponPlayer, SmrForce $forces) {
-		if (!$this->canShootForces()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
+		if (!$this->canShootForces()) {
+			// If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
+		}
 		$damage =& $this->getModifiedDamage();
 		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstForces($weaponPlayer, $forces) / 100);
 		$damage['Kamikaze'] = 0;
@@ -151,8 +152,10 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 	}
 	
 	public function &getModifiedDamageAgainstPort(AbstractSmrPlayer $weaponPlayer, SmrPort $port) {
-		if (!$this->canShootPorts()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
+		if (!$this->canShootPorts()) {
+			// If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
+		}
 		$damage =& $this->getModifiedDamage();
 		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPort($weaponPlayer, $port) / 100);
 		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
@@ -163,8 +166,10 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 	}
 	
 	public function &getModifiedDamageAgainstPlanet(AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet) {
-		if (!$this->canShootPlanets()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
+		if (!$this->canShootPlanets()) {
+			// If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
+		}
 		$damage =& $this->getModifiedDamage();
 		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPlanet($weaponPlayer, $planet) / 100);
 		$planetMod = self::PLANET_DAMAGE_MOD;

--- a/lib/Default/SmrForce.class.php
+++ b/lib/Default/SmrForce.class.php
@@ -279,8 +279,7 @@ class SmrForce {
 		// Changed (26/10/05) - scout drones count * 2
 		if ($this->getCDs() == 0 && $this->getMines() == 0 && $this->getSDs() > 0) {
 			$time = self::TIME_PER_SCOUT_ONLY * $this->getSDs();
-		}
-		else {
+		} else {
 			$time = ($this->getCDs() * self::TIME_PERCENT_PER_COMBAT + $this->getSDs() * self::TIME_PERCENT_PER_SCOUT + $this->getMines() * self::TIME_PERCENT_PER_MINE) * $this->getMaxGalaxyExpireTime();
 		}
 		$this->setExpire(TIME + $time);
@@ -307,11 +306,9 @@ class SmrForce {
 		}
 		if ($mines < 10) {
 			$turns = 1;
-		}
-		else if ($mines < 25) {
+		} else if ($mines < 25) {
 			$turns = 2;
-		}
-		else {
+		} else {
 			$turns = 3;
 		}
 		if ($ship->isFederal() || $ship->hasDCS()) {
@@ -366,12 +363,10 @@ class SmrForce {
 			if (!$this->exists()) {
 				$this->db->query('DELETE FROM sector_has_forces WHERE ' . $this->SQL);
 				$this->isNew = true;
-			}
-			else if ($this->hasChanged) {
+			} else if ($this->hasChanged) {
 				$this->db->query('UPDATE sector_has_forces SET combat_drones = ' . $this->db->escapeNumber($this->combatDrones) . ', scout_drones = ' . $this->db->escapeNumber($this->scoutDrones) . ', mines = ' . $this->db->escapeNumber($this->mines) . ', expire_time = ' . $this->db->escapeNumber($this->expire) . ' WHERE ' . $this->SQL);
 			}
-		}
-		else if ($this->exists()) {
+		} else if ($this->exists()) {
 			$this->db->query('INSERT INTO sector_has_forces (game_id, sector_id, owner_id, combat_drones, scout_drones, mines, expire_time)
 								VALUES('.$this->db->escapeNumber($this->gameID) . ', ' . $this->db->escapeNumber($this->sectorID) . ', ' . $this->db->escapeNumber($this->ownerID) . ', ' . $this->db->escapeNumber($this->combatDrones) . ', ' . $this->db->escapeNumber($this->scoutDrones) . ', ' . $this->db->escapeNumber($this->mines) . ', ' . $this->db->escapeNumber($this->expire) . ')');
 			$this->isNew = false;

--- a/lib/Default/SmrForce.class.php
+++ b/lib/Default/SmrForce.class.php
@@ -270,8 +270,9 @@ class SmrForce {
 		}
 		$this->hasChanged = true;
 		$this->expire = $time;
-		if (!$this->isNew)
+		if (!$this->isNew) {
 			$this->update();
+		}
 	}
 
 	public function updateExpire() {

--- a/lib/Default/SmrPlanet.class.php
+++ b/lib/Default/SmrPlanet.class.php
@@ -580,13 +580,16 @@ class SmrPlanet {
 			// get supplies from db
 			$this->db->query('SELECT good_id, amount FROM planet_has_cargo WHERE ' . $this->SQL);
 			// adding cargo and amount to array
-			while ($this->db->nextRecord())
+			while ($this->db->nextRecord()) {
 				$this->stockpile[$this->db->getInt('good_id')] = $this->db->getInt('amount');
+			}
 		}
-		if ($goodID === false)
+		if ($goodID === false) {
 			return $this->stockpile;
-		if (isset($this->stockpile[$goodID]))
+		}
+		if (isset($this->stockpile[$goodID])) {
 			return $this->stockpile[$goodID];
+		}
 		return 0;
 	}
 
@@ -612,14 +615,16 @@ class SmrPlanet {
 	}
 
 	public function decreaseStockpile($goodID, $amount) {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to decrease negative stockpile.');
+		}
 		$this->setStockpile($goodID, $this->getStockpile($goodID) - $amount);
 	}
 
 	public function increaseStockpile($goodID, $amount) {
-		if ($amount < 0)
+		if ($amount < 0) {
 			throw new Exception('Trying to increase negative stockpile.');
+		}
 		$this->setStockpile($goodID, $this->getStockpile($goodID) + $amount);
 	}
 
@@ -653,8 +658,9 @@ class SmrPlanet {
 	}
 
 	public function setBuilding($buildingTypeID, $number) {
-		if ($this->getBuilding($buildingTypeID) == $number)
+		if ($this->getBuilding($buildingTypeID) == $number) {
 			return;
+		}
 
 		$this->buildings[$buildingTypeID] = $number;
 		$this->hasChangedBuildings[$buildingTypeID] = true;
@@ -1106,23 +1112,27 @@ class SmrPlanet {
 	}
 
 	public function hasEnemyTraders(AbstractSmrPlayer $player) {
-		if (!$this->hasOtherTraders($player))
+		if (!$this->hasOtherTraders($player)) {
 			return false;
+		}
 		$otherPlayers = $this->getOtherTraders($player);
 		foreach ($otherPlayers as $otherPlayer) {
-			if (!$player->traderNAPAlliance($otherPlayer))
+			if (!$player->traderNAPAlliance($otherPlayer)) {
 				return true;
+			}
 		}
 		return false;
 	}
 
 	public function hasFriendlyTraders(AbstractSmrPlayer $player) {
-		if (!$this->hasOtherTraders($player))
+		if (!$this->hasOtherTraders($player)) {
 			return false;
+		}
 		$otherPlayers = $this->getOtherTraders($player);
 		foreach ($otherPlayers as $otherPlayer) {
-			if ($player->traderNAPAlliance($otherPlayer))
+			if ($player->traderNAPAlliance($otherPlayer)) {
 				return true;
+			}
 		}
 		return false;
 	}

--- a/lib/Default/SmrPlanet.class.php
+++ b/lib/Default/SmrPlanet.class.php
@@ -151,26 +151,19 @@ class SmrPlanet {
 		$level = $this->getLevel();
 		if ($level < 9) {
 			return .0404;
-		}
-		elseif ($level < 19) {
+		} elseif ($level < 19) {
 			return .0609;
-		}
-		elseif ($level < 29) {
+		} elseif ($level < 29) {
 			return .1236;
-		}
-		elseif ($level < 39) {
+		} elseif ($level < 39) {
 			return .050625;
-		}
-		elseif ($level < 49) {
+		} elseif ($level < 49) {
 			return .0404;
-		}
-		elseif ($level < 59) {
+		} elseif ($level < 59) {
 			return .030225;
-		}
-		elseif ($level < 69) {
+		} elseif ($level < 69) {
 			return .0201;
-		}
-		else {
+		} else {
 			return .018081;
 		}
 	}
@@ -383,8 +376,7 @@ class SmrPlanet {
 		}
 		if ($delayed === false) {
 			$this->setShields($this->getShields() - $number);
-		}
-		else {
+		} else {
 			$this->delayedShieldsDelta -= $number;
 		}
 	}
@@ -395,8 +387,7 @@ class SmrPlanet {
 		}
 		if ($delayed === false) {
 			$this->setShields($this->getShields() + $number);
-		}
-		else {
+		} else {
 			$this->delayedShieldsDelta += $number;
 		}
 	}
@@ -428,8 +419,7 @@ class SmrPlanet {
 		}
 		if ($delayed === false) {
 			$this->setArmour($this->getArmour() - $number);
-		}
-		else {
+		} else {
 			$this->delayedArmourDelta -= $number;
 		}
 	}
@@ -440,8 +430,7 @@ class SmrPlanet {
 		}
 		if ($delayed === false) {
 			$this->setArmour($this->getArmour() + $number);
-		}
-		else {
+		} else {
 			$this->delayedArmourDelta += $number;
 		}
 	}
@@ -473,8 +462,7 @@ class SmrPlanet {
 		}
 		if ($delayed === false) {
 			$this->setCDs($this->getCDs() - $number);
-		}
-		else {
+		} else {
 			$this->delayedCDsDelta -= $number;
 		}
 	}
@@ -485,8 +473,7 @@ class SmrPlanet {
 		}
 		if ($delayed === false) {
 			$this->setCDs($this->getCDs() + $number);
-		}
-		else {
+		} else {
 			$this->delayedCDsDelta += $number;
 		}
 	}
@@ -597,8 +584,7 @@ class SmrPlanet {
 		if ($goodID === false) {
 			$stockpile = $this->getStockpile($goodID);
 			return count($stockpile) > 0 && max($stockpile) > 0;
-		}
-		else {
+		} else {
 			return $this->getStockpile($goodID) > 0;
 		}
 	}
@@ -832,8 +818,7 @@ class SmrPlanet {
 				if ($amount != 0) {
 					$this->db->query('REPLACE INTO planet_has_cargo (game_id, sector_id, good_id, amount) ' .
 										 'VALUES(' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getSectorID()) . ', ' . $this->db->escapeNumber($id) . ', ' . $this->db->escapeNumber($amount) . ')');
-				}
-				else {
+				} else {
 					$this->db->query('DELETE FROM planet_has_cargo WHERE ' . $this->SQL . '
 										AND good_id = ' . $this->db->escapeNumber($id));
 				}
@@ -862,8 +847,7 @@ class SmrPlanet {
 				if ($this->hasBuilding($id)) {
 					$this->db->query('REPLACE INTO planet_has_building (game_id, sector_id, construction_id, amount) ' .
 										'VALUES(' . $this->db->escapeNumber($this->gameID) . ', ' . $this->db->escapeNumber($this->sectorID) . ', ' . $this->db->escapeNumber($id) . ', ' . $this->db->escapeNumber($this->getBuilding($id)) . ')');
-				}
-				else {
+				} else {
 					$this->db->query('DELETE FROM planet_has_building WHERE ' . $this->SQL . '
 										AND construction_id = ' . $this->db->escapeNumber($id));
 				}
@@ -1237,8 +1221,7 @@ class SmrPlanet {
 					}
 				}
 
-			}
-			else { // hit drones behind shields - we should only use this reduced damage branch if we cannot hit shields.
+			} else { // hit drones behind shields - we should only use this reduced damage branch if we cannot hit shields.
 				$cdDamage = $this->doCDDamage(IFloor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT), $delayed);
 			}
 		}

--- a/lib/Default/SmrPlayer.class.php
+++ b/lib/Default/SmrPlayer.class.php
@@ -59,8 +59,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	public static function getSectorPlayersByAlliances($gameID, $sectorID, array $allianceIDs, $forceUpdate = false) {
 		$players = self::getSectorPlayers($gameID, $sectorID, $forceUpdate); // Don't use & as we do an unset
 		foreach ($players as $accountID => $player) {
-			if (!in_array($player->getAllianceID(), $allianceIDs))
+			if (!in_array($player->getAllianceID(), $allianceIDs)) {
 				unset($players[$accountID]);
+			}
 		}
 		return $players;
 	}
@@ -286,22 +287,25 @@ class SmrPlayer extends AbstractSmrPlayer {
 	protected function setZoom($zoom) {
 		// Set the zoom level between [1, 9]
 		$zoom = max(1, min(9, $zoom));
-		if ($this->zoom == $zoom)
+		if ($this->zoom == $zoom) {
 			return;
+		}
 		$this->zoom = $zoom;
 		$this->hasChanged = true;
 //		$this->db->query('UPDATE player SET zoom = ' . $zoom . ' WHERE ' . $this->SQL . ' LIMIT 1');
 	}
 
 	public function increaseZoom($zoom) {
-		if ($zoom < 0)
+		if ($zoom < 0) {
 			throw new Exception('Trying to increase negative zoom.');
+		}
 		$this->setZoom($this->getZoom() + $zoom);
 	}
 
 	public function decreaseZoom($zoom) {
-		if ($zoom < 0)
+		if ($zoom < 0) {
 			throw new Exception('Trying to decrease negative zoom.');
+		}
 		$this->setZoom($this->getZoom() - $zoom);
 	}
 
@@ -316,8 +320,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function setLastSectorID($lastSectorID) {
-		if ($this->lastSectorID == $lastSectorID)
+		if ($this->lastSectorID == $lastSectorID) {
 			return;
+		}
 		$this->lastSectorID = $lastSectorID;
 		$this->hasChanged = true;
 //		$this->db->query('UPDATE player SET last_sector_id = '.$this->lastSectorID.' WHERE '.$this->SQL.' LIMIT 1');
@@ -382,8 +387,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	private function setAllianceJoinable($time) {
-		if ($this->allianceJoinable == $time)
+		if ($this->allianceJoinable == $time) {
 			return;
+		}
 		$this->allianceJoinable = $time;
 		$this->hasChanged = true;
 	}
@@ -393,8 +399,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function setAttackColour($colour) {
-		if ($this->attackColour == $colour)
+		if ($this->attackColour == $colour) {
 			return;
+		}
 		$this->attackColour = $colour;
 		$this->hasChanged = true;
 //		$this->db->query('UPDATE player SET attack_warning = ' . $this->db->escapeString($this->attackColour) . ' WHERE ' . $this->SQL . ' LIMIT 1');
@@ -405,28 +412,35 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function increaseBank($credits) {
-		if ($credits < 0)
+		if ($credits < 0) {
 			throw new Exception('Trying to increase negative credits.');
-		if ($credits == 0)
+		}
+		if ($credits == 0) {
 			return;
+		}
 		$credits += $this->bank;
 		$this->setBank($credits);
 	}
 	public function decreaseBank($credits) {
-		if ($credits < 0)
+		if ($credits < 0) {
 			throw new Exception('Trying to decrease negative credits.');
-		if ($credits == 0)
+		}
+		if ($credits == 0) {
 			return;
+		}
 		$credits = $this->bank - $credits;
 		$this->setBank($credits);
 	}
 	public function setBank($credits) {
-		if ($this->bank == $credits)
+		if ($this->bank == $credits) {
 			return;
-		if ($credits < 0)
+		}
+		if ($credits < 0) {
 			throw new Exception('Trying to set negative credits.');
-		if ($credits > MAX_MONEY)
+		}
+		if ($credits > MAX_MONEY) {
 			throw new Exception('Trying to set more than max credits.');
+		}
 		$this->bank = $credits;
 		$this->hasChanged = true;
 //		$this->db->query('UPDATE player SET bank = '.$this->bank.' WHERE '.$this->SQL.' LIMIT 1');
@@ -437,8 +451,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	private function setLastNewsUpdate($time) {
-		if ($this->lastNewsUpdate == $time)
+		if ($this->lastNewsUpdate == $time) {
 			return;
+		}
 		$this->lastNewsUpdate = $time;
 		$this->hasChanged = true;
 //		$this->db->query('UPDATE player SET last_news_update = ' . $time . ' WHERE ' . $this->SQL . ' LIMIT 1');
@@ -504,8 +519,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function setIgnoreGlobals($bool) {
-		if ($this->ignoreGlobals == $bool)
+		if ($this->ignoreGlobals == $bool) {
 			return;
+		}
 		$this->ignoreGlobals = $bool;
 		$this->hasChanged = true;
 //		$this->db->query('UPDATE player SET ignore_globals = '.$this->db->escapeBoolean($bool).' WHERE '.$this->SQL.' LIMIT 1');
@@ -517,8 +533,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function setLastPort($lastPort) {
-		if ($this->lastPort == $lastPort)
+		if ($this->lastPort == $lastPort) {
 			return;
+		}
 		$this->lastPort = $lastPort;
 		$this->hasChanged = true;
 //		$this->db->query('UPDATE player SET last_port = ' . $this->lastPort . ' WHERE ' . $this->SQL . ' LIMIT 1');
@@ -529,8 +546,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function setDisplayMissions($bool) {
-		if ($this->displayMissions == $bool)
+		if ($this->displayMissions == $bool) {
 			return;
+		}
 		$this->displayMissions = $bool;
 		$this->hasChanged = true;
 	}
@@ -545,8 +563,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	 * which does not acquire a sector lock.
 	 */
 	public function setDisplayWeapons($bool) {
-		if ($this->displayWeapons == $bool)
+		if ($this->displayWeapons == $bool) {
 			return;
+		}
 		$this->displayWeapons = $bool;
 		$this->db->query('UPDATE player SET display_weapons=' . $this->db->escapeBoolean($this->displayWeapons) . ' WHERE ' . $this->SQL);
 	}
@@ -556,8 +575,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function setForceDropMessages($bool) {
-		if ($this->forceDropMessages == $bool)
+		if ($this->forceDropMessages == $bool) {
 			return;
+		}
 		$this->forceDropMessages = $bool;
 		$this->hasChanged = true;
 	}
@@ -589,8 +609,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function setLastTurnUpdate($time) {
-		if ($this->lastTurnUpdate == $time)
+		if ($this->lastTurnUpdate == $time) {
 			return;
+		}
 		$this->lastTurnUpdate = $time;
 		$this->hasChanged = true;
 //		$sql = $this->db->query('UPDATE player SET last_turn_update = ' . $this->lastTurnUpdate . ' WHERE '. $this->SQL . ' LIMIT 1');
@@ -630,27 +651,33 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function increaseRelations($relations, $raceID) {
-		if ($relations < 0)
+		if ($relations < 0) {
 			throw new Exception('Trying to increase negative relations.');
-		if ($relations == 0)
+		}
+		if ($relations == 0) {
 			return;
+		}
 		$relations += $this->getPureRelation($raceID);
 		$this->setRelations($relations, $raceID);
 	}
 	public function decreaseRelations($relations, $raceID) {
-		if ($relations < 0)
+		if ($relations < 0) {
 			throw new Exception('Trying to decrease negative relations.');
-		if ($relations == 0)
+		}
+		if ($relations == 0) {
 			return;
+		}
 		$relations = $this->getPureRelation($raceID) - $relations;
 		$this->setRelations($relations, $raceID);
 	}
 	public function setRelations($relations, $raceID) {
 		$this->getRelations();
-		if ($this->pureRelations[$raceID] == $relations)
+		if ($this->pureRelations[$raceID] == $relations) {
 			return;
-		if ($relations < MIN_RELATIONS)
+		}
+		if ($relations < MIN_RELATIONS) {
 			$relations = MIN_RELATIONS;
+		}
 		$relationsDiff = IRound($relations - $this->pureRelations[$raceID]);
 		$this->pureRelations[$raceID] = $relations;
 		$this->relations[$raceID] += $relationsDiff;
@@ -714,10 +741,12 @@ class SmrPlayer extends AbstractSmrPlayer {
 				$this->knowledge['Underground'] = 0;
 			}
 		}
-		if ($knowledgeType === false)
+		if ($knowledgeType === false) {
 			return $this->knowledge;
-		if (isset($this->knowledge[$knowledgeType]))
+		}
+		if (isset($this->knowledge[$knowledgeType])) {
 			return $this->knowledge[$knowledgeType];
+		}
 		return false;
 	}
 
@@ -730,9 +759,10 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$sector->diedHere($this);
 
 		// if we are in an alliance we increase their deaths
-		if ($this->hasAlliance())
+		if ($this->hasAlliance()) {
 			$this->db->query('UPDATE alliance SET alliance_deaths = alliance_deaths + 1
 							WHERE game_id = ' . $this->db->escapeNumber($this->getGameID()) . ' AND alliance_id = ' . $this->db->escapeNumber($this->getAllianceID()) . ' LIMIT 1');
+		}
 
 		// record death stat
 		$this->increaseHOF(1, array('Dying', 'Deaths'), HOF_PUBLIC);
@@ -745,8 +775,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$newCredits = IRound($this->getShip()->getCost() / 4);
 		$old_speed = $this->getShip()->getSpeed();
 
-		if ($newCredits < 100000)
+		if ($newCredits < 100000) {
 			$newCredits = 100000;
+		}
 		$this->setCredits($newCredits);
 
 		$this->setSectorID($this::getHome($this->getGameID(), $this->getRaceID()));
@@ -821,8 +852,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$relation = $relations[$killer->getRaceID()];
 
 		$alignChangePerRelation = 0.1;
-		if ($relation >= RELATIONS_PEACE || $relation <= RELATIONS_WAR)
+		if ($relation >= RELATIONS_PEACE || $relation <= RELATIONS_WAR) {
 			$alignChangePerRelation = 0.04;
+		}
 
 		$return['KillerAlign'] = -$relation * $alignChangePerRelation; //Lose relations when killing a peaceful race
 		if ($return['KillerAlign'] > 0) {
@@ -1098,11 +1130,12 @@ class SmrPlayer extends AbstractSmrPlayer {
 				$bountyChanged = false;
 				$bounty = $this->getBounty($key);
 				if ($bounty['New'] === true) {
-					if ($bounty['Amount'] > 0 || $bounty['SmrCredits'] > 0)
+					if ($bounty['Amount'] > 0 || $bounty['SmrCredits'] > 0) {
 						$this->db->query('INSERT INTO bounty (account_id,game_id,type,amount,smr_credits,claimer_id,time) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeString($bounty['Type']) . ',' . $this->db->escapeNumber($bounty['Amount']) . ',' . $this->db->escapeNumber($bounty['SmrCredits']) . ',' . $this->db->escapeNumber($bounty['Claimer']) . ',' . $this->db->escapeNumber($bounty['Time']) . ')');
+					}
 				}
 				else {
-					if ($bounty['Amount'] > 0 || $bounty['SmrCredits'] > 0)
+					if ($bounty['Amount'] > 0 || $bounty['SmrCredits'] > 0) {
 						$this->db->query('UPDATE bounty
 							SET amount=' . $this->db->escapeNumber($bounty['Amount']) . ',
 							smr_credits=' . $this->db->escapeNumber($bounty['SmrCredits']) . ',
@@ -1110,8 +1143,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 							claimer_id=' . $this->db->escapeNumber($bounty['Claimer']) . ',
 							time=' . $this->db->escapeNumber($bounty['Time']) . '
 							WHERE bounty_id=' . $this->db->escapeNumber($bounty['ID']) . ' AND ' . $this->SQL . ' LIMIT 1');
-					else
+					} else {
 						$this->db->query('DELETE FROM bounty WHERE bounty_id=' . $this->db->escapeNumber($bounty['ID']) . ' AND ' . $this->SQL . ' LIMIT 1');
+					}
 				}
 			}
 		}
@@ -1119,14 +1153,16 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function saveHOF() {
-		if ($this->hasHOFChanged !== false)
+		if ($this->hasHOFChanged !== false) {
 			$this->doHOFSave($this->hasHOFChanged);
+		}
 		if (!empty(self::$hasHOFVisChanged)) {
 			foreach (self::$hasHOFVisChanged as $hofType => $changeType) {
-				if ($changeType == self::HOF_NEW)
+				if ($changeType == self::HOF_NEW) {
 					$this->db->query('INSERT INTO hof_visibility (type, visibility) VALUES (' . $this->db->escapeString($hofType) . ',' . $this->db->escapeString(self::$HOFVis[$hofType]) . ')');
-				else
+				} else {
 					$this->db->query('UPDATE hof_visibility SET visibility = ' . $this->db->escapeString(self::$HOFVis[$hofType]) . ' WHERE type = ' . $this->db->escapeString($hofType) . ' LIMIT 1');
+				}
 				unset(self::$hasHOFVisChanged[$hofType]);
 			}
 		}
@@ -1141,8 +1177,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 			else {
 				$amount = $this->getHOF($tempTypeList);
 				if ($hofChanged == self::HOF_NEW) {
-					if ($amount > 0)
+					if ($amount > 0) {
 						$this->db->query('INSERT INTO player_hof (account_id,game_id,type,amount) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeArray($tempTypeList, false, true, ':', false) . ',' . $this->db->escapeNumber($amount) . ')');
+					}
 				}
 				else if ($hofChanged == self::HOF_CHANGED) {
 	//				if($amount > 0)
@@ -1255,11 +1292,12 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$this->tickers = array();
 			//get ticker info
 			$this->db->query('SELECT type,time,expires,recent FROM player_has_ticker WHERE ' . $this->SQL . ' AND expires > ' . $this->db->escapeNumber(TIME));
-			while ($this->db->nextRecord())
+			while ($this->db->nextRecord()) {
 				$this->tickers[$this->db->getField('type')] = array('Type' => $this->db->getField('type'),
 																				'Time' => $this->db->getInt('time'),
 																				'Expires' => $this->db->getInt('expires'),
 																				'Recent' => $this->db->getField('recent'));
+			}
 		}
 		return $this->tickers;
 	}
@@ -1270,8 +1308,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	public function getTicker($tickerType) {
 		$tickers = $this->getTickers();
-		if (isset($tickers[$tickerType]))
+		if (isset($tickers[$tickerType])) {
 			return $tickers[$tickerType];
+		}
 		return false;
 	}
 
@@ -1360,8 +1399,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	public function sendGlobalMessage($message, $canBeIgnored = true) {
 		if ($canBeIgnored) {
-			if ($this->getAccount()->isMailBanned())
+			if ($this->getAccount()->isMailBanned()) {
 				create_error('You are currently banned from sending messages');
+			}
 		}
 		$this->sendMessageToBox(BOX_GLOBALS, $message);
 
@@ -1384,12 +1424,14 @@ class SmrPlayer extends AbstractSmrPlayer {
 	public function sendMessage($receiverID, $messageTypeID, $message, $canBeIgnored = true, $unread = true, $expires = false, $senderDelete = false) {
 		//get expire time
 		if ($canBeIgnored) {
-			if ($this->getAccount()->isMailBanned())
+			if ($this->getAccount()->isMailBanned()) {
 				create_error('You are currently banned from sending messages');
+			}
 			// Don't send messages to players ignoring us
 			$this->db->query('SELECT account_id FROM message_blacklist WHERE account_id=' . $this->db->escapeNumber($receiverID) . ' AND blacklisted_id=' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
-			if ($this->db->nextRecord())
+			if ($this->db->nextRecord()) {
 				return;
+			}
 		}
 
 		$message = word_filter($message);
@@ -1470,32 +1512,36 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	public static function sendMessageFromAdmin($gameID, $receiverID, $message, $expires = false) {
 		//get expire time
-		if ($expires === false)
+		if ($expires === false) {
 			$expires = TIME + 86400 * 365;
+		}
 		// send him the message
 		self::doMessageSending(ACCOUNT_ID_ADMIN, $receiverID, $gameID, MSG_ADMIN, $message, $expires);
 	}
 
 	public static function sendMessageFromAllianceAmbassador($gameID, $receiverID, $message, $expires = false) {
 		//get expire time
-		if ($expires === false)
+		if ($expires === false) {
 			$expires = TIME + 86400 * 31;
+		}
 		// send him the message
 		self::doMessageSending(ACCOUNT_ID_ALLIANCE_AMBASSADOR, $receiverID, $gameID, MSG_ALLIANCE, $message, $expires);
 	}
 
 	public static function sendMessageFromCasino($gameID, $receiverID, $message, $expires = false) {
 		//get expire time
-		if ($expires === false)
+		if ($expires === false) {
 			$expires = TIME + 86400 * 7;
+		}
 		// send him the message
 		self::doMessageSending(ACCOUNT_ID_CASINO, $receiverID, $gameID, MSG_CASINO, $message, $expires);
 	}
 
 	public static function sendMessageFromRace($raceID, $gameID, $receiverID, $message, $expires = false) {
 		//get expire time
-		if ($expires === false)
+		if ($expires === false) {
 			$expires = TIME + 86400 * 5;
+		}
 		// send him the message
 		self::doMessageSending(ACCOUNT_ID_GROUP_RACES + $raceID, $receiverID, $gameID, MSG_POLITICAL, $message, $expires);
 	}
@@ -1538,11 +1584,11 @@ class SmrPlayer extends AbstractSmrPlayer {
 	public function setPlottedCourse(Distance $plottedCourse) {
 		$hadPlottedCourse = $this->hasPlottedCourse();
 		$this->plottedCourse = $plottedCourse;
-		if ($this->plottedCourse->getTotalSectors() > 0)
+		if ($this->plottedCourse->getTotalSectors() > 0) {
 			$this->db->query('REPLACE INTO player_plotted_course
 				(account_id, game_id, course)
 				VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeBinary(serialize($this->plottedCourse)) . ')');
-		else if ($hadPlottedCourse) {
+		} else if ($hadPlottedCourse) {
 			$this->deletePlottedCourse();
 		}
 	}
@@ -1552,12 +1598,14 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function isPartOfCourse($sectorOrSectorID) {
-		if (!$this->hasPlottedCourse())
+		if (!$this->hasPlottedCourse()) {
 			return false;
-		if ($sectorOrSectorID instanceof SmrSector)
+		}
+		if ($sectorOrSectorID instanceof SmrSector) {
 			$sectorID = $sectorOrSectorID->getSectorID();
-		else
+		} else {
 			$sectorID = $sectorOrSectorID;
+		}
 		return $this->getPlottedCourse()->isInPath($sectorID);
 	}
 

--- a/lib/Default/SmrPlayer.class.php
+++ b/lib/Default/SmrPlayer.class.php
@@ -200,8 +200,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$this->newbieWarning = $db->getBoolean('newbie_warning');
 			$this->nameChanged = $db->getBoolean('name_changed');
 			$this->combatDronesKamikazeOnMines = $db->getBoolean('combat_drones_kamikaze_on_mines');
-		}
-		else {
+		} else {
 			throw new PlayerNotFoundException('Invalid accountID: ' . $accountID . ' OR gameID:' . $gameID);
 		}
 	}
@@ -335,11 +334,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$kickedBy->sendMessage($this->getAccountID(), MSG_PLAYER, 'You were kicked out of the alliance!', false);
 			$this->actionTaken('PlayerKicked', array('Alliance' => $alliance, 'Player' => $kickedBy));
 			$kickedBy->actionTaken('KickPlayer', array('Alliance' => $alliance, 'Player' => $this));
-		}
-		else if ($this->isAllianceLeader()) {
+		} else if ($this->isAllianceLeader()) {
 			$this->actionTaken('DisbandAlliance', array('Alliance' => $alliance));
-		}
-		else {
+		} else {
 			$this->actionTaken('LeaveAlliance', array('Alliance' => $alliance));
 			if ($alliance->getLeaderID() != 0 && $alliance->getLeaderID() != ACCOUNT_ID_NHL) {
 				$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I left your alliance!', false);
@@ -367,7 +364,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 			try {
 				$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I joined your alliance!', false);
 			} catch (AccountNotFoundException $e) {
-				if ($alliance->getLeaderID() != ACCOUNT_ID_NHL) throw $e;
+				if ($alliance->getLeaderID() != ACCOUNT_ID_NHL) {
+					throw $e;
+				}
 			}
 
 			$roleID = ALLIANCE_ROLE_NEW_MEMBER;
@@ -500,7 +499,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 	public function updateTurns() {
 		// is account validated?
-		if (!$this->getAccount()->isValidated()) return;
+		if (!$this->getAccount()->isValidated()) {
+			return;
+		}
 
 		// how many turns would he get right now?
 		$extraTurns = $this->getTurnsGained(TIME);
@@ -712,8 +713,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$this->db->query('SELECT * FROM ship_has_name WHERE ' . $this->SQL . ' LIMIT 1');
 			if ($this->db->nextRecord()) {
 				$this->customShipName = $this->db->getField('ship_name');
-			}
-			else {
+			} else {
 				$this->customShipName = false;
 			}
 		}
@@ -731,8 +731,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 				$this->knowledge['Nyx'] = $this->db->getInt('nyx');
 				$this->knowledge['Federation'] = 0;
 				$this->knowledge['Underground'] = 0;
-			}
-			else {
+			} else {
 				$this->knowledge['Erebus'] = 0;
 				$this->knowledge['Aether'] = 0;
 				$this->knowledge['Tartarus'] = 0;
@@ -859,8 +858,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$return['KillerAlign'] = -$relation * $alignChangePerRelation; //Lose relations when killing a peaceful race
 		if ($return['KillerAlign'] > 0) {
 			$killer->increaseAlignment($return['KillerAlign']);
-		}
-		else {
+		} else {
 			$killer->decreaseAlignment(-$return['KillerAlign']);
 		}
 		// War setting gives them military pay
@@ -894,8 +892,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 			// If the podded players alignment makes them deputy or member then set bounty
 			if ($this->getAlignment() >= 100) {
 				$return['BountyGained']['Type'] = 'HQ';
-			}
-			else if ($this->getAlignment() <= 100) {
+			} else if ($this->getAlignment() <= 100) {
 				$return['BountyGained']['Type'] = 'UG';
 			}
 
@@ -917,16 +914,14 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 			if ($return['KillerAlign'] > 0) {
 				$killer->increaseHOF($return['KillerAlign'], array('Killing', 'NPC', 'Alignment', 'Gain'), HOF_PUBLIC);
-			}
-			else {
+			} else {
 				$killer->increaseHOF(-$return['KillerAlign'], array('Killing', 'NPC', 'Alignment', 'Loss'), HOF_PUBLIC);
 			}
 
 			$killer->increaseHOF($return['BountyGained']['Amount'], array('Killing', 'NPC', 'Money', 'Bounty Gained'), HOF_PUBLIC);
 
 			$killer->increaseHOF(1, array('Killing', 'NPC Kills'), HOF_PUBLIC);
-		}
-		else {
+		} else {
 			$killer->increaseHOF($return['KillerExp'], array('Killing', 'Experience', 'Gained'), HOF_PUBLIC);
 			$killer->increaseHOF($this->getExperience(), array('Killing', 'Experience', 'Of Traders Killed'), HOF_PUBLIC);
 
@@ -938,8 +933,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 			if ($return['KillerAlign'] > 0) {
 				$killer->increaseHOF($return['KillerAlign'], array('Killing', 'Alignment', 'Gain'), HOF_PUBLIC);
-			}
-			else {
+			} else {
 				$killer->increaseHOF(-$return['KillerAlign'], array('Killing', 'Alignment', 'Loss'), HOF_PUBLIC);
 			}
 
@@ -947,8 +941,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 
 			if ($this->getShip()->getAttackRatingWithMaxCDs() <= MAX_ATTACK_RATING_NEWBIE && $this->hasNewbieStatus() && !$killer->hasNewbieStatus()) { //Newbie kill
 				$killer->increaseHOF(1, array('Killing', 'Newbie Kills'), HOF_PUBLIC);
-			}
-			else {
+			} else {
 				$killer->increaseKills(1);
 				$killer->increaseHOF(1, array('Killing', 'Kills'), HOF_PUBLIC);
 
@@ -1133,8 +1126,7 @@ class SmrPlayer extends AbstractSmrPlayer {
 					if ($bounty['Amount'] > 0 || $bounty['SmrCredits'] > 0) {
 						$this->db->query('INSERT INTO bounty (account_id,game_id,type,amount,smr_credits,claimer_id,time) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeString($bounty['Type']) . ',' . $this->db->escapeNumber($bounty['Amount']) . ',' . $this->db->escapeNumber($bounty['SmrCredits']) . ',' . $this->db->escapeNumber($bounty['Claimer']) . ',' . $this->db->escapeNumber($bounty['Time']) . ')');
 					}
-				}
-				else {
+				} else {
 					if ($bounty['Amount'] > 0 || $bounty['SmrCredits'] > 0) {
 						$this->db->query('UPDATE bounty
 							SET amount=' . $this->db->escapeNumber($bounty['Amount']) . ',
@@ -1173,15 +1165,13 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$tempTypeList[] = $type;
 			if (is_array($hofChanged)) {
 				$this->doHOFSave($hofChanged, $tempTypeList);
-			}
-			else {
+			} else {
 				$amount = $this->getHOF($tempTypeList);
 				if ($hofChanged == self::HOF_NEW) {
 					if ($amount > 0) {
 						$this->db->query('INSERT INTO player_hof (account_id,game_id,type,amount) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeArray($tempTypeList, false, true, ':', false) . ',' . $this->db->escapeNumber($amount) . ')');
 					}
-				}
-				else if ($hofChanged == self::HOF_CHANGED) {
+				} else if ($hofChanged == self::HOF_CHANGED) {
 	//				if($amount > 0)
 						$this->db->query('UPDATE player_hof
 							SET amount=' . $this->db->escapeNumber($amount) . '
@@ -1319,9 +1309,15 @@ class SmrPlayer extends AbstractSmrPlayer {
 	}
 
 	public function getTurnsLevel() {
-		if (!$this->hasTurns()) return 'NONE';
-		if ($this->getTurns() <= 25) return 'LOW';
-		if ($this->getTurns() <= 75) return 'MEDIUM';
+		if (!$this->hasTurns()) {
+			return 'NONE';
+		}
+		if ($this->getTurns() <= 25) {
+			return 'LOW';
+		}
+		if ($this->getTurns() <= 75) {
+			return 'MEDIUM';
+		}
 		return 'HIGH';
 	}
 

--- a/lib/Default/SmrSector.class.php
+++ b/lib/Default/SmrSector.class.php
@@ -167,52 +167,59 @@ class SmrSector {
 	}
 
 	public function markVisited(AbstractSmrPlayer $player) {
-		if ($this->hasPort())
+		if ($this->hasPort()) {
 			$this->getPort()->addCachePort($player->getAccountID());
+		}
 
 		//now delete the entry from visited
-		if (!$this->isVisited($player))
+		if (!$this->isVisited($player)) {
 			$this->db->query('DELETE FROM player_visited_sector WHERE ' . $this->SQL . '
 								 AND account_id = ' . $this->db->escapeNumber($player->getAccountID()) . ' LIMIT 1');
+		}
 		$this->visited[$player->getAccountID()] = true;
 	}
 
 	public function hasWeaponShop() {
 		foreach ($this->getLocations() as $location) {
-			if ($location->isWeaponSold())
+			if ($location->isWeaponSold()) {
 				return true;
+			}
 		}
 		return false;
 	}
 
 	public function hasHQ() {
 		foreach ($this->getLocations() as $location) {
-			if ($location->isHQ())
+			if ($location->isHQ()) {
 				return true;
+			}
 		}
 		return false;
 	}
 
 	public function hasUG() {
 		foreach ($this->getLocations() as $location) {
-			if ($location->isUG())
+			if ($location->isUG()) {
 				return true;
+			}
 		}
 		return false;
 	}
 
 	public function hasShipShop() {
 		foreach ($this->getLocations() as $location) {
-			if ($location->isShipSold())
+			if ($location->isShipSold()) {
 				return true;
+			}
 		}
 		return false;
 	}
 
 	public function offersFederalProtection() {
 		foreach ($this->getLocations() as $location) {
-			if ($location->isFed())
+			if ($location->isFed()) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -220,32 +227,36 @@ class SmrSector {
 	public function getFedRaceIDs() {
 		$raceIDs = array();
 		foreach ($this->getLocations() as $location) {
-			if ($location->isFed())
+			if ($location->isFed()) {
 				$raceIDs[$location->getRaceID()] = $location->getRaceID();
+			}
 		}
 		return $raceIDs;
 	}
 
 	public function hasBar() {
 		foreach ($this->getLocations() as $location) {
-			if ($location->isBar())
+			if ($location->isBar()) {
 				return true;
+			}
 		}
 		return false;
 	}
 
 	public function hasHardwareShop() {
 		foreach ($this->getLocations() as $location) {
-			if ($location->isHardwareSold())
+			if ($location->isHardwareSold()) {
 				return true;
+			}
 		}
 		return false;
 	}
 
 	public function hasBank() {
 		foreach ($this->getLocations() as $location) {
-			if ($location->isBank())
+			if ($location->isBank()) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -322,8 +333,9 @@ class SmrSector {
 	}
 
 	public function setGalaxyID($galaxyID) {
-		if ($this->galaxyID == $galaxyID)
+		if ($this->galaxyID == $galaxyID) {
 			return;
+		}
 		$this->galaxyID = $galaxyID;
 		$this->hasChanged = true;
 	}
@@ -334,18 +346,22 @@ class SmrSector {
 
 	public function getNumberOfLinks() {
 		$num = 0;
-		if (!is_array($this->getLinks()))
+		if (!is_array($this->getLinks())) {
 			return $num;
-		foreach ($this->getLinks() as $link)
-			if ($link !== 0)
+		}
+		foreach ($this->getLinks() as $link) {
+			if ($link !== 0) {
 				$num++;
+			}
+		}
 		return $num;
 	}
 
 	public function getNumberOfConnections() {
 		$links = $this->getNumberOfLinks();
-		if ($this->hasWarp())
+		if ($this->hasWarp()) {
 			$links++;
+		}
 		return $links;
 	}
 
@@ -354,30 +370,35 @@ class SmrSector {
 	}
 
 	public function getNeighbourID($dir) {
-		if ($this->hasLink($dir))
+		if ($this->hasLink($dir)) {
 			return $this->getLink($dir);
+		}
 		$galaxy = $this->getGalaxy();
 		$neighbour = $this->getSectorID();
 		switch ($dir) {
 			case 'Up':
 				$neighbour -= $galaxy->getWidth();
-				if ($neighbour < $galaxy->getStartSector())
+				if ($neighbour < $galaxy->getStartSector()) {
 					$neighbour += $galaxy->getSize();
+				}
 			break;
 			case 'Down':
 				$neighbour += $galaxy->getWidth();
-				if ($neighbour > $galaxy->getEndSector())
+				if ($neighbour > $galaxy->getEndSector()) {
 					$neighbour -= $galaxy->getSize();
+				}
 			break;
 			case 'Left':
 				$neighbour -= 1;
-				if ((1 + $neighbour - $galaxy->getStartSector()) % $galaxy->getWidth() == 0)
+				if ((1 + $neighbour - $galaxy->getStartSector()) % $galaxy->getWidth() == 0) {
 					$neighbour += $galaxy->getWidth();
+				}
 			break;
 			case 'Right':
 				$neighbour += 1;
-				if (($neighbour - $galaxy->getStartSector()) % $galaxy->getWidth() == 0)
+				if (($neighbour - $galaxy->getStartSector()) % $galaxy->getWidth() == 0) {
 					$neighbour -= $galaxy->getWidth();
+				}
 			break;
 			default:
 				throw new Exception($dir . ': is not a valid direction');
@@ -386,13 +407,16 @@ class SmrSector {
 	}
 
 	public function getSectorDirection($sectorID) {
-		if ($sectorID == $this->getSectorID())
+		if ($sectorID == $this->getSectorID()) {
 			return 'Current';
+		}
 		$dir = array_search($sectorID, $this->getLinks());
-		if ($dir !== false)
+		if ($dir !== false) {
 			return $dir;
-		if ($sectorID == $this->getWarp())
+		}
+		if ($sectorID == $this->getWarp()) {
 			return 'Warp';
+		}
 		return 'None';
 	}
 
@@ -417,8 +441,9 @@ class SmrSector {
 	}
 
 	public function getLinkSector($name) {
-		if ($this->hasLink($name))
+		if ($this->hasLink($name)) {
 			return SmrSector::getSector($this->getGameID(), $this->getLink($name));
+		}
 		return false;
 	}
 
@@ -426,12 +451,14 @@ class SmrSector {
 	 * Cannot be used for Warps
 	 */
 	public function setLink($name, $linkID) {
-		if ($this->getLink($name) == $linkID)
+		if ($this->getLink($name) == $linkID) {
 			return;
-		if ($linkID == 0)
+		}
+		if ($linkID == 0) {
 			unset($this->links[$name]);
-		else
+		} else {
 			$this->links[$name] = $linkID;
+		}
 		$this->hasChanged = true;
 	}
 
@@ -439,8 +466,9 @@ class SmrSector {
 	 * Cannot be used for Warps
 	 */
 	public function setLinkSector($dir, SmrSector $linkSector) {
-		if ($this->getLink($dir) == $linkSector->getSectorID() || $linkSector->equals($this))
+		if ($this->getLink($dir) == $linkSector->getSectorID() || $linkSector->equals($this)) {
 			return;
+		}
 		$this->setLink($dir, $linkSector->getSectorID());
 		$linkSector->setLink(self::oppositeDir($dir), $this->getSectorID());
 		$this->hasChanged = true;
@@ -629,21 +657,25 @@ class SmrSector {
 		$locations = SmrLocation::getSectorLocations($this->getGameID(), $this->getSectorID());
 		$hasAction = false;
 		foreach ($locations as $location) {
-			if ($location->hasAction())
+			if ($location->hasAction()) {
 				$hasAction = true;
+			}
 		}
 		return $hasAction;
 	}
 
 	public function hasLocation($locationTypeID = false) {
 		$locations = $this->getLocations();
-		if (count($locations) == 0)
+		if (count($locations) == 0) {
 			return false;
-		if ($locationTypeID == false)
+		}
+		if ($locationTypeID == false) {
 			return true;
+		}
 		foreach ($locations as $location) {
-			if ($location->getTypeID() == $locationTypeID)
+			if ($location->getTypeID() == $locationTypeID) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -703,11 +735,13 @@ class SmrSector {
 	}
 
 	public function hasEnemyForces(AbstractSmrPlayer $player = null) {
-		if ($player == null || !$this->hasForces())
+		if ($player == null || !$this->hasForces()) {
 			return false;
+		}
 		foreach ($this->getForces() as $force) {
-			if (!$player->forceNAPAlliance($force->getOwner()))
+			if (!$player->forceNAPAlliance($force->getOwner())) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -715,8 +749,9 @@ class SmrSector {
 	public function getEnemyForces(AbstractSmrPlayer $player) {
 		$enemyForces = array();
 		foreach ($this->getForces() as $force) {
-			if (!$player->forceNAPAlliance($force->getOwner()))
+			if (!$player->forceNAPAlliance($force->getOwner())) {
 				$enemyForces[] = $force;
+			}
 		}
 		return $enemyForces;
 	}
@@ -734,11 +769,13 @@ class SmrSector {
 	}
 
 	public function hasFriendlyForces(AbstractSmrPlayer $player = null) {
-		if ($player == null || !$this->hasForces())
+		if ($player == null || !$this->hasForces()) {
 			return false;
+		}
 		foreach ($this->getForces() as $force) {
-			if ($player->forceNAPAlliance($force->getOwner()))
+			if ($player->forceNAPAlliance($force->getOwner())) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -746,8 +783,9 @@ class SmrSector {
 	public function getFriendlyForces(AbstractSmrPlayer $player) {
 		$friendlyForces = array();
 		foreach ($this->getForces() as $force) {
-			if ($player->forceNAPAlliance($force->getOwner()))
+			if ($player->forceNAPAlliance($force->getOwner())) {
 				$friendlyForces[] = $force;
+			}
 		}
 		return $friendlyForces;
 	}
@@ -775,8 +813,9 @@ class SmrSector {
 	}
 
 	public function hasEnemyTraders(AbstractSmrPlayer $player = null) {
-		if ($player == null || !$this->hasOtherTraders($player))
+		if ($player == null || !$this->hasOtherTraders($player)) {
 			return false;
+		}
 		$otherPlayers = $this->getOtherTraders($player);
 		foreach ($otherPlayers as $otherPlayer) {
 			if (!$player->traderNAPAlliance($otherPlayer) 
@@ -789,12 +828,14 @@ class SmrSector {
 	}
 
 	public function hasFriendlyTraders(AbstractSmrPlayer $player = null) {
-		if ($player == null || !$this->hasOtherTraders($player))
+		if ($player == null || !$this->hasOtherTraders($player)) {
 			return false;
+		}
 		$otherPlayers = $this->getOtherTraders($player);
 		foreach ($otherPlayers as $otherPlayer) {
-			if ($player->traderNAPAlliance($otherPlayer))
+			if ($player->traderNAPAlliance($otherPlayer)) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -816,8 +857,9 @@ class SmrSector {
 	}
 
 	public function hasProtectedTraders(AbstractSmrPlayer $player = null) {
-		if ($player == null || !$this->hasOtherTraders($player))
+		if ($player == null || !$this->hasOtherTraders($player)) {
 			return false;
+		}
 		$otherPlayers = $this->getOtherTraders($player);
 		foreach ($otherPlayers as $otherPlayer) {
 			if (!$player->traderNAPAlliance($otherPlayer) 
@@ -853,8 +895,9 @@ class SmrSector {
 			$planetOwner = $defendingPlanet->getOwner();
 			foreach ($alliancePlayers as $accountID => $player) {
 				if ($player->canFight()) {
-					if ($attackingPlayer->traderAttackPlanetAlliance($player) && !$planetOwner->planetNAPAlliance($player))
+					if ($attackingPlayer->traderAttackPlanetAlliance($player) && !$planetOwner->planetNAPAlliance($player)) {
 						$fightingPlayers[$accountID] = $alliancePlayers[$accountID];
+					}
 				}
 			}
 		}
@@ -862,8 +905,9 @@ class SmrSector {
 	}
 
 	public function getFightingTraders(AbstractSmrPlayer $attackingPlayer, AbstractSmrPlayer $defendingPlayer, $checkForCloak = false) {
-		if ($attackingPlayer->traderNAPAlliance($defendingPlayer))
+		if ($attackingPlayer->traderNAPAlliance($defendingPlayer)) {
 			throw new Exception('These traders are NAPed.');
+		}
 		$fightingPlayers = array('Attackers' => array(), 'Defenders' => array());
 		$alliancePlayers = SmrPlayer::getSectorPlayersByAlliances($this->getGameID(), $this->getSectorID(), array($attackingPlayer->getAllianceID(), $defendingPlayer->getAllianceID()));
 		$attackers = array();
@@ -923,8 +967,9 @@ class SmrSector {
 	}
 
 	public function setBattles($amount) {
-		if ($this->battles == $amount)
+		if ($this->battles == $amount) {
 			return;
+		}
 		$this->battles = $amount;
 		$this->hasChanged = true;
 	}
@@ -946,8 +991,9 @@ class SmrSector {
 	}
 
 	public function isVisited(AbstractSmrPlayer $player = null) {
-		if ($player === null)
+		if ($player === null) {
 			return true;
+		}
 		if (!isset($this->visited[$player->getAccountID()])) {
 			$this->db->query('SELECT sector_id FROM player_visited_sector WHERE ' . $this->SQL . ' AND account_id=' . $this->db->escapeNumber($player->getAccountID()) . ' LIMIT 1');
 			$this->visited[$player->getAccountID()] = !$this->db->nextRecord();
@@ -988,10 +1034,11 @@ class SmrSector {
 			return $x->contains($this);
 		}
 
-		if (is_array($x) && $x['Type'] == 'Good') //Check if it's possible for port to have X, hacky but nice performance gains
-			if ($this->hasPort())
-				if ($this->getPort()->hasX($x))
-					return true;
+		if (is_array($x) && $x['Type'] == 'Good') { //Check if it's possible for port to have X, hacky but nice performance gains
+			if ($this->hasPort() && $this->getPort()->hasX($x)) {
+				return true;
+			}
+		}
 
 		//Check if it's possible for location to have X, hacky but nice performance gains
 		if ($x instanceof SmrWeapon || (is_array($x) && ($x['Type'] == 'Ship' || $x['Type'] == 'Hardware')) || (is_string($x) && ($x == 'Bank' || $x == 'Bar' || $x == 'Fed' || $x == 'SafeFed' || $x == 'HQ' || $x == 'UG' || $x == 'Hardware' || $x == 'Ship' || $x == 'Weapon'))) {

--- a/lib/Default/SmrSector.class.php
+++ b/lib/Default/SmrSector.class.php
@@ -126,15 +126,13 @@ class SmrSector {
 				$this->links['Right'] = $db->getInt('link_right');
 			}
 			$this->warp = $db->getInt('warp');
-		}
-		else if ($create) {
+		} else if ($create) {
 			$this->battles = 0;
 			$this->links = array();
 			$this->warp = 0;
 			$this->isNew = true;
 			return;
-		}
-		else {
+		} else {
 			throw new SectorNotFoundException('No sector ' . $sectorID . ' in game ' . $gameID);
 		}
 	}
@@ -492,8 +490,7 @@ class SmrSector {
 	public function toggleLink($dir) {
 		if ($this->hasLink($dir)) {
 			$this->disableLink($dir);
-		}
-		else {
+		} else {
 			$this->enableLink($dir);
 		}
 	}

--- a/lib/Default/SmrWeapon.class.php
+++ b/lib/Default/SmrWeapon.class.php
@@ -12,17 +12,19 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 
 	
 	protected static function initialiseDatabase() {
-		if (self::$db == null)
+		if (self::$db == null) {
 			self::$db = new SmrMySqlDatabase();
+		}
 	}
 
 	public static function getWeapon($weaponTypeID, $forceUpdate = false, $db = null) {
 		if ($forceUpdate || !isset(self::$CACHE_WEAPONS[$weaponTypeID])) {
 			$w = new SmrWeapon($weaponTypeID, $db);
-			if ($w->exists())
+			if ($w->exists()) {
 				self::$CACHE_WEAPONS[$weaponTypeID] = $w;
-			else
+			} else {
 				self::$CACHE_WEAPONS[$weaponTypeID] = false;
+			}
 		}
 		return self::$CACHE_WEAPONS[$weaponTypeID];
 	}
@@ -151,8 +153,9 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 		$weaponShip = $weaponPlayer->getShip();
 		$targetShip = $targetPlayer->getShip();
 		$mrDiff = $targetShip->getMR() - $weaponShip->getMR();
-		if ($mrDiff > 0)
+		if ($mrDiff > 0) {
 			$modifiedAccuracy -= $this->getBaseAccuracy() * ($mrDiff / MR_FACTOR) / 100;
+		}
 	
 		return $modifiedAccuracy;
 	}

--- a/lib/Default/SmrWeapon.class.php
+++ b/lib/Default/SmrWeapon.class.php
@@ -193,22 +193,28 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	}
 	
 	public function &getModifiedDamageAgainstForces(AbstractSmrPlayer $weaponPlayer, SmrForce $forces) {
-		if (!$this->canShootForces()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
+		if (!$this->canShootForces()) {
+			// If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
+		}
 		$damage =& $this->getModifiedDamage();
 		return $damage;
 	}
 	
 	public function &getModifiedDamageAgainstPort(AbstractSmrPlayer $weaponPlayer, SmrPort $port) {
-		if (!$this->canShootPorts()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
+		if (!$this->canShootPorts()) {
+			// If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
+		}
 		$damage =& $this->getModifiedDamage();
 		return $damage;
 	}
 	
 	public function &getModifiedDamageAgainstPlanet(AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet) {
-		if (!$this->canShootPlanets()) // If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
+		if (!$this->canShootPlanets()) {
+			// If we can't shoot forces then just return a damageless array and don't waste resources calculated any damage mods.
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
+		}
 		$damage =& $this->getModifiedDamage();
 		
 		$planetMod = self::PLANET_DAMAGE_MOD;

--- a/lib/Default/council.inc
+++ b/lib/Default/council.inc
@@ -17,17 +17,19 @@ function modifyRelations($race_id_1) {
 		$race_id_2 = $db->getInt('race_id_2');
 		$action = $db->getField('action');
 
-		if ($action == 'INC')
+		if ($action == 'INC') {
 			$relation_modifier = RELATIONS_VOTE_CHANGE;
-		else
+		} else {
 			$relation_modifier = -RELATIONS_VOTE_CHANGE;
+		}
 
 		$db2->query('SELECT * FROM race_has_relation ' .
 					'WHERE race_id_1 = ' . $db2->escapeNumber($race_id_1) . '
 						AND race_id_2 = ' . $db2->escapeNumber($race_id_2) . '
 						AND game_id = ' . $db2->escapeNumber($player->getGameID()));
-		if ($db2->nextRecord())
+		if ($db2->nextRecord()) {
 			$relation = $db2->getInt('relation') + $relation_modifier;
+		}
 
 		if ($relation < MIN_GLOBAL_RELATIONS) {
 			$relation = MIN_GLOBAL_RELATIONS;
@@ -108,10 +110,11 @@ function checkPacts($race_id_1) {
 					$expireTime = TIME + TIME_FOR_WAR_VOTE_FED_SAFETY;
 					$query = 'REPLACE INTO player_can_fed (account_id, game_id, race_id, expiry, allowed) VALUES ';
 					foreach ($currentlyParkedAccountIDs as $raceID => $accountIDs) {
-						if ($raceID == $race_id_1)
+						if ($raceID == $race_id_1) {
 							$message = 'We have declared war upon your race';
-						else
+						} else {
 							$message = 'Your race has declared war upon us';
+						}
 						$message .= ', you have ' . format_time(TIME_FOR_WAR_VOTE_FED_SAFETY) . ' to vacate our federal space, after that time you will no longer be protected (unless you have strong personal relations).';
 						foreach ($accountIDs as $accountID) {
 							$query .= '(' . $db2->escapeNumber($accountID) . ',' . $db2->escapeNumber($player->getGameID()) . ',' . $db2->escapeNumber($raceID) . ',' . $db2->escapeNumber($expireTime) . ',' . $db2->escapeBoolean(true) . '),';

--- a/lib/Default/council.inc
+++ b/lib/Default/council.inc
@@ -139,8 +139,7 @@ function checkPacts($race_id_1) {
 				$news = 'The [race=' . $race_id_1 . '] have declared <span class="red">WAR</span> on the [race=' . $race_id_2 . ']';
 				$db2->query('INSERT INTO news (game_id, time, news_message) VALUES ' .
 							'(' . $db2->escapeNumber($player->getGameID()) . ', ' . $db2->escapeNumber(TIME) . ', ' . $db2->escapeString($news) . ')');
-			}
-			elseif ($type == 'PEACE') {
+			} elseif ($type == 'PEACE') {
 				// get 'yes' votes
 				$db2->query('SELECT * FROM player_votes_pact
 							WHERE game_id = '.$db2->escapeNumber($player->getGameID()) . '

--- a/lib/Default/message.functions.inc
+++ b/lib/Default/message.functions.inc
@@ -26,30 +26,30 @@ function getAdminBoxNames() {
 }
 
 function getMessagePlayer($accountID, $gameID, $messageType = false) {
-	if ($accountID == ACCOUNT_ID_PORT)
+	if ($accountID == ACCOUNT_ID_PORT) {
 		$return = '<span class="yellow">Port Defenses</span>';
-	else if ($accountID == ACCOUNT_ID_ADMIN)
+	} else if ($accountID == ACCOUNT_ID_ADMIN) {
 		$return = '<span class="admin">Administrator</span>';
-	else if ($accountID == ACCOUNT_ID_PLANET)
+	} else if ($accountID == ACCOUNT_ID_PLANET) {
 		$return = '<span class="yellow">Planetary Defenses</span>';
-	else if ($accountID == ACCOUNT_ID_ALLIANCE_AMBASSADOR)
+	} else if ($accountID == ACCOUNT_ID_ALLIANCE_AMBASSADOR) {
 		$return = '<span class="green">Alliance Ambassador</span>';
-	else if ($accountID == ACCOUNT_ID_CASINO)
+	} else if ($accountID == ACCOUNT_ID_CASINO) {
 		$return = '<span class="yellow">Casino</span>';
-	else if ($accountID == ACCOUNT_ID_FED_CLERK)
+	} else if ($accountID == ACCOUNT_ID_FED_CLERK) {
 		$return = '<span class="yellow">Federal Clerk</span>';
-	else if ($accountID == ACCOUNT_ID_OP_ANNOUNCE || $accountID == ACCOUNT_ID_ALLIANCE_COMMAND)
+	} else if ($accountID == ACCOUNT_ID_OP_ANNOUNCE || $accountID == ACCOUNT_ID_ALLIANCE_COMMAND) {
 		$return = '<span class="green">Alliance Command</span>';
-	else {
+	} else {
 		foreach (Globals::getRaces() as $raceID => $raceInfo) {
 			if ($accountID == ACCOUNT_ID_GROUP_RACES + $raceID) {
 				$return = '<span class="yellow">' . $raceInfo['Race Name'] . ' Government</span>';
 				return $return;
 			}
 		}
-		if (!empty($accountID))
+		if (!empty($accountID)) {
 			$return = SmrPlayer::getPlayer($accountID, $gameID);
-		else {
+		} else {
 			switch ($messageType) {
 				case MSG_ADMIN:
 					$return = '<span class="admin">Administrator</span>';

--- a/lib/Default/shop_goods.inc
+++ b/lib/Default/shop_goods.inc
@@ -1,18 +1,18 @@
 <?php declare(strict_types=1);
 
 function checkPortTradeable($port, $player) {
-	if ($port->getSectorID() != $player->getSectorID())
+	if ($port->getSectorID() != $player->getSectorID()) {
 		return 'That port is not in this sector!';
-	
-	if (!$port->exists())
+	}
+	if (!$port->exists()) {
 		return 'There is no port in this sector!';
-	
-	if ($player->getRelation($port->getRaceID()) <= RELATIONS_WAR)
+	}
+	if ($player->getRelation($port->getRaceID()) <= RELATIONS_WAR) {
 		return 'We will not trade with our enemies!';
-	
-	if ($port->getReinforceTime() > TIME)
+	}
+	if ($port->getReinforceTime() > TIME) {
 		return 'We are still repairing damage caused during the last raid.';
-	
+	}
 	return true;
 }
 
@@ -50,39 +50,44 @@ function check_bargain_number($amount, $ideal_price, $offered_price, $bargain_pr
 		if (abs($port_off_rel) > abs($trader_off_rel)) {
 			// get a random number between
 			// (port_off) and (100 +/- $trader_off_rel)
-			if (100 + $trader_off_rel < $port_off)
+			if (100 + $trader_off_rel < $port_off) {
 				$offer_modifier = mt_rand(100 + $trader_off_rel, $port_off);
-			else
+			} else {
 				$offer_modifier = mt_rand($port_off, 100 + $trader_off_rel);
+			}
 
 			$container['offered_price'] = round($container['ideal_price'] * $offer_modifier / 100);
 		}
 	}
-	else
+	else {
 		$container['overall_number_of_bargains'] = mt_rand(2, 5);
+	}
 }
 
 function get_amount() {
 	global $var;
 
 	// retrieve amount
-	if (isset($var['amount']))
+	if (isset($var['amount'])) {
 		$amount = $var['amount'];
-	else if (isset($_REQUEST['amount']))
+	} else if (isset($_REQUEST['amount'])) {
 		$amount = $_REQUEST['amount'];
-	else
+	} else {
 		$amount = 0;
+	}
 
 	// only numbers
-	if (!is_numeric($amount))
+	if (!is_numeric($amount)) {
 		create_error('You must actually enter a number!');
+	}
 
 	// we take as it is but round it
 	$amount = floor($amount);
 
 	// no negative amounts are allowed
-	if ($amount <= 0)
+	if ($amount <= 0) {
 		create_error('You must actually enter an amount > 0!');
+	}
 
 	return $amount;
 }
@@ -91,23 +96,26 @@ function get_bargain_price() {
 	global $var;
 
 	// we get it from form
-	if (isset($_REQUEST['bargain_price']))
+	if (isset($_REQUEST['bargain_price'])) {
 		$price = $_REQUEST['bargain_price'];
-	else if (isset($var['bargain_price']))
+	} else if (isset($var['bargain_price'])) {
 		$price = $var['bargain_price'];
-	else
+	} else {
 		$price = 0;
+	}
 
 	// only numbers
-	if (!is_numeric($price))
+	if (!is_numeric($price)) {
 		create_error('You must actually enter a number!');
+	}
 
 	// we take as it is but round it
 	$price = floor($price);
 
 	// no negative amounts are allowed
-	if ($price < 0)
+	if ($price < 0) {
 		create_error('No negative prices are allowed!');
+	}
 
 	return $price;
 }

--- a/lib/Default/shop_goods.inc
+++ b/lib/Default/shop_goods.inc
@@ -58,8 +58,7 @@ function check_bargain_number($amount, $ideal_price, $offered_price, $bargain_pr
 
 			$container['offered_price'] = round($container['ideal_price'] * $offer_modifier / 100);
 		}
-	}
-	else {
+	} else {
 		$container['overall_number_of_bargains'] = mt_rand(2, 5);
 	}
 }

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -132,8 +132,7 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 				return '<div class="buttonA"><a class="buttonA" href="' . SmrSession::getNewHREF($container) . '">Join ' . $alliance->getAllianceDisplayName() . '</a></div>';
 			break;
 		}
-	}
-	catch (Exception $e) {
+	} catch (Exception $e) {
 	}
 	if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
 		return false;
@@ -186,8 +185,7 @@ function bbifyMessage($message, $noLinks = false) {
 	if (strpos($message, '[') !== false) { //We have BBCode so let's do a full parse.
 		$message = $bbParser->parse($message);
 		$message = str_replace('&lt;br /&gt;', '<br />', $message);
-	}
-	else { //Otherwise just convert newlines
+	} else { //Otherwise just convert newlines
 		$message = nl2br($message, true);
 	}
 	return $message;
@@ -227,8 +225,7 @@ function create_form($container, $actions) {
 
 	if (!is_array($actions)) {
 		$form['submit'] = '<input class="submit" type="submit" name="action" value="' . htmlspecialchars($actions) . '">';
-	}
-	else {
+	} else {
 		$form['submit'] = array();
 		foreach ($actions as $action) {
 			$form['submit'][$action[0]] = '<input class="submit" type="submit" name="action" value="' . htmlspecialchars($action[1]) . '">';
@@ -319,8 +316,7 @@ function get_colored_text_range($value, $maxValue, $text = null, $minValue = 0, 
 	}
 	if ($maxValue - $minValue == 0) {
 		return $text;
-	}
-	else {
+	} else {
 		$normalisedValue = round(510 * max(0, min($maxValue, $value) - $minValue) / ($maxValue - $minValue)) - 255;
 	}
 	if ($type == 'Game') {
@@ -330,28 +326,33 @@ function get_colored_text_range($value, $maxValue, $text = null, $minValue = 0, 
 			if (strlen($g_component) == 1) {
 				$g_component = '0' . $g_component;
 			}
-		}
-		else if ($normalisedValue > 0) {
+		} else if ($normalisedValue > 0) {
 			$g_component = 'ff';
 			$r_component = dechex(255 - $normalisedValue);
 			if (strlen($r_component) == 1) {
 				$r_component = '0' . $r_component;
 			}
-		}
-		else {
+		} else {
 			$r_component = 'ff';
 			$g_component = 'ff';
 		}
 		$colour = $r_component . $g_component . '00';
-		if ($return_type == 'Colour') return $colour;
+		if ($return_type == 'Colour') {
+			return $colour;
+		}
 		return '<span style="color:#' . $colour . '">' . $text . '</span>';
-	}
-	elseif ($type == 'IRC') {
+	} elseif ($type == 'IRC') {
 		//IRC color codes
-		if ($normalisedValue == 255) $colour = '[k03]';
-		elseif ($normalisedValue == -255) $colour = '[k04]';
-		else $colour = '[k08]';
-		if ($return_type == 'Colour') return $colour;
+		if ($normalisedValue == 255) {
+			$colour = '[k03]';
+		} elseif ($normalisedValue == -255) {
+			$colour = '[k04]';
+		} else {
+			$colour = '[k08]';
+		}
+		if ($return_type == 'Colour') {
+			return $colour;
+		}
 		return $colour . $text;
 	}
 }
@@ -410,10 +411,18 @@ function do_voodoo() {
 	// create account object
 	$account = SmrSession::getAccount();
 
-	if (!defined('DATE_DATE_SHORT')) define('DATE_DATE_SHORT', $account->getShortDateFormat());
-	if (!defined('DATE_TIME_SHORT')) define('DATE_TIME_SHORT', $account->getShortTimeFormat());
-	if (!defined('DATE_FULL_SHORT')) define('DATE_FULL_SHORT', DATE_DATE_SHORT . ' ' . DATE_TIME_SHORT);
-	if (!defined('DATE_FULL_SHORT_SPLIT')) define('DATE_FULL_SHORT_SPLIT', DATE_DATE_SHORT . '\<b\r /\>' . DATE_TIME_SHORT);
+	if (!defined('DATE_DATE_SHORT')) {
+		define('DATE_DATE_SHORT', $account->getShortDateFormat());
+	}
+	if (!defined('DATE_TIME_SHORT')) {
+		define('DATE_TIME_SHORT', $account->getShortTimeFormat());
+	}
+	if (!defined('DATE_FULL_SHORT')) {
+		define('DATE_FULL_SHORT', DATE_DATE_SHORT . ' ' . DATE_TIME_SHORT);
+	}
+	if (!defined('DATE_FULL_SHORT_SPLIT')) {
+		define('DATE_FULL_SHORT_SPLIT', DATE_DATE_SHORT . '\<b\r /\>' . DATE_TIME_SHORT);
+	}
 
 	// initialize objects we usually need, like player, ship
 	if (SmrSession::hasGame()) {
@@ -567,8 +576,7 @@ function acquire_lock($sector) {
 
 			usleep(25000 * $locksInQueue);
 			continue;
-		}
-		else {
+		} else {
 			return true;
 		}
 	}
@@ -765,7 +773,9 @@ function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account, $v
 		$container['player_id'] = $player->getPlayerID();
 		$template->assign('PlayerNameLink', SmrSession::getNewHREF($container));
 
-		if (is_array(Globals::getHiddenPlayers()) && in_array($player->getAccountID(), Globals::getHiddenPlayers())) $template->assign('PlayerInvisible', true);
+		if (is_array(Globals::getHiddenPlayers()) && in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
+			$template->assign('PlayerInvisible', true);
+		}
 
 		// ******* Hardware *******
 		$container = create_container('skeleton.php', 'configure_hardware.php');

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -8,8 +8,9 @@ function htmliseMessage($message) {
 
 function parseBoolean($check) {
 	// Only negative strings are not implicitly converted to the correct bool
-	if (is_string($check) && (strcasecmp($check, 'NO') == 0 || strcasecmp($check, 'FALSE') == 0))
+	if (is_string($check) && (strcasecmp($check, 'NO') == 0 || strcasecmp($check, 'FALSE') == 0)) {
 		return false;
+	}
 	return (bool)$check;
 }
 
@@ -32,8 +33,9 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 			break;
 			case 'player':
 				$playerID = $default;
-				if (!is_numeric($playerID))
+				if (!is_numeric($playerID)) {
 					$playerID = $tagParams['id'];
+				}
 				$bbPlayer = SmrPlayer::getPlayerByPlayerID($playerID, $overrideGameID);
 				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
 					return true;
@@ -46,8 +48,9 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 			break;
 			case 'alliance':
 				$allianceID = $default;
-				if (!is_numeric($allianceID))
+				if (!is_numeric($allianceID)) {
 					$allianceID = $tagParams['id'];
+				}
 				$alliance = SmrAlliance::getAlliance($allianceID, $overrideGameID);
 				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
 					return true;
@@ -56,10 +59,11 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 				if ($disableBBLinks === false && $overrideGameID == SmrSession::getGameID()) {
 					$container = create_container('skeleton.php');
 					$container['alliance_id'] = $alliance->getAllianceID();
-					if (is_object($player) && $alliance->getAllianceID() == $player->getAllianceID())
+					if (is_object($player) && $alliance->getAllianceID() == $player->getAllianceID()) {
 						$container['body'] = 'alliance_mod.php';
-					else
+					} else {
 						$container['body'] = 'alliance_roster.php';
+					}
 					return create_link($container, $alliance->getAllianceDisplayName());
 				}
 				return $alliance->getAllianceDisplayName();
@@ -83,8 +87,9 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 					return true;
 				}
 				if ($timeString != '' && ($time = strtotime($timeString)) !== false) {
-					if (is_object($account))
+					if (is_object($account)) {
 						$time += $account->getOffset() * 3600;
+					}
 					return date(DATE_FULL_SHORT, $time);
 				}
 			break;
@@ -173,10 +178,11 @@ function bbifyMessage($message, $noLinks = false) {
 		$bbParser->addRule('join_alliance', $smrRule);
 	}
 	global $disableBBLinks;
-	if ($noLinks === true)
+	if ($noLinks === true) {
 		$disableBBLinks = true;
-	else
+	} else {
 		$disableBBLinks = false;
+	}
 	if (strpos($message, '[') !== false) { //We have BBCode so let's do a full parse.
 		$message = $bbParser->parse($message);
 		$message = str_replace('&lt;br /&gt;', '<br />', $message);
@@ -267,8 +273,9 @@ function resetContainer($new_container) {
 }
 
 function forward($new_container) {
-	if (defined('OVERRIDE_FORWARD') && OVERRIDE_FORWARD === true)
+	if (defined('OVERRIDE_FORWARD') && OVERRIDE_FORWARD === true) {
 		return overrideForward($new_container);
+	}
 	resetContainer($new_container);
 	do_voodoo();
 }
@@ -277,16 +284,15 @@ function forwardURL($new_container) {
 	resetContainer($new_container);
 	global $var;
 	require_once(get_file_loc($var['url']));
-
 }
 
 function transfer($what) {
 	global $var, $container;
 
 	// transfer this value to next container
-	if (isset($var[$what]))
+	if (isset($var[$what])) {
 		$container[$what] = $var[$what];
-
+	}
 }
 
 function create_container($file, $body = '', array $extra = array(), $remainingPageLoads = null) {
@@ -533,8 +539,9 @@ function do_voodoo() {
 function acquire_lock($sector) {
 	global $db, $lock, $locksFailed;
 
-	if ($lock)
+	if ($lock) {
 		return true;
+	}
 
 	// Insert ourselves into the queue.
 	$db->query('INSERT INTO locks_queue (game_id,account_id,sector_id,timestamp) VALUES(' . $db->escapeNumber(SmrSession::getGameID()) . ',' . $db->escapeNumber(SmrSession::getAccountID()) . ',' . $db->escapeNumber($sector) . ',' . $db->escapeNumber(TIME) . ')');
@@ -898,16 +905,18 @@ function format_time($seconds, $short = false) {
 
 function number_colour_format($number, $justSign = false) {
 	$formatted = '<span';
-	if ($number > 0)
+	if ($number > 0) {
 		$formatted .= ' class="green">+';
-	else if ($number < 0)
+	} else if ($number < 0) {
 		$formatted .= ' class="red">-';
-	else
+	} else {
 		$formatted .= '>';
+	}
 	if ($justSign === false) {
 		$decimalPlaces = 0;
-		if (($pos = strpos((string)$number, '.')) !== false)
+		if (($pos = strpos((string)$number, '.')) !== false) {
 			$decimalPlaces = strlen(substr((string)$number, $pos + 1));
+		}
 		$formatted .= number_format(abs($number), $decimalPlaces);
 	}
 	$formatted .= '</span>';

--- a/tools/irc/channel_msg.php
+++ b/tools/irc/channel_msg.php
@@ -85,36 +85,50 @@ function channel_msg_with_registration($fp, $rdata)
 			return true;
 		}
 
-		if (channel_msg_money($fp, $rdata, $account, $player))
+		if (channel_msg_money($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_forces($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_forces($fp, $rdata, $account, $player)) {
 			return true;
+		}
 
-		if (channel_msg_seed($fp, $rdata, $account, $player))
+		if (channel_msg_seed($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_seedlist_add($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_seedlist_add($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_seedlist_del($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_seedlist_del($fp, $rdata, $account, $player)) {
 			return true;
+		}
 
-		if (channel_msg_op_info($fp, $rdata, $account, $player))
+		if (channel_msg_op_info($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_op_cancel($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_op_cancel($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_op_set($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_op_set($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_op_turns($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_op_turns($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_op_response($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_op_response($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_op_list($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_op_list($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_sd_set($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_sd_set($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_sd_del($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_sd_del($fp, $rdata, $account, $player)) {
 			return true;
-		if (channel_msg_sd_list($fp, $rdata, $account, $player))
+		}
+		if (channel_msg_sd_list($fp, $rdata, $account, $player)) {
 			return true;
+		}
 
 	}
 
@@ -253,8 +267,9 @@ function channel_msg_timer($fp, $rdata)
 		$countdown = intval($msg[5]);
 		$message = 'ALERT! ALERT! ALERT!';
 
-		if (isset($msg[6]))
+		if (isset($msg[6])) {
 			$message .= ' ' . $msg[6];
+		}
 
 		echo_r('[TIMER] ' . $nick . ' started a timer with ' . $countdown . ' minute(s) (' . $message . ') in ' . $channel);
 
@@ -364,8 +379,9 @@ function channel_msg_help($fp, $rdata)
 		if ($topic == 'seen') {
 			fputs($fp, 'NOTICE ' . $nick . ' :Syntax !seen <nickname>' . EOL);
 			fputs($fp, 'NOTICE ' . $nick . ' :   Displays the last time <nickname> was seen' . EOL);
-		} else
+		} else {
 			fputs($fp, 'NOTICE ' . $nick . ' :There is no help available for this command! Try !help' . EOL);
+		}
 
 		//		if ($topic == 'login')
 		//			fputs($fp, 'NOTICE '.$nick.' :No help available yet! Ask MrSpock!'.EOL);

--- a/tools/irc/channel_msg.php
+++ b/tools/irc/channel_msg.php
@@ -47,8 +47,7 @@ function check_for_registration(&$account, &$player, $fp, $nick, $channel, $call
 	// get smr player
 	try {
 		$player = SmrPlayer::getPlayer($account->getAccountID(), $alliance->getGameId(), true);
-	}
-	catch (PlayerNotFoundException $e) {
+	} catch (PlayerNotFoundException $e) {
 		if ($validationMessages === true) {
 			fputs($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', you have not joined the game that this channel belongs to.' . EOL);
 		}

--- a/tools/irc/channel_msg_sd.php
+++ b/tools/irc/channel_msg_sd.php
@@ -45,8 +45,9 @@ function channel_msg_sd_set($fp, $rdata, $account, $player)
 		// delete any old entries in the list
 		foreach ($sds as $key => $value) {
 
-			if ($value[3] != $channel)
+			if ($value[3] != $channel) {
 				continue;
+			}
 
 			if ($value[0] == $sector) {
 				unset($sds[$key]);
@@ -82,8 +83,9 @@ function channel_msg_sd_del($fp, $rdata, $account, $player)
 
 		foreach ($sds as $key => $sd) {
 
-			if ($sd[3] != $channel)
+			if ($sd[3] != $channel) {
 				continue;
+			}
 
 			if ($sd[0] == $sector) {
 				fputs($fp, 'PRIVMSG ' . $channel . ' :The supply/demand for sector ' . $sector . ' has been deleted.' . EOL);

--- a/tools/irc/channel_msg_sd.php
+++ b/tools/irc/channel_msg_sd.php
@@ -123,7 +123,9 @@ function channel_msg_sd_list($fp, $rdata, $account, $player)
 			if ($sd[3] == $channel) {
 
 				$seconds_since_refresh = time() - $sd[2];
-				if ($seconds_since_refresh < 0) $seconds_since_refresh = 0;
+				if ($seconds_since_refresh < 0) {
+					$seconds_since_refresh = 0;
+				}
 				$amt_to_add = floor($seconds_since_refresh * $refresh_per_sec);
 
 				if ($sd[1] + $amt_to_add > 4000) {

--- a/tools/irc/irc.php
+++ b/tools/irc/irc.php
@@ -6,11 +6,12 @@ class TimeoutException extends Exception {}
 function echo_r($message)
 {
 	if (is_array($message)) {
-		foreach ($message as $msg)
+		foreach ($message as $msg) {
 			echo_r($msg);
-	}
-	else
+		}
+	} else {
 		echo date("d.m.Y H:i:s => ") . $message . EOL;
+	}
 }
 
 // not keeping the filehandle might not be the wisest idea.
@@ -164,12 +165,14 @@ function readFromStream($fp) {
 	$rdata = preg_replace('/\s+/', ' ', $rdata);
 
 	// log for reports (if enabled via command line (-log)
-	if (IRC_LOGGING && strlen($rdata) > 0)
+	if (IRC_LOGGING && strlen($rdata) > 0) {
 		write_log_message($rdata);
+	}
 
 	// remember the last time we got something from the server
-	if (strlen($rdata) > 0)
+	if (strlen($rdata) > 0) {
 		$last_ping = time();
+	}
 
 	// timeout detection!
 	if ($last_ping < time() - 300) {
@@ -186,76 +189,102 @@ function readFromStream($fp) {
 	}
 
 	// required!!! otherwise timeout!
-	if (server_ping($fp, $rdata))
+	if (server_ping($fp, $rdata)) {
 		return;
+	}
 
 	// server msg
-	if (server_msg_307($fp, $rdata))
+	if (server_msg_307($fp, $rdata)) {
 		return;
-	if (server_msg_318($fp, $rdata))
+	}
+	if (server_msg_318($fp, $rdata)) {
 		return;
-	if (server_msg_352($fp, $rdata))
+	}
+	if (server_msg_352($fp, $rdata)) {
 		return;
-	if (server_msg_401($fp, $rdata))
+	}
+	if (server_msg_401($fp, $rdata)) {
 		return;
+	}
 
 	//Are they using a linked nick instead
-	if (notice_nickserv_registered_user($fp, $rdata))
+	if (notice_nickserv_registered_user($fp, $rdata)) {
 		return;
-	if (notice_nickserv_unknown_user($fp, $rdata))
+	}
+	if (notice_nickserv_unknown_user($fp, $rdata)) {
 		return;
+	}
 
 	// some nice things
-	if (ctcp_version($fp, $rdata))
+	if (ctcp_version($fp, $rdata)) {
 		return;
-	if (ctcp_finger($fp, $rdata))
+	}
+	if (ctcp_finger($fp, $rdata)) {
 		return;
-	if (ctcp_time($fp, $rdata))
+	}
+	if (ctcp_time($fp, $rdata)) {
 		return;
-	if (ctcp_ping($fp, $rdata))
+	}
+	if (ctcp_ping($fp, $rdata)) {
 		return;
+	}
 
-	if (invite($fp, $rdata))
+	if (invite($fp, $rdata)) {
 		return;
+	}
 
 	// join and part
-	if (channel_join($fp, $rdata))
+	if (channel_join($fp, $rdata)) {
 		return;
-	if (channel_part($fp, $rdata))
+	}
+	if (channel_part($fp, $rdata)) {
 		return;
+	}
 
 	// nick change and quit
-	if (user_nick($fp, $rdata))
+	if (user_nick($fp, $rdata)) {
 		return;
-	if (user_quit($fp, $rdata))
+	}
+	if (user_quit($fp, $rdata)) {
 		return;
+	}
 
-	if (channel_action_slap($fp, $rdata))
+	if (channel_action_slap($fp, $rdata)) {
 		return;
+	}
 
 	// channel msg (!xyz) without registration
-	if (channel_msg_help($fp, $rdata))
+	if (channel_msg_help($fp, $rdata)) {
 		return;
-	if (channel_msg_seedlist($fp, $rdata))
+	}
+	if (channel_msg_seedlist($fp, $rdata)) {
 		return;
-	if (channel_msg_op($fp, $rdata))
+	}
+	if (channel_msg_op($fp, $rdata)) {
 		return;
-	if (channel_msg_timer($fp, $rdata))
+	}
+	if (channel_msg_timer($fp, $rdata)) {
 		return;
-	if (channel_msg_8ball($fp, $rdata))
+	}
+	if (channel_msg_8ball($fp, $rdata)) {
 		return;
-	if (channel_msg_seen($fp, $rdata))
+	}
+	if (channel_msg_seen($fp, $rdata)) {
 		return;
-	if (channel_msg_sd($fp, $rdata))
+	}
+	if (channel_msg_sd($fp, $rdata)) {
 		return;
+	}
 
 	// channel msg (!xyz) with registration
-	if (channel_msg_with_registration($fp, $rdata))
+	if (channel_msg_with_registration($fp, $rdata)) {
 		return;
+	}
 
 	// MrSpock can use this to send commands as caretaker
-	if (query_command($fp, $rdata))
+	if (query_command($fp, $rdata)) {
 		return;
+	}
 
 
 	// debug

--- a/tools/irc/irc.php
+++ b/tools/irc/irc.php
@@ -145,8 +145,7 @@ while ($running) {
 			sleep(60);
 
 		}
-	}
-	catch (TimeoutException $e) {
+	} catch (TimeoutException $e) {
 		// Ignore the timeout exception, we'll loop round and reconnect.
 	}
 } // end of while running

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -89,12 +89,10 @@ try {
 
 	try {
 		changeNPCLogin();
-	}
-	catch (ForwardException $e) {}
+	} catch (ForwardException $e) {}
 
 	NPCStuff();
-}
-catch (Throwable $e) {
+} catch (Throwable $e) {
 	logException($e);
 	// Try to shut down cleanly
 	exitNPC();
@@ -157,8 +155,7 @@ function NPCStuff() {
 			$fedContainer = null;
 			if ($var['url'] == 'shop_ship_processing.php' && ($fedContainer = plotToFed($player, true)) !== true) { //We just bought a ship, we should head back to our trade gal/uno - we use HQ for now as it's both in our gal and a UNO, plus it's safe which is always a bonus
 				processContainer($fedContainer);
-			}
-			else if ($player->getShip()->isUnderAttack() === true
+			} else if ($player->getShip()->isUnderAttack() === true
 				&&($player->hasPlottedCourse() === false || $player->getPlottedCourse()->getEndSector()->offersFederalProtection() === false)
 				&&($fedContainer == null ? $fedContainer = plotToFed($player, true) : $fedContainer) !== true) { //We're under attack and need to plot course to fed.
 				// Get the lock, remove under attack and update.
@@ -171,20 +168,16 @@ function NPCStuff() {
 				debug('Under Attack');
 				$underAttack = true;
 				processContainer($fedContainer);
-			}
-			else if ($player->hasPlottedCourse() === true && $player->getPlottedCourse()->getEndSector()->offersFederalProtection()) { //We have a route to fed to follow, figure it's probably a damned sensible thing to follow.
+			} else if ($player->hasPlottedCourse() === true && $player->getPlottedCourse()->getEndSector()->offersFederalProtection()) { //We have a route to fed to follow, figure it's probably a damned sensible thing to follow.
 				debug('Follow Course: ' . $player->getPlottedCourse()->getNextOnPath());
 				processContainer(moveToSector($player, $player->getPlottedCourse()->getNextOnPath()));
-			}
-			else if (($container = canWeUNO($player, true)) !== false) { //We have money and are at a uno, let's uno!
+			} else if (($container = canWeUNO($player, true)) !== false) { //We have money and are at a uno, let's uno!
 				debug('We\'re UNOing');
 				processContainer($container);
-			}
-			else if ($player->hasPlottedCourse() === true) { //We have a route to follow, figure it's probably a sensible thing to follow.
+			} else if ($player->hasPlottedCourse() === true) { //We have a route to follow, figure it's probably a sensible thing to follow.
 				debug('Follow Course: ' . $player->getPlottedCourse()->getNextOnPath());
 				processContainer(moveToSector($player, $player->getPlottedCourse()->getNextOnPath()));
-			}
-			else if ($player->getTurns() < NPC_LOW_TURNS || ($player->getTurns() < $player->getMaxTurns() / 2 && $player->getNewbieTurns() < NPC_LOW_NEWBIE_TURNS) || $underAttack) { //We're low on turns or have been under attack and need to plot course to fed
+			} else if ($player->getTurns() < NPC_LOW_TURNS || ($player->getTurns() < $player->getMaxTurns() / 2 && $player->getNewbieTurns() < NPC_LOW_NEWBIE_TURNS) || $underAttack) { //We're low on turns or have been under attack and need to plot course to fed
 				if ($player->getTurns() < NPC_LOW_TURNS) {
 					debug('Low Turns:' . $player->getTurns());
 				}
@@ -201,16 +194,13 @@ function NPCStuff() {
 				}
 				$ship = $player->getShip();
 				processContainer(plotToFed($player, !$ship->hasMaxShields() || !$ship->hasMaxArmour() || !$ship->hasMaxCargoHolds()));
-			}
-			else if (($container = checkForShipUpgrade($player)) !== false) { //We have money and are at a uno, let's uno!
+			} else if (($container = checkForShipUpgrade($player)) !== false) { //We have money and are at a uno, let's uno!
 				debug('We\'re reshipping!');
 				processContainer($container);
-			}
-			else if (($container = canWeUNO($player, false)) !== false) { //We need to UNO and have enough money to do it properly so let's do it sooner rather than later.
+			} else if (($container = canWeUNO($player, false)) !== false) { //We need to UNO and have enough money to do it properly so let's do it sooner rather than later.
 				debug('We need to UNO, so off we go!');
 				processContainer($container);
-			}
-			else if ($TRADE_ROUTE instanceof \Routes\Route) {
+			} else if ($TRADE_ROUTE instanceof \Routes\Route) {
 				debug('Trade Route');
 				$forwardRoute = $TRADE_ROUTE->getForwardRoute();
 				$returnRoute = $TRADE_ROUTE->getReturnRoute();
@@ -218,8 +208,7 @@ function NPCStuff() {
 					if ($forwardRoute->getBuySectorId() == $player->getSectorID()) {
 						$buyRoute = $forwardRoute;
 						$sellRoute = $returnRoute;
-					}
-					else if ($returnRoute->getBuySectorId() == $player->getSectorID()) {
+					} else if ($returnRoute->getBuySectorId() == $player->getSectorID()) {
 						$buyRoute = $returnRoute;
 						$sellRoute = $forwardRoute;
 					}
@@ -236,30 +225,25 @@ function NPCStuff() {
 								//Sell goods
 								debug('Sell Goods');
 								processContainer(tradeGoods($goodID, $player, $port));
-							}
-							else {
+							} else {
 								//Move to next route or fed.
 								if (($TRADE_ROUTE =& changeRoute($TRADE_ROUTES)) === false) {
 									debug('Changing Route Failed');
 									processContainer(plotToFed($player));
-								}
-								else {
+								} else {
 									debug('Route Changed');
 									continue;
 								}
 							}
-						}
-						else if ($ship->hasCargo($buyRoute->getGoodID()) === true) { //We've bought goods, plot to sell
+						} else if ($ship->hasCargo($buyRoute->getGoodID()) === true) { //We've bought goods, plot to sell
 							debug('Plot To Sell: ' . $buyRoute->getSellSectorId());
 							processContainer(plotToSector($player, $buyRoute->getSellSectorId()));
-						}
-						else {
+						} else {
 							//Dump goods
 							debug('Dump Goods');
 							processContainer(dumpCargo($player));
 						}
-					}
-					else { //Buy goods
+					} else { //Buy goods
 						$goodID = $buyRoute->getGoodID();
 
 						$port = $player->getSector()->getPort();
@@ -268,26 +252,22 @@ function NPCStuff() {
 						if ($tradeable === true && $port->getGoodAmount($goodID) >= $ship->getEmptyHolds()) { //Buy goods
 							debug('Buy Goods');
 							processContainer(tradeGoods($goodID, $player, $port));
-						}
-						else {
+						} else {
 							//Move to next route or fed.
 							if (($TRADE_ROUTE =& changeRoute($TRADE_ROUTES)) === false) {
 								debug('Changing Route Failed');
 								processContainer(plotToFed($player));
-							}
-							else {
+							} else {
 								debug('Route Changed');
 								continue;
 							}
 						}
 					}
-				}
-				else {
+				} else {
 					debug('Plot To Buy: ' . $forwardRoute->getBuySectorId());
 					processContainer(plotToSector($player, $forwardRoute->getBuySectorId()));
 				}
-			}
-			else { //Something weird is going on.. Let's fed and wait.
+			} else { //Something weird is going on.. Let's fed and wait.
 				debug('No actual action? Wtf?');
 				processContainer(plotToFed($player));
 			}
@@ -299,8 +279,7 @@ function NPCStuff() {
 				processContainer(moveToSector($player,$moveTo));
 			}
 			*/
-		}
-		catch (ForwardException $e) {
+		} catch (ForwardException $e) {
 			global $lock;
 			if ($lock) { //only save if we have the lock.
 				SmrSector::saveSectors();
@@ -469,8 +448,7 @@ function canWeUNO(AbstractSmrPlayer $player, $oppurtunisticOnly) {
 			$hardwareSold = $location->getHardwareSold();
 			if ($player->getNewbieTurns() > MIN_NEWBIE_TURNS_TO_BUY_CARGO && !$ship->hasMaxCargoHolds() && isset($hardwareSold[HARDWARE_CARGO]) && ($amount = floor(($player->getCredits() - MINUMUM_RESERVE_CREDITS) / Globals::getHardwareCost(HARDWARE_CARGO))) > 0) { // Buy cargo holds first if we have plenty of newbie turns left.
 				$hardwareID = HARDWARE_CARGO;
-			}
-			else {
+			} else {
 				foreach ($hardwareArray as $hardwareArrayID) {
 					if (!$ship->hasMaxHardware($hardwareArrayID) && isset($hardwareSold[$hardwareArrayID]) && ($amount = floor(($player->getCredits() - MINUMUM_RESERVE_CREDITS) / Globals::getHardwareCost($hardwareArrayID))) > 0) {
 						$hardwareID = $hardwareArrayID;
@@ -579,8 +557,10 @@ function moveToSector($player, $targetSector) {
 
 function checkForShipUpgrade(AbstractSmrPlayer $player) {
 	foreach (SHIP_UPGRADE_PATH[$player->getRaceID()] as $upgradeShipID) {
-		if ($player->getShipTypeID() == $upgradeShipID) //We can't upgrade, only downgrade.
+		if ($player->getShipTypeID() == $upgradeShipID) {
+			//We can't upgrade, only downgrade.
 			return false;
+		}
 		$cost = $player->getShip()->getCostToUpgrade($upgradeShipID);
 		if ($cost <= 0 || $player->getCredits() - $cost > MINUMUM_RESERVE_CREDITS) {
 			return doShipUpgrade($player, $upgradeShipID);
@@ -649,8 +629,7 @@ function &findRoutes($player) {
 		$routes = unserialize(gzuncompress($db->getField('routes')));
 		debug('Using Cached Routes: #' . count($routes));
 		return $routes;
-	}
-	else {
+	} else {
 		debug('Generating Routes');
 		$allSectors = array();
 		foreach (SmrGalaxy::getGameGalaxies($player->getGameID()) as $galaxy) {

--- a/tools/npc/npc.php
+++ b/tools/npc/npc.php
@@ -308,8 +308,9 @@ function NPCStuff() {
 				SmrPlayer::savePlayers();
 				SmrForce::saveForces();
 				SmrPort::savePorts();
-				if (class_exists('WeightedRandom', false))
+				if (class_exists('WeightedRandom', false)) {
 					WeightedRandom::saveWeightedRandoms();
+				}
 				release_lock();
 			}
 			//Clean up the caches as the data may get changed by other players
@@ -448,11 +449,13 @@ function changeNPCLogin() {
 }
 
 function canWeUNO(AbstractSmrPlayer $player, $oppurtunisticOnly) {
-	if ($player->getCredits() < MINUMUM_RESERVE_CREDITS)
+	if ($player->getCredits() < MINUMUM_RESERVE_CREDITS) {
 		return false;
+	}
 	$ship = $player->getShip();
-	if ($ship->hasMaxShields() && $ship->hasMaxArmour() && $ship->hasMaxCargoHolds())
+	if ($ship->hasMaxShields() && $ship->hasMaxArmour() && $ship->hasMaxCargoHolds()) {
 		return false;
+	}
 	$sector = $player->getSector();
 
 	// We buy armour in preference to shields as it's cheaper.
@@ -481,11 +484,13 @@ function canWeUNO(AbstractSmrPlayer $player, $oppurtunisticOnly) {
 		}
 	}
 
-	if ($oppurtunisticOnly === true)
+	if ($oppurtunisticOnly === true) {
 		return false;
+	}
 
-	if ($player->getCredits() - $ship->getCostToUNO() < MINUMUM_RESERVE_CREDITS)
+	if ($player->getCredits() - $ship->getCostToUNO() < MINUMUM_RESERVE_CREDITS) {
 		return false; //Only do non-oppurtunistic UNO if we have the money to do it properly!
+	}
 
 	foreach ($hardwareArray as $hardwareArrayID) {
 		if (!$ship->hasMaxHardware($hardwareArrayID)) {
@@ -597,8 +602,9 @@ function doShipUpgrade(AbstractSmrPlayer $player, $upgradeShipID) {
 
 function &changeRoute(array &$tradeRoutes) {
 	$false = false;
-	if (count($tradeRoutes) == 0)
+	if (count($tradeRoutes) == 0) {
 		return $false;
+	}
 	$routeKey = array_rand($tradeRoutes);
 	$tradeRoute =& $tradeRoutes[$routeKey];
 	unset($tradeRoutes[$routeKey]);
@@ -612,10 +618,11 @@ function &findRoutes($player) {
 
 	$tradeGoods = array(GOOD_NOTHING => false);
 	foreach (Globals::getGoods() as $goodID => $good) {
-		if ($player->meetsAlignmentRestriction($good['AlignRestriction']))
+		if ($player->meetsAlignmentRestriction($good['AlignRestriction'])) {
 			$tradeGoods[$goodID] = true;
-		else
+		} else {
 			$tradeGoods[$goodID] = false;
+		}
 	}
 
 	// Only allow NPCs to trade at ports of their race and neutral ports
@@ -652,10 +659,11 @@ function &findRoutes($player) {
 
 		$distances = Plotter::calculatePortToPortDistances($allSectors, $maxDistance, $startSectorID, $endSectorID);
 
-		if ($maxNumberOfPorts == 1)
+		if ($maxNumberOfPorts == 1) {
 			$allRoutes = \Routes\RouteGenerator::generateOneWayRoutes($allSectors, $distances, $tradeGoods, $tradeRaces, $routesForPort);
-		else
+		} else {
 			$allRoutes = \Routes\RouteGenerator::generateMultiPortRoutes($maxNumberOfPorts, $allSectors, $tradeGoods, $tradeRaces, $distances, $routesForPort, $numberOfRoutes);
+		}
 
 		unset($distances);
 


### PR DESCRIPTION
It is safer to use explicit braces when a conditional extends onto
multiple lines. (Without them, you have to trust that the indentation
correctly implies the scope of the conditional).

This is done manually because Scrutinizer's auto-formatting doesn't
correctly fix dangling-ifs (it adds too much indentation).

git grep "if\s*\(.*\)\s*$"

VIM: /if\s*(.*)\s*$