### PR TITLE
Fix call to renamed SmrPlayer method

### DIFF
--- a/engine/Default/bank_alliance.php
+++ b/engine/Default/bank_alliance.php
@@ -48,7 +48,7 @@ if ($alliance->getAllianceID() == $player->getAllianceID()) {
 	$role_id = $player->getAllianceRole($alliance->getAllianceID());
 	$query = 'role_id = ' . $db->escapeNumber($role_id);
 } else {
-	$query = 'role = ' . $db->escapeString($player->getAllianceName());
+	$query = 'role = ' . $db->escapeString($player->getAlliance()->getAllianceName());
 }
 
 $db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND ' . $query);

--- a/engine/Default/bank_alliance_processing.php
+++ b/engine/Default/bank_alliance_processing.php
@@ -46,7 +46,7 @@ if ($action == 'Deposit') {
 		$query = 'role_id = ' . $db->escapeNumber($role_id);
 	} else {
 		// Alliance treaties create new roles with alliance names
-		$query = 'role = ' . $db->escapeString($player->getAllianceName());
+		$query = 'role = ' . $db->escapeString($player->getAlliance()->getAllianceName());
 	}
 	$db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND ' . $query);
 	$db->nextRecord();

--- a/engine/Default/rankings_alliance_death.php
+++ b/engine/Default/rankings_alliance_death.php
@@ -16,7 +16,7 @@ if ($player->hasAlliance()) {
 					alliance_deaths > '.$db->escapeNumber($player->getAlliance()->getDeaths()) . '
 					OR (
 						alliance_deaths = '.$db->escapeNumber($player->getAlliance()->getDeaths()) . '
-						AND alliance_name <= ' . $db->escapeString($player->getAllianceName()) . '
+						AND alliance_name <= ' . $db->escapeString($player->getAlliance()->getAllianceName()) . '
 					)
 				)');
 	$db->nextRecord();

--- a/engine/Default/rankings_alliance_experience.php
+++ b/engine/Default/rankings_alliance_experience.php
@@ -27,7 +27,7 @@ if ($player->hasAlliance()) {
 					t.amount > us.amount
 					OR (
 						t.amount = us.amount
-						AND alliance_name <= ' . $db->escapeString($player->getAllianceName()) . '
+						AND alliance_name <= ' . $db->escapeString($player->getAlliance()->getAllianceName()) . '
 					)
 				)');
 	$db->nextRecord();

--- a/engine/Default/rankings_alliance_kills.php
+++ b/engine/Default/rankings_alliance_kills.php
@@ -16,7 +16,7 @@ if ($player->hasAlliance()) {
 					alliance_kills > '.$db->escapeNumber($player->getAlliance()->getKills()) . '
 					OR (
 						alliance_kills = '.$db->escapeNumber($player->getAlliance()->getKills()) . '
-						AND alliance_name <= ' . $db->escapeString($player->getAllianceName()) . '
+						AND alliance_name <= ' . $db->escapeString($player->getAlliance()->getAllianceName()) . '
 					)
 				)');
 	$db->nextRecord();

--- a/engine/Default/rankings_alliance_profit.php
+++ b/engine/Default/rankings_alliance_profit.php
@@ -31,7 +31,7 @@ if ($player->hasAlliance()) {
 					t.amount > us.amount
 					OR (
 						COALESCE(t.amount,0) = COALESCE(us.amount,0)
-						AND alliance_name <= ' . $db->escapeString($player->getAllianceName()) . '
+						AND alliance_name <= ' . $db->escapeString($player->getAlliance()->getAllianceName()) . '
 					)
 				)');
 	$db->nextRecord();


### PR DESCRIPTION
In 2c5a0340984352, the `getAllianceName` method of SmrPlayer was
renamed to `getAllianceDisplayName`; however, there were still some
calls to the old method name, causing the following error:

Call to undefined method SmrPlayer::getAllianceName()

These were all related to database operations, so we use the method
to get the raw alliance name, SmrAlliance::getAllianceName().