### PR TITLE
135 balance change proposal

### DIFF
--- a/db/patches/V1_6_64_06__update_lvl5_weapons.sql
+++ b/db/patches/V1_6_64_06__update_lvl5_weapons.sql
@@ -1,0 +1,3 @@
+-- Decrease damage of HHG/Nuke by 10%
+UPDATE weapon_type SET armour_damage = 270 WHERE weapon_name = 'Nuke';
+UPDATE weapon_type SET shield_damage = 270 WHERE weapon_name = 'Holy Hand Grenade';

--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -979,12 +979,12 @@ class AbstractSmrPort {
 			// Trader sells
 			$supplyFactor = 1 + ($supply / $maxSupply);
 			$relationsFactor = 1.2 + 1.8 * ($relations / 1000); // [0.75-3]
-			$scale = 0.084;
+			$scale = 0.092;
 		} elseif ($transactionType == 'Buy') {
 			// Trader buys
 			$supplyFactor = 2 - ($supply / $maxSupply);
 			$relationsFactor = 3 - 2 * ($relations / 1000);
-			$scale = 0.0315;
+			$scale = 0.03;
 		} else {
 			throw new Exception('Unknown transaction type');
 		}

--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -23,7 +23,8 @@ class AbstractSmrPort {
 	const REFRESH_PER_GOOD = .9;
 	const TIME_TO_CREDIT_RAID = 10800; // 3 hours
 	const GOODS_TRADED_MONEY_MULTIPLIER = 50;
-	const RAZE_MONEY_PERCENT = 75;
+	const RAZE_MONEY_PERCENT = 56;	//0.75*75
+	const LOOT_MONEY_PERCENT = 75;
 	
 	protected $db;
 	
@@ -1324,7 +1325,7 @@ class AbstractSmrPort {
 	}
 
 	public function lootPort(AbstractSmrPlayer $killer) {
-		$credits = $this->getCredits();
+		$credits = IFloor($this->getCredits() * self::LOOT_MONEY_PERCENT / 100);
 		$this->payout($killer, $credits, 'Looted');
 		return $credits;
 	}

--- a/templates/Default/engine/Default/port_attack.php
+++ b/templates/Default/engine/Default/port_attack.php
@@ -19,7 +19,7 @@
 				<a href="<?php echo $Port->getClaimHREF(); ?>" class="buttonA">Claim this port for your race</a><?php
 				if ($Port->getCredits() > 0) { ?>&nbsp;
 					<a href="<?php echo $Port->getLootHREF(); ?>" class="buttonA">Loot the port<?php if ($Port->getCredits() > 0) { ?> (100% money)<?php } ?></a>&nbsp;
-					<a href="<?php echo $Port->getRazeHREF(); ?>" class="buttonA">Raze the port (<?php echo SmrPort::RAZE_MONEY_PERCENT; ?>% money, 1 downgrade)</a><?php
+					<a href="<?php echo $Port->getRazeHREF(); ?>" class="buttonA">Raze the port (75% money, 1 downgrade)</a><?php
 				}
 			} ?>
 		</div><?php


### PR DESCRIPTION
I'm throwing this out there for whatever use or non use.  My aim is to cut down the profits from port raids, encourage trading, balance out P5 weapons a bit, and to slow de-mining somewhat.  Especially from fed ships.

Holy Hand Grenade and Nuke damage reduced by 10% from 300 to 270.  This brings damage per shot with stacked P5 guns down to numbers similar to what they were before the power slot change.  I am targeting the damage and not accuracy because the swing shot/burst damage needs to come down as well for lower power weapons to be decent substitutes.

Port payouts down 25%.  This method of farming cash is driving too much in to the game economy and too quickly.

Trade profits boosted up to +15% from pre 134.  To further encourage trading for money.

Mine armor increase from 20 to 25.  This takes a full force stack from 1250 armor to 1500 armor.  So 1-3 more weapon strikes per stack.  This should make it harder to bump + one shot stacks.

Fed ship turn bonus against forces removed.  Fed ships are already very capable of ramming down forces with a damage reduction.