### PR TITLE
Perform file inspection tests in phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ git:
   depth: false
 script:
   - docker-compose --version
-  - test/phplint.sh
-  - test/strict_types.sh
   - mv .env.sample .env
   - mv config/config.specific.sample.php config/config.specific.php
   - mv config/discord/config.specific.sample.php config/discord/config.specific.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,7 @@ services:
             - ./lib:/smr/lib
             - ./templates:/smr/templates
             - ./test:/smr/test
+            - ./tools:/smr/tools
         depends_on:
             - mysql-integration-test
         labels:

--- a/test/SmrTest/BaseIntegrationSpec.php
+++ b/test/SmrTest/BaseIntegrationSpec.php
@@ -15,9 +15,9 @@ class BaseIntegrationSpec extends TestCase {
 	public static function setUpBeforeClass(): void {
 		if (!isset(self::$conn)) {
 			$mysqlProperties = DiContainer::get(MySqlProperties::class);
-			print "Attempting to connect to MySQL at " . $mysqlProperties->getHost() . "\n";
+			print "\nAttempting to connect to MySQL at " . $mysqlProperties->getHost() . ": ";
 			self::$conn = DiContainer::make(mysqli::class);
-			print "Connected.\n";
+			print "Connected\n";
 			$query = "SELECT table_name FROM information_schema.tables WHERE table_rows > 0 AND TABLE_SCHEMA='smr_live'";
 			$rs = self::$conn->query($query);
 			$all = $rs->fetch_all();
@@ -37,7 +37,6 @@ class BaseIntegrationSpec extends TestCase {
 	}
 
 	private function cleanUp() {
-		echo "Cleaning non-default populated tables for next test...\n";
 		$implode = implode(",", self::$defaultPopulatedTables);
 		$query = "SELECT Concat('TRUNCATE TABLE ', TABLE_NAME, ';') FROM INFORMATION_SCHEMA.TABLES where TABLE_SCHEMA = 'smr_live' and TABLE_NAME not in (${implode})";
 		$rs = self::$conn->query($query);

--- a/test/SmrTest/PhpFileInspectionTest.php
+++ b/test/SmrTest/PhpFileInspectionTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest;
+
+use PHPUnit\Framework\TestCase;
+
+class PhpFileInspectionTest extends TestCase {
+
+	public function test_all_files_use_strict_type() {
+		$exit_code = 1;
+		$output = [];
+		exec(ROOT . 'test/strict_types.sh', $output, $exit_code);
+		$this->assertSame(0, $exit_code, join("\n", $output));
+		$this->assertEquals(end($output), 'Success! No strict_type errors.');
+	}
+
+	public function test_all_files_pass_phplint() {
+		$exit_code = 1;
+		$output = [];
+		exec(ROOT . 'test/phplint.sh', $output, $exit_code);
+		$this->assertSame(0, $exit_code, join("\n", $output));
+		$this->assertEquals(end($output), 'Success! No linting errors.');
+	}
+
+}

--- a/test/phplint.sh
+++ b/test/phplint.sh
@@ -15,7 +15,7 @@ do
         echo "$RESULTS"
         ERROR="true"
     fi
-done < <(find $ROOT -type f \( -name "*.php" -o -name "*.inc" \) -print0)
+done < <(find $ROOT/admin $ROOT/engine $ROOT/lib $ROOT/test $ROOT/templates $ROOT/tools -type f \( -name "*.php" -o -name "*.inc" \) -print0)
 
 if [[ "$ERROR" == "true" ]] ; then
     exit 1

--- a/test/strict_types.sh
+++ b/test/strict_types.sh
@@ -15,7 +15,7 @@ do
         echo "$LINE"
         ERROR="true"
     fi
-done < <(find $ROOT/admin $ROOT/engine $ROOT/lib $ROOT/test -type f \( -name "*.php" -o -name "*.inc" \) -print0)
+done < <(find $ROOT/admin $ROOT/engine $ROOT/lib $ROOT/test $ROOT/tools -type f \( -name "*.php" -o -name "*.inc" \) -print0)
 
 if [[ "$ERROR" == "true" ]] ; then
     exit 1

--- a/tools/irc/irc.php
+++ b/tools/irc/irc.php
@@ -1,4 +1,3 @@
-#!/usr/bin/php -q
 <?php declare(strict_types=1);
 
 class TimeoutException extends Exception {}

--- a/tools/rerunChessGames.php
+++ b/tools/rerunChessGames.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 require_once('../htdocs/config.inc');
 
 SmrSession::updateGame(44);

--- a/tools/reserializeCombatLogs.php
+++ b/tools/reserializeCombatLogs.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 require_once('../htdocs/config.inc');
 

--- a/tools/updatePortCache.php
+++ b/tools/updatePortCache.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 require_once('../htdocs/config.inc');
 
 $db = MySqlDatabase::getInstance();


### PR DESCRIPTION
This allows the phplint and strict_type tests to be easily run in the containerized PHP environment.