### PR TITLE
Use getColouredRaceName second argument consistently

### DIFF
--- a/engine/Default/shop_goods.php
+++ b/engine/Default/shop_goods.php
@@ -14,10 +14,6 @@ if ($tradeable !== true) {
 $template->assign('PageTopic', 'Port In Sector #' . $player->getSectorID());
 $template->assign('Port', $port);
 
-$container = create_container('skeleton.php', 'council_list.php');
-$container['race_id'] = $port->getRaceID();
-$template->assign('CouncilHREF', SmrSession::getNewHREF($container));
-
 $account->log(LOG_TYPE_TRADING, 'Player examines port', $player->getSectorID());
 $searchedByFeds = false;
 

--- a/engine/Default/trader_status.php
+++ b/engine/Default/trader_status.php
@@ -12,9 +12,6 @@ $container = create_container('skeleton.php');
 $container['body'] = 'trader_relations.php';
 $template->assign('RelationsHREF', SmrSession::getNewHREF($container));
 
-$container['body'] = 'council_list.php';
-$template->assign('CouncilHREF', SmrSession::getNewHREF($container));
-
 $container['body'] = 'trader_savings.php';
 $template->assign('SavingsHREF', SmrSession::getNewHREF($container));
 

--- a/templates/Default/engine/Default/alliance_roster.php
+++ b/templates/Default/engine/Default/alliance_roster.php
@@ -70,7 +70,7 @@ if ($ShowRoles && $CanChangeRoles) { ?>
 						echo $AlliancePlayer->getLevelName(); ?>&nbsp;<?php echo $AlliancePlayer->getLinkedDisplayName(false); ?>
 					</td>
 					<td class="race"><?php
-						echo $ThisPlayer->getColouredRaceName($AlliancePlayer->getRaceID()); ?>
+						echo $ThisPlayer->getColouredRaceName($AlliancePlayer->getRaceID(), true); ?>
 					</td>
 					<td class="experience"><?php
 						echo number_format($AlliancePlayer->getExperience()); ?>

--- a/templates/Default/engine/Default/council_embassy.php
+++ b/templates/Default/engine/Default/council_embassy.php
@@ -13,7 +13,7 @@
 
 	foreach ($VoteRaceHrefs as $RaceID => $FormHref) { ?>
 		<tr>
-			<td><img src="<?php echo Globals::getRaceHeadImage($RaceID); ?>" width="60" height="64" /><br /><a href="<?php echo Globals::getCouncilHREF($RaceID); ?>"><?php echo $ThisPlayer->getColouredRaceName($RaceID); ?></a></td>
+			<td><img src="<?php echo Globals::getRaceHeadImage($RaceID); ?>" width="60" height="64" /><br /><?php echo $ThisPlayer->getColouredRaceName($RaceID, true); ?></td>
 			<td>
 				<form method="POST" action="<?php echo $FormHref; ?>">
 					<input type="submit" name="action" value="Peace" class="InputFields" />

--- a/templates/Default/engine/Default/council_vote.php
+++ b/templates/Default/engine/Default/council_vote.php
@@ -23,7 +23,7 @@ if (!$VoteTreaties) { ?>
 
 	foreach ($VoteTreaties as $RaceID => $VoteInfo) { ?>
 		<tr>
-			<td><a href="<?php echo Globals::getCouncilHREF($RaceID); ?>"><?php echo $ThisPlayer->getColouredRaceName($RaceID); ?></a></td>
+			<td><?php echo $ThisPlayer->getColouredRaceName($RaceID, true); ?></td>
 			<td><?php echo $VoteInfo['Type']; ?></td>
 			<td class="noWrap">
 				<form method="POST" action="<?php echo $VoteInfo['HREF']; ?>">

--- a/templates/Default/engine/Default/includes/RightPanelPlayer.inc
+++ b/templates/Default/engine/Default/includes/RightPanelPlayer.inc
@@ -8,7 +8,7 @@ if (isset($GameID)) { ?>
 		<span class="smallFont smallCaps red">INVISIBLE</span><br /><?php
 	} ?>
 	<br />
-	Race : <a href="<?php echo Globals::getCouncilHREF($ThisPlayer->getRaceID()); ?>"><?php echo $ThisPlayer->getColouredRaceName($ThisPlayer->getRaceID()); ?></a><br />
+	Race : <?php echo $ThisPlayer->getColouredRaceName($ThisPlayer->getRaceID(), true); ?><br />
 	Turns : <span id="turns">
 		<span class="<?php echo $ThisPlayer->getTurnsColor(); ?>"><?php
 				echo $ThisPlayer->getTurns() . '/' . $ThisPlayer->getMaxTurns();

--- a/templates/Default/engine/Default/shop_goods.php
+++ b/templates/Default/engine/Default/shop_goods.php
@@ -1,4 +1,4 @@
-<p>This is a level <?php echo $Port->getLevel(); ?> port run by the <a href="<?php echo $CouncilHREF; ?>"><?php echo $ThisPlayer->getColouredRaceName($Port->getRaceID()); ?></a>.<br />
+<p>This is a level <?php echo $Port->getLevel(); ?> port run by the <?php echo $ThisPlayer->getColouredRaceName($Port->getRaceID(), true); ?>.<br />
 Your relations with them are <?php echo get_colored_text($ThisPlayer->getRelation($Port->getRaceID())); ?>.</p>
 <br />
 

--- a/templates/Default/engine/Default/shop_weapon.php
+++ b/templates/Default/engine/Default/shop_weapon.php
@@ -21,7 +21,7 @@ if ($ThisLocation->isWeaponSold()) { ?>
 					<td class="sort_shield"><?php echo $Weapon->getShieldDamage(); ?></td>
 					<td class="sort_armor"><?php echo $Weapon->getArmourDamage(); ?></td>
 					<td class="sort_acc"><?php echo $Weapon->getBaseAccuracy(); ?>%</td>
-					<td class="sort_race"><?php echo $ThisPlayer->getColouredRaceName($Weapon->getRaceID()); ?></td>
+					<td class="sort_race"><?php echo $ThisPlayer->getColouredRaceName($Weapon->getRaceID(), true); ?></td>
 					<td class="sort_power"><?php echo $Weapon->getPowerLevel(); ?></td>
 					<td class="sort_cost"><?php echo $Weapon->getCost(); ?></td>
 					<td><a href="<?php echo $Weapon->getBuyHREF($ThisLocation); ?>" class="submitStyle">Buy</a></td>

--- a/templates/Default/engine/Default/trader_search_result.php
+++ b/templates/Default/engine/Default/trader_search_result.php
@@ -25,7 +25,7 @@ function DisplayResult(array $Links, SmrPlayer $Player) { ?>
 				</td>
 				<td><?php echo $Link['Player']->getAllianceDisplayName(true); ?></td>
 				<td class="shrink center">
-					<a href="<?php echo $Link['RaceHREF']; ?>"><?php echo $Player->getColouredRaceName($Link['Player']->getRaceID()); ?></a>
+					<?php echo $Player->getColouredRaceName($Link['Player']->getRaceID(), true); ?>
 				</td>
 				<td class="shrink center"><?php echo $Link['Player']->getExperience(); ?></td><?php
 				if ($Link['Player']->hasNewbieStatus()) { ?>

--- a/templates/Default/engine/Default/trader_status.php
+++ b/templates/Default/engine/Default/trader_status.php
@@ -35,7 +35,7 @@
 
 			<br />
 
-			<a href="<?php echo $CouncilHREF; ?>">
+			<a href="<?php echo Globals::getCouncilHREF(); ?>">
 				<span class="yellow bold">Politics</span>
 			</a>
 			<a href="<?php echo WIKI_URL; ?>/game-guide/politics" target="_blank">

--- a/templates/Freon22/engine/Default/skeleton.php
+++ b/templates/Freon22/engine/Default/skeleton.php
@@ -26,7 +26,7 @@
 										</td>
 										<td>
 											<div class="topcenterOne noWrap">
-												Race: <a href="<?php echo Globals::getCouncilHREF($ThisPlayer->getRaceID()); ?>"><?php echo $ThisPlayer->getColouredRaceName($ThisPlayer->getRaceID()); ?></a><br />
+												Race: <?php echo $ThisPlayer->getColouredRaceName($ThisPlayer->getRaceID(), true); ?><br />
 												
 												Turns : <span id="turns">
 													<span class="<?php echo $ThisPlayer->getTurnsColor(); ?>"><?php


### PR DESCRIPTION
When the second argument is `true`, the race name becomes a link to
the given race's council page.

In some cases, this just simplifies the code (by generating the link
automatically instead of creating it manually). In others, it adds a
link to the race name where there was none before, e.g.:

* Alliance Roster (for player race)
* Weapon Shop (for weapon race)