### PR TITLE
Add Globals::getBuyShipNameCosts

### DIFF
--- a/engine/Default/buy_ship_name.php
+++ b/engine/Default/buy_ship_name.php
@@ -1,4 +1,10 @@
 <?php declare(strict_types=1);
 
+$costs = Globals::getBuyShipNameCosts();
+
+$container = create_container('buy_ship_name_processing.php');
+$container['costs'] = $costs;
+
 $template->assign('PageTopic', 'Naming Your Ship');
-$template->assign('ShipNameFormHref', SmrSession::getNewHREF(create_container('buy_ship_name_processing.php')));
+$template->assign('Costs', $costs);
+$template->assign('ShipNameFormHref', SmrSession::getNewHREF($container));

--- a/engine/Default/buy_ship_name_preview.php
+++ b/engine/Default/buy_ship_name_preview.php
@@ -4,6 +4,7 @@ $template->assign('PageTopic', 'Naming Your Ship');
 
 $container = create_container('buy_ship_name_preview_processing.php');
 transfer('ShipName');
+transfer('cost');
 $template->assign('ContinueHREF', SmrSession::getNewHREF($container));
 
 $template->assign('ShipName', $var['ShipName']);

--- a/engine/Default/buy_ship_name_preview_processing.php
+++ b/engine/Default/buy_ship_name_preview_processing.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 $player->setCustomShipName($var['ShipName']);
-$account->decreaseTotalSmrCredits(CREDITS_PER_HTML_SHIP_NAME);
+$account->decreaseTotalSmrCredits($var['cost']);
 
 $container = create_container('skeleton.php', 'current_sector.php');
 $container['msg'] = 'Thanks for your purchase! Your ship is ready!<br /><small>If your ship is found to use HTML inappropriately you may be banned. If your ship does contain inappropriate HTML, please notify an admin ASAP.</small>';

