### PR TITLE
irc.php: fix PHP 8 error

### DIFF
--- a/src/tools/irc/irc.php
+++ b/src/tools/irc/irc.php
@@ -9,7 +9,7 @@ function echo_r($message)
 			echo_r($msg);
 		}
 	} else {
-		echo date("d.m.Y H:i:s => ") . $message . EOL;
+		echo date("Y-m-d H:i:s => ") . $message . EOL;
 	}
 }
 
@@ -159,19 +159,6 @@ function safefputs($fp, $text) {
 function readFromStream($fp) {
 	global $last_ping;
 
-	$rdata = fgets($fp, 4096);
-	$rdata = preg_replace('/\s+/', ' ', $rdata);
-
-	// log for reports (if enabled via command line (-log)
-	if (IRC_LOGGING && strlen($rdata) > 0) {
-		write_log_message($rdata);
-	}
-
-	// remember the last time we got something from the server
-	if (strlen($rdata) > 0) {
-		$last_ping = time();
-	}
-
 	// timeout detection!
 	if ($last_ping < time() - 300) {
 		echo_r('TIMEOUT detected!');
@@ -182,8 +169,16 @@ function readFromStream($fp) {
 	// we simply do some poll stuff here
 	check_events($fp);
 
-	if (strlen($rdata) == 0) {
+	// try to get message from the server
+	$rdata = fgets($fp, 4096);
+	if ($rdata === false) { // no message or error
 		return false;
+	}
+	$rdata = preg_replace('/\s+/', ' ', $rdata);
+
+	// log for reports (if enabled via command line (-log)
+	if (IRC_LOGGING) {
+		write_log_message($rdata);
 	}
 
 	// required!!! otherwise timeout!

--- a/src/tools/irc/server.php
+++ b/src/tools/irc/server.php
@@ -4,10 +4,14 @@
 // if we do not answer the ping from server we will be disconnected
 function server_ping($fp, $rdata)
 {
+	global $last_ping;
 
 	if (preg_match('/^PING\s:(.*)\s/i', $rdata, $msg)) {
 
 		$server = $msg[1];
+
+		// remember the last time we got a ping from the server
+		$last_ping = time();
 
 		// This message is very spammy
 		if (defined('IRC_BOT_VERBOSE_PING') && IRC_BOT_VERBOSE_PING) {


### PR DESCRIPTION
As of PHP 8, it is a fatal error to pass a bool to `preg_replace`,
whereas in PHP 7.4, it returned an empty string.

This change broke irc.php, because we treated the result of `fgets`
as a string (by passing it to `preg_replace`) before we verified that
it was not `false`, which is the value it returns when there is no
message from the server (or in the case of an error).

To fix this, we simply rearrange the logic at the beginning of the
`readFromStream`. The checks independent of the server message are
performed first (1. server timeout check and 2. player timer check).
Next we poll for a message from the server, and at this point we can
properly return early if we get `false` (no message or error).

Setting the "last ping" time has been moved into the `server_ping`
function, which seems like a more appropriate place for it.
(Pings come about once every 90 seconds, and our timeout is 300s.)