### PR TITLE
SmrShip: remove "old hardware" paradigm

### DIFF
--- a/db/patches/V1_6_65_13__change_under_attack.sql
+++ b/db/patches/V1_6_65_13__change_under_attack.sql
@@ -1,0 +1,3 @@
+-- Change how player being under attack is stored
+ALTER TABLE `player` ADD COLUMN `under_attack` enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE';
+ALTER TABLE `ship_has_hardware` DROP COLUMN `old_amount`;

--- a/src/engine/Default/beta_func_processing.php
+++ b/src/engine/Default/beta_func_processing.php
@@ -53,7 +53,6 @@ if ($var['func'] == 'Map') {
 	$type_hard = Request::getInt('type_hard');
 	$amount_hard = Request::getInt('amount_hard');
 	$ship->setHardware($type_hard, $amount_hard);
-	$ship->removeUnderAttack();
 } elseif ($var['func'] == 'Relations') {
 	$amount = Request::getInt('amount');
 	$race = Request::getInt('race');

--- a/src/engine/Default/cargo_dump_processing.php
+++ b/src/engine/Default/cargo_dump_processing.php
@@ -57,7 +57,6 @@ if ($player->getExperience() > 0) {
 	}
 
 	$ship->decreaseArmour($damage);
-	$ship->removeUnderAttack(); // don't trigger attack warning
 
 	$container['msg'] = 'You have jettisoned <span class="yellow">' . $amount . '</span> ' . pluralise('unit', $amount) . ' of ' . $good_name . '. Due to your lack of piloting experience, the cargo pierces the hull of your ship as you clumsily try to jettison the goods through the bay doors, destroying <span class="red">' . $damage . '</span> ' . pluralise('plate', $damage) . ' of armour!';
 	// log action

--- a/src/engine/Default/forces_attack_processing.php
+++ b/src/engine/Default/forces_attack_processing.php
@@ -96,8 +96,6 @@ if (!$bump) {
 	$forces->updateExpire();
 }
 
-$ship->removeUnderAttack(); //Don't show attacker the under attack message.
-
 // Add this log to the `combat_logs` database table
 $serializedResults = serialize($results);
 $db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'FORCE\',' . $db->escapeNumber($forces->getSectorID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($forceOwner->getAccountID()) . ',' . $db->escapeNumber($forceOwner->getAllianceID()) . ',' . $db->escapeBinary(gzcompress($serializedResults)) . ')');

--- a/src/engine/Default/forces_drop_processing.php
+++ b/src/engine/Default/forces_drop_processing.php
@@ -113,10 +113,10 @@ if ($change_mines != 0) {
 
 if ($change_combat_drones != 0) {
 	if ($change_combat_drones > 0) {
-		$ship->decreaseCDs($change_combat_drones, true);
+		$ship->decreaseCDs($change_combat_drones);
 		$forces->addCDs($change_combat_drones);
 	} else {
-		$ship->increaseCDs(-$change_combat_drones, true);
+		$ship->increaseCDs(-$change_combat_drones);
 		$forces->takeCDs(-$change_combat_drones);
 	}
 }

--- a/src/engine/Default/planet_attack_processing.php
+++ b/src/engine/Default/planet_attack_processing.php
@@ -76,8 +76,6 @@ $results['Planet'] = $planet->shootPlayers($attackers);
 
 $account->log(LOG_TYPE_PLANET_BUSTING, 'Player attacks planet, the planet does ' . $results['Planet']['TotalDamage'] . ', their team does ' . $results['Attackers']['TotalDamage'] . ' and downgrades: ' . var_export($results['Attackers']['Downgrades'], true), $planet->getSectorID());
 
-$ship->removeUnderAttack(); //Don't show attacker the under attack message.
-
 // Add this log to the `combat_logs` database table
 $serializedResults = serialize($results);
 $db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLANET\',' . $planet->getSectorID() . ',' . SmrSession::getTime() . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $planetOwner->getAccountID() . ',' . $planetOwner->getAllianceID() . ',' . $db->escapeBinary(gzcompress($serializedResults)) . ')');

--- a/src/engine/Default/planet_defense_processing.php
+++ b/src/engine/Default/planet_defense_processing.php
@@ -120,6 +120,4 @@ if ($action == 'Ship') {
 	create_error('You must choose if you want to transfer to planet or to the ship!');
 }
 
-$ship->removeUnderAttack();
-
 forward(create_container('skeleton.php', 'planet_defense.php'));

--- a/src/engine/Default/port_attack_processing.php
+++ b/src/engine/Default/port_attack_processing.php
@@ -71,7 +71,6 @@ $results['Port'] = $port->shootPlayers($attackers);
 
 $account->log(LOG_TYPE_PORT_RAIDING, 'Player attacks port, the port does ' . $results['Port']['TotalDamage'] . ', their team does ' . $results['Attackers']['TotalDamage'] . ' and downgrades ' . $results['Attackers']['Downgrades'] . ' levels.', $port->getSectorID());
 
-$ship->removeUnderAttack(); //Don't show attacker the under attack message.
 $port->update();
 
 $serializedResults = serialize($results);

--- a/src/engine/Default/shop_hardware_processing.php
+++ b/src/engine/Default/shop_hardware_processing.php
@@ -47,7 +47,7 @@ if ($action == 'Buy') {
 	}
 
 	$player->increaseCredits(IRound($cost * CDS_REFUND_PERCENT) * $amount);
-	$ship->decreaseCDs($amount, true); // 2nd arg avoids under attack warning
+	$ship->decreaseCDs($amount);
 } else {
 	throw new Exception('Action must be either Buy or Sell.');
 }