--- a/engine/Default/buy_ship_name_processing.php
+++ b/engine/Default/buy_ship_name_processing.php
@@ -97,39 +97,27 @@ function checkHtmlShipName(string $name) : void {
 
 $action = Request::get('action');
 
-$actionHtmlShipName = 'Include HTML (' . CREDITS_PER_HTML_SHIP_NAME . ' SMR Credits)';
-$actionTextShipName = 'Get It Painted! (' . CREDITS_PER_TEXT_SHIP_NAME . ' SMR Credit)';
-$actionShipLogo = 'Paint a logo (' . CREDITS_PER_SHIP_LOGO . ' SMR Credits)';
-
-if ($action == $actionHtmlShipName) {
-	$cred_cost = CREDITS_PER_HTML_SHIP_NAME;
-} elseif ($action == $actionShipLogo) {
-	$cred_cost = CREDITS_PER_SHIP_LOGO;
-} elseif ($action == $actionTextShipName) {
-	$cred_cost = CREDITS_PER_TEXT_SHIP_NAME;
-} else {
-	throw new Exception('Did not match an expected ship name type.');
-}
-
+$cred_cost = $var['costs'][$action];
 if ($account->getTotalSmrCredits() < $cred_cost) {
-	create_error('You don\'t have enough SMR Credits. Donate to SMR to gain SMR Credits!');
+	create_error('You don\'t have enough SMR Credits. These can be earned by donating to SMR!');
 }
 
-if ($action == $actionShipLogo) {
+if ($action == 'logo') {
 	$filename = $player->getAccountID() . 'logo' . $player->getGameID();
 	checkShipLogo($filename);
 	$name = '<img style="padding:3px;" src="upload/' . $filename . '">';
 } else {
 	// Player submitted a text or HTML ship name
 	$name = Request::get('ship_name');
-	if ($action == $actionTextShipName) {
+	if ($action == 'text') {
 		checkTextShipName($name, 48);
 		$name = htmlentities($name, ENT_NOQUOTES, 'utf-8');
-	} else {
+	} elseif ($action == 'html') {
 		checkTextShipName($name, 128);
 		checkHtmlShipName($name);
 		$container = create_container('skeleton.php', 'buy_ship_name_preview.php');
 		$container['ShipName'] = $name;
+		$container['cost'] = $cred_cost;
 		forward($container);
 	}
 }

--- a/lib/Default/Globals.class.php
+++ b/lib/Default/Globals.class.php
@@ -513,6 +513,14 @@ class Globals {
 		return SmrSession::getNewHREF(create_container('skeleton.php', 'buy_ship_name.php'));
 	}
 
+	public static function getBuyShipNameCosts() : array {
+		return [
+			'text' => CREDITS_PER_TEXT_SHIP_NAME,
+			'html' => CREDITS_PER_HTML_SHIP_NAME,
+			'logo' => CREDITS_PER_SHIP_LOGO,
+		];
+	}
+
 	public static function getSectorBBLink($sectorID) {
 		return '[sector=' . $sectorID . ']';
 	}

--- a/templates/Default/engine/Default/bar_main.php
+++ b/templates/Default/engine/Default/bar_main.php
@@ -47,7 +47,7 @@ if ($WinningTicket) { ?>
 Well... of course you could always pay our painters to customise your ship name, or even spray on your favourite logo!<br />
 <br />
 <div class="buttonA">
-	<a class="buttonA" href="<?php echo Globals::getBuyShipnameHREF(); ?>">Customize Ship Name (<?php echo min(CREDITS_PER_TEXT_SHIP_NAME, CREDITS_PER_HTML_SHIP_NAME, CREDITS_PER_SHIP_LOGO); ?>-<?php echo max(CREDITS_PER_TEXT_SHIP_NAME, CREDITS_PER_HTML_SHIP_NAME, CREDITS_PER_SHIP_LOGO); ?> SMR Credits)</a>
+	<a class="buttonA" href="<?php echo Globals::getBuyShipnameHREF(); ?>">Customize Ship Name (<?php echo min(Globals::getBuyShipNameCosts()); ?>-<?php echo max(Globals::getBuyShipNameCosts()); ?> SMR Credits)</a>
 </div>
 
 <br />

--- a/templates/Default/engine/Default/buy_ship_name.php
+++ b/templates/Default/engine/Default/buy_ship_name.php
@@ -5,15 +5,15 @@
 	<form name="ship_naming" method="POST" action="<?php echo $ShipNameFormHref; ?>">
 		<input type="text" name="ship_name" required placeholder="Enter Name Here" class="InputFields">
 		<br /><br />
-		<input type="submit" name="action" value="Get It Painted! (<?php echo CREDITS_PER_TEXT_SHIP_NAME; ?> SMR Credit)" class="InputFields" />
+		<button type="submit" name="action" value="text" class="InputFields">Get It Painted! (<?php echo $Costs['text']; ?> SMR Credits)</button>
 		<br /><br />
-		<input type="submit" name="action" value="Include HTML (<?php echo CREDITS_PER_HTML_SHIP_NAME; ?> SMR Credits)" class="InputFields" />
+		<button type="submit" name="action" value="html" class="InputFields">Include HTML (<?php echo $Costs['html']; ?> SMR Credits)</button>
 	</form>
 	<br /><br /><br />
 	Or you can paint a logo on your ship! (max <?php echo MAX_IMAGE_HEIGHT; ?> height by <?php echo MAX_IMAGE_WIDTH; ?> width and <?php echo MAX_IMAGE_SIZE; ?>kB)<br /><br />
 	<form name="ship_logo" enctype="multipart/form-data" method="POST" action="<?php echo $ShipNameFormHref; ?>">
 		Image: <input type="file" name="photo" required accept="image/jpeg, image/png" class="InputFields" style="width:40%;">
 		<br /><br />
-		<input type="submit" name="action" value="Paint a logo (<?php echo CREDITS_PER_SHIP_LOGO; ?> SMR Credits)" class="InputFields" />
+		<button type="submit" name="action" value="logo" class="InputFields">Paint A Logo (<?php echo $Costs['logo']; ?> SMR Credits)</button>
 	</form>
 </div>

--- a/templates/Default/engine/Default/donation.php
+++ b/templates/Default/engine/Default/donation.php
@@ -38,6 +38,6 @@ if (isset($GameID)) { ?>
 	<h2>Ship Name</h2>
 	<p>Customise your ship name, or even spray on your favourite logo!</p>
 	<div class="buttonA">
-		<a class="buttonA" href="<?php echo Globals::getBuyShipNameHref(); ?>">Customize Ship Name (<?php echo min(CREDITS_PER_TEXT_SHIP_NAME, CREDITS_PER_HTML_SHIP_NAME, CREDITS_PER_SHIP_LOGO); ?>-<?php echo max(CREDITS_PER_TEXT_SHIP_NAME, CREDITS_PER_HTML_SHIP_NAME, CREDITS_PER_SHIP_LOGO); ?> SMR Credits)</a>
+		<a class="buttonA" href="<?php echo Globals::getBuyShipNameHref(); ?>">Customize Ship Name (<?php echo min(Globals::getBuyShipNameCosts()); ?>-<?php echo max(Globals::getBuyShipNameCosts()); ?> SMR Credits)</a>
 	</div><?php
 }


### PR DESCRIPTION
Refactor the `buy_ship_name*` pages so that they do not hard-code the
costs. Instead, they will be taken from this new `Globals` method,
which will allow us to, e.g., make them game-dependent.

Note that the `buy_ship_name.php` form was simplified a lot by passing
the costs through the container and by using `<button>` instead of
`<input>` (since a button's text display can be different from its
value).