### PR TITLE
run-tests.yml: use buildkit for docker builds

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,15 @@ on:
 
 jobs:
   build-and-test:
+    name: Build and Test
+
     runs-on: ubuntu-20.04
+
+    env:
+      # Use buildkit for faster builds
+      COMPOSE_DOCKER_CLI_BUILD: 1
+      DOCKER_BUILDKIT: 1
+      BUILDKIT_PROGRESS: plain
 
     steps:
       - name: Checkout the source code


### PR DESCRIPTION
GitHub Actions environments support buildkit, which is a new build API
that is supposed to offer a lot of benefits over the legacy build
(see https://docs.docker.com/develop/develop-images/build_enhancements/).

We use the "plain" progress output so that the CI logs have the full
output (since the default buildkit output is compactified).