### PR TITLE
phpunit.xml: track code coverage in all of lib

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
 
     smr-integration-test:
         <<: *smr-common
-        command: /smr/vendor/bin/phpunit test --coverage-clover test/coverage.xml
+        command: /smr/vendor/bin/phpunit test
         volumes:
             - ./config:/smr/config:ro
             - ./test.env:/smr/.env

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,9 +16,9 @@
 	</testsuites>
 	<coverage
 		cacheDirectory=".phpunit.cache/code-coverage"
-		includeUncoveredFiles="false">
+		includeUncoveredFiles="true">
 		<include>
-			<directory suffix=".php">lib/Default</directory>
+			<directory suffix=".php">lib</directory>
 		</include>
 	</coverage>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,5 +20,8 @@
 		<include>
 			<directory suffix=".php">lib</directory>
 		</include>
+		<report>
+			<clover outputFile="test/coverage.xml" />
+		</report>
 	</coverage>
 </phpunit>


### PR DESCRIPTION
We will want to test the entirety of `lib`, so don't restrict the
code coverage reporting to just `lib/Default`.