### PR TITLE
new shield weapons

### DIFF
--- a/db/patches/V1_6_65_X__neutral_shield_weapons.sql
+++ b/db/patches/V1_6_65_X__neutral_shield_weapons.sql
@@ -1,0 +1,4 @@
+-- Add two new neutral anti-shield weapons.  One P3 and one P4.
+INSERT INTO `weapon_type` (`weapon_type_id`, `weapon_name`, `race_id`, `cost`, `shield_damage`, `armour_damage`, `accuracy`, `power_level`, `buyer_restriction`) VALUES
+(56, 'Resonant Shield Disruptor', 1, 99000, 110, 0, 65, 3, 0),
+(57, 'Harmonic Shield Disruptor', 1, 199000, 125, 0, 62, 4, 0);


### PR DESCRIPTION
add two new anti shield weapons:

P3, Resonant Shield Disruptor, 110 shield damage at 65% accuracy
P4, Harmonic Shield Disruptor, 125 shield damage at 62% accuracy

There are currently only 2 neutral shield weapons that do not require an alignment selection to equip.  Neither of them over power 2.  By contrast, there are 11 armor weapons of the same nature ranging from P1 to P4.  This is a puzzling and somewhat frustrating part of the game world.

This will reduce the value of Thev/WQ/Nij/Creo relations as they currently carry all the reasonable shield weapons.  But their weapons are still better than these.