### PR TITLE
Enhanced Weapons

### DIFF
--- a/admin/Default/location_edit.php
+++ b/admin/Default/location_edit.php
@@ -40,7 +40,7 @@ if (isset($var['location_type_id'])) {
 	
 	$template->assign('Location', $location);
 	$template->assign('Ships', AbstractSmrShip::getAllBaseShips($var['game_type_id']));
-	$template->assign('Weapons', SmrWeapon::getAllWeapons($var['game_type_id']));
+	$template->assign('Weapons', SmrWeaponType::getAllWeaponTypes());
 	
 	
 	$db->query('SELECT * FROM hardware_type');

--- a/db/patches/V1_6_65_01__weapon_bonuses.sql
+++ b/db/patches/V1_6_65_01__weapon_bonuses.sql
@@ -1,0 +1,5 @@
+-- Add fields for bonus accuracy/damage for weapons
+ALTER TABLE ship_has_weapon ADD COLUMN bonus_accuracy enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE';
+ALTER TABLE ship_has_weapon ADD COLUMN bonus_damage enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE';
+ALTER TABLE planet_has_weapon ADD COLUMN bonus_accuracy enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE';
+ALTER TABLE planet_has_weapon ADD COLUMN bonus_damage enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE';

--- a/db/patches/V1_6_65_02__location_sells_special.sql
+++ b/db/patches/V1_6_65_02__location_sells_special.sql
@@ -1,0 +1,11 @@
+-- Add table to track locations that have enhanced weapon events
+CREATE TABLE location_sells_special (
+  game_id int unsigned NOT NULL,
+  sector_id int unsigned NOT NULL,
+  location_type_id int unsigned NOT NULL,
+  weapon_type_id int unsigned NOT NULL,
+  expires int unsigned NOT NULL,
+  bonus_accuracy enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE',
+  bonus_damage enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE',
+  PRIMARY KEY (game_id, sector_id, location_type_id, weapon_type_id)
+);

--- a/engine/Default/bar_talk_bartender.php
+++ b/engine/Default/bar_talk_bartender.php
@@ -13,7 +13,7 @@ if (!isset($var['Message'])) {
 	}
 	SmrSession::updateVar('Message', $message);
 }
-$template->assign('Message', $var['Message']);
+$template->assign('Message', bbifyMessage($var['Message']));
 
 $container = create_container('skeleton.php', 'bar_talk_bartender.php');
 transfer('LocationID');
@@ -21,4 +21,4 @@ $template->assign('ListenHREF', SmrSession::getNewHREF($container));
 
 $container = create_container('bar_talk_bartender_processing.php');
 transfer('LocationID');
-$template->assign('GossipHREF', SmrSession::getNewHREF($container));
+$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));

--- a/engine/Default/bar_talk_bartender_processing.php
+++ b/engine/Default/bar_talk_bartender_processing.php
@@ -3,19 +3,52 @@
 $container = create_container('skeleton.php', 'bar_talk_bartender.php');
 transfer('LocationID');
 
