### PR TITLE
Fix swallowing exceptions from DiscordPHP

### DIFF
--- a/src/tools/discord/GameLink.class.php
+++ b/src/tools/discord/GameLink.class.php
@@ -16,7 +16,8 @@ class GameLink
 		$this->account = SmrAccount::getAccountByDiscordId($user_id, true);
 
 		if (is_null($this->account)) {
-			$channel->sendMessage("There is no SMR account associated with your Discord User ID. To set this up, go to `Preferences` in-game and set `$user_id` as your `Discord User ID`.");
+			$channel->sendMessage("There is no SMR account associated with your Discord User ID. To set this up, go to `Preferences` in-game and set `$user_id` as your `Discord User ID`.")
+				->done(null, 'logException');
 			return;
 		}
 
@@ -27,7 +28,8 @@ class GameLink
 			if ($db->nextRecord()) {
 				$game_id = $db->getInt('MAX(game_id)');
 			} else {
-				$channel->sendMessage('Could not find any games!');
+				$channel->sendMessage('Could not find any games!')
+					->done(null, 'logException');
 				return;
 			}
 
@@ -41,13 +43,15 @@ class GameLink
 			$this->alliance = SmrAlliance::getAllianceByDiscordChannel($channel_id, true);
 
 			if (is_null($this->alliance)) {
-				$channel->sendMessage("There is no SMR alliance associated with this Discord Channel ID. To set this up (you must have permission to set this for your alliance), go to `Change Alliance Stats` and set `$channel_id` as your `Discord Channel ID`.\n\n-- If this Discord Channel is public, you probably want to choose a different channel for your alliance.\n-- If you are not in an alliance (or if your alliance doesn't want a channel), send your command again in a direct message to me.");
+				$channel->sendMessage("There is no SMR alliance associated with this Discord Channel ID. To set this up (you must have permission to set this for your alliance), go to `Change Alliance Stats` and set `$channel_id` as your `Discord Channel ID`.\n\n-- If this Discord Channel is public, you probably want to choose a different channel for your alliance.\n-- If you are not in an alliance (or if your alliance doesn't want a channel), send your command again in a direct message to me.")
+					->done(null, 'logException');
 				return;
 			}
 
 			$this->player = SmrPlayer::getPlayer($this->account->getAccountID(), $this->alliance->getGameID(), true);
 			if ($this->player->getAllianceID() != $this->alliance->getAllianceID()) {
-				$channel->sendMessage("Player `" . $this->player->getPlayerName() . "` is not a member of alliance `" . $this->alliance->getAllianceName() . "`");
+				$channel->sendMessage("Player `" . $this->player->getPlayerName() . "` is not a member of alliance `" . $this->alliance->getAllianceName() . "`")
+					->done(null, 'logException');
 				return;
 			}
 		}

