### PR TITLE
Upgrade to grunt-cache-bust v1.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM node:alpine as builder
 
 WORKDIR /smr/
 
-# See https://github.com/hollandben/grunt-cache-bust/issues/236
-RUN npm i --save grunt grunt-contrib-uglify grunt-contrib-cssmin grunt-cache-bust@1.4.1
+RUN npm i --save grunt grunt-contrib-uglify grunt-contrib-cssmin grunt-cache-bust@1.7.0
 
 # Copy the SMR source code directories
 COPY src src

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -66,6 +66,6 @@ try {
 		<script>
 			const graph = <?php echo $data; ?>;
 		</script>
-		<script src="js/map_warps.js"></script>
+		<script src="/js/map_warps.js"></script>
 	</body>
 </html>

--- a/src/templates/Default/engine/Default/course_plot.php
+++ b/src/templates/Default/engine/Default/course_plot.php
@@ -101,7 +101,7 @@ Add new destinations below. Stored destinations can be organized by dragging.
 		</div><?php
 	} ?>
 </div>
-<?php $this->addJavascriptSource('js/course_plot.js'); ?>
+<?php $this->addJavascriptSource('/js/course_plot.js'); ?>
 
 <br/><br/>
 <h2>Add new destination</h2>

--- a/src/templates/Default/engine/Default/includes/EndingJavascript.inc.php
+++ b/src/templates/Default/engine/Default/includes/EndingJavascript.inc.php
@@ -1,5 +1,5 @@
-<script src="js/jquery.hotkeys.js"></script>
-<script src="js/ajax.js"></script>
+<script src="/js/jquery.hotkeys.js"></script>
+<script src="/js/ajax.js"></script>
 
 <?php
 foreach ($this->jsSources as $src) { ?>
@@ -12,7 +12,7 @@ foreach ($this->jsAlerts as $string) {
 
 if (!empty($this->listjsInclude)) { ?>
 	<script src="<?php echo LISTJS_URL; ?>"></script>
-	<script src="js/listjs_include.js"></script>
+	<script src="/js/listjs_include.js"></script>
 	<script>
 		listjs.<?php echo $this->listjsInclude; ?>();
 	</script><?php

--- a/src/templates/Default/engine/Default/includes/Head.inc.php
+++ b/src/templates/Default/engine/Default/includes/Head.inc.php
@@ -40,7 +40,7 @@ if (isset($ExtraCSSLink)) {
 if (isset($HeaderTemplateInclude)) {
 	$this->includeTemplate($HeaderTemplateInclude);
 } ?>
-<link rel="stylesheet" href="css/colorpicker.css" />
+<link rel="stylesheet" href="/css/colorpicker.css" />
 <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
 <script src="https://code.jquery.com/ui/1.12.0/jquery-ui.min.js"></script>
-<script src="js/smr15.js"></script>
+<script src="/js/smr15.js"></script>

--- a/src/templates/Default/engine/Default/preferences.php
+++ b/src/templates/Default/engine/Default/preferences.php
@@ -456,4 +456,4 @@ if (isset($GameID)) { ?>
 	</table>
 </form>
 
-<?php $this->addJavascriptSource('js/colorpicker.js'); ?>
+<?php $this->addJavascriptSource('/js/colorpicker.js'); ?>

--- a/src/templates/Default/engine/Default/weapon_reorder.php
+++ b/src/templates/Default/engine/Default/weapon_reorder.php
@@ -37,7 +37,7 @@ if ($ThisShip->hasWeapons()) { ?>
 			<input type="submit" value="Update Weapon Order" />
 		</form>
 	</div>
-	<?php $this->addJavascriptSource('js/weapon_reorder.js');
+	<?php $this->addJavascriptSource('/js/weapon_reorder.js');
 } else {
 	?>You don't have any weapons!<?php
 } ?>

--- a/src/templates/Default/login/login.php
+++ b/src/templates/Default/login/login.php
@@ -114,4 +114,4 @@ if (isset($Story)) { ?>
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-<script src="js/login.js"></script>
+<script src="/js/login.js"></script>

--- a/src/templates/Default/login/skeleton.php
+++ b/src/templates/Default/login/skeleton.php
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title><?php echo PAGE_TITLE; ?></title>
-		<link rel="stylesheet" href="css/login.css" />
+		<link rel="stylesheet" href="/css/login.css" />
 		<?php
 		// Include Google Analytics global site tag if we have one
 		if (!empty(GOOGLE_ANALYTICS_ID)) { ?>

--- a/src/templates/Default/ship_list.php
+++ b/src/templates/Default/ship_list.php
@@ -17,7 +17,7 @@
 			color: #80C870;
 		}
 		</style>
-		<script src="js/filter_list.js"></script>
+		<script src="/js/filter_list.js"></script>
 	</head>
 
 	<body>

--- a/src/templates/Default/weapon_list.php
+++ b/src/templates/Default/weapon_list.php
@@ -17,7 +17,7 @@
 			color: #80C870;
 		}
 		</style>
-		<script src="js/filter_list.js"></script>
+		<script src="/js/filter_list.js"></script>
 	</head>
 
 	<body onload="resetBoxes()">


### PR DESCRIPTION
The behavior of this package has changed since v1.4.1, such that the
replacements are made in files with a strict adherence to relative
paths from the `baseDir` option. Since many of our PHP files aren't
located where they are served from (e.g. templates, includes, etc.),
grunt-cache-bust doesn't bust these files anymore.

The easiest fix is reference all JS/CSS with absolute URL paths (e.g.
`css/Default.css` -> `/css/Default.css`). While this is not an ideal
solution, due to its degradation of our support for serving the game
from a subdirectory (e.g. `http://localhost/smr` instead of just
`http://localhost`), it solves the problem for our current dev and
production configurations.

See https://github.com/benhoIIand/grunt-cache-bust/pull/211 for the
PR that introduced this breaking change.

See https://github.com/benhoIIand/grunt-cache-bust/issues/236 for a
summary of how this change impacted our usage.

Thanks to @Page- for the deep dive into grunt-cache-bust!