### PR TITLE
Prevent unnecessary page refresh errors

### DIFF
--- a/src/lib/Default/Request.class.php
+++ b/src/lib/Default/Request.class.php
@@ -87,34 +87,27 @@ class Request {
 	 * Note that this does not save the result in $var (see SmrSession).
 	 */
 	public static function getVar(string $index, string $default = null) : string {
-		global $var;
-		if (isset($var[$index])) {
-			if (self::has($index)) {
-				throw new Exception('Index "' . $index . '" must not be in both $var and $_REQUEST!');
-			}
-			return $var[$index];
-		}
-		return self::get($index, $default);
+		return self::getVarX($index, $default, 'get');
 	}
 
 	/**
 	 * Like getVar, but returns an int instead of a string.
 	 */
 	public static function getVarInt(string $index, int $default = null) : int {
-		global $var;
-		if (isset($var[$index])) {
-			if (self::has($index)) {
-				throw new Exception('Index "' . $index . '" must not be in both $var and $_REQUEST!');
-			}
-			return $var[$index];
-		}
-		return self::getInt($index, $default);
+		return self::getVarX($index, $default, 'getInt');
 	}
 
 	/**
 	 * Like getVar, but returns an array of ints instead of a string.
 	 */
 	public static function getVarIntArray(string $index, array $default = null) : array {
+		return self::getVarX($index, $default, 'getIntArray');
+	}
+
+	/**
+	 * Helper function to avoid code duplication in getVar* functions.
+	 */
+	private static function getVarX($index, $default, $func) {
 		global $var;
 		if (isset($var[$index])) {
 			if (self::has($index)) {
@@ -122,7 +115,7 @@ class Request {
 			}
 			return $var[$index];
 		}
-		return self::getIntArray($index, $default);
+		return self::$func($index, $default);
 	}
 
 

--- a/src/lib/Default/Request.class.php
+++ b/src/lib/Default/Request.class.php
@@ -110,8 +110,11 @@ class Request {
 	private static function getVarX($index, $default, $func) {
 		global $var;
 		if (isset($var[$index])) {
-			if (self::has($index)) {
-				throw new Exception('Index "' . $index . '" must not be in both $var and $_REQUEST!');
+			// An index may be present in both var and request. This indicates
+			// a logical error in the code, unless the values are the same,
+			// which can occur if, e.g., player refreshes a page (this is OK).
+			if (self::has($index) && $var[$index] !== self::$func($index, $default)) {
+				throw new Exception('Index "' . $index . '" inconsistent between $var and $_REQUEST!');
 			}
 			return $var[$index];
 		}

--- a/test/SmrTest/lib/DefaultGame/RequestTest.php
+++ b/test/SmrTest/lib/DefaultGame/RequestTest.php
@@ -156,10 +156,17 @@ class RequestTest extends \PHPUnit\Framework\TestCase {
 	public function test_getVar_exception_index_in_both() {
 		global $var;
 		$var['str'] = 'ing:var';
-		// An index that exists in both var and request
+		// An index that exists in both var and request, with different values
 		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('Index "str" must not be in both $var and $_REQUEST!');
+		$this->expectExceptionMessage('Index "str" inconsistent between $var and $_REQUEST!');
 		Request::getVar('str');
+	}
+
+	public function test_getVar_index_same_in_both() {
+		global $var;
+		$var['str'] = 'ing';
+		// An index that exists in both var and request, with the same value
+		$this->assertSame(Request::getVar('str'), 'ing');
 	}
 
 	//------------------------------------------------------------------------
@@ -192,10 +199,17 @@ class RequestTest extends \PHPUnit\Framework\TestCase {
 	public function test_getVarInt_exception_index_in_both() {
 		global $var;
 		$var['int'] = 3;
-		// An index that exists in both var and request
+		// An index that exists in both var and request, with different values
 		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('Index "int" must not be in both $var and $_REQUEST!');
+		$this->expectExceptionMessage('Index "int" inconsistent between $var and $_REQUEST!');
 		Request::getVarInt('int');
+	}
+
+	public function test_getVarInt_index_same_in_both() {
+		global $var;
+		$var['int'] = 2;
+		// An index that exists in both var and request, with the same value
+		$this->assertSame(Request::getVarInt('int'), 2);
 	}
 
 	//------------------------------------------------------------------------
@@ -228,10 +242,17 @@ class RequestTest extends \PHPUnit\Framework\TestCase {
 	public function test_getVarIntArray_exception_index_in_both() {
 		global $var;
 		$var['array_int'] = [];
-		// An index that exists in both var and request
+		// An index that exists in both var and request, with different values
 		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('Index "array_int" must not be in both $var and $_REQUEST!');
+		$this->expectExceptionMessage('Index "array_int" inconsistent between $var and $_REQUEST!');
 		Request::getVarIntArray('array_int');
+	}
+
+	public function test_getVarIntArray_index_same_in_both() {
+		global $var;
+		$var['array_int'] = [1, 2, 3];
+		// An index that exists in both var and request, with the same value
+		$this->assertSame(Request::getVarIntArray('array_int'), [1, 2, 3]);
 	}
 
 }

--- a/test/SmrTest/lib/DefaultGame/RequestTest.php
+++ b/test/SmrTest/lib/DefaultGame/RequestTest.php
@@ -1,0 +1,237 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use Request;
+
+/**
+ * Class RequestTest
+ * @package SmrTest\lib\DefaultGame
+ * @covers Request
+ */
+class RequestTest extends \PHPUnit\Framework\TestCase {
+
+	public static function setUpBeforeClass() : void {
+		$_REQUEST = [
+			'int' => 2,
+			'float' => 3.14,
+			'str' => 'ing',
+			'array_empty' => [],
+			'array_str' => ['a', 'b', 'c'],
+			'array_int' => [1, 2, 3],
+		];
+	}
+
+	protected function setUp() : void {
+		// Reset $var for each test function
+		unset($GLOBALS['var']);
+	}
+
+	//------------------------------------------------------------------------
+
+	public function test_has() {
+		// An index that exists
+		$this->assertTrue(Request::has('str'));
+		// An index that doesn't exist
+		$this->assertFalse(Request::has('noexist'));
+	}
+
+	//------------------------------------------------------------------------
+
+	public function test_getInt() {
+		// An index that exists, with default
+		$this->assertSame(Request::getInt('int', 3), 2);
+		// An index that exists, no default
+		$this->assertSame(Request::getInt('int'), 2);
+		// An index that doesn't exist, with default
+		$this->assertSame(Request::getInt('noexist', 3), 3);
+	}
+
+	public function test_getInt_exception() {
+		// An index that doesn't exist, no default
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('No request variable "noexist"');
+		Request::getInt('noexist');
+	}
+
+	//------------------------------------------------------------------------
+
+	public function test_getFloat() {
+		// An index that exists, with default
+		$this->assertSame(Request::getFloat('float', 2.0), 3.14);
+		// An index that exists, no default
+		$this->assertSame(Request::getFloat('float'), 3.14);
+		// An index that doesn't exist, with default
+		$this->assertSame(Request::getFloat('noexist', 3.14), 3.14);
+	}
+
+	public function test_getFloat_exception() {
+		// An index that doesn't exist, no default
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('No request variable "noexist"');
+		Request::getFloat('noexist');
+	}
+
+	//------------------------------------------------------------------------
+
+	public function test_getArray() {
+		// An index that exists, with default
+		$this->assertSame(Request::getArray('array_str', []), ['a', 'b', 'c']);
+		// An index that exists, no default
+		$this->assertSame(Request::getArray('array_str'), ['a', 'b', 'c']);
+		// An index that doesn't exist, with default
+		$this->assertSame(Request::getArray('noexist', ['a']), ['a']);
+	}
+
+	public function test_getArray_exception() {
+		// An index that doesn't exist, no default
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('No request variable "noexist"');
+		Request::getArray('noexist');
+	}
+
+	//------------------------------------------------------------------------
+
+	public function test_getIntArray() {
+		// An index that exists, with default
+		$this->assertSame(Request::getIntArray('array_int', []), [1, 2, 3]);
+		// An index that exists, no default
+		$this->assertSame(Request::getIntArray('array_int'), [1, 2, 3]);
+		// An index that doesn't exist, with default
+		$this->assertSame(Request::getIntArray('noexist', [1]), [1]);
+	}
+
+	public function test_getIntArray_exception() {
+		// An index that doesn't exist, no default
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('No request variable "noexist"');
+		Request::getIntArray('noexist');
+	}
+
+	//------------------------------------------------------------------------
+
+	public function test_get() {
+		// An index that exists, with default
+		$this->assertSame(Request::get('str', 'foo'), 'ing');
+		// An index that exists, no default
+		$this->assertSame(Request::get('str'), 'ing');
+		// An index that doesn't exist, with default
+		$this->assertSame(Request::get('noexist', 'foo'), 'foo');
+	}
+
+	public function test_get_exception() {
+		// An index that doesn't exist, no default
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('No request variable "noexist"');
+		Request::get('noexist');
+	}
+
+	//------------------------------------------------------------------------
+
+	public function test_getVar() {
+		global $var;
+		$var['var:str'] = 'ing';
+		// An index that exists in var but not request, no default
+		$this->assertSame(Request::getVar('var:str'), 'ing');
+		// An index that exists in var but not request, with default
+		$this->assertSame(Request::getVar('var:str', 'foo'), 'ing');
+	}
+
+	public function test_getVar_no_var() {
+		// An index that exists in request but not var, no default
+		$this->assertSame(Request::getVar('str'), 'ing');
+		// An index that exists in request but not var, with default
+		$this->assertSame(Request::getVar('str', 'foo'), 'ing');
+		// An index neither in request nor var, with default
+		$this->assertSame(Request::getVar('noexist', 'foo'), 'foo');
+	}
+
+	public function test_getVar_exception_no_default() {
+		// An index that doesn't exist in request or var, no default
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('No request variable "noexist"');
+		Request::getVar('noexist');
+	}
+
+	public function test_getVar_exception_index_in_both() {
+		global $var;
+		$var['str'] = 'ing:var';
+		// An index that exists in both var and request
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Index "str" must not be in both $var and $_REQUEST!');
+		Request::getVar('str');
+	}
+
+	//------------------------------------------------------------------------
+
+	public function test_getVarInt() {
+		global $var;
+		$var['var:int'] = 2;
+		// An index that exists in var but not request, no default
+		$this->assertSame(Request::getVarInt('var:int'), 2);
+		// An index that exists in var but not request, with default
+		$this->assertSame(Request::getVarInt('var:int', 3), 2);
+	}
+
+	public function test_getVarInt_no_var() {
+		// An index that exists in request but not var, no default
+		$this->assertSame(Request::getVarInt('int'), 2);
+		// An index that exists in request but not var, with default
+		$this->assertSame(Request::getVarInt('int', 3), 2);
+		// An index neither in request nor var, with default
+		$this->assertSame(Request::getVarInt('noexist', 3), 3);
+	}
+
+	public function test_getVarInt_exception_no_default() {
+		// An index that doesn't exist in request or var, no default
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('No request variable "noexist"');
+		Request::getVarInt('noexist');
+	}
+
+	public function test_getVarInt_exception_index_in_both() {
+		global $var;
+		$var['int'] = 3;
+		// An index that exists in both var and request
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Index "int" must not be in both $var and $_REQUEST!');
+		Request::getVarInt('int');
+	}
+
+	//------------------------------------------------------------------------
+
+	public function test_getVarIntArray() {
+		global $var;
+		$var['var:array_int'] = [1, 2, 3];
+		// An index that exists in var but not request, no default
+		$this->assertSame(Request::getVarIntArray('var:array_int'), [1, 2, 3]);
+		// An index that exists in var but not request, with default
+		$this->assertSame(Request::getVarIntArray('var:array_int', []), [1, 2, 3]);
+	}
+
+	public function test_getVarIntArray_no_var() {
+		// An index that exists in request but not var, no default
+		$this->assertSame(Request::getVarIntArray('array_int'), [1, 2, 3]);
+		// An index that exists in request but not var, with default
+		$this->assertSame(Request::getVarIntArray('array_int', []), [1, 2, 3]);
+		// An index neither in request nor var, with default
+		$this->assertSame(Request::getVarIntArray('noexist', [1]), [1]);
+	}
+
+	public function test_getVarIntArray_exception_no_default() {
+		// An index that doesn't exist in request or var, no default
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('No request variable "noexist"');
+		Request::getVarIntArray('noexist');
+	}
+
+	public function test_getVarIntArray_exception_index_in_both() {
+		global $var;
+		$var['array_int'] = [];
+		// An index that exists in both var and request
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Index "array_int" must not be in both $var and $_REQUEST!');
+		Request::getVarIntArray('array_int');
+	}
+
+}


### PR DESCRIPTION
On pages with form submission, we typically save the form data in the
SmrSession $var. If the player then refreshes this page and resubmits
the form data (which is the default for most browsers), then we would
raise an exception due to the data being present both in $var and in
$_REQUEST. We want to allow this behavior, while still catching any
coding errors that result from setting session data incorrectly.

To do this, we now allow duplicate indices in $var and $_REQUEST if
and only if the values are the same in both. This could still hide a
coding error (if the values were accidentally the same), but at least
in this case it has no impact on the displayed page (unlike if the
values are different).

Also added a unit test for the Request class, and some minor refactoring.