### PR TITLE
Don't use skeleton.php in processing containers

### DIFF
--- a/admin/Default/npc_manage.php
+++ b/admin/Default/npc_manage.php
@@ -23,7 +23,7 @@ while ($db->nextRecord()) {
 $template->assign('Games', $games);
 $template->assign('SelectedGameID', $selectedGameID);
 
-$container = create_container('skeleton.php', 'npc_manage_processing.php');
+$container = create_container('npc_manage_processing.php');
 $container['selected_game_id'] = $selectedGameID;
 $template->assign('AddAccountHREF', SmrSession::getNewHREF($container));
 

--- a/engine/Default/bank_anon_create.php
+++ b/engine/Default/bank_anon_create.php
@@ -3,5 +3,5 @@
 $template->assign('PageTopic', 'Create Anonymous Account');
 Menu::bank();
 
-$container = create_container('skeleton.php', 'bank_anon_create_processing.php');
+$container = create_container('bank_anon_create_processing.php');
 $template->assign('CreateHREF', SmrSession::getNewHREF($container));

--- a/engine/Default/buy_ship_name.php
+++ b/engine/Default/buy_ship_name.php
@@ -4,7 +4,7 @@ $template->assign('PageTopic', 'Naming Your Ship');
 
 if (isset($var['Preview'])) {
 	$template->assign('Preview', $var['Preview']);
-	$template->assign('ContinueHref', SmrSession::getNewHREF(create_container('skeleton.php', 'buy_ship_name_processing.php', array('ShipName'=>$var['Preview']))));
+	$template->assign('ContinueHref', SmrSession::getNewHREF(create_container('buy_ship_name_processing.php', '', array('ShipName'=>$var['Preview']))));
 } else {
-	$template->assign('ShipNameFormHref', SmrSession::getNewHREF(create_container('skeleton.php', 'buy_ship_name_processing.php')));
+	$template->assign('ShipNameFormHref', SmrSession::getNewHREF(create_container('buy_ship_name_processing.php')));
 }

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -1260,7 +1260,7 @@ abstract class AbstractSmrAccount {
 
 	public function getToggleAJAXHREF() {
 		global $var;
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'toggle_processing.php', array('toggle'=>'AJAX', 'referrer'=>$var['body'])));
+		return SmrSession::getNewHREF(create_container('toggle_processing.php', '', array('toggle'=>'AJAX', 'referrer'=>$var['body'])));
 	}
 
 	public function getUserRankingHREF() {

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -1425,7 +1425,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function getToggleWeaponHidingHREF($ajax = false) {
-		$container = create_container('skeleton.php', 'toggle_processing.php');
+		$container = create_container('toggle_processing.php');
 		$container['toggle'] = 'WeaponHiding';
 		$container['AJAX'] = $ajax;
 		return SmrSession::getNewHREF($container);

--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -1044,7 +1044,7 @@ class AbstractSmrPort {
 	}
 	
 	public function getAttackHREF() {
-		$container = create_container('skeleton.php', 'port_attack_processing.php');
+		$container = create_container('port_attack_processing.php');
 		$container['port_id'] = $this->getSectorID();
 		return SmrSession::getNewHREF($container);
 	}
@@ -1056,14 +1056,14 @@ class AbstractSmrPort {
 	}
 
 	public function getRazeHREF($justContainer = false) {
-		$container = create_container('skeleton.php', 'port_payout_processing.php');
+		$container = create_container('port_payout_processing.php');
 		$container['PayoutType'] = 'Raze';
 		return $justContainer === false ? SmrSession::getNewHREF($container) : $container;
 	}
 
 	public function getLootHREF($justContainer = false) {
 		if ($this->getCredits() > 0) {
-			$container = create_container('skeleton.php', 'port_payout_processing.php');
+			$container = create_container('port_payout_processing.php');
 			$container['PayoutType'] = 'Loot';
 		} else {
 			$container = create_container('skeleton.php', 'current_sector.php');

--- a/lib/Default/ChessGame.class.php
+++ b/lib/Default/ChessGame.class.php
@@ -857,6 +857,6 @@ class ChessGame {
 	}
 
 	public function getResignHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'chess_resign_processing.php', array('ChessGameID' => $this->chessGameID)));
+		return SmrSession::getNewHREF(create_container('chess_resign_processing.php', '', array('ChessGameID' => $this->chessGameID)));
 	}
 }

--- a/lib/Default/Globals.class.php
+++ b/lib/Default/Globals.class.php
@@ -289,7 +289,7 @@ class Globals {
 	}
 
 	public static function getAttackTraderHREF($accountID) {
-		$container = create_container('skeleton.php', 'trader_attack_processing.php');
+		$container = create_container('trader_attack_processing.php');
 		$container['target'] = $accountID;
 		return self::$AVAILABLE_LINKS['AttackTrader'] = SmrSession::getNewHREF($container);
 	}
@@ -481,7 +481,7 @@ class Globals {
 	}
 
 	public static function getChessCreateHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'chess_create_processing.php'));
+		return SmrSession::getNewHREF(create_container('chess_create_processing.php'));
 	}
 
 	public static function getBarMainHREF() {

--- a/lib/Default/Mission.class.php
+++ b/lib/Default/Mission.class.php
@@ -3,19 +3,19 @@
 class Mission {
 
 	public static function getAcceptHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_accept_processing.php', ['MissionID' => $missionID]));
+		return SmrSession::getNewHREF(create_container('mission_accept_processing.php', '', ['MissionID' => $missionID]));
 	}
 
 	public static function getDeclineHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_decline_processing.php', ['MissionID' => $missionID]));
+		return SmrSession::getNewHREF(create_container('mission_decline_processing.php', '', ['MissionID' => $missionID]));
 	}
 
 	public static function getAbandonHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_abandon_processing.php', ['MissionID' => $missionID]));
+		return SmrSession::getNewHREF(create_container('mission_abandon_processing.php', '', ['MissionID' => $missionID]));
 	}
 
 	public static function getClaimRewardHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'mission_claim_processing.php', ['MissionID' => $missionID]));
+		return SmrSession::getNewHREF(create_container('mission_claim_processing.php', '', ['MissionID' => $missionID]));
 	}
 
 }


### PR DESCRIPTION
If an engine filename has the "processing" suffix, then it should
not ever be responsible for creating a display page (i.e. it should
always forward to another page).

Therefore, we should not ever be creating a processing container that
uses `skeleton.php` as the url.