### PR TITLE
Use SmrPlayer::getSQL when possible

### DIFF
--- a/admin/Default/account_edit_processing.php
+++ b/admin/Default/account_edit_processing.php
@@ -146,15 +146,17 @@ if (!empty($delete)) {
 				$actions[] = 'player has made alliance transaction';
 				continue;
 			}
+
+			$sql = 'account_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id);
+
 			// Check anon accounts for transactions
-			$db->query('SELECT * FROM anon_bank_transactions WHERE account_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id) . ' LIMIT 1');
+			$db->query('SELECT * FROM anon_bank_transactions WHERE ' . $sql . ' LIMIT 1');
 			if ($db->getNumRows() != 0) {
 				// Can't delete
 				$actions[] = 'player has made anonymous transaction';
 				continue;
 			}
 
-			$sql = 'account_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id);
 			$db->query('DELETE FROM alliance_thread
 						WHERE sender_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id));
 			$db->query('DELETE FROM bounty WHERE ' . $sql);

--- a/admin/Default/manage_draft_leaders_processing.php
+++ b/admin/Default/manage_draft_leaders_processing.php
@@ -33,7 +33,7 @@ if ($action == "Assign") {
 	if (!$selectedPlayer->isDraftLeader()) {
 		$msg = "<span class='red'>ERROR: </span>$name is not a draft leader in game $game!";
 	} else {
-		$db->query('DELETE FROM draft_leaders WHERE account_id=' . $db->escapeNumber($accountId) . ' AND game_id=' . $db->escapeNumber($gameId));
+		$db->query('DELETE FROM draft_leaders WHERE ' . $selectedPlayer->getSQL());
 	}
 } else {
 	$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";

--- a/admin/Default/manage_post_editors_processing.php
+++ b/admin/Default/manage_post_editors_processing.php
@@ -32,7 +32,7 @@ if ($action == "Assign") {
 	if (!$selected_player->isGPEditor()) {
 		$msg = "<span class='red'>ERROR: </span>$name is not an editor in game $game!";
 	} else {
-		$db->query('DELETE FROM galactic_post_writer WHERE account_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id));
+		$db->query('DELETE FROM galactic_post_writer WHERE ' . $selected_player->getSQL());
 	}
 } else {
 	$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";

--- a/engine/Default/alliance_leadership_processing.php
+++ b/engine/Default/alliance_leadership_processing.php
@@ -5,7 +5,7 @@ $alliance = $player->getAlliance();
 $alliance->setLeaderID($leader_id);
 $alliance->update();
 
-$db->query('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ' WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
+$db->query('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ' WHERE ' . $player->getSQL() . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
 $db->query('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ' WHERE account_id = ' . $db->escapeNumber($leader_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
 
 // Notify the new leader

--- a/engine/Default/alliance_message.php
+++ b/engine/Default/alliance_message.php
@@ -55,8 +55,7 @@ if ($db->getNumRows() > 0) {
 		
 		$db2->query('SELECT time
 					FROM player_read_thread 
-					WHERE account_id=' . $db2->escapeNumber($player->getAccountID()) . '
-					AND game_id=' . $db2->escapeNumber($player->getGameID()) . '
+					WHERE ' . $player->getSQL() . '
 					AND alliance_id =' . $db2->escapeNumber($alliance->getAllianceID()) . '
 					AND thread_id=' . $db2->escapeNumber($threadID) . '
 					AND time>' . $db2->escapeNumber($db->getInt('sendtime')) . ' LIMIT 1');
@@ -80,7 +79,7 @@ if ($db->getNumRows() > 0) {
 		}
 		$threads[$i]['Sender'] = $playerName;
 
-		$db2->query('SELECT * FROM player_has_alliance_role JOIN alliance_has_roles USING(game_id,alliance_id,role_id) WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . ' LIMIT 1');
+		$db2->query('SELECT * FROM player_has_alliance_role JOIN alliance_has_roles USING(game_id,alliance_id,role_id) WHERE ' . $player->getSQL() . ' AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . ' LIMIT 1');
 		$db2->nextRecord();
 		$threads[$i]['CanDelete'] = $player->getAccountID() == $sender_id || $db2->getBoolean('mb_messages');
 		if ($threads[$i]['CanDelete']) {

--- a/engine/Default/alliance_message_view.php
+++ b/engine/Default/alliance_message_view.php
@@ -53,7 +53,7 @@ while ($db->nextRecord()) {
 	$players[$db->getInt('account_id')] = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID())->getLinkedDisplayName(false);
 }
 
-$db->query('SELECT mb_messages FROM player_has_alliance_role JOIN alliance_has_roles USING(game_id,alliance_id,role_id) WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . ' LIMIT 1');
+$db->query('SELECT mb_messages FROM player_has_alliance_role JOIN alliance_has_roles USING(game_id,alliance_id,role_id) WHERE ' . $player->getSQL() . ' AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . ' LIMIT 1');
 $db->requireRecord();
 $thread['CanDelete'] = $db->getBoolean('mb_messages');
 

--- a/engine/Default/alliance_mod.php
+++ b/engine/Default/alliance_mod.php
@@ -19,7 +19,7 @@ if ($db->nextRecord()) {
 
 	// Has player responded yet?
 	$db2 = new SmrMySqlDatabase();
-	$db2->query('SELECT response FROM alliance_has_op_response WHERE alliance_id=' . $db2->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db2->escapeNumber($player->getGameID()) . ' AND account_id=' . $db2->escapeNumber($player->getAccountID()) . ' LIMIT 1');
+	$db2->query('SELECT response FROM alliance_has_op_response WHERE alliance_id=' . $db2->escapeNumber($player->getAllianceID()) . ' AND ' . $player->getSQL() . ' LIMIT 1');
 
 	$response = $db2->nextRecord() ? $db2->getField('response') : null;
 	$responseHREF = SmrSession::getNewHREF(create_container('alliance_op_response_processing.php'));

--- a/engine/Default/alliance_share_maps_processing.php
+++ b/engine/Default/alliance_share_maps_processing.php
@@ -20,10 +20,7 @@ if (empty($alliance_ids)) {
 $unvisitedSectors = array(0);
 
 // get the sectors the user hasn't visited yet
-$db->query('SELECT sector_id
-			FROM player_visited_sector
-			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-				AND account_id = ' . $db->escapeNumber($player->getAccountID()));
+$db->query('SELECT sector_id FROM player_visited_sector WHERE ' . $player->getSQL());
 while ($db->nextRecord()) {
 	$unvisitedSectors[] = $db->getInt('sector_id');
 }
@@ -39,10 +36,7 @@ $db->query('DELETE
 unset($unvisitedSectors);
 
 // get a list of all visited ports
-$db->query('SELECT sector_id
-			FROM player_visited_port
-			WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-				AND game_id = ' . $db->escapeNumber($player->getGameID()));
+$db->query('SELECT sector_id FROM player_visited_port WHERE ' . $player->getSQL());
 while ($db->nextRecord()) {
 	$cachedPort = SmrPort::getCachedPort($player->getGameID(), $db->getInt('sector_id'), $player->getAccountID());
 	$cachedPort->addCachePorts($alliance_ids);

--- a/engine/Default/bar_buy_drink_processing.php
+++ b/engine/Default/bar_buy_drink_processing.php
@@ -10,7 +10,7 @@ $player->decreaseCredits(10);
 if (isset($var['action']) && $var['action'] != 'drink') {
 	$drinkName = 'water';
 	$message .= 'You ask the bartender for some water and you quickly down it.<br />You don\'t feel quite so intoxicated anymore.<br />';
-	$db->query('DELETE FROM player_has_drinks WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND account_id=' . $db->escapeNumber($player->getAccountID()) . ' LIMIT 1');
+	$db->query('DELETE FROM player_has_drinks WHERE ' . $player->getSQL() . ' LIMIT 1');
 	$player->increaseHOF(1, array('Bar', 'Drinks', 'Water'), HOF_PUBLIC);
 } else {
 	$random = mt_rand(1, 20);
@@ -58,7 +58,7 @@ if (isset($var['action']) && $var['action'] != 'drink') {
 		}
 
 	}
-	$db->query('SELECT count(*) FROM player_has_drinks WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND account_id=' . $db->escapeNumber($player->getAccountID()));
+	$db->query('SELECT count(*) FROM player_has_drinks WHERE ' . $player->getSQL());
 	$db->requireRecord();
 	$num_drinks = $db->getInt('count(*)');
 	//display woozy message
@@ -81,7 +81,7 @@ if (isset($num_drinks) && $num_drinks > 15) {
 	$player->increaseHOF(1, array('Bar', 'Robbed', 'Number Of Times'), HOF_PUBLIC);
 	$player->increaseHOF($lostCredits, array('Bar', 'Robbed', 'Money Lost'), HOF_PUBLIC);
 
-	$db->query('DELETE FROM player_has_drinks WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND account_id=' . $db->escapeNumber($player->getAccountID()));
+	$db->query('DELETE FROM player_has_drinks WHERE ' . $player->getSQL());
 
 }
 $player->increaseHOF(1, array('Bar', 'Drinks', 'Total'), HOF_PUBLIC);

--- a/engine/Default/bar_galmap_buy.php
+++ b/engine/Default/bar_galmap_buy.php
@@ -20,7 +20,7 @@ if (isset($var['process'])) {
 	$high = $galaxy->getEndSector();
 
 	// Have they already got this map? (Are there any unexplored sectors?
-	$db->query('SELECT * FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' LIMIT 1');
+	$db->query('SELECT * FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND ' . $player->getSQL() . ' LIMIT 1');
 	if (!$db->nextRecord()) {
 		create_error('You already have maps of this galaxy!');
 	}
@@ -31,7 +31,7 @@ if (isset($var['process'])) {
 	//now give maps
 	
 	// delete all entries from the player_visited_sector/port table
-	$db->query('DELETE FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->query('DELETE FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND ' . $player->getSQL());
 	//start section
 	
 	// add port infos

--- a/engine/Default/bar_lotto_buy_processing.php
+++ b/engine/Default/bar_lotto_buy_processing.php
@@ -19,8 +19,7 @@ $db->query('INSERT INTO player_has_ticket (game_id, account_id, time) VALUES (' 
 $player->decreaseCredits(1000000);
 $player->increaseHOF(1000000, array('Bar', 'Lotto', 'Money', 'Spent'), HOF_PUBLIC);
 $player->increaseHOF(1, array('Bar', 'Lotto', 'Tickets Bought'), HOF_PUBLIC);
-$db->query('SELECT count(*) as num FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-	AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND time > 0 GROUP BY account_id');
+$db->query('SELECT count(*) as num FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0 GROUP BY account_id');
 $db->requireRecord();
 $num = $db->getInt('num');
 $message = ('<div class="center">Thanks for your purchase and good luck!  You currently');

--- a/engine/Default/bar_lotto_claim.php
+++ b/engine/Default/bar_lotto_claim.php
@@ -2,8 +2,7 @@
 
 $message = '';
 //check if we really are a winner
-$db->query('SELECT * FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-			AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND time = 0');
+$db->query('SELECT * FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
 if ($db->nextRecord()) {
 	$prize = $db->getInt('prize');
 	$NHLAmount = ($prize - 1000000) / 9;
@@ -12,8 +11,7 @@ if ($db->nextRecord()) {
 	$player->increaseHOF($prize, array('Bar', 'Lotto', 'Money', 'Claimed'), HOF_PUBLIC);
 	$player->increaseHOF(1, array('Bar', 'Lotto', 'Results', 'Claims'), HOF_PUBLIC);
 	$message .= '<div class="center">You have claimed <span class="red">$' . number_format($prize) . '</span>!<br /></div><br />';
-	$db->query('DELETE FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-				AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND prize = ' . $db->escapeNumber($prize) . ' AND time = 0 LIMIT 1');
+	$db->query('DELETE FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND prize = ' . $db->escapeNumber($prize) . ' AND time = 0 LIMIT 1');
 	$db->query('DELETE FROM news WHERE type = \'lotto\' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 }
 //offer another drink and such

--- a/engine/Default/bar_main.php
+++ b/engine/Default/bar_main.php
@@ -19,7 +19,7 @@ if (isset($var['message'])) {
 
 $winningTicket = false;
 //check for winner
-$db->query('SELECT prize FROM player_has_ticket WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND time = 0 LIMIT 1');
+$db->query('SELECT prize FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0 LIMIT 1');
 if ($db->nextRecord()) {
 	$winningTicket = $db->getInt('prize');
 

--- a/engine/Default/beta_func_processing.php
+++ b/engine/Default/beta_func_processing.php
@@ -4,7 +4,7 @@ if ($var['func'] == 'Map') {
 	$account_id = $player->getAccountID();
 	$game_id = $player->getGameID();
 	// delete all entries from the player_visited_sector/port table
-	$db->query('DELETE FROM player_visited_sector WHERE account_id = ' . $db->escapeNumber($account_id) . ' AND game_id = ' . $db->escapeNumber($game_id));
+	$db->query('DELETE FROM player_visited_sector WHERE ' . $player->getSQL());
 
 	// add port infos
 	$db->query('SELECT * FROM port WHERE game_id = ' . $db->escapeNumber($game_id));

--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -28,7 +28,7 @@ $links['Warp'] = array('ID'=>$sector->getWarp());
 
 $unvisited = array();
 
-$db->query('SELECT sector_id FROM player_visited_sector WHERE sector_id IN (' . $db->escapeArray($links) . ') AND account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
+$db->query('SELECT sector_id FROM player_visited_sector WHERE sector_id IN (' . $db->escapeArray($links) . ') AND ' . $player->getSQL());
 while ($db->nextRecord()) {
 	$unvisited[$db->getInt('sector_id')] = TRUE;
 }
@@ -99,10 +99,10 @@ if (!empty($protectionMessage)) {
 
 //enableProtectionDependantRefresh($template,$player);
 
-$db->query('SELECT * FROM sector_message WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+$db->query('SELECT * FROM sector_message WHERE ' . $player->getSQL());
 if ($db->nextRecord()) {
 	$msg = $db->getField('message');
-	$db->query('DELETE FROM sector_message WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->query('DELETE FROM sector_message WHERE ' . $player->getSQL());
 	checkForForceRefreshMessage($msg);
 	checkForAttackMessage($msg);
 }

--- a/engine/Default/message_blacklist_add.php
+++ b/engine/Default/message_blacklist_add.php
@@ -13,7 +13,7 @@ if (isset($var['account_id'])) {
 	}
 }
 
-$db->query('SELECT account_id FROM message_blacklist WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND blacklisted_id=' . $db->escapeNumber($blacklisted->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' LIMIT 1');
+$db->query('SELECT account_id FROM message_blacklist WHERE ' . $player->getSQL() . ' AND blacklisted_id=' . $db->escapeNumber($blacklisted->getAccountID()) . ' LIMIT 1');
 
 if ($db->nextRecord()) {
 	$container['msg'] = '<span class="red bold">ERROR: </span>Player is already blacklisted.';

--- a/engine/Default/message_view.php
+++ b/engine/Default/message_view.php
@@ -86,7 +86,7 @@ if ($var['folder_id'] == MSG_SCOUT && !isset($var['show_all']) && $messageBox['T
 }
 if (!USING_AJAX) {
 	$db->query('UPDATE message SET msg_read = \'TRUE\'
-				WHERE message_type_id = ' . $db->escapeNumber($var['folder_id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id = ' . $db->escapeNumber($player->getAccountID()));
+				WHERE message_type_id = ' . $db->escapeNumber($var['folder_id']) . ' AND ' . $player->getSQL());
 }
 $template->assign('MessageBox', $messageBox);
 

--- a/engine/Default/trader_savings.php
+++ b/engine/Default/trader_savings.php
@@ -19,7 +19,7 @@ checkForLottoWinner($player->getGameID());
 $template->assign('LottoInfo', getLottoInfo($player->getGameID()));
 
 // Number of active lotto tickets this player has
-$db->query('SELECT count(*) FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND time > 0');
+$db->query('SELECT count(*) FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0');
 $db->requireRecord();
 $tickets = $db->getInt('count(*)');
 $template->assign('LottoTickets', $tickets);
@@ -36,6 +36,6 @@ if ($tickets == 0) {
 $template->assign('LottoWinChance', $win_chance);
 
 // Number of winning lotto tickets this player has to claim
-$db->query('SELECT count(*) FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND time = 0');
+$db->query('SELECT count(*) FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
 $db->requireRecord();
 $template->assign('WinningTickets', $db->getInt('count(*)'));

--- a/engine/Default/trader_status.php
+++ b/engine/Default/trader_status.php
@@ -62,7 +62,7 @@ $container = create_container('note_delete_processing.php');
 $template->assign('NoteDeleteHREF', SmrSession::getNewHREF($container));
 
 $notes = [];
-$db->query('SELECT * FROM player_has_notes WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND account_id=' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY note_id DESC');
+$db->query('SELECT * FROM player_has_notes WHERE ' . $player->getSQL() . ' ORDER BY note_id DESC');
 while ($db->nextRecord()) {
 	$notes[$db->getInt('note_id')] = $db->getField('note');
 }

--- a/lib/Default/smr.inc
+++ b/lib/Default/smr.inc
@@ -659,7 +659,7 @@ function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account, $v
 
 
 	if (SmrSession::hasGame()) {
-		$db->query('SELECT message_type_id,COUNT(*) FROM player_has_unread_messages WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' GROUP BY message_type_id');
+		$db->query('SELECT message_type_id,COUNT(*) FROM player_has_unread_messages WHERE ' . $player->getSQL() . ' GROUP BY message_type_id');
 
 		if ($db->getNumRows()) {
 			$messages = array();

--- a/tools/chat_helpers/channel_msg_op_info.php
+++ b/tools/chat_helpers/channel_msg_op_info.php
@@ -18,7 +18,7 @@ function shared_channel_msg_op_info($player) {
 	$getOpInfoMessage = function($player) use ($opTime) {
 		// have we signed up?
 		$db = new SmrMySqlDatabase();
-		$db->query('SELECT response FROM alliance_has_op_response WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id = ' . $db->escapeNumber($player->getAccountID()));
+		$db->query('SELECT response FROM alliance_has_op_response WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND ' . $player->getSQL());
 		if ($db->nextRecord()) {
 			$msg = $player->getPlayerName() . ' is on the ' . $db->getField('response') . ' list.';
 		} else {


### PR DESCRIPTION
This visually shortens many queries that have both an `account_id`
and `game_id` in the `WHERE` clause, and also makes the query more
or less agnostic to what columns make an SmrPlayer unique.