--- a/src/engine/Default/shop_ship_processing.php
+++ b/src/engine/Default/shop_ship_processing.php
@@ -35,7 +35,6 @@ $ship->setShipTypeID($shipID);
 
 
 // update again
-$ship->removeUnderAttack();
 $ship->update();
 $player->update();
 

--- a/src/engine/Default/trader_attack_processing.php
+++ b/src/engine/Default/trader_attack_processing.php
@@ -73,8 +73,6 @@ $results = [
 	'Defenders' => teamAttack($fightingPlayers, 'Defenders', 'Attackers'),
 ];
 
-$ship->removeUnderAttack(); //Don't show attacker the under attack message.
-
 $account->log(LOG_TYPE_TRADER_COMBAT, 'Player attacks player, their team does ' . $results['Attackers']['TotalDamage'] . ' and the other team does ' . $results['Defenders']['TotalDamage'], $sector->getSectorID());
 
 $serializedResults = serialize($results);

--- a/src/lib/Default/AbstractSmrShip.class.php
+++ b/src/lib/Default/AbstractSmrShip.class.php
@@ -34,13 +34,11 @@ class AbstractSmrShip {
 	protected int $gameID;
 	protected array $baseShip;
 
-	protected array $hardware;
-	protected array $oldHardware;
-
-	protected array $cargo = [];
 	protected array $weapons = [];
-	protected array|false $illusionShip = false;
+	protected array $cargo = [];
+	protected array $hardware = [];
 	protected bool $isCloaked = false;
+	protected array|false $illusionShip = false;
 
 	protected bool $hasChangedWeapons = false;
 	protected bool $hasChangedCargo = false;
@@ -201,7 +199,6 @@ class AbstractSmrShip {
 		foreach ($this->getMaxHardware() as $key => $max) {
 			$this->setHardware($key, $max);
 		}
-		$this->removeUnderAttack();
 	}
 
 	public function getPowerUsed() : int {
@@ -352,7 +349,6 @@ class AbstractSmrShip {
 			$this->hasChangedHardware[$hardwareTypeID] = true;
 		}
 		$this->hardware = [];
-		$this->oldHardware = [];
 		$this->decloak();
 		$this->disableIllusion();
 	}
@@ -363,18 +359,16 @@ class AbstractSmrShip {
 		$this->removeAllHardware();
 
 		if ($isNewbie) {
-			$this->setShields(75, true);
-			$this->setArmour(150, true);
+			$this->setShields(75);
+			$this->setArmour(150);
 			$this->setCargoHolds(40);
 			$this->setShipTypeID(SHIP_TYPE_NEWBIE_MERCHANT_VESSEL);
 		} else {
-			$this->setShields(50, true);
-			$this->setArmour(50, true);
+			$this->setShields(50);
+			$this->setArmour(50);
 			$this->setCargoHolds(5);
 			$this->setShipTypeID(SHIP_TYPE_ESCAPE_POD);
 		}
-
-		$this->removeUnderAttack();
 	}
 
 	public function giveStarterShip() : void {
@@ -388,8 +382,8 @@ class AbstractSmrShip {
 			$amount_armour = 50;
 		}
 		$this->setShipTypeID($shipID);
-		$this->setShields($amount_shields, true);
-		$this->setArmour($amount_armour, true);
+		$this->setShields($amount_shields);
+		$this->setArmour($amount_armour);
 		$this->setCargoHolds(40);
 		$this->addWeapon(SmrWeapon::getWeapon(WEAPON_TYPE_LASER));
 	}
@@ -607,21 +601,6 @@ class AbstractSmrShip {
 		$this->setHardware($hardwareTypeID, $this->getHardware($hardwareTypeID) + $amount);
 	}
 
-	public function getOldHardware(int $hardwareTypeID = null) : array|int {
-		if ($hardwareTypeID === null) {
-			return $this->oldHardware;
-		}
-		return $this->oldHardware[$hardwareTypeID] ?? 0;
-	}
-
-	public function setOldHardware(int $hardwareTypeID, int $amount) : void {
-		if ($this->getOldHardware($hardwareTypeID) == $amount) {
-			return;
-		}
-		$this->oldHardware[$hardwareTypeID] = $amount;
-		$this->hasChangedHardware[$hardwareTypeID] = true;
-	}
-
 	public function hasMaxHardware(int $hardwareTypeID) : bool {
 		return $this->getHardware($hardwareTypeID) == $this->getMaxHardware($hardwareTypeID);
 	}
@@ -637,10 +616,7 @@ class AbstractSmrShip {
 		return $this->getHardware(HARDWARE_SHIELDS);
 	}
 
-	public function setShields(int $amount, bool $updateOldAmount = false) : void {
-		if ($updateOldAmount && !$this->hasLostShields()) {
-			$this->setOldHardware(HARDWARE_SHIELDS, $amount);
-		}
+	public function setShields(int $amount) : void {
 		$this->setHardware(HARDWARE_SHIELDS, $amount);
 	}
 
@@ -652,20 +628,8 @@ class AbstractSmrShip {
 		$this->setShields($this->getShields() + $amount);
 	}
 
-	public function getOldShields() : int {
-		return $this->getOldHardware(HARDWARE_SHIELDS);
-	}
-
-	public function setOldShields(int $amount) : void {
-		$this->setOldHardware(HARDWARE_SHIELDS, $amount);
-	}
-
 	public function hasShields() : bool {
 		return $this->getShields() > 0;
-	}
-
-	public function hasLostShields() : bool {
-		return $this->getShields() < $this->getOldShields();
 	}
 
 	public function hasMaxShields() : bool {
@@ -680,10 +644,7 @@ class AbstractSmrShip {
 		return $this->getHardware(HARDWARE_ARMOUR);
 	}
 
-	public function setArmour(int $amount, bool $updateOldAmount = false) : void {
-		if ($updateOldAmount && !$this->hasLostArmour()) {
-			$this->setOldHardware(HARDWARE_ARMOUR, $amount);
-		}
+	public function setArmour(int $amount) : void {
 		$this->setHardware(HARDWARE_ARMOUR, $amount);
 	}
 
@@ -695,20 +656,8 @@ class AbstractSmrShip {
 		$this->setArmour($this->getArmour() + $amount);
 	}
 
-	public function getOldArmour() : int {
-		return $this->getOldHardware(HARDWARE_ARMOUR);
-	}
-
-	public function setOldArmour(int $amount) : void {
-		$this->setOldHardware(HARDWARE_ARMOUR, $amount);
-	}
-
 	public function hasArmour() : bool {
 		return $this->getArmour() > 0;
-	}
-
-	public function hasLostArmour() : bool {
-		return $this->getArmour() < $this->getOldArmour();
 	}
 
 	public function hasMaxArmour() : bool {
@@ -751,35 +700,16 @@ class AbstractSmrShip {
 		return $this->getHardware(HARDWARE_COMBAT);
 	}
 
-	public function setCDs(int $amount, bool $updateOldAmount = false) : void {
-		if ($updateOldAmount && !$this->hasLostCDs()) {
-			$this->setOldHardware(HARDWARE_COMBAT, $amount);
-		}
+	public function setCDs(int $amount) : void {
 		$this->setHardware(HARDWARE_COMBAT, $amount);
 	}
 
-	/**
-	 * Decreases the ship CDs. Use $updateOldAmount=true to prevent
-	 * this change from triggering `isUnderAttack`.
-	 */
-	public function decreaseCDs(int $amount, bool $updateOldAmount = false) : void {
-		$this->setCDs($this->getCDs() - $amount, $updateOldAmount);
+	public function decreaseCDs(int $amount) : void {
+		$this->setCDs($this->getCDs() - $amount);
 	}
 
 	public function increaseCDs(int $amount) : void {
 		$this->setCDs($this->getCDs() + $amount);
-	}
-
-	public function getOldCDs() : int {
-		return $this->getOldHardware(HARDWARE_COMBAT);
-	}
-
-	public function setOldCDs(int $amount) : void {
-		$this->setOldHardware(HARDWARE_COMBAT, $amount);
-	}
-
-	public function hasLostCDs() : bool {
-		return $this->getCDs() < $this->getOldCDs();
 	}
 
 	public function getMaxCDs() : int {
@@ -887,25 +817,6 @@ class AbstractSmrShip {
 
 	public function getMaxCargoHolds() : int {
 		return $this->getMaxHardware(HARDWARE_CARGO);
-	}
-
-	public function isUnderAttack() : bool {
-		return $this->hasLostShields() || $this->hasLostArmour() || $this->hasLostCDs();
-	}
-
-	public function removeUnderAttack() : bool {
-		global $var;
-		$underAttack = $this->isUnderAttack();
-		foreach ($this->getHardware() as $hardwareID => $value) {
-			$this->setOldHardware($hardwareID, $value);
-		}
-		if (isset($var['UnderAttack'])) {
-			return $var['UnderAttack'];
-		}
-		if ($underAttack && !USING_AJAX) {
-			SmrSession::updateVar('UnderAttack', $underAttack); //Remember we are under attack for AJAX
-		}
-		return $underAttack;
 	}
 
 	public function hasWeapons() : bool {
@@ -1097,6 +1008,10 @@ class AbstractSmrShip {
 		$cdDamage = 0;
 		$shieldDamage = 0;
 		if (!$alreadyDead) {
+			// Even if the weapon doesn't do any damage, it was fired at the
+			// player, so alert them that they're under attack.
+			$this->getPlayer()->setUnderAttack(true);
+
 			$shieldDamage = $this->doShieldDamage(min($damage['MaxDamage'], $damage['Shield']));
 			$damage['MaxDamage'] -= $shieldDamage;
 			if (!$this->hasShields() && ($shieldDamage == 0 || $damage['Rollover'])) {

--- a/src/lib/Default/SmrShip.class.php
+++ b/src/lib/Default/SmrShip.class.php
@@ -84,7 +84,6 @@ class SmrShip extends AbstractSmrShip {
 
 	protected function loadHardware() : void {
 		$this->hardware = array();
-		$this->oldHardware = array();
 
 		// get currently hardware from db
 		$db = MySqlDatabase::getInstance();
@@ -98,7 +97,6 @@ class SmrShip extends AbstractSmrShip {
 
 			// adding hardware to array
 			$this->hardware[$hardwareTypeID] = $db->getInt('amount');
-			$this->oldHardware[$hardwareTypeID] = $db->getInt('old_amount');
 		}
 		$this->checkForExcessHardware();
 	}
@@ -145,7 +143,7 @@ class SmrShip extends AbstractSmrShip {
 			}
 			$amount = $this->getHardware($hardwareTypeID);
 			if ($amount > 0) {
-				$db->query('REPLACE INTO ship_has_hardware (account_id, game_id, hardware_type_id, amount, old_amount) VALUES(' . $db->escapeNumber($this->getAccountID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber($hardwareTypeID) . ', ' . $db->escapeNumber($amount) . ', ' . $db->escapeNumber($this->getOldHardware($hardwareTypeID)) . ')');
+				$db->query('REPLACE INTO ship_has_hardware (account_id, game_id, hardware_type_id, amount) VALUES(' . $db->escapeNumber($this->getAccountID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber($hardwareTypeID) . ', ' . $db->escapeNumber($amount) . ')');
 			} else {
 				$db->query('DELETE FROM ship_has_hardware WHERE ' . $this->SQL . ' AND hardware_type_id = ' . $db->escapeNumber($hardwareTypeID));
 			}

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -440,7 +440,7 @@ function do_voodoo() {
 	}
 
 	if (SmrSession::hasGame()) {
-		$template->assign('UnderAttack', $ship->removeUnderAttack());
+		$template->assign('UnderAttack', $player->removeUnderAttack());
 	}
 
 	if ($lock) { //Only save if we have the lock.

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -135,8 +135,8 @@ function NPCStuff() {
 
 				// Ensure the NPC doesn't think it's under attack at startup,
 				// since this could cause it to get stuck in a loop in Fed.
-				$player->getShip()->removeUnderAttack();
-				$player->getShip()->updateHardware();
+				$player->removeUnderAttack();
+				$player->update();
 			}
 
 			if (!isset($TRADE_ROUTE)) { //We only want to change trade route if there isn't already one set.
@@ -157,16 +157,10 @@ function NPCStuff() {
 			$fedContainer = null;
 			if (isset($var['url']) && $var['url'] == 'shop_ship_processing.php' && ($fedContainer = plotToFed($player, true)) !== true) { //We just bought a ship, we should head back to our trade gal/uno - we use HQ for now as it's both in our gal and a UNO, plus it's safe which is always a bonus
 				processContainer($fedContainer);
-			} elseif ($player->getShip()->isUnderAttack() === true
-				&&($player->hasPlottedCourse() === false || $player->getPlottedCourse()->getEndSector()->offersFederalProtection() === false)
-				&&($fedContainer == null ? $fedContainer = plotToFed($player, true) : $fedContainer) !== true) { //We're under attack and need to plot course to fed.
-				// Get the lock, remove under attack and update.
-				acquire_lock($player->getSectorID());
-				$ship = $player->getShip(true);
-				$ship->removeUnderAttack();
-				$ship->updateHardware();
-				release_lock();
-
+			} elseif (!$underAttack && $player->isUnderAttack() === true
+				&& ($player->hasPlottedCourse() === false || $player->getPlottedCourse()->getEndSector()->offersFederalProtection() === false)
+				&& ($fedContainer == null ? $fedContainer = plotToFed($player, true) : $fedContainer) !== true) {
+				// We're under attack and need to plot course to fed.
 				debug('Under Attack');
 				$underAttack = true;
 				processContainer($fedContainer);


### PR DESCRIPTION
We will no longer try to infer whether a ship is under attack by
keeping track of the "old hardware" values.

This was unnecessarily complicated, and the methods for setting the
"old hardware" were prone to misuse. They also caused inconsistency
in the display for the player (if two players are triggering on each
other, sometimes you will see the "under attack" warning, but other
times you won't).

Other problems include NPCs getting stuck in a state of thinking they
were under attack (which is kind of ironic...), and needing to call
the `removeUnderAttack` function in the many places where hardware is
being modified in a non-combat context.

The fix is to remove the "old hardware" paradigm entirely, and then
replace it with a simple `under_attack` column in the `player` db.
This is set explicitly _only_ when a player is actually under attack.

Gameplay Note: The "under attack" warning will now display whenever
you are the target of a weapon (whether it is fired defensively as
the result of your own trigger, or offensively as the result of
another player's trigger). There is potentially some tactical intel
lost because of this change, but it is reliable and unambiguous.