### PR TITLE
Throw user error on invalid social login type

### DIFF
--- a/htdocs/login_social_processing.php
+++ b/htdocs/login_social_processing.php
@@ -12,8 +12,11 @@ try {
 		// immediately forwards to the social login URL after it is generated.
 
 		require_once('config.inc');
-		header('Location: ' . SocialLogin::get($type)->getLoginUrl());
-		exit;
+		try {
+			header('Location: ' . SocialLogin::get($type)->getLoginUrl());
+		} catch (SocialLoginNotFound $e) {
+			header('location: /error.php?msg=' . urlencode('Unknown social login type'));
+		}
 	}
 
 } catch (Throwable $e) {

--- a/lib/Default/SocialLogin.class.php
+++ b/lib/Default/SocialLogin.class.php
@@ -1,6 +1,11 @@
 <?php declare(strict_types=1);
 
 /**
+ * Exception thrown when a SocialLogin type cannot be found
+ */
+class SocialLoginNotFound extends Exception {}
+
+/**
  * Defines the methods to be implemented by each social login platform.
  */
 abstract class SocialLogin {
@@ -23,7 +28,7 @@ abstract class SocialLogin {
 		} elseif ($loginType === SocialLogins\Twitter::getLoginType()) {
 			return new SocialLogins\Twitter();
 		} else {
-			throw new Exception('Unknown social login type: ' . $loginType);
+			throw new SocialLoginNotFound('Unknown social login type: ' . $loginType);
 		}
 	}
 


### PR DESCRIPTION
Because the social login type should be internally consistent between
the URL on the login page and the types accepted by the SocialLogin
class, we were raising an exception if the type passed in the URL to
the login_social_processing.php page was unknown. This helped ensure
that we would be notified (by bugs emails) if we accidentally broke
social logins.

Unfortunately, because the login_social_processing.php page is linked
on the public-facing login page, it has been added to a bunch of bot
databases. Most of the search engine spiders respect our robots.txt
file, but some do not, and SQL injection attacks obviously do not.

As a result, we get a lot of unwanted bugs emails where a bot uses an
outdated or malicious social login type. This is just too much noise,
and so we now redirect to error.php if the social login type is not
valid.