### PR TITLE
Clean up get/escape methods in MySqlDatabase

### DIFF
--- a/admin/Default/game_status_processing.php
+++ b/admin/Default/game_status_processing.php
@@ -5,7 +5,7 @@ $container = create_container('skeleton.php', 'admin_tools.php');
 $action = Request::get('action');
 if ($action == 'Close') {
 	$reason = Request::get('close_reason');
-	$db->query('REPLACE INTO game_disable (reason) VALUES (' . $db->escapeString($reason, true) . ');');
+	$db->query('REPLACE INTO game_disable (reason) VALUES (' . $db->escapeString($reason) . ');');
 	$db->query('DELETE FROM active_session;');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have closed the server. You will now be logged out!';
 } elseif ($action == 'Open') {

--- a/admin/Default/log_console_detail.php
+++ b/admin/Default/log_console_detail.php
@@ -96,7 +96,7 @@ if ($action == 'Delete') {
 	$db->query('SELECT * FROM account_has_logs WHERE account_id IN (' . $account_list . ') AND log_type_id IN (' . $db->escapeArray($log_type_id_list) . ') ORDER BY microtime DESC');
 	while ($db->nextRecord()) {
 		$account_id = $db->getInt('account_id');
-		$microtime = $db->getMicrotime('microtime', true); //fix value length errors
+		$microtime = $db->getMicrotime('microtime');
 		$message = stripslashes($db->getField('message'));
 		$log_type_id = $db->getInt('log_type_id');
 		$sector_id = $db->getInt('sector_id');

--- a/engine/Default/hall_of_fame_new.php
+++ b/engine/Default/hall_of_fame_new.php
@@ -54,11 +54,11 @@ if (!isset($var['view'])) {
 		$query = 'SELECT account_id, ' . $statements['CASE'] . ' amount FROM (SELECT account_id, type, SUM(amount) amount FROM player_hof WHERE type IN (' . $statements['IN'] . ')' . $gameIDSql . ' GROUP BY account_id,type) x GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25';
 		$db->query($query);
 	} else {
-		$db->query('SELECT visibility FROM hof_visibility WHERE type = ' . $db->escapeArray($viewType, false, true, ':', false) . ' LIMIT 1');
+		$db->query('SELECT visibility FROM hof_visibility WHERE type = ' . $db->escapeArray($viewType, ':', false) . ' LIMIT 1');
 		if ($db->nextRecord()) {
 			$vis = $db->getField('visibility');
 		}
-		$db->query('SELECT account_id,SUM(amount) amount FROM player_hof WHERE type=' . $db->escapeArray($viewType, false, true, ':', false) . $gameIDSql . ' GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
+		$db->query('SELECT account_id,SUM(amount) amount FROM player_hof WHERE type=' . $db->escapeArray($viewType, ':', false) . $gameIDSql . ' GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
 	}
 	$rows = [];
 	while ($db->nextRecord()) {

--- a/engine/Default/rankings_alliance_profit.php
+++ b/engine/Default/rankings_alliance_profit.php
@@ -7,7 +7,7 @@ $db->query('SELECT count(*) FROM alliance
 $db->requireRecord();
 $numAlliances = $db->getInt('count(*)');
 $profitType = array('Trade', 'Money', 'Profit');
-$profitTypeEscaped = $db->escapeArray($profitType, false, true, ':', false);
+$profitTypeEscaped = $db->escapeArray($profitType, ':', false);
 
 $ourRank = 0;
 if ($player->hasAlliance()) {

--- a/engine/Default/rankings_player_profit.php
+++ b/engine/Default/rankings_player_profit.php
@@ -5,7 +5,7 @@ $template->assign('PageTopic', 'Profit Rankings');
 Menu::rankings(0, 1);
 
 $profitType = array('Trade', 'Money', 'Profit');
-$profitTypeEscaped = $db->escapeArray($profitType, false, true, ':', false);
+$profitTypeEscaped = $db->escapeArray($profitType, ':', false);
 
 // what rank are we?
 $db->query('SELECT count(*)

--- a/lib/Default/AbstractSmrAccount.class.php
+++ b/lib/Default/AbstractSmrAccount.class.php
@@ -169,12 +169,12 @@ abstract class AbstractSmrAccount {
 		$userRankingTypes = array();
 		$case = 'FLOOR(SUM(CASE type ';
 		foreach (self::USER_RANKINGS_SCORE as $userRankingScore) {
-			$userRankingType = $db->escapeArray($userRankingScore[0], false, false, ':', false);
+			$userRankingType = $db->escapeArray($userRankingScore[0], ':', false);
 			$userRankingTypes[] = $userRankingType;
-			$case .= ' WHEN ' . $db->escapeString($userRankingType) . ' THEN POW(amount*' . $userRankingScore[1] . ',' . SmrAccount::USER_RANKINGS_EACH_STAT_POW . ')*' . $userRankingScore[2];
+			$case .= ' WHEN ' . $userRankingType . ' THEN POW(amount*' . $userRankingScore[1] . ',' . SmrAccount::USER_RANKINGS_EACH_STAT_POW . ')*' . $userRankingScore[2];
 		}
 		$case .= ' END))';
-		return array('CASE'=>$case, 'IN'=>$db->escapeArray($userRankingTypes));
+		return array('CASE' => $case, 'IN' => join(',', $userRankingTypes));
 	}
 
 	protected function __construct($accountID) {
@@ -284,16 +284,16 @@ abstract class AbstractSmrAccount {
 			', logging = ' . $this->db->escapeBoolean($this->logging) .
 			', time_short = ' . $this->db->escapeString($this->timeShort) .
 			', date_short = ' . $this->db->escapeString($this->dateShort) .
-			', discord_id = ' . $this->db->escapeString($this->discordId, true, true) .
-			', irc_nick = ' . $this->db->escapeString($this->ircNick, true, true) .
+			', discord_id = ' . $this->db->escapeString($this->discordId, true) .
+			', irc_nick = ' . $this->db->escapeString($this->ircNick, true) .
 			', hof_name = ' . $this->db->escapeString($this->hofName) .
 			', template = ' . $this->db->escapeString($this->template) .
 			', colour_scheme = ' . $this->db->escapeString($this->colourScheme) .
 			', fontsize = ' . $this->db->escapeNumber($this->fontSize) .
-			', css_link = ' . $this->db->escapeString($this->cssLink, true, true) .
-			', friendly_colour = ' . $this->db->escapeString($this->friendlyColour, true, true) .
-			', neutral_colour = ' . $this->db->escapeString($this->neutralColour, true, true) .
-			', enemy_colour = ' . $this->db->escapeString($this->enemyColour, true, true) .
+			', css_link = ' . $this->db->escapeString($this->cssLink, true) .
+			', friendly_colour = ' . $this->db->escapeString($this->friendlyColour, true) .
+			', neutral_colour = ' . $this->db->escapeString($this->neutralColour, true) .
+			', enemy_colour = ' . $this->db->escapeString($this->enemyColour, true) .
 			' WHERE ' . $this->SQL . ' LIMIT 1');
 		$this->hasChanged = false;
 	}

--- a/lib/Default/AbstractSmrPlayer.class.php
+++ b/lib/Default/AbstractSmrPlayer.class.php
@@ -1742,7 +1742,7 @@ abstract class AbstractSmrPlayer {
 
 		$this->db->query('
 			INSERT INTO player_stored_sector (account_id, game_id, sector_id, label, offset_top, offset_left)
-			VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($sectorID) . ',' . $this->db->escapeString($label, true) . ',1,1)'
+			VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($sectorID) . ',' . $this->db->escapeString($label) . ',1,1)'
 		);
 	}
 
@@ -2221,7 +2221,7 @@ abstract class AbstractSmrPlayer {
 		}
 		$msg .= ' in Sector&nbsp;' . Globals::getSectorBBLink($this->getSectorID());
 		$this->getSector()->increaseBattles(1);
-		$this->db->query('INSERT INTO news (game_id,time,news_message,type,killer_id,killer_alliance,dead_id,dead_alliance) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber(SmrSession::getTime()) . ',' . $this->db->escapeString($msg, true) . ',\'regular\',' . $this->db->escapeNumber($killer->getAccountID()) . ',' . $this->db->escapeNumber($killer->getAllianceID()) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
+		$this->db->query('INSERT INTO news (game_id,time,news_message,type,killer_id,killer_alliance,dead_id,dead_alliance) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber(SmrSession::getTime()) . ',' . $this->db->escapeString($msg) . ',\'regular\',' . $this->db->escapeNumber($killer->getAccountID()) . ',' . $this->db->escapeNumber($killer->getAllianceID()) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
 		self::sendMessageFromFedClerk($this->getGameID(), $this->getAccountID(), 'You were <span class="red">DESTROYED</span> by ' . $killer->getBBLink() . ' in sector ' . Globals::getSectorBBLink($this->getSectorID()));
 		self::sendMessageFromFedClerk($this->getGameID(), $killer->getAccountID(), 'You <span class="red">DESTROYED</span>&nbsp;' . $this->getBBLink() . ' in sector ' . Globals::getSectorBBLink($this->getSectorID()));
@@ -3185,12 +3185,12 @@ abstract class AbstractSmrPlayer {
 				$amount = $this->getHOF($tempTypeList);
 				if ($hofChanged == self::HOF_NEW) {
 					if ($amount > 0) {
-						$this->db->query('INSERT INTO player_hof (account_id,game_id,type,amount) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeArray($tempTypeList, false, true, ':', false) . ',' . $this->db->escapeNumber($amount) . ')');
+						$this->db->query('INSERT INTO player_hof (account_id,game_id,type,amount) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeArray($tempTypeList, ':', false) . ',' . $this->db->escapeNumber($amount) . ')');
 					}
 				} elseif ($hofChanged == self::HOF_CHANGED) {
 					$this->db->query('UPDATE player_hof
 						SET amount=' . $this->db->escapeNumber($amount) . '
-						WHERE ' . $this->SQL . ' AND type = ' . $this->db->escapeArray($tempTypeList, false, true, ':', false) . ' LIMIT 1');
+						WHERE ' . $this->SQL . ' AND type = ' . $this->db->escapeArray($tempTypeList, ':', false) . ' LIMIT 1');
 				}
 			}
 		}

--- a/lib/Default/ChessGame.class.php
+++ b/lib/Default/ChessGame.class.php
@@ -680,7 +680,7 @@ class ChessGame {
 				$this->db->query('INSERT INTO chess_game_moves
 								(chess_game_id,piece_id,start_x,start_y,end_x,end_y,checked,piece_taken,castling,en_passant,promote_piece_id)
 								VALUES
-								(' . $this->db->escapeNumber($p->chessGameID) . ',' . $this->db->escapeNumber($pieceID) . ',' . $this->db->escapeNumber($x) . ',' . $this->db->escapeNumber($y) . ',' . $this->db->escapeNumber($toX) . ',' . $this->db->escapeNumber($toY) . ',' . $this->db->escapeString($checking, true, true) . ',' . ($moveInfo['PieceTaken'] == null ? 'NULL' : $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID)) . ',' . $this->db->escapeString($castlingType, true, true) . ',' . $this->db->escapeBoolean($moveInfo['EnPassant']) . ',' . ($moveInfo['PawnPromotion'] == false ? 'NULL' : $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceID'])) . ');');
+								(' . $this->db->escapeNumber($p->chessGameID) . ',' . $this->db->escapeNumber($pieceID) . ',' . $this->db->escapeNumber($x) . ',' . $this->db->escapeNumber($y) . ',' . $this->db->escapeNumber($toX) . ',' . $this->db->escapeNumber($toY) . ',' . $this->db->escapeString($checking, true) . ',' . ($moveInfo['PieceTaken'] == null ? 'NULL' : $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID)) . ',' . $this->db->escapeString($castlingType, true) . ',' . $this->db->escapeBoolean($moveInfo['EnPassant']) . ',' . ($moveInfo['PawnPromotion'] == false ? 'NULL' : $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceID'])) . ');');
 
 
 				$currentPlayer->increaseHOF(1, array($chessType, 'Moves', 'Total Taken'), HOF_PUBLIC);

--- a/lib/Default/MySqlDatabase.class.php
+++ b/lib/Default/MySqlDatabase.class.php
@@ -167,8 +167,11 @@ class MySqlDatabase {
 		return sprintf('%f', $data / 1E6);
 	}
 
-	public function getObject($name, $compressed = false) {
+	public function getObject($name, $compressed = false, $nullable = false) {
 		$object = $this->getField($name);
+		if ($nullable === true && $object === null) {
+			return null;
+		}
 		if ($compressed === true) {
 			$object = gzuncompress($object);
 		}
@@ -269,10 +272,13 @@ class MySqlDatabase {
 		}
 	}
 
-	public function escapeObject($object, $compress = false, $nullable = false) {
+	public function escapeObject($object, bool $compress = false, bool $nullable = false) : string {
+		if ($nullable === true && $object === null) {
+			return 'NULL';
+		}
 		if ($compress === true) {
 			return $this->escapeBinary(gzcompress(serialize($object)));
 		}
-		return $this->escapeString(serialize($object), $nullable);
+		return $this->escapeString(serialize($object));
 	}
 }

--- a/lib/Default/MySqlDatabase.class.php
+++ b/lib/Default/MySqlDatabase.class.php
@@ -144,13 +144,13 @@ class MySqlDatabase {
 		return $this->dbRecord[$name];
 	}
 
-	public function getBoolean($name) {
-		if ($this->dbRecord[$name] == 'TRUE') {
+	public function getBoolean(string $name) : bool {
+		if ($this->dbRecord[$name] === 'TRUE') {
 			return true;
+		} elseif ($this->dbRecord[$name] === 'FALSE') {
+			return false;
 		}
-//		if($this->dbRecord[$name] == 'FALSE')
-		return false;
-//		$this->error('Field is not a boolean');
+		$this->error('Field is not a boolean: ' . $name);
 	}
 
 	public function getInt($name) {
@@ -205,11 +205,7 @@ class MySqlDatabase {
 
 	public function escape($escape, $autoQuotes = true, $quotes = true) {
 		if (is_bool($escape)) {
-			if ($autoQuotes) {
-				return $this->escapeBoolean($escape);
-			} else {
-				return $this->escapeBoolean($escape, $quotes);
-			}
+			return $this->escapeBoolean($escape);
 		}
 		if (is_numeric($escape)) {
 			return $this->escapeNumber($escape);
@@ -291,13 +287,12 @@ class MySqlDatabase {
 		return sprintf('%d', $microtime * 1E6);
 	}
 
-	public function escapeBoolean($bool, $quotes = true) {
-		if ($bool === true) {
-			return $this->escapeString('TRUE', $quotes);
-		} elseif ($bool === false) {
-			return $this->escapeString('FALSE', $quotes);
+	public function escapeBoolean(bool $bool) : string {
+		// We store booleans as an enum
+		if ($bool) {
+			return '\'TRUE\'';
 		} else {
-			$this->error('Not a boolean: ' . $bool);
+			return '\'FALSE\'';
 		}
 	}
 

--- a/lib/Default/SmrAlliance.class.php
+++ b/lib/Default/SmrAlliance.class.php
@@ -568,7 +568,7 @@ class SmrAlliance {
 		$opLeader = TRUE;
 		$viewBonds = TRUE;
 		$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
-			'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ', \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+			'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ', \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 
 		switch ($newMemberPermission) {
 			case 'full':
@@ -602,7 +602,7 @@ class SmrAlliance {
 			break;
 		}
 		$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
-					'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ', \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeString($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+					'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ', \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 
 	}
 

--- a/lib/Default/SmrAlliance.class.php
+++ b/lib/Default/SmrAlliance.class.php
@@ -463,13 +463,13 @@ class SmrAlliance {
 								alliance_password = ' . $this->db->escapeString($this->password) . ',
 								recruiting = ' . $this->db->escapeBoolean($this->recruiting) . ',
 								alliance_account = ' . $this->db->escapeNumber($this->bank) . ',
-								alliance_description = ' . $this->db->escapeString($this->description, true, true) . ',
+								alliance_description = ' . $this->db->escapeString($this->description, true) . ',
 								`mod` = ' . $this->db->escapeString($this->motd) . ',
 								img_src = ' . $this->db->escapeString($this->imgSrc) . ',
 								alliance_kills = ' . $this->db->escapeNumber($this->kills) . ',
 								alliance_deaths = ' . $this->db->escapeNumber($this->deaths) . ',
-								discord_server = ' . $this->db->escapeString($this->discordServer, true, true) . ',
-								discord_channel = ' . $this->db->escapeString($this->discordChannel, true, true) . ',
+								discord_server = ' . $this->db->escapeString($this->discordServer, true) . ',
+								discord_channel = ' . $this->db->escapeString($this->discordChannel, true) . ',
 								flagship_id = ' . $this->db->escapeNumber($this->flagshipID) . ',
 								leader_id = ' . $this->db->escapeNumber($this->leaderID) . '
 							WHERE ' . $this->SQL);

--- a/lib/Default/hof.functions.inc
+++ b/lib/Default/hof.functions.inc
@@ -80,12 +80,12 @@ function getHofRank($view, $viewType, $accountID, $gameID) {
 		$query = 'SELECT ' . $statements['CASE'] . ' amount FROM (SELECT type, SUM(amount) amount FROM player_hof WHERE type IN (' . $statements['IN'] . ') AND account_id=' . $db->escapeNumber($accountID) . $gameIDSql . ' GROUP BY account_id,type) x ORDER BY amount DESC';
 		$db->query($query);
 	} else {
-		$db->query('SELECT visibility FROM hof_visibility WHERE type=' . $db->escapeArray($viewType, false, true, ':', false) . ' LIMIT 1');
+		$db->query('SELECT visibility FROM hof_visibility WHERE type=' . $db->escapeArray($viewType, ':', false) . ' LIMIT 1');
 		if (!$db->nextRecord()) {
 			return $rank;
 		}
 		$vis = $db->getField('visibility');
-		$db->query('SELECT SUM(amount) amount FROM player_hof WHERE type=' . $db->escapeArray($viewType, false, true, ':', false) . ' AND account_id=' . $db->escapeNumber($accountID) . $gameIDSql . ' GROUP BY account_id LIMIT 1');
+		$db->query('SELECT SUM(amount) amount FROM player_hof WHERE type=' . $db->escapeArray($viewType, ':', false) . ' AND account_id=' . $db->escapeNumber($accountID) . $gameIDSql . ' GROUP BY account_id LIMIT 1');
 	}
 
 	$realAmount = 0;
@@ -102,7 +102,7 @@ function getHofRank($view, $viewType, $accountID, $gameID) {
 		$query = 'SELECT COUNT(account_id) `rank` FROM (SELECT account_id FROM player_hof WHERE type IN (' . $statements['IN'] . ')' . $gameIDSql . ' GROUP BY account_id HAVING ' . $statements['CASE'] . '>' . $db->escapeNumber($rank['Amount']) . ') x';
 		$db->query($query);
 	} else {
-		$db->query('SELECT COUNT(account_id) `rank` FROM (SELECT account_id FROM player_hof WHERE type=' . $db->escapeArray($viewType, false, true, ':', false) . $gameIDSql . ' GROUP BY account_id HAVING SUM(amount)>' . $db->escapeNumber($realAmount) . ') x');
+		$db->query('SELECT COUNT(account_id) `rank` FROM (SELECT account_id FROM player_hof WHERE type=' . $db->escapeArray($viewType, ':', false) . $gameIDSql . ' GROUP BY account_id HAVING SUM(amount)>' . $db->escapeNumber($realAmount) . ') x');
 	}
 	if ($db->nextRecord()) {
 		$rank['Rank'] = $db->getInt('rank') + 1;

--- a/test/SmrTest/BaseIntegrationSpec.php
+++ b/test/SmrTest/BaseIntegrationSpec.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace SmrTest;
 

--- a/test/SmrTest/Container/DiContainerTest.php
+++ b/test/SmrTest/Container/DiContainerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace SmrTest\Container;
 

--- a/test/SmrTest/MySqlPropertiesTest.php
+++ b/test/SmrTest/MySqlPropertiesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace SmrTest;
 

--- a/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
@@ -133,4 +133,16 @@ class MySqlDatabaseIntegrationTest extends TestCase {
 		$this->expectExceptionMessage('Not a number');
 		$db->escapeNumber('bla');
 	}
+
+	public function test_escapeObject() {
+		$db = MySqlDatabase::getInstance();
+		// Test null
+		self::assertSame('NULL', $db->escapeObject(null, false, true));
+		// Test empty array
+		self::assertSame("'a:0:{}'", $db->escapeObject([]));
+		// Test empty string
+		self::assertSame('\'s:0:\"\";\'', $db->escapeObject(''));
+		// Test zero
+		self::assertSame("'i:0;'", $db->escapeObject(0));
+	}
 }

--- a/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
@@ -115,4 +115,22 @@ class MySqlDatabaseIntegrationTest extends TestCase {
 		$this->expectNoticeMessage('Array to string conversion');
 		$db->escapeArray(['a', ['x', 9, 'y'], 2, 'c'], ':', false);
 	}
+
+	public function test_escapeNumber() {
+		// No escaping is done of numeric types
+		$db = MySqlDatabase::getInstance();
+		// Test int
+		self::assertSame(42, $db->escapeNumber(42));
+		// Test float
+		self::assertSame(0.21, $db->escapeNumber(0.21));
+		// Test numeric string
+		self::assertSame('42', $db->escapeNumber('42'));
+	}
+
+	public function test_escapeNumber_nonnumeric_throws() {
+		$db = MySqlDatabase::getInstance();
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('Not a number');
+		$db->escapeNumber('bla');
+	}
 }

--- a/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
@@ -76,4 +76,43 @@ class MySqlDatabaseIntegrationTest extends TestCase {
 		self::assertSame("'TRUE'", $db->escapeBoolean(true));
 		self::assertSame("'FALSE'", $db->escapeBoolean(false));
 	}
+
+	public function test_escapeString() {
+		$db = MySqlDatabase::getInstance();
+		// Test the empty string
+		self::assertSame("''", $db->escapeString(''));
+		self::assertSame('NULL', $db->escapeString('', true)); // nullable
+		// Test null
+		self::assertSame('NULL', $db->escapeString(null, true)); // nullable
+		// Test a normal string
+		self::assertSame("'bla'", $db->escapeString('bla'));
+		self::assertSame("'bla'", $db->escapeString('bla', true)); // nullable
+	}
+
+	public function test_escapeString_null_throws() {
+		$db = MySqlDatabase::getInstance();
+		$this->expectException(\TypeError::class);
+		$db->escapeString(null);
+	}
+
+	public function test_escapeArray() {
+		$db = MySqlDatabase::getInstance();
+		// Test a mixed array
+		self::assertSame("'a',2,'c'", $db->escapeArray(['a', 2, 'c']));
+		// Test a different implodeString
+		self::assertSame("'a':2:'c'", $db->escapeArray(['a', 2, 'c'], ':'));
+		// Test escapeIndividually=false
+		self::assertSame("'a,2,c'", $db->escapeArray(['a', 2, 'c'], ',', false));
+		// Test nested arrays
+		// Warning: The array is flattened, which may be unexpected!
+		self::assertSame("'a','x',9,2", $db->escapeArray(['a', ['x', 9], 2], ',', true));
+	}
+
+	public function test_escapeArray_nested_array_throws() {
+		// Warning: It is dangerous to use nested arrays with escapeIndividually=false
+		$db = MySqlDatabase::getInstance();
+		$this->expectNotice();
+		$this->expectNoticeMessage('Array to string conversion');
+		$db->escapeArray(['a', ['x', 9, 'y'], 2, 'c'], ':', false);
+	}
 }

--- a/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
@@ -61,4 +61,12 @@ class MySqlDatabaseIntegrationTest extends TestCase {
 		// Then the two mysqli instances are the same
 		self::assertSame($originalMysql, $this->container->get(mysqli::class));
 	}
+
+	public function test_escapeMicrotime() {
+		$db = MySqlDatabase::getInstance();
+		// The current microtime must not throw an exception
+		$db->escapeMicrotime(microtime(true));
+		// Check that the formatting preserves all digits
+		self::assertSame("1608455259123456", $db->escapeMicrotime(1608455259.123456));
+	}
 }

--- a/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace SmrTest\lib\DefaultGame;
 

--- a/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
@@ -69,4 +69,11 @@ class MySqlDatabaseIntegrationTest extends TestCase {
 		// Check that the formatting preserves all digits
 		self::assertSame("1608455259123456", $db->escapeMicrotime(1608455259.123456));
 	}
+
+	public function test_escapeBoolean() {
+		$db = MySqlDatabase::getInstance();
+		// Test both boolean values
+		self::assertSame("'TRUE'", $db->escapeBoolean(true));
+		self::assertSame("'FALSE'", $db->escapeBoolean(false));
+	}
 }

--- a/test/SmrTest/lib/DefaultGame/MySqlDatabaseTest.php
+++ b/test/SmrTest/lib/DefaultGame/MySqlDatabaseTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace SmrTest\lib\DefaultGame;
 

--- a/test/strict_types.sh
+++ b/test/strict_types.sh
@@ -15,7 +15,7 @@ do
         echo "$LINE"
         ERROR="true"
     fi
-done < <(find $ROOT/admin $ROOT/engine $ROOT/lib -type f \( -name "*.php" -o -name "*.inc" \) -print0)
+done < <(find $ROOT/admin $ROOT/engine $ROOT/lib $ROOT/test -type f \( -name "*.php" -o -name "*.inc" \) -print0)
 
 if [[ "$ERROR" == "true" ]] ; then
     exit 1


### PR DESCRIPTION
* Simplify many of the get/escape methods (adding type-hints, removing arguments, using more straightforward logic).
* Remove the microtime hack for incorrectly stored microtimes.
* Fix nullable for object methods.
* Add many unit tests for the escape methods (the get methods are difficult to test due to a lack of DI with the query results).

See individual commit messages for more details.