### PR TITLE
Make submitStyle links look like submit input elements

### DIFF
--- a/htdocs/css/Default.css
+++ b/htdocs/css/Default.css
@@ -32,23 +32,24 @@ h3 {
 }
 .submitStyle:link {
 	font: inherit;
-	padding: 0px 8px;
+	padding: 1px 6px;
 }
 .submitStyle:visited {
 	font: inherit;
-	padding: 0px 8px;
+	padding: 1px 6px;
 }
 .submitStyle:hover {
 	font: inherit;
-	padding: 0px 8px;
+	padding: 1px 6px;
 }
 .submitStyle:active {
 	font: inherit;
-	padding: 0px 8px;
+	padding: 1px 6px;
 }
 .submitStyle {
 	font: inherit;
-	padding: 0px 8px;
+	padding: 1px 6px;
+	border-spacing: 0px;
 	display: inline-table; /* Fixes the problems with vertical overlap in FF, but not IE :( */
 }
 /* ------------------------------------ */


### PR DESCRIPTION
This change fixes the box spacing around links with the `submitStyle`
class so that they are styled the same way as submit input elements.

In Chrome, the user agent stylesheet specifies `padding` for submit
input elements as 1px (top/bottom) and 6px (left/right). Perhaps this
was different (0px and 8px) in the past or for other browsers. We
should probably set this explicitly, to ensure it is consistent with
the `submitStyle` class, but for now it is sufficient to assume a
recent Chrome version.

The `border-spacing` is a more subtle issue. We set it to 0 for a lot
of tables in our CSS, and it seems to be inherited by `submitStyle`
links contained in those tables. However, if the link is inside a
default table, then its `border-spacing` gets reset to the user agent
stylesheet default of 2px. We set it explicitly for `submitStyle` to
avoid this issue.

An example of the submit element (left) being sized differently than the "submitStyle link" (right):
![image](https://user-images.githubusercontent.com/846186/73114656-5e55f500-3ed1-11ea-8c19-eb465a2db7fd.png)

Some tables will look slightly less compact, old (top) vs. new (bottom):
![image](https://user-images.githubusercontent.com/846186/73114685-9b21ec00-3ed1-11ea-9da3-55f1f5724c3c.png)
![image](https://user-images.githubusercontent.com/846186/73114688-a8d77180-3ed1-11ea-88ef-ec78b73ca93f.png)
