### PR TITLE
Translate between SMR and RouteGenerator transaction perspectives

### DIFF
--- a/lib/Default/Routes/OneWayRoute.class.php
+++ b/lib/Default/Routes/OneWayRoute.class.php
@@ -66,15 +66,16 @@ class OneWayRoute extends Route {
 
 	public function getMoneyMultiplierSum() : int {
 		// Relations factors assume maximum relations
-		$sellRelFactor = 3; // Note that this assumes maximum relations
-		$buyRelFactor = 1;
+		$buyRelFactor = 3; // Note that this assumes maximum relations
+		$sellRelFactor = 1;
 		// Supply factors assume maximum supply
-		$sellSupplyFactor = 2;
-		$buySupplyFactor = 1;
+		$buySupplyFactor = 2;
+		$sellSupplyFactor = 1;
 		$goodInfo = \Globals::getGood($this->goodId);
-		$buyPrice = IRound(0.03 * $goodInfo['BasePrice'] * pow($this->buyDi, 1.3) * $buyRelFactor * $buySupplyFactor);
-		$sellPrice = IRound(0.08 * $goodInfo['BasePrice'] * pow($this->sellDi, 1.3) * $sellRelFactor * $sellSupplyFactor);
-		return $sellPrice - $buyPrice;
+		$sellPrice = IRound(0.03 * $goodInfo['BasePrice'] * pow($this->sellDi, 1.3) * $sellRelFactor * $sellSupplyFactor);
+		$buyPrice = IRound(0.088 * $goodInfo['BasePrice'] * pow($this->buyDi, 1.3) * $buyRelFactor * $buySupplyFactor);
+		// NOTE: RouteGenerator code uses buy/sell from the perspective of the PORT not the player, hence why this seems the wrong way round
+		return $buyPrice - $sellPrice;
 	}
 
 	public function getExpMultiplierSum() : int {

--- a/lib/Default/Routes/RouteGenerator.class.php
+++ b/lib/Default/Routes/RouteGenerator.class.php
@@ -3,9 +3,9 @@
 namespace Routes;
 
 class RouteGenerator {
-	// Transactions are from the perspective of the player (not the port).
-	const GOOD_BUYS = 'Buy';
-	const GOOD_SELLS = 'Sell';
+	// RouteGenerator transactions are from the perspective of the port, but SMR uses player perspective elsewhere, so we invert here.
+	const GOOD_BUYS = 'Sell';
+	const GOOD_SELLS = 'Buy';
 
 	const EXP_ROUTE = 0;
 	const MONEY_ROUTE = 1;


### PR DESCRIPTION
RouteGenerator code assumes transactions from port perspective whilst
SMR assumes transactions from player perspective, this moves the
conversion into the `GOOD_BUYS`/`GOOD_SELLS` constants so the rest of
the code can ignore the difference