### PR TITLE
Add infrastructure for Xdebug profiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,13 @@ RUN MODE=$([ "$PHP_DEBUG" = "1" ] && echo "development" || echo "production") &&
 	echo "Using $MODE php.ini" && \
 	mv "$PHP_INI_DIR/php.ini-$MODE" "$PHP_INI_DIR/php.ini"
 
+# Install xdebug (use /tmp/xdebug for profiler output)
 RUN if [ "$PHP_DEBUG" = "1" ]; \
 	then \
 		pecl install xdebug-3.0.2 && \
-		docker-php-ext-enable xdebug; \
+		docker-php-ext-enable xdebug && \
+		echo "xdebug.output_dir = /tmp/xdebug" > "$PHP_INI_DIR/conf.d/xdebug.ini" && \
+		mkdir /tmp/xdebug; \
 	fi
 
 # Disable apache access logging (error logging is still enabled)

--- a/config/env.sample
+++ b/config/env.sample
@@ -12,3 +12,4 @@ MYSQL_HOST=smr-mysql
 MYSQL_DATABASE=smr_live
 SMR_HOST=smr-game
 PHP_DEBUG=0
+#XDEBUG_MODE=profile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ x-mysql-common: &mysql-common
 services:
     smr:
         <<: *smr-common
+        environment:
+            - XDEBUG_MODE
 
     smr-dev:
         <<: *smr-common
@@ -72,8 +74,11 @@ services:
             - ./config:/smr/config:ro
             # Mount the source code instead of copying it.
             - ./src:/smr/src
+            # Directory for Xdebug profiler output
+            - ./vol_xdebug:/tmp/xdebug
         environment:
-            DISABLE_PHPDI_COMPILATION: "true"
+            - XDEBUG_MODE
+            - DISABLE_PHPDI_COMPILATION="true"
 
     smtp:
         image: hemberger/postfix-relay
@@ -195,3 +200,18 @@ services:
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
             - ./vol_portainer:/data
+
+    # Web interface to display Xdebug profiler results
+    webgrind:
+        image: jokkedk/webgrind
+        networks:
+            - frontend
+        labels:
+            - "traefik.enable=true"
+            - "traefik.http.routers.webgrind.rule=PathPrefix(`/webgrind`)"
+            - "traefik.http.routers.webgrind.middlewares=strip-pathprefix@file"
+        volumes:
+            # Webgrind looks for Xdebug profiler files in /tmp by default
+            - ./vol_xdebug:/tmp
+            # Files mapped under /host will be available for code lookup
+            - ./src:/host/smr/src:ro


### PR DESCRIPTION
Specify `XDEBUG_MODE=profile` in the `.env` file to enable profiling
output by Xdebug. This will work with both the `smr` and `smr-dev`
services (but not `smr-integration-test`, because the profiling does
not work properly with long-running processes). If not specified,
`XDEBUG_MODE` will use the Xdebug default value 'develop' (for more
information, see https://xdebug.org/docs/all_settings#mode).

Profiling data is output to `./vol_xdebug`. These files can get quite
large, so you may want to clean them up from time to time.

The `webgrind` service can be used to quickly visualize the profiler
output, and is served at http://localhost/webgrind.