### PR TITLE
Remove unused EMP Damage and Raid weapon attributes

### DIFF
--- a/engine/Default/smr_file_create.php
+++ b/engine/Default/smr_file_create.php
@@ -34,11 +34,10 @@ foreach (Globals::getGoods() as $good) {
 }
 
 $file .= '[Weapons]
-; Weapon = Race,Cost,Shield,Armour,Accuracy,Power level,EMP (%),Align Restriction,Attack Restriction
-; Align: 0=none, 1=good, 2=evil, 3=newbie
-; Attack: 0=none, 1=raid' . EOL;
+; Weapon = Race,Cost,Shield,Armour,Accuracy,Power level,Restriction
+; Restriction: 0=none, 1=good, 2=evil, 3=newbie, 4=port, 5=planet' . EOL;
 foreach (SmrWeapon::getAllWeapons(Globals::getGameType($gameID)) as $weapon) {
-	$file .= inify($weapon->getName()) . '=' . inify($weapon->getRaceName()) . ',' . $weapon->getCost() . ',' . $weapon->getShieldDamage() . ',' . $weapon->getArmourDamage() . ',' . $weapon->getBaseAccuracy() . ',' . $weapon->getPowerLevel() . ',' . $weapon->getEmpDamage() . ',' . $weapon->getBuyerRestriction() . ',' . ($weapon->isRaidWeapon() ? '1' : '0') . EOL;
+	$file .= inify($weapon->getName()) . '=' . inify($weapon->getRaceName()) . ',' . $weapon->getCost() . ',' . $weapon->getShieldDamage() . ',' . $weapon->getArmourDamage() . ',' . $weapon->getBaseAccuracy() . ',' . $weapon->getPowerLevel() . ',' . $weapon->getBuyerRestriction() . EOL;
 }
 
 $file .= '[ShipEquipment]

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -411,7 +411,7 @@ const CDS_REFUND_PERCENT = .5;
 
 const EOL = "\n";
 
-const SMR_FILE_VERSION = '1.06';
+const SMR_FILE_VERSION = '1.07';
 
 // These CSS URLs must be hard-coded here so that grunt-cache-bust
 // can replace them with the hashed filenames.

--- a/lib/Default/AbstractSmrCombatWeapon.class.php
+++ b/lib/Default/AbstractSmrCombatWeapon.class.php
@@ -12,10 +12,8 @@ abstract class AbstractSmrCombatWeapon {
 	protected $maxDamage;
 	protected $shieldDamage;
 	protected $armourDamage;
-	protected $empDamage = 0;
 	protected $accuracy;
 	protected $damageRollover;
-	protected $raidWeapon;
 	
 	public function getBaseAccuracy() {
 		return $this->accuracy;
@@ -45,20 +43,12 @@ abstract class AbstractSmrCombatWeapon {
 		return $this->armourDamage;
 	}
 	
-	public function getEmpDamage() {
-		return $this->empDamage;
-	}
-	
 	public function isDamageRollover() {
 		return $this->damageRollover;
 	}
 	
-	public function isRaidWeapon() {
-		return $this->raidWeapon;
-	}
-	
 	public function canShootForces() {
-		return !$this->isRaidWeapon();
+		return true;
 	}
 	
 	public function canShootPorts() {
@@ -70,7 +60,7 @@ abstract class AbstractSmrCombatWeapon {
 	}
 	
 	public function canShootTraders() {
-		return !$this->isRaidWeapon();
+		return true;
 	}
 	
 	public function getDamage() {

--- a/lib/Default/SmrCombatDrones.class.php
+++ b/lib/Default/SmrCombatDrones.class.php
@@ -20,7 +20,6 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 		}
 		$this->accuracy = 3;
 		$this->damageRollover = true;
-		$this->raidWeapon = false;
 	}
 	
 	public function getNumberOfCDs() {

--- a/lib/Default/SmrMines.class.php
+++ b/lib/Default/SmrMines.class.php
@@ -16,7 +16,6 @@ class SmrMines extends AbstractSmrCombatWeapon {
 		$this->armourDamage = 20;
 		$this->accuracy = 100;
 		$this->damageRollover = false;
-		$this->raidWeapon = false;
 	}
 	
 	public function getNumberOfMines() {

--- a/lib/Default/SmrScoutDrones.class.php
+++ b/lib/Default/SmrScoutDrones.class.php
@@ -13,7 +13,6 @@ class SmrScoutDrones extends AbstractSmrCombatWeapon {
 		$this->armourDamage = 20;
 		$this->accuracy = 100;
 		$this->damageRollover = false;
-		$this->raidWeapon = false;
 	}
 	
 	public function getNumberOfSDs() {

--- a/lib/Default/SmrWeapon.class.php
+++ b/lib/Default/SmrWeapon.class.php
@@ -62,7 +62,6 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 			$this->powerLevel = $db->getInt('power_level');
 			$this->buyerRestriction = $db->getInt('buyer_restriction');
 			$this->damageRollover = false;
-			$this->raidWeapon = false;
 			$this->maxDamage = max($this->shieldDamage, $this->armourDamage);
 		}
 	}


### PR DESCRIPTION
These weapon features are no longer in use (I believe they were an
SMR 1.5 experiment), so remove them to avoid confusion and clutter.

We could retain them in case we want to re-implement these features
in the future, but the infrastructure for them is so minimal that it
would be just as much work with and without the existing code.

Update the SMR file version to 1.07 due to a corresponding change in
the [Weapons] section format.