### PR TITLE
SmrGalaxy: don't store escaped name in database

### DIFF
--- a/admin/Default/1.6/check_map.php
+++ b/admin/Default/1.6/check_map.php
@@ -46,7 +46,7 @@ $allGalaxyRoutes = [];
 foreach (SmrGalaxy::getGameGalaxies($var['game_id']) as $galaxy) {
 	$galaxy->getPorts(); // Efficiently construct the port cache
 	$distances = Plotter::calculatePortToPortDistances($galaxy->getSectors(), $maxDistance, $galaxy->getStartSector(), $galaxy->getEndSector());
-	$allGalaxyRoutes[$galaxy->getName()] = \Routes\RouteGenerator::generateMultiPortRoutes($maxNumberOfPorts, $galaxy->getSectors(), $tradeGoods, $tradeRaces, $distances, $routesForPort, $numberOfRoutes);
+	$allGalaxyRoutes[$galaxy->getDisplayName()] = \Routes\RouteGenerator::generateMultiPortRoutes($maxNumberOfPorts, $galaxy->getSectors(), $tradeGoods, $tradeRaces, $distances, $routesForPort, $numberOfRoutes);
 }
 $template->assign('AllGalaxyRoutes', $allGalaxyRoutes);
 
@@ -74,7 +74,7 @@ foreach (SmrGalaxy::getGameGalaxies($var['game_id']) as $galaxy) {
 	}
 	if (!empty($max)) {
 		$output = $max['Distance'] . 'x ' . Globals::getGoodName($max['GoodID']) . ' at Port #' . $max['Port']->getSectorID() . ' (' . $max['Port']->getRaceName() . ')';
-		$maxSellMultipliers[$galaxy->getName()] = $output;
+		$maxSellMultipliers[$galaxy->getDisplayName()] = $output;
 	}
 }
 $template->assign('MaxSellMultipliers', $maxSellMultipliers);

