### PR TITLE
Rename account.images Yes/No enum to TRUE/FALSE

### DIFF
--- a/db/patches/V1_6_65_09__change_yesno_enum.sql
+++ b/db/patches/V1_6_65_09__change_yesno_enum.sql
@@ -1,0 +1,5 @@
+-- Rename account.images Yes/No enum to TRUE/FALSE for consistency
+ALTER TABLE `account` MODIFY `images` enum('Yes','No','TRUE','FALSE') NOT NULL DEFAULT 'Yes';
+UPDATE `account` SET `images` = 'TRUE' WHERE `images` = 'Yes';
+UPDATE `account` SET `images` = 'FALSE' WHERE `images` = 'No';
+ALTER TABLE `account` MODIFY `images` enum('TRUE','FALSE') NOT NULL DEFAULT 'TRUE';

--- a/engine/Default/preferences_processing.php
+++ b/engine/Default/preferences_processing.php
@@ -144,7 +144,7 @@ if ($action == 'Save and resend validation code') {
 	$account->setShortTimeFormat(Request::get('timeformat'));
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your date formats.';
 } elseif ($action == 'Change Images') {
-	$account->setDisplayShipImages(Request::get('images'));
+	$account->setDisplayShipImages(Request::get('images') == 'Yes');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your ship images preferences.';
 } elseif ($action == 'Change Centering') {
 	$account->setCenterGalaxyMapOnPlayer(Request::get('centergalmap') == 'Yes');

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -196,7 +196,7 @@ abstract class AbstractSmrAccount {
 			$this->veteranForced = $this->db->getBoolean('veteran');
 			$this->logging = $this->db->getBoolean('logging');
 			$this->offset			= $row['offset'];
-			$this->images			= $row['images'];
+			$this->images = $this->db->getBoolean('images');
 			$this->fontSize = $row['fontsize'];
 
 			$this->passwordReset = $row['password_reset'];
@@ -271,7 +271,7 @@ abstract class AbstractSmrAccount {
 			', validation_code = ' . $this->db->escapeString($this->validation_code) .
 			', validated = ' . $this->db->escapeBoolean($this->validated) .
 			', password = ' . $this->db->escapeString($this->passwordHash) .
-			', images = ' . $this->db->escapeString($this->images) .
+			', images = ' . $this->db->escapeBoolean($this->images) .
 			', password_reset = ' . $this->db->escapeString($this->passwordReset) .
 			', use_ajax=' . $this->db->escapeBoolean($this->useAJAX) .
 			', mail_banned=' . $this->db->escapeNumber($this->mailBanned) .
@@ -935,14 +935,14 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function isDisplayShipImages() {
-		return $this->images == 'Yes';
+		return $this->images;
 	}
 
-	public function setDisplayShipImages($yesNo) {
-		if ($this->images == $yesNo) {
+	public function setDisplayShipImages($bool) {
+		if ($this->images == $bool) {
 			return;
 		}
-		$this->images = $yesNo;
+		$this->images = $bool;
 		$this->hasChanged = true;
 	}
 


### PR DESCRIPTION
All other boolean columns in the database use the TRUE/FALSE enum, so
we switch to that for `account.images` for consistency.

Note that to do this transition, we needed to add TRUE/FALSE, map the
old values to the new values, and then remove Yes/No.