--- a/src/tools/discord/commands/8ball.php
+++ b/src/tools/discord/commands/8ball.php
@@ -4,10 +4,11 @@ require_once(TOOLS . 'chat_helpers/channel_msg_8ball.php');
 
 $fn_8ball = function($message, $params) {
 	if (empty($params)) {
-		$message->reply('do you have a question for the magic 8-ball?');
+		$response = 'do you have a question for the magic 8-ball?';
 	} else {
-		$message->reply(shared_channel_msg_8ball());
+		$response = shared_channel_msg_8ball();
 	}
+	$message->reply($response)->done(null, 'logException');
 };
 
 $discord->registerCommand('8ball', mysql_cleanup($fn_8ball),

--- a/src/tools/discord/commands/forces.php
+++ b/src/tools/discord/commands/forces.php
@@ -11,7 +11,8 @@ $fn_forces = function($message, $params) {
 	// print the next expiring forces
 	$option = $params[0] ?? null;
 	$results = shared_channel_msg_forces($link->player, $option);
-	$message->channel->sendMessage(join(EOL, $results));
+	$message->channel->sendMessage(join(EOL, $results))
+		->done(null, 'logException');
 };
 
 $discord->registerCommand('forces', mysql_cleanup($fn_forces),

--- a/src/tools/discord/commands/game.php
+++ b/src/tools/discord/commands/game.php
@@ -9,7 +9,7 @@ $fn_game = function($message) {
 	$game = SmrGame::getGame($link->player->getGameID(), true);
 	$msg = "I am linked to game `" . $game->getDisplayName() . "` in this channel.";
 
-	$message->channel->sendMessage($msg);
+	$message->channel->sendMessage($msg)->done(null, 'logException');
 };
 
 $discord->registerCommand('game', mysql_cleanup($fn_game), ['description' => 'Get name of game linked to this channel']);

--- a/src/tools/discord/commands/invite.php
+++ b/src/tools/discord/commands/invite.php
@@ -2,7 +2,7 @@
 
 $fn_invite = function($message) use ($discord) {
 	$msg = "$discord->username can be invited to join your server! Just click this link and select your server:\n<https://discordapp.com/oauth2/authorize?&client_id=$discord->id&scope=bot&permissions=0>\n\nNOTE: you must have manager permissions to perform this action.";
-	$message->channel->sendMessage($msg);
+	$message->channel->sendMessage($msg)->done(null, 'logException');
 };
 
 $discord->registerCommand('invite', $fn_invite, ['description' => 'Invite Autopilot to join your server!']);

--- a/src/tools/discord/commands/money.php
+++ b/src/tools/discord/commands/money.php
@@ -11,7 +11,7 @@ $fn_money = function($message) {
 	$result = shared_channel_msg_money($link->player);
 	if ($result) {
 		$text = implode(EOL, $result);
-		$message->channel->sendMessage($text);
+		$message->channel->sendMessage($text)->done(null, 'logException');
 	}
 };
 

--- a/src/tools/discord/commands/op.php
+++ b/src/tools/discord/commands/op.php
@@ -13,7 +13,8 @@ $fn_op = function($message) {
 
 	// print info about the next op
 	$results = shared_channel_msg_op_info($player);
-	$message->channel->sendMessage(join(EOL, $results));
+	$message->channel->sendMessage(join(EOL, $results))
+		->done(null, 'logException');
 };
 
 $fn_op_list = function($message) {
@@ -25,7 +26,8 @@ $fn_op_list = function($message) {
 
 	// print list of attendees
 	$results = shared_channel_msg_op_list($player);
-	$message->channel->sendMessage(join(EOL, $results));
+	$message->channel->sendMessage(join(EOL, $results))
+		->done(null, 'logException');
 };
 
 $fn_op_turns = function($message) {
@@ -37,7 +39,8 @@ $fn_op_turns = function($message) {
 
 	// print list of attendees
 	$results = shared_channel_msg_op_turns($player);
-	$message->channel->sendMessage(join(EOL, $results));
+	$message->channel->sendMessage(join(EOL, $results))
+		->done(null, 'logException');
 };
 
 $cmd_op = $discord->registerCommand('op', mysql_cleanup($fn_op), ['description' => 'Get information about the next scheduled op']);

--- a/src/tools/discord/commands/seed.php
+++ b/src/tools/discord/commands/seed.php
@@ -9,7 +9,8 @@ $fn_seed = function($message) {
 	}
 
 	$result = shared_channel_msg_seed($link->player);
-	$message->channel->sendMessage(join(EOL, $result));
+	$message->channel->sendMessage(join(EOL, $result))
+		->done(null, 'logException');
 };
 
 $discord->registerCommand('seed', mysql_cleanup($fn_seed), ['description' => 'List sectors with missing seeds']);

--- a/src/tools/discord/commands/seedlist.php
+++ b/src/tools/discord/commands/seedlist.php
@@ -10,7 +10,8 @@ $fn_seedlist = function($message) {
 
 	// print the entire seedlist
 	$results = shared_channel_msg_seedlist($link->player);
-	$message->channel->sendMessage(join(EOL, $results));
+	$message->channel->sendMessage(join(EOL, $results))
+		->done(null, 'logException');
 };
 
 $fn_seedlist_add = function($message, $sectors) {
@@ -21,7 +22,8 @@ $fn_seedlist_add = function($message, $sectors) {
 
 	// add sectors to the seedlist
 	$results = shared_channel_msg_seedlist_add($link->player, $sectors);
-	$message->channel->sendMessage(join(EOL, $results));
+	$message->channel->sendMessage(join(EOL, $results))
+		->done(null, 'logException');
 };
 
 $fn_seedlist_del = function($message, $sectors) {
@@ -32,7 +34,8 @@ $fn_seedlist_del = function($message, $sectors) {
 
 	// delete sectors from the seedlist
 	$results = shared_channel_msg_seedlist_del($link->player, $sectors);
-	$message->channel->sendMessage(join(EOL, $results));
+	$message->channel->sendMessage(join(EOL, $results))
+		->done(null, 'logException');
 };
 
 $cmd_seedlist = $discord->registerCommand('seedlist', mysql_cleanup($fn_seedlist), ['description' => 'Print the entire seedlist']);

--- a/src/tools/discord/commands/turns.php
+++ b/src/tools/discord/commands/turns.php
@@ -23,7 +23,8 @@ $fn_turns = function($message) {
 	$player = $link->player;
 
 	$results = array_map('get_turns_message', $player->getSharingPlayers(true));
-	$message->channel->sendMessage(join("\n", $results));
+	$message->channel->sendMessage(join("\n", $results))
+		->done(null, 'logException');
 };
 
 $cmd_turns = $discord->registerCommand('turns', mysql_cleanup($fn_turns), ['description' => 'Show current turns']);

--- a/src/tools/discord/mysql_cleanup.php
+++ b/src/tools/discord/mysql_cleanup.php
@@ -10,9 +10,9 @@ function mysql_cleanup(callable $func) {
 		try {
 			$func($message, $params);
 		} catch (Throwable $e) {
-			print('Error in ' . $e->getFile() . ' line ' . $e->getLine() . ':' . EOL);
-			print($e->getMessage() . EOL);
-			$message->reply('I encountered an error. Please report this to an admin!');
+			logException($e);
+			$message->reply('I encountered an error. Please report this to an admin!')
+				->done(null, 'logException');
 		}
 
 		// Then, close the mysql connection to prevent timeouts


### PR DESCRIPTION
DiscordPHP uses reactphp/promise for async events (such as sending
messages). If no rejection handler is supplied, then exceptions that
are thrown by the event get swalled (i.e. silently ignored).

Since our primary goal is to ensure all errors are reported, we call
`->done(null, 'logException')` on all returned promises. This means
that it will do nothing on success and call `logException` on failure.
Note that if `logException` throws an exception itself, it will cause
a fatal PHP error.

We also use `logException` for the normal handling of exceptions that
are thrown during the command responses instead of just printing them
(e.g. for additional logging machinery).
