### PR TITLE
Limit destroying planetary mounted weapons

### DIFF
--- a/engine/Default/planet_defense_weapon_processing.php
+++ b/engine/Default/planet_defense_weapon_processing.php
@@ -19,7 +19,10 @@ if (Request::has('transfer')) {
 	$planet->addMountedWeapon($weaponTypeID, $planetOrderID);
 	$ship->removeWeapon($shipOrderID);
 } elseif (Request::has('destroy')) {
-	// Destroy the weapon on the planet
+	// Destroy the weapon on the planet (but only if all mounts are filled)
+	if (count($planet->getMountedWeapons()) != $planet->getMaxMountedWeapons()) {
+		create_error('You can only destroy a mounted weapon once all mounts are filled!');
+	}
 	$planet->removeMountedWeapon(Request::getInt('destroy'));
 } elseif (Request::has('move_up')) {
 	$planet->moveMountedWeaponUp(Request::getInt('move_up'));

--- a/templates/Default/engine/Default/planet_defense.php
+++ b/templates/Default/engine/Default/planet_defense.php
@@ -84,7 +84,12 @@ if ($ThisPlanet->getMaxMountedWeapons() > 0) { ?>
 						<td><?php echo $weapons[$i]->getShieldDamage() . ' / ' . $weapons[$i]->getArmourDamage(); ?></td>
 						<td><?php echo $weapons[$i]->getBaseAccuracy(); ?>%</td>
 						<td><?php echo $weapons[$i]->getPowerLevel(); ?></td>
-						<td><button type="submit" name="destroy" value="<?php echo $i; ?>">Destroy</button></td><?php
+						<td><?php
+							if (count($weapons) == $ThisPlanet->getMaxMountedWeapons()) {
+								// Only allow destroying mounted weapons when all slots are filled ?>
+								<button type="submit" name="destroy" value="<?php echo $i; ?>">Destroy</button><?php
+							} ?>
+						</td><?php
 					} else { ?>
 						<td class="left">
 							<select name="ship_order<?php echo $i; ?>" onchange="showWeaponInfo(this)" data-target=".weapon-info<?php echo $i; ?>"><?php


### PR DESCRIPTION
Mounted weapons can now only be destroyed when all the mount slots
are filled (i.e. if you destroy one, you must replace it before you
can destroy another one).

The original intention was only to allow a way to replace or upgrade
weapons, and the previous implementation was the best design I could
think of at the time. However, it allowed for mounted weapons to be
entirely depleted at no cost, which was not fair (or intended).

Some unsavory tactics are still available (e.g. you can replace the
most powerful weapons with weak weapons), but the impact is no longer
devastating and comes at a small cost.