### PR TITLE
Add ability to cancel alliance invitations

### DIFF
--- a/db/patches/V1_6_63_22__track_alliance_invite.sql
+++ b/db/patches/V1_6_63_22__track_alliance_invite.sql
@@ -1,0 +1,2 @@
+-- Add message_id column to alliance_invites_player table
+ALTER TABLE `alliance_invites_player` ADD COLUMN `message_id` mediumint(8) unsigned NOT NULL;

--- a/engine/Default/alliance_invite_accept_processing.php
+++ b/engine/Default/alliance_invite_accept_processing.php
@@ -1,19 +1,14 @@
 <?php declare(strict_types=1);
 
-// Remove any expired invitations
-$db->query('DELETE FROM alliance_invites_player WHERE expires < ' . $db->escapeNumber(TIME));
-
 // Check that the invitation is registered in the database
-$newAlliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
-$db->query('SELECT 1 FROM alliance_invites_player
-            WHERE game_id = '.$db->escapeNumber($player->getGameID()) . '
-              AND alliance_id = '.$db->escapeNumber($newAlliance->getAllianceID()) . '
-              AND account_id = '.$db->escapeNumber($player->getAccountID()));
-if (!$db->nextRecord()) {
-	create_error('You do not have an invitation to join this alliance!');
+try {
+	$invite = SmrInvitation::get($var['alliance_id'], $player->getGameID(), $player->getAccountID());
+} catch (InvitationNotFoundException $e) {
+	create_error('Your invitation to join this alliance has expired or been canceled!');
 }
 
 // Make sure the player can join the new alliance before leaving the current one
+$newAlliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
 $canJoin = $newAlliance->canJoinAlliance($player, false);
 if ($canJoin !== true) {
 	create_error($canJoin);
@@ -27,8 +22,11 @@ if ($player->hasAlliance()) {
 	$player->leaveAlliance();
 }
 
-// Join new alliance (this deletes the invitation)
+// Join new alliance
 $player->joinAlliance($newAlliance->getAllianceID());
+
+// Delete the invitation now that the player has joined
+$invite->delete();
 
 $container = create_container('skeleton.php', 'alliance_mod.php');
 forward($container);

--- a/engine/Default/alliance_invite_cancel_processing.php
+++ b/engine/Default/alliance_invite_cancel_processing.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+// Delete the alliance invitation
+$var['invite']->delete();
+forward(create_container('skeleton.php', 'alliance_invite_player.php'));

--- a/engine/Default/alliance_invite_player_processing.php
+++ b/engine/Default/alliance_invite_player_processing.php
@@ -25,11 +25,7 @@ if (!empty($addMessage)) {
 	$msg .= '<br />' . $addMessage;
 }
 
-// Send mail to player
-$player->sendMessage($receiverID, MSG_PLAYER, $msg, false, true, $expires, true);
-
-// Record invitation in the database
-$db->query('INSERT INTO alliance_invites_player (game_id, account_id, alliance_id, invited_by_id, expires) VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($receiverID) . ', ' . $db->escapeNumber($player->getAllianceID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($expires) . ')');
+$player->sendAllianceInvitation($receiverID, $msg, $expires);
 
 $container = create_container('skeleton.php', 'alliance_invite_player.php');
 forward($container);

--- a/lib/Default/SmrInvitation.class.php
+++ b/lib/Default/SmrInvitation.class.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+// Exception thrown when an alliance invitation cannot be found in the database
+class InvitationNotFoundException extends Exception {}
+
+/**
+ * Object interfacing with the alliance_invites_player table.
+ */
+class SmrInvitation {
+
+	private int $allianceID;
+	private int $gameID;
+	private int $receiverAccountID;
+	private int $senderAccountID;
+	private int $messageID;
+	private int $expires;
+
+	static public function send(int $allianceID, int $gameID, int $receiverAccountID, int $senderAccountID, int $messageID, int $expires) : void {
+		$db = new SmrMySqlDatabase();
+		$db->query('INSERT INTO alliance_invites_player (game_id, account_id, alliance_id, invited_by_id, expires, message_id) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber($receiverAccountID) . ', ' . $db->escapeNumber($allianceID) . ', ' . $db->escapeNumber($senderAccountID) . ', ' . $db->escapeNumber($expires) . ', ' . $db->escapeNumber($messageID) . ')');
+	}
+
+	/**
+	 * Get all unexpired invitations for the given alliance
+	 */
+	static public function getAll(int $allianceID, int $gameID) : array {
+		// Remove any expired invitations
+		$db = new SmrMySqlDatabase();
+		$db->query('DELETE FROM alliance_invites_player WHERE expires < ' . $db->escapeNumber(TIME));
+
+		$db->query('SELECT * FROM alliance_invites_player WHERE alliance_id=' . $db->escapeNumber($allianceID) . ' AND game_id=' . $db->escapeNumber($gameID));
+		$invites = [];
+		while ($db->nextRecord()) {
+			$invites[] = new SmrInvitation($db);
+		}
+		return $invites;
+	}
+
+	/**
+	 * Get the alliance invitation for a single recipient, if not expired
+	 */
+	static public function get(int $allianceID, int $gameID, int $receiverAccountID) : SmrInvitation {
+		// Remove any expired invitations
+		$db = new SmrMySqlDatabase();
+		$db->query('DELETE FROM alliance_invites_player WHERE expires < ' . $db->escapeNumber(TIME));
+
+		$db->query('SELECT * FROM alliance_invites_player WHERE alliance_id=' . $db->escapeNumber($allianceID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' AND account_id=' . $db->escapeNumber($receiverAccountID));
+		if ($db->nextRecord()) {
+			return new SmrInvitation($db);
+		}
+		throw new InvitationNotFoundException();
+	}
+
+	public function __construct(MySqlDatabase $db) {
+		$this->allianceID = $db->getInt('alliance_id');
+		$this->gameID = $db->getInt('game_id');
+		$this->receiverAccountID = $db->getInt('account_id');
+		$this->senderAccountID = $db->getInt('invited_by_id');
+		$this->messageID = $db->getInt('message_id');
+		$this->expires = $db->getInt('expires');
+	}
+
+	public function delete() : void {
+		$db = new SmrMySqlDatabase();
+		$db->query('DELETE FROM alliance_invites_player WHERE alliance_id=' . $db->escapeNumber($this->allianceID) . ' AND game_id=' . $db->escapeNumber($this->gameID) . ' AND account_id=' . $db->escapeNumber($this->receiverAccountID));
+		$db->query('DELETE FROM message WHERE message_id=' . $db->escapeNumber($this->messageID));
+	}
+
+	public function getSender() : SmrPlayer {
+		return SmrPlayer::getPlayer($this->senderAccountID, $this->gameID);
+	}
+
+	public function getReceiver() : SmrPlayer {
+		return SmrPlayer::getPlayer($this->receiverAccountID, $this->gameID);
+	}
+
+	public function getExpires() : int {
+		return $this->expires;
+	}
+
+}

--- a/lib/Default/SmrPlayer.class.php
+++ b/lib/Default/SmrPlayer.class.php
@@ -1372,6 +1372,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$db->escapeNumber($expires) . ',' .
 			$db->escapeBoolean($senderDelete) . ')'
 		);
+		// Keep track of the message_id so it can be returned
+		$insertID = $db->getInsertID();
 
 		if ($unread === true) {
 			// give him the message icon
@@ -1400,6 +1402,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 				}
 			break;
 		}
+
+		return $insertID;
 	}
 
 	public function sendMessageToBox($boxTypeID, $message) {
@@ -1484,8 +1488,8 @@ class SmrPlayer extends AbstractSmrPlayer {
 			$senderDelete = true;
 		}
 
-		// send him the message
-		self::doMessageSending($this->getAccountID(), $receiverID, $this->getGameID(), $messageTypeID, $message, $expires, $senderDelete, $unread);
+		// send him the message and return the message_id
+		return self::doMessageSending($this->getAccountID(), $receiverID, $this->getGameID(), $messageTypeID, $message, $expires, $senderDelete, $unread);
 	}
 
 	public function sendMessageFromOpAnnounce($receiverID, $message, $expires = false) {

--- a/lib/Default/SmrPlayer.class.php
+++ b/lib/Default/SmrPlayer.class.php
@@ -385,9 +385,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$this->db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($roleID) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
 		$this->actionTaken('JoinAlliance', array('Alliance' => $alliance));
-
-		// Joining an alliance cancels all open invitations
-		$this->db->query('DELETE FROM alliance_invites_player WHERE ' . $this->SQL);
 	}
 
 	public function getAllianceJoinable() {
@@ -400,6 +397,18 @@ class SmrPlayer extends AbstractSmrPlayer {
 		}
 		$this->allianceJoinable = $time;
 		$this->hasChanged = true;
+	}
+
+	/**
+	 * Invites player with $accountID to this player's alliance.
+	 */
+	public function sendAllianceInvitation(int $accountID, string $message, int $expires) : void {
+		if (!$this->hasAlliance()) {
+			throw new Exception('Must be in an alliance to send alliance invitations');
+		}
+		// Send message to invited player
+		$messageID = $this->sendMessage($accountID, MSG_PLAYER, $message, false, true, $expires, true);
+		SmrInvitation::send($this->getAllianceID(), $this->getGameID(), $accountID, $this->getAccountID(), $messageID, $expires);
 	}
 
 	public function getAttackColour() {

--- a/templates/Default/engine/Default/alliance_invite_player.php
+++ b/templates/Default/engine/Default/alliance_invite_player.php
@@ -58,12 +58,14 @@ if (count($PendingInvites) == 0) { ?>
 			<th>Invited Player</th>
 			<th>Invited By</th>
 			<th>Expires</th>
+			<th>Cancel</th>
 		</tr><?php
 		foreach ($PendingInvites as $invite) { ?>
 			<tr>
 				<td><?php echo $invite['invited']; ?></td>
 				<td><?php echo $invite['invited_by']; ?></td>
 				<td><?php echo $invite['expires']; ?></td>
+				<td class="center"><a href="<?php echo $invite['cancelHREF']; ?>"><img class="bottom" src="images/silk/cross.png" width="16" height="16" alt="Cancel" title="Cancel Invitation" /></a></td>
 			</tr><?php
 		} ?>
 	</table><?php

--- a/templates/Default/engine/Default/alliance_invite_player.php
+++ b/templates/Default/engine/Default/alliance_invite_player.php
@@ -48,25 +48,27 @@ if (count($InvitePlayers) == 0) { ?>
 <br /><br />
 <h2>Pending Invitations</h2>
 
+<div class="ajax" id="pending">
 <?php
 if (count($PendingInvites) == 0) { ?>
 	<p>Your alliance has no pending invitations.</p><?php
 } else { ?>
 	<br />
-	<table class="standard">
+	<table class="standard inset">
 		<tr>
 			<th>Invited Player</th>
 			<th>Invited By</th>
 			<th>Expires</th>
-			<th>Cancel</th>
+			<th class="shrink">Cancel</th>
 		</tr><?php
 		foreach ($PendingInvites as $invite) { ?>
 			<tr>
 				<td><?php echo $invite['invited']; ?></td>
 				<td><?php echo $invite['invited_by']; ?></td>
-				<td><?php echo $invite['expires']; ?></td>
+				<td class="center"><?php echo $invite['expires']; ?></td>
 				<td class="center"><a href="<?php echo $invite['cancelHREF']; ?>"><img class="bottom" src="images/silk/cross.png" width="16" height="16" alt="Cancel" title="Cancel Invitation" /></a></td>
 			</tr><?php
 		} ?>
 	</table><?php
 } ?>
+</div>


### PR DESCRIPTION
This can be done from the "Invite Player" alliance option page.
It will also delete the invitation message sent to the player.

The new `SmrInvitation` class is responsible for interfacing with the
`alliance_invites_player` table.

Note that accepting one invitation no longer cancels all other open
invitations (with the notion that it's more similar to the scenario
with alliance passwords).


![image](https://user-images.githubusercontent.com/846186/82283522-73a4d280-994b-11ea-931b-30fc6ee11639.png)
