### PR TITLE
weapon_list.php: add locations where weapons are sold

### DIFF
--- a/htdocs/js/filter_list.js
+++ b/htdocs/js/filter_list.js
@@ -14,7 +14,7 @@ function filterSelect(element) {
 	var selected = element.options[element.selectedIndex].value;
 	var columnId = element.parentElement.cellIndex;
 
-	filter[columnId] = selected;
+	filter[columnId] = [selected];
 	applyFilter('data-list');
 }
 
@@ -37,16 +37,20 @@ function applyFilter(tableId) {
 		for (var j=0; j < table.rows[i].cells.length; j++) {
 			// No filtering for null, undefined, and "All".
 			// But we do filter on the empty string (for the "None" option).
-			if (filter[j] == null || filter[j] === "All") {
+			if (filter[j] == null || filter[j][0] === "All") {
 				continue;
 			}
-			if (Array.isArray(filter[j])) {
-				if (filter[j].indexOf(table.rows[i].cells[j].textContent) === -1) {
+			var cell = table.rows[i].cells[j];
+			if (cell.className == "locs") {
+				// At least one of the (line-break delimited) Locations must
+				// match the filter (there will be only one filter).
+				if (cell.innerHTML.split('<br>').indexOf(filter[j][0]) === -1) {
 					show = false;
 					break;
 				}
 			} else {
-				if (table.rows[i].cells[j].textContent != filter[j]) {
+				// The cell content must match exactly at least one filter.
+				if (filter[j].indexOf(cell.textContent) === -1) {
 					show = false;
 					break;
 				}

--- a/htdocs/weapon_list.php
+++ b/htdocs/weapon_list.php
@@ -4,6 +4,20 @@ try {
 
 	$template = new Template();
 
+	// Get a list of all the shops that sell each weapon
+	$weaponLocs = [];
+	$db = new SmrMySqlDatabase();
+	$db->query('SELECT weapon_type_id, location_type.* FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) JOIN location_type USING (location_type_id) WHERE location_type_id != ' . $db->escapeNumber(RACE_WARS_WEAPONS));
+	while ($db->nextRecord()) {
+		$weaponLocs[$db->getInt('weapon_type_id')][] = SmrLocation::getLocation($db->getInt('location_type_id'), false, $db)->getName();
+	}
+
+	// Get a list of all locations that sell weapons
+	$allLocs = array_unique(array_merge(...$weaponLocs));
+	sort($allLocs);
+	$template->assign('AllLocs', $allLocs);
+
+	// Get all the properties to display for each weapon
 	$weapons = [];
 	foreach (SmrWeaponType::getAllWeaponTypes() as $weapon) {
 		switch ($weapon->getBuyerRestriction()) {
@@ -35,6 +49,7 @@ try {
 			'armour_damage' => $weapon->getArmourDamage(),
 			'accuracy' => $weapon->getAccuracy(),
 			'power_level' => $weapon->getPowerLevel(),
+			'locs' => $weaponLocs[$weapon->getWeaponTypeID()] ?? [],
 		];
 	}
 	$template->assign('Weapons', $weapons);

--- a/templates/Default/weapon_list.php
+++ b/templates/Default/weapon_list.php
@@ -75,6 +75,15 @@
 								<option style="color: #06F;">Newbie</option>
 							</select>
 						</th>
+						<th>
+							Locations<br />
+							<select onchange="filterSelect(this)">
+								<option>All</option><?php
+								foreach ($AllLocs as $Loc) { ?>
+									<option><?php echo $Loc; ?></option><?php
+								} ?>
+							</select>
+						</th>
 					</tr>
 				</thead>
 				<tbody class="list"><?php
@@ -88,6 +97,7 @@
 							<td class="accuracy"><?php echo $weapon['accuracy']; ?></td>
 							<td class="level"><?php echo $weapon['power_level']; ?></td>
 							<td class="restriction"><?php echo $weapon['restriction']; ?></td>
+							<td class="locs"><?php echo join('<br />', $weapon['locs']); ?></td>
 						</tr><?php
 					} ?>
 				</tbody>


### PR DESCRIPTION
The Weapon List page now displays a "Locations" column that lists
all the shops where each weapon is sold.

This was requested as a result of the Enhanced Weapons feature,
since it will be very helpful to know what weapons are sold at
each shop.

Note that we sacrifice a bit of visual conformity (equal height
rows) to support this feature.

![image](https://user-images.githubusercontent.com/846186/94763054-1fc8e200-035e-11eb-95d7-6319ddc5f510.png)
