### PR TITLE
Improve admin message boxes

### DIFF
--- a/admin/Default/box_reply.php
+++ b/admin/Default/box_reply.php
@@ -1,16 +1,22 @@
 <?php declare(strict_types=1);
 
-$template->assign('PageTopic', 'Reply To Reported Messages');
+require_once(get_file_loc('message.functions.inc'));
+$boxName = getAdminBoxNames()[$var['box_type_id']];
+$template->assign('PageTopic', 'Reply To ' . $boxName);
 
 $container = create_container('box_reply_processing.php');
 transfer('game_id');
 transfer('sender_id');
+transfer('box_type_id');
 $template->assign('BoxReplyFormHref', SmrSession::getNewHREF($container));
 $template->assign('Sender', SmrPlayer::getPlayer($var['sender_id'], $var['game_id']));
 $template->assign('SenderAccount', SmrAccount::getAccount($var['sender_id']));
 if (isset($var['Preview'])) {
 	$template->assign('Preview', $var['Preview']);
 }
-if (isset($var['BanPoints'])) {
-	$template->assign('BanPoints', $var['BanPoints']);
-}
+$template->assign('BanPoints', $var['BanPoints'] ?? 0);
+$template->assign('RewardCredits', $var['RewardCredits'] ?? 0);
+
+$container = create_container('skeleton.php', 'box_view.php');
+transfer('box_type_id');
+$template->assign('BackHREF', SmrSession::getNewHREF($container));

--- a/admin/Default/box_reply_processing.php
+++ b/admin/Default/box_reply_processing.php
@@ -2,20 +2,27 @@
 
 $message = trim(Request::get('message'));
 $banPoints = Request::getInt('BanPoints');
+$rewardCredits = Request::getInt('RewardCredits');
 if (Request::get('action') == 'Preview message') {
 	$container = create_container('skeleton.php', 'box_reply.php');
 	$container['BanPoints'] = $banPoints;
+	$container['RewardCredits'] = $rewardCredits;
 	transfer('game_id');
 	transfer('sender_id');
+	transfer('box_type_id');
 	$container['Preview'] = $message;
 	forward($container);
 }
 
 SmrPlayer::sendMessageFromAdmin($var['game_id'], $var['sender_id'], $message);
+
 //do we have points?
 if ($banPoints > 0) {
 	$suspicion = 'Inappropriate Actions';
 	$senderAccount = SmrAccount::getAccount($var['sender_id']);
 	$senderAccount->addPoints($banPoints, $account, BAN_REASON_BAD_BEHAVIOR, $suspicion);
 }
+
+$senderAccount->increaseSmrRewardCredits($rewardCredits);
+
 forward(create_container('skeleton.php', 'box_view.php'));

--- a/admin/Default/box_view.php
+++ b/admin/Default/box_view.php
@@ -1,11 +1,12 @@
 <?php declare(strict_types=1);
 
-$template->assign('PageTopic', 'Viewing Message Boxes');
+require_once(get_file_loc('message.functions.inc'));
 
 if (!isset($var['box_type_id'])) {
+	$template->assign('PageTopic', 'Viewing Message Boxes');
+
 	$container = create_container('skeleton.php', 'box_view.php');
 	$boxes = array();
-	require_once(get_file_loc('message.functions.inc'));
 	foreach (getAdminBoxNames() as $boxTypeID => $boxName) {
 		$container['box_type_id'] = $boxTypeID;
 		$boxes[$boxTypeID] = array(
@@ -22,6 +23,9 @@ if (!isset($var['box_type_id'])) {
 	}
 	$template->assign('Boxes', $boxes);
 } else {
+	$boxName = getAdminBoxNames()[$var['box_type_id']];
+	$template->assign('PageTopic', 'Viewing ' . $boxName);
+
 	$template->assign('BackHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'box_view.php')));
 	$db->query('SELECT * FROM message_boxes WHERE box_type_id=' . $db->escapeNumber($var['box_type_id']) . ' ORDER BY send_time DESC');
 	$messages = array();
@@ -49,6 +53,7 @@ if (!isset($var['box_type_id'])) {
 					$container = create_container('skeleton.php', 'box_reply.php');
 					$container['sender_id'] = $senderID;
 					$container['game_id'] = $gameID;
+					transfer('box_type_id');
 					$messages[$messageID]['ReplyHREF'] = SmrSession::getNewHREF($container);
 				}
 			}

--- a/templates/Default/admin/Default/box_reply.php
+++ b/templates/Default/admin/Default/box_reply.php
@@ -1,10 +1,12 @@
-<?php if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbifyMessage($Preview); ?></td></tr></table><?php } ?>
+<a href="<?php echo $BackHREF; ?>">&lt;&lt; Back</a><br /><br />
+<?php if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbifyMessage($Preview); ?></td></tr></table><br /><?php } ?>
 <form name="BoxReplyForm" method="POST" action="<?php echo $BoxReplyFormHref; ?>">
 	<b>From: </b><span class="admin">Administrator</span><br />
 	<b>To: </b><?php echo $Sender->getDisplayName(); ?> a.k.a <?php echo $SenderAccount->getLogin(); ?>
 	<br />
 	<textarea required spellcheck="true" name="message" class="InputFields"><?php if (isset($Preview)) { echo $Preview; } ?></textarea><br /><br />
-	<input type="number" value="<?php if (isset($BanPoints)) { echo htmlspecialchars($BanPoints); } else { ?>0<?php } ?>" name="BanPoints" size="4" /> Add Ban Points<br />
-	<p>Sending the message will add ban points, if specified above.</p>
+	<input type="number" value="<?php echo $BanPoints; ?>" name="BanPoints" size="4" /> Add Ban Points<br /><br />
+	<input type="number" value="<?php echo $RewardCredits; ?>" name="RewardCredits" size="4" /> Add Reward Credits<br />
+	<p>Sending the message will add ban points or reward credits, if specified above.</p>
 	<input type="submit" name="action" value="Send message" class="InputFields" />&nbsp;<input type="submit" name="action" value="Preview message" class="InputFields" />
 </form>

--- a/templates/Default/admin/Default/box_view.php
+++ b/templates/Default/admin/Default/box_view.php
@@ -13,7 +13,7 @@ if (isset($Boxes)) { ?>
 		} ?>
 	</table><?php
 } else { ?>
-	<a href="<?php echo $BackHREF; ?>">Back</a><br /><?php
+	<a href="<?php echo $BackHREF; ?>">&lt;&lt; Back</a><br /><br /><?php
 	if (isset($Messages)) { ?>
 		<form method="POST" action="<?php echo $DeleteHREF; ?>">
 			<input type="submit" name="action" value="Delete" class="InputFields" />


### PR DESCRIPTION
* Display which box we're viewing/replying to in the page title.
  On the "Reply To" page, this fixes a copy+paste error that titled
  the page as "Reply To Reported Messages".

* Add a back button on the "Reply To" page, which returns to the
  message box we were viewing.

* Add the option to grant SMR reward credits from the "Reply To"
  page. This is useful especially for the "Player Bug Reports".

![image](https://user-images.githubusercontent.com/846186/84135338-b6177780-a9fe-11ea-9825-6c3e556652cf.png)
