### PR TITLE
Improve design for switching between databases

### DIFF
--- a/config/SmrMySqlSecrets.sample.inc
+++ b/config/SmrMySqlSecrets.sample.inc
@@ -8,8 +8,4 @@ trait SmrMySqlSecrets {
 	// Set to null to use defaults
 	private static $port = null;
 	private static $socket = null;
-
-	// Uncomment if using history databases
-	//protected static $dbName_Smr12History = 'smr_12_history';
-	//protected static $dbName_SmrClassicHistory = 'smr_classic_history';
 }

--- a/config/config.specific.sample.php
+++ b/config/config.specific.sample.php
@@ -26,6 +26,6 @@ const BUG_REPORT_TO_ADDRESSES = [];
 
 //const HISTORY_DATABASES =
 //	array(
-//		'SmrClassicHistoryMySqlDatabase' => 'old_account_id',
-//		'Smr12HistoryMySqlDatabase' => 'old_account_id2',
+//		'smr_classic_history' => 'old_account_id',
+//		'smr_12_history' => 'old_account_id2',
 //	);

--- a/engine/Default/game_play.php
+++ b/engine/Default/game_play.php
@@ -147,25 +147,25 @@ if ($db->getNumRows()) {
 	}
 }
 
-foreach (Globals::getHistoryDatabases() as $databaseClassName => $oldColumn) {
+foreach (Globals::getHistoryDatabases() as $databaseName => $oldColumn) {
 	//Old previous games
-	$historyDB = new $databaseClassName();
-	$historyDB->query('SELECT start_date, end_date, game_name, type, speed, game_id
+	$db->switchDatabases($databaseName);
+	$db->query('SELECT start_date, end_date, game_name, type, speed, game_id
 						FROM game ORDER BY game_id DESC');
-	if ($historyDB->getNumRows()) {
-		while ($historyDB->nextRecord()) {
-			$game_id = $historyDB->getInt('game_id');
-			$index = $databaseClassName . $game_id;
+	if ($db->getNumRows()) {
+		while ($db->nextRecord()) {
+			$game_id = $db->getInt('game_id');
+			$index = $databaseName . $game_id;
 			$games['Previous'][$index]['ID'] = $game_id;
-			$games['Previous'][$index]['Name'] = $historyDB->getField('game_name');
-			$games['Previous'][$index]['StartDate'] = date(DATE_DATE_SHORT, $historyDB->getInt('start_date'));
-			$games['Previous'][$index]['EndDate'] = date(DATE_DATE_SHORT, $historyDB->getInt('end_date'));
-			$games['Previous'][$index]['Type'] = $historyDB->getField('type');
-			$games['Previous'][$index]['Speed'] = $historyDB->getFloat('speed');
+			$games['Previous'][$index]['Name'] = $db->getField('game_name');
+			$games['Previous'][$index]['StartDate'] = date(DATE_DATE_SHORT, $db->getInt('start_date'));
+			$games['Previous'][$index]['EndDate'] = date(DATE_DATE_SHORT, $db->getInt('end_date'));
+			$games['Previous'][$index]['Type'] = $db->getField('type');
+			$games['Previous'][$index]['Speed'] = $db->getFloat('speed');
 			// create a container that will hold next url and additional variables.
 			$container = create_container('skeleton.php');
 			$container['view_game_id'] = $game_id;
-			$container['HistoryDatabase'] = $databaseClassName;
+			$container['HistoryDatabase'] = $databaseName;
 			$container['game_name'] = $games['Previous'][$index]['Name'];
 
 			$container['body'] = 'history_games.php';
@@ -179,7 +179,7 @@ foreach (Globals::getHistoryDatabases() as $databaseClassName => $oldColumn) {
 		}
 	}
 }
-$db = new SmrMySqlDatabase(); // restore database
+$db->switchDatabaseToLive(); // restore database
 
 $template->assign('Games', $games);
 

--- a/engine/Default/history_alliance_detail.php
+++ b/engine/Default/history_alliance_detail.php
@@ -9,7 +9,7 @@ $template->assign('BackHREF', SmrSession::getNewHREF($container));
 
 $game_id = $var['view_game_id'];
 $id = $var['alliance_id'];
-$db = new $var['HistoryDatabase']();
+$db->switchDatabases($var['HistoryDatabase']);
 $db->query('SELECT * FROM alliance WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($game_id));
 $db->requireRecord();
 $template->assign('PageTopic', 'Alliance Roster - ' . htmlentities($db->getField('alliance_name')));
@@ -32,4 +32,4 @@ while ($db->nextRecord()) {
 }
 $template->assign('Players', $players);
 
-$db = new SmrMySqlDatabase();
+$db->switchDatabaseToLive(); // restore database

--- a/engine/Default/history_games.php
+++ b/engine/Default/history_games.php
@@ -9,7 +9,7 @@ $game_id = $var['view_game_id'];
 $template->assign('PageTopic', 'Old SMR Game : ' . $game_name);
 Menu::history_games(0);
 
-$db = new $var['HistoryDatabase']();
+$db->switchDatabases($var['HistoryDatabase']);
 $db->query('SELECT start_date, type, end_date, game_name, speed, game_id ' .
            'FROM game WHERE game_id = ' . $db->escapeNumber($game_id));
 $db->requireRecord();
@@ -93,5 +93,4 @@ while ($db->nextRecord()) {
 }
 $template->assign('AllianceKills', $allianceKills);
 
-//to stop errors on the following scripts
-$db = new SmrMySqlDatabase();
+$db->switchDatabaseToLive(); // restore database

--- a/engine/Default/history_games_detail.php
+++ b/engine/Default/history_games_detail.php
@@ -28,7 +28,7 @@ if (!empty($action)) {
 	$template->assign('Description', $dis);
 
 	$rankings = [];
-	$db = new $var['HistoryDatabase']();
+	$db->switchDatabases($var['HistoryDatabase']);
 	if ($from != 'alliance') {
 		$template->assign('Name', 'Sector ID');
 		$db->query('SELECT ' . $sql . ' as val, sector_id FROM ' . $from . ' WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY val DESC LIMIT 25');
@@ -56,4 +56,4 @@ if (!empty($action)) {
 	$template->assign('Rankings', $rankings);
 }
 
-$db = new SmrMySqlDatabase();
+$db->switchDatabaseToLive(); // restore database

--- a/engine/Default/history_games_hof.php
+++ b/engine/Default/history_games_hof.php
@@ -2,7 +2,7 @@
 
 // NOTE: this is only for history database games
 
-$db = new $var['HistoryDatabase']();
+$db->switchDatabases($var['HistoryDatabase']);
 
 $template->assign('PageTopic', 'Hall of Fame : ' . $var['game_name']);
 Menu::history_games(2);
@@ -45,4 +45,4 @@ if (!isset($var['stat'])) {
 	$template->assign('Rankings', $rankings);
 }
 
-$db = new SmrMySqlDatabase();
+$db->switchDatabaseToLive(); // restore database

--- a/engine/Default/history_games_news.php
+++ b/engine/Default/history_games_news.php
@@ -18,7 +18,7 @@ $template->assign('Min', $min);
 
 $template->assign('ShowHREF', SmrSession::getNewHREF($var));
 
-$db = new $var['HistoryDatabase']();
+$db->switchDatabases($var['HistoryDatabase']);
 $db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($var['view_game_id']) . ' AND news_id >= ' . $db->escapeNumber($min) . ' AND news_id <= ' . $db->escapeNumber($max));
 $rows = [];
 while ($db->nextRecord()) {
@@ -29,4 +29,4 @@ while ($db->nextRecord()) {
 }
 $template->assign('Rows', $rows);
 
-$db = new SmrMySqlDatabase();
+$db->switchDatabaseToLive(); // restore database

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -619,19 +619,11 @@ abstract class AbstractSmrAccount {
 		return $this->account_id;
 	}
 
-	public function getOldAccountIDs() {
-		return $this->oldAccountIDs;
-	}
-
+	/**
+	 * Return the ID associated with this account in the given history database.
+	 */
 	public function getOldAccountID($dbName) {
 		return $this->oldAccountIDs[$dbName] ?? 0;
-	}
-
-	public function hasOldAccountID($dbName = false) {
-		if ($dbName === false) {
-			return count($this->getOldAccountIDs()) != 0;
-		}
-		return $this->getOldAccountID($dbName) != 0;
 	}
 
 	public function getLogin() {

--- a/lib/Default/Globals.class.php
+++ b/lib/Default/Globals.class.php
@@ -535,8 +535,8 @@ class Globals {
 
 	/**
 	 * Returns an array of history databases for which we have ancient saved
-	 * game data. Array keys are database class names and values are the
-	 * columns in the `account` table with the linked historical account ID's.
+	 * game data. Array keys are database names and values are the columns in
+	 * the `account` table with the linked historical account ID's.
 	 */
 	public static function getHistoryDatabases() {
 		if (defined('HISTORY_DATABASES')) {

--- a/lib/Default/MySqlDatabase.class.php
+++ b/lib/Default/MySqlDatabase.class.php
@@ -10,7 +10,7 @@ abstract class MySqlDatabase {
 	protected $dbResult = null;
 	protected $dbRecord = null;
 
-	public function __construct($dbName) {
+	public function __construct() {
 		if (!self::$dbConn) {
 			// Set the mysqli driver to raise exceptions on errors
 			if (!mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT)) {
@@ -31,8 +31,8 @@ abstract class MySqlDatabase {
 			}
 
 			self::$dbConn = new mysqli($host, $user, $password,
-				$dbName, $port, self::$socket);
-			self::$selectedDbName = $dbName;
+				self::$databaseName, $port, self::$socket);
+			self::$selectedDbName = self::$databaseName;
 
 			// Default server charset should be set correctly. Using the default
 			// avoids the additional query involved in `set_charset`.
@@ -41,12 +41,24 @@ abstract class MySqlDatabase {
 				$this->error('Unexpected charset: ' . $charset);
 			}
 		}
+	}
 
-		// Do we need to switch databases (e.g. for compatability db access)?
-		if (self::$selectedDbName != $dbName) {
-			self::$dbConn->select_db($dbName);
-			self::$selectedDbName = $dbName;
-		}
+	/**
+	 * This method will switch the connection to the specified database.
+	 * Useful for switching back and forth between historical, and live databases.
+	 *
+	 * @param string $databaseName The name of the database to switch to
+	 */
+	public function switchDatabases(string $databaseName) {
+		self::$dbConn->select_db($databaseName);
+		self::$selectedDbName = $databaseName;
+	}
+
+	/**
+	 * Switch back to the configured live database
+	 */
+	public function switchDatabaseToLive() {
+		$this->switchDatabases(self::$databaseName);
 	}
 
 	/**

--- a/lib/Default/Smr12HistoryMySqlDatabase.class.php
+++ b/lib/Default/Smr12HistoryMySqlDatabase.class.php
@@ -1,7 +1,0 @@
-<?php declare(strict_types=1);
-
-class Smr12HistoryMySqlDatabase extends MySqlDatabase {
-	public function __construct() {
-		parent::__construct(self::$dbName_Smr12History);
-	}
-}

--- a/lib/Default/SmrClassicHistoryMySqlDatabase.class.php
+++ b/lib/Default/SmrClassicHistoryMySqlDatabase.class.php
@@ -1,7 +1,0 @@
-<?php declare(strict_types=1);
-
-class SmrClassicHistoryMySqlDatabase extends MySqlDatabase {
-	public function __construct() {
-		parent::__construct(self::$dbName_SmrClassicHistory);
-	}
-}


### PR DESCRIPTION
Add the methods `switchDatabases` and `switchDatabaseToLive` to switch
between history and live databases. Updated the config.specific.sample
to reflect that the keys of the global history databases array is the
database name, and not the old abstract implementation class name.

This was refactored out of #915 and finalized separately here.