### PR TITLE
Add SmrWeaponType::getAllSoldWeaponTypes

### DIFF
--- a/lib/Default/SmrEnhancedWeaponEvent.class.php
+++ b/lib/Default/SmrEnhancedWeaponEvent.class.php
@@ -61,7 +61,7 @@ class SmrEnhancedWeaponEvent {
 	 */
 	private static function createEvent(int $gameID) : SmrEnhancedWeaponEvent {
 		// First, randomly select a weapon type to enhance
-		$weaponTypeID = array_rand(SmrWeaponType::getAllWeaponTypes());
+		$weaponTypeID = array_rand(SmrWeaponType::getAllSoldWeaponTypes($gameID));
 
 		$db = new SmrMySqlDatabase();
 		$db->query('SELECT location_type_id, sector_id FROM location JOIN location_sells_weapons USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND weapon_type_id = ' . $db->escapeNumber($weaponTypeID) . ' ORDER BY RAND() LIMIT 1');

--- a/lib/Default/SmrWeaponType.class.php
+++ b/lib/Default/SmrWeaponType.class.php
@@ -41,6 +41,20 @@ class SmrWeaponType {
 		return $weapons;
 	}
 
+	/**
+	 * Returns all weapon types that are purchasable in the given game.
+	 */
+	public static function getAllSoldWeaponTypes(int $gameID) : array {
+		$db = new SmrMySqlDatabase();
+		$db->query('SELECT DISTINCT weapon_type.* FROM weapon_type JOIN location_sells_weapons USING (weapon_type_id) JOIN location USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID));
+		$weapons = [];
+		while ($db->nextRecord()) {
+			$weaponTypeID = $db->getInt('weapon_type_id');
+			$weapons[$weaponTypeID] = self::getWeaponType($weaponTypeID, $db);
+		}
+		return $weapons;
+	}
+
 	protected function __construct(int $weaponTypeID, SmrMySqlDatabase $db) {
 		$this->weaponTypeID = $weaponTypeID;
 		$this->name = $db->getField('weapon_name');

--- a/templates/Default/engine/Default/course_plot.php
+++ b/templates/Default/engine/Default/course_plot.php
@@ -45,7 +45,7 @@ if (isset($XType)) { ?>
 					}
 				break;
 				case 'Weapons':
-					$Weapons = SmrWeaponType::getAllWeaponTypes();
+					$Weapons = SmrWeaponType::getAllSoldWeaponTypes($ThisPlayer->getGameID());
 					Sorter::sortByNumMethod($Weapons, 'getName');
 					foreach ($Weapons as $Weapon) {
 						?><option value="<?php echo $Weapon->getWeaponTypeID(); ?>"><?php echo $Weapon->getName(); ?></option><?php


### PR DESCRIPTION
This function returns all weapon types that can be purchased in the
given game. It has two main purposes:

1. Fix a bug with enhanced weapons where `createEvent` could randomly
   choose a weapon type that is not purchasable at a weapon shop
   (e.g. Planet Turret, Hell Blaster, etc.).

2. Improve "Plot To Nearest" by only listing weapons that are sold by
   weapon shops that exist in the current game. This aims to prevent
   needlessly getting the "Unable to find what you are looking for"
   error message for inaccessible weapons.