### PR TITLE
Tweaks to message boxes

### DIFF
--- a/engine/Default/message_box.php
+++ b/engine/Default/message_box.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+require_once(get_file_loc('message.functions.inc'));
+Menu::messages();
+
+$template->assign('PageTopic', 'View Messages');
+
+$messageBoxes = array();
+foreach (getMessageTypeNames() as $message_type_id => $message_type_name) {
+	$messageBox = [];
+	$messageBox['Name'] = $message_type_name;
+
+	// do we have unread msges in that folder?
+	if ($message_type_id == MSG_SENT) {
+		$messageBox['HasUnread'] = false;
+	} else {
+		$db->query('SELECT 1 FROM message
+				WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
+					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+					AND message_type_id = ' . $db->escapeNumber($message_type_id) . '
+					AND msg_read = ' . $db->escapeBoolean(false) . '
+					AND receiver_delete = ' . $db->escapeBoolean(false) . ' LIMIT 1');
+		$messageBox['HasUnread'] = $db->getNumRows() != 0;
+	}
+
+	// get number of msges
+	if ($message_type_id == MSG_SENT) {
+		$db->query('SELECT count(message_id) as message_count FROM message
+				WHERE sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
+					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+					AND message_type_id = ' . $db->escapeNumber(MSG_PLAYER) . '
+					AND sender_delete = ' . $db->escapeBoolean(false));
+	} else {
+		$db->query('SELECT count(message_id) as message_count FROM message
+				WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
+					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+					AND message_type_id = ' . $db->escapeNumber($message_type_id) . '
+					AND receiver_delete = ' . $db->escapeBoolean(false));
+	}
+	$db->requireRecord();
+	$messageBox['MessageCount'] = $db->getInt('message_count');
+
+	$container = create_container('skeleton.php', 'message_view.php');
+	$container['folder_id'] = $message_type_id;
+	$messageBox['ViewHref'] = SmrSession::getNewHREF($container);
+
+	$container = create_container('message_box_delete_processing.php');
+	$container['folder_id'] = $message_type_id;
+	$messageBox['DeleteHref'] = SmrSession::getNewHREF($container);
+	$messageBoxes[] = $messageBox;
+}
+
+$template->assign('MessageBoxes', $messageBoxes);

--- a/engine/Default/message_box_delete_processing.php
+++ b/engine/Default/message_box_delete_processing.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+if ($var['folder_id'] == MSG_SENT) {
+	$db->query('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . '
+				WHERE sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
+					AND game_id = ' . $db->escapeNumber($player->getGameID()));
+} else {
+	$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . '
+				WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
+					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+					AND message_type_id = ' . $db->escapeNumber($var['folder_id']) . '
+					AND msg_read = ' . $db->escapeBoolean(true));
+}
+
+forward(create_container('skeleton.php', 'message_box.php'));

--- a/engine/Default/message_delete_processing.php
+++ b/engine/Default/message_delete_processing.php
@@ -1,7 +1,11 @@
 <?php declare(strict_types=1);
 
 // If not deleting marked messages, we are deleting entire folders
-if (Request::get('action', '') == 'Marked Messages') {
+if (Request::get('action') == 'All Messages') {
+	$container = create_container('message_box_delete_processing.php');
+	transfer('folder_id');
+	forward($container);
+} else {
 	if (!Request::has('message_id')) {
 		create_error('You must choose the messages you want to delete.');
 	}
@@ -28,23 +32,8 @@ if (Request::get('action', '') == 'Marked Messages') {
 	} else {
 		$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . ' WHERE message_id IN (' . $db->escapeArray($message_id_list) . ')');
 	}
-} else {
-	if ($var['folder_id'] == MSG_SCOUT) {
-		$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . '
-					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-						AND message_type_id = '.$db->escapeNumber($var['folder_id']) . '
-						AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	} elseif ($var['folder_id'] == MSG_SENT) {
-		$db->query('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . '
-					WHERE sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
-						AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	} else {
-		$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . '
-					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND message_type_id = ' . $db->escapeNumber($var['folder_id']) . '
-						AND msg_read = ' . $db->escapeBoolean(true));
-	}
 }
 
-forward(create_container('skeleton.php', 'message_view.php'));
+$container = create_container('skeleton.php', 'message_view.php');
+transfer('folder_id');
+forward($container);

--- a/engine/Default/message_notify_confirm.php
+++ b/engine/Default/message_notify_confirm.php
@@ -19,6 +19,7 @@ if (!$db->nextRecord()) {
 $template->assign('MessageText', $db->getField('message_text'));
 
 $container = create_container('message_notify_processing.php', '');
+transfer('folder_id');
 transfer('message_id');
 transfer('sent_time');
 transfer('notified_time');

--- a/engine/Default/message_notify_processing.php
+++ b/engine/Default/message_notify_processing.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+$container = create_container('skeleton.php', 'message_view.php');
+transfer('folder_id');
+
 if (Request::get('action') == 'No') {
-	forward(create_container('skeleton.php', 'message_view.php'));
+	forward($container);
 }
 
 if (empty($var['message_id'])) {
@@ -29,4 +32,4 @@ $db->query('INSERT INTO message_notify
 			(notify_id, game_id, from_id, to_id, text, sent_time, notify_time)
 			VALUES ('.$notify_id . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->getInt('sender_id') . ', ' . $db->getInt('account_id') . ', ' . $db->escapeString($db->getField('message_text')) . ', ' . $var['sent_time'] . ', ' . $var['notified_time'] . ')');
 
-forward(create_container('skeleton.php', 'message_view.php'));
+forward($container);

--- a/engine/Default/message_view.php
+++ b/engine/Default/message_view.php
@@ -162,32 +162,34 @@ function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $me
 	$message['Unread'] = !$msg_read;
 	$message['SendTime'] = date(DATE_FULL_SHORT, $send_time);
 
-	$sender = getMessagePlayer($sender_id, $player->getGameID(), $type);
-	if ($sender instanceof SmrPlayer) {
-		$message['Sender'] = $sender;
-		$container = create_container('skeleton.php', 'trader_search_result.php');
-		$container['player_id'] = $sender->getPlayerID();
-		$message['SenderDisplayName'] = create_link($container, $sender->getDisplayName());
+	// Display the sender (except for scout messages)
+	if ($type != MSG_SCOUT) {
+		$sender = getMessagePlayer($sender_id, $player->getGameID(), $type);
+		if ($sender instanceof SmrPlayer) {
+			$message['Sender'] = $sender;
+			$container = create_container('skeleton.php', 'trader_search_result.php');
+			$container['player_id'] = $sender->getPlayerID();
+			$message['SenderDisplayName'] = create_link($container, $sender->getDisplayName());
 
-		// Add actions that we can take on messages sent by players.
-		// Scout messages are always procedural and don't need these options.
-		if ($type != MSG_SCOUT) {
-			$container = create_container('skeleton.php', 'message_notify_confirm.php');
-			$container['message_id'] = $message_id;
-			$container['sent_time'] = $send_time;
-			$container['folder_id'] = $type;
-			$message['ReportHref'] = SmrSession::getNewHREF($container);
+			// Add actions that we can take on messages sent by other players.
+			if ($type != MSG_SENT) {
+				$container = create_container('skeleton.php', 'message_notify_confirm.php');
+				$container['message_id'] = $message_id;
+				$container['sent_time'] = $send_time;
+				$container['folder_id'] = $type;
+				$message['ReportHref'] = SmrSession::getNewHREF($container);
 
-			$container = create_container('skeleton.php', 'message_blacklist_add.php');
-			$container['account_id'] = $sender_id;
-			$message['BlacklistHref'] = SmrSession::getNewHREF($container);
+				$container = create_container('skeleton.php', 'message_blacklist_add.php');
+				$container['account_id'] = $sender_id;
+				$message['BlacklistHref'] = SmrSession::getNewHREF($container);
 
-			$container = create_container('skeleton.php', 'message_send.php');
-			$container['receiver'] = $sender->getAccountID();
-			$message['ReplyHref'] = SmrSession::getNewHREF($container);
+				$container = create_container('skeleton.php', 'message_send.php');
+				$container['receiver'] = $sender->getAccountID();
+				$message['ReplyHref'] = SmrSession::getNewHREF($container);
+			}
+		} else {
+			$message['SenderDisplayName'] = $sender;
 		}
-	} else {
-		$message['SenderDisplayName'] = $sender;
 	}
 
 	if ($type == MSG_SENT) {

--- a/engine/Default/message_view.php
+++ b/engine/Default/message_view.php
@@ -2,174 +2,94 @@
 require_once(get_file_loc('message.functions.inc'));
 Menu::messages();
 
-if (!isset ($var['folder_id'])) {
-	$template->assign('PageTopic', 'View Messages');
-
-	$db2 = new SmrMySqlDatabase();
-
-	$db->query('SELECT 1 FROM message
-				WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-					AND message_type_id = ' . $db->escapeNumber(MSG_POLITICAL) . '
-					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND receiver_delete = ' . $db->escapeBoolean(false) . '
-				LIMIT 1');
-	$showPoliticalBox = $db->getNumRows() > 0 || $player->isOnCouncil();
-	$messageBoxes = array();
-	foreach (getMessageTypeNames() as $message_type_id => $message_type_name) {
-		if (!$showPoliticalBox && $message_type_id == MSG_POLITICAL) {
-			continue;
-		}
-		$messageBox['Name'] = $message_type_name;
-
-		// do we have unread msges in that folder?
-		$db2->query('SELECT 1 FROM message
-					WHERE account_id = ' . $db2->escapeNumber($player->getAccountID()) . '
-						AND game_id = ' . $db2->escapeNumber($player->getGameID()) . '
-						AND message_type_id = ' . $db2->escapeNumber($message_type_id) . '
-						AND msg_read = ' . $db2->escapeBoolean(false) . '
-						AND receiver_delete = ' . $db2->escapeBoolean(false) . ' LIMIT 1');
-		$messageBox['HasUnread'] = $db2->getNumRows() != 0;
-
-		$messageBox['MessageCount'] = 0;
-		// get number of msges
-		$db2->query('SELECT count(message_id) as message_count FROM message
-					WHERE account_id = ' . $db2->escapeNumber($player->getAccountID()) . '
-						AND game_id = ' . $db2->escapeNumber($player->getGameID()) . '
-						AND message_type_id = ' . $db2->escapeNumber($message_type_id) . '
-						AND receiver_delete = ' . $db2->escapeBoolean(false));
-		if ($db2->nextRecord()) {
-			$messageBox['MessageCount'] = $db2->getInt('message_count');
-		}
-
-		$container = create_container('skeleton.php', 'message_view.php');
-		$container['folder_id'] = $message_type_id;
-		$messageBox['ViewHref'] = SmrSession::getNewHREF($container);
-
-		$container = create_container('message_delete_processing.php');
-		$container['folder_id'] = $message_type_id;
-		$messageBox['DeleteHref'] = SmrSession::getNewHREF($container);
-		$messageBoxes[] = $messageBox;
-	}
-
-	$messageBox = array();
-	$messageBox['MessageCount'] = 0;
-	$db->query('SELECT count(message_id) as count FROM message
-				WHERE sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
-					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+$whereClause = 'WHERE game_id = ' . $db->escapeNumber($player->getGameID());
+if ($var['folder_id'] == MSG_SENT) {
+	$whereClause .= ' AND sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND message_type_id = ' . $db->escapeNumber(MSG_PLAYER) . '
-					AND sender_delete = ' . $db->escapeBoolean(false));
-	if ($db->nextRecord()) {
-		$messageBox['MessageCount'] = $db->getInt('count');
-	}
-	$messageBox['Name'] = 'Sent Messages';
-	$messageBox['HasUnread'] = false;
-	$container = create_container('skeleton.php', 'message_view.php');
-	$container['folder_id'] = MSG_SENT;
-	$messageBox['ViewHref'] = SmrSession::getNewHREF($container);
-
-	$container = create_container('message_delete_processing.php');
-	$container['folder_id'] = MSG_SENT;
-	$messageBox['DeleteHref'] = SmrSession::getNewHREF($container);
-	$messageBoxes[] = $messageBox;
-
-	$template->assign('MessageBoxes', $messageBoxes);
-
-	$container = create_container('skeleton.php', 'message_blacklist.php');
-	$container['folder_id'] = $message_type_id;
-	$template->assign('ManageBlacklistLink', SmrSession::getNewHREF($container));
+					AND sender_delete = ' . $db->escapeBoolean(false);
 } else {
-	$whereClause = 'WHERE game_id = ' . $db->escapeNumber($player->getGameID());
-	if ($var['folder_id'] == MSG_SENT) {
-		$whereClause .= ' AND sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
-						AND message_type_id = ' . $db->escapeNumber(MSG_PLAYER) . '
-						AND sender_delete = ' . $db->escapeBoolean(false);
-	} else {
-		$whereClause .= ' AND account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-						AND message_type_id = ' . $db->escapeNumber($var['folder_id']) . '
-						AND receiver_delete = ' . $db->escapeBoolean(false);
-	}
-
-	if ($var['folder_id'] == MSG_SENT) {
-		$messageBox['UnreadMessages'] = 0;
-	} else {
-		$db->query('SELECT count(*) as count
-					FROM message ' . $whereClause . '
-						AND msg_read = ' . $db->escapeBoolean(false));
-		$db->requireRecord();
-		$messageBox['UnreadMessages'] = $db->getInt('count');
-	}
-	$db->query('SELECT count(*) as count FROM message ' . $whereClause);
-	$db->requireRecord();
-	$messageBox['TotalMessages'] = $db->getInt('count');
-	$messageBox['Type'] = $var['folder_id'];
-
-	$page = 0;
-	if (isset ($var['page'])) {
-		$page = $var['page'];
-	}
-
-	$container = $var;
-	$container['page'] = $page - 1;
-	if ($page > 0) {
-		$template->assign('PreviousPageHREF', SmrSession::getNewHREF($container));
-	}
-	$container['page'] = $page + 1;
-	if (($page + 1) * MESSAGES_PER_PAGE < $messageBox['TotalMessages']) {
-		$template->assign('NextPageHREF', SmrSession::getNewHREF($container));
-	}
-
-	// remove entry for this folder from unread msg table
-	if ($page == 0 && !USING_AJAX) {
-		$player->setMessagesRead($messageBox['Type']);
-	}
-
-	if ($var['folder_id'] == MSG_SENT) {
-		$messageBox['Name'] = 'Sent Messages';
-	} else {
-		$messageBox['Name'] = getMessageTypeNames($var['folder_id']);
-	}
-	$template->assign('PageTopic', 'Viewing ' . $messageBox['Name']);
-
-	if ($messageBox['Type'] == MSG_GLOBAL || $messageBox['Type'] == MSG_SCOUT) {
-		$container = create_container('message_preference_processing.php');
-		transfer('folder_id');
-		$template->assign('PreferencesFormHREF', SmrSession::getNewHREF($container));
-	}
-
-	$container = create_container('message_delete_processing.php');
-	transfer('folder_id');
-	$messageBox['DeleteFormHref'] = SmrSession::getNewHREF($container);
-
-	$db->query('SELECT * FROM message ' .
-				$whereClause . '
-				ORDER BY send_time DESC
-				LIMIT ' . ($page * MESSAGES_PER_PAGE) . ', ' . MESSAGES_PER_PAGE);
-
-	$messageBox['NumberMessages'] = $db->getNumRows();
-	$messageBox['Messages'] = array();
-
-	// Group scout messages if they wouldn't fit on a single page
-	if ($var['folder_id'] == MSG_SCOUT && !isset($var['show_all']) && $messageBox['TotalMessages'] > $player->getScoutMessageGroupLimit()) {
-		// get rid of all old scout messages (>48h)
-		$db->query('DELETE FROM message WHERE expire_time < ' . $db->escapeNumber(TIME) . ' AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT));
-
-		$dispContainer = create_container('skeleton.php', 'message_view.php');
-		$dispContainer['folder_id'] = MSG_SCOUT;
-		$dispContainer['show_all'] = true;
-		$messageBox['ShowAllHref'] = SmrSession::getNewHREF($dispContainer);
-
-		displayScouts($messageBox, $player);
-	} else {
-		while ($db->nextRecord()) {
-			displayMessage($messageBox, $db->getInt('message_id'), $db->getInt('account_id'), $db->getInt('sender_id'), $db->getField('message_text'), $db->getInt('send_time'), $db->getBoolean('msg_read'), $var['folder_id']);
-		}
-	}
-	if (!USING_AJAX) {
-		$db->query('UPDATE message SET msg_read = \'TRUE\'
-					WHERE message_type_id = ' . $db->escapeNumber($var['folder_id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id = ' . $db->escapeNumber($player->getAccountID()));
-	}
-	$template->assign('MessageBox', $messageBox);
+	$whereClause .= ' AND account_id = ' . $db->escapeNumber($player->getAccountID()) . '
+					AND message_type_id = ' . $db->escapeNumber($var['folder_id']) . '
+					AND receiver_delete = ' . $db->escapeBoolean(false);
 }
+
+if ($var['folder_id'] == MSG_SENT) {
+	$messageBox['UnreadMessages'] = 0;
+} else {
+	$db->query('SELECT count(*) as count
+				FROM message ' . $whereClause . '
+					AND msg_read = ' . $db->escapeBoolean(false));
+	$db->requireRecord();
+	$messageBox['UnreadMessages'] = $db->getInt('count');
+}
+$db->query('SELECT count(*) as count FROM message ' . $whereClause);
+$db->requireRecord();
+$messageBox['TotalMessages'] = $db->getInt('count');
+$messageBox['Type'] = $var['folder_id'];
+
+$page = 0;
+if (isset ($var['page'])) {
+	$page = $var['page'];
+}
+
+$container = $var;
+$container['page'] = $page - 1;
+if ($page > 0) {
+	$template->assign('PreviousPageHREF', SmrSession::getNewHREF($container));
+}
+$container['page'] = $page + 1;
+if (($page + 1) * MESSAGES_PER_PAGE < $messageBox['TotalMessages']) {
+	$template->assign('NextPageHREF', SmrSession::getNewHREF($container));
+}
+
+// remove entry for this folder from unread msg table
+if ($page == 0 && !USING_AJAX) {
+	$player->setMessagesRead($messageBox['Type']);
+}
+
+$messageBox['Name'] = getMessageTypeNames($var['folder_id']);
+$template->assign('PageTopic', 'Viewing ' . $messageBox['Name']);
+
+if ($messageBox['Type'] == MSG_GLOBAL || $messageBox['Type'] == MSG_SCOUT) {
+	$container = create_container('message_preference_processing.php');
+	transfer('folder_id');
+	$template->assign('PreferencesFormHREF', SmrSession::getNewHREF($container));
+}
+
+$container = create_container('message_delete_processing.php');
+transfer('folder_id');
+$messageBox['DeleteFormHref'] = SmrSession::getNewHREF($container);
+
+$db->query('SELECT * FROM message ' .
+			$whereClause . '
+			ORDER BY send_time DESC
+			LIMIT ' . ($page * MESSAGES_PER_PAGE) . ', ' . MESSAGES_PER_PAGE);
+
+$messageBox['NumberMessages'] = $db->getNumRows();
+$messageBox['Messages'] = array();
+
+// Group scout messages if they wouldn't fit on a single page
+if ($var['folder_id'] == MSG_SCOUT && !isset($var['show_all']) && $messageBox['TotalMessages'] > $player->getScoutMessageGroupLimit()) {
+	// get rid of all old scout messages (>48h)
+	$db->query('DELETE FROM message WHERE expire_time < ' . $db->escapeNumber(TIME) . ' AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT));
+
+	$dispContainer = create_container('skeleton.php', 'message_view.php');
+	$dispContainer['folder_id'] = MSG_SCOUT;
+	$dispContainer['show_all'] = true;
+	$messageBox['ShowAllHref'] = SmrSession::getNewHREF($dispContainer);
+
+	displayScouts($messageBox, $player);
+} else {
+	while ($db->nextRecord()) {
+		displayMessage($messageBox, $db->getInt('message_id'), $db->getInt('account_id'), $db->getInt('sender_id'), $db->getField('message_text'), $db->getInt('send_time'), $db->getBoolean('msg_read'), $var['folder_id']);
+	}
+}
+if (!USING_AJAX) {
+	$db->query('UPDATE message SET msg_read = \'TRUE\'
+				WHERE message_type_id = ' . $db->escapeNumber($var['folder_id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id = ' . $db->escapeNumber($player->getAccountID()));
+}
+$template->assign('MessageBox', $messageBox);
+
 
 function displayScouts(&$messageBox, $player) {
 	// Generate the group messages
@@ -255,6 +175,7 @@ function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $me
 			$container = create_container('skeleton.php', 'message_notify_confirm.php');
 			$container['message_id'] = $message_id;
 			$container['sent_time'] = $send_time;
+			$container['folder_id'] = $type;
 			$message['ReportHref'] = SmrSession::getNewHREF($container);
 
 			$container = create_container('skeleton.php', 'message_blacklist_add.php');

--- a/htdocs/js/listjs_include.js
+++ b/htdocs/js/listjs_include.js
@@ -54,7 +54,7 @@ var listjs = (function() {
 		defaultList('forces-list', ['sort_sector', 'sort_cds', 'sort_sds', 'sort_mines', {name: 'sort_expire', attr: 'data-expire'}]);
 	};
 
-	listjs.message_view = function() {
+	listjs.message_box = function() {
 		defaultList('folders', ['sort_name', 'sort_messages']);
 	};
 

--- a/lib/Default/AbstractMenu.class.php
+++ b/lib/Default/AbstractMenu.class.php
@@ -142,7 +142,7 @@ class AbstractMenu {
 	public static function messages() {
 		global $player, $template;
 		$menuItems = array();
-		$menuItems[] = array('Link'=>Globals::getViewMessagesHREF(), 'Text'=>'View Messages');
+		$menuItems[] = array('Link'=>Globals::getViewMessageBoxesHREF(), 'Text'=>'View Messages');
 		$menuItems[] = array('Link'=>Globals::getSendGlobalMessageHREF(), 'Text'=>'Send Global Message');
 		if ($player->isOnCouncil()) {
 			$menuItems[] = array('Link'=>Globals::getSendCouncilMessageHREF($player->getRaceID()), 'Text'=>'Send Council Message');

--- a/lib/Default/Globals.class.php
+++ b/lib/Default/Globals.class.php
@@ -429,8 +429,8 @@ class Globals {
 		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_list_financial.php', array('alliance_id'=>$allianceID)));
 	}
 
-	public static function getViewMessagesHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'message_view.php'));
+	public static function getViewMessageBoxesHREF() {
+		return SmrSession::getNewHREF(create_container('skeleton.php', 'message_box.php'));
 	}
 
 	public static function getSendGlobalMessageHREF() {

--- a/lib/Default/message.functions.inc
+++ b/lib/Default/message.functions.inc
@@ -2,14 +2,15 @@
 
 function getMessageTypeNames($typeID = false) {
 	$typeNames = [
-		MSG_GLOBAL => 'Global Messages',
 		MSG_PLAYER => 'Player Messages',
 		MSG_PLANET => 'Planet Messages',
 		MSG_SCOUT => 'Scout Messages',
-		MSG_POLITICAL => 'Political Messages',
 		MSG_ALLIANCE => 'Alliance Messages',
+		MSG_POLITICAL => 'Political Messages',
+		MSG_GLOBAL => 'Global Messages',
 		MSG_ADMIN => 'Admin Messages',
 		MSG_CASINO => 'Casino Messages',
+		MSG_SENT => 'Sent Messages',
 	];
 	return $typeID === false ? $typeNames : $typeNames[$typeID];
 }

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -606,8 +606,7 @@ function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account, $v
 		$container['body'] = 'forces_list.php';
 		$template->assign('ForcesLink', SmrSession::getNewHREF($container));
 
-		$container['body'] = 'message_view.php';
-		$template->assign('MessagesLink', SmrSession::getNewHREF($container));
+		$template->assign('MessagesLink', Globals::getViewMessageBoxesHREF());
 
 		$container['body'] = 'news_read_current.php';
 		$template->assign('ReadNewsLink', SmrSession::getNewHREF($container));

--- a/templates/Default/engine/Default/message_box.php
+++ b/templates/Default/engine/Default/message_box.php
@@ -1,0 +1,23 @@
+<p>Please choose your Message folder!</p>
+
+<table id="folders" class="standard">
+	<thead>
+		<tr>
+			<th class="sort" data-sort="sort_name">Folder</th>
+			<th class="sort" data-sort="sort_messages">Messages</th>
+			<th>&nbsp;</th>
+		</tr>
+	</thead>
+	<tbody class="list"><?php
+		foreach ($MessageBoxes as $MessageBox) { ?>
+			<tr id="<?php echo str_replace(' ', '-', $MessageBox['Name']); ?>" class="ajax<?php if ($MessageBox['HasUnread']) { ?> bold<?php } ?>">
+				<td class="sort_name">
+					<a href="<?php echo $MessageBox['ViewHref']; ?>"><?php echo $MessageBox['Name']; ?></a>
+				</td>
+				<td class="sort_messages center yellow"><?php echo $MessageBox['MessageCount']; ?></td>
+				<td><a href="<?php echo $MessageBox['DeleteHref']; ?>">Empty Read Messages</a></td>
+			</tr><?php
+		} ?>
+	</tbody>
+</table>
+<?php $this->setListjsInclude('message_box'); ?>

--- a/templates/Default/engine/Default/message_view.php
+++ b/templates/Default/engine/Default/message_view.php
@@ -44,54 +44,60 @@ if ($MessageBox['Type'] == MSG_GLOBAL) { ?>
 	} ?>
 	<table class="standard fullwidth"><?php
 		if (isset($MessageBox['Messages'])) {
-			foreach ($MessageBox['Messages'] as $Message) { ?>
-				<tr>
-					<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $Message['ID']; ?>" /><?php if ($Message['Unread']) { ?>*<?php } ?></td>
-					<td class="noWrap" width="100%"><?php
-						if (isset($Message['ReceiverDisplayName'])) {
-							?>To: <?php echo $Message['ReceiverDisplayName'];
-						} else {
-							?>From: <?php echo $Message['SenderDisplayName'];
-						} ?>
-					</td>
-					<td class="noWrap"<?php if (!isset($Message['ReplyHref'])) { ?> colspan="4"<?php } ?>>Date: <?php echo $Message['SendTime']; ?></td>
-					<?php
-					if (isset($Message['ReplyHref'])) { ?>
-						<td>
-							<a href="<?php echo $Message['ReportHref']; ?>"><img class="bottom" src="images/report.png" width="16" height="16" border="0" title="Report this message to an admin" /></a>
+			foreach ($MessageBox['Messages'] as $Message) {
+				if ($MessageBox['Type'] == MSG_SCOUT) { ?>
+					<tr>
+						<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $Message['ID']; ?>" /><?php if ($Message['Unread']) { ?>*<?php } ?></td>
+						<td><?php echo bbifyMessage($Message['Text']); ?></td>
+						<td class="noWrap"><?php echo $Message['SendTime']; ?></td>
+					</tr><?php
+					if (isset($MessageBox['GroupedMessages'])) { ?>
+						<tr>
+							<td colspan="3"><?php
+								$SubMessages = $MessageBox['GroupedMessages'][$Message['SenderID']]['Messages']; ?>
+								<div class="shrink noWrap pointer" id="toggle-recent<?php echo $Message['SenderID']; ?>" onclick="toggleScoutGroup(<?php echo $Message['SenderID']; ?>);">
+									Show/Hide Recent (<?php echo count($SubMessages); ?>)
+								</div>
+								<table id="group<?php echo $Message['SenderID']; ?>" class="standard fullwidth" style="display:none;margin:5px 0 2px 0;"><?php
+									foreach ($SubMessages as $SubMessage) { ?>
+										<tr>
+											<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $SubMessage['ID']; ?>" /><?php if ($SubMessage['Unread']) { ?>*<?php } ?></td>
+											<td><?php echo bbifyMessage($SubMessage['Text']); ?></td>
+											<td class="noWrap"><?php echo $SubMessage['SendTime']; ?></td>
+										</tr><?php
+									} ?>
+								</table>
+							</td>
+						</tr><?php
+					}
+				} else { ?>
+					<tr>
+						<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $Message['ID']; ?>" /><?php if ($Message['Unread']) { ?>*<?php } ?></td>
+						<td class="noWrap" width="100%"><?php
+							if (isset($Message['ReceiverDisplayName'])) {
+								?>To: <?php echo $Message['ReceiverDisplayName'];
+							} else {
+								?>From: <?php echo $Message['SenderDisplayName'];
+							} ?>
 						</td>
-						<td>
-							<a href="<?php echo $Message['BlacklistHref']; ?>">Blacklist Player</a>
-						</td>
-						<td>
-							<a href="<?php echo $Message['ReplyHref']; ?>">Reply</a>
-						</td><?php
-					} ?>
-				</tr>
-				<tr>
-					<td colspan="6"><?php
-						echo bbifyMessage($Message['Text']);
-						if (isset($MessageBox['GroupedMessages'])) {
-							$SubMessages = $MessageBox['GroupedMessages'][$Message['SenderID']]['Messages']; ?>
-							<br />
-							<div class="shrink noWrap pointer" id="toggle-recent<?php echo $Message['SenderID']; ?>" onclick="toggleScoutGroup(<?php echo $Message['SenderID']; ?>);">
-								Show/Hide Recent (<?php echo count($SubMessages); ?>)
-							</div>
-							<table id="group<?php echo $Message['SenderID']; ?>" class="standard fullwidth" style="display:none;margin:5px 0 2px 0;"><?php
-								foreach ($SubMessages as $SubMessage) { ?>
-									<tr>
-										<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $SubMessage['ID']; ?>" /><?php if ($SubMessage['Unread']) { ?>*<?php } ?></td>
-										<td class="noWrap" width="100%">From: <?php echo $SubMessage['SenderDisplayName']; ?></td>
-										<td class="noWrap" colspan="4">Date: <?php echo $SubMessage['SendTime']; ?></td>
-									</tr>
-									<tr>
-										<td colspan="6"><?php echo bbifyMessage($SubMessage['Text']); ?></td>
-									</tr><?php
-								} ?>
-							</table><?php
+						<td class="noWrap"<?php if (!isset($Message['ReplyHref'])) { ?> colspan="4"<?php } ?>>Date: <?php echo $Message['SendTime']; ?></td>
+						<?php
+						if (isset($Message['ReplyHref'])) { ?>
+							<td>
+								<a href="<?php echo $Message['ReportHref']; ?>"><img class="bottom" src="images/report.png" width="16" height="16" border="0" title="Report this message to an admin" /></a>
+							</td>
+							<td>
+								<a href="<?php echo $Message['BlacklistHref']; ?>">Blacklist Player</a>
+							</td>
+							<td>
+								<a href="<?php echo $Message['ReplyHref']; ?>">Reply</a>
+							</td><?php
 						} ?>
-					</td>
-				</tr><?php
+					</tr>
+					<tr>
+						<td colspan="6"><?php echo bbifyMessage($Message['Text']); ?></td>
+					</tr><?php
+				}
 			}
 		} ?>
 	</table>

--- a/templates/Default/engine/Default/message_view.php
+++ b/templates/Default/engine/Default/message_view.php
@@ -1,143 +1,115 @@
 <?php
-if (isset($MessageBoxes)) { ?>
-	<p>Please choose your Message folder!</p>
-
-	<table id="folders" class="standard">
-		<thead>
-			<tr>
-				<th class="sort" data-sort="sort_name">Folder</th>
-				<th class="sort" data-sort="sort_messages">Messages</th>
-				<th>&nbsp;</th>
-			</tr>
-		</thead>
-		<tbody class="list"><?php
-			foreach ($MessageBoxes as $MessageBox) { ?>
-				<tr id="<?php echo str_replace(' ', '-', $MessageBox['Name']); ?>" class="ajax<?php if ($MessageBox['HasUnread']) { ?> bold<?php } ?>">
-					<td class="sort_name">
-						<a href="<?php echo $MessageBox['ViewHref']; ?>"><?php echo $MessageBox['Name']; ?></a>
-					</td>
-					<td class="sort_messages center yellow"><?php echo $MessageBox['MessageCount']; ?></td>
-					<td><a href="<?php echo $MessageBox['DeleteHref']; ?>">Empty Read Messages</a></td>
-				</tr><?php
-			} ?>
-		</tbody>
-	</table>
-	<?php $this->setListjsInclude('message_view'); ?>
-	<p><a href="<?php echo $ManageBlacklistLink; ?>">Manage Player Blacklist</a></p>
-	<?php
-} else {
-	if ($MessageBox['Type'] == MSG_GLOBAL) { ?>
-		<form name="FORM" method="POST" action="<?php echo $PreferencesFormHREF; ?>">
-			<div class="center">Ignore global messages?&nbsp;&nbsp;
-				<input type="submit" name="ignore_globals" value="Yes" <?php if ($ThisPlayer->isIgnoreGlobals()) { ?> style="background-color:green;"<?php } ?> />&nbsp;
-				<input type="submit" name="ignore_globals" value="No" <?php if (!$ThisPlayer->isIgnoreGlobals()) { ?> style="background-color:green;"<?php } ?> />
-			</div>
-		</form><?php
-	} elseif ($MessageBox['Type'] == MSG_SCOUT) { ?>
-		<form name="FORM" method="POST" action="<?php echo $PreferencesFormHREF; ?>">
-			<div class="center">Group scout messages?&nbsp;&nbsp;
-				<input type="submit" name="group_scouts" value="Never" <?php if ($ThisPlayer->getGroupScoutMessages() == 'NEVER') { ?> style="background-color:green;" <?php } ?> />&nbsp;
-				<input type="submit" name="group_scouts" value="Auto" <?php if ($ThisPlayer->getGroupScoutMessages() == 'AUTO') { ?> style="background-color:green;" <?php } ?> />&nbsp;
-				<input type="submit" name="group_scouts" value="Always" <?php if ($ThisPlayer->getGroupScoutMessages() == 'ALWAYS') { ?> style="background-color:green;" <?php } ?> />
-			</div>
-		</form><?php
-	} ?>
-	<br />
-	<form name="MessageDeleteForm" method="POST" action="<?php echo $MessageBox['DeleteFormHref']; ?>">
-		<table class="fullwidth center">
-			<tr>
-				<td style="width: 30%" valign="middle"><?php
-					if (isset($PreviousPageHREF)) {
-						?><a href="<?php echo $PreviousPageHREF; ?>"><img src="images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
-					} ?>
-				</td>
-				<td>
-					<input type="submit" name="action" value="Delete" />&nbsp;<select name="action" size="1">
-																						<option>Marked Messages</option>
-																						<option>All Messages</option>
-																					</select>
-					<p>You have <span class="yellow"><?php echo $MessageBox['TotalMessages']; ?></span> <?php echo pluralise('message', $MessageBox['TotalMessages']); if ($MessageBox['TotalMessages'] != $MessageBox['NumberMessages']) { ?> of which <span class="yellow"><?php echo $MessageBox['NumberMessages']; ?></span> <?php echo pluralise('is', $MessageBox['NumberMessages']); ?> being displayed<?php } ?>.</p>
-				</td>
-				<td style="width: 30%" valign="middle"><?php
-					if (isset($NextPageHREF)) {
-						?><a href="<?php echo $NextPageHREF; ?>"><img src="images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
-					} ?>
-				</td>
-			</tr>
-		</table><?php
-		
-		if (isset($MessageBox['ShowAllHref'])) {
-			?><div class="buttonA"><a class="buttonA" href="<?php echo $MessageBox['ShowAllHref'] ?>">Show all Messages</a></div><br /><br /><?php
-		} ?>
-		<table class="standard fullwidth"><?php
-			if (isset($MessageBox['Messages'])) {
-				foreach ($MessageBox['Messages'] as $Message) { ?>
-					<tr>
-						<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $Message['ID']; ?>" /><?php if ($Message['Unread']) { ?>*<?php } ?></td>
-						<td class="noWrap" width="100%"><?php
-							if (isset($Message['ReceiverDisplayName'])) {
-								?>To: <?php echo $Message['ReceiverDisplayName'];
-							} else {
-								?>From: <?php echo $Message['SenderDisplayName'];
-							} ?>
-						</td>
-						<td class="noWrap"<?php if (!isset($Message['ReplyHref'])) { ?> colspan="4"<?php } ?>>Date: <?php echo $Message['SendTime']; ?></td>
-						<?php
-						if (isset($Message['ReplyHref'])) { ?>
-							<td>
-								<a href="<?php echo $Message['ReportHref']; ?>"><img class="bottom" src="images/report.png" width="16" height="16" border="0" title="Report this message to an admin" /></a>
-							</td>
-							<td>
-								<a href="<?php echo $Message['BlacklistHref']; ?>">Blacklist Player</a>
-							</td>
-							<td>
-								<a href="<?php echo $Message['ReplyHref']; ?>">Reply</a>
-							</td><?php
-						} ?>
-					</tr>
-					<tr>
-						<td colspan="6"><?php
-							echo bbifyMessage($Message['Text']);
-							if (isset($MessageBox['GroupedMessages'])) {
-								$SubMessages = $MessageBox['GroupedMessages'][$Message['SenderID']]['Messages']; ?>
-								<br />
-								<div class="shrink noWrap pointer" id="toggle-recent<?php echo $Message['SenderID']; ?>" onclick="toggleScoutGroup(<?php echo $Message['SenderID']; ?>);">
-									Show/Hide Recent (<?php echo count($SubMessages); ?>)
-								</div>
-								<table id="group<?php echo $Message['SenderID']; ?>" class="standard fullwidth" style="display:none;margin:5px 0 2px 0;"><?php
-									foreach ($SubMessages as $SubMessage) { ?>
-										<tr>
-											<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $SubMessage['ID']; ?>" /><?php if ($SubMessage['Unread']) { ?>*<?php } ?></td>
-											<td class="noWrap" width="100%">From: <?php echo $SubMessage['SenderDisplayName']; ?></td>
-											<td class="noWrap" colspan="4">Date: <?php echo $SubMessage['SendTime']; ?></td>
-										</tr>
-										<tr>
-											<td colspan="6"><?php echo bbifyMessage($SubMessage['Text']); ?></td>
-										</tr><?php
-									} ?>
-								</table><?php
-							} ?>
-						</td>
-					</tr><?php
-				}
-			} ?>
-		</table>
-
-		<table class="fullwidth center">
-			<tr>
-				<td style="width: 30%" valign="middle"><?php
-					if (isset($PreviousPageHREF)) {
-						?><a href="<?php echo $PreviousPageHREF; ?>"><img src="images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
-					} ?>
-				</td>
-				<td>
-				</td>
-				<td style="width: 30%" valign="middle"><?php
-					if (isset($NextPageHREF)) {
-						?><a href="<?php echo $NextPageHREF; ?>"><img src="images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
-					} ?>
-				</td>
-			</tr>
-		</table>
+if ($MessageBox['Type'] == MSG_GLOBAL) { ?>
+	<form name="FORM" method="POST" action="<?php echo $PreferencesFormHREF; ?>">
+		<div class="center">Ignore global messages?&nbsp;&nbsp;
+			<input type="submit" name="ignore_globals" value="Yes" <?php if ($ThisPlayer->isIgnoreGlobals()) { ?> style="background-color:green;"<?php } ?> />&nbsp;
+			<input type="submit" name="ignore_globals" value="No" <?php if (!$ThisPlayer->isIgnoreGlobals()) { ?> style="background-color:green;"<?php } ?> />
+		</div>
+	</form><?php
+} elseif ($MessageBox['Type'] == MSG_SCOUT) { ?>
+	<form name="FORM" method="POST" action="<?php echo $PreferencesFormHREF; ?>">
+		<div class="center">Group scout messages?&nbsp;&nbsp;
+			<input type="submit" name="group_scouts" value="Never" <?php if ($ThisPlayer->getGroupScoutMessages() == 'NEVER') { ?> style="background-color:green;" <?php } ?> />&nbsp;
+			<input type="submit" name="group_scouts" value="Auto" <?php if ($ThisPlayer->getGroupScoutMessages() == 'AUTO') { ?> style="background-color:green;" <?php } ?> />&nbsp;
+			<input type="submit" name="group_scouts" value="Always" <?php if ($ThisPlayer->getGroupScoutMessages() == 'ALWAYS') { ?> style="background-color:green;" <?php } ?> />
+		</div>
 	</form><?php
 } ?>
+<br />
+<form name="MessageDeleteForm" method="POST" action="<?php echo $MessageBox['DeleteFormHref']; ?>">
+	<table class="fullwidth center">
+		<tr>
+			<td style="width: 30%" valign="middle"><?php
+				if (isset($PreviousPageHREF)) {
+					?><a href="<?php echo $PreviousPageHREF; ?>"><img src="images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
+				} ?>
+			</td>
+			<td>
+				<input type="submit" name="action" value="Delete" />&nbsp;<select name="action" size="1">
+					<option>Marked Messages</option>
+					<option>All Messages</option>
+				</select>
+				<p>You have <span class="yellow"><?php echo $MessageBox['TotalMessages']; ?></span> <?php echo pluralise('message', $MessageBox['TotalMessages']); if ($MessageBox['TotalMessages'] != $MessageBox['NumberMessages']) { ?> of which <span class="yellow"><?php echo $MessageBox['NumberMessages']; ?></span> <?php echo pluralise('is', $MessageBox['NumberMessages']); ?> being displayed<?php } ?>.</p>
+			</td>
+			<td style="width: 30%" valign="middle"><?php
+				if (isset($NextPageHREF)) {
+					?><a href="<?php echo $NextPageHREF; ?>"><img src="images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
+				} ?>
+			</td>
+		</tr>
+	</table><?php
+	
+	if (isset($MessageBox['ShowAllHref'])) {
+		?><div class="buttonA"><a class="buttonA" href="<?php echo $MessageBox['ShowAllHref'] ?>">Show all Messages</a></div><br /><br /><?php
+	} ?>
+	<table class="standard fullwidth"><?php
+		if (isset($MessageBox['Messages'])) {
+			foreach ($MessageBox['Messages'] as $Message) { ?>
+				<tr>
+					<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $Message['ID']; ?>" /><?php if ($Message['Unread']) { ?>*<?php } ?></td>
+					<td class="noWrap" width="100%"><?php
+						if (isset($Message['ReceiverDisplayName'])) {
+							?>To: <?php echo $Message['ReceiverDisplayName'];
+						} else {
+							?>From: <?php echo $Message['SenderDisplayName'];
+						} ?>
+					</td>
+					<td class="noWrap"<?php if (!isset($Message['ReplyHref'])) { ?> colspan="4"<?php } ?>>Date: <?php echo $Message['SendTime']; ?></td>
+					<?php
+					if (isset($Message['ReplyHref'])) { ?>
+						<td>
+							<a href="<?php echo $Message['ReportHref']; ?>"><img class="bottom" src="images/report.png" width="16" height="16" border="0" title="Report this message to an admin" /></a>
+						</td>
+						<td>
+							<a href="<?php echo $Message['BlacklistHref']; ?>">Blacklist Player</a>
+						</td>
+						<td>
+							<a href="<?php echo $Message['ReplyHref']; ?>">Reply</a>
+						</td><?php
+					} ?>
+				</tr>
+				<tr>
+					<td colspan="6"><?php
+						echo bbifyMessage($Message['Text']);
+						if (isset($MessageBox['GroupedMessages'])) {
+							$SubMessages = $MessageBox['GroupedMessages'][$Message['SenderID']]['Messages']; ?>
+							<br />
+							<div class="shrink noWrap pointer" id="toggle-recent<?php echo $Message['SenderID']; ?>" onclick="toggleScoutGroup(<?php echo $Message['SenderID']; ?>);">
+								Show/Hide Recent (<?php echo count($SubMessages); ?>)
+							</div>
+							<table id="group<?php echo $Message['SenderID']; ?>" class="standard fullwidth" style="display:none;margin:5px 0 2px 0;"><?php
+								foreach ($SubMessages as $SubMessage) { ?>
+									<tr>
+										<td width="10"><input type="checkbox" name="message_id[]" value="<?php echo $SubMessage['ID']; ?>" /><?php if ($SubMessage['Unread']) { ?>*<?php } ?></td>
+										<td class="noWrap" width="100%">From: <?php echo $SubMessage['SenderDisplayName']; ?></td>
+										<td class="noWrap" colspan="4">Date: <?php echo $SubMessage['SendTime']; ?></td>
+									</tr>
+									<tr>
+										<td colspan="6"><?php echo bbifyMessage($SubMessage['Text']); ?></td>
+									</tr><?php
+								} ?>
+							</table><?php
+						} ?>
+					</td>
+				</tr><?php
+			}
+		} ?>
+	</table>
+</form>
+
+<table class="fullwidth center">
+	<tr>
+		<td style="width: 30%" valign="middle"><?php
+			if (isset($PreviousPageHREF)) {
+				?><a href="<?php echo $PreviousPageHREF; ?>"><img src="images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
+			} ?>
+		</td>
+		<td>
+		</td>
+		<td style="width: 30%" valign="middle"><?php
+			if (isset($NextPageHREF)) {
+				?><a href="<?php echo $NextPageHREF; ?>"><img src="images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
+			} ?>
+		</td>
+	</tr>
+</table>


### PR DESCRIPTION
See commit messages for details.

Scout message UI/UX changes:

* The sender will no longer be displayed as a separate (redundant) field so
  that the message can fit on a single line.

Message box UI/UX changes:

* The "Political Messages" box now always shows up in box view.
  Conditionally hiding it seemed unnecessary.

* Remove redundant link to "Manage Blacklist" in box view. We keep the
  link in the navigation bar.

* Clicking "Empty Read Messages" for Scout messages used to delete all
  Scout messages (even unread ones). Now it behaves like all other box
  types, and only deletes read messages.

* Deleting messages now stays in the selected folder instead of going
  back to the box view, unless deleting "All Messages" (since it does
  not make sense to display an empty list of messages).

* Reporting a message now returns to the currently selected folder.
