### PR TITLE
missions.inc: simplify requirement checking

### DIFF
--- a/engine/Default/bar_buy_drink_processing.php
+++ b/engine/Default/bar_buy_drink_processing.php
@@ -66,7 +66,7 @@ if (isset($var['action']) && $var['action'] != 'drink') {
 }
 
 $player->actionTaken('BuyDrink', array(
-	'Sector' => $sector,
+	'SectorID' => $sector->getSectorID(),
 	'Drink' => $drinkName
 ));
 

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -2737,7 +2737,11 @@ abstract class AbstractSmrPlayer {
 			}
 			$path = Plotter::findDistanceToX($realX, $this->getSector(), true, null, $this);
 			if ($path === false) {
-				throw new Exception('Cannot find location: ' . $missionID);
+				// Abandon the mission if it cannot be completed due to a
+				// sector that does not exist or cannot be reached.
+				// (Probably shouldn't bestow this mission in the first place)
+				$this->deleteMission($missionID);
+				create_error('Cannot find a path to the destination!');
 			}
 			$mission['Sector'] = $path->getEndSectorID();
 		}

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -2787,16 +2787,9 @@ abstract class AbstractSmrPlayer {
 			// If we have completed this mission just use false to indicate no current task.
 			$currentStep = false;
 		} else {
+			$data = ['player' => $this, 'mission' => $mission];
 			$currentStep = MISSIONS[$missionID]['Steps'][$mission['On Step']];
-			$currentStep['Text'] = str_replace(array('<Race>', '<Sector>', '<Starting Sector>', '<trader>'), array($this->getRaceID(), $mission['Sector'], $mission['Starting Sector'], $this->playerName), $currentStep['Text']);
-			if (isset($currentStep['Task'])) {
-				$currentStep['Task'] = str_replace(array('<Race>', '<Sector>', '<Starting Sector>', '<trader>'), array($this->getRaceID(), $mission['Sector'], $mission['Starting Sector'], $this->playerName), $currentStep['Task']);
-			}
-			if (isset($currentStep['Level'])) {
-				$currentStep['Level'] = str_replace('<Player Level>', $this->getLevelID(), $currentStep['Level']);
-			} else {
-				$currentStep['Level'] = 0;
-			}
+			array_walk_recursive($currentStep, 'replaceMissionTemplate', $data);
 		}
 		$this->missions[$missionID]['Task'] = $currentStep;
 	}
@@ -2901,7 +2894,8 @@ abstract class AbstractSmrPlayer {
 		$this->getMissions();
 		foreach ($this->missions as $missionID => &$mission) {
 			if ($mission['Task'] !== false && $mission['Task']['Step'] == $actionID) {
-				if (checkMissionRequirements($values, $mission, $this) === true) {
+				$requirements = $mission['Task']['Detail'];
+				if (checkMissionRequirements($values, $requirements) === true) {
 					$mission['On Step']++;
 					$mission['Unread'] = true;
 					$this->setupMissionStep($missionID);

--- a/lib/Default/missions.inc
+++ b/lib/Default/missions.inc
@@ -114,38 +114,24 @@ const MISSIONS = array(
 	)
 );
 
-function checkMissionRequirements($values, array $mission, AbstractSmrPlayer $player, array $requirements = null) {
-	if ($requirements == null) {
-		return checkMissionRequirements($values, $mission, $player, $mission['Task']['Detail']);
+/**
+ * Callback for array_walk_recursive in SmrPlayer::rebuildMission.
+ * Searches for placeholders in template and replaces them with values
+ * derived from the supplied data.
+ */
+function replaceMissionTemplate(&$template, $key, array $data) : void {
+	if (!is_string($template)) {
+		return;
 	}
-	foreach ($requirements as $reqName => $req) {
-		if (is_string($req)) {
-			// Handle aliases
-			switch ($reqName) {
-				case 'SectorID':
-					$reqName = 'Sector';
-					$req = array(
-						'getSectorID' => $req
-					);
-					break;
-				default:
-					$req = str_replace(array('<Race>', '<Sector>', '<Starting Sector>', '<trader>'), array($player->getRaceID(), $mission['Sector'], $mission['Starting Sector'], $player->getPlayerName()), $req);
+	$search = ['<Race>', '<Sector>', '<Starting Sector>'];
+	$replace = [$data['player']->getRaceID(), $data['mission']['Sector'], $data['mission']['Starting Sector']];
+	$template = str_replace($search, $replace, $template);
+}
 
-			}
-		}
-		if (is_array($values)) {
-			$value = $values[$reqName];
-		} else if (is_object($values)) {
-			$value = $values->$reqName();
-		}
-		if (is_array($req)) {
-			if (checkMissionRequirements($value, $mission, $player, $req) === false) {
-				return false;
-			}
-		} else {
-			if ($value != $req) {
-				return false;
-			}
+function checkMissionRequirements(array $values, array $requirements) : bool {
+	foreach ($requirements as $reqName => $reqValue) {
+		if ($values[$reqName] != $reqValue) {
+			return false;
 		}
 	}
 	return true;


### PR DESCRIPTION
The mission 'Steps' array has a variety of placeholders for data that
needs to be determined dynamically (sector ID, drink name, etc.).
Some of the replacements were being done in SmrPlayer::rebuildMission,
and others in `checkMissionRequirements`. This split was unnecessarily
complicated, so now it is done entirely in `rebuildMission`.

Two additional simplifications:

1. Instead of replacing placeholders manually in each element of the
   mission step array, walk recursively over all (string-like) array
   leaves. (Note that `str_replace` always outputs a string, which
   is why we skip any non-string-like leaves.)

2. Remove aliases in `checkMissionRequirements`. If we want to check
   a requirement, we now need to pass in values that have the same
   keys. This fixes a bug with {Enter,Leave}Sector actions, which were
   broken by 3f6a8a87240.