### PR TITLE
bounty_place.php: restructure forwarding

### DIFF
--- a/engine/Default/bounty_place.php
+++ b/engine/Default/bounty_place.php
@@ -9,7 +9,7 @@ if ($sector->hasHQ()) {
 	create_ug_menu();
 }
 
-$container = create_container('skeleton.php', 'bounty_place_confirm.php');
+$container = create_container('bounty_place_processing.php');
 transfer('LocationID');
 $template->assign('SubmitHREF', SmrSession::getNewHREF($container));
 

--- a/engine/Default/bounty_place_confirm.php
+++ b/engine/Default/bounty_place_confirm.php
@@ -1,32 +1,5 @@
 <?php declare(strict_types=1);
 
-// get request variables
-$amount = SmrSession::getRequestVar('amount');
-$smrCredits = SmrSession::getRequestVar('smrcredits');
-$playerID = SmrSession::getRequestVar('player_id');
-
-if ($playerID == '0') {
-	create_error('Uhhh...who is [Please Select]?');
-}
-
-$amount = intval($amount);
-if ($player->getCredits() < $amount) {
-	create_error('You dont have that much money.');
-}
-
-$smrCredits = intval($smrCredits);
-if ($account->getSmrCredits() < $smrCredits) {
-	create_error('You dont have that many SMR credits.');
-}
-
-if ($amount <= 0 && $smrCredits <= 0) {
-	create_error('You must enter an amount greater than 0!');
-}
-
-if ((empty($amount) && empty($smrCredits)) || empty($playerID)) {
-	create_error('Don\'t you want to place bounty?');
-}
-
 $template->assign('PageTopic', 'Placing a bounty');
 
 require_once(get_file_loc('menu_hq.inc'));
@@ -37,15 +10,15 @@ if ($sector->hasHQ()) {
 }
 
 // get this guy from db
-$bounty_guy = SmrPlayer::getPlayerByPlayerID($playerID, $player->getGameID());
+$bountyPlayer = SmrPlayer::getPlayerByPlayerID($var['player_id'], $player->getGameID());
 
-$template->assign('Amount', number_format($amount));
-$template->assign('SmrCredits', number_format($smrCredits));
-$template->assign('BountyPlayer', $bounty_guy->getLinkedDisplayName());
+$template->assign('Amount', number_format($var['amount']));
+$template->assign('SmrCredits', number_format($var['SmrCredits']));
+$template->assign('BountyPlayer', $bountyPlayer->getLinkedDisplayName());
 
-$container = create_container('bounty_place_processing.php');
-$container['account_id'] = $bounty_guy->getAccountID();
-$container['amount'] = $amount;
-$container['SmrCredits'] = $smrCredits;
+$container = create_container('bounty_place_confirm_processing.php');
+$container['account_id'] = $bountyPlayer->getAccountID();
+transfer('amount');
+transfer('SmrCredits');
 transfer('LocationID');
 $template->assign('ProcessingHREF', SmrSession::getNewHREF($container));

--- a/engine/Default/bounty_place_confirm_processing.php
+++ b/engine/Default/bounty_place_confirm_processing.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+if (!$player->getSector()->hasLocation($var['LocationID'])) {
+	create_error('That location does not exist in this sector');
+}
+
+$location = SmrLocation::getLocation($var['LocationID']);
+$container = create_container('skeleton.php');
+transfer('LocationID');
+if ($location->isHQ()) {
+	$container['body'] = 'government.php';
+	$type = 'HQ';
+} elseif ($location->isUG()) {
+	$container['body'] = 'underground.php';
+	$type = 'UG';
+} else {
+	create_error('The location is not a UG or HQ, how did you get here?');
+}
+// if we don't have a yes we leave immediatly
+if (Request::get('action') != 'Yes') {
+	forward($container);
+}
+
+// get values from container (validated in bounty_place_processing.php)
+$amount = $var['amount'];
+$smrCredits = $var['SmrCredits'];
+$account_id = $var['account_id'];
+
+// take the bounty from the cash
+$player->decreaseCredits($amount);
+$account->decreaseSmrCredits($smrCredits);
+
+$player->increaseHOF($smrCredits, array('Bounties', 'Placed', 'SMR Credits'), HOF_PUBLIC);
+$player->increaseHOF($amount, array('Bounties', 'Placed', 'Money'), HOF_PUBLIC);
+$player->increaseHOF(1, array('Bounties', 'Placed', 'Number'), HOF_PUBLIC);
+
+$placed = SmrPlayer::getPlayer($account_id, $player->getGameID());
+$placed->increaseCurrentBountyAmount($type, $amount);
+$placed->increaseCurrentBountySmrCredits($type, $smrCredits);
+$placed->increaseHOF($smrCredits, array('Bounties', 'Received', 'SMR Credits'), HOF_PUBLIC);
+$placed->increaseHOF($amount, array('Bounties', 'Received', 'Money'), HOF_PUBLIC);
+$placed->increaseHOF(1, array('Bounties', 'Received', 'Number'), HOF_PUBLIC);
+
+//Update for top bounties list
+$player->update();
+$account->update();
+$placed->update();
+forward($container);

