### PR TITLE
SmrShip: simplify power functions

### DIFF
--- a/lib/Default/AbstractSmrShip.class.php
+++ b/lib/Default/AbstractSmrShip.class.php
@@ -202,10 +202,8 @@ abstract class AbstractSmrShip {
 
 	public function getPowerUsed() {
 		$power = 0;
-		if ($this->getNumWeapons() > 0) {
-			foreach ($this->weapons as $weapon) {
-				$power += $weapon->getPowerLevel();
-			}
+		foreach ($this->weapons as $weapon) {
+			$power += $weapon->getPowerLevel();
 		}
 		return $power;
 	}
@@ -214,8 +212,11 @@ abstract class AbstractSmrShip {
 		return $this->getMaxPower() - $this->getPowerUsed();
 	}
 
-	public function hasRemainingPower() {
-		return $this->getRemainingPower() > 0;
+	/**
+	 * given power level of new weapon, return whether there is enough power available to install it on this ship
+	 */
+	public function checkPowerAvailable($powerLevel) {
+		return $this->getRemainingPower() >= $powerLevel;
 	}
 
 	public function getMaxPower() {
@@ -268,12 +269,10 @@ abstract class AbstractSmrShip {
 
 
 	public function addWeapon(SmrWeapon $weapon) {
-		if ($this->hasOpenWeaponSlots() && $this->hasRemainingPower()) {
-			if ($this->getRemainingPower() >= $weapon->getPowerLevel()) {
-				array_push($this->weapons, $weapon);
-				$this->hasChangedWeapons = true;
-				return $weapon;
-			}
+		if ($this->hasOpenWeaponSlots() && $this->checkPowerAvailable($weapon->getPowerLevel())) {
+			array_push($this->weapons, $weapon);
+			$this->hasChangedWeapons = true;
+			return $weapon;
 		}
 		$return = false;
 		return $return;

--- a/lib/Default/SmrShip.class.php
+++ b/lib/Default/SmrShip.class.php
@@ -160,13 +160,6 @@ class SmrShip extends AbstractSmrShip {
 		$this->getPlayer()->update();
 	}
 	
-	/**
-	 * given power level of new weapon, return whether there is enough power available to install it on this ship
-	 */
-	public function checkPowerAvailable($powerLevel) {
-		return $this->getRemainingPower() >= $powerLevel;
-	}
-	
 	public function isCloaked() {
 		if (!$this->hasCloak()) {
 			return false;


### PR DESCRIPTION
* In `getPowerUsed` no need to check the number of weapons since
  we're looping over the weapons array.

* In `addWeapon`, use the `checkPowerAvailable` function instead
  of duplicating that function's logic.

We no longer need `hasRemainingPower` (unused), and we need to move
the `checkPowerAvailable` function to the abstract class so that it
can be used there.