### PR TITLE
run-tests.yml: split up build and test stage

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,10 +28,11 @@ jobs:
           # Needed by Codecov
           fetch-depth: 2
 
+      - name: Build test environment
+        run: composer run start:integration-services
+
       - name: Run tests
-        run: |
-          composer run start:integration-services
-          composer run test
+        run: composer run test
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Running these commands in separate stages will make it easier to find
the output of interest, since GitHub only provides structured output
at the stage level (and not individual commands within each stage).

The build output is quite long, so it takes a while to find the test
output when they are run in the same stage.