--- a/admin/Default/1.6/galaxies_edit.php
+++ b/admin/Default/1.6/galaxies_edit.php
@@ -16,7 +16,7 @@ $template->assign('Submit', $submit);
 $galaxies = [];
 foreach (SmrGalaxy::getGameGalaxies($var['game_id']) as $galaxy) {
 	$galaxies[$galaxy->getGalaxyID()] = [
-		'Name' => $galaxy->getName(),
+		'Name' => $galaxy->getDisplayName(),
 		'Width' => $galaxy->getWidth(),
 		'Height' => $galaxy->getHeight(),
 		'Type' => $galaxy->getGalaxyType(),

--- a/admin/Default/1.6/universe_create_sector_details.php
+++ b/admin/Default/1.6/universe_create_sector_details.php
@@ -2,7 +2,7 @@
 
 $editSectorID = SmrSession::getRequestVarInt('sector_edit');
 $editSector = SmrSector::getSector($var['game_id'], $editSectorID);
-$template->assign('PageTopic', 'Edit Sector #' . $editSector->getSectorID() . ' (' . $editSector->getGalaxyName() . ')');
+$template->assign('PageTopic', 'Edit Sector #' . $editSector->getSectorID() . ' (' . $editSector->getGalaxy()->getDisplayName() . ')');
 $template->assign('EditSector', $editSector);
 
 $container = $var;
@@ -34,7 +34,7 @@ $template->assign('SectorLocationIDs', $sectorLocationIDs);
 if ($editSector->hasWarp()) {
 	$warpSector = $editSector->getWarpSector();
 	$warpSectorID = $warpSector->getSectorID();
-	$warpGal = $warpSector->getGalaxyName();
+	$warpGal = $warpSector->getGalaxy()->getDisplayName();
 } else {
 	$warpSectorID = 0;
 	$warpGal = 'No Warp';

--- a/admin/Default/1.6/universe_create_warps.php
+++ b/admin/Default/1.6/universe_create_warps.php
@@ -8,7 +8,7 @@ if (isset($var['message'])) {
 $galaxies = SmrGalaxy::getGameGalaxies($var['game_id']);
 $galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
 
-$template->assign('PageTopic', 'Warps for Galaxy : ' . $galaxy->getName() . ' (' . $galaxy->getGalaxyID() . ')');
+$template->assign('PageTopic', 'Warps for Galaxy : ' . $galaxy->getDisplayName() . ' (' . $galaxy->getGalaxyID() . ')');
 
 
 // Initialize warps array

--- a/engine/Default/bar_talk_bartender_processing.php
+++ b/engine/Default/bar_talk_bartender_processing.php
@@ -38,7 +38,7 @@ if ($action == 'tell') {
 		if ($player->getSector()->getGalaxy()->equals($eventGalaxy)) {
 			$locationHint = 'Sector ' . Globals::getSectorBBLink($eventSectorID);
 		} else {
-			$locationHint = 'the ' . $eventGalaxy->getName() . ' galaxy';
+			$locationHint = 'the ' . $eventGalaxy->getDisplayName() . ' galaxy';
 		}
 
 		if ($event->getWeapon()->hasBonusDamage() && $event->getWeapon()->hasBonusAccuracy()) {

--- a/engine/Default/current_sector.php
+++ b/engine/Default/current_sector.php
@@ -7,7 +7,7 @@ if ($player->isLandedOnPlanet()) {
 
 $template->assign('SpaceView', true);
 
-$template->assign('PageTopic', 'Current Sector: ' . $player->getSectorID() . ' (' . $sector->getGalaxyName() . ')');
+$template->assign('PageTopic', 'Current Sector: ' . $player->getSectorID() . ' (' . $sector->getGalaxy()->getDisplayName() . ')');
 
 Menu::navigation($template, $player);
 

--- a/engine/Default/map_local.php
+++ b/engine/Default/map_local.php
@@ -50,7 +50,7 @@ $template->assign('MapShrinkHREF', SmrSession::getNewHREF($container));
 
 $galaxy = $player->getSector()->getGalaxy();
 
-$template->assign('GalaxyName', $galaxy->getName());
+$template->assign('GalaxyName', $galaxy->getDisplayName());
 
 $mapSectors = $galaxy->getMapSectors($player->getSectorID(), $player->getZoom());
 $template->assign('MapSectors', $mapSectors);

--- a/engine/Default/sector_scan.php
+++ b/engine/Default/sector_scan.php
@@ -7,7 +7,7 @@ if (!$sector->isLinked($var['target_sector']) && $sector->getSectorID() != $var[
 // initialize vars
 $scanSector = SmrSector::getSector($player->getGameID(), $var['target_sector']);
 
-$template->assign('PageTopic', 'Sector Scan of #' . $scanSector->getSectorID() . ' (' . $scanSector->getGalaxyName() . ')');
+$template->assign('PageTopic', 'Sector Scan of #' . $scanSector->getSectorID() . ' (' . $scanSector->getGalaxy()->getDisplayName() . ')');
 Menu::navigation($template, $player);
 
 $friendly_forces = 0;

--- a/htdocs/map_warps.php
+++ b/htdocs/map_warps.php
@@ -34,8 +34,8 @@ try {
 		$warp1 = SmrSector::getSector($gameID, $db->getInt('sector_id'));
 		$warp2 = SmrSector::getSector($gameID, $db->getInt('warp'));
 		$links[] = [
-			'source' => $warp1->getGalaxyName(),
-			'target' => $warp2->getGalaxyName(),
+			'source' => $warp1->getGalaxy()->getName(),
+			'target' => $warp2->getGalaxy()->getName(),
 		];
 	}
 

--- a/lib/Default/SmrGalaxy.class.php
+++ b/lib/Default/SmrGalaxy.class.php
@@ -119,13 +119,23 @@ class SmrGalaxy {
 	public function getGalaxyMapHREF() {
 		return 'map_galaxy.php?galaxy_id=' . $this->getGalaxyID();
 	}
-	
+
+	/**
+	 * Returns the galaxy name.
+	 * Use getDisplayName for an HTML-safe version.
+	 */
 	public function getName() {
 		return $this->name;
 	}
-	
+
+	/**
+	 * Returns the galaxy name, suitable for HTML display.
+	 */
+	public function getDisplayName() : string {
+		return htmlentities($this->name);
+	}
+
 	public function setName($name) {
-		$name = htmlentities($name, ENT_COMPAT, 'utf-8');
 		if ($this->name == $name) {
 			return;
 		}

--- a/lib/Default/SmrSector.class.php
+++ b/lib/Default/SmrSector.class.php
@@ -338,10 +338,6 @@ class SmrSector {
 		$this->hasChanged = true;
 	}
 
-	public function getGalaxyName() {
-		return $this->getGalaxy()->getName();
-	}
-
 	public function getNumberOfLinks() {
 		$num = 0;
 		if (!is_array($this->getLinks())) {

--- a/templates/Default/admin/Default/1.6/universe_create_locations.php
+++ b/templates/Default/admin/Default/1.6/universe_create_locations.php
@@ -3,7 +3,7 @@
 	<select name="gal_on" onchange="this.form.submit()"><?php
 		foreach ($Galaxies as $OtherGalaxy) { ?>
 			<option value="<?php echo $OtherGalaxy->getGalaxyID(); ?>"<?php if ($OtherGalaxy->equals($Galaxy)) { ?> selected<?php } ?>><?php
-				echo $OtherGalaxy->getName() . ' (' . $OtherGalaxy->getGalaxyID() . ')'; ?>
+				echo $OtherGalaxy->getDisplayName() . ' (' . $OtherGalaxy->getGalaxyID() . ')'; ?>
 			</option><?php
 		} ?>
 	</select>

--- a/templates/Default/admin/Default/1.6/universe_create_planets.php
+++ b/templates/Default/admin/Default/1.6/universe_create_planets.php
@@ -3,7 +3,7 @@
 	<select name="gal_on" onchange="this.form.submit()"><?php
 		foreach ($Galaxies as $OtherGalaxy) { ?>
 			<option value="<?php echo $OtherGalaxy->getGalaxyID(); ?>"<?php if ($OtherGalaxy->equals($Galaxy)) { ?> selected<?php } ?>><?php
-				echo $OtherGalaxy->getName() . ' (' . $OtherGalaxy->getGalaxyID() . ')'; ?>
+				echo $OtherGalaxy->getDisplayName() . ' (' . $OtherGalaxy->getGalaxyID() . ')'; ?>
 			</option><?php
 		} ?>
 	</select>

--- a/templates/Default/admin/Default/1.6/universe_create_ports.php
+++ b/templates/Default/admin/Default/1.6/universe_create_ports.php
@@ -3,7 +3,7 @@
 	<select name="gal_on" onchange="this.form.submit()"><?php
 		foreach ($Galaxies as $OtherGalaxy) { ?>
 			<option value="<?php echo $OtherGalaxy->getGalaxyID(); ?>"<?php if ($OtherGalaxy->equals($Galaxy)) { ?> selected<?php } ?>><?php
-				echo $OtherGalaxy->getName() . ' (' . $OtherGalaxy->getGalaxyID() . ')'; ?>
+				echo $OtherGalaxy->getDisplayName() . ' (' . $OtherGalaxy->getGalaxyID() . ')'; ?>
 			</option><?php
 		} ?>
 	</select>

--- a/templates/Default/admin/Default/1.6/universe_create_sectors.php
+++ b/templates/Default/admin/Default/1.6/universe_create_sectors.php
@@ -13,7 +13,7 @@
 				<select name="gal_on" onchange="this.form.submit()"><?php
 					foreach ($Galaxies as $CurrentGalaxy) { ?>
 						<option value="<?php echo $CurrentGalaxy->getGalaxyID(); ?>"<?php if ($CurrentGalaxy->equals($Galaxy)) { ?> selected="SELECTED"<?php } ?>><?php
-							echo $CurrentGalaxy->getName(); ?>
+							echo $CurrentGalaxy->getDisplayName(); ?>
 						</option><?php
 					} ?>
 				</select>

--- a/templates/Default/admin/Default/1.6/universe_create_warps.php
+++ b/templates/Default/admin/Default/1.6/universe_create_warps.php
@@ -14,7 +14,7 @@ if (isset($Message)) {
 					</tr><?php
 					foreach ($Galaxies as $eachGalaxy) { ?>
 						<tr>
-							<td class="right"><?php echo $eachGalaxy->getName(); ?></td>
+							<td class="right"><?php echo $eachGalaxy->getDisplayName(); ?></td>
 							<td><input class="center" type="number" value="<?php echo $Warps[$Galaxy->getGalaxyID()][$eachGalaxy->getGalaxyID()]; ?>" name="warp<?php echo $eachGalaxy->getGalaxyID(); ?>"></td>
 						</tr><?php
 					} ?>
@@ -65,7 +65,7 @@ p.vert {
 		foreach ($Galaxies as $gal) { ?>
 			<th>
 				<p class="vert">
-					<a href="<?php echo $GalLinks[$gal->getGalaxyID()]; ?>"><?php echo $gal->getName(); ?></a>
+					<a href="<?php echo $GalLinks[$gal->getGalaxyID()]; ?>"><?php echo $gal->getDisplayName(); ?></a>
 				</p>
 			</th><?php
 		} ?>
@@ -73,7 +73,7 @@ p.vert {
 	</tr><?php
 	foreach ($Galaxies as $galRow) { ?>
 		<tr>
-			<th><a href="<?php echo $GalLinks[$galRow->getGalaxyID()]; ?>"><?php echo $galRow->getName(); ?></a></th><?php
+			<th><a href="<?php echo $GalLinks[$galRow->getGalaxyID()]; ?>"><?php echo $galRow->getDisplayName(); ?></a></th><?php
 			foreach ($Galaxies as $galCol) {
 				$count = $Warps[$galRow->getGalaxyID()][$galCol->getGalaxyID()];
 				$display = $count == 0 ? '' : $count; ?>

--- a/templates/Default/engine/Default/GalaxyMap.inc
+++ b/templates/Default/engine/Default/GalaxyMap.inc
@@ -19,7 +19,7 @@
 		<div class="gal_map_header">
 			<table cellspacing="0" cellpadding="0">
 				<tr>
-					<td>Map of the known <span class="big bold"><?php echo $ThisGalaxy->getName(); ?></span> galaxy.</td>
+					<td>Map of the known <span class="big bold"><?php echo $ThisGalaxy->getDisplayName(); ?></span> galaxy.</td>
 					<td>
 						&thinsp;
 						<a href="map_warps.php?game=<?php echo $ThisPlayer->getGameID(); ?>">
@@ -35,7 +35,7 @@
 								foreach ($GameGalaxies as $GameGalaxy) {
 									$GalaxyID = $GameGalaxy->getGalaxyID(); ?>
 									<option value="<?php echo $GalaxyID; ?>"<?php if ($ThisGalaxy->equals($GameGalaxy)) { ?> selected="selected"<?php } ?>>
-									<?php echo $GameGalaxy->getName(); ?>
+									<?php echo $GameGalaxy->getDisplayName(); ?>
 									</option><?php
 								} ?>
 							</select>&nbsp;

--- a/templates/Default/engine/Default/alliance_forces.php
+++ b/templates/Default/engine/Default/alliance_forces.php
@@ -53,7 +53,7 @@ if (empty($Forces)) { ?>
 	foreach ($Forces as $Force) { ?>
 		<tr>
 			<td class="sort_name"><?php echo $Force->getOwner()->getLinkedDisplayName(false); ?></td>
-			<td class="sort_sector noWrap"><?php echo $Force->getSectorID(); ?> (<?php echo $Force->getGalaxy()->getName(); ?>)</td>
+			<td class="sort_sector noWrap"><?php echo $Force->getSectorID(); ?> (<?php echo $Force->getGalaxy()->getDisplayName(); ?>)</td>
 			<td class="sort_cds center"><?php echo $Force->getCDs(); ?></td>
 			<td class="sort_sds center"><?php echo $Force->getSDs(); ?></td>
 			<td class="sort_mines center"><?php echo $Force->getMines(); ?></td>

--- a/templates/Default/engine/Default/bar_galmap_buy.php
+++ b/templates/Default/engine/Default/bar_galmap_buy.php
@@ -5,7 +5,7 @@
 			<option value="" disabled selected>[Select a galaxy]</option><?php
 			$GameGalaxies = SmrGalaxy::getGameGalaxies($ThisPlayer->getGameID());
 			foreach ($GameGalaxies as $Galaxy) { ?>
-				<option value="<?php echo $Galaxy->getGalaxyID(); ?>"><?php echo $Galaxy->getName(); ?></option><?php
+				<option value="<?php echo $Galaxy->getGalaxyID(); ?>"><?php echo $Galaxy->getDisplayName(); ?></option><?php
 			} ?>
 		</select>
 		<br /><br />

--- a/templates/Default/engine/Default/course_plot.php
+++ b/templates/Default/engine/Default/course_plot.php
@@ -76,7 +76,7 @@ if (isset($XType)) { ?>
 				case 'Galaxies':
 					$Galaxies = SmrGalaxy::getGameGalaxies($ThisPlayer->getGameID());
 					foreach ($Galaxies as $Galaxy) {
-						?><option value="<?php echo $Galaxy->getGalaxyID(); ?>"><?php echo $Galaxy->getName(); ?></option><?php
+						?><option value="<?php echo $Galaxy->getGalaxyID(); ?>"><?php echo $Galaxy->getDisplayName(); ?></option><?php
 					}
 				break;
 				default:

--- a/templates/Default/engine/Default/forces_list.php
+++ b/templates/Default/engine/Default/forces_list.php
@@ -22,7 +22,7 @@ if (empty($Forces)) { ?>
 		<tbody class="list"><?php
 		foreach ($Forces as $Force) { ?>
 			<tr>
-				<td class="sort_sector noWrap"><?php echo $Force->getSectorID(); ?> (<?php echo $Force->getGalaxy()->getName(); ?>)</td>
+				<td class="sort_sector noWrap"><?php echo $Force->getSectorID(); ?> (<?php echo $Force->getGalaxy()->getDisplayName(); ?>)</td>
 				<td class="sort_cds center"><?php echo $Force->getCDs(); ?></td>
 				<td class="sort_sds center"><?php echo $Force->getSDs(); ?></td>
 				<td class="sort_mines center"><?php echo $Force->getMines(); ?></td>

--- a/templates/Default/engine/Default/includes/PlanetList.inc
+++ b/templates/Default/engine/Default/includes/PlanetList.inc
@@ -24,7 +24,7 @@ if (count($Planets) > 0) { ?>
 					<td class="sort_name"><?php echo $Planet->getDisplayName(); ?></td>
 					<td class="sort_lvl center"><?php echo number_format($Planet->getLevel(), 2); ?></td>
 					<td class="sort_owner noWrap"><?php echo $Planet->getOwner()->getLinkedDisplayName(false); ?></td>
-					<td class="sort_sector center"><a href="<?php echo Globals::getPlotCourseHREF($ThisPlayer->getSectorID(), $Planet->getSectorID()); ?>"><?php echo $Planet->getSectorID(); ?></a>&nbsp;(<a href="<?php echo $Planet->getGalaxy()->getGalaxyMapHREF(); ?>" target="gal_map"><?php echo $Planet->getGalaxy()->getName(); ?></a>)</td>
+					<td class="sort_sector center"><a href="<?php echo Globals::getPlotCourseHREF($ThisPlayer->getSectorID(), $Planet->getSectorID()); ?>"><?php echo $Planet->getSectorID(); ?></a>&nbsp;(<a href="<?php echo $Planet->getGalaxy()->getGalaxyMapHREF(); ?>" target="gal_map"><?php echo $Planet->getGalaxy()->getDisplayName(); ?></a>)</td>
 					<td class="noWrap"><?php
 						foreach ($Planet->getStructureTypes() as $Structure) { ?>
 							<img style="padding:1px;" class="bottom" src="images/<?php echo $Structure->image(); ?>"  width="16" height="16" alt="" title="<?php echo $Structure->name(); ?>" />&nbsp;<?php echo $Planet->getBuilding($Structure->structureID()); ?>&nbsp;/&nbsp;<?php echo $Planet->getMaxBuildings($Structure->structureID()); ?><br /><?php

--- a/templates/Default/engine/Default/includes/PlanetListFinancial.inc
+++ b/templates/Default/engine/Default/includes/PlanetListFinancial.inc
@@ -26,7 +26,7 @@ if (count($Planets) > 0) { ?>
 					<td class="sort_name left"><?php echo $Planet->getDisplayName(); ?></td>
 					<td class="sort_lvl"><?php echo number_format($Planet->getLevel(), 2); ?></td>
 					<td class="sort_owner noWrap left"><?php echo $Planet->getOwner()->getLinkedDisplayName(false); ?></td>
-					<td class="sort_sector"><a href="<?php echo Globals::getPlotCourseHREF($ThisPlayer->getSectorID(), $Planet->getSectorID()); ?>"><?php echo $Planet->getSectorID(); ?></a>&nbsp;(<a href="<?php echo $Planet->getGalaxy()->getGalaxyMapHREF(); ?>" target="gal_map"><?php echo $Planet->getGalaxy()->getName(); ?></a>)</td>
+					<td class="sort_sector"><a href="<?php echo Globals::getPlotCourseHREF($ThisPlayer->getSectorID(), $Planet->getSectorID()); ?>"><?php echo $Planet->getSectorID(); ?></a>&nbsp;(<a href="<?php echo $Planet->getGalaxy()->getGalaxyMapHREF(); ?>" target="gal_map"><?php echo $Planet->getGalaxy()->getDisplayName(); ?></a>)</td>
 
 					<?php
 					if ($Planet->hasMenuOption('FINANCE')) { ?>

--- a/templates/Default/engine/Default/includes/SectorMap.inc
+++ b/templates/Default/engine/Default/includes/SectorMap.inc
@@ -91,7 +91,7 @@
 								if ($isVisited) {
 									if ($Sector->hasWarp()) {
 										if ($GalaxyMap) { ?><a href="<?php echo $Sector->getWarpSector()->getGalaxyMapHREF(); ?>"><?php } else if ($isCurrentSector) { ?><a href="<?php echo $Sector->getWarpSector()->getLocalMapMoveHREF(); ?>"><?php } ?>
-											<img title="Warp to #<?php echo $Sector->getWarp(); ?> (<?php echo $Sector->getWarpSector()->getGalaxyName(); ?>)" alt="Warp to #<?php echo $Sector->getWarp(); ?>" src="images/warp.png" width="16" height="16" /><?php
+											<img title="Warp to #<?php echo $Sector->getWarp(); ?> (<?php echo $Sector->getWarpSector()->getGalaxy()->getDisplayName(); ?>)" alt="Warp to #<?php echo $Sector->getWarp(); ?>" src="images/warp.png" width="16" height="16" /><?php
 										if ($isCurrentSector || $GalaxyMap) { ?></a><?php }
 									}
 								} ?>


### PR DESCRIPTION
This continues the effort to store raw data in the database, leaving
it intact to be processed in whatever ways are necessary (since an
escaped string cannot be "unescaped").

We add `SmrGalaxy::getDisplayName` and replace most calls to `getName`
with this new method. Also remove `SmrSector::getGalaxyName` as it is
a wrapper that becomes less useful with this design.

I confirmed that no galaxy names in the live database have the `&`
character, so no database changes should be needed.