### PR TITLE
Cloak on examine

### DIFF
--- a/templates/Default/engine/Default/trader_examine.php
+++ b/templates/Default/engine/Default/trader_examine.php
@@ -15,6 +15,8 @@ if ($ThisPlayer->hasNewbieTurns()) {
 	?><p class="big blue">You are under federal protection! That wouldn't be fair.</p><?php
 } elseif ($TargetPlayer->hasFederalProtection()) {
 	?><p class="big blue">Your target is under federal protection!</p><?php
+}elseif (!$ThisPlayer->canSee($TargetPlayer)) {
+	?><p class="big red">Your target has cloaked!</p><?php
 } else {
 	$canAttack = true;
 	$fightingPlayers = $ThisSector->getFightingTraders($ThisPlayer, $TargetPlayer, true);

--- a/templates/Default/engine/Default/trader_examine.php
+++ b/templates/Default/engine/Default/trader_examine.php
@@ -15,7 +15,7 @@ if ($ThisPlayer->hasNewbieTurns()) {
 	?><p class="big blue">You are under federal protection! That wouldn't be fair.</p><?php
 } elseif ($TargetPlayer->hasFederalProtection()) {
 	?><p class="big blue">Your target is under federal protection!</p><?php
-}elseif (!$ThisPlayer->canSee($TargetPlayer)) {
+} elseif (!$ThisPlayer->canSee($TargetPlayer)) {
 	?><p class="big red">Your target has cloaked!</p><?php
 } else {
 	$canAttack = true;


### PR DESCRIPTION
add a unique message indicating a ship being examined has cloaked.  in contrast, the current behavior is the catch all "You have no targets!" message which may be confusing.