### PR TITLE
Balance L4 weapon power efficiency

### DIFF
--- a/db/patches/Vunknown__update_level4_weapons.sql
+++ b/db/patches/Vunknown__update_level4_weapons.sql
@@ -1,0 +1,10 @@
+-- Increase damage of Level 4 weapons by 15% to bring power efficiency in step with other power levels
+UPDATE weapon_type SET armour_damage = 230 WHERE weapon_name = 'Big Momma Torpedo Launcher';
+UPDATE weapon_type SET armour_damage = 115 WHERE weapon_name = 'Little Junior Torpedo';
+UPDATE weapon_type SET shield_damage = 290 WHERE weapon_name = 'WQ Human Shield Vaporizer';
+UPDATE weapon_type SET shield_damage = 90, armour_damage = 90 WHERE weapon_name = 'Huge Pulse Laser';
+UPDATE weapon_type SET armour_damage = 290 WHERE weapon_name = 'Creonti "Big Daddy"';
+UPDATE weapon_type SET shield_damage = 200 WHERE weapon_name = 'Thevian Shield Disperser';
+UPDATE weapon_type SET armour_damage = 200 WHERE weapon_name = 'Nijarin Claymore Missile';
+UPDATE weapon_type SET shield_damage = 55, armour_damage = 55 WHERE weapon_name = 'Alskant Focused Laser';
+UPDATE weapon_type SET shield_damage = 115 WHERE weapon_name = 'Human Harmonic Disruptor';


### PR DESCRIPTION
L4 weapons are 5-10% less power efficient than L5 weapons. This is out of step with the other power level changes.

L3 weapons are around 20% more power efficient than L5 weapons. L2 weapons are around 70% more power efficient as compared to L5. and L1 around 120% more efficient than L5.

This change will move L4 weapons in to the range of 5-10% more power efficient than L5.