### PR TITLE
Wq rebalance

### DIFF
--- a/db/patches/VUnknown__ship_changes.sql
+++ b/db/patches/VUnknown__ship_changes.sql
@@ -16,8 +16,8 @@ UPDATE ship_type SET hardpoint = 3 where ship_type_id = 64;
 UPDATE ship_type SET cost = 465702 WHERE ship_type_id = 65;
 -- Rogue +2 hardpoints (2 -> 4)
 UPDATE ship_type SET hardpoint = 4 where ship_type_id = 65;
--- Rogue -100 armor (550 -> 450)
-UPDATE ship_type_support_hardware SET max_amount = 450 where ship_type_id = 65 AND hardware_type_id = 2;
+-- Rogue -150 armor (550 -> 400)
+UPDATE ship_type_support_hardware SET max_amount = 400 where ship_type_id = 65 AND hardware_type_id = 2;
 
 -- Blockade Runner -50% cost (5,131,071 -> 2,565,536)
 UPDATE ship_type SET cost = 2565536 WHERE ship_type_id = 66;

--- a/db/patches/VUnknown__ship_changes.sql
+++ b/db/patches/VUnknown__ship_changes.sql
@@ -16,8 +16,8 @@ UPDATE ship_type SET hardpoint = 3 where ship_type_id = 64;
 UPDATE ship_type SET cost = 465702 WHERE ship_type_id = 65;
 -- Rogue +2 hardpoints (2 -> 4)
 UPDATE ship_type SET hardpoint = 4 where ship_type_id = 65;
--- Rogue -150 armor (550 -> 400)
-UPDATE ship_type_support_hardware SET max_amount = 400 where ship_type_id = 65 AND hardware_type_id = 2;
+-- Rogue -200 armor (550 -> 350)
+UPDATE ship_type_support_hardware SET max_amount = 350 where ship_type_id = 65 AND hardware_type_id = 2;
 
 -- Blockade Runner -50% cost (5,131,071 -> 2,565,536)
 UPDATE ship_type SET cost = 2565536 WHERE ship_type_id = 66;

--- a/db/patches/VUnknown__ship_changes.sql
+++ b/db/patches/VUnknown__ship_changes.sql
@@ -1,0 +1,31 @@
+-- Negotiator cost increase x4 (155,234 -> 620,936)
+UPDATE ship_type SET cost = 620936 WHERE ship_type_id = 63;
+-- Negotiator +50 shields (200 -> 250)
+UPDATE ship_type_support_hardware SET max_amount = 250 where ship_type_id = 63 AND hardware_type_id = 1;
+-- Negotiator +50 armor (150 -> 200)
+UPDATE ship_type_support_hardware SET max_amount = 200 where ship_type_id = 63 AND hardware_type_id = 2;
+-- Negotiator +90 holds (40 -> 130)
+UPDATE ship_type_support_hardware SET max_amount = 130 where ship_type_id = 63 AND hardware_type_id = 3;
+-- Negotiator add cloak
+UPDATE ship_type_support_hardware SET max_amount = 1 where ship_type_id = 63 AND hardware_type_id = 8;
+
+-- Resistance +1 hardpoint (2 -> 3)
+UPDATE ship_type SET hardpoint = 3 where ship_type_id = 64;
+
+-- Rogue cost increase +50% (2,074,860 -> 3,112,290)
+UPDATE ship_type SET cost = 465702 WHERE ship_type_id = 65;
+-- Rogue +2 hardpoints (2 -> 4)
+UPDATE ship_type SET hardpoint = 4 where ship_type_id = 65;
+-- Rogue -100 armor (550 -> 450)
+UPDATE ship_type_support_hardware SET max_amount = 450 where ship_type_id = 65 AND hardware_type_id = 2;
+
+-- Blockade Runner -50% cost (5,131,071 -> 2,565,536)
+UPDATE ship_type SET cost = 2565536 WHERE ship_type_id = 66;
+-- Blockade Runner -1 hardpoint (3 -> 2_)
+UPDATE ship_type SET hardpoint = 2 where ship_type_id = 66;
+-- Blockade Runner -100 shields (550 -> 450)
+UPDATE ship_type_support_hardware SET max_amount = 450 where ship_type_id = 66 AND hardware_type_id = 1;
+-- Blockade Runner -100 armor (500 -> 400)
+UPDATE ship_type_support_hardware SET max_amount = 400 where ship_type_id = 66 AND hardware_type_id = 2;
+-- Blockade Runner +15 holds (175 -> 190)
+UPDATE ship_type_support_hardware SET max_amount = 190 where ship_type_id = 66 AND hardware_type_id = 3;


### PR DESCRIPTION
WQ have four ships that just aren't useful.  The Negotiator is currently a weaker trader than the starter ship.  The hunters only have two hard points.  And the Blockade Runner cost is in line with end game traders but without the stats to back it up.  I'm proposing the following in the interest of making the ships useful:

Negotiator - turn in to an early game trader
cost quadrupled to justify stat buffs.  
+50 armor and shields to shore up defense in line with other ships around new cost.
+90 cargo holds.  this brings trading power to 1430.  93% of a Merchant Vessel.
add cloak.  WQ ships should cloak.
a trade ship like this would give WQ players a way to generate a bit of fast cash to hop in to a hunter early on.  the cloak is a way to justify keeping it over a MV while trading towards a larger ship.

Resistance - convert early game hunter
+1 hard point to 3.  can't hunt trade ships when you're out gunned by them.
given the stats and price point this will become an effective hunter very early in the game.

Rogue - convert to small mid game hunter
+50% cost to justify stat increases.
+2 hard points to 4.
-200 armor to keep D in line with hunters of similar cost.
this will turn in to a sort of mini-Assassin.

Blockade Runner - convert to mid game trader
cost cut in half which puts it near the top of mid tier traders.  close to Favored Offspring.
-1 hard point to bring firepower more in line with ships of similar cost and purpose.  but still formidable at 2HP + 50CD.
-100 to shields and armor to bring defense more in line with ships of similar cost.
additional 15 holds bring trade power to 1710.  90% of a thief and 102% of a leviathan.
this will still be expensive but it will also be a strong mid tier trade ship.