### PR TITLE
soften neutral relations grind

### DIFF
--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -1493,10 +1493,14 @@ abstract class AbstractSmrPlayer {
 	 * of the port given by $raceID.
 	 */
 	public function increaseRelationsByTrade($numGoods, $raceID) {
-		$relations = ICeil(min($numGoods, 300) / 30);
-		//Cap relations to a max of 1 after 500 have been reached
-		if ($this->getPersonalRelation($raceID) + $relations >= 500) {
-			$relations = max(1, min($relations, 500 - $this->getPersonalRelation($raceID)));
+		if ($raceID == RACE_NEUTRAL) {
+			$relations = ICeil(min($numGoods, 150) / 30);
+		} else {
+			$relations = ICeil(min($numGoods, 300) / 30);
+			//Cap relations to a max of 1 after 500 have been reached
+			if ($this->getPersonalRelation($raceID) + $relations >= 500) {
+				$relations = max(1, min($relations, 500 - $this->getPersonalRelation($raceID)));
+			}
 		}
 		$this->increaseRelations($relations, $raceID);
 	}
@@ -1506,7 +1510,11 @@ abstract class AbstractSmrPlayer {
 	 * bargaining and getting caught stealing.
 	 */
 	public function decreaseRelationsByTrade($numGoods, $raceID) {
-		$relations = ICeil(min($numGoods, 300) / 30);
+		if ($raceID == RACE_NEUTRAL) {
+			$relations = ICeil(min($numGoods, 150) / 30);
+		}else{
+			$relations = ICeil(min($numGoods, 300) / 30);
+		}
 		$this->decreaseRelations($relations, $raceID);
 	}
 


### PR DESCRIPTION
Currently relations gain logic for neutral matches racial.  The game mechanic is 1 relation point gained per 30 holds up to 300 holds for a max of 10 relations gained up until relations hit 500.  After which the gain is capped to 1 relation per trade.  This makes perfect sense for racial space as it provides a home court advantage and makes political relations paramount to efficient inter racial trading.

The same reasoning does not follow with neutral relations.  There is no political relation mechanic here.  The result is a short grind to 500 and a miserable grind to 1000.

This commit singles out neutral relations in the increase/decrease logic and changes the way they scale.  New model is: one relation gained per 30 cargo traded up to 150 cargo.  That means a max of 5 relations gain (or loss when an error occurs) per trade.  And the cap at 500 is simply removed.

tl;dr: neutral relations grow at half the speed of racial relations but never cap at 1 per trade.