### PR TITLE
add scouts to backyard drone farm

### DIFF
--- a/db/patches/V1_6_65_07__add_scouts_to_BYDF.sql
+++ b/db/patches/V1_6_65_07__add_scouts_to_BYDF.sql
@@ -1,0 +1,1 @@
+INSERT INTO `location_sells_hardware` (`location_type_id`, `hardware_type_id`) VALUES (609, 5);


### PR DESCRIPTION
Currently scouts are only sold at a Combat Accessories during normal games.  This makes scouts unnecessarily rare as the CA locations are tightly controlled in order to keep mines away from fed beacons.  Furthermore, placing a CA in a place accessible to racial galaxies but not in a place to be mined in is a time consuming pain in the ass.

We could bypass that SNAFU by simply adding scout drones to the drone farm inventory.  Which this PR does!  (assuming no errors were committed!)