### PR TITLE
Change credits given to players on death

### DIFF
--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -10,6 +10,8 @@ abstract class AbstractSmrPlayer {
 	const TIME_FOR_FEDERAL_BOUNTY_ON_PR = 10800;
 	const TIME_FOR_ALLIANCE_SWITCH = 0;
 
+	const SHIP_INSURANCE_FRACTION = 0.25; // ship value regained on death
+
 	const HOF_CHANGED = 1;
 	const HOF_NEW = 2;
 
@@ -2189,12 +2191,10 @@ abstract class AbstractSmrPlayer {
 		// reset turns since last death
 		$this->setHOF(0, array('Movement', 'Turns Used', 'Since Last Death'), HOF_ALLIANCE);
 
-		// 1/4 of ship value -> insurance
-		$newCredits = IRound($this->getShip()->getCost() / 4);
-		if ($newCredits < 100000) {
-			$newCredits = 100000;
-		}
-		$this->setCredits($newCredits);
+		// Reset credits to starting amount + ship insurance
+		$credits = $this->getGame()->getStartingCredits();
+		$credits += IRound($this->getShip()->getCost() * self::SHIP_INSURANCE_FRACTION);
+		$this->setCredits($credits);
 
 		$this->setSectorID($this->getHome());
 		$this->increaseDeaths(1);

--- a/src/templates/Default/admin/Default/1.6/GameDetails.inc.php
+++ b/src/templates/Default/admin/Default/1.6/GameDetails.inc.php
@@ -59,7 +59,10 @@
 	</tr>
 	<tr>
 		<td class="right">Starting Credits</td>
-		<td><input required type="number" size="6" name="starting_credits" value="<?php echo $Game['startCredits']; ?>"></td>
+		<td>
+			<input required type="number" size="6" name="starting_credits" value="<?php echo $Game['startCredits']; ?>">
+			Given at game start and on death
+		</td>
 	</tr>
 	<tr>
 		<td class="right">Ignore Stats</td>


### PR DESCRIPTION
Previously, players would get 100k credits or 1/4 their ship value,
whichever was higher.

Now, players will get the starting credits + 1/4 their ship value.

This change allows us to modify the minimum credits supplied on death
for a given game (whereas previously it was a hard-coded constant).
However, it would be even better to have a separate knob to change
the on-death credits.

The two components are added instead of taking the larger amount only
for simplicity. It also makes death slightly less punishing (in a
monetary sense) for players in ships less than ~1M credits, which is
probably a good thing.