--- a/engine/Default/bounty_place_processing.php
+++ b/engine/Default/bounty_place_processing.php
@@ -1,56 +1,24 @@
 <?php declare(strict_types=1);
 
-if (!$player->getSector()->hasLocation($var['LocationID'])) {
-	create_error('That location does not exist in this sector');
+$amount = Request::getInt('amount');
+$smrCredits = Request::getInt('smrcredits');
+
+if ($player->getCredits() < $amount) {
+	create_error('You dont have that much money.');
 }
 
-$location = SmrLocation::getLocation($var['LocationID']);
-$container = create_container('skeleton.php');
+if ($account->getSmrCredits() < $smrCredits) {
+	create_error('You dont have that many SMR credits.');
+}
+
+if ($amount <= 0 && $smrCredits <= 0) {
+	create_error('You must enter an amount greater than 0!');
+}
+
+$container = create_container('skeleton.php', 'bounty_place_confirm.php');
+$container['amount'] = $amount;
+$container['SmrCredits'] = $smrCredits;
+$container['player_id'] = Request::getInt('player_id');
 transfer('LocationID');
-if ($location->isHQ()) {
-	$container['body'] = 'government.php';
-	$type = 'HQ';
-} elseif ($location->isUG()) {
-	$container['body'] = 'underground.php';
-	$type = 'UG';
-} else {
-	create_error('The location is not a UG or HQ, how did you get here?');
-}
-// if we don't have a yes we leave immediatly
-if (Request::get('action') != 'Yes') {
-	forward($container);
-}
 
-// get values from container
-$amount = $var['amount'];
-$smrCredits = $var['SmrCredits'];
-$account_id = $var['account_id'];
-if ((!is_numeric($amount) && !is_numeric($smrCredits)) || ($amount == 0 && $smrCredits == 0)) {
-	create_error('You must enter an amount!');
-}
-if ($amount < 0) {
-	create_error('You must enter a positive amount!');
-}
-if ($smrCredits < 0) {
-	create_error('You must enter a positive SMR credits amount!');
-}
-// take the bounty from the cash
-$player->decreaseCredits($amount);
-$account->decreaseSmrCredits($smrCredits);
-
-$player->increaseHOF($smrCredits, array('Bounties', 'Placed', 'SMR Credits'), HOF_PUBLIC);
-$player->increaseHOF($amount, array('Bounties', 'Placed', 'Money'), HOF_PUBLIC);
-$player->increaseHOF(1, array('Bounties', 'Placed', 'Number'), HOF_PUBLIC);
-
-$placed = SmrPlayer::getPlayer($account_id, $player->getGameID());
-$placed->increaseCurrentBountyAmount($type, $amount);
-$placed->increaseCurrentBountySmrCredits($type, $smrCredits);
-$placed->increaseHOF($smrCredits, array('Bounties', 'Received', 'SMR Credits'), HOF_PUBLIC);
-$placed->increaseHOF($amount, array('Bounties', 'Received', 'Money'), HOF_PUBLIC);
-$placed->increaseHOF(1, array('Bounties', 'Received', 'Number'), HOF_PUBLIC);
-
-//Update for top bounties list
-$player->update();
-$account->update();
-$placed->update();
 forward($container);

--- a/templates/Default/engine/Default/bounty_place.php
+++ b/templates/Default/engine/Default/bounty_place.php
@@ -1,7 +1,7 @@
 <form method="POST" action="<?php echo $SubmitHREF; ?>">
 	Select the player you want to add the bounty to<br />
-	<select name="player_id" size="1" class="InputFields">
-		<option value="0">[Please Select]</option>
+	<select name="player_id" required size="1" class="InputFields">
+		<option value="" disabled selected>[Please Select]</option>
 
 		<?php
 		foreach ($BountyPlayers as $id => $name) { ?>


### PR DESCRIPTION
Move input validation out of bounty_place_confirm.php and into
bounty_place_processing.php.

So the flow now looks like this:

bp.php -> Display the input form
bp_processing.php -> Validate the input data and forward
bp_confirm.php -> Display confirmation of input data
bp_confirm_processing.php -> Validate confirmation and process

This flow avoids any need for SmrSession::getRequestVar, and instead
we can just use the Request class in the processing pages. (When the
form validation was in bp_confirm.php, we were reprocessing the form
validation on each ajax refresh as well!)