### PR TITLE
planet_construction.php: builds now cost 1 turn

### DIFF
--- a/engine/Default/planet_construction_processing.php
+++ b/engine/Default/planet_construction_processing.php
@@ -9,6 +9,11 @@ if ($action == 'Build') {
 		create_error($message);
 	}
 
+	if ($player->getTurns() < TURNS_TO_BUILD) {
+		create_error('You don\'t have enough turns to build!');
+	}
+	$player->takeTurns(TURNS_TO_BUILD);
+
 	// now start the construction
 	$planet->startBuilding($player, $var['construction_id']);
 	$player->increaseHOF(1, array('Planet', 'Buildings', 'Started'), HOF_ALLIANCE);

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -311,6 +311,7 @@ const TURNS_JUMP_MINIMUM = 10;
 
 const TURNS_TO_CLOAK = 1;
 const TURNS_TO_SHOOT_PORT = 2;
+const TURNS_TO_BUILD = 1;
 
 const GOOD_NOTHING = 0;
 /*

--- a/templates/Default/engine/Default/planet_construction.php
+++ b/templates/Default/engine/Default/planet_construction.php
@@ -18,7 +18,7 @@ You are currently building: <?php
 		<th>Description</th>
 		<th>Capacity</th>
 		<th colspan="2">Cost</th>
-		<th width="8%">Build</th>
+		<th width="8%">Action</th>
 	</tr><?php
 
 	foreach ($ThisPlanet->getStructureTypes() as $StructureID => $Structure) { ?>
@@ -44,7 +44,7 @@ You are currently building: <?php
 		</td>
 			<td><?php
 				if ($ThisPlanet->canBuild($ThisPlayer, $StructureID) === true) { ?>
-					<div class="buttonA"><a class="buttonA" href="<?php echo $ThisPlanet->getBuildHREF($StructureID); ?>">Build</a></div><?php
+					<div class="buttonA"><a class="buttonA" href="<?php echo $ThisPlanet->getBuildHREF($StructureID); ?>">Build (<?php echo TURNS_TO_BUILD; ?>)</a></div><?php
 				} ?>
 			</td>
 		</tr><?php


### PR DESCRIPTION
Since planet construction awards experience, it is sensible to incur
a turn cost. At one turn per build, this change is mostly symbolic,
but at least it prevents infinite exp gain per turn. (It also adds
some much needed cost to draining the stockpile after a planet bust.)