### PR TITLE
Add test to check "strict_types" declaration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ git:
   depth: false
 script:
   - tests/phplint.sh
+  - tests/strict_types.sh

--- a/engine/Default/game_play_preprocessing.php
+++ b/engine/Default/game_play_preprocessing.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 // Reset the game ID if necessary
 if (SmrSession::hasGame()) {

--- a/tests/strict_types.sh
+++ b/tests/strict_types.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Checks that every (non-template) PHP file starts with a "strict_types"
+# declaration, since this is easy to accidentally omit.
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+ERROR="false"
+while IFS= read -d '' FILE;
+do
+    LINE=$(head -n 1 "$FILE")
+
+    if [[ "$LINE" != "<?php declare(strict_types=1);" ]] ; then
+        echo "====> $FILE"
+        echo "$LINE"
+        ERROR="true"
+    fi
+done < <(find $ROOT/admin $ROOT/engine $ROOT/lib -type f \( -name "*.php" -o -name "*.inc" \) -print0)
+
+if [[ "$ERROR" == "true" ]] ; then
+    exit 1
+else
+    echo "Success! No strict_type errors."
+    exit 0
+fi


### PR DESCRIPTION
This declaration must come at the top of every (non-template) file.
Since it is easy to accidentally omit when creating a new file, this
test will help ensure that such omissions are caught.