### PR TITLE
Fix chess board from black's perspective

### DIFF
--- a/engine/Default/chess_play.php
+++ b/engine/Default/chess_play.php
@@ -1,5 +1,24 @@
 <?php declare(strict_types=1);
 
+$chessGame = ChessGame::getChessGame($var['ChessGameID']);
+$template->assign('ChessGame', $chessGame);
+
+// Board orientation depends on the player's color.
+$playerIsWhite = $chessGame->getWhiteID() == $player->getAccountID();
+if ($playerIsWhite) {
+	$board = $chessGame->getBoard();
+} else {
+	$board = $chessGame->getBoardReversed();
+}
+$template->assign('Board', $board);
+
+// File coordinates depend on the player's color.
+// (So do row coordinates, but these are reversed automatically.)
+$fileCoords = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+if (!$playerIsWhite) {
+	$fileCoords = array_reverse($fileCoords);
+}
+$template->assign('FileCoords', $fileCoords);
+
 $template->assign('MoveMessage', $var['MoveMessage'] ?? '');
-$template->assign('ChessGame', ChessGame::getChessGame($var['ChessGameID']));
 $template->assign('ChessMoveHREF', SmrSession::getNewHREF(create_container('chess_move_processing.php', '', array('AJAX' => true, 'ChessGameID' => $var['ChessGameID']))));

--- a/lib/Default/ChessGame.class.php
+++ b/lib/Default/ChessGame.class.php
@@ -171,6 +171,18 @@ class ChessGame {
 		return $this->board;
 	}
 
+	/**
+	 * Get the board from black's perspective
+	 */
+	public function getBoardReversed() : array {
+		// Need to reverse both the rows and the files to rotate the board
+		$board = array_reverse($this->getBoard(), true);
+		foreach ($board as $key => $row) {
+			$board[$key] = array_reverse($row, true);
+		}
+		return $board;
+	}
+
 	public function getLastMove() {
 		$this->getMoves();
 		return $this->lastMove;

--- a/templates/Default/engine/Default/chess_play.php
+++ b/templates/Default/engine/Default/chess_play.php
@@ -7,14 +7,6 @@
 			<div style="height: 500px; width: 500px;">
 				<table class="chess chessFont">
 					<td class="chessOutline">&nbsp;</td><?php
-					for ($X = ord('a'); $X <= ord('h'); $X++) { ?>
-						<td class="chessOutline"><?php echo chr($X); ?></td><?php
-					} ?><?php
-					$Board = $ChessGame->getBoard();
-					//If we are the black player then reverse the board
-					if ($ChessGame->getBlackID() == $ThisPlayer->getAccountID()) {
-						$Board = array_reverse($Board, true);
-					}
 					foreach ($Board as $Y => $Row) { ?>
 						<tr>
 							<td class="chessOutline"><?php echo 8 - $Y; ?></td><?php
@@ -23,12 +15,11 @@
 									if ($Cell == null) { ?>&nbsp;<?php } else { ?><span class="pointer"><?php echo $Cell->getPieceSymbol(); ?></span><?php } ?>
 								</td><?php
 							} ?>
-							<td class="chessOutline"><?php echo 8 - $Y; ?></td>
 						</tr><?php
 					}?>
 					<td class="chessOutline">&nbsp;</td><?php
-					for ($X = ord('a'); $X <= ord('h'); $X++) { ?>
-						<td class="chessOutline"><?php echo chr($X); ?></td><?php
+					foreach ($FileCoords as $FileCoord) { ?>
+						<td class="chessOutline"><?php echo $FileCoord; ?></td><?php
 					} ?>
 				</table>
 			</div>


### PR DESCRIPTION
The board has never displayed correctly from black's perspective,
because while the rows were correctly reversed, the files were
not (so the board was mirrored, not rotated).

Also display the coordinates on only the bottom and left, rather
than all sides (as in regulation boards).

![image](https://user-images.githubusercontent.com/846186/94776390-7fcb8280-0376-11eb-8985-c2bb7b81893e.png)
