### PR TITLE
Dockerfile: reduce verbosity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,24 +18,24 @@ RUN rm -rf node_modules
 #---------------------------
 
 FROM php:7.4.14-apache
-RUN apt-get update \
-	&& apt-get install -y zip unzip \
+RUN apt-get --quiet=2 update \
+	&& apt-get --quiet=2 install zip unzip \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install mysqli opcache
+	&& docker-php-ext-install mysqli opcache > /dev/null
 
 # Set the baseline php.ini version based on the value of PHP_DEBUG
 ARG PHP_DEBUG=0
-RUN MODE=$([ "$PHP_DEBUG" = "1" ] && echo "development" || echo "production") && \
-	echo "Using $MODE php.ini" && \
-	mv "$PHP_INI_DIR/php.ini-$MODE" "$PHP_INI_DIR/php.ini"
+RUN MODE=$([ "$PHP_DEBUG" = "1" ] && echo "development" || echo "production") \
+	&& echo "Using $MODE php.ini" \
+	&& mv "$PHP_INI_DIR/php.ini-$MODE" "$PHP_INI_DIR/php.ini"
 
 # Install xdebug (use /tmp/xdebug for profiler output)
 RUN if [ "$PHP_DEBUG" = "1" ]; \
 	then \
-		pecl install xdebug-3.0.2 && \
-		docker-php-ext-enable xdebug && \
-		echo "xdebug.output_dir = /tmp/xdebug" > "$PHP_INI_DIR/conf.d/xdebug.ini" && \
-		mkdir /tmp/xdebug; \
+		pecl install xdebug-3.0.2 > /dev/null \
+		&& docker-php-ext-enable xdebug \
+		&& echo "xdebug.output_dir = /tmp/xdebug" > "$PHP_INI_DIR/conf.d/xdebug.ini" \
+		&& mkdir /tmp/xdebug; \
 	fi
 
 # Disable apache access logging (error logging is still enabled)
@@ -50,7 +50,7 @@ RUN curl -sS https://getcomposer.org/installer | \
 	php -- --install-dir=/usr/local/bin --filename=composer --version=2.0.9
 
 COPY composer.json .
-RUN composer install --no-interaction
+RUN composer update --quiet --no-interaction
 
 COPY --from=builder /smr .
 RUN rm -rf /var/www/html/ && ln -s "$(pwd)/src/htdocs" /var/www/html
@@ -65,6 +65,6 @@ RUN a2enmod headers
 # Store the git commit hash of the repo in the final image
 COPY .git/HEAD .git/HEAD
 COPY .git/refs .git/refs
-RUN REF="ref: HEAD" && \
-	while [ -n "$(echo $REF | grep ref:)" ]; do REF=$(cat ".git/$(echo $REF | awk '{print $2}')"); done && \
-	echo $REF > git-commit
+RUN REF="ref: HEAD" \
+	&& while [ -n "$(echo $REF | grep ref:)" ]; do REF=$(cat ".git/$(echo $REF | awk '{print $2}')"); done \
+	&& echo $REF > git-commit


### PR DESCRIPTION
* Use the `--quiet=2` option for apt-get commands (note that this
  implies `-y` for install).

* Add the `--quiet` option to composer, and use `update` instead of
  `install` as per the instructions in the warning that we don't use
  a composer.lock file.

* Redirect stdout of `docker-php-ext-install` commands to /dev/null,
  as recommended by the docker-php maintainer (see, e.g.,
  https://github.com/docker-library/php/issues/319).

* Redirect stdout of xdebug installation to /dev/null, because there
  is no recommended way to make the command quieter. While some of
  its stdout is useful (e.g. notification when a new xdebug version
  is available), there is simply too much compiler output.