### PR TITLE
Upgrade to PHP 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN rm -rf node_modules
 
 #---------------------------
 
-FROM php:7.4.14-apache
+FROM php:8.0.2-apache
 RUN apt-get --quiet=2 update \
 	&& apt-get --quiet=2 install zip unzip \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"google/recaptcha": "^1.1",
 		"league/oauth2-facebook": "2.0.5",
 		"league/oauth2-google": "3.0.3",
-		"php": "^7.4",
+		"php": "^8.0",
 		"php-di/php-di": "6.3.0",
 		"phpmailer/phpmailer": "6.2.0",
 		"team-reflex/discord-php": "5.1.1",

--- a/src/lib/Default/AbstractSmrAccount.class.php
+++ b/src/lib/Default/AbstractSmrAccount.class.php
@@ -244,9 +244,9 @@ abstract class AbstractSmrAccount {
 	}
 
 	/**
-	 * @return array|false
+	 * Check if the account is disabled.
 	 */
-	public function isDisabled() {
+	public function isDisabled() : array | false {
 		$this->db->query('SELECT * FROM account_is_closed JOIN closing_reason USING(reason_id) ' .
 			'WHERE ' . $this->SQL . ' LIMIT 1');
 		if ($this->db->nextRecord()) {

--- a/src/lib/Default/SmrGalaxy.class.php
+++ b/src/lib/Default/SmrGalaxy.class.php
@@ -338,9 +338,9 @@ class SmrGalaxy {
 	}
 
 	/**
-	 * @param int|SmrSector $sectorID
+	 * Check if the galaxy contains a specific sector.
 	 */
-	public function contains($sectorID) : bool {
+	public function contains(int | SmrSector $sectorID) : bool {
 		if ($sectorID instanceof SmrSector) {
 			return $sectorID->getGalaxyID() == $this->getGalaxyID();
 		}

--- a/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
@@ -111,8 +111,8 @@ class MySqlDatabaseIntegrationTest extends TestCase {
 	public function test_escapeArray_nested_array_throws() {
 		// Warning: It is dangerous to use nested arrays with escapeIndividually=false
 		$db = MySqlDatabase::getInstance();
-		$this->expectNotice();
-		$this->expectNoticeMessage('Array to string conversion');
+		$this->expectWarning();
+		$this->expectWarningMessage('Array to string conversion');
 		$db->escapeArray(['a', ['x', 9, 'y'], 2, 'c'], ':', false);
 	}
 


### PR DESCRIPTION
* Add union types to interfaces. These were omitted when adding type
  hints to some classes prior to switching to PHP 8.

* The "Array to string conversion" notice has been promoted to a
  warning.