### PR TITLE
SmrPlayer: convert to unescaped names in database

### DIFF
--- a/admin/Default/box_view.php
+++ b/admin/Default/box_view.php
@@ -45,10 +45,7 @@ if (!isset($var['box_type_id'])) {
 				$senderName = $senderAccount->getLogin() . ' (' . $senderID . ')';
 				if ($validGame) {
 					$senderPlayer = SmrPlayer::getPlayer($senderID, $gameID);
-					if ($senderAccount->getLogin() != $senderPlayer->getPlayerName()) {
-						$senderName .= ' a.k.a ' . $senderPlayer->getPlayerName();
-					}
-				
+					$senderName .= ' a.k.a ' . $senderPlayer->getDisplayName();
 					$container = create_container('skeleton.php', 'box_reply.php');
 					$container['sender_id'] = $senderID;
 					$container['game_id'] = $gameID;

--- a/admin/Default/notify_view.php
+++ b/admin/Default/notify_view.php
@@ -22,9 +22,7 @@ while ($db->nextRecord()) {
 	if (is_object($sender)) {
 		$sender_acc = $sender->getAccount();
 		$offender = $sender_acc->getLogin() . ' (' . $sender_acc->getAccountID() . ')';
-		if ($sender_acc->getLogin() != $sender->getPlayerName()) {
-			$offender .= ' a.k.a ' . $sender->getPlayerName();
-		}
+		$offender .= ' a.k.a ' . $sender->getDisplayName();
 	}
 	$senderLink = create_link($container, $offender);
 
@@ -32,9 +30,7 @@ while ($db->nextRecord()) {
 	if (is_object($receiver)) {
 		$receiver_acc = $receiver->getAccount();
 		$offended = $receiver_acc->getLogin() . ' (' . $receiver_acc->getAccountID() . ')';
-		if ($receiver_acc->getLogin() != $receiver->getPlayerName()) {
-			$offended .= ' a.k.a ' . $receiver->getPlayerName();
-		}
+		$offended .= ' a.k.a ' . $receiver->getDisplayName();
 	}
 	$receiverLink = create_link($container, $offended);
 

--- a/admin/Default/npc_manage.php
+++ b/admin/Default/npc_manage.php
@@ -38,7 +38,7 @@ while ($db->nextRecord()) {
 
 	$npcs[$accountID] = [
 		'login' => $login,
-		'default_player_name' => $db->getField('player_name'),
+		'default_player_name' => htmlentities($db->getField('player_name')),
 		'default_alliance' => htmlentities($db->getField('alliance_name')),
 		'active' => $db->getBoolean('active'),
 		'working' => $db->getBoolean('working'),

--- a/admin/Default/ship_check.php
+++ b/admin/Default/ship_check.php
@@ -19,7 +19,7 @@ while ($db->nextRecord()) {
 	$container['max_amount'] = $db->getInt('max_amount');
 
 	$excessHardware[] = [
-		'player' => stripslashes($db->getField('player_name')),
+		'player' => htmlentities($db->getField('player_name')),
 		'game_id' => $db->getInt('game_id'),
 		'hardware' => $db->getField('hardware_name'),
 		'amount' => $db->getInt('amount'),

--- a/engine/Default/alliance_exempt_authorize.php
+++ b/engine/Default/alliance_exempt_authorize.php
@@ -18,7 +18,7 @@ if ($db->getNumRows()) {
 	while ($db->nextRecord()) {
 		$transactions[] = [
 			'type' => $db->getField('transaction') == 'Payment' ? 'Withdraw' : 'Deposit',
-			'player' => $players[$db->getInt('payee_id')]->getPlayerName(),
+			'player' => $players[$db->getInt('payee_id')]->getDisplayName(),
 			'reason' => $db->getField('reason'),
 			'amount' => number_format($db->getInt('amount')),
 			'transactionID' => $db->getInt('transaction_id'),

--- a/engine/Default/alliance_message.php
+++ b/engine/Default/alliance_message.php
@@ -64,7 +64,6 @@ if ($db->getNumRows() > 0) {
 		
 		// Determine the thread author display name
 		$sender_id = $db->getInt('sender_id');
-		$playerName = 'Unknown'; // default
 		if ($sender_id == ACCOUNT_ID_PLANET) {
 			$playerName = 'Planet Reporter';
 		} elseif ($sender_id == ACCOUNT_ID_BANK_REPORTER) {
@@ -72,20 +71,11 @@ if ($db->getNumRows() > 0) {
 		} elseif ($sender_id == ACCOUNT_ID_ADMIN) {
 			$playerName = 'Game Admins';
 		} else {
-			$db2->query('SELECT
-						player.player_name as player_name,
-						alliance_thread.sender_id as sender_id
-						FROM player
-						JOIN alliance_thread ON alliance_thread.game_id = player.game_id AND player.account_id=alliance_thread.sender_id
-						WHERE player.game_id=' . $db2->escapeNumber($player->getGameID()) . '
-						AND alliance_thread.alliance_id=' . $db2->escapeNumber($alliance->getAllianceID()) . '
-						AND alliance_thread.thread_id=' . $db2->escapeNumber($threadID) . '
-						AND alliance_thread.reply_id=1 LIMIT 1
-						');
-			if ($db2->nextRecord()) {
-				$sender_id = $db2->getInt('sender_id');
+			try {
 				$author = SmrPlayer::getPlayer($sender_id, $player->getGameID());
 				$playerName = $author->getLinkedDisplayName(false);
+			} catch (PlayerNotFoundException $e) {
+				$playerName = 'Unknown'; // default
 			}
 		}
 		$threads[$i]['Sender'] = $playerName;

--- a/engine/Default/alliance_remove_member.php
+++ b/engine/Default/alliance_remove_member.php
@@ -27,7 +27,7 @@ while ($db->nextRecord()) {
 
 	$members[] = [
 		'last_active' => $lastActive,
-		'display_name' => $db->getField('player_name') . ' (' . $db->getInt('player_id') . ')',
+		'display_name' => htmlentities($db->getField('player_name')) . ' (' . $db->getInt('player_id') . ')',
 		'account_id' => $db->getInt('account_id'),
 	];
 }

--- a/engine/Default/bank_anon_detail.php
+++ b/engine/Default/bank_anon_detail.php
@@ -43,7 +43,7 @@ if ($var['minValue'] <= $maxValue && $var['minValue'] > 0) {
 	$minValue = $var['minValue'];
 }
 
-$query = 'SELECT time, player_name, player_id, alignment, transaction_id, transaction, amount
+$query = 'SELECT *
 			FROM player
 			JOIN anon_bank_transactions USING (game_id, account_id)
 			WHERE player.game_id=' . $db->escapeNumber($player->getGameID()) . '
@@ -68,19 +68,16 @@ if ($db->getNumRows() > 0) {
 	$container['account_num'] = $account_num;
 	$template->assign('ShowHREF', SmrSession::getNewHREF($container));
 
-	$container = create_container('skeleton.php', 'trader_search_result.php');
-
 	$transactions = [];
 	while ($db->nextRecord()) {
-		$container['player_id'] = $db->getInt('player_id');
-		$link = create_link($container, get_colored_text($db->getInt('alignment'), $db->getField('player_name')));
+		$transactionPlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
 		$transaction = $db->getField('transaction');
 		$amount = number_format($db->getInt('amount'));
 		$transactions[$db->getInt('transaction_id')] = [
 			'date' => date(DATE_FULL_SHORT_SPLIT, $db->getInt('time')),
 			'payment' => $transaction == 'Payment' ? $amount : '',
 			'deposit' => $transaction == 'Deposit' ? $amount : '',
-			'link' => $link,
+			'link' => $transactionPlayer->getLinkedDisplayName(),
 		];
 	}
 	$template->assign('Transactions', $transactions);

--- a/engine/Default/bank_report.php
+++ b/engine/Default/bank_report.php
@@ -31,7 +31,7 @@ arsort($totals, SORT_NUMERIC);
 $db->query('SELECT * FROM player WHERE account_id IN (' . $db->escapeArray($playerIDs) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY player_name');
 $players[0] = 'Alliance Funds';
 while ($db->nextRecord()) {
-	$players[$db->getInt('account_id')] = $db->getField('player_name');
+	$players[$db->getInt('account_id')] = htmlentities($db->getField('player_name'));
 }
 
 //format it this way so its easy to send to the alliance MB if requested.

--- a/engine/Default/bounty_claim.php
+++ b/engine/Default/bounty_claim.php
@@ -27,7 +27,7 @@ if (!isset($var['ClaimText'])) {
 			// add bounty to our cash
 			$player->increaseCredits($amount);
 			$account->increaseSmrCredits($smrCredits);
-			$claimText .= ('<span class="yellow">' . $bounty['player']->getPlayerName() . '</span> : <span class="creds">' . number_format($amount) . '</span> credits and <span class="red">' . number_format($smrCredits) . '</span> SMR credits<br />');
+			$claimText .= ($bounty['player']->getDisplayName() . ' : <span class="creds">' . number_format($amount) . '</span> credits and <span class="red">' . number_format($smrCredits) . '</span> SMR credits<br />');
 	
 			// add HoF stat
 			$player->increaseHOF(1, array('Bounties', 'Claimed', 'Results'), HOF_PUBLIC);

--- a/engine/Default/bounty_place.php
+++ b/engine/Default/bounty_place.php
@@ -11,6 +11,6 @@ $template->assign('SubmitHREF', SmrSession::getNewHREF($container));
 $bountyPlayers = [];
 $db->query('SELECT player_id, player_name FROM player JOIN account USING(account_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id != ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY player_name');
 while ($db->nextRecord()) {
-	$bountyPlayers[$db->getInt('player_id')] = $db->getField('player_name');
+	$bountyPlayers[$db->getInt('player_id')] = htmlentities($db->getField('player_name'));
 }
 $template->assign('BountyPlayers', $bountyPlayers);

--- a/engine/Default/bounty_view.php
+++ b/engine/Default/bounty_view.php
@@ -1,4 +1,4 @@
 <?php declare(strict_types=1);
 $bountyPlayer = SmrPlayer::getPlayer($var['id'], $player->getGameID());
-$template->assign('PageTopic', 'Viewing ' . $bountyPlayer->getPlayerName());
+$template->assign('PageTopic', 'Viewing Bounties');
 $template->assign('BountyPlayer', $bountyPlayer);

--- a/engine/Default/chat_sharing.php
+++ b/engine/Default/chat_sharing.php
@@ -20,7 +20,7 @@ while ($db->nextRecord()) {
 		'Player ID'   => $otherPlayer == null ? '-' : $otherPlayer->getPlayerID(),
 		'Player Name' => $otherPlayer == null ?
 		                 '<b>Account</b>: ' . SmrAccount::getAccount($fromAccountId)->getHofDisplayName() :
-		                 $otherPlayer->getPlayerName(),
+		                 $otherPlayer->getDisplayName(),
 		'All Games'   => $gameId == 0 ? '<span class="green">YES</span>' : '<span class="red">NO</span>',
 		'Game ID'     => $gameId,
 	);
@@ -41,7 +41,7 @@ while ($db->nextRecord()) {
 		'Player ID'   => $otherPlayer == null ? '-' : $otherPlayer->getPlayerID(),
 		'Player Name' => $otherPlayer == null ?
 		                 '<b>Account</b>: ' . SmrAccount::getAccount($toAccountId)->getHofDisplayName() :
-		                 $otherPlayer->getPlayerName(),
+		                 $otherPlayer->getDisplayName(),
 		'All Games'   => $gameId == 0 ? '<span class="green">YES</span>' : '<span class="red">NO</span>',
 		'Game ID'     => $gameId,
 	);

--- a/engine/Default/chess.php
+++ b/engine/Default/chess.php
@@ -13,7 +13,7 @@ foreach ($chessGames as $chessGame) {
 $players = array();
 $db->query('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) WHERE npc = ' . $db->escapeBoolean(false) . ' AND validated = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
 while ($db->nextRecord()) {
-	$players[$db->getInt('player_id')] = $db->getField('player_name');
+	$players[$db->getInt('player_id')] = htmlentities($db->getField('player_name'));
 }
 $template->assign('PlayerList', $players);
 
@@ -21,7 +21,7 @@ if (ENABLE_NPCS_CHESS) {
 	$npcs = array();
 	$db->query('SELECT player_id, player.player_name FROM player WHERE npc = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
 	while ($db->nextRecord()) {
-		$npcs[$db->getInt('player_id')] = $db->getField('player_name');
+		$npcs[$db->getInt('player_id')] = htmlentities($db->getField('player_name'));
 	}
 	$template->assign('NPCList', $npcs);
 }

--- a/engine/Default/forces_drop.php
+++ b/engine/Default/forces_drop.php
@@ -2,7 +2,7 @@
 
 if (isset($var['owner_id'])) {
 	$owner = SmrPlayer::getPlayer($var['owner_id'], $player->getGameID());
-	$template->assign('PageTopic', 'Change ' . $owner->getPlayerName() . '\'s Forces');
+	$template->assign('PageTopic', 'Change ' . htmlentities($owner->getPlayerName()) . '\'s Forces');
 	$owner_id = $var['owner_id'];
 } else {
 	$template->assign('PageTopic', 'Drop Forces');

--- a/engine/Default/forces_drop_processing.php
+++ b/engine/Default/forces_drop_processing.php
@@ -187,7 +187,7 @@ if ($forces->getOwnerID() != $player->getAccountID() && $forces->getOwner()->isF
 	}
 
 	// now compile it together
-	$message = $player->getPlayerName() . ' has ' . $mines_message;
+	$message = $player->getBBLink() . ' has ' . $mines_message;
 
 	if (!empty($mines_message) && isset($combat_drones_message) && !isset($scout_drones_message)) {
 		$message .= ' and ' . $combat_drones_message;

--- a/engine/Default/galactic_post_view_article.php
+++ b/engine/Default/galactic_post_view_article.php
@@ -20,7 +20,7 @@ while ($db->nextRecord()) {
 	$container['id'] = $db->getInt('article_id');
 	$articles[] = [
 		'title' => $title,
-		'writer' => $writer->getPlayerName(),
+		'writer' => $writer->getDisplayName(),
 		'link' => SmrSession::getNewHREF($container),
 	];
 }

--- a/engine/Default/hall_of_fame_player_detail.php
+++ b/engine/Default/hall_of_fame_player_detail.php
@@ -17,7 +17,7 @@ if (isset($var['game_id'])) {
 	} catch (PlayerNotFoundException $e) {
 		create_error('That player has not yet joined this game.');
 	}
-	$template->assign('PageTopic', $hofPlayer->getPlayerName() . '\'s Personal Hall of Fame: ' . SmrGame::getGame($game_id)->getDisplayName());
+	$template->assign('PageTopic', htmlentities($hofPlayer->getPlayerName()) . '\'s Personal Hall of Fame: ' . SmrGame::getGame($game_id)->getDisplayName());
 } else {
 	$hofName = SmrAccount::getAccount($account_id)->getHofDisplayName();
 	$template->assign('PageTopic', $hofName . '\'s All Time Personal Hall of Fame');

--- a/engine/Default/history_games.php
+++ b/engine/Default/history_games.php
@@ -42,7 +42,7 @@ while ($db->nextRecord()) {
 	$playerExp[] = [
 		'bold' => $db->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
 		'exp' => $db->getInt('experience'),
-		'name' => stripslashes($db->getField('player_name')),
+		'name' => $db->getField('player_name'),
 	];
 }
 $template->assign('PlayerExp', $playerExp);
@@ -53,7 +53,7 @@ while ($db->nextRecord()) {
 	$playerKills[] = [
 		'bold' => $db->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
 		'kills' => $db->getInt('kills'),
-		'name' => stripslashes($db->getField('player_name')),
+		'name' => $db->getField('player_name'),
 	];
 }
 $template->assign('PlayerKills', $playerKills);

--- a/engine/Default/history_games_hof.php
+++ b/engine/Default/history_games_hof.php
@@ -38,7 +38,7 @@ if (!isset($var['stat'])) {
 	while ($db->nextRecord()) {
 		$rankings[] = [
 			'bold' => $db->getInt('account_id') == $oldAccountId ? 'class="bold"' : '',
-			'name' => stripslashes($db->getField('player_name')),
+			'name' => $db->getField('player_name'),
 			'stat' => $db->getInt($var['stat']),
 		];
 	}

--- a/engine/Default/message_blacklist_add.php
+++ b/engine/Default/message_blacklist_add.php
@@ -22,5 +22,5 @@ if ($db->nextRecord()) {
 
 $db->query('INSERT INTO message_blacklist (game_id,account_id,blacklisted_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($blacklisted->getAccountID()) . ')');
 
-$container['msg'] = '<span class="yellow">' . $blacklisted->getPlayerName() . '</span> has been added to your blacklist.';
+$container['msg'] = $blacklisted->getDisplayName() . ' has been added to your blacklist.';
 forward($container);

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -212,9 +212,6 @@ if ($action == 'Save and resend validation code') {
 		create_error('You must enter a player name!');
 	}
 
-	// Escape html elements so the name displays correctly
-	$player_name = htmlentities($player_name);
-
 	// Check if name is in use.
 	// The player_name field has case-insensitive collation, so check against ID
 	// to allow player to change the case of their name.

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -9,7 +9,7 @@ abstract class AbstractSmrPlayer {
 
 	protected $accountID;
 	protected $gameID;
-	protected $playerName; // This is escaped with htmlentities in the db
+	protected $playerName;
 	protected $playerID;
 	protected $sectorID;
 	protected $lastSectorID;
@@ -491,6 +491,10 @@ abstract class AbstractSmrPlayer {
 		return $this->playerID;
 	}
 
+	/**
+	 * Returns the player name.
+	 * Use getDisplayName or getLinkedDisplayName for HTML-safe versions.
+	 */
 	public function getPlayerName() {
 		return $this->playerName;
 	}
@@ -500,8 +504,12 @@ abstract class AbstractSmrPlayer {
 		$this->hasChanged = true;
 	}
 
+	/**
+	 * Returns the decorated player name, suitable for HTML display.
+	 */
 	public function getDisplayName($includeAlliance = false) {
-		$return = get_colored_text($this->getAlignment(), $this->playerName . ' (' . $this->getPlayerID() . ')');
+		$name = htmlentities($this->playerName) . ' (' . $this->getPlayerID() . ')';
+		$return = get_colored_text($this->getAlignment(), $name);
 		if ($this->isNPC()) {
 			$return .= ' <span class="npcColour">[NPC]</span>';
 		}

--- a/lib/Default/SmrPlayer.class.php
+++ b/lib/Default/SmrPlayer.class.php
@@ -224,9 +224,6 @@ class SmrPlayer extends AbstractSmrPlayer {
 		$db = new SmrMySqlDatabase();
 		$db->lockTable('player');
 
-		// Escape html elements so the name displays correctly
-		$playerName = htmlentities($playerName);
-
 		// Player names must be unique within each game
 		$db->query('SELECT 1 FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND player_name = ' . $db->escapeString($playerName) . ' LIMIT 1');
 		if ($db->nextRecord() > 0) {

--- a/lib/Default/bar.functions.inc
+++ b/lib/Default/bar.functions.inc
@@ -35,7 +35,7 @@ function checkForLottoWinner($gameID) {
 		$winner = SmrPlayer::getPlayer($winner_id, $gameID);
 		$winner->increaseHOF($lottoInfo['Prize'], array('Bar', 'Lotto', 'Money', 'Winnings'), HOF_PUBLIC);
 		$winner->increaseHOF(1, array('Bar', 'Lotto', 'Results', 'Wins'), HOF_PUBLIC);
-		$news_message = '<span class="yellow">' . $winner->getPlayerName() . '</span> has won the lotto! The jackpot was ' . number_format($lottoInfo['Prize']) . '. <span class="yellow">' . $winner->getPlayerName() . '</span> can report to any bar to claim their prize before the next drawing!';
+		$news_message = $winner->getBBLink() . ' has won the lotto! The jackpot was ' . number_format($lottoInfo['Prize']) . '. ' . $winner->getBBLink() . ' can report to any bar to claim their prize before the next drawing!';
 		// insert the news entry
 		$db->query('DELETE FROM news WHERE type = \'lotto\' AND game_id = ' . $db->escapeNumber($gameID));
 		$db->query('INSERT INTO news

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -136,7 +136,7 @@ function displayHOFRow($rank, $accountID, $amount) {
 	}
 
 	if (isset($hofPlayer) && is_object($hofPlayer)) {
-		$return .= ('<td ' . $bold . '>' . create_link($container, $hofPlayer->getPlayerName()) . '</td>');
+		$return .= ('<td ' . $bold . '>' . create_link($container, htmlentities($hofPlayer->getPlayerName())) . '</td>');
 	} else if (isset($hofAccount) && is_object($hofAccount)) {
 		$return .= ('<td ' . $bold . '>' . create_link($container, $hofAccount->getHofDisplayName()) . '</td>');
 	} else {

--- a/templates/Default/admin/Default/account_edit.php
+++ b/templates/Default/admin/Default/account_edit.php
@@ -61,7 +61,7 @@
 								</tr>
 								<tr>
 									<td class="right">Name:</td>
-									<td><input type=text name=player_name[<?php echo $CurrentPlayer->getGameID(); ?>] placeholder="<?php echo $CurrentPlayer->getPlayerName(); ?>" />(<?php echo $CurrentPlayer->getPlayerID(); ?>)</td>
+									<td><input type=text name=player_name[<?php echo $CurrentPlayer->getGameID(); ?>] placeholder="<?php echo htmlentities($CurrentPlayer->getPlayerName()); ?>" />(<?php echo $CurrentPlayer->getPlayerID(); ?>)</td>
 								</tr>
 								<tr>
 									<td class="right">Experience:</td>

--- a/templates/Default/admin/Default/anon_acc_view.php
+++ b/templates/Default/admin/Default/anon_acc_view.php
@@ -8,7 +8,7 @@
 	</tr><?php
 	foreach ($Rows as $Row) { ?>
 		<tr>
-			<td><?php echo $Row['player_name']; ?></td>
+			<td><?php echo htmlentities($Row['player_name']); ?></td>
 			<td><?php echo $Row['transaction']; ?></td>
 			<td class="right"><?php echo number_format($Row['amount']); ?></td>
 		</tr><?php

--- a/templates/Default/admin/Default/box_reply.php
+++ b/templates/Default/admin/Default/box_reply.php
@@ -1,7 +1,7 @@
 <?php if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbifyMessage($Preview); ?></td></tr></table><?php } ?>
 <form name="BoxReplyForm" method="POST" action="<?php echo $BoxReplyFormHref; ?>">
 	<b>From: </b><span class="admin">Administrator</span><br />
-	<b>To: </b><?php echo $Sender->getPlayerName(); ?> a.k.a <?php echo $SenderAccount->getLogin(); ?>
+	<b>To: </b><?php echo $Sender->getDisplayName(); ?> a.k.a <?php echo $SenderAccount->getLogin(); ?>
 	<br />
 	<textarea required spellcheck="true" name="message" class="InputFields"><?php if (isset($Preview)) { echo $Preview; } ?></textarea><br /><br />
 	<input type="number" value="<?php if (isset($BanPoints)) { echo htmlspecialchars($BanPoints); } else { ?>0<?php } ?>" name="BanPoints" size="4" /> Add Ban Points<br />

--- a/templates/Default/admin/Default/notify_reply.php
+++ b/templates/Default/admin/Default/notify_reply.php
@@ -3,13 +3,13 @@ Leave a message box blank to not reply to that player.<br />
 <form name="NotifyReplyForm" method="POST" action="<?php echo $NotifyReplyFormHref; ?>">
 	<?php if (isset($PreviewOffender)) { ?><table class="standard"><tr><td><?php echo bbifyMessage($PreviewOffender); ?></td></tr></table><?php } ?>
 	<b>From: </b><span class="admin">Administrator</span><br />
-	<b>To: </b><?php if (is_object($Offender)) { echo $Offender->getPlayerName(); ?> a.k.a <?php echo $OffenderAccount->getLogin(); } ?> (Offender)<br />
+	<b>To: </b><?php if (is_object($Offender)) { echo $Offender->getDisplayName(); ?> a.k.a <?php echo $OffenderAccount->getLogin(); } ?> (Offender)<br />
 	<input type="number" value="<?php if (isset($OffenderBanPoints)) { echo htmlspecialchars($OffenderBanPoints); } else { ?>0<?php } ?>" name="offenderBanPoints" size="4" /> Points<br />
 	<textarea spellcheck="true" name="offenderReply" class="InputFields"><?php if (isset($PreviewOffender)) { echo $PreviewOffender; } ?></textarea><br /><br />
 
 	<?php if (isset($PreviewOffended)) { ?><table class="standard"><tr><td><?php echo bbifyMessage($PreviewOffended); ?></td></tr></table><?php } ?>
 	<b>From: </b><span class="admin">Administrator</span><br />
-	<b>To: </b><?php if (is_object($Offended)) { echo $Offended->getPlayerName(); ?> a.k.a <?php echo $OffendedAccount->getLogin(); } ?> (Offended)<br />
+	<b>To: </b><?php if (is_object($Offended)) { echo $Offended->getDisplayName(); ?> a.k.a <?php echo $OffendedAccount->getLogin(); } ?> (Offended)<br />
 	<input type="number" value="<?php if (isset($OffendedBanPoints)) { echo htmlspecialchars($OffendedBanPoints); } else { ?>0<?php } ?>" name="offendedBanPoints" size="4" /> Points<br />
 	<textarea spellcheck="true" name="offendedReply" class="InputFields"><?php if (isset($PreviewOffended)) { echo $PreviewOffended; } ?></textarea><br /><br />
 

--- a/templates/Default/engine/Default/alliance_pick.php
+++ b/templates/Default/engine/Default/alliance_pick.php
@@ -51,7 +51,7 @@ if (count($PickPlayers) > 0) { ?>
 				} ?>
 				</td>
 				<td>
-					<?php echo $PickPlayer['Player']->getPlayerName(); ?>
+					<?php echo $PickPlayer['Player']->getDisplayName(); ?>
 				</td>
 				<td>
 					<?php echo $PickPlayer['Player']->getRaceName(); ?>
@@ -86,9 +86,9 @@ if (count($History) > 0) { ?>
 		foreach (array_reverse($History, true) as $i => $Pick) { ?>
 			<tr>
 				<td class="center"><?php echo $i + 1; ?></td>
-				<td><?php echo $Pick['Leader']->getPlayerName(); ?></td>
+				<td><?php echo $Pick['Leader']->getDisplayName(); ?></td>
 				<td><?php echo date(DATE_FULL_SHORT, $Pick['Time']); ?></td>
-				<td><?php echo $Pick['Player']->getPlayerName(); ?></td>
+				<td><?php echo $Pick['Player']->getDisplayName(); ?></td>
 				<td><?php echo $Pick['Player']->getRaceName(); ?></td>
 				<td><?php echo $Pick['Player']->getAccount()->getHofDisplayName(true); ?></td>
 				<td><?php echo $Pick['Player']->getAccount()->getScore(); ?></td>

--- a/templates/Default/engine/Default/alliance_roster.php
+++ b/templates/Default/engine/Default/alliance_roster.php
@@ -66,7 +66,7 @@ if ($ShowRoles && $CanChangeRoles) { ?>
 						if ($AlliancePlayer->getAccountID() == $Alliance->getLeaderID()) { ?>*<?php }
 						echo $Count++; ?>
 					</td>
-					<td class="left name" data-name="<?php echo $AlliancePlayer->getPlayerName(); ?>"><?php
+					<td class="left name" data-name="<?php echo htmlentities($AlliancePlayer->getPlayerName()); ?>"><?php
 						echo $AlliancePlayer->getLevelName(); ?>&nbsp;<?php echo $AlliancePlayer->getLinkedDisplayName(false); ?>
 					</td>
 					<td class="race"><?php

--- a/templates/Default/engine/Default/bank_alliance.php
+++ b/templates/Default/engine/Default/bank_alliance.php
@@ -9,7 +9,7 @@ if (count($AlliedAllianceBanks) > 0) { ?>
 	</ul><br /><?php
 } ?>
 
-Hello <?php echo $ThisPlayer->getPlayerName(); ?>,<br /><?php
+Hello <?php echo $ThisPlayer->getDisplayName(); ?>,<br /><?php
 if (isset($UnlimitedWithdrawal) && $UnlimitedWithdrawal === true) {
 	?>You can withdraw an unlimited amount from this account.<?php
 } elseif (isset($PositiveWithdrawal)) {

--- a/templates/Default/engine/Default/bank_personal.php
+++ b/templates/Default/engine/Default/bank_personal.php
@@ -1,4 +1,4 @@
-Hello <?php echo $ThisPlayer->getPlayerName(); ?>
+Hello <?php echo $ThisPlayer->getDisplayName(); ?>
 <br /><br />
 
 Balance: <b><?php echo number_format($ThisPlayer->getBank()); ?></b>

--- a/templates/Default/engine/Default/bounty_view.php
+++ b/templates/Default/engine/Default/bounty_view.php
@@ -4,9 +4,9 @@ if ($BountyPlayer->hasBounties()) {
 	$HasHQBounty = false;
 	foreach ($Bounties as $Bounty) {
 		if ($Bounty['Type'] == 'HQ') { ?>
-			The <span class="green">Federal Government</span> is offering a bounty on <?php echo $BountyPlayer->getPlayerName(); ?> worth <span class="creds"><?php echo $Bounty['Amount']; ?></span> credits and <span class="yellow"><?php echo $Bounty['SmrCredits']; ?></span> SMR credits.<br /><?php
+			The <span class="green">Federal Government</span> is offering a bounty on <?php echo $BountyPlayer->getDisplayName(); ?> worth <span class="creds"><?php echo $Bounty['Amount']; ?></span> credits and <span class="yellow"><?php echo $Bounty['SmrCredits']; ?></span> SMR credits.<br /><?php
 			if ($Bounty['Claimer'] != 0) { ?>
-				This bounty can be claimed by <?php echo SmrPlayer::getPlayer($Bounty['Claimer'], $ThisPlayer->getGameID())->getPlayerName(); ?><br /><?php
+				This bounty can be claimed by <?php echo SmrPlayer::getPlayer($Bounty['Claimer'], $ThisPlayer->getGameID())->getDisplayName(); ?><br /><?php
 				$HasHQBounty = true;
 			}
 		}
@@ -16,12 +16,12 @@ if ($BountyPlayer->hasBounties()) {
 	}
 	foreach ($Bounties as $Bounty) {
 		if ($Bounty['Type'] == 'UG') { ?>
-			The <span class="red">Underground</span> is offering a bounty on <?php echo $BountyPlayer->getPlayerName(); ?> worth <span class="creds"><?php echo $Bounty['Amount']; ?></span> credits and <span class="yellow"><?php echo $Bounty['SmrCredits']; ?></span> SMR credits.<br /><?php
+			The <span class="red">Underground</span> is offering a bounty on <?php echo $BountyPlayer->getDisplayName(); ?> worth <span class="creds"><?php echo $Bounty['Amount']; ?></span> credits and <span class="yellow"><?php echo $Bounty['SmrCredits']; ?></span> SMR credits.<br /><?php
 			if ($Bounty['Claimer'] != 0) {
-				?>This bounty can be claimed by <?php echo SmrPlayer::getPlayer($Bounty['Claimer'], $ThisPlayer->getGameID())->getPlayerName(); ?><br /><?php
+				?>This bounty can be claimed by <?php echo SmrPlayer::getPlayer($Bounty['Claimer'], $ThisPlayer->getGameID())->getDisplayName(); ?><br /><?php
 			}
 		}
 	}
 } else {
-	?>This player has no bounties<br /><?php
+	echo $BountyPlayer->getDisplayName(); ?> has no bounties<br /><?php
 } ?>

--- a/templates/Default/engine/Default/chat_rules.php
+++ b/templates/Default/engine/Default/chat_rules.php
@@ -5,7 +5,7 @@ Chat with your fellow players as you navigate the universe! You may join via IRC
 	<b>Please read the <u><a href="<?php echo WIKI_URL; ?>/rules#irc-and-discord-rules" target="_blank">Chat Rules</a></u> before joining!</b>
 	<br /><br /><br />
 
-	<div class="buttonA"><a class="buttonA" href="http://widget.mibbit.com/?settings=5f6a385735f22a3138c5cc6059dab2f4&amp;server=irc.theairlock.net&amp;channel=<?php echo $AutoChannels; ?>&amp;autoConnect=true&amp;nick=<?php echo urlencode('SMR-' . str_replace(' ', '_', $ThisPlayer->getPlayerName())); ?>" target="_chat">Connect to IRC</a></div>
+	<div class="buttonA"><a class="buttonA" href="http://widget.mibbit.com/?settings=5f6a385735f22a3138c5cc6059dab2f4&amp;server=irc.theairlock.net&amp;channel=<?php echo $AutoChannels; ?>&amp;autoConnect=true&amp;nick=<?php echo urlencode('SMR-' . str_replace(' ', '_', htmlentities($ThisPlayer->getPlayerName()))); ?>" target="_chat">Connect to IRC</a></div>
 
 	<br /><br /><br />
 

--- a/templates/Default/engine/Default/council_list.php
+++ b/templates/Default/engine/Default/council_list.php
@@ -47,7 +47,7 @@
 					$CouncilPlayer = SmrPlayer::getPlayer($AccountID, $ThisPlayer->getGameID()); ?>
 					<tr id="player-<?php echo $CouncilPlayer->getPlayerID(); ?>" class="ajax<?php if ($ThisPlayer->equals($CouncilPlayer)) { ?> bold<?php } ?>">
 						<td><?php echo $Ranking; ?></td>
-						<td class="left name" data-name="<?php echo $CouncilPlayer->getPlayerName(); ?>"><?php echo $CouncilPlayer->getLevelName(); ?> <?php echo $CouncilPlayer->getLinkedDisplayName(false); ?></td>
+						<td class="left name" data-name="<?php echo htmlentities($CouncilPlayer->getPlayerName()); ?>"><?php echo $CouncilPlayer->getLevelName(); ?> <?php echo $CouncilPlayer->getLinkedDisplayName(false); ?></td>
 						<td><?php echo $ThisPlayer->getColouredRaceName($CouncilPlayer->getRaceID(), true); ?></td>
 						<td class="alliance"><?php echo $CouncilPlayer->getAllianceDisplayName(true); ?></td>
 						<td class="experience right"><?php echo number_format($CouncilPlayer->getExperience()); ?></td>

--- a/templates/Default/engine/Default/current_players.php
+++ b/templates/Default/engine/Default/current_players.php
@@ -23,7 +23,7 @@
 			<tbody class="list"><?php
 				foreach ($AllRows as $Row) { ?>
 					<tr <?php echo $Row['tr_class']; ?>>
-						<td class="sort_name left" data-name="<?php echo $Row['player']->getPlayerName(); ?>" valign="top"><?php echo $Row['name_link']; ?></td>
+						<td class="sort_name left" data-name="<?php echo htmlentities($Row['player']->getPlayerName()); ?>" valign="top"><?php echo $Row['name_link']; ?></td>
 						<td class="sort_race">
 							<?php echo $ThisPlayer->getColouredRaceName($Row['player']->getRaceID(), true); ?>
 						</td>

--- a/templates/Default/engine/Default/galactic_post.php
+++ b/templates/Default/engine/Default/galactic_post.php
@@ -1,4 +1,4 @@
-Welcome <?php echo $ThisPlayer->getPlayerName(); ?>, your position is <i>Editor</i><br /><br />
+Welcome <?php echo $ThisPlayer->getDisplayName(); ?>, your position is <i>Editor</i><br /><br />
 <b>EDITOR OPTIONS</b>
 <ul>
 	<li><a href="<?php echo $ViewArticlesHREF; ?>">View the articles</a></li>

--- a/templates/Default/engine/Default/game_stats.php
+++ b/templates/Default/engine/Default/game_stats.php
@@ -141,7 +141,7 @@
 						foreach ($ExperienceRankings as $Rank => $RankedPlayer) { ?>
 							<tr>
 								<td><?php echo $Rank; ?></td>
-								<td><?php echo $RankedPlayer->getPlayerName(); ?></td>
+								<td><?php echo $RankedPlayer->getDisplayName(); ?></td>
 								<td><?php echo number_format($RankedPlayer->getExperience()); ?></td>
 							</tr><?php
 						} ?>
@@ -159,7 +159,7 @@
 						foreach ($KillRankings as $Rank => $RankedPlayer) { ?>
 							<tr>
 								<td><?php echo $Rank; ?></td>
-								<td><?php echo $RankedPlayer->getPlayerName(); ?></td>
+								<td><?php echo $RankedPlayer->getDisplayName(); ?></td>
 								<td><?php echo number_format($RankedPlayer->getKills()); ?></td>
 							</tr><?php
 						} ?>

--- a/templates/Default/engine/Default/message_blacklist.php
+++ b/templates/Default/engine/Default/message_blacklist.php
@@ -21,7 +21,7 @@ if ($Blacklist) { ?>
 						<input type="checkbox" name="entry_ids[]" value="<?php echo $Entry['entry_id']; ?>">
 					</td>
 					<td class="center shrink"><?php echo $Entry['game_id']; ?></td>
-					<td><?php echo $Entry['player_name']; ?></td>
+					<td><?php echo htmlentities($Entry['player_name']); ?></td>
 				</tr><?php
 			} ?>
 		</table><br />

--- a/templates/Default/engine/Default/news_read_advanced.php
+++ b/templates/Default/engine/Default/news_read_advanced.php
@@ -64,7 +64,7 @@
 	</table>
 	<br /><br /><?php
 	if (isset($ResultsFor)) { ?>
-		Returning results for <?php echo $ResultsFor; ?>.<br /><?php
+		Returning results for <?php echo htmlentities($ResultsFor); ?>.<br /><?php
 	} ?>
 </div>
 

--- a/templates/Default/engine/Default/preferences.php
+++ b/templates/Default/engine/Default/preferences.php
@@ -43,7 +43,7 @@ if (isset($GameID)) { ?>
 			<tr>
 				<td>Player Name</td>
 				<td>
-					<input type="text" maxlength="32" name="PlayerName" value="<?php echo $ThisPlayer->getPlayerName(); ?>" size="32"><br/><?php
+					<input type="text" maxlength="32" name="PlayerName" value="<?php echo htmlentities($ThisPlayer->getPlayerName()); ?>" size="32"><br/><?php
 					if ($ThisPlayer->isNameChanged()) {
 						?>(You have already changed your name for free, further changes will cost <?php echo CREDITS_PER_NAME_CHANGE; ?> SMR Credits)<?php
 					} else {

--- a/templates/Default/engine/Default/trader_savings.php
+++ b/templates/Default/engine/Default/trader_savings.php
@@ -1,5 +1,5 @@
 <div>
-	<h2>Anonymous accounts for <?php echo $ThisPlayer->getPlayerName(); ?></h2>
+	<h2>Anonymous Accounts</h2>
 	<br />
 	<?php
 	if ($AnonAccounts) { ?>
@@ -14,7 +14,7 @@
 </div>
 <br /><br />
 <div>
-	<h2>Lotto Tickets for <?php echo $ThisPlayer->getPlayerName(); ?></h2>
+	<h2>Lotto Tickets</h2>
 	<br />You own <span class="yellow"><?php echo $LottoTickets; ?></span> Lotto Tickets.
 	<br />There are <?php echo format_time($LottoInfo['TimeRemaining']); ?> remaining until the next drawing.
 	<br />Currently you have a <?php echo $LottoWinChance; ?>% chance to win.


### PR DESCRIPTION
We are going to transition towards keeping raw data in the database whenever possible. The player name is the most high-profile example where our current strategy will change.

This required a careful examination of all places where the player name is used, both `player_name` directly taken from the `player` table, and all uses of the `SmrPlayer::getPlayerName` method.