### PR TITLE
SmrGalaxy: add types

### DIFF
--- a/lib/Default/Plotter.class.php
+++ b/lib/Default/Plotter.class.php
@@ -3,18 +3,26 @@
 class Plotter {
 
 	public static function getX($xType, $X, $gameID, $player = null) {
+		// Special case for Location categories (i.e. Bar, HQ, SafeFed)
+		if (!is_numeric($X)) {
+			if ($xType != 'Locations') {
+				throw new Exception('Non-numeric X only exists for Locations');
+			}
+			return $X;
+		}
+
+		// In all other cases, X is a numeric ID
+		$X = (int)$X;
+
 		switch ($xType) {
 			case 'Technology':
 				return Globals::getHardwareTypes($X);
 			case 'Ships':
 				return AbstractSmrShip::getBaseShip(Globals::getGameType($gameID), $X);
 			case 'Weapons':
-				return SmrWeaponType::getWeaponType((int)$X);
+				return SmrWeaponType::getWeaponType($X);
 			case 'Locations':
-				if (is_numeric($X)) {
-					return SmrLocation::getLocation($X);
-				}
-				return $X;
+				return SmrLocation::getLocation($X);
 			case 'Sell Goods':
 			case 'Buy Goods':
 				// $X is the good ID

--- a/lib/Default/SmrGalaxy.class.php
+++ b/lib/Default/SmrGalaxy.class.php
@@ -5,23 +5,23 @@ class SmrGalaxy {
 
 	const TYPES = ['Racial', 'Neutral', 'Planet'];
 
-	protected $db;
-	protected $SQL;
+	protected MySqlDatabase $db;
+	protected string $SQL;
 
-	protected $gameID;
-	protected $galaxyID;
-	protected $name;
-	protected $width;
-	protected $height;
-	protected $galaxyType;
-	protected $maxForceTime;
+	protected int $gameID;
+	protected int $galaxyID;
+	protected string $name;
+	protected int $width;
+	protected int $height;
+	protected string $galaxyType;
+	protected int $maxForceTime;
 
-	protected $startSector = false;
+	protected int $startSector;
 
-	protected $hasChanged = false;
-	protected $isNew = false;
+	protected bool $hasChanged = false;
+	protected bool $isNew = false;
 
-	public static function getGameGalaxies($gameID, $forceUpdate = false) {
+	public static function getGameGalaxies(int $gameID, bool $forceUpdate = false) : array {
 		if ($forceUpdate || !isset(self::$CACHE_GAME_GALAXIES[$gameID])) {
 			$db = MySqlDatabase::getInstance();
 			$db->query('SELECT * FROM game_galaxy WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY galaxy_id ASC');
@@ -35,7 +35,7 @@ class SmrGalaxy {
 		return self::$CACHE_GAME_GALAXIES[$gameID];
 	}
 
-	public static function getGalaxy($gameID, $galaxyID, $forceUpdate = false, $db = null) {
+	public static function getGalaxy(int $gameID, int $galaxyID, bool $forceUpdate = false, MySqlDatabase $db = null) : SmrGalaxy {
 		if ($forceUpdate || !isset(self::$CACHE_GALAXIES[$gameID][$galaxyID])) {
 			$g = new SmrGalaxy($gameID, $galaxyID, false, $db);
 			self::$CACHE_GALAXIES[$gameID][$galaxyID] = $g;
@@ -43,7 +43,7 @@ class SmrGalaxy {
 		return self::$CACHE_GALAXIES[$gameID][$galaxyID];
 	}
 
-	public static function saveGalaxies() {
+	public static function saveGalaxies() : void {
 		foreach (self::$CACHE_GALAXIES as $gameGalaxies) {
 			foreach ($gameGalaxies as $galaxy) {
 				$galaxy->save();
@@ -51,7 +51,7 @@ class SmrGalaxy {
 		}
 	}
 
-	public static function createGalaxy($gameID, $galaxyID) {
+	public static function createGalaxy(int $gameID, int $galaxyID) : SmrGalaxy {
 		if (!isset(self::$CACHE_GALAXIES[$gameID][$galaxyID])) {
 			$g = new SmrGalaxy($gameID, $galaxyID, true);
 			self::$CACHE_GALAXIES[$gameID][$galaxyID] = $g;
@@ -59,7 +59,7 @@ class SmrGalaxy {
 		return self::$CACHE_GALAXIES[$gameID][$galaxyID];
 	}
 
-	protected function __construct($gameID, $galaxyID, $create = false, $db = null) {
+	protected function __construct(int $gameID, int $galaxyID, bool $create = false, MySqlDatabase $db = null) {
 		$this->db = MySqlDatabase::getInstance();
 		$this->SQL = 'game_id = ' . $this->db->escapeNumber($gameID) . '
 		              AND galaxy_id = ' . $this->db->escapeNumber($galaxyID);
@@ -72,8 +72,8 @@ class SmrGalaxy {
 			$this->isNew = !$db->nextRecord();
 		}
 
-		$this->gameID = (int)$gameID;
-		$this->galaxyID = (int)$galaxyID;
+		$this->gameID = $gameID;
+		$this->galaxyID = $galaxyID;
 		if (!$this->isNew) {
 			$this->name = $db->getField('galaxy_name');
 			$this->width = $db->getInt('width');
@@ -85,7 +85,7 @@ class SmrGalaxy {
 		}
 	}
 
-	public function save() {
+	public function save() : void {
 		if ($this->isNew) {
 				$this->db->query('INSERT INTO game_galaxy (game_id,galaxy_id,galaxy_name,width,height,galaxy_type,max_force_time)
 									values
@@ -108,15 +108,15 @@ class SmrGalaxy {
 		$this->hasChanged = false;
 	}
 
-	public function getGameID() {
+	public function getGameID() : int {
 		return $this->gameID;
 	}
 
-	public function getGalaxyID() {
+	public function getGalaxyID() : int {
 		return $this->galaxyID;
 	}
 
-	public function getGalaxyMapHREF() {
+	public function getGalaxyMapHREF() : string {
 		return 'map_galaxy.php?galaxy_id=' . $this->getGalaxyID();
 	}
 
@@ -124,7 +124,7 @@ class SmrGalaxy {
 	 * Returns the galaxy name.
 	 * Use getDisplayName for an HTML-safe version.
 	 */
-	public function getName() {
+	public function getName() : string {
 		return $this->name;
 	}
 
@@ -135,40 +135,40 @@ class SmrGalaxy {
 		return htmlentities($this->name);
 	}
 
-	public function setName($name) {
-		if ($this->name == $name) {
+	public function setName(string $name) : void {
+		if (!$this->isNew && $this->name === $name) {
 			return;
 		}
 		$this->name = $name;
 		$this->hasChanged = true;
 	}
 
-	public function getWidth() {
+	public function getWidth() : int {
 		return $this->width;
 	}
 
-	public function setWidth($width) {
-		if ($this->width == $width) {
+	public function setWidth(int $width) : void {
+		if (!$this->isNew && $this->width === $width) {
 			return;
 		}
 		$this->width = $width;
 		$this->hasChanged = true;
 	}
 
-	public function getHeight() {
+	public function getHeight() : int {
 		return $this->height;
 	}
 
-	public function setHeight($height) {
-		if ($this->height == $height) {
+	public function setHeight(int $height) : void {
+		if (!$this->isNew && $this->height === $height) {
 			return;
 		}
 		$this->height = $height;
 		$this->hasChanged = true;
 	}
 
-	public function getStartSector() {
-		if ($this->startSector === false) {
+	public function getStartSector() : int {
+		if (!isset($this->startSector)) {
 			$this->startSector = 1;
 			if ($this->getGalaxyID() != 1) {
 				$galaxies = SmrGalaxy::getGameGalaxies($this->getGameID());
@@ -180,35 +180,35 @@ class SmrGalaxy {
 		return $this->startSector;
 	}
 
-	public function getEndSector() {
+	public function getEndSector() : int {
 		return $this->getStartSector() + $this->getSize() - 1;
 	}
 
-	public function getSize() {
+	public function getSize() : int {
 		return $this->getHeight() * $this->getWidth();
 	}
 
-	public function getSectors() {
+	public function getSectors() : array {
 		return SmrSector::getGalaxySectors($this->getGameID(), $this->getGalaxyID());
 	}
 
-	public function getPorts() {
+	public function getPorts() : array {
 		return SmrPort::getGalaxyPorts($this->getGameID(), $this->getGalaxyID());
 	}
 
-	public function getLocations() {
+	public function getLocations() : array {
 		return SmrLocation::getGalaxyLocations($this->getGameID(), $this->getGalaxyID());
 	}
 
-	public function getPlanets() {
+	public function getPlanets() : array {
 		return SmrPlanet::getGalaxyPlanets($this->getGameID(), $this->getGalaxyID());
 	}
 
-	public function getForces() {
+	public function getForces() : array {
 		return SmrForce::getGalaxyForces($this->getGameID(), $this->getGalaxyID());
 	}
 
-	public function getPlayers() {
+	public function getPlayers() : array {
 		return SmrPlayer::getGalaxyPlayers($this->getGameID(), $this->getGalaxyID());
 	}
 
@@ -220,28 +220,28 @@ class SmrGalaxy {
 	 * NOTE: This routine queries sectors inefficiently. You may want to
 	 * construct the cache efficiently before calling this.
 	 */
-	public function getMapSectors($centerSectorID = false, $dist = false) {
-		if ($centerSectorID === false) {
+	public function getMapSectors(int $centerSectorID = null, int $dist = null) : array {
+		if (is_null($centerSectorID)) {
 			$topLeft = SmrSector::getSector($this->getGameID(), $this->getStartSector());
 		} else {
 			$topLeft = SmrSector::getSector($this->getGameID(), $centerSectorID);
 			// go left then up
-			for ($i = 0; ($dist === false || $i < $dist) && $i < floor($this->getWidth() / 2); $i++) {
+			for ($i = 0; (is_null($dist) || $i < $dist) && $i < floor($this->getWidth() / 2); $i++) {
 				$topLeft = $topLeft->getNeighbourSector('Left');
 			}
-			for ($i = 0; ($dist === false || $i < $dist) && $i < floor($this->getHeight() / 2); $i++) {
+			for ($i = 0; (is_null($dist) || $i < $dist) && $i < floor($this->getHeight() / 2); $i++) {
 				$topLeft = $topLeft->getNeighbourSector('Up');
 			}
 		}
 
 		$mapSectors = array();
-		for ($i = 0; ($dist === false || $i < 2 * $dist + 1) && $i < $this->getHeight(); $i++) {
+		for ($i = 0; (is_null($dist) || $i < 2 * $dist + 1) && $i < $this->getHeight(); $i++) {
 			$mapSectors[$i] = array();
 			// get left most sector for this row
 			$rowLeft = $i == 0 ? $topLeft : $rowLeft->getNeighbourSector('Down');
 
 			// iterate through the columns
-			for ($j = 0; ($dist === false || $j < 2 * $dist + 1) && $j < $this->getWidth(); $j++) {
+			for ($j = 0; (is_null($dist) || $j < 2 * $dist + 1) && $j < $this->getWidth(); $j++) {
 				$nextSec = $j == 0 ? $rowLeft : $nextSec->getNeighbourSector('Right');
 				$mapSectors[$i][$j] = $nextSec;
 			}
@@ -249,31 +249,31 @@ class SmrGalaxy {
 		return $mapSectors;
 	}
 
-	public function getGalaxyType() {
+	public function getGalaxyType() : string {
 		return $this->galaxyType;
 	}
 
-	public function setGalaxyType($galaxyType) {
-		if ($this->galaxyType == $galaxyType) {
+	public function setGalaxyType(string $galaxyType) : void {
+		if (!$this->isNew && $this->galaxyType === $galaxyType) {
 			return;
 		}
 		$this->galaxyType = $galaxyType;
 		$this->hasChanged = true;
 	}
 
-	public function getMaxForceTime() {
+	public function getMaxForceTime() : int {
 		return $this->maxForceTime;
 	}
 
-	public function setMaxForceTime($maxForceTime) {
-		if ($this->maxForceTime == $maxForceTime) {
+	public function setMaxForceTime(int $maxForceTime) : void {
+		if (!$this->isNew && $this->maxForceTime === $maxForceTime) {
 			return;
 		}
 		$this->maxForceTime = $maxForceTime;
 		$this->hasChanged = true;
 	}
 
-	public function generateSectors() {
+	public function generateSectors() : void {
 		$sectorID = $this->getStartSector();
 		for ($i = 0; $i < $this->getSize(); $i++) {
 			$sector = SmrSector::createSector($this->gameID, $sectorID);
@@ -288,7 +288,7 @@ class SmrGalaxy {
 	 * Randomly set the connections between all galaxy sectors.
 	 * $connectivity = (average) percent of connections to enable.
 	 */
-	public function setConnectivity($connectivity) {
+	public function setConnectivity(float $connectivity) : bool {
 		// Only set down/right, otherwise we double-hit every link
 		$linkDirs = array('Down', 'Right');
 
@@ -327,7 +327,7 @@ class SmrGalaxy {
 	/**
 	 * Returns the sector connectivity of the galaxy as a percent.
 	 */
-	public function getConnectivity() {
+	public function getConnectivity() : float {
 		$totalLinks = 0;
 		foreach ($this->getSectors() as $galSector) {
 			$totalLinks += $galSector->getNumberOfLinks();
@@ -337,18 +337,21 @@ class SmrGalaxy {
 		return $connectivity;
 	}
 
-	public function contains($sectorID) {
+	/**
+	 * @param int|SmrSector $sectorID
+	 */
+	public function contains($sectorID) : bool {
 		if ($sectorID instanceof SmrSector) {
 			return $sectorID->getGalaxyID() == $this->getGalaxyID();
 		}
 		return $sectorID >= $this->getStartSector() && $sectorID <= $this->getEndSector();
 	}
 
-	public static function getGalaxyContaining($gameID, $sectorID) {
+	public static function getGalaxyContaining(int $gameID, int $sectorID) : SmrGalaxy {
 		return SmrSector::getSector($gameID, $sectorID)->getGalaxy();
 	}
 
-	public function equals(SmrGalaxy $otherGalaxy) {
+	public function equals(SmrGalaxy $otherGalaxy) : bool {
 		return $otherGalaxy->getGalaxyID() == $this->getGalaxyID() && $otherGalaxy->getGameID() == $this->getGameID();
 	}
 }


### PR DESCRIPTION
Adds type-hints for function interfaces and typed class properties.

Minor internal changes:

* startSector now defaults to uninitialized, and when we call
  getStartSector, it will do an `isset` check instead of checking
  if it is false. This allows us to specify it as a single type (int).

* The function arguments for getMapSectors now default to null instead
  of false. Then we will do an `is_null` check instead of checking
  if they are false. This allows us to use an int type-hint.