### PR TITLE
Fully transition to using menu bar template

### DIFF
--- a/engine/Default/bounty_place.php
+++ b/engine/Default/bounty_place.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$template->assign('PageTopic', 'Place a Bounty');
+$template->assign('PageTopic', 'Place Bounty');
 
 Menu::headquarters();
 

--- a/engine/Default/bounty_place_confirm.php
+++ b/engine/Default/bounty_place_confirm.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$template->assign('PageTopic', 'Place a Bounty');
+$template->assign('PageTopic', 'Place Bounty');
 
 Menu::headquarters();
 

--- a/lib/Semi Wars/Menu.class.php
+++ b/lib/Semi Wars/Menu.class.php
@@ -4,24 +4,30 @@ class Menu extends AbstractMenu {
 
 	// No bounties in Semi Wars games
 	public static function headquarters() {
-		global $var;
-		$menu_items = [];
-		$container = create_container('skeleton.php');
-		$container['LocationID'] = $var['LocationID'];
+		global $var, $template;
 
+		$links = [];
 		$location = SmrLocation::getLocation($var['LocationID']);
 		if ($location->isHQ()) {
-			$container['body'] = 'government.php';
-			$menu_items[] = create_link($container, 'Government', 'nav');
-			$container['body'] = 'military_payment_claim.php';
-			$menu_items[] = create_link($container, 'Claim Military Payment', 'nav');
+			$links[] = ['government.php', 'Government'];
+			$links[] = ['military_payment_claim.php', 'Claim Military Payment'];
 		} elseif ($location->isUG()) {
-			$container['body'] = 'underground.php';
-			$menu_items[] = create_link($container, 'Underground', 'nav');
+			$links[] = ['underground.php', 'Underground'];
 		} else {
 			throw new Exception("Location is not HQ or UG: " . $location->getName());
 		}
-		create_menu($menu_items);
+
+		$menuItems = [];
+		$container = create_container('skeleton.php');
+		$container['LocationID'] = $var['LocationID'];
+		foreach ($links as $link) {
+			$container['body'] = $link[0];
+			$menuItems[] = [
+				'Link' => SmrSession::getNewHREF($container),
+				'Text' => $link[1],
+			];
+		}
+		$template->assign('MenuItems', $menuItems);
 	}
 
 }

--- a/templates/Default/engine/Default/skeleton.php
+++ b/templates/Default/engine/Default/skeleton.php
@@ -16,14 +16,10 @@
 						if (isset($PageTopic)) {
 							?><h1><?php echo $PageTopic; ?></h1><br /><?php
 						}
-						if (isset($MenuItems) || isset($MenuBar)) { ?>
+						if (isset($MenuItems)) { ?>
 							<div class="bar1">
 								<div><?php
-									if (isset($MenuItems)) {
-										$this->includeTemplate('includes/menu.inc');
-									} elseif (isset($MenuBar)) {
-										echo $MenuBar;
-									} ?>
+									$this->includeTemplate('includes/menu.inc'); ?>
 								</div>
 							</div><br /><?php
 						} elseif (isset($SubMenuBar)) {

--- a/templates/Freon22/engine/Default/skeleton.php
+++ b/templates/Freon22/engine/Default/skeleton.php
@@ -68,14 +68,10 @@
 									</tr>
 								</table>
 								<div class="clear"></div><?php
-								if (isset($MenuItems) || isset($MenuBar)) { ?>
+								if (isset($MenuItems)) { ?>
 									<div class="bar1Separator"></div>
 									<div class="bar1"><?php
-										if (isset($MenuItems)) {
-											$this->includeTemplate('includes/menu.inc');
-										} elseif (isset($MenuBar)) {
-											echo $MenuBar;
-										} ?>
+										$this->includeTemplate('includes/menu.inc'); ?>
 									</div><?php
 								} elseif (isset($SubMenuBar)) {
 									echo $SubMenuBar;


### PR DESCRIPTION
Remove the `create_menu` function in favor of setting the `MenuItems`
template variable, which will use the menu.inc template to display
the menu bar.

This transition had been partially complete for a very long time!

Misc: rename page "Place a Bounty" to "Place Bounty".