### PR TITLE
Fix escaping of HTML entities in planet names

### DIFF
--- a/engine/Default/planet.inc
+++ b/engine/Default/planet.inc
@@ -19,6 +19,6 @@ if (!$player->isLandedOnPlanet()) {
 
 $planet = $player->getSectorPlanet();
 $template->assign('ThisPlanet', $planet);
-$template->assign('PageTopic', 'Planet : ' . $planet->getName() . ' [Sector #' . $player->getSectorID() . ']');
+$template->assign('PageTopic', 'Planet : ' . $planet->getDisplayName() . ' [Sector #' . $player->getSectorID() . ']');
 
 Menu::planet($planet);

--- a/engine/Default/planet_attack_processing.php
+++ b/engine/Default/planet_attack_processing.php
@@ -80,9 +80,9 @@ if ($planet->isDestroyed()) {
 	$planet->removePassword();
 
 	// Prepare message for planet owners
-	$planetAttackMessage = 'The defenses of ' . $planet->getDisplayName() . ' have been breached. The planet is lost! [combatlog=' . $logId . ']';
+	$planetAttackMessage = 'The defenses of ' . $planet->getCombatName() . ' have been breached. The planet is lost! [combatlog=' . $logId . ']';
 } else {
-	$planetAttackMessage = 'Reports from the surface of ' . $planet->getDisplayName() . ' confirm that it is under <span class="red">attack</span>! [combatlog=' . $logId . ']';
+	$planetAttackMessage = 'Reports from the surface of ' . $planet->getCombatName() . ' confirm that it is under <span class="red">attack</span>! [combatlog=' . $logId . ']';
 }
 
 // Send notification to planet owners

--- a/engine/Default/planet_kick_processing.php
+++ b/engine/Default/planet_kick_processing.php
@@ -9,7 +9,7 @@ $owner = $planet->getOwner();
 if ($owner->getAllianceID() != $player->getAllianceID()) {
 	create_error('You can not kick someone off a planet your alliance does not own!');
 }
-$message = 'You have been kicked from ' . $planet->getName() . ' in ' . Globals::getSectorBBLink($player->getSectorID());
+$message = 'You have been kicked from ' . $planet->getDisplayName() . ' in ' . Globals::getSectorBBLink($player->getSectorID());
 $player->sendMessage($planetPlayer->getAccountID(), MSG_PLAYER, $message, false);
 
 $planetPlayer->setLandedOnPlanet(false);

--- a/lib/Default/SmrPlanet.class.php
+++ b/lib/Default/SmrPlanet.class.php
@@ -999,7 +999,7 @@ class SmrPlanet {
 	 * Returns the name of the planet, intended for combat messages.
 	 */
 	public function getCombatName() {
-		return '<span style="color:yellow;font-variant:small-caps">' . $this->getDisplayName() . '(#' . $this->getSectorID() . ')</span>';
+		return '<span style="color:yellow;font-variant:small-caps">' . $this->getDisplayName() . ' (#' . $this->getSectorID() . ')</span>';
 	}
 
 	public function isInhabitable() {

--- a/lib/Default/SmrPlanet.class.php
+++ b/lib/Default/SmrPlanet.class.php
@@ -980,10 +980,6 @@ class SmrPlanet {
 		return false;
 	}
 
-	public function getName() {
-		return $this->planetName;
-	}
-
 	public function setName($name) {
 		if ($this->planetName == $name) {
 			return;
@@ -992,8 +988,18 @@ class SmrPlanet {
 		$this->hasChanged = true;
 	}
 
+	/**
+	 * Returns the name of the planet, suitably escaped for HTML display.
+	 */
 	public function getDisplayName() {
-		return '<span style="color:yellow;font-variant:small-caps">' . $this->getName() . '(#' . $this->getSectorID() . ')</span>';
+		return htmlentities($this->planetName);
+	}
+
+	/**
+	 * Returns the name of the planet, intended for combat messages.
+	 */
+	public function getCombatName() {
+		return '<span style="color:yellow;font-variant:small-caps">' . $this->getDisplayName() . '(#' . $this->getSectorID() . ')</span>';
 	}
 
 	public function isInhabitable() {

--- a/lib/Default/SmrPlayer.class.php
+++ b/lib/Default/SmrPlayer.class.php
@@ -1058,14 +1058,14 @@ class SmrPlayer extends AbstractSmrPlayer {
 		// send a message to the person who died
 		$planetOwner = $planet->getOwner();
 		self::sendMessageFromFedClerk($this->getGameID(), $planetOwner->getAccountID(), 'Your planet <span class="red">DESTROYED</span>&nbsp;' . $this->getBBLink() . ' in sector ' . Globals::getSectorBBLink($planet->getSectorID()));
-		self::sendMessageFromFedClerk($this->getGameID(), $this->getAccountID(), 'You were <span class="red">DESTROYED</span> by the planetary defenses of ' . $planet->getDisplayName());
+		self::sendMessageFromFedClerk($this->getGameID(), $this->getAccountID(), 'You were <span class="red">DESTROYED</span> by the planetary defenses of ' . $planet->getCombatName());
 
 		$news_message = $this->getBBLink();
 		if ($this->hasCustomShipName()) {
 			$named_ship = strip_tags($this->getCustomShipName(), '<font><span><img>');
 			$news_message .= ' flying <span class="yellow">' . $named_ship . '</span>';
 		}
-		$news_message .= ' was destroyed by ' . $planet->getDisplayName() . '\'s planetary defenses in sector ' . Globals::getSectorBBLink($planet->getSectorID()) . '.';
+		$news_message .= ' was destroyed by ' . $planet->getCombatName() . '\'s planetary defenses in sector ' . Globals::getSectorBBLink($planet->getSectorID()) . '.';
 		// insert the news entry
 		$this->db->query('INSERT INTO news (game_id, time, news_message,killer_id,killer_alliance,dead_id,dead_alliance)
 						VALUES(' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(TIME) . ', ' . $this->db->escapeString($news_message) . ',' . $this->db->escapeNumber($planetOwner->getAccountID()) . ',' . $this->db->escapeNumber($planetOwner->getAllianceID()) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');

--- a/templates/Default/engine/Default/includes/PlanetCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PlanetCombatResults.inc
@@ -2,7 +2,7 @@
 $CombatPlanet = $PlanetCombatResults['Planet'];
 $TotalDamage = $PlanetCombatResults['TotalDamage'];
 if($MinimalDisplay) {
-	echo $CombatPlanet->getDisplayName();
+	echo $CombatPlanet->getCombatName();
 	if($TotalDamage > 0) {
 		?> hit for a total of <span class="red"><?php echo $TotalDamage; ?></span> damage in this round of combat of which <span class="red"><?php echo $PlanetCombatResults['TotalDamagePerTargetPlayer'][$ThisPlayer->getAccountID()]; ?></span> was done to you<?php
 	}
@@ -19,7 +19,7 @@ if(isset($PlanetCombatResults['Weapons']) && is_array($PlanetCombatResults['Weap
 		$WeaponDamage =& $WeaponResults['WeaponDamage'];
 		$TargetPlayer =& $WeaponResults['TargetPlayer'];
 		
-		echo $CombatPlanet->getDisplayName() ?> fires a <?php echo $ShootingWeapon->getName(); ?> at <?php if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?> the debris that was once <?php } echo $TargetPlayer->getDisplayName();
+		echo $CombatPlanet->getCombatName() ?> fires a <?php echo $ShootingWeapon->getName(); ?> at <?php if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?> the debris that was once <?php } echo $TargetPlayer->getDisplayName();
 		if (!$ShotHit || !$ActualDamage['TargetAlreadyDead']) {
 			if(!$ShotHit) {
 				?> and misses<?php
@@ -76,7 +76,7 @@ if(isset($PlanetCombatResults['Drones'])) {
 	if($ActualDamage['NumCDs'] > 0){ $DamageTypes = $DamageTypes+1; }
 	if($ActualDamage['Armour'] > 0){ $DamageTypes = $DamageTypes+1; }
 	
-	echo $CombatPlanet->getDisplayName();
+	echo $CombatPlanet->getCombatName();
 	if($WeaponDamage['Launched'] == 0) {
 		?> fails to launch it's combat drones<?php
 	}
@@ -121,7 +121,7 @@ if(isset($PlanetCombatResults['Drones'])) {
 	}
 }
 
-echo $CombatPlanet->getDisplayName();
+echo $CombatPlanet->getCombatName();
 if($TotalDamage > 0) {
 	?> hit for a total of <span class="red"><?php echo $TotalDamage; ?></span> damage in this round of combat<?php
 }

--- a/templates/Default/engine/Default/includes/PlanetKillMessage.inc
+++ b/templates/Default/engine/Default/includes/PlanetKillMessage.inc
@@ -1,1 +1,1 @@
-<?php echo $TargetPlanet->getDisplayName() ?>'s defenses are <span class="red">DESTROYED!</span><br />
+<?php echo $TargetPlanet->getCombatName() ?>'s defenses are <span class="red">DESTROYED!</span><br />

--- a/templates/Default/engine/Default/includes/PlanetList.inc
+++ b/templates/Default/engine/Default/includes/PlanetList.inc
@@ -21,7 +21,7 @@ if (count($Planets) > 0) { ?>
 				<tr id="planet-<?php echo $Planet->getSectorID(); ?>" class="ajax">
 					<td class="image noWrap">
 						<img src="<?php echo $Planet->getTypeImage(); ?>"  width="16" height="16" alt="" title="<?php echo $Planet->getTypename() . ': ' . $Planet->getTypeDescription(); ?>" /></td>
-					<td class="name"><?php echo $Planet->getName(); ?></td>
+					<td class="name"><?php echo $Planet->getDisplayName(); ?></td>
 					<td class="lvl center"><?php echo number_format($Planet->getLevel(), 2); ?></td>
 					<td class="owner noWrap"><?php echo $Planet->getOwner()->getLinkedDisplayName(false); ?></td>
 					<td class="sector center"><a href="<?php echo Globals::getPlotCourseHREF($ThisPlayer->getSectorID(), $Planet->getSectorID()); ?>"><?php echo $Planet->getSectorID(); ?></a>&nbsp;(<a href="<?php echo $Planet->getGalaxy()->getGalaxyMapHREF(); ?>" target="gal_map"><?php echo $Planet->getGalaxy()->getName(); ?></a>)</td>

--- a/templates/Default/engine/Default/includes/PlanetListFinancial.inc
+++ b/templates/Default/engine/Default/includes/PlanetListFinancial.inc
@@ -23,7 +23,7 @@ if (count($Planets) > 0) { ?>
 				<tr id="planet-<?php echo $Planet->getSectorID(); ?>" class="ajax">
 					<td class="sort_type shrink">
 						<img src="<?php echo $Planet->getTypeImage(); ?>"  width="16" height="16" alt="" title="<?php echo $Planet->getTypename() . ': ' . $Planet->getTypeDescription(); ?>" /></td>
-					<td class="sort_name left"><?php echo $Planet->getName(); ?></td>
+					<td class="sort_name left"><?php echo $Planet->getDisplayName(); ?></td>
 					<td class="sort_lvl"><?php echo number_format($Planet->getLevel(), 2); ?></td>
 					<td class="sort_owner noWrap left"><?php echo $Planet->getOwner()->getLinkedDisplayName(false); ?></td>
 					<td class="sort_sector"><a href="<?php echo Globals::getPlotCourseHREF($ThisPlayer->getSectorID(), $Planet->getSectorID()); ?>"><?php echo $Planet->getSectorID(); ?></a>&nbsp;(<a href="<?php echo $Planet->getGalaxy()->getGalaxyMapHREF(); ?>" target="gal_map"><?php echo $Planet->getGalaxy()->getName(); ?></a>)</td>

--- a/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc
+++ b/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc
@@ -23,7 +23,7 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 				$WeaponDamage =& $WeaponResults['WeaponDamage'];
 				$TargetPlanet =& $WeaponResults['TargetPlanet'];
 				
-				echo $ShootingPlayer->getDisplayName() ?> fires their <?php echo $ShootingWeapon->getName() ?> at <?php if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?>the debris that was once <?php } echo $TargetPlanet->getDisplayName();
+				echo $ShootingPlayer->getDisplayName() ?> fires their <?php echo $ShootingWeapon->getName() ?> at <?php if($ShotHit && $ActualDamage['TargetAlreadyDead']){ ?>the debris that was once <?php } echo $TargetPlanet->getCombatName();
 				if (!$ShotHit || !$ActualDamage['TargetAlreadyDead']) {
 					if(!$ShotHit) {
 						?> and misses<?php
@@ -83,7 +83,7 @@ foreach($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 				if($ActualDamage['TargetAlreadyDead']) {
 					?>the debris that was once <?php
 				}
-				echo $TargetPlanet->getDisplayName();
+				echo $TargetPlanet->getCombatName();
 				if(!$ActualDamage['TargetAlreadyDead']) {
 					if($ActualDamage['TotalDamage'] == 0) {
 						if($WeaponDamage['Shield'] > 0) {

--- a/templates/Default/engine/Default/includes/SectorPlanet.inc
+++ b/templates/Default/engine/Default/includes/SectorPlanet.inc
@@ -9,7 +9,7 @@ if ($ThisSector->hasPlanet()) {
 		<tr>
 			<td>
 				<img class="bottom" src="<?php echo $Planet->getTypeImage()?>" width="16" height="16" alt="Planet" title="<?php echo $Planet->getTypeName() ?>" />
-				&nbsp;<?php echo $Planet->getName() ?>&nbsp;
+				&nbsp;<?php echo $Planet->getDisplayName() ?>&nbsp;
 				<?php echo $Planet->getTypeName() ?>&nbsp;
 				<?php if ($Planet->isInhabitable()) { ?>
 					<span class="inhab">Inhabitable</span>

--- a/templates/Default/engine/Default/planet_examine.php
+++ b/templates/Default/engine/Default/planet_examine.php
@@ -1,7 +1,7 @@
 <table>
 	<tr>
 		<td class="bold">Planet Name:</td>
-		<td><?php echo $ThisPlanet->getName(); ?></td>
+		<td><?php echo $ThisPlanet->getDisplayName(); ?></td>
 	</tr>
 	<tr>
 		<td class="bold">Planet Type:</td>

--- a/templates/Default/engine/Default/planet_ownership.php
+++ b/templates/Default/engine/Default/planet_ownership.php
@@ -33,7 +33,7 @@ if (!$Planet->hasOwner()) { ?>
 		<br />
 
 		<form method="POST" action="<?php echo $ProcessingHREF; ?>">
-			<input required type="text" name="name" value="<?php echo htmlspecialchars($Planet->getName()); ?>" class="InputFields" />&nbsp;&nbsp;&nbsp;
+			<input required type="text" name="name" value="<?php echo $Planet->getDisplayName(); ?>" class="InputFields" />&nbsp;&nbsp;&nbsp;
 			<input type="submit" name="action" value="Rename" class="InputFields" />
 		</form><?php
 	}


### PR DESCRIPTION
The `SmrPlanet` methods change as follows:

* Replace `getName()` -> `getDisplayName()` and escape HTML entities,
  for consistency with the naming scheme for other classes that need
  to display user-generated names.

* Replace `getDisplayName()` -> `getCombatName()`, which is now also
  escaped for HTML, but the name change signifies that it should be
  used only in the context of combat messages.

Note that there is no longer a function to return the raw planet name,
because there is nothing that needs it right now.
