### PR TITLE
MySqlDatabase: fix repeated calls to close()

### DIFF
--- a/src/lib/Default/MySqlDatabase.class.php
+++ b/src/lib/Default/MySqlDatabase.class.php
@@ -97,16 +97,21 @@ class MySqlDatabase {
 	 *
 	 * You must call MySqlDatabase::getInstance() again to retrieve a valid instance that
 	 * is reconnected to the database.
+	 *
+	 * @return bool Whether the underlying connection was closed by this call.
 	 */
-	public function close() {
-		if ($this->dbConn) {
-			$this->dbConn->close();
-			unset($this->dbConn);
-			// Set the mysqli instance in the dependency injection container to
-			// null so that the MySqlDatabase constructor will reconnect the
-			// next time it is called.
-			DiContainer::getContainer()->set(mysqli::class, null);
+	public function close() : bool {
+		if (!isset($this->dbConn)) {
+			// Connection is already closed; nothing to do.
+			return false;
 		}
+		$this->dbConn->close();
+		unset($this->dbConn);
+		// Set the mysqli instance in the dependency injection container to
+		// null so that the MySqlDatabase constructor will reconnect the
+		// next time it is called.
+		DiContainer::getContainer()->set(mysqli::class, null);
+		return true;
 	}
 
 	public function query($query) {

--- a/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/MySqlDatabaseIntegrationTest.php
@@ -53,6 +53,14 @@ class MySqlDatabaseIntegrationTest extends TestCase {
 		$mysqlDatabase->query("foo query");
 	}
 
+	public function test_closing_database_returns_boolean() {
+		$db = MySqlDatabase::getInstance();
+		// Returns true when closing an open database connection
+		self::assertTrue($db->close());
+		// Returns false if the database has already been closed
+		self::assertFalse($db->close());
+	}
+
 	public function test_getInstance_will_perform_reconnect_after_connection_closed() {
 		// Given an original mysql connection
 		$originalMysql = DiContainer::get(mysqli::class);


### PR DESCRIPTION
In #924, the `$dbConn` property was changed so that it is unset when
`close()` is called instead of being set to `false`. Therefore, when
we call `close()` on an already closed MySqlDatabase instance, we need
to perform an `isset` check on `$dbConn` instead of a boolean check.

This fix allows us to make repeated calls to `close()` again, and we
add a test to ensure this functionality.

Note that this impacted the IRC bot, which will make repeated calls to
close without reconnecting to the database if it processes an event
that doesn't require the database.