-$gossip = Request::get('gossip_tell');
-if (!empty($gossip)) {
-	$db->query('SELECT message_id FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY message_id DESC LIMIT 1');
-	if ($db->nextRecord()) {
-		$amount = $db->getInt('message_id') + 1;
+$action = Request::get('action');
+
+if ($action == 'tell') {
+	$gossip = Request::get('gossip_tell');
+	if (!empty($gossip)) {
+		$db->query('SELECT message_id FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY message_id DESC LIMIT 1');
+		if ($db->nextRecord()) {
+			$amount = $db->getInt('message_id') + 1;
+		} else {
+			$amount = 1;
+		}
+
+		$db->query('INSERT INTO bar_tender (game_id, message_id, message) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($amount) . ',  ' . $db->escapeString($gossip) . ' )');
+		SmrAccount::doMessageSendingToBox($player->getAccountID(), BOX_BARTENDER, $gossip, $player->getGameID());
+
+		$container['Message'] = 'Huh, that\'s news to me...<br /><br />Got anything else to tell me?';
 	} else {
-		$amount = 1;
+		$container['Message'] = 'So you\'re the tight-lipped sort, eh? No matter, no matter...<br /><br /><i>The bartender slowly scans the room with squinted eyes and then leans in close.</i><br /><br />Must be a sensational story you\'ve got there. Don\'t worry, I can keep a secret. What\'s on your mind?';
 	}
+} elseif ($action == 'tip') {
+	$event = SmrEnhancedWeaponEvent::getLatestEvent($player->getGameID());
+	$cost = $event->getWeapon()->getCost();
 
-	$db->query('INSERT INTO bar_tender (game_id, message_id, message) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($amount) . ',  ' . $db->escapeString($gossip) . ' )');
-	SmrAccount::doMessageSendingToBox($player->getAccountID(), BOX_BARTENDER, $gossip, $player->getGameID());
-
-	$container['Message'] = 'Huh, that\'s news to me...<br /><br />Got anything else to tell me?';
+	// Tip needs to be more than a specific fraction of the weapon cost
+	$tip = Request::getInt('tip');
+	$player->decreaseCredits($tip);
+	$container['Message'] = '<i>The bartender notices your ' . number_format($tip) . ' credit tip.</i><br /><br />';
+	if ($tip > 0.25 * $cost) {
+		$eventSectorID = $event->getSectorID();
+		$eventGalaxy = SmrGalaxy::getGalaxyContaining($player->getGameID(), $eventSectorID);
+		if ($player->getSector()->getGalaxy()->equals($eventGalaxy)) {
+			$locationHint = 'Sector ' . Globals::getSectorBBLink($eventSectorID);
+		} else {
+			$locationHint = 'the ' . $eventGalaxy->getName() . ' galaxy';
+		}
+		if ($event->getWeapon()->hasBonusDamage() && $event->getWeapon()->hasBonusAccuracy()) {
+			$qualifier = 'very special';
+		} else {
+			$qualifier = 'special';
+		}
+		$container['Message'] .= 'Thank you kindly!<br /><br /><i>The bartender begins to turn away, hesitates, and then turns back to you.</i><br /><br />By the way, I heard that a weapon shop in ' . $locationHint . ' has some ' . $qualifier . ' stock that a person like you just might be interested in. That\'s all I know about it...<br /><br />Got anything to tell me?';
+	} elseif ($tip > 0.05 * $cost) {
+		$container['Message'] .= 'Oh, so it\'s secrets you\'re after, eh? Well, it\'ll cost ya more than that...<br /><br />Got anything to tell me?';
+	} else {
+		$container['Message'] .= 'Thanks, I guess...<br /><br />Got anything to tell me?';
+	}
 }
 
 forward($container);

--- a/engine/Default/beta_func_processing.php
+++ b/engine/Default/beta_func_processing.php
@@ -25,10 +25,10 @@ if ($var['func'] == 'Map') {
 		$ship->setHardwareToMax();
 	}
 } elseif ($var['func'] == 'Weapon') {
-	$weapon_id = Request::getInt('weapon_id');
+	$weapon = SmrWeapon::getWeapon(Request::getInt('weapon_id'));
 	$amount = Request::getInt('amount');
 	for ($i = 1; $i <= $amount; $i++) {
-		$ship->addWeapon($weapon_id);
+		$ship->addWeapon($weapon);
 	}
 } elseif ($var['func'] == 'Uno') {
 	$ship->setHardwareToMax();

--- a/engine/Default/edit_dummys.php
+++ b/engine/Default/edit_dummys.php
@@ -4,7 +4,7 @@ $template->assign('PageTopic', 'Edit Dummys');
 //TODO add game type id
 $template->assign('CombatSimLink', SmrSession::getNewHREF(create_container('skeleton.php', 'combat_simulator.php')));
 $template->assign('BaseShips', AbstractSmrShip::getAllBaseShips(0));
-$template->assign('Weapons', SmrWeapon::getAllWeapons(0));
+$template->assign('Weapons', SmrWeaponType::getAllWeaponTypes());
 
 $template->assign('EditDummysLink', SmrSession::getNewHREF(create_container('skeleton.php', 'edit_dummys.php')));
 
@@ -20,7 +20,7 @@ if (isset($_REQUEST['save_dummy'])) {
 		$dummyShip->removeAllWeapons();
 		foreach ($_REQUEST['weapons'] as $weaponTypeID) {
 			if ($weaponTypeID != 0) {
-				$dummyShip->addWeapon($weaponTypeID);
+				$dummyShip->addWeapon(SmrWeapon::getWeapon($weaponTypeID));
 			}
 		}
 	}

--- a/engine/Default/planet_defense_weapon_processing.php
+++ b/engine/Default/planet_defense_weapon_processing.php
@@ -15,8 +15,8 @@ if (Request::has('transfer')) {
 		create_error('You must select a weapon to transfer!');
 	}
 	$shipOrderID = Request::getInt('ship_order' . $planetOrderID);
-	$weaponTypeID = $ship->getWeapons()[$shipOrderID]->getWeaponTypeID();
-	$planet->addMountedWeapon($weaponTypeID, $planetOrderID);
+	$weapon = $ship->getWeapons()[$shipOrderID];
+	$planet->addMountedWeapon($weapon, $planetOrderID);
 	$ship->removeWeapon($shipOrderID);
 } elseif (Request::has('destroy')) {
 	// Destroy the weapon on the planet (but only if all mounts are filled)

--- a/engine/Default/shop_weapon.php
+++ b/engine/Default/shop_weapon.php
@@ -3,3 +3,14 @@
 $location = SmrLocation::getLocation($var['LocationID']);
 $template->assign('PageTopic', $location->getName());
 $template->assign('ThisLocation', $location);
+
+$weaponsSold = $location->getWeaponsSold();
+
+// Check if any enhanced weapons are available
+$events = SmrEnhancedWeaponEvent::getShopEvents($player->getGameID(), $player->getSectorID(), $location->getTypeID());
+foreach ($events as $event) {
+	$weapon = $event->getWeapon();
+	$weaponsSold[$weapon->getWeaponTypeID()] = $weapon;
+}
+
+$template->assign('WeaponsSold', $weaponsSold);

--- a/engine/Default/shop_weapon_processing.php
+++ b/engine/Default/shop_weapon_processing.php
@@ -3,11 +3,11 @@ if (!$player->getSector()->hasLocation($var['LocationID'])) {
 	create_error('That location does not exist in this sector');
 }
 
-$weapon = SmrWeapon::getWeapon($var['WeaponTypeID']);
-// Are we buying?
+$weapon = $var['Weapon'];
 if (!isset($var['OrderID'])) {
+	// If here, we are buying
 	$location = SmrLocation::getLocation($var['LocationID']);
-	if (!$location->isWeaponSold($var['WeaponTypeID'])) {
+	if (!$location->isWeaponSold($weapon->getWeaponTypeID())) {
 		create_error('We do not sell that weapon here!');
 	}
 	
@@ -41,7 +41,7 @@ if (!isset($var['OrderID'])) {
 	$player->decreaseCredits($weapon->getCost());
 
 	// add the weapon to the users ship
-	$ship->addWeapon($weapon->getWeaponTypeID());
+	$ship->addWeapon($weapon);
 	$account->log(LOG_TYPE_HARDWARE, 'Player Buys a ' . $weapon->getName(), $player->getSectorID());
 } else {
 	// mhh we wanna sell our weapon

--- a/engine/Default/smr_file_create.php
+++ b/engine/Default/smr_file_create.php
@@ -36,7 +36,7 @@ foreach (Globals::getGoods() as $good) {
 $file .= '[Weapons]
 ; Weapon = Race,Cost,Shield,Armour,Accuracy,Power level,Restriction
 ; Restriction: 0=none, 1=good, 2=evil, 3=newbie, 4=port, 5=planet' . EOL;
-foreach (SmrWeapon::getAllWeapons(Globals::getGameType($gameID)) as $weapon) {
+foreach (SmrWeaponType::getAllWeaponTypes() as $weapon) {
 	$file .= inify($weapon->getName()) . '=' . inify($weapon->getRaceName()) . ',' . $weapon->getCost() . ',' . $weapon->getShieldDamage() . ',' . $weapon->getArmourDamage() . ',' . $weapon->getBaseAccuracy() . ',' . $weapon->getPowerLevel() . ',' . $weapon->getBuyerRestriction() . EOL;
 }
 

--- a/htdocs/config.php
+++ b/htdocs/config.php
@@ -108,7 +108,6 @@ const LOG_TYPE_ACCOUNT_CHANGES = 13;
 /*
  * Race types
  */
-
 const RACE_NEUTRAL = 1;
 const RACE_ALSKANT = 2;
 const RACE_CREONTI = 3;
@@ -139,7 +138,6 @@ const GOODS_NARCOTICS = 12;
 /*
  * Ship types
  */
-
 const SHIP_TYPE_GALACTIC_SEMI = 1;
 const SHIP_TYPE_INTERSTELLAR_TRADER = 9;
 const SHIP_TYPE_PLANETARY_SUPER_FREIGHTER = 12;
@@ -180,6 +178,11 @@ const SHIP_TYPE_REDEEMER = 70;
 const SHIP_TYPE_RETALIATION = 71;
 const SHIP_TYPE_VENGEANCE = 72;
 const SHIP_TYPE_FURY = 75;
+
+/*
+ * Weapon types
+ */
+const WEAPON_TYPE_LASER = 46;
 
 /*
  * Combat log pages

--- a/lib/Default/AbstractSmrLocation.class.php
+++ b/lib/Default/AbstractSmrLocation.class.php
@@ -330,7 +330,8 @@ class AbstractSmrLocation {
 			$this->weaponsSold = array();
 			$this->db->query('SELECT * FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) WHERE ' . $this->SQL);
 			while ($this->db->nextRecord()) {
-				$this->weaponsSold[$this->db->getInt('weapon_type_id')] = SmrWeapon::getWeapon($this->db->getInt('weapon_type_id'), false, $this->db);
+				$weaponTypeID = $this->db->getInt('weapon_type_id');
+				$this->weaponsSold[$weaponTypeID] = SmrWeapon::getWeapon($weaponTypeID, $this->db);
 			}
 		}
 		return $this->weaponsSold;
@@ -349,9 +350,6 @@ class AbstractSmrLocation {
 			return;
 		}
 		$weapon = SmrWeapon::getWeapon($weaponTypeID);
-		if ($weapon === false) {
-			throw new Exception('Invalid weapon type id given');
-		}
 		$this->db->query('INSERT INTO location_sells_weapons (location_type_id,weapon_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($weaponTypeID) . ')');
 		$this->weaponsSold[$weaponTypeID] = $weapon;
 	}
@@ -398,7 +396,7 @@ class AbstractSmrLocation {
 	}
 
 	public function hasX(/*Object*/ $x, AbstractSmrPlayer $player = null) {
-		if ($x instanceof SmrWeapon) {
+		if ($x instanceof SmrWeaponType) {
 			return $this->isWeaponSold($x->getWeaponTypeID());
 		}
 		if (is_array($x)) {

--- a/lib/Default/AbstractSmrShip.class.php
+++ b/lib/Default/AbstractSmrShip.class.php
@@ -267,9 +267,8 @@ abstract class AbstractSmrShip {
 
 
 
-	public function addWeapon($weaponTypeID) {
+	public function addWeapon(SmrWeapon $weapon) {
 		if ($this->hasOpenWeaponSlots() && $this->hasRemainingPower()) {
-			$weapon = SmrWeapon::getWeapon($weaponTypeID);
 			if ($this->getRemainingPower() >= $weapon->getPowerLevel()) {
 				array_push($this->weapons, $weapon);
 				$this->hasChangedWeapons = true;
@@ -382,7 +381,7 @@ abstract class AbstractSmrShip {
 		$this->setShields($amount_shields, true);
 		$this->setArmour($amount_armour, true);
 		$this->setCargoHolds(40);
-		$this->addWeapon(46); // Laser
+		$this->addWeapon(SmrWeapon::getWeapon(WEAPON_TYPE_LASER));
 	}
 
 	public function hasCloak() {

--- a/lib/Default/Plotter.class.php
+++ b/lib/Default/Plotter.class.php
@@ -9,7 +9,7 @@ class Plotter {
 			case 'Ships':
 				return AbstractSmrShip::getBaseShip(Globals::getGameType($gameID), $X);
 			case 'Weapons':
-				return SmrWeapon::getWeapon($X);
+				return SmrWeaponType::getWeaponType((int)$X);
 			case 'Locations':
 				if (is_numeric($X)) {
 					return SmrLocation::getLocation($X);

--- a/lib/Default/SmrEnhancedWeaponEvent.class.php
+++ b/lib/Default/SmrEnhancedWeaponEvent.class.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+/**
+ * Defines enhanced weapon sale events for weapon shops.
+ */
+class SmrEnhancedWeaponEvent {
+
+	const GRACE_PERIOD = 3600; // 1 hour
+	const DURATION = 21600; // 6 hours
+
+	protected int $gameID;
+	protected int $sectorID;
+	protected int $locationTypeID;
+	protected int $expires;
+	protected SmrWeapon $weapon;
+
+	/**
+	 * Return all the valid events for the given location in a sector.
+	 */
+	public static function getShopEvents(int $gameID, int $sectorID, int $locationID) : array {
+		$events = [];
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT * FROM location_sells_special WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND location_type_id = ' . $db->escapeNumber($locationID) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' AND expires > ' . $db->escapeNumber(TIME));
+		while ($db->nextRecord()) {
+			$events[] = self::getEventFromDatabase($db);
+		}
+		return $events;
+	}
+
+	/**
+	 * Get the most recent event.
+	 *
+	 * This function also does the work of cleaning up expired events and
+	 * creating new ones when necessary.
+	 */
+	public static function getLatestEvent(int $gameID) : SmrEnhancedWeaponEvent {
+		// First, remove any expired events from the database
+		$db = new SmrMySqlDatabase();
+		$db->query('DELETE FROM location_sells_special WHERE expires < ' . $db->escapeNumber(TIME));
+
+		// Next, check if an existing event can be advertised
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT * FROM location_sells_special WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY expires DESC LIMIT 1');
+		if ($db->nextRecord()) {
+			$event = self::getEventFromDatabase($db);
+			// Don't advertise if the event expires within one GRACE_PERIOD
+			if (TIME < $event->getExpireTime() - self::GRACE_PERIOD) {
+				return $event;
+			}
+		}
+
+		// Otherwise, create a new event
+		return self::createEvent($gameID);
+	}
+
+	/**
+	 * Create a new event.
+	 *
+	 * Events are generated randomly across all weapon types available in the
+	 * game, and then randomly across locations that offer that weapon type.
+	 */
+	private static function createEvent(int $gameID) : SmrEnhancedWeaponEvent {
+		// First, randomly select a weapon type to enhance
+		$weaponTypeID = array_rand(SmrWeaponType::getAllWeaponTypes());
+
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT location_type_id, sector_id FROM location JOIN location_sells_weapons USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND weapon_type_id = ' . $db->escapeNumber($weaponTypeID) . ' ORDER BY RAND() LIMIT 1');
+		$db->requireRecord();
+		$locationTypeID = $db->getInt('location_type_id');
+		$sectorID = $db->getInt('sector_id');
+
+		$expires = TIME + self::DURATION;
+
+		// Determine which bonuses the weapon should have
+		$random = rand(1, 100);
+		if ($random <= 40) {
+			$bonusAccuracy = false;
+			$bonusDamage = true;
+		} elseif ($random <= 80) {
+			$bonusAccuracy = true;
+			$bonusDamage = false;
+		} else {
+			$bonusAccuracy = true;
+			$bonusDamage = true;
+		}
+
+		$db->query('INSERT INTO location_sells_special (game_id, sector_id, location_type_id, weapon_type_id, expires, bonus_accuracy, bonus_damage) VALUES (' . $db->escapeNumber($gameID) . ',' . $db->escapeNumber($sectorID) . ',' . $db->escapeNumber($locationTypeID) . ',' . $db->escapeNumber($weaponTypeID) . ',' . $db->escapeNumber($expires) . ',' . $db->escapeBoolean($bonusAccuracy) . ',' . $db->escapeBoolean($bonusDamage) . ')');
+
+		return new SmrEnhancedWeaponEvent($gameID, $weaponTypeID, $locationTypeID, $sectorID, $expires, $bonusAccuracy, $bonusDamage);
+	}
+
+	/**
+	 * Convenience function to instantiate an event from a query result.
+	 */
+	private static function getEventFromDatabase(SmrMySqlDatabase $db) : SmrEnhancedWeaponEvent {
+		return new SmrEnhancedWeaponEvent($db->getInt('game_id'), $db->getInt('weapon_type_id'), $db->getInt('location_type_id'), $db->getInt('sector_id'), $db->getInt('expires'), $db->getBoolean('bonus_accuracy'), $db->getBoolean('bonus_damage'));
+	}
+
+	protected function __construct(int $gameID, int $weaponTypeID, int $locationTypeID, int $sectorID, int $expires, bool $bonusAccuracy, bool $bonusDamage) {
+		$this->gameID = $gameID;
+		$this->locationTypeID = $locationTypeID;
+		$this->sectorID = $sectorID;
+		$this->expires = $expires;
+
+		$this->weapon = SmrWeapon::getWeapon($weaponTypeID);
+		$this->weapon->setBonusDamage($bonusDamage);
+		$this->weapon->setBonusAccuracy($bonusAccuracy);
+	}
+
+	public function getSectorID() : int {
+		return $this->sectorID;
+	}
+
+	public function getExpireTime() : int {
+		return $this->expires;
+	}
+
+	public function getWeapon() : SmrWeapon {
+		return $this->weapon;
+	}
+
+}

--- a/lib/Default/SmrSector.class.php
+++ b/lib/Default/SmrSector.class.php
@@ -1038,7 +1038,7 @@ class SmrSector {
 		}
 
 		//Check if it's possible for location to have X, hacky but nice performance gains
-		if ($x instanceof SmrWeapon || (is_array($x) && ($x['Type'] == 'Ship' || $x['Type'] == 'Hardware')) || (is_string($x) && ($x == 'Bank' || $x == 'Bar' || $x == 'Fed' || $x == 'SafeFed' || $x == 'HQ' || $x == 'UG' || $x == 'Hardware' || $x == 'Ship' || $x == 'Weapon'))) {
+		if ($x instanceof SmrWeaponType || (is_array($x) && ($x['Type'] == 'Ship' || $x['Type'] == 'Hardware')) || (is_string($x) && ($x == 'Bank' || $x == 'Bar' || $x == 'Fed' || $x == 'SafeFed' || $x == 'HQ' || $x == 'UG' || $x == 'Hardware' || $x == 'Ship' || $x == 'Weapon'))) {
 			foreach ($this->getLocations() as $loc) {
 				if ($loc->hasX($x, $player)) {
 					return true;

--- a/lib/Default/SmrWeaponType.class.php
+++ b/lib/Default/SmrWeaponType.class.php
@@ -35,7 +35,8 @@ class SmrWeaponType {
 		$db->query('SELECT * FROM weapon_type');
 		$weapons = array();
 		while ($db->nextRecord()) {
-			$weapons[] = self::getWeaponType($db->getInt('weapon_type_id'), $db);
+			$weaponTypeID = $db->getInt('weapon_type_id');
+			$weapons[$weaponTypeID] = self::getWeaponType($weaponTypeID, $db);
 		}
 		return $weapons;
 	}

--- a/lib/Default/SmrWeaponType.class.php
+++ b/lib/Default/SmrWeaponType.class.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+/**
+ * Defines the base weapon types for ships/planets.
+ */
+class SmrWeaponType {
+
+	protected static array $CACHE_WEAPON_TYPES = [];
+
+	protected int $weaponTypeID;
+	protected string $name;
+	protected int $raceID;
+	protected int $cost;
+	protected int $shieldDamage;
+	protected int $armourDamage;
+	protected int $accuracy;
+	protected int $powerLevel;
+	protected int $buyerRestriction;
+
+	public static function getWeaponType(int $weaponTypeID, SmrMySqlDatabase $db = null) : SmrWeaponType {
+		if (!isset(self::$CACHE_WEAPON_TYPES[$weaponTypeID])) {
+			if (is_null($db)) {
+				$db = new SmrMySqlDatabase();
+				$db->query('SELECT * FROM weapon_type WHERE weapon_type_id = ' . $db->escapeNumber($weaponTypeID));
+				$db->requireRecord();
+			}
+			$weapon = new SmrWeaponType($weaponTypeID, $db);
+			self::$CACHE_WEAPON_TYPES[$weaponTypeID] = $weapon;
+		}
+		return self::$CACHE_WEAPON_TYPES[$weaponTypeID];
+	}
+
+	public static function getAllWeaponTypes() : array {
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT * FROM weapon_type');
+		$weapons = array();
+		while ($db->nextRecord()) {
+			$weapons[] = self::getWeaponType($db->getInt('weapon_type_id'), $db);
+		}
+		return $weapons;
+	}
+
+	protected function __construct(int $weaponTypeID, SmrMySqlDatabase $db) {
+		$this->weaponTypeID = $weaponTypeID;
+		$this->name = $db->getField('weapon_name');
+		$this->raceID = $db->getInt('race_id');
+		$this->cost = $db->getInt('cost');
+		$this->shieldDamage = $db->getInt('shield_damage');
+		$this->armourDamage = $db->getInt('armour_damage');
+		$this->accuracy = $db->getInt('accuracy');
+		$this->powerLevel = $db->getInt('power_level');
+		$this->buyerRestriction = $db->getInt('buyer_restriction');
+	}
+
+	public function getWeaponTypeID() {
+		return $this->weaponTypeID;
+	}
+
+	public function getName() {
+		return $this->name;
+	}
+
+	public function getRaceID() {
+		return $this->raceID;
+	}
+
+	public function getCost() {
+		return $this->cost;
+	}
+
+	public function getShieldDamage() {
+		return $this->shieldDamage;
+	}
+
+	public function getArmourDamage() {
+		return $this->armourDamage;
+	}
+
+	public function getAccuracy() {
+		return $this->accuracy;
+	}
+
+	public function getPowerLevel() {
+		return $this->powerLevel;
+	}
+
+	public function getBuyerRestriction() {
+		return $this->buyerRestriction;
+	}
+
+}

--- a/templates/Default/engine/Default/bar_talk_bartender.php
+++ b/templates/Default/engine/Default/bar_talk_bartender.php
@@ -1,9 +1,12 @@
 <p><?php echo $Message; ?></p>
 <br />
 
-<form method="POST" action="<?php echo $GossipHREF; ?>">
+<form method="POST" action="<?php echo $ProcessingHREF; ?>">
 	<input type="text" name="gossip_tell" size="30" />
-	<input type="submit" name="action" value="Tell him" />
+	<button type="submit" name="action" value="tell">Spread gossip</button>
+	<br /><br />
+	<input type="number" name="tip" class="center" min="1" max="<?php echo $ThisPlayer->getCredits(); ?>" />
+	<button type="submit" name="action" value="tip">Give to tip jar</button>
 </form>
 
 <br />

--- a/templates/Default/engine/Default/course_plot.php
+++ b/templates/Default/engine/Default/course_plot.php
@@ -45,7 +45,7 @@ if (isset($XType)) { ?>
 					}
 				break;
 				case 'Weapons':
-					$Weapons = SmrWeapon::getAllWeapons(Globals::getGameType($ThisPlayer->getGameID()));
+					$Weapons = SmrWeaponType::getAllWeaponTypes();
 					Sorter::sortByNumMethod($Weapons, 'getName');
 					foreach ($Weapons as $Weapon) {
 						?><option value="<?php echo $Weapon->getWeaponTypeID(); ?>"><?php echo $Weapon->getName(); ?></option><?php

--- a/templates/Default/engine/Default/shop_weapon.php
+++ b/templates/Default/engine/Default/shop_weapon.php
@@ -16,7 +16,7 @@ if ($ThisLocation->isWeaponSold()) { ?>
 		</thead>
 
 		<tbody class="list"><?php
-			foreach ($ThisLocation->getWeaponsSold() as $Weapon) { ?>
+			foreach ($WeaponsSold as $Weapon) { ?>
 				<tr>
 					<td class="sort_name"><?php echo $Weapon->getName(); ?></td>
 					<td class="sort_shield"><?php echo $Weapon->getShieldDamage(); ?></td>


### PR DESCRIPTION
Weapons can now have one or both of two possible enhancements:

1. Increased damage (multiplicative +5% bonus)

2. Increased accuracy (additive +3% bonus)

The magnitude of these bonuses will likely need to be tweaked as we
see how they play out in the game. The intention is for them to be
small enough that they don't become mandatory in battles, but big
enough so that people will want to invest some resources to acquire
them.

If either of these enhancements are present, a weapon will be shown
in green with a "+" for each enhancement it has.

One enhanced weapon will now be sold from a single weapon shop every
6 hours (a number likely to be tweaked).

Players can get a hint about where the sale is taking place by giving
a bartender a sufficiently big tip. If the sale is in a different
galaxy, only the galaxy name will be given; otherwise, the exact
sector is given.

The bartender will generate a new enhanced weapon sale any time after
there is less than 1 hour before the end of the current sale (so that
players have enough time to get to the shop before the sale ends).

Note that this means players cannot randomly stumble across a shop
with an enhanced weapon sale without *at least one* player having
triggered it by tipping a bartender. (It's possible that we'll also
want entering a weapon shop to be a trigger. We'll have to see.)