### PR TITLE
Replace switch with match where possible

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -87,6 +87,7 @@ const DEFAULT_DATE_FULL_LONG = 'l F jS Y ' . DEFAULT_DATE_TIME_SHORT;
 /*
  * Buyer restrictions for ships and weapons
  */
+const BUYER_RESTRICTION_NONE = 0;
 const BUYER_RESTRICTION_GOOD = 1;
 const BUYER_RESTRICTION_EVIL = 2;
 const BUYER_RESTRICTION_NEWBIE = 3;

--- a/src/engine/Default/chess_move_processing.php
+++ b/src/engine/Default/chess_move_processing.php
@@ -12,29 +12,16 @@ if (!$chessGame->hasEnded()) {
 	if ($chessGame->isCurrentTurn($account->getAccountID())) {
 		$board = $chessGame->getBoard();
 		if ($board[$y][$x] != null) {
-			switch ($chessGame->tryMove($x, $y, $toX, $toY, $account->getAccountID(), ChessPiece::QUEEN)) {
-				case 0:
-					//Success
-				break;
-				case 1:
-					$container['MoveMessage'] = 'You have just checkmated your opponent, congratulations!';
-				break;
-				case 2:
-					$container['MoveMessage'] = 'There is no piece in that square.';
-				break;
-				case 3:
-					$container['MoveMessage'] = 'You cannot end your turn in check.';
-				break;
-				case 4:
-					$container['MoveMessage'] = 'It is not your turn to move.';
-				break;
-				case 5:
-					$container['MoveMessage'] = 'The game is over.';
-				break;
-				case 6:
-					$container['MoveMessage'] = 'That is not a valid move!';
-				break;
-			}
+			$result = $chessGame->tryMove($x, $y, $toX, $toY, $account->getAccountID(), ChessPiece::QUEEN);
+			$container['MoveMessage'] = match($result) {
+				0 => '', // valid move, no message
+				1 => 'You have just checkmated your opponent, congratulations!',
+				2 => 'There is no piece in that square.',
+				3 => 'You cannot end your turn in check.',
+				4 => 'It is not your turn to move.',
+				5 => 'The game is over.',
+				6 => 'That is not a valid move!',
+			};
 		}
 	} else {
 		$container['MoveMessage'] = 'It is not your turn to move.';

--- a/src/engine/Default/chess_resign_processing.php
+++ b/src/engine/Default/chess_resign_processing.php
@@ -5,13 +5,9 @@ $result = $chessGame->resign($player->getAccountID());
 
 $container = create_container('skeleton.php', 'current_sector.php');
 
-switch ($result) {
-	case 0:
-		$container['msg'] = '[color=green]Success:[/color] You have resigned from [chess=' . $var['ChessGameID'] . '].';
-	break;
-	case 1:
-		$container['msg'] = '[color=green]Success:[/color] [chess=' . $var['ChessGameID'] . '] has been cancelled.';
-	break;
-}
+$container['msg'] = match($result) {
+	0 => '[color=green]Success:[/color] You have resigned from [chess=' . $var['ChessGameID'] . '].',
+	1 => '[color=green]Success:[/color] [chess=' . $var['ChessGameID'] . '] has been cancelled.',
+};
 
 forward($container);

--- a/src/engine/Default/combat_log_list.php
+++ b/src/engine/Default/combat_log_list.php
@@ -14,35 +14,22 @@ if (!isset($var['action'])) {
 }
 $action = $var['action'];
 
-switch ($action) {
-	case COMBAT_LOG_PERSONAL:
-	case COMBAT_LOG_ALLIANCE:
-		$query = 'type=\'PLAYER\'';
-	break;
-	case COMBAT_LOG_PORT:
-		$query = 'type=\'PORT\'';
-	break;
-	case COMBAT_LOG_PLANET:
-		$query = 'type=\'PLANET\'';
-	break;
-	case COMBAT_LOG_SAVED:
-		$query = 'EXISTS(
+$query = match($action) {
+	COMBAT_LOG_PERSONAL, COMBAT_LOG_ALLIANCE => 'type=\'PLAYER\'',
+	COMBAT_LOG_PORT => 'type=\'PORT\'',
+	COMBAT_LOG_PLANET => 'type=\'PLANET\'',
+	COMBAT_LOG_SAVED => 'EXISTS(
 					SELECT 1
 					FROM player_saved_combat_logs
 					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 						AND log_id = c.log_id
-				)';
-	break;
-	case COMBAT_LOG_FORCE:
-		$query = 'type=\'FORCE\'';
-	break;
-	default:
-}
+				)',
+	COMBAT_LOG_FORCE => 'type=\'FORCE\'',
+};
 if (isset($query) && $query) {
 	$query .= ' AND game_id=' . $db->escapeNumber($player->getGameID());
-	if ($action != COMBAT_LOG_PERSONAL
-		&& $player->hasAlliance()) {
+	if ($action != COMBAT_LOG_PERSONAL && $player->hasAlliance()) {
 		$query .= ' AND (attacker_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' OR defender_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ') ';
 	} else {
 		$query .= ' AND (attacker_id=' . $db->escapeNumber($player->getAccountID()) . ' OR defender_id=' . $db->escapeNumber($player->getAccountID()) . ') ';
@@ -72,26 +59,14 @@ function getParticipantName($accountID, $sectorID) {
 }
 
 // For display purposes, describe the type of log
-switch ($action) {
-	case COMBAT_LOG_PERSONAL:
-		$type = ' personal';
-	break;
-	case COMBAT_LOG_ALLIANCE:
-		$type = ' alliance';
-	break;
-	case COMBAT_LOG_PORT:
-		$type = ' port';
-	break;
-	case COMBAT_LOG_PLANET:
-		$type = ' planet';
-	break;
-	case COMBAT_LOG_SAVED:
-		$type = ' saved';
-	break;
-	case COMBAT_LOG_FORCE:
-		$type = ' force';
-	break;
-}
+$type = match($action) {
+	COMBAT_LOG_PERSONAL => 'personal',
+	COMBAT_LOG_ALLIANCE => 'alliance',
+	COMBAT_LOG_PORT => 'port',
+	COMBAT_LOG_PLANET => 'planet',
+	COMBAT_LOG_SAVED => 'saved',
+	COMBAT_LOG_FORCE => 'force',
+};
 $template->assign('LogType', $type);
 
 // Construct the list of logs of this type

--- a/src/engine/Default/course_plot_nearest_processing.php
+++ b/src/engine/Default/course_plot_nearest_processing.php
@@ -7,9 +7,6 @@ if (isset($var['RealX'])) {
 	$xType = Request::get('xtype');
 	$X = Request::get('X');
 	$realX = Plotter::getX($xType, $X, $player->getGameID(), $player);
-	if ($realX === false) {
-		create_error('Invalid search.');
-	}
 
 	$player->log(LOG_TYPE_MOVEMENT, 'Player plots to nearest ' . $xType . ': ' . $X . '.');
 }

--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -61,22 +61,16 @@ $template->assign('UnreadMissions', $var['UnreadMissions']);
 // * Force and other Results
 // *
 // *******************************************
-$turnsMessage = '';
 $game = SmrGame::getGame($player->getGameID());
 if (!$game->hasStarted()) {
 	$turnsMessage = 'The game will start in ' . format_time($game->getStartTime() - SmrSession::getTime()) . '!';
 } else {
-	switch ($player->getTurnsLevel()) {
-		case 'NONE':
-			$turnsMessage = '<span class="red">WARNING</span>: You have run out of turns!';
-		break;
-		case 'LOW':
-			$turnsMessage = '<span class="red">WARNING</span>: You are almost out of turns!';
-		break;
-		case 'MEDIUM':
-			$turnsMessage = '<span class="yellow">WARNING</span>: You are running out of turns!';
-		break;
-	}
+	$turnsMessage = match($player->getTurnsLevel()) {
+		'NONE' => '<span class="red">WARNING</span>: You have run out of turns!',
+		'LOW' => '<span class="red">WARNING</span>: You are almost out of turns!',
+		'MEDIUM' => '<span class="yellow">WARNING</span>: You are running out of turns!',
+		'HIGH' => '',
+	};
 }
 $template->assign('TurnsMessage', $turnsMessage);
 

--- a/src/engine/Default/port_payout_processing.php
+++ b/src/engine/Default/port_payout_processing.php
@@ -1,15 +1,9 @@
 <?php declare(strict_types=1);
 $port = $player->getSectorPort();
-switch ($var['PayoutType']) {
-	case 'Raze':
-		$credits = $port->razePort($player);
-	break;
-	case 'Loot':
-		$credits = $port->lootPort($player);
-	break;
-	default:
-		throw new Exception('Unknown payout type: ', $var['PayoutType']);
-}
+$credits = match($var['PayoutType']) {
+	'Raze' => $port->razePort($player),
+	'Loot' => $port->lootPort($player),
+};
 $player->log(LOG_TYPE_TRADING, 'Player Triggers Payout: ' . $var['PayoutType']);
 $port->update();
 $container = create_container('skeleton.php', 'current_sector.php');

--- a/src/htdocs/weapon_list.php
+++ b/src/htdocs/weapon_list.php
@@ -20,24 +20,14 @@ try {
 	// Get all the properties to display for each weapon
 	$weapons = [];
 	foreach (SmrWeaponType::getAllWeaponTypes() as $weapon) {
-		$restrictions = [];
-		switch ($weapon->getBuyerRestriction()) {
-			case BUYER_RESTRICTION_GOOD:
-				$restrictions[] = '<div class="dgreen">Good</div>';
-			break;
-			case BUYER_RESTRICTION_EVIL:
-				$restrictions[] = '<div class="red">Evil</div>';
-			break;
-			case BUYER_RESTRICTION_NEWBIE:
-				$restrictions[] = '<div style="color: #06F;">Newbie</div>';
-			break;
-			case BUYER_RESTRICTION_PORT:
-				$restrictions[] = '<div class="yellow">Port</div>';
-			break;
-			case BUYER_RESTRICTION_PLANET:
-				$restrictions[] = '<div class="yellow">Planet</div>';
-			break;
-		}
+		$restrictions = match($weapon->getBuyerRestriction()) {
+			BUYER_RESTRICTION_NONE => [],
+			BUYER_RESTRICTION_GOOD => ['<div class="dgreen">Good</div>'],
+			BUYER_RESTRICTION_EVIL => ['<div class="red">Evil</div>'],
+			BUYER_RESTRICTION_NEWBIE => ['<div style="color: #06F;">Newbie</div>'],
+			BUYER_RESTRICTION_PORT => ['<div class="yellow">Port</div>'],
+			BUYER_RESTRICTION_PLANET => ['<div class="yellow">Planet</div>'],
+		};
 		if (SmrWeapon::getWeapon($weapon->getWeaponTypeID())->isUniqueType()) {
 			$restrictions[] = '<div style="color: #64B9B9">Unique</div>';
 		}

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -735,34 +735,17 @@ abstract class AbstractSmrPlayer {
 
 		// If expires not specified, use default based on message type
 		if ($expires === false) {
-			switch ($messageTypeID) {
-				case MSG_GLOBAL: //We don't send globals to the box here or it gets done loads of times.
-					$expires = 3600; // 1h
-				break;
-				case MSG_PLAYER:
-					$expires = 86400 * 31;
-				break;
-				case MSG_PLANET:
-					$expires = 86400 * 7;
-				break;
-				case MSG_SCOUT:
-					$expires = 86400 * 3;
-				break;
-				case MSG_POLITICAL:
-					$expires = 86400 * 31;
-				break;
-				case MSG_ALLIANCE:
-					$expires = 86400 * 31;
-				break;
-				case MSG_ADMIN:
-					$expires = 86400 * 365;
-				break;
-				case MSG_CASINO:
-					$expires = 86400 * 31;
-				break;
-				default:
-					$expires = 86400 * 7;
-			}
+			$expires = match($messageTypeID) {
+				MSG_GLOBAL => 3600, // 1h
+				MSG_PLAYER => 86400 * 31, // 1 month
+				MSG_PLANET => 86400 * 7, // 1 week
+				MSG_SCOUT => 86400 * 3, // 3 days
+				MSG_POLITICAL => 86400 * 31, // 1 month
+				MSG_ALLIANCE => 86400 * 31, // 1 month
+				MSG_ADMIN => 86400 * 365, // 1 year
+				MSG_CASINO => 86400 * 31, // 1 month
+				default => 86400 * 7, // 1 week
+			};
 			$expires += SmrSession::getTime();
 		}
 
@@ -2497,15 +2480,11 @@ abstract class AbstractSmrPlayer {
 	 * Returns the CSS class color to use when displaying the player's turns
 	 */
 	public function getTurnsColor() {
-		switch ($this->getTurnsLevel()) {
-			case 'NONE':
-			case 'LOW':
-				return 'red';
-			case 'MEDIUM':
-				return 'yellow';
-			default:
-				return 'green';
-		}
+		return match($this->getTurnsLevel()) {
+			'NONE', 'LOW' => 'red',
+			'MEDIUM' => 'yellow',
+			'HIGH' => 'green',
+		};
 	}
 
 	public function getTurns() {
@@ -2739,9 +2718,6 @@ abstract class AbstractSmrPlayer {
 		$step = MISSIONS[$missionID]['Steps'][$stepID];
 		if (isset($step['PickSector'])) {
 			$realX = Plotter::getX($step['PickSector']['Type'], $step['PickSector']['X'], $this->getGameID());
-			if ($realX === false) {
-				throw new Exception('Invalid PickSector definition in mission: ' . $missionID);
-			}
 			$path = Plotter::findDistanceToX($realX, $this->getSector(), true, null, $this);
 			if ($path === false) {
 				// Abandon the mission if it cannot be completed due to a
@@ -2866,9 +2842,6 @@ abstract class AbstractSmrPlayer {
 				continue;
 			}
 			$realX = Plotter::getX($mission['HasX']['Type'], $mission['HasX']['X'], $this->getGameID());
-			if ($realX === false) {
-				throw new Exception('Invalid HasX definition in mission: ' . $missionID);
-			}
 			if ($this->getSector()->hasX($realX)) {
 				$availableMissions[$missionID] = $mission;
 			}

--- a/src/lib/Default/ChessGame.class.php
+++ b/src/lib/Default/ChessGame.class.php
@@ -235,14 +235,10 @@ class ChessGame {
 				$blanks = 0;
 			}
 		}
-		switch ($this->getCurrentTurnColour()) {
-			case self::PLAYER_WHITE:
-				$fen .= ' w ';
-			break;
-			case self::PLAYER_BLACK:
-				$fen .= ' b ';
-			break;
-		}
+		$fen .= match($this->getCurrentTurnColour()) {
+			self::PLAYER_WHITE => ' w ',
+			self::PLAYER_BLACK => ' b ',
+		};
 
 		// Castling
 		$castling = '';
@@ -269,14 +265,10 @@ class ChessGame {
 
 		if ($this->hasMoved[ChessPiece::PAWN][0] != -1) {
 			$fen .= chr(ord('a') + $this->hasMoved[ChessPiece::PAWN][0]);
-			switch ($this->hasMoved[ChessPiece::PAWN][1]) {
-				case 3:
-					$fen .= '6';
-				break;
-				case 4:
-					$fen .= '3';
-				break;
-			}
+			$fen .= match($this->hasMoved[ChessPiece::PAWN][1]) {
+				3 => '6',
+				4 => '3',
+			};
 		} else {
 			$fen .= '-';
 		}
@@ -850,7 +842,7 @@ class ChessGame {
 
 	public function resign($accountID) {
 		if ($this->hasEnded() || !$this->getColourForAccountID($accountID)) {
-			return false;
+			throw new Exception('Invalid resign conditions');
 		}
 		// If only 1 person has moved then just end the game.
 		if (count($this->getMoves()) < 2) {

--- a/src/lib/Default/Plotter.class.php
+++ b/src/lib/Default/Plotter.class.php
@@ -14,30 +14,24 @@ class Plotter {
 		// In all other cases, X is a numeric ID
 		$X = (int)$X;
 
-		switch ($xType) {
-			case 'Technology':
-				return Globals::getHardwareTypes($X);
-			case 'Ships':
-				return AbstractSmrShip::getBaseShip($X);
-			case 'Weapons':
-				return SmrWeaponType::getWeaponType($X);
-			case 'Locations':
-				return SmrLocation::getLocation($X);
-			case 'Sell Goods':
-			case 'Buy Goods':
-				// $X is the good ID
-				$good = Globals::getGood($X);
-				if (isset($player) && !$player->meetsAlignmentRestriction($good['AlignRestriction'])) {
-					create_error('You do not have the correct alignment to see this good!');
-				}
-				$good['TransactionType'] = explode(' ', $xType)[0];
-				return $good;
-			case 'Galaxies':
-				// $X is the galaxyID
-				return SmrGalaxy::getGalaxy($gameID, $X);
-			default:
-				return false;
-		}
+		// Helper function for plots to trade goods
+		$getGoodWithTransaction = function(int $goodID) use ($xType, $player) {
+			$good = Globals::getGood($goodID);
+			if (isset($player) && !$player->meetsAlignmentRestriction($good['AlignRestriction'])) {
+				create_error('You do not have the correct alignment to see this good!');
+			}
+			$good['TransactionType'] = explode(' ', $xType)[0]; // use 'Buy' or 'Sell'
+			return $good;
+		};
+
+		return match($xType) {
+			'Technology' => Globals::getHardwareTypes($X),
+			'Ships' => AbstractSmrShip::getBaseShip($X),
+			'Weapons' => SmrWeaponType::getWeaponType($X),
+			'Locations' => SmrLocation::getLocation($X),
+			'Sell Goods', 'Buy Goods' => $getGoodWithTransaction($X),
+			'Galaxies' => SmrGalaxy::getGalaxy($gameID, $X), // $X is the galaxyID
+		};
 	}
 
 	/**

--- a/src/lib/Default/SmrSector.class.php
+++ b/src/lib/Default/SmrSector.class.php
@@ -262,17 +262,11 @@ class SmrSector {
 	public function enteringSector(AbstractSmrPlayer $player, $movementType) {
 		// send scout messages to user
 		$message = 'Your forces have spotted ' . $player->getBBLink() . ' ';
-		switch ($movementType) {
-			case MOVEMENT_JUMP:
-				$message .= 'jumping into';
-			break;
-			case MOVEMENT_WARP:
-				$message .= 'warping into';
-			break;
-			case MOVEMENT_WALK:
-			default:
-				$message .= 'entering';
-		}
+		$message .= match($movementType) {
+			MOVEMENT_JUMP => 'jumping into',
+			MOVEMENT_WARP => 'warping into',
+			MOVEMENT_WALK => 'entering',
+		};
 		$message .= ' sector ' . Globals::getSectorBBLink($this->getSectorID());
 
 		$forces = $this->getForces();
@@ -284,17 +278,11 @@ class SmrSector {
 	public function leavingSector(AbstractSmrPlayer $player, $movementType) {
 		// send scout messages to user
 		$message = 'Your forces have spotted ' . $player->getBBLink() . ' ';
-		switch ($movementType) {
-			case MOVEMENT_JUMP:
-				$message .= 'jumping from';
-			break;
-			case MOVEMENT_WARP:
-				$message .= 'warping from';
-			break;
-			case MOVEMENT_WALK:
-			default:
-				$message .= 'leaving';
-		}
+		$message .= match($movementType) {
+			MOVEMENT_JUMP => 'jumping from',
+			MOVEMENT_WARP => 'warping from',
+			MOVEMENT_WALK => 'leaving',
+		};
 		$message .= ' sector ' . Globals::getSectorBBLink($this->getSectorID());
 
 		// iterate over all scout drones in sector
@@ -492,13 +480,13 @@ class SmrSector {
 	}
 
 	protected static function oppositeDir($dir) {
-		switch ($dir) {
-			case 'Up': return 'Down';
-			case 'Down': return 'Up';
-			case 'Left': return 'Right';
-			case 'Right': return 'Left';
-			case 'Warp': return 'Warp';
-		}
+		return match($dir) {
+			'Up' => 'Down',
+			'Down' => 'Up',
+			'Left' => 'Right',
+			'Right' => 'Left',
+			'Warp' => 'Warp',
+		};
 	}
 
 	public function getLinkUp() {

--- a/src/lib/Default/messages.inc.php
+++ b/src/lib/Default/messages.inc.php
@@ -51,18 +51,11 @@ function getMessagePlayer($accountID, $gameID, $messageType = false) {
 		if (!empty($accountID)) {
 			$return = SmrPlayer::getPlayer($accountID, $gameID);
 		} else {
-			switch ($messageType) {
-				case MSG_ADMIN:
-					$return = '<span class="admin">Administrator</span>';
-				break;
-
-				case MSG_ALLIANCE:
-					$return = '<span class="green">Alliance Ambassador</span>';
-				break;
-
-				default:
-					$return = 'Unknown';
-			}
+			$return = match($messageType) {
+				MSG_ADMIN => '<span class="admin">Administrator</span>',
+				MSG_ALLIANCE => '<span class="green">Alliance Ambassador</span>',
+				default => 'Unknown',
+			};
 		}
 	}
 	return $return;


### PR DESCRIPTION
The PHP8 `match` function is much more robust (strict types, throw on
unmatched) and compact than the `switch` function. We use it anywhere
we can sensibly return a value.