### PR TITLE
Add open and closed recruiting options for alliances

### DIFF
--- a/admin/Default/1.6/game_create_processing.php
+++ b/admin/Default/1.6/game_create_processing.php
@@ -51,8 +51,8 @@ function createNHA($gameID) {
 	$db = new SmrMySqlDatabase();
 
 	// create the Newbie Help Alliance
-	$db->query('REPLACE INTO alliance (alliance_id, game_id, alliance_name, alliance_description, alliance_password, leader_id, `mod`) VALUES
-				(' . $db->escapeNumber(NHA_ID) . ',' . $db->escapeNumber($gameID) . ',\'Newbie Help Alliance\',\'Newbie Help Alliance\',\'*\',' . $db->escapeNumber(ACCOUNT_ID_NHL) . ',\'Alliance message board includes tips and FAQs.\')');
+	$db->query('REPLACE INTO alliance (alliance_id, game_id, alliance_name, alliance_description, alliance_password, leader_id, `mod`, recruiting) VALUES
+				(' . $db->escapeNumber(NHA_ID) . ',' . $db->escapeNumber($gameID) . ',\'Newbie Help Alliance\',\'Newbie Help Alliance\',\'\',' . $db->escapeNumber(ACCOUNT_ID_NHL) . ',\'Alliance message board includes tips and FAQs.\', \'FALSE\')');
 
 	$alliance = SmrAlliance::getAlliance(NHA_ID, $gameID);
 	$alliance->createDefaultRoles();

--- a/admin/Default/npc_manage_processing.php
+++ b/admin/Default/npc_manage_processing.php
@@ -25,7 +25,7 @@ if (Request::has('create_npc_player')) {
 	$allianceName = Request::get('player_alliance');
 	$alliance = SmrAlliance::getAllianceByName($allianceName, $gameID);
 	if (is_null($alliance)) {
-		$alliance = SmrAlliance::createAlliance($gameID, $allianceName, '*', false);
+		$alliance = SmrAlliance::createAlliance($gameID, $allianceName);
 		$alliance->setLeaderID($npcPlayer->getAccountID());
 		$alliance->update();
 		$alliance->createDefaultRoles();

--- a/engine/Default/alliance_create_processing.php
+++ b/engine/Default/alliance_create_processing.php
@@ -6,6 +6,9 @@ if ($player->getAllianceJoinable() > TIME) {
 
 // trim input first
 $name = trim(Request::get('name'));
+if (empty($name)) {
+	throw new Exception('No alliance name entered');
+}
 
 // disallow certain ascii chars
 for ($i = 0; $i < strlen($name); $i++) {
@@ -14,16 +17,11 @@ for ($i = 0; $i < strlen($name); $i++) {
 	}
 }
 
-$password = Request::get('password');
+$password = trim(Request::get('password', ''));
 $description = Request::get('description');
-$recruit = Request::get('recruit') == 'yes';
+$recruitType = Request::get('recruit_type');
 $perms = Request::get('Perms');
-if (empty($password)) {
-	create_error('You must enter a password!');
-}
-if (empty($name)) {
-	create_error('You must enter an alliance name!');
-}
+
 $name2 = strtolower($name);
 if ($name2 == 'none' || $name2 == '(none)' || $name2 == '( none )' || $name2 == 'no alliance') {
 	create_error('That is not a valid alliance name!');
@@ -34,7 +32,8 @@ if ($name != $filteredName) {
 }
 
 // create the alliance
-$alliance = SmrAlliance::createAlliance($player->getGameID(), $name, $password, $recruit);
+$alliance = SmrAlliance::createAlliance($player->getGameID(), $name);
+$alliance->setRecruitType($recruitType, $password);
 $alliance->setAllianceDescription($description);
 $alliance->setLeaderID($player->getAccountID());
 $alliance->createDefaultRoles($perms);

--- a/engine/Default/alliance_stat.php
+++ b/engine/Default/alliance_stat.php
@@ -32,3 +32,4 @@ $template->assign('CanChangeDescription', $change_mod || $account->hasPermission
 $template->assign('CanChangePassword', $change_pass);
 $template->assign('CanChangeChatChannel', $change_chat);
 $template->assign('CanChangeMOTD', $change_mod);
+$template->assign('HidePassword', $alliance->getRecruitType() != SmrAlliance::RECRUIT_PASSWORD);

--- a/engine/Default/alliance_stat_processing.php
+++ b/engine/Default/alliance_stat_processing.php
@@ -3,9 +3,6 @@ if (!isset($var['alliance_id'])) {
 	SmrSession::updateVar('alliance_id', $player->getAllianceID());
 }
 $alliance_id = $var['alliance_id'];
-if (Request::has('password')) {
-	$password = trim(Request::get('password'));
-}
 if (Request::has('description')) {
 	$description = trim(Request::get('description'));
 }
@@ -30,13 +27,11 @@ if (isset($url) && preg_match('/"/', $url)) {
 	create_error('You cannot use a " in the image link!');
 }
 
-if (isset($password) && $password == '') {
-	create_error('You cannot set an empty password!');
-}
-
 $alliance = SmrAlliance::getAlliance($alliance_id, $player->getGameID());
-if (isset($password)) {
-	$alliance->setPassword($password);
+if (Request::has('recruit_type')) {
+	$recruitType = Request::get('recruit_type');
+	$password = Request::get('password', '');
+	$alliance->setRecruitType($recruitType, $password);
 }
 if (isset($description)) {
 	$alliance->setAllianceDescription($description);

--- a/htdocs/js/smr15.js
+++ b/htdocs/js/smr15.js
@@ -103,3 +103,16 @@ function showRaceInfo(select) {
 	$(desc).children().addClass('hide');
 	$(".race_descr" + race_id, desc).removeClass('hide');
 }
+
+// Used by alliance_create.php and alliance_stat.php
+function togglePassword(select) {
+	var showPassword = $(select).val() === "password";
+	// We need to both toggle the element display (for the user) and toggle the
+	// disabled property (for the form submission).
+	if (showPassword) {
+		$("#password-display").show();
+	} else {
+		$("#password-display").hide();
+	}
+	$("#password-input").prop("disabled", !showPassword);
+}

--- a/templates/Default/engine/Default/alliance_create.php
+++ b/templates/Default/engine/Default/alliance_create.php
@@ -1,5 +1,5 @@
 <form method="POST" action="<?php echo $CreateHREF; ?>">
-	<table cellspacing="0" cellpadding="0" class="nobord nohpad">
+	<table class="standard">
 		<tr>
 			<td class="top">Name:</td>
 			<td><input required type="text" name="name" size="30"></td>
@@ -7,10 +7,6 @@
 		<tr>
 			<td class="top">Description:</td>
 			<td><textarea spellcheck="true" name="description"></textarea></td>
-		</tr>
-		<tr>
-			<td class="top">Password:</td>
-			<td><input required type="password" name="password" size="30"></td>
 		</tr>
 		<tr>
 			<td class="top">Members start with:&nbsp;&nbsp;&nbsp;</td>
@@ -21,8 +17,16 @@
 		</tr>
 		<tr>
 			<td class="top">Recruiting:</td>
-			<td>Yes<input type="radio" name="recruit" value="yes" checked><br />
-				No<input type="radio" name="recruit" value="no">
+			<td>
+				<select name="recruit_type" class="InputFields" onchange="togglePassword(this)"><?php
+					foreach (SmrAlliance::allRecruitTypes() as $type => $text) { ?>
+						<option value="<?php echo $type; ?>"><?php echo $text; ?></option><?php
+					} ?>
+				</select>
+				<br />
+				<div id="password-display">
+					<input required id="password-input" name="password" placeholder=" Enter password here" size="30">
+				</div>
 			</td>
 		</tr>
 	</table>

--- a/templates/Default/engine/Default/alliance_roster.php
+++ b/templates/Default/engine/Default/alliance_roster.php
@@ -128,13 +128,17 @@ if ($Alliance->getAllianceID() == $ThisPlayer->getAllianceID()) { ?>
 }
 
 if ($CanJoin === true) { ?>
-	<br />
-	<form class="standard" method="POST" action="<?php echo $JoinHREF; ?>">
-		Enter password to join alliance<br /><br />
-		<input type="password" name="password" size="30">&nbsp;<input class="submit" type="submit" name="action" value="Join">
+	<form class="standard" method="POST" action="<?php echo $JoinHREF; ?>"><?php
+		if ($Alliance->getRecruitType() == SmrAlliance::RECRUIT_OPEN) { ?>
+			<p>This alliance is accepting all recruits!</p>
+			<input hidden name="password" value=""><?php
+		} else { ?>
+			<p>Enter password to join alliance</p>
+			<input required name="password" size="30">&nbsp;<?php
+		} ?>
+		<input class="submit" type="submit" name="action" value="Join">
 	</form><?php
 } elseif ($CanJoin !== false) { ?>
-	<br /><?php
-	echo $CanJoin;
+	<p><?php echo $CanJoin; ?></p><?php
 }
 ?>

--- a/templates/Default/engine/Default/alliance_stat.php
+++ b/templates/Default/engine/Default/alliance_stat.php
@@ -4,7 +4,18 @@
 <?php
 if ($CanChangePassword) { ?>
 	<tr>
-		<td class="top">Password:&nbsp;</td><td><input type="password" name="password" size="30" value="<?php echo htmlspecialchars($Alliance->getPassword()); ?>"></td>
+		<td class="top">Recruiting:</td>
+		<td>
+			<select name="recruit_type" class="InputFields" onchange="togglePassword(this)"><?php
+				foreach (SmrAlliance::allRecruitTypes() as $type => $text) { ?>
+					<option value="<?php echo $type; ?>" <?php if ($Alliance->getRecruitType() == $type) { ?> selected<?php } ?>><?php echo $text; ?></option><?php
+				} ?>
+			</select>
+		</td>
+	</tr>
+	<tr id="password-display" <?php if ($HidePassword) { ?> class="hide" <?php } ?>>
+		<td class="top">Password:&nbsp;</td>
+		<td><input required id="password-input" name="password" size="30" placeholder=" Enter password here" value="<?php echo htmlspecialchars($Alliance->getPassword()); ?>" <?php if ($HidePassword) { echo "disabled"; } ?>></td>
 	</tr><?php
 }
 


### PR DESCRIPTION
When creating and modifying alliances, there will now be three
recruitment options:

1) Open - Anyone can join freely, no password is needed
2) Closed - Players can only join by direct invitation
3) Password - Players can join by invitation or with a password

This creates a lot more flexibility for alliance leaders to manage
their membership.

Note: We use a combination of the `password` and `recruiting`
attributes of SmrAlliance to infer the "recruitment type". This
is perhaps not ideal, but it requires no database changes.