### PR TITLE
Remove unused break statements

### DIFF
--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -2508,10 +2508,8 @@ abstract class AbstractSmrPlayer {
 			case 'NONE':
 			case 'LOW':
 				return 'red';
-			break;
 			case 'MEDIUM':
 				return 'yellow';
-			break;
 			default:
 				return 'green';
 		}

--- a/lib/Default/ChessPiece.class.php
+++ b/lib/Default/ChessPiece.class.php
@@ -266,27 +266,21 @@ class ChessPiece {
 			case 'k':
 			case 'K':
 				return self::KING;
-			break;
 			case 'q':
 			case 'Q':
 				return self::QUEEN;
-			break;
 			case 'r':
 			case 'R':
 				return self::ROOK;
-			break;
 			case 'b':
 			case 'B':
 				return self::BISHOP;
-			break;
 			case 'n':
 			case 'N':
 				return self::KNIGHT;
-			break;
 			case 'p':
 			case 'P':
 				return self::PAWN;
-			break;
 		}
 	}
 }


### PR DESCRIPTION
A `switch` construct that uses `return` in a case does not need to
also `break` (since it will never be executed). As the `break` is
unused code, it can be safely removed.

This was identified by Scrutinizer.