### PR TITLE
SmrAccount: add types

### DIFF
--- a/db/patches/V1_6_65_10__change_message_notifications.sql
+++ b/db/patches/V1_6_65_10__change_message_notifications.sql
@@ -1,0 +1,4 @@
+-- Change account.message_notifications default to null
+ALTER TABLE `account` MODIFY `message_notifications` varchar(100) DEFAULT NULL;
+-- Set any non-array values to null
+UPDATE `account` SET `message_notifications` = NULL WHERE `message_notifications` NOT LIKE 'a%';

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
@@ -52,8 +52,8 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 	}
 
 	public function test_get_account_by_name_returns_null_when_no_account_name_provided() {
-		// When retrieving account by null name
-		$account = AbstractSmrAccount::getAccountByName(null);
+		// When retrieving account by empty string name
+		$account = AbstractSmrAccount::getAccountByName('');
 		// Then the record is null
 		$this->assertNull($account);
 	}
@@ -148,7 +148,8 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 
 		// Given a record exists
 		$original = AbstractSmrAccount::createAccount("test", "test", "test@test.com", 9, 0);
-		$original->addAuthMethod(Facebook::getLoginType(), $original->getAccountID());
+		$authUserID = 'MySocialUserID';
+		$original->addAuthMethod(Facebook::getLoginType(), $authUserID);
 		// And a valid social login
 		/*
 		 * Unfortunately we cannot use the simple createMock() method, because the SocialLogin class uses
@@ -166,7 +167,7 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 		$socialLogin
 			->expects(self::once())
 			->method($getUserId)
-			->willReturn($original->getAccountID());
+			->willReturn($authUserID);
 		// When retrieving account by social
 		$account = AbstractSmrAccount::getAccountBySocialLogin($socialLogin, true);
 		// Then the record is found


### PR DESCRIPTION
Adds type-hints for function interfaces and typed class properties.

Minor internal changes:

* Setters now use `===` to check against current value instead of `==`
  now that type equality is ensured.

* Many functions using `false` for a default argument value now use
  `null` instead. This is necessary to use typed arguments.