### PR TITLE
Balance changes for Game 137

### DIFF
--- a/db/patches/V1_6_65_05__revert_lvl5_weapons.sql
+++ b/db/patches/V1_6_65_05__revert_lvl5_weapons.sql
@@ -1,0 +1,3 @@
+-- Revert accuracy of HHG/Nuke back to 35%
+UPDATE weapon_type SET accuracy = 35 WHERE weapon_name = 'Nuke';
+UPDATE weapon_type SET accuracy = 35 WHERE weapon_name = 'Holy Hand Grenade';

--- a/db/patches/V1_6_65_06__update_photon_torpedos.sql
+++ b/db/patches/V1_6_65_06__update_photon_torpedos.sql
@@ -1,0 +1,3 @@
+-- Make HPT a bit stronger than the PT
+UPDATE weapon_type SET armour_damage = 170, accuracy = 43 WHERE weapon_name = 'Human Photon Torpedo';
+UPDATE weapon_type SET accuracy = 41 WHERE weapon_name = 'Photon Torpedo';

--- a/engine/Default/bar_talk_bartender_processing.php
+++ b/engine/Default/bar_talk_bartender_processing.php
@@ -30,20 +30,36 @@ if ($action == 'tell') {
 	$tip = Request::getInt('tip');
 	$player->decreaseCredits($tip);
 	$container['Message'] = '<i>The bartender notices your ' . number_format($tip) . ' credit tip.</i><br /><br />';
+
 	if ($tip > 0.25 * $cost) {
 		$eventSectorID = $event->getSectorID();
 		$eventGalaxy = SmrGalaxy::getGalaxyContaining($player->getGameID(), $eventSectorID);
+
 		if ($player->getSector()->getGalaxy()->equals($eventGalaxy)) {
 			$locationHint = 'Sector ' . Globals::getSectorBBLink($eventSectorID);
 		} else {
 			$locationHint = 'the ' . $eventGalaxy->getName() . ' galaxy';
 		}
+
 		if ($event->getWeapon()->hasBonusDamage() && $event->getWeapon()->hasBonusAccuracy()) {
 			$qualifier = 'very special';
 		} else {
 			$qualifier = 'special';
 		}
-		$container['Message'] .= 'Thank you kindly!<br /><br /><i>The bartender begins to turn away, hesitates, and then turns back to you.</i><br /><br />By the way, I heard that a weapon shop in ' . $locationHint . ' has some ' . $qualifier . ' stock that a person like you just might be interested in. That\'s all I know about it...<br /><br />Got anything to tell me?';
+
+		// Add a message indicating how much time is left in the event
+		$percTimeLeft = $event->getDurationRemainingPercent();
+		if ($percTimeLeft > 95) {
+			$timeHint = 'just heard';
+		} elseif ($percTimeLeft > 66) {
+			$timeHint = 'recently heard';
+		} elseif ($percTimeLeft > 33) {
+			$timeHint = 'heard';
+		} else {
+			$timeHint = 'heard some time ago';
+		}
+
+		$container['Message'] .= 'Thank you kindly!<br /><br /><i>The bartender begins to turn away, hesitates, and then turns back to you.</i><br /><br />By the way, I ' . $timeHint . ' that a weapon shop in ' . $locationHint . ' has some ' . $qualifier . ' stock that a person like you just might be interested in. That\'s all I know about it...<br /><br />Got anything to tell me?';
 	} elseif ($tip > 0.05 * $cost) {
 		$container['Message'] .= 'Oh, so it\'s secrets you\'re after, eh? Well, it\'ll cost ya more than that...<br /><br />Got anything to tell me?';
 	} else {

--- a/engine/Default/planet_attack_processing.php
+++ b/engine/Default/planet_attack_processing.php
@@ -56,12 +56,20 @@ foreach ($attackers as $attacker) {
 	$attacker->getShip()->decloak();
 }
 
+$totalShieldDamage = 0;
 foreach ($attackers as $attacker) {
 	$playerResults =& $attacker->shootPlanet($planet, false);
 	$results['Attackers']['Traders'][$attacker->getAccountID()] =& $playerResults;
 	$results['Attackers']['TotalDamage'] += $playerResults['TotalDamage'];
+	foreach ($playerResults['Weapons'] as $weapon) {
+		$totalShieldDamage += $weapon['ActualDamage']['Shield'];
+	}
 }
-$results['Attackers']['Downgrades'] = $planet->checkForDowngrade($results['Attackers']['TotalDamage']);
+
+// Planet downgrades only occur on non-shield damage
+$downgradeDamage = $results['Attackers']['TotalDamage'] - $totalShieldDamage;
+$results['Attackers']['Downgrades'] = $planet->checkForDowngrade($downgradeDamage);
+
 $results['Planet'] =& $planet->shootPlayers($attackers);
 
 $account->log(LOG_TYPE_PLANET_BUSTING, 'Player attacks planet, the planet does ' . $results['Planet']['TotalDamage'] . ', their team does ' . $results['Attackers']['TotalDamage'] . ' and downgrades: ' . var_export($results['Attackers']['Downgrades'], true), $planet->getSectorID());

--- a/engine/Default/port_attack_processing.php
+++ b/engine/Default/port_attack_processing.php
@@ -51,12 +51,20 @@ foreach ($attackers as $attacker) {
 	$attacker->getShip()->decloak();
 }
 
+$totalShieldDamage = 0;
 foreach ($attackers as $attacker) {
 	$playerResults =& $attacker->shootPort($port);
 	$results['Attackers']['Traders'][$attacker->getAccountID()] =& $playerResults;
 	$results['Attackers']['TotalDamage'] += $playerResults['TotalDamage'];
+	foreach ($playerResults['Weapons'] as $weapon) {
+		$totalShieldDamage += $weapon['ActualDamage']['Shield'];
+	}
 }
-$results['Attackers']['Downgrades'] = $port->checkForDowngrade($results['Attackers']['TotalDamage']);
+
+// Planet downgrades only occur on non-shield damage
+$downgradeDamage = $results['Attackers']['TotalDamage'] - $totalShieldDamage;
+$results['Attackers']['Downgrades'] = $port->checkForDowngrade($downgradeDamage);
+
 $results['Port'] =& $port->shootPlayers($attackers);
 
 $account->log(LOG_TYPE_PORT_RAIDING, 'Player attacks port, the port does ' . $results['Port']['TotalDamage'] . ', their team does ' . $results['Attackers']['TotalDamage'] . ' and downgrades ' . $results['Attackers']['Downgrades'] . ' levels.', $port->getSectorID());

--- a/engine/Default/sector_mines.inc
+++ b/engine/Default/sector_mines.inc
@@ -11,11 +11,16 @@ foreach ($sectorForces as $forces) {
 }
 
 if ($mine_owner_id) {
-	if ($player->hasNewbieTurns()) {
+	if ($player->hasNewbieTurns() || $ship->getShipClassID() === SmrShip::SHIP_CLASS_SCOUT) {
 		$turns = $sectorForces[$mine_owner_id]->getBumpTurnCost($ship);
 		$player->takeTurns($turns, $turns);
 		$container = create_container('skeleton.php', 'current_sector.php');
-		$container['msg'] = 'You have just flown past a sprinkle of mines.<br />Because of your newbie status you have been spared from the harsh reality of the forces.<br />It has cost you ' . $turns . ' ' . pluralise('turn', $turns) . ' to navigate the minefield safely.';
+		if ($player->hasNewbieTurns()) {
+			$flavor = 'Because of your newbie status you have been spared from the harsh reality of the forces';
+		} else {
+			$flavor = 'Your ship was sufficiently agile to evade them';
+		}
+		$container['msg'] = 'You have just flown past a sprinkle of mines.<br />' . $flavor . ',<br />but it has cost you <span class="red">' . $turns . ' ' . pluralise('turn', $turns) . '</span> to navigate the minefield safely.';
 		forward($container);
 	} else {
 		$container = create_container('forces_attack_processing.php');

--- a/engine/Default/shop_weapon_processing.php
+++ b/engine/Default/shop_weapon_processing.php
@@ -37,6 +37,14 @@ if (!isset($var['OrderID'])) {
 		create_error('You can\'t buy newbie weapons!');
 	}
 
+	if ($weapon->isUniqueType()) {
+		foreach ($ship->getWeapons() as $shipWeapon) {
+			if ($weapon->getWeaponTypeID() === $shipWeapon->getWeaponTypeID()) {
+				create_error('This weapon is unique, and your ship already has one equipped!');
+			}
+		}
+	}
+
 	// take the money from the user
 	$player->decreaseCredits($weapon->getCost());
 

--- a/htdocs/js/filter_list.js
+++ b/htdocs/js/filter_list.js
@@ -33,6 +33,8 @@ function raceToggle() {
 function applyFilter(tableId) {
 	var table = document.getElementById(tableId);
 	for (var i=1; i < table.rows.length; i++) {
+		// Loop over columns with active filters, and hide row if any column
+		// fails its respective filter.
 		var show = true;
 		for (var j=0; j < table.rows[i].cells.length; j++) {
 			// No filtering for null, undefined, and "All".
@@ -40,20 +42,25 @@ function applyFilter(tableId) {
 			if (filter[j] == null || filter[j][0] === "All") {
 				continue;
 			}
+
+			// Prepare the list of values in this cell for filtering.
+			// If there are no divs, then entire cell is the only value.
 			var cell = table.rows[i].cells[j];
-			if (cell.className == "locs") {
-				// At least one of the (line-break delimited) Locations must
-				// match the filter (there will be only one filter).
-				if (cell.innerHTML.split('<br>').indexOf(filter[j][0]) === -1) {
-					show = false;
-					break;
-				}
-			} else {
-				// The cell content must match exactly at least one filter.
-				if (filter[j].indexOf(cell.textContent) === -1) {
-					show = false;
-					break;
-				}
+			var values = cell.getElementsByTagName('div');
+			if (values.length === 0) {
+				values = [cell];
+			}
+
+			// The filters match against raw values, so extract them here.
+			var rawValues = [];
+			for (var k=0; k < values.length; k++) {
+				rawValues.push(values[k].textContent);
+			}
+
+			// One of the values must match at least one of the filters
+			if (rawValues.filter(function(value) { return filter[j].indexOf(value) !== -1; }).length === 0) {
+				show = false;
+				break;
 			}
 		}
 		if (show) {

--- a/htdocs/weapon_list.php
+++ b/htdocs/weapon_list.php
@@ -20,27 +20,29 @@ try {
 	// Get all the properties to display for each weapon
 	$weapons = [];
 	foreach (SmrWeaponType::getAllWeaponTypes() as $weapon) {
+		$restrictions = [];
 		switch ($weapon->getBuyerRestriction()) {
 			case BUYER_RESTRICTION_GOOD:
-				$restriction = '<span class="dgreen">Good</span>';
+				$restrictions[] = '<div class="dgreen">Good</div>';
 			break;
 			case BUYER_RESTRICTION_EVIL:
-				$restriction = '<span class="red">Evil</span>';
+				$restrictions[] = '<div class="red">Evil</div>';
 			break;
 			case BUYER_RESTRICTION_NEWBIE:
-				$restriction = '<span style="color: #06F;">Newbie</span>';
+				$restrictions[] = '<div style="color: #06F;">Newbie</div>';
 			break;
 			case BUYER_RESTRICTION_PORT:
-				$restriction = '<span class="yellow">Port</span>';
+				$restrictions[] = '<div class="yellow">Port</div>';
 			break;
 			case BUYER_RESTRICTION_PLANET:
-				$restriction = '<span class="yellow">Planet</span>';
+				$restrictions[] = '<div class="yellow">Planet</div>';
 			break;
-			default:
-				$restriction = '';
+		}
+		if (SmrWeapon::getWeapon($weapon->getWeaponTypeID())->isUniqueType()) {
+			$restrictions[] = '<div style="color: #64B9B9">Unique</div>';
 		}
 		$weapons[] = [
-			'restriction' => $restriction,
+			'restriction' => $restrictions,
 			'weapon_name' => $weapon->getName(),
 			'race_id' => $weapon->getRaceID(),
 			'race_name' => $weapon->getRaceName(),

--- a/lib/Default/AbstractSmrShip.class.php
+++ b/lib/Default/AbstractSmrShip.class.php
@@ -4,6 +4,7 @@ abstract class AbstractSmrShip {
 	protected static $CACHE_BASE_SHIPS = array();
 
 	const SHIP_CLASS_RAIDER = 3;
+	const SHIP_CLASS_SCOUT = 4;
 
 	// Player exp gained for each point of damage done
 	const EXP_PER_DAMAGE_PLAYER = 0.375;
@@ -475,6 +476,10 @@ abstract class AbstractSmrShip {
 
 	public function getShipTypeID() {
 		return $this->baseShip['ShipTypeID'];
+	}
+
+	public function getShipClassID() {
+		return $this->baseShip['ShipClassID'];
 	}
 
 	/**

--- a/lib/Default/SmrEnhancedWeaponEvent.class.php
+++ b/lib/Default/SmrEnhancedWeaponEvent.class.php
@@ -119,4 +119,12 @@ class SmrEnhancedWeaponEvent {
 		return $this->weapon;
 	}
 
+	/**
+	 * Returns the amount of time left in the event as a percent of the
+	 * total duration of the event.
+	 */
+	public function getDurationRemainingPercent() : float {
+		return max(0, min(100, ($this->expires - TIME) / self::DURATION * 100));
+	}
+
 }

--- a/lib/Default/SmrPlanetType.class.php
+++ b/lib/Default/SmrPlanetType.class.php
@@ -147,14 +147,20 @@ class DwarfPlanet extends SmrPlanetType {
 
 class ProtoPlanet extends SmrPlanetType {
 	const STRUCTURES = [
+		PLANET_GENERATOR => [
+			'max_amount' => 5,
+			'base_time' => 10800,
+			'credit_cost' => 100000,
+			'exp_gain' => 90,
+		],
 		PLANET_HANGAR => [
-			'max_amount' => 40,
+			'max_amount' => 50,
 			'base_time' => 21600,
 			'credit_cost' => 100000,
 			'exp_gain' => 180,
 		],
 		PLANET_BUNKER => [
-			'max_amount' => 20,
+			'max_amount' => 15,
 			'base_time' => 10800,
 			'credit_cost' => 50000,
 			'exp_gain' => 90,

--- a/lib/Default/SmrWeapon.class.php
+++ b/lib/Default/SmrWeapon.class.php
@@ -9,6 +9,8 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	const BONUS_DAMAGE = 15; // additive bonus
 	const BONUS_ACCURACY = 4; // additive bonus
 
+	const HIGHEST_POWER_LEVEL = 5; // must track the highest power level in db
+
 	protected int $weaponTypeID;
 	protected SmrWeaponType $weaponType;
 	protected bool $bonusAccuracy = false; // default
@@ -134,7 +136,14 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	public function getBuyerRestriction() {
 		return $this->weaponType->getBuyerRestriction();
 	}
-	
+
+	/**
+	 * Ships are only allowed to equip one of each type of Unique weapon
+	 */
+	public function isUniqueType() : bool {
+		return $this->getPowerLevel() === self::HIGHEST_POWER_LEVEL;
+	}
+
 	protected function getWeightedRandomForPlayer(AbstractSmrPlayer $player) {
 		return WeightedRandom::getWeightedRandomForPlayer($player, 'Weapon', $this->getWeaponTypeID());
 	}

--- a/lib/Default/SmrWeapon.class.php
+++ b/lib/Default/SmrWeapon.class.php
@@ -6,8 +6,8 @@
 class SmrWeapon extends AbstractSmrCombatWeapon {
 	use Traits\RaceID;
 
-	const BONUS_DAMAGE = 1.05; // multiplicative bonus
-	const BONUS_ACCURACY = 3; // additive bonus
+	const BONUS_DAMAGE = 15; // additive bonus
+	const BONUS_ACCURACY = 4; // additive bonus
 
 	protected int $weaponTypeID;
 	protected SmrWeaponType $weaponType;
@@ -65,30 +65,33 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	 * (Override) Return the weapon base accuracy.
 	 */
 	public function getBaseAccuracy() : int {
+		$baseAccuracy = $this->weaponType->getAccuracy();
 		if ($this->bonusAccuracy) {
-			return $this->weaponType->getAccuracy() + self::BONUS_ACCURACY;
+			$baseAccuracy += self::BONUS_ACCURACY;
 		}
-		return $this->weaponType->getAccuracy();
+		return $baseAccuracy;
 	}
 
 	/**
 	 * (Override) Return the weapon shield damage.
 	 */
 	public function getShieldDamage() : int {
-		if ($this->bonusDamage) {
-			return IFloor($this->weaponType->getShieldDamage() * self::BONUS_DAMAGE);
+		$shieldDamage = $this->weaponType->getShieldDamage();
+		if ($this->bonusDamage && $shieldDamage > 0) {
+			$shieldDamage += self::BONUS_DAMAGE;
 		}
-		return $this->weaponType->getShieldDamage();
+		return $shieldDamage;
 	}
 
 	/**
 	 * (Override) Return the weapon armour damage.
 	 */
 	public function getArmourDamage() : int {
-		if ($this->bonusDamage) {
-			return IFloor($this->weaponType->getArmourDamage() * self::BONUS_DAMAGE);
+		$armourDamage = $this->weaponType->getArmourDamage();
+		if ($this->bonusDamage && $armourDamage > 0) {
+			$armourDamage += self::BONUS_DAMAGE;
 		}
-		return $this->weaponType->getArmourDamage();
+		return $armourDamage;
 	}
 
 	/**

--- a/templates/Default/weapon_list.php
+++ b/templates/Default/weapon_list.php
@@ -66,13 +66,16 @@
 							</select>
 						</th>
 						<th style="width: 92px;">
-							<span class="sort" data-sort="restriction">Restriction</span><br />
+							<span class="sort" data-sort="restrictions">Restriction</span><br />
 							<select onchange="filterSelect(this)">
 								<option>All</option>
 								<option value="">None</option>
-								<option class="dgreen">Good</option>
 								<option class="red">Evil</option>
+								<option class="dgreen">Good</option>
 								<option style="color: #06F;">Newbie</option>
+								<option class="yellow">Planet</option>
+								<option class="yellow">Port</option>
+								<option style="color: #64B9B9;">Unique</option>
 							</select>
 						</th>
 						<th>
@@ -96,8 +99,12 @@
 							<td class="armour_damage"><?php echo $weapon['armour_damage']; ?></td>
 							<td class="accuracy"><?php echo $weapon['accuracy']; ?></td>
 							<td class="level"><?php echo $weapon['power_level']; ?></td>
-							<td class="restriction"><?php echo $weapon['restriction']; ?></td>
-							<td class="locs"><?php echo join('<br />', $weapon['locs']); ?></td>
+							<td class="restriction"><?php echo join('', $weapon['restriction']); ?></td>
+							<td class="locs"><?php
+								foreach ($weapon['locs'] as $loc) { ?>
+									<div><?php echo $loc; ?></div><?php
+								} ?>
+							</td>
 						</tr><?php
 					} ?>
 				</tbody>


### PR DESCRIPTION
* Planets/ports don't take structure damage until shields are breached.
* Enhanced weapons can now have +4% accuracy (previously +3%) and +15 damage (previously +5%).
* Power level 5 weapons are now unique (i.e. you can only have one of each type on a ship).
* HHG/Nuke accuracy is reverted to 35% (previously 30%).
* Protoplanets have been given 10 additional structures (+10 hangars, +5 generators, -5 bunkers).
* Slightly reduce strength of Photon Torpedo (PT => -1% accuracy, HPT => +1% accuracy, -5 damage).
* Scout ships no longer hit mines, but take additional turns to traverse minefields.