### PR TITLE
Add option to resend validation code

### DIFF
--- a/engine/Default/validate_processing.php
+++ b/engine/Default/validate_processing.php
@@ -1,9 +1,16 @@
 <?php declare(strict_types=1);
 
+$container = create_container('skeleton.php', 'validate.php');
+
+if (Request::get('action') == "resend") {
+	$account->sendValidationEmail();
+	$container['msg'] = '<span class="green">The validation code has been resent to your e-mail address!</span>';
+	forward($container);
+}
+
 // Only skip validation check if we explicitly chose to validate later
-if (Request::get('action') != "I'll validate later.") {
+if (Request::get('action') != "skip") {
 	if ($account->getValidationCode() != Request::get('validation_code')) {
-		$container = create_container('skeleton.php', 'validate.php');
 		$container['msg'] = '<span class="red">The validation code you entered is incorrect!</span>';
 		forward($container);
 	}
@@ -16,6 +23,7 @@ if (Request::get('action') != "I'll validate later.") {
 				WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . '
 				AND notification_type = \'validation_code\'');
 }
+
 $container = create_container('login_check_processing.php');
 $container['CheckType'] = 'Announcements';
 forward($container);

--- a/htdocs/login_create_processing.php
+++ b/htdocs/login_create_processing.php
@@ -165,21 +165,7 @@ try {
 	$account->updateIP();
 
 	if (!$account->isValidated()) {
-		// send email with validation code to user
-		$emailMessage =
-			'Your validation code is: ' . $account->getValidationCode() . EOL .
-			'The Space Merchant Realms server is on the web at ' . URL;
-
-		$mail = setupMailer();
-		$mail->Subject = 'New Space Merchant Realms Account';
-		$mail->setFrom('support@smrealms.de', 'SMR Support');
-		$mail->msgHTML(nl2br($emailMessage));
-		$mail->addAddress($account->getEmail(), $account->getHofName());
-		$mail->send();
-
-		// remember when we sent validation code
-		$db->query('INSERT INTO notification (notification_type, account_id, time) ' .
-		           'VALUES(\'validation_code\', ' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber(TIME) . ')');
+		$account->sendValidationEmail();
 	}
 
 	forwardURL(create_container('login_processing.php'));

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -674,22 +674,7 @@ abstract class AbstractSmrAccount {
 		$this->setEmail($email);
 		$this->setValidationCode(random_string(10));
 		$this->setValidated(false);
-
-		// remember when we sent validation code
-		$this->db->query('REPLACE INTO notification (notification_type, account_id, time)
-				VALUES(\'validation_code\', '.$this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber(TIME) . ')');
-
-		$emailMessage =
-			'You changed your email address registered with SMR and need to revalidate now!' . EOL . EOL .
-			'   Your new validation code is: ' . $this->getValidationCode() . EOL . EOL .
-			'The Space Merchant Realms server is on the web at ' . URL;
-
-		$mail = setupMailer();
-		$mail->Subject = 'Your validation code!';
-		$mail->setFrom('support@smrealms.de', 'SMR Support');
-		$mail->msgHTML(nl2br($emailMessage));
-		$mail->addAddress($this->getEmail(), $this->getHofName());
-		$mail->send();
+		$this->sendValidationEmail();
 
 		// Remove an "Invalid email" ban (may or may not have one)
 		if ($disabled = $this->isDisabled()) {
@@ -697,6 +682,23 @@ abstract class AbstractSmrAccount {
 				$this->unbanAccount($this);
 			}
 		}
+	}
+
+	public function sendValidationEmail() : void {
+		// remember when we sent validation code
+		$this->db->query('REPLACE INTO notification (notification_type, account_id, time)
+				VALUES(\'validation_code\', '.$this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber(TIME) . ')');
+
+		$emailMessage =
+			'Your validation code is: ' . $this->getValidationCode() . EOL . EOL .
+			'The Space Merchant Realms server is on the web at ' . URL;
+
+		$mail = setupMailer();
+		$mail->Subject = 'Space Merchant Realms Validation Code';
+		$mail->setFrom('support@smrealms.de', 'SMR Support');
+		$mail->msgHTML(nl2br($emailMessage));
+		$mail->addAddress($this->getEmail(), $this->getHofName());
+		$mail->send();
 	}
 
 	public function getOffset() {

--- a/templates/Default/engine/Default/validate.php
+++ b/templates/Default/engine/Default/validate.php
@@ -1,10 +1,5 @@
 <form name="FORM" method="POST" action="<?php echo $ValidateFormHref ?>">
 
-<?php
-if (isset($Message)) {
-	echo $Message; ?><br /><?php
-} ?>
-
 <p>
 	Thank you for trying out Space Merchant Realms! We hope that you are enjoying the game. However,
 	in order for you to experience the full features of the game, you need to validate your e-mail address.
@@ -31,6 +26,13 @@ if (isset($Message)) {
 <p class="center">
 	<input type="submit" name="action" value="Validate me now!">
 	&nbsp;&nbsp;
-	<input type="submit" name="action" value="I'll validate later.">
+	<button type="submit" name="action" value="resend">Resend code</button>
+	&nbsp;&nbsp;
+	<button type="submit" name="action" value="skip">I'll validate later</button>
 </p>
 </form>
+
+<?php
+if (isset($Message)) { ?>
+	<p class="center"><?php echo $Message; ?></p><?php
+} ?>


### PR DESCRIPTION
validate.php: add option to resend the code

There are a variety of reasons why someone may need the validation
code resent. There was no obvious option to do this previously.
(The only method was to change your e-mail to the same address.)

![image](https://user-images.githubusercontent.com/846186/88256691-c7e07180-cc70-11ea-921d-37989f66ab88.png)
