### PR TITLE
Changes for Draft Rounds

### DIFF
--- a/admin/Default/manage_draft_leaders.php
+++ b/admin/Default/manage_draft_leaders.php
@@ -21,10 +21,14 @@ if ($activeGames) {
 
 	// Get the list of current draft leaders for the selected game
 	$currentLeaders = array();
-	$db->query('SELECT account_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($selectedGameID));
+	$db->query('SELECT account_id, home_sector_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($selectedGameID));
 	while ($db->nextRecord()) {
-		$editor = SmrPlayer::getPlayer($db->getInt('account_id'), $selectedGameID);
-		$currentLeaders[] = $editor->getDisplayName();
+		$homeSectorID = $db->getInt('home_sector_id');
+		$leader = SmrPlayer::getPlayer($db->getInt('account_id'), $selectedGameID);
+		$currentLeaders[] = [
+			'Name' => $leader->getDisplayName(),
+			'HomeSectorID' => $homeSectorID === 0 ? 'None' : $homeSectorID,
+		];
 	}
 	$template->assign('CurrentLeaders', $currentLeaders);
 }

--- a/admin/Default/manage_draft_leaders_processing.php
+++ b/admin/Default/manage_draft_leaders_processing.php
@@ -8,6 +8,7 @@ SmrSession::updateVar('processing_msg', null);
 
 // Get the POST variables
 $playerId = Request::getInt('player_id');
+$homeSectorID = Request::getInt('home_sector_id');
 $action = Request::get('submit');
 
 try {
@@ -26,7 +27,7 @@ if ($action == "Assign") {
 	if ($selectedPlayer->isDraftLeader()) {
 		$msg = "<span class='red'>ERROR: </span>$name is already a draft leader in game $game!";
 	} else {
-		$db->query('INSERT INTO draft_leaders (account_id, game_id) VALUES (' . $db->escapeNumber($accountId) . ', ' . $db->escapeNumber($gameId) . ')');
+		$db->query('INSERT INTO draft_leaders (account_id, game_id, home_sector_id) VALUES (' . $db->escapeNumber($accountId) . ', ' . $db->escapeNumber($gameId) . ', ' . $db->escapeNumber($homeSectorID) . ')');
 	}
 } elseif ($action == "Remove") {
 	if (!$selectedPlayer->isDraftLeader()) {

--- a/db/patches/V1_6_64_03__add_draft_leader_home_sector.sql
+++ b/db/patches/V1_6_64_03__add_draft_leader_home_sector.sql
@@ -1,0 +1,2 @@
+-- Add `home_sector_id` to `draft_leaders` table
+ALTER TABLE draft_leaders ADD COLUMN home_sector_id int(10) unsigned NOT NULL DEFAULT '0'

--- a/engine/Draft/alliance_pick.php
+++ b/engine/Draft/alliance_pick.php
@@ -14,7 +14,7 @@ $template->assign('CanPick', $teams[$player->getAccountID()]['CanPick']);
 
 // Get a list of players still in the pick pool
 $players = array();
-$db->query('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_id=0 OR alliance_id=' . $db->escapeNumber(NHA_ID) . ') AND account_id NOT IN (SELECT account_id FROM draft_leaders WHERE draft_leaders.game_id=player.game_id) AND sector_id!=1 AND account_id != ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ';');
+$db->query('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_id=0 OR alliance_id=' . $db->escapeNumber(NHA_ID) . ') AND account_id NOT IN (SELECT account_id FROM draft_leaders WHERE draft_leaders.game_id=player.game_id) AND account_id NOT IN (SELECT picked_account_id FROM draft_history WHERE draft_history.game_id=player.game_id) AND account_id != ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ';');
 while ($db->nextRecord()) {
 	$pickPlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
 	$players[] = array('Player' => $pickPlayer,

--- a/engine/Draft/alliance_pick_processing.php
+++ b/engine/Draft/alliance_pick_processing.php
@@ -24,8 +24,16 @@ if ($pickedPlayer->hasAlliance()) {
 		create_error('Picked player already has an alliance.');
 	}
 }
+
 // assign the player to the current alliance
 $pickedPlayer->joinAlliance($player->getAllianceID());
+
+// move the player to the alliance home sector if not using traditional HQ's
+if ($pickedPlayer->getSectorID() === 1) {
+	$pickedPlayer->setSectorID($pickedPlayer->getHome());
+	$pickedPlayer->getSector()->markVisited($pickedPlayer);
+}
+
 $pickedPlayer->update();
 
 // Update the draft history

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -486,12 +486,12 @@ abstract class AbstractSmrPlayer {
 		$port->addCachePort($this->getAccountID()); //Add port of sector we were just in, to make sure it is left totally up to date.
 
 		$this->setLastSectorID($this->getSectorID());
-		$this->actionTaken('LeaveSector', array('Sector'=>$this->getSector()));
+		$this->actionTaken('LeaveSector', ['SectorID' => $this->getSectorID()]);
 		$this->sectorID = $sectorID;
-		$this->actionTaken('EnterSector', array('Sector'=>$this->getSector()));
+		$this->actionTaken('EnterSector', ['SectorID' => $this->getSectorID()]);
 		$this->hasChanged = true;
 
-		$port = SmrPort::getPort($this->getGameID(), $sectorID);
+		$port = SmrPort::getPort($this->getGameID(), $this->getSectorID());
 		$port->addCachePort($this->getAccountID()); //Add the port of sector we are now in.
 	}
 

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -267,9 +267,6 @@ abstract class AbstractSmrPlayer {
 	 * Insert a new player into the database. Returns the new player object.
 	 */
 	public static function createPlayer($accountID, $gameID, $playerName, $raceID, $isNewbie, $npc=false) {
-		// Put the player in a sector with an HQ
-		$startSectorID = self::getHome($gameID, $raceID);
-
 		$db = new SmrMySqlDatabase();
 		$db->lockTable('player');
 
@@ -288,12 +285,15 @@ abstract class AbstractSmrPlayer {
 			$playerID = 1;
 		}
 
+		$startSectorID = 0; // Temporarily put player into non-existent sector
 		$db->query('INSERT INTO player (account_id, game_id, player_id, player_name, race_id, sector_id, last_cpl_action, last_active, npc, newbie_status)
 					VALUES(' . $db->escapeNumber($accountID) . ', ' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber($playerID) . ', ' . $db->escapeString($playerName) . ', ' . $db->escapeNumber($raceID) . ', ' . $db->escapeNumber($startSectorID) . ', ' . $db->escapeNumber(TIME) . ', ' . $db->escapeNumber(TIME) . ',' . $db->escapeBoolean($npc) . ',' . $db->escapeBoolean($isNewbie) . ')');
 
 		$db->unlock();
 
-		return SmrPlayer::getPlayer($accountID, $gameID);
+		$player = SmrPlayer::getPlayer($accountID, $gameID);
+		$player->setSectorID($player->getHome());
+		return $player;
 	}
 
 	/**
@@ -507,10 +507,10 @@ abstract class AbstractSmrPlayer {
 		$this->hasChanged = true;
 	}
 
-	static public function getHome($gameID, $raceID) {
+	public function getHome() {
 		// get his home sector
-		$hq_id = GOVERNMENT + $raceID;
-		$raceHqSectors = SmrSector::getLocationSectors($gameID, $hq_id);
+		$hq_id = GOVERNMENT + $this->getRaceID();
+		$raceHqSectors = SmrSector::getLocationSectors($this->getGameID(), $hq_id);
 		if (!empty($raceHqSectors)) {
 			// If race has multiple HQ's for some reason, use the first one
 			return key($raceHqSectors);
@@ -2142,7 +2142,7 @@ abstract class AbstractSmrPlayer {
 		}
 		$this->setCredits($newCredits);
 
-		$this->setSectorID($this::getHome($this->getGameID(), $this->getRaceID()));
+		$this->setSectorID($this->getHome());
 		$this->increaseDeaths(1);
 		$this->setLandedOnPlanet(false);
 		$this->setDead(true);

--- a/lib/Draft/SmrPlayer.class.php
+++ b/lib/Draft/SmrPlayer.class.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+class SmrPlayer extends AbstractSmrPlayer {
+
+	public function getHome() {
+		if ($this->hasAlliance()) {
+			$leaderID = $this->getAlliance()->getLeaderID();
+			$this->db->query('SELECT home_sector_id FROM draft_leaders WHERE account_id = ' . $this->db->escapeNumber($leaderID) . ' AND game_id = ' . $this->db->escapeNumber($this->getGameID()));
+			if ($this->db->nextRecord()) {
+				return $this->db->getInt('home_sector_id');
+			}
+		}
+		// Fallback to the standard home sector
+		return parent::getHome();
+	}
+
+}

--- a/templates/Default/admin/Default/manage_draft_leaders.php
+++ b/templates/Default/admin/Default/manage_draft_leaders.php
@@ -18,12 +18,23 @@ if (empty($ActiveGames)) {
 		</select>
 	</form><br />
 
-	Player ID:&nbsp;
 	<form method="POST" action="<?php echo $ProcessingHREF; ?>">
-		<input type="number" name="player_id" class="InputFields center">
-		<br />
-		<input type="submit" name="submit" value="Assign">&nbsp;
-		<input type="submit" name="submit" value="Remove">
+		<table>
+			<tr>
+				<td>Player ID:</td>
+				<td>Home Sector ID (optional):</td>
+			</tr>
+			<tr>
+				<td><input required type="number" name="player_id" class="InputFields center"></td>
+				<td><input type="number" name="home_sector_id" class="InputFields center"></td>
+			</tr>
+			<tr>
+				<td colspan=2>
+					<input type="submit" name="submit" value="Assign">&nbsp;
+					<input type="submit" name="submit" value="Remove">
+				</td>
+			</tr>
+		</table>
 	</form>
 	<?php
 
@@ -38,8 +49,8 @@ if (empty($ActiveGames)) {
 		<br />
 		Current Draft Leaders:
 		<ul><?php
-		foreach ($CurrentLeaders as $Leader) {
-			echo "<li>$Leader</li>";
+		foreach ($CurrentLeaders as $Leader) { ?>
+			<li><?php echo $Leader['Name']; ?><br />Home Sector: <?php echo $Leader['HomeSectorID']; ?></li><?php
 		} ?>
 		</ul><?php
 	}


### PR DESCRIPTION
* Draft leaders may be associated with "home sectors" when assigned, which is where players will be moved to (if in Sector 1 to start), and where they will return when podded.
* Players are eligible to be picked if they are in Sector 1, so long as they have not previously been drafted.

Some minor refactoring of `SmrPlayer` was needed to achieve this behavior.