### PR TITLE
Add Traits/RaceID

### DIFF
--- a/admin/Default/1.6/check_map.php
+++ b/admin/Default/1.6/check_map.php
@@ -73,7 +73,7 @@ foreach (SmrGalaxy::getGameGalaxies($var['game_id']) as $galaxy) {
 		}
 	}
 	if (!empty($max)) {
-		$output = $max['Distance'] . 'x ' . Globals::getGoodName($max['GoodID']) . ' at Port #' . $max['Port']->getSectorID() . ' (' . Globals::getRaceName($max['Port']->getRaceID()) . ')';
+		$output = $max['Distance'] . 'x ' . Globals::getGoodName($max['GoodID']) . ' at Port #' . $max['Port']->getSectorID() . ' (' . $max['Port']->getRaceName() . ')';
 		$maxSellMultipliers[$galaxy->getName()] = $output;
 	}
 }

--- a/htdocs/weapon_list.php
+++ b/htdocs/weapon_list.php
@@ -29,7 +29,7 @@ try {
 			'restriction' => $restriction,
 			'weapon_name' => $weapon->getName(),
 			'race_id' => $weapon->getRaceID(),
-			'race_name' => Globals::getRaceName($weapon->getRaceID()),
+			'race_name' => $weapon->getRaceName(),
 			'cost' => number_format($weapon->getCost()),
 			'shield_damage' => $weapon->getShieldDamage(),
 			'armour_damage' => $weapon->getArmourDamage(),

--- a/lib/Default/AbstractSmrCombatWeapon.class.php
+++ b/lib/Default/AbstractSmrCombatWeapon.class.php
@@ -8,7 +8,6 @@ abstract class AbstractSmrCombatWeapon {
 
 	protected $gameTypeID;
 	protected $name;
-	protected $raceID;
 	protected $maxDamage;
 	protected $shieldDamage;
 	protected $armourDamage;
@@ -21,14 +20,6 @@ abstract class AbstractSmrCombatWeapon {
 	
 	public function getName() {
 		return $this->name;
-	}
-	
-	public function getRaceID() {
-		return $this->raceID;
-	}
-	
-	public function getRaceName() {
-		return Globals::getRaceName($this->getRaceID());
 	}
 	
 	public function getMaxDamage() {

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -5,6 +5,7 @@ require_once('missions.inc');
 class PlayerNotFoundException extends Exception {}
 
 abstract class AbstractSmrPlayer {
+	use Traits\RaceID;
 
 	const TIME_FOR_FEDERAL_BOUNTY_ON_PR = 10800;
 	const TIME_FOR_ALLIANCE_SWITCH = 0;
@@ -33,7 +34,6 @@ abstract class AbstractSmrPlayer {
 	protected $newbieWarning;
 	protected $landedOnPlanet;
 	protected $lastActive;
-	protected $raceID;
 	protected $credits;
 	protected $alignment;
 	protected $experience;
@@ -1267,14 +1267,6 @@ abstract class AbstractSmrPlayer {
 
 	public function canChangeRace() : bool {
 		return !$this->isRaceChanged() && (TIME - $this->getGame()->getStartTime() < TIME_FOR_RACE_CHANGE);
-	}
-
-	public function getRaceID() {
-		return $this->raceID;
-	}
-
-	public function getRaceName() {
-		return Globals::getRaceName($this->getRaceID());
 	}
 
 	public static function getColouredRaceNameOrDefault($otherRaceID, AbstractSmrPlayer $player = null, $linked = false) {

--- a/lib/Default/AbstractSmrPort.class.php
+++ b/lib/Default/AbstractSmrPort.class.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 class AbstractSmrPort {
+	use Traits\RaceID;
+
 	protected static $CACHE_PORTS = array();
 	protected static $CACHE_CACHED_PORTS = array();
 	
@@ -30,7 +32,6 @@ class AbstractSmrPort {
 	
 	protected $gameID;
 	protected $sectorID;
-	protected $raceID;
 	protected $shields;
 	protected $combatDrones;
 	protected $armour;
@@ -828,10 +829,6 @@ class AbstractSmrPort {
 		return SmrSector::getSector($this->getGameID(), $this->getSectorID());
 	}
 	
-	public function getRaceID() {
-		return $this->raceID;
-	}
-	
 	public function setRaceID($raceID) {
 		if ($this->raceID == $raceID) {
 			return;
@@ -841,10 +838,6 @@ class AbstractSmrPort {
 		$this->cacheIsValid = false;
 		// route_cache tells NPC's where they can trade
 		$this->db->query('DELETE FROM route_cache WHERE game_id=' . $this->db->escapeNumber($this->getGameID()));
-	}
-	
-	public function getRaceName() {
-		return Globals::getRaceName($this->getRaceID());
 	}
 	
 	public function getLevel() {

--- a/lib/Default/SmrWeapon.class.php
+++ b/lib/Default/SmrWeapon.class.php
@@ -4,6 +4,7 @@
  * Defines a concrete realization of a weapon type for ships/planets.
  */
 class SmrWeapon extends AbstractSmrCombatWeapon {
+	use Traits\RaceID;
 
 	const BONUS_DAMAGE = 1.05; // multiplicative bonus
 	const BONUS_ACCURACY = 3; // additive bonus

--- a/lib/Default/SmrWeaponType.class.php
+++ b/lib/Default/SmrWeaponType.class.php
@@ -4,12 +4,12 @@
  * Defines the base weapon types for ships/planets.
  */
 class SmrWeaponType {
+	use Traits\RaceID;
 
 	protected static array $CACHE_WEAPON_TYPES = [];
 
 	protected int $weaponTypeID;
 	protected string $name;
-	protected int $raceID;
 	protected int $cost;
 	protected int $shieldDamage;
 	protected int $armourDamage;
@@ -73,10 +73,6 @@ class SmrWeaponType {
 
 	public function getName() {
 		return $this->name;
-	}
-
-	public function getRaceID() {
-		return $this->raceID;
 	}
 
 	public function getCost() {

--- a/lib/Default/Traits/RaceID.class.php
+++ b/lib/Default/Traits/RaceID.class.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Traits;
+
+/**
+ * Implements the interface for classes that need a $raceID property.
+ */
+trait RaceID {
+	protected int $raceID;
+
+	public function getRaceID() : int {
+		return $this->raceID;
+	}
+
+	public function getRaceName() : string {
+		return \Globals::getRaceName($this->raceID);
+	}
+}

--- a/templates/Default/admin/Default/npc_manage.php
+++ b/templates/Default/admin/Default/npc_manage.php
@@ -47,7 +47,7 @@ if (!empty($SelectedGameID)) { ?>
 					</form><?php
 				} else { ?>
 					<td><?php echo $npc['player']->getDisplayName(); ?></td>
-					<td><?php echo Globals::getRaceName($npc['player']->getRaceID()); ?></td>
+					<td><?php echo $npc['player']->getRaceName(); ?></td>
 					<td><?php echo $npc['player']->getAllianceDisplayName(); ?></td>
 					<td class="center"><?php echo $npc['working'] ? 'Working' : 'Idle'; ?></td><?php
 				} ?>


### PR DESCRIPTION
This PHP trait is used to implement the interface for any class that
needs to have a `$raceID` property. It provides the `getRaceID` and
`getRaceName` methods.

Additional notes:

1. This fixes a bug in smr_file_create.php, where `getRaceName` was
   being called on an `SmrWeaponType`, which did not implement this
   method. By inheriting the RaceID trait, it now has access to the
   `getRaceName` method.

2. Moved the RaceID trait from AbstractSmrCombatWeapon to SmrWeapon,
   since the abstract class doesn't need to know about race (the other
   classes extending AbstractSmrCombatWeapon don't have a notion of
   race, e.g. SmrScoutDrone, SmrCombatDrone, etc.).