### PR TITLE
announcements.php: escape HTML entities

### DIFF
--- a/admin/Default/announcement_create.php
+++ b/admin/Default/announcement_create.php
@@ -2,5 +2,5 @@
 $template->assign('PageTopic', 'Create Announcement');
 $template->assign('AnnouncementCreateFormHref', SmrSession::getNewHREF(create_container('announcement_create_processing.php')));
 if (isset($var['preview'])) {
-	$template->assign('Preview', $var['preview']);
+	$template->assign('Preview', htmlentities($var['preview']));
 }

--- a/engine/Default/announcements.php
+++ b/engine/Default/announcements.php
@@ -16,7 +16,7 @@ if (!isset($var['view_all'])) {
 $announcements = [];
 while ($db->nextRecord()) {
 	$announcements[] = ['Time' => $db->getInt('time'),
-	                    'Msg' => $db->getField('msg')];
+	                    'Msg' => htmlentities($db->getField('msg'))];
 }
 $template->assign('Announcements', $announcements);
 

--- a/templates/Default/admin/Default/announcement_create.php
+++ b/templates/Default/admin/Default/announcement_create.php
@@ -1,4 +1,5 @@
-Announcements are displayed to all users the next time they log in.<br /><br />
+Announcements are displayed to all users the next time they log in.<br />
+You may use BBCode in your message, but not HTML.<br /><br />
 <?php if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbifyMessage($Preview); ?></td></tr></table><br /><?php } ?>
 <form name="AnnouncementCreateForm" method="POST" action="<?php echo $AnnouncementCreateFormHref; ?>">
 	<textarea required spellcheck="true" name="message" class="InputFields"><?php if (isset($Preview)) { echo $Preview; } ?></textarea><br />


### PR DESCRIPTION
The Announcements messages have been historically written with only
BBCode in mind. Recently, I've started using HTML (because it was
allowed), but this prevents us from easily escaping the unintended
HTML entities in old messages.

Rather than manually escaping all the old messages, I've decided to
disallow HTML in Announcements and instead rely on BBCode. All recent
messages using HTML have been manually converted to BBCode.