### PR TITLE
SmrPlayer: make relations naming more consistent

### DIFF
--- a/engine/Default/council_vote.php
+++ b/engine/Default/council_vote.php
@@ -18,7 +18,7 @@ if ($db->nextRecord()) {
 }
 
 $voteRelations = array();
-$globalRelations = Globals::getRaceRelations($player->getGameID(), $player->getRaceID());
+$raceRelations = Globals::getRaceRelations($player->getGameID(), $player->getRaceID());
 foreach (Globals::getRaces() as $raceID => $raceInfo) {
 	if ($raceID == RACE_NEUTRAL || $raceID == $player->getRaceID()) {
 		continue;
@@ -28,7 +28,7 @@ foreach (Globals::getRaces() as $raceID => $raceInfo) {
 		'HREF' => SmrSession::getNewHREF($container),
 		'Increased' => $votedForRace == $raceID && $votedFor == 'INC',
 		'Decreased' => $votedForRace == $raceID && $votedFor == 'DEC',
-		'Relations' => $globalRelations[$raceID],
+		'Relations' => $raceRelations[$raceID],
 	);
 }
 $template->assign('VoteRelations', $voteRelations);

--- a/engine/Default/trader_relations.php
+++ b/engine/Default/trader_relations.php
@@ -6,10 +6,10 @@ Menu::trader();
 $politicalRelations = array();
 $personalRelations = array();
 
-$globalRelations = Globals::getRaceRelations($player->getGameID(), $player->getRaceID());
+$raceRelations = Globals::getRaceRelations($player->getGameID(), $player->getRaceID());
 foreach (Globals::getRaces() as $raceID => $race) {
-	$politicalRelations[$race['Race Name']] = $globalRelations[$raceID];
-	$personalRelations[$race['Race Name']] = $player->getPureRelation($raceID);
+	$politicalRelations[$race['Race Name']] = $raceRelations[$raceID];
+	$personalRelations[$race['Race Name']] = $player->getPersonalRelation($raceID);
 }
 $template->assign('PoliticalRelations', $politicalRelations);
 $template->assign('PersonalRelations', $personalRelations);

--- a/lib/Default/DummyPlayer.class.php
+++ b/lib/Default/DummyPlayer.class.php
@@ -28,11 +28,11 @@ class DummyPlayer extends AbstractSmrPlayer {
 		$this->bank						= 0;
 		$this->zoom						= 0;
 		
-		$this->pureRelations = array();
+		$this->personalRelations = array();
 		$this->bounties = array();
 	}
 	
-	protected function getPureRelationsData() {
+	protected function getPersonalRelationsData() {
 	}
 	
 	protected function getHOFData() {

--- a/templates/Default/engine/Default/trader_status.php
+++ b/templates/Default/engine/Default/trader_status.php
@@ -28,8 +28,8 @@
 
 			<br /><?php
 			foreach (Globals::getRaces() as $raceID => $raceInfo) {
-				if ($ThisPlayer->getPureRelation($raceID) != 0) {
-					echo $raceInfo['Race Name'] . ' : ' . get_colored_text($ThisPlayer->getPureRelation($raceID)) . '<br />';
+				if ($ThisPlayer->getPersonalRelation($raceID) != 0) {
+					echo $raceInfo['Race Name'] . ' : ' . get_colored_text($ThisPlayer->getPersonalRelation($raceID)) . '<br />';
 				}
 			} ?>
 


### PR DESCRIPTION
The "personal" relations (as displayed to the player) was often
referred to in the code as "pure" relations. We change the code
(function and variable names) to use "personal" instead.

Also change a few instances of "global" relations in code variable
names to "race" relations (since "global" may be confused with the
"total" relations). In the future this may be renamed consistently
to "political" relations, but for now we'll stick with "race" since
it results in fewer code changes.