### PR TITLE
Replace array containers with the Page class

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,22 +122,22 @@ require_once(get_file_loc('SmrAlliance.class.php'));
 
 ## Links
 If possible use a function from Globals or a relevant object to generate links (eg Globals::getCurrentSectorHREF(), $otherPlayer->getExamineTraderHREF()), this is usually clearer and allows hooking into the hotkey system.
-To create a link you first create a "container" using the create_container() function from smr.inc.php declared as
+To create a link you first create a "container" using the Page::create() function from smr.inc.php declared as
 
 ```php
-create_container($file, $body = '', array $extra = array(), $remainingPageLoads = null)
+Page::create($file, $body = '', array $extra = array(), $remainingPageLoads = null)
 ```
 There are two common usages of this:
-- $container = create_container('skeleton.php', $displayOnlyPage) with $displayOnlyPage being something such as 'current_sector.php'
-- $container = create_container($processingPage) with $processingPage being something such as 'sector_move_processing.php'.
+- $container = Page::create('skeleton.php', $displayOnlyPage) with $displayOnlyPage being something such as 'current_sector.php'
+- $container = Page::create($processingPage) with $processingPage being something such as 'sector_move_processing.php'.
 
-You can then call SmrSession::getNewHREF($container) to get a HREF which will load the given page or SmrSession::generateSN($container) to get just the sn.
+You can then call $container->href() to get a HREF which will load the given page or SmrSession::generateSN($container) to get just the sn.
 Along with this you can also assign extra values to $container which will be available on the next page under $var
 
 ```php
-$container = create_container('sector_move_processing.php');
+$container = Page::create('sector_move_processing.php');
 $container['target_sector'] = 1;
-$link = SmrSession::getNewHREF($container);
+$link = $container->href();
 ```
 
 ## Global variables

--- a/src/admin/Default/1.6/check_map.php
+++ b/src/admin/Default/1.6/check_map.php
@@ -3,10 +3,10 @@
 $game = SmrGame::getGame($var['game_id']);
 $template->assign('PageTopic', 'Check Map : ' . $game->getDisplayName());
 
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
-transfer('game_id');
-transfer('gal_on');
-$template->assign('BackHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
+$template->assign('BackHREF', $container->href());
 
 $galaxies = SmrGalaxy::getGameGalaxies($var['game_id']);
 

--- a/src/admin/Default/1.6/galaxies_edit.php
+++ b/src/admin/Default/1.6/galaxies_edit.php
@@ -4,12 +4,12 @@ $game = SmrGame::getGame($var['game_id']);
 $template->assign('PageTopic', 'Edit Galaxies : ' . $game->getDisplayName());
 $template->assign('GameEnabled', $game->isEnabled());
 
-$container = create_container('1.6/galaxies_edit_processing.php');
-transfer('game_id');
-transfer('gal_on');
+$container = Page::create('1.6/galaxies_edit_processing.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
 $submit = [
 	'value' => 'Edit Galaxies',
-	'href' => SmrSession::getNewHREF($container),
+	'href' => $container->href(),
 ];
 $template->assign('Submit', $submit);
 
@@ -25,7 +25,7 @@ foreach (SmrGalaxy::getGameGalaxies($var['game_id']) as $galaxy) {
 }
 $template->assign('Galaxies', $galaxies);
 
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
-transfer('game_id');
-transfer('gal_on');
-$template->assign('BackHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
+$template->assign('BackHREF', $container->href());

--- a/src/admin/Default/1.6/galaxies_edit_processing.php
+++ b/src/admin/Default/1.6/galaxies_edit_processing.php
@@ -4,9 +4,9 @@ $gameID = $var['game_id'];
 $galaxies = SmrGalaxy::getGameGalaxies($gameID);
 
 // Prepare our forwarding container
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
-transfer('gal_on');
-transfer('game_id');
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');
+$container->addVar('gal_on');
+$container->addVar('game_id');
 
 // Save the original sizes for later processing
 $origGals = [];
@@ -39,7 +39,7 @@ foreach ($galaxies as $i => $galaxy) {
 if ($galaxySizesUnchanged) {
 	SmrGalaxy::saveGalaxies();
 	$container['message'] = '<span class="green">SUCCESS: </span>Edited galaxies (sizes unchanged).';
-	forward($container);
+	$container->go();
 }
 
 
@@ -201,4 +201,4 @@ SmrGalaxy::saveGalaxies();
 SmrSector::saveSectors();
 
 $container['message'] = '<span class="green">SUCCESS: </span>Edited galaxies (sizes have changed).';
-forward($container);
+$container->go();

--- a/src/admin/Default/1.6/galaxy_reset_processing.php
+++ b/src/admin/Default/1.6/galaxy_reset_processing.php
@@ -16,8 +16,8 @@ foreach ($galaxy->getSectors() as $galSector) {
 
 SmrSector::saveSectors();
 
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
-transfer('game_id');
-transfer('gal_on');
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
 $container['message'] = '<span class="green">Success</span> : reset galaxy.';
-forward($container);
+$container->go();

--- a/src/admin/Default/1.6/game_create.php
+++ b/src/admin/Default/1.6/game_create.php
@@ -1,11 +1,11 @@
 <?php declare(strict_types=1);
 
 //get information
-$container = create_container('1.6/game_create_processing.php');
-$template->assign('CreateGalaxiesHREF', SmrSession::getNewHREF($container));
+$container = Page::create('1.6/game_create_processing.php');
+$template->assign('CreateGalaxiesHREF', $container->href());
 
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
-$template->assign('EditGameHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');
+$template->assign('EditGameHREF', $container->href());
 
 $canEditStartedGames = $account->hasPermission(PERMISSION_EDIT_STARTED_GAMES);
 $template->assign('CanEditStartedGames', $canEditStartedGames);

--- a/src/admin/Default/1.6/game_create_processing.php
+++ b/src/admin/Default/1.6/game_create_processing.php
@@ -52,9 +52,9 @@ $game->save();
 
 createNHA($game->getGameID()); //do the alliances/message stuff
 
-$container = create_container('skeleton.php', '1.6/universe_create_galaxies.php');
+$container = Page::create('skeleton.php', '1.6/universe_create_galaxies.php');
 $container['game_id'] = $game->getGameID();
-forward($container);
+$container->go();
 
 function createNHA($gameID) {
 	$db = MySqlDatabase::getInstance();

--- a/src/admin/Default/1.6/game_edit.php
+++ b/src/admin/Default/1.6/game_edit.php
@@ -28,13 +28,13 @@ $gameArray = [
 ];
 $template->assign('Game', $gameArray);
 
-$container = create_container('1.6/game_edit_processing.php');
-transfer('game_id');
-transfer('gal_on');
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
+$container = Page::create('1.6/game_edit_processing.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
+$template->assign('ProcessingHREF', $container->href());
 $template->assign('SubmitValue', 'Modify Game');
 
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
-transfer('game_id');
-transfer('gal_on');
-$template->assign('CancelHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
+$template->assign('CancelHREF', $container->href());

--- a/src/admin/Default/1.6/game_edit_processing.php
+++ b/src/admin/Default/1.6/game_edit_processing.php
@@ -27,8 +27,8 @@ if (!$game->hasStarted()) {
 }
 $game->save();
 
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');
 $container['message'] = '<span class="green">SUCCESS: edited game details</span>';
-transfer('game_id');
-transfer('gal_on');
-forward($container);
+$container->addVar('game_id');
+$container->addVar('gal_on');
+$container->go();

--- a/src/admin/Default/1.6/universe_create_galaxies.php
+++ b/src/admin/Default/1.6/universe_create_galaxies.php
@@ -7,23 +7,23 @@ $template->assign('PageTopic', 'Create Galaxies : ' . $game->getDisplayName());
 $template->assign('GameEnabled', $game->isEnabled());
 
 // Link for updating the number of galaxies
-$container = create_container('skeleton.php', '1.6/universe_create_galaxies.php');
-transfer('game_id');
-$template->assign('UpdateNumGalsHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_galaxies.php');
+$container->addVar('game_id');
+$template->assign('UpdateNumGalsHREF', $container->href());
 
 // Link for creating galaxies
-$container = create_container('1.6/universe_create_save_processing.php', '1.6/universe_create_sectors.php');
-transfer('game_id');
-transfer('num_gals');
+$container = Page::create('1.6/universe_create_save_processing.php', '1.6/universe_create_sectors.php');
+$container->addVar('game_id');
+$container->addVar('num_gals');
 $submit = [
 	'value' => 'Create Galaxies',
-	'href' => SmrSession::getNewHREF($container),
+	'href' => $container->href(),
 ];
 $template->assign('Submit', $submit);
 
 // Link for creating universe from SMR file
 $container['url'] = '1.6/upload_smr_file_processing.php';
-$template->assign('UploadSmrFileHREF', SmrSession::getNewHREF($container));
+$template->assign('UploadSmrFileHREF', $container->href());
 
 //Galaxy Creation area
 $defaultNames = array(0, 'Alskant', 'Creonti', 'Human', 'Ik\'Thorne', 'Nijarin', 'Salvene', 'Thevian', 'WQ Human', 'Omar', 'Salzik', 'Manton', 'Livstar', 'Teryllia', 'Doriath', 'Anconus', 'Valheru', 'Sardine', 'Clacher', 'Tangeria');

--- a/src/admin/Default/1.6/universe_create_locations.php
+++ b/src/admin/Default/1.6/universe_create_locations.php
@@ -3,9 +3,9 @@
 SmrSession::getRequestVarInt('gal_on');
 $template->assign('Galaxies', SmrGalaxy::getGameGalaxies($var['game_id']));
 
-$container = create_container('skeleton.php', '1.6/universe_create_locations.php');
-transfer('game_id');
-$template->assign('JumpGalaxyHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_locations.php');
+$container->addVar('game_id');
+$template->assign('JumpGalaxyHREF', $container->href());
 
 $locations = SmrLocation::getAllLocations();
 
@@ -93,10 +93,10 @@ $template->assign('LocText', $locText);
 $template->assign('LocTypes', $categories->locTypes);
 
 // Form to make location changes
-$container = create_container('1.6/universe_create_save_processing.php',
+$container = Page::create('1.6/universe_create_save_processing.php',
                               '1.6/universe_create_sectors.php', $var);
-$template->assign('CreateLocationsFormHREF', SmrSession::getNewHREF($container));
+$template->assign('CreateLocationsFormHREF', $container->href());
 
 // HREF to cancel and return to the previous page
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php', $var);
-$template->assign('CancelHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php', $var);
+$template->assign('CancelHREF', $container->href());

--- a/src/admin/Default/1.6/universe_create_planets.php
+++ b/src/admin/Default/1.6/universe_create_planets.php
@@ -3,9 +3,9 @@
 SmrSession::getRequestVarInt('gal_on');
 $template->assign('Galaxies', SmrGalaxy::getGameGalaxies($var['game_id']));
 
-$container = create_container('skeleton.php', '1.6/universe_create_planets.php');
-transfer('game_id');
-$template->assign('JumpGalaxyHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_planets.php');
+$container->addVar('game_id');
+$template->assign('JumpGalaxyHREF', $container->href());
 
 // Get a list of all available planet types
 $allowedTypes = array();
@@ -32,10 +32,10 @@ $template->assign('Galaxy', $galaxy);
 $template->assign('NumberOfPlanets', $numberOfPlanets);
 
 // Form to make planet changes
-$container = create_container('1.6/universe_create_save_processing.php',
+$container = Page::create('1.6/universe_create_save_processing.php',
                               '1.6/universe_create_sectors.php', $var);
-$template->assign('CreatePlanetsFormHREF', SmrSession::getNewHREF($container));
+$template->assign('CreatePlanetsFormHREF', $container->href());
 
 // HREF to cancel and return to the previous page
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php', $var);
-$template->assign('CancelHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php', $var);
+$template->assign('CancelHREF', $container->href());

--- a/src/admin/Default/1.6/universe_create_ports.php
+++ b/src/admin/Default/1.6/universe_create_ports.php
@@ -3,9 +3,9 @@
 SmrSession::getRequestVarInt('gal_on');
 $template->assign('Galaxies', SmrGalaxy::getGameGalaxies($var['game_id']));
 
-$container = create_container('skeleton.php', '1.6/universe_create_ports.php');
-transfer('game_id');
-$template->assign('JumpGalaxyHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_ports.php');
+$container->addVar('game_id');
+$template->assign('JumpGalaxyHREF', $container->href());
 
 $galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
 $template->assign('Galaxy', $galaxy);
@@ -31,10 +31,10 @@ if ($total > 0) {
 $template->assign('RacePercents', $racePercents);
 $template->assign('TotalPercent', array_sum($racePercents));
 
-$container = $var;
+$container = Page::copy($var);
 $container['url'] = '1.6/universe_create_save_processing.php';
 $container['body'] = '1.6/universe_create_sectors.php';
-$template->assign('CreateHREF', SmrSession::getNewHREF($container));
+$template->assign('CreateHREF', $container->href());
 
 $template->assign('TotalPorts', $totalPorts);
 $template->assign('Total', array_sum($totalPorts));

--- a/src/admin/Default/1.6/universe_create_save_processing.php
+++ b/src/admin/Default/1.6/universe_create_save_processing.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 $submit = Request::getVar('submit');
-unset($var['submit']);
+SmrSession::updateVar('submit', null);
 
 if ($submit == 'Create Galaxies') {
 	for ($i = 1; $i <= $var['num_gals']; $i++) {
@@ -244,9 +244,9 @@ if ($submit == 'Create Galaxies') {
 	SmrSector::saveSectors();
 }
 
-$container = $var;
+$container = Page::copy($var);
 $container['url'] = 'skeleton.php';
-forward($container);
+$container->go();
 
 
 function checkSectorAllowedForLoc(SmrSector $sector, SmrLocation $location) {

--- a/src/admin/Default/1.6/universe_create_sector_details.php
+++ b/src/admin/Default/1.6/universe_create_sector_details.php
@@ -5,10 +5,10 @@ $editSector = SmrSector::getSector($var['game_id'], $editSectorID);
 $template->assign('PageTopic', 'Edit Sector #' . $editSector->getSectorID() . ' (' . $editSector->getGalaxy()->getDisplayName() . ')');
 $template->assign('EditSector', $editSector);
 
-$container = $var;
+$container = Page::copy($var);
 $container['url'] = '1.6/universe_create_save_processing.php';
 $container['body'] = '1.6/universe_create_sector_details.php';
-$template->assign('EditHREF', SmrSession::getNewHREF($container));
+$template->assign('EditHREF', $container->href());
 
 $selectedPlanetType = 0;
 if ($editSector->hasPlanet()) {
@@ -42,9 +42,9 @@ if ($editSector->hasWarp()) {
 $template->assign('WarpGal', $warpGal);
 $template->assign('WarpSectorID', $warpSectorID);
 
-$container = $var;
+$container = Page::copy($var);
 $container['body'] = '1.6/universe_create_sectors.php';
-$template->assign('CancelHREF', SmrSession::getNewHREF($container));
+$template->assign('CancelHREF', $container->href());
 
 if (isset($var['message'])) {
 	$template->assign('Message', $var['message']);

--- a/src/admin/Default/1.6/universe_create_sectors.php
+++ b/src/admin/Default/1.6/universe_create_sectors.php
@@ -8,9 +8,9 @@ $galaxies = SmrGalaxy::getGameGalaxies($var['game_id']);
 if (empty($galaxies)) {
 	// Game was created, but no galaxies exist, so go back to
 	// the galaxy generation page
-	$container = create_container('skeleton.php', '1.6/universe_create_galaxies.php');
-	transfer('game_id');
-	forward($container);
+	$container = Page::create('skeleton.php', '1.6/universe_create_galaxies.php');
+	$container->addVar('game_id');
+	$container->go();
 }
 
 $galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
@@ -44,61 +44,61 @@ if (isset($var['message'])) {
 	SmrSession::updateVar('message', null); // Only show message once
 }
 
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
-transfer('game_id');
-$template->assign('JumpGalaxyHREF', SmrSession::getNewHref($container));
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');
+$container->addVar('game_id');
+$template->assign('JumpGalaxyHREF', $container->href());
 
-transfer('gal_on');
-$template->assign('RecenterHREF', SmrSession::getNewHref($container));
+$container->addVar('gal_on');
+$template->assign('RecenterHREF', $container->href());
 
 $container['url'] = '1.6/universe_create_save_processing.php';
-$template->assign('SubmitChangesHREF', SmrSession::getNewHref($container));
+$template->assign('SubmitChangesHREF', $container->href());
 
 $container['submit'] = 'Toggle Link';
 $container['AJAX'] = true;
 $template->assign('ToggleLink', $container);
 
-$container = create_container('skeleton.php', '1.6/universe_create_sector_details.php');
-transfer('game_id');
-transfer('gal_on');
+$container = Page::create('skeleton.php', '1.6/universe_create_sector_details.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
 $template->assign('UniGen', $container);
 
-$container = create_container('skeleton.php');
-transfer('game_id');
-transfer('gal_on');
+$container = Page::create('skeleton.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
 $container['body'] = '1.6/universe_create_locations.php';
-$template->assign('ModifyLocationsHREF', SmrSession::getNewHREF($container));
+$template->assign('ModifyLocationsHREF', $container->href());
 
 $container['body'] = '1.6/universe_create_planets.php';
-$template->assign('ModifyPlanetsHREF', SmrSession::getNewHREF($container));
+$template->assign('ModifyPlanetsHREF', $container->href());
 
 $container['body'] = '1.6/universe_create_ports.php';
-$template->assign('ModifyPortsHREF', SmrSession::getNewHREF($container));
+$template->assign('ModifyPortsHREF', $container->href());
 
 $container['body'] = '1.6/universe_create_warps.php';
-$template->assign('ModifyWarpsHREF', SmrSession::getNewHREF($container));
+$template->assign('ModifyWarpsHREF', $container->href());
 
 $container['body'] = '1.6/universe_create_sector_details.php';
-$template->assign('ModifySectorHREF', SmrSession::getNewHREF($container));
+$template->assign('ModifySectorHREF', $container->href());
 
 $template->assign('SMRFileHREF', Globals::getSmrFileCreateHREF($var['game_id']));
 
-$container = create_container('skeleton.php', '1.6/game_edit.php');
-transfer('game_id');
-transfer('gal_on');
-$template->assign('EditGameDetailsHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/game_edit.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
+$template->assign('EditGameDetailsHREF', $container->href());
 
-$container = create_container('skeleton.php', '1.6/check_map.php');
-transfer('game_id');
-transfer('gal_on');
-$template->assign('CheckMapHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/check_map.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
+$template->assign('CheckMapHREF', $container->href());
 
-$container = create_container('skeleton.php', '1.6/galaxies_edit.php');
-transfer('game_id');
-transfer('gal_on');
-$template->assign('EditGalaxyDetailsHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', '1.6/galaxies_edit.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
+$template->assign('EditGalaxyDetailsHREF', $container->href());
 
-$container = create_container('1.6/galaxy_reset_processing.php');
-transfer('game_id');
-transfer('gal_on');
-$template->assign('ResetGalaxyHREF', SmrSession::getNewHREF($container));
+$container = Page::create('1.6/galaxy_reset_processing.php');
+$container->addVar('game_id');
+$container->addVar('gal_on');
+$template->assign('ResetGalaxyHREF', $container->href());

--- a/src/admin/Default/1.6/universe_create_warps.php
+++ b/src/admin/Default/1.6/universe_create_warps.php
@@ -37,23 +37,23 @@ while ($db->nextRecord()) {
 }
 
 // Get links to other pages
-$container = create_container('skeleton.php', '1.6/universe_create_warps.php');
+$container = Page::create('skeleton.php', '1.6/universe_create_warps.php');
 $container['game_id'] = $var['game_id'];
 $galLinks = array();
 foreach ($galaxies as $gal) {
 	$container['gal_on'] = $gal->getGalaxyID();
-	$galLinks[$gal->getGalaxyID()] = SmrSession::getNewHREF($container);
+	$galLinks[$gal->getGalaxyID()] = $container->href();
 }
 $template->assign('GalLinks', $galLinks);
 
-$container = $var;
+$container = Page::copy($var);
 $container['url'] = '1.6/universe_create_save_processing.php';
 $container['body'] = '1.6/universe_create_warps.php';
-$template->assign('SubmitHREF', SmrSession::getNewHREF($container));
+$template->assign('SubmitHREF', $container->href());
 
-$container = $var;
+$container = Page::copy($var);
 $container['body'] = '1.6/universe_create_sectors.php';
-$template->assign('CancelHREF', SmrSession::getNewHREF($container));
+$template->assign('CancelHREF', $container->href());
 
 $template->assign('Galaxy', $galaxy);
 $template->assign('Galaxies', $galaxies);

--- a/src/admin/Default/1.6/upload_smr_file_processing.php
+++ b/src/admin/Default/1.6/upload_smr_file_processing.php
@@ -114,6 +114,6 @@ foreach ($data as $key => $vals) {
 SmrSector::saveSectors();
 SmrPort::savePorts();
 
-$container = create_container('skeleton.php', '1.6/universe_create_sectors.php');
-transfer('game_id');
-forward($container);
+$container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');
+$container->addVar('game_id');
+$container->go();

--- a/src/admin/Default/account_close.php
+++ b/src/admin/Default/account_close.php
@@ -54,6 +54,6 @@ $msg = 'You have disabled ' . $amount . ' accounts.';
 if ($amount > 20) {
 	$msg .= '  How do you sleep at night ;)';
 }
-$container = create_container('skeleton.php', 'admin_tools.php');
+$container = Page::create('skeleton.php', 'admin_tools.php');
 $container['msg'] = $msg;
-forward($container);
+$container->go();

--- a/src/admin/Default/account_edit.php
+++ b/src/admin/Default/account_edit.php
@@ -6,8 +6,8 @@ $account_id = $var['account_id'];
 $curr_account = SmrAccount::getAccount($account_id);
 
 $template->assign('EditingAccount', $curr_account);
-$template->assign('EditFormHREF', SmrSession::getNewHREF(create_container('account_edit_processing.php', '', array('account_id' => $curr_account->getAccountID()))));
-$template->assign('ResetFormHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'account_edit_search.php')));
+$template->assign('EditFormHREF', Page::create('account_edit_processing.php', '', array('account_id' => $curr_account->getAccountID()))->href());
+$template->assign('ResetFormHREF', Page::create('skeleton.php', 'account_edit_search.php')->href());
 
 $editingPlayers = array();
 $db->query('SELECT * FROM player WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY game_id ASC');

--- a/src/admin/Default/account_edit_processing.php
+++ b/src/admin/Default/account_edit_processing.php
@@ -196,9 +196,9 @@ if (!empty($delete)) {
 }
 
 //get his login name
-$container = create_container('skeleton.php', 'account_edit_search.php');
+$container = Page::create('skeleton.php', 'account_edit_search.php');
 $container['msg'] = 'You ' . join(' and ', $actions) . ' for the account of ' . $curr_account->getLogin() . '.';
 
 // Update the selected account in case it has been changed
 $curr_account->update();
-forward($container);
+$container->go();

--- a/src/admin/Default/account_edit_search.php
+++ b/src/admin/Default/account_edit_search.php
@@ -9,7 +9,7 @@ while ($db->nextRecord()) {
 	$games[$gameID] = $db->getField('game_name') . ' (' . $gameID . ')';
 }
 $template->assign('Games', $games);
-$template->assign('SearchHREF', SmrSession::getNewHREF(create_container('account_edit_search_processing.php')));
+$template->assign('SearchHREF', Page::create('account_edit_search_processing.php')->href());
 
 if (isset($var['errorMsg'])) {
 	$template->assign('ErrorMessage', $var['errorMsg']);

--- a/src/admin/Default/account_edit_search_processing.php
+++ b/src/admin/Default/account_edit_search_processing.php
@@ -27,10 +27,10 @@ $db->query('SELECT account_id FROM account WHERE account_id = ' . $db->escapeNum
 									   'hof_name LIKE ' . $db->escapeString(Request::get('hofname')) . ' OR ' .
 									   'validation_code LIKE ' . $db->escapeString(Request::get('val_code')));
 if ($db->nextRecord()) {
-	$container = create_container('skeleton.php', 'account_edit.php');
+	$container = Page::create('skeleton.php', 'account_edit.php');
 	$container['account_id'] = $db->getInt('account_id');
 } else {
-	$container = create_container('skeleton.php', 'account_edit_search.php');
+	$container = Page::create('skeleton.php', 'account_edit_search.php');
 	$container['errorMsg'] = 'No matching accounts were found!';
 }
-forward($container);
+$container->go();

--- a/src/admin/Default/admin_message_send.php
+++ b/src/admin/Default/admin_message_send.php
@@ -3,9 +3,9 @@
 $template->assign('PageTopic', 'Send Admin Message');
 
 $gameID = SmrSession::getRequestVarInt('SendGameID');
-$container = create_container('admin_message_send_processing.php');
+$container = Page::create('admin_message_send_processing.php');
 $container['SendGameID'] = $gameID;
-$template->assign('AdminMessageSendFormHref', SmrSession::getNewHREF($container));
+$template->assign('AdminMessageSendFormHref', $container->href());
 $template->assign('MessageGameID', $gameID);
 $template->assign('ExpireTime', $var['expire'] ?? 0.5);
 
@@ -26,5 +26,5 @@ if (isset($var['preview'])) {
 	$template->assign('Preview', $var['preview']);
 }
 
-$container = create_container('skeleton.php', 'admin_message_send_select.php');
-$template->assign('BackHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'admin_message_send_select.php');
+$template->assign('BackHREF', $container->href());

--- a/src/admin/Default/admin_message_send_processing.php
+++ b/src/admin/Default/admin_message_send_processing.php
@@ -9,14 +9,14 @@ if ($game_id != ALL_GAMES_ID) {
 }
 
 if (Request::get('action') == 'Preview message') {
-	$container = create_container('skeleton.php', 'admin_message_send.php');
-	transfer('SendGameID');
+	$container = Page::create('skeleton.php', 'admin_message_send.php');
+	$container->addVar('SendGameID');
 	$container['preview'] = $message;
 	$container['expire'] = $expire;
 	if ($game_id != ALL_GAMES_ID) {
 		$container['account_id'] = $account_id;
 	}
-	forward($container);
+	$container->go();
 }
 
 if ($expire < 0) {
@@ -51,6 +51,6 @@ foreach ($receivers as $receiver) {
 }
 $msg = '<span class="green">SUCCESS: </span>Your message has been sent.';
 
-$container = create_container('skeleton.php', 'admin_tools.php');
+$container = Page::create('skeleton.php', 'admin_tools.php');
 $container['msg'] = $msg;
-forward($container);
+$container->go();

--- a/src/admin/Default/admin_message_send_select.php
+++ b/src/admin/Default/admin_message_send_select.php
@@ -2,7 +2,7 @@
 
 $template->assign('PageTopic', 'Send Admin Message');
 
-$template->assign('AdminMessageChooseGameFormHref', SmrSession::getNewHREF(create_container('skeleton.php', 'admin_message_send.php')));
+$template->assign('AdminMessageChooseGameFormHref', Page::create('skeleton.php', 'admin_message_send.php')->href());
 
 // Get a list of all games that have not yet ended
 $activeGames = array();

--- a/src/admin/Default/admin_tools.php
+++ b/src/admin/Default/admin_tools.php
@@ -11,7 +11,7 @@ $adminPermissions = [];
 foreach (array_keys($account->getPermissions()) as $permissionID) {
 	list($name, $link, $categoryID) = AdminPermissions::getPermissionInfo($permissionID);
 	$adminPermissions[$categoryID][] = [
-		'Link' => empty($link) ? false : SmrSession::getNewHREF(create_container('skeleton.php', $link)),
+		'Link' => empty($link) ? false : Page::create('skeleton.php', $link)->href(),
 		'Name' => $name,
 	];
 }

--- a/src/admin/Default/album_approve.php
+++ b/src/admin/Default/album_approve.php
@@ -75,10 +75,10 @@ if ($db->nextRecord()) {
 	$time_passed = SmrSession::getTime() - $last_changed;
 	$template->assign('TimePassed', $time_passed);
 
-	$container = create_container('album_approve_processing.php', '');
+	$container = Page::create('album_approve_processing.php', '');
 	$container['album_id'] = $album_id;
 	$container['approved'] = true;
-	$template->assign('ApproveHREF', SmrSession::getNewHREF($container));
+	$template->assign('ApproveHREF', $container->href());
 	$container['approved'] = false;
-	$template->assign('RejectHREF', SmrSession::getNewHREF($container));
+	$template->assign('RejectHREF', $container->href());
 }

--- a/src/admin/Default/album_approve_processing.php
+++ b/src/admin/Default/album_approve_processing.php
@@ -6,4 +6,4 @@ $db->query('UPDATE album
 			SET approved = '.$db->escapeString($approved) . '
 			WHERE account_id = ' . $db->escapeNumber($var['album_id']));
 
-forward(create_container('skeleton.php', 'album_approve.php'));
+Page::create('skeleton.php', 'album_approve.php')->go();

--- a/src/admin/Default/album_moderate.php
+++ b/src/admin/Default/album_moderate.php
@@ -43,25 +43,25 @@ $entry = [
 ];
 $template->assign('Entry', $entry);
 
-$template->assign('BackHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'album_moderate_select.php')));
+$template->assign('BackHREF', Page::create('skeleton.php', 'album_moderate_select.php')->href());
 
-$container = create_container('album_moderate_processing.php');
+$container = Page::create('album_moderate_processing.php');
 $container['account_id'] = $account_id;
 
 $container['task'] = 'reset_image';
-$template->assign('ResetImageHREF', SmrSession::getNewHREF($container));
+$template->assign('ResetImageHREF', $container->href());
 $container['task'] = 'reset_location';
-$template->assign('ResetLocationHREF', SmrSession::getNewHREF($container));
+$template->assign('ResetLocationHREF', $container->href());
 $container['task'] = 'reset_email';
-$template->assign('ResetEmailHREF', SmrSession::getNewHREF($container));
+$template->assign('ResetEmailHREF', $container->href());
 $container['task'] = 'reset_website';
-$template->assign('ResetWebsiteHREF', SmrSession::getNewHREF($container));
+$template->assign('ResetWebsiteHREF', $container->href());
 $container['task'] = 'reset_birthdate';
-$template->assign('ResetBirthdateHREF', SmrSession::getNewHREF($container));
+$template->assign('ResetBirthdateHREF', $container->href());
 $container['task'] = 'reset_other';
-$template->assign('ResetOtherHREF', SmrSession::getNewHREF($container));
+$template->assign('ResetOtherHREF', $container->href());
 $container['task'] = 'delete_comment';
-$template->assign('DeleteCommentHREF', SmrSession::getNewHREF($container));
+$template->assign('DeleteCommentHREF', $container->href());
 
 $default_email = 'Dear Photo Album User,' . EOL . EOL .
 				 'You have received this email as notification that the picture you submitted to the Space Merchant Realms Photo Album has been temporarily disabled due to a Photo Album Rules violation.' . EOL .

--- a/src/admin/Default/album_moderate_processing.php
+++ b/src/admin/Default/album_moderate_processing.php
@@ -54,6 +54,6 @@ if ($var['task'] == 'reset_image') {
 	create_error('No action chosen!');
 }
 
-$container = create_container('skeleton.php', 'album_moderate.php');
-transfer('account_id');
-forward($container);
+$container = Page::create('skeleton.php', 'album_moderate.php');
+$container->addVar('account_id');
+$container->go();

--- a/src/admin/Default/album_moderate_select.php
+++ b/src/admin/Default/album_moderate_select.php
@@ -4,7 +4,7 @@ $template->assign('PageTopic', 'Moderate Photo Album');
 
 require_once(LIB . 'Album/album_functions.php');
 
-$moderateHREF = SmrSession::getNewHREF(create_container('skeleton.php', 'album_moderate.php'));
+$moderateHREF = Page::create('skeleton.php', 'album_moderate.php')->href();
 $template->assign('ModerateHREF', $moderateHREF);
 
 // Get all accounts that are eligible for moderation

--- a/src/admin/Default/announcement_create.php
+++ b/src/admin/Default/announcement_create.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 $template->assign('PageTopic', 'Create Announcement');
-$template->assign('AnnouncementCreateFormHref', SmrSession::getNewHREF(create_container('announcement_create_processing.php')));
+$template->assign('AnnouncementCreateFormHref', Page::create('announcement_create_processing.php')->href());
 if (isset($var['preview'])) {
 	$template->assign('Preview', htmlentities($var['preview']));
 }

--- a/src/admin/Default/announcement_create_processing.php
+++ b/src/admin/Default/announcement_create_processing.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 $message = trim(Request::get('message'));
 if (Request::get('action') == 'Preview announcement') {
-	$container = create_container('skeleton.php', 'announcement_create.php');
+	$container = Page::create('skeleton.php', 'announcement_create.php');
 	$container['preview'] = $message;
-	forward($container);
+	$container->go();
 }
 
 // put the msg into the database
 $db->query('INSERT INTO announcement (time, admin_id, msg) VALUES(' . $db->escapeNumber(SmrSession::getTime()) . ', ' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($message) . ')');
 
-forward(create_container('skeleton.php', 'admin_tools.php'));
+Page::create('skeleton.php', 'admin_tools.php')->go();

--- a/src/admin/Default/anon_acc_view.php
+++ b/src/admin/Default/anon_acc_view.php
@@ -3,8 +3,8 @@
 //view anon acct activity.
 $template->assign('PageTopic', 'View Anonymous Account Info');
 
-$container = create_container('skeleton.php', 'anon_acc_view_select.php');
-$template->assign('BackHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'anon_acc_view_select.php');
+$template->assign('BackHREF', $container->href());
 
 $anonID = SmrSession::getRequestVarInt('anon_account');
 $gameID = SmrSession::getRequestVarInt('view_game_id');
@@ -26,7 +26,7 @@ while ($db->nextRecord()) {
 if (!$rows) {
 	$message = '<p><span class="red">Anon account #' . $anonID . ' in Game ' . $gameID . ' does NOT exist!</span></p>';
 	$container['message'] = $message;
-	forward($container);
+	$container->go();
 }
 $template->assign('Rows', $rows);
 $template->assign('AnonID', $anonID);

--- a/src/admin/Default/anon_acc_view_select.php
+++ b/src/admin/Default/anon_acc_view_select.php
@@ -3,8 +3,8 @@
 //view anon acct activity.
 $template->assign('PageTopic', 'View Anonymous Account Info');
 
-$container = create_container('skeleton.php', 'anon_acc_view.php');
-$template->assign('AnonViewHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'anon_acc_view.php');
+$template->assign('AnonViewHREF', $container->href());
 
 if (isset($var['message'])) {
 	$template->assign('Message', $var['message']);

--- a/src/admin/Default/box_delete_processing.php
+++ b/src/admin/Default/box_delete_processing.php
@@ -14,4 +14,4 @@ if ($action == 'Marked Messages') {
 	}
 	$db->query('DELETE FROM message_boxes WHERE box_type_id = ' . $db->escapeNumber($var['box_type_id']));
 }
-forward(create_container('skeleton.php', 'box_view.php'));
+Page::create('skeleton.php', 'box_view.php')->go();

--- a/src/admin/Default/box_reply.php
+++ b/src/admin/Default/box_reply.php
@@ -4,11 +4,11 @@ require_once(get_file_loc('messages.inc.php'));
 $boxName = getAdminBoxNames()[$var['box_type_id']];
 $template->assign('PageTopic', 'Reply To ' . $boxName);
 
-$container = create_container('box_reply_processing.php');
-transfer('game_id');
-transfer('sender_id');
-transfer('box_type_id');
-$template->assign('BoxReplyFormHref', SmrSession::getNewHREF($container));
+$container = Page::create('box_reply_processing.php');
+$container->addVar('game_id');
+$container->addVar('sender_id');
+$container->addVar('box_type_id');
+$template->assign('BoxReplyFormHref', $container->href());
 $template->assign('Sender', SmrPlayer::getPlayer($var['sender_id'], $var['game_id']));
 $template->assign('SenderAccount', SmrAccount::getAccount($var['sender_id']));
 if (isset($var['Preview'])) {
@@ -17,6 +17,6 @@ if (isset($var['Preview'])) {
 $template->assign('BanPoints', $var['BanPoints'] ?? 0);
 $template->assign('RewardCredits', $var['RewardCredits'] ?? 0);
 
-$container = create_container('skeleton.php', 'box_view.php');
-transfer('box_type_id');
-$template->assign('BackHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'box_view.php');
+$container->addVar('box_type_id');
+$template->assign('BackHREF', $container->href());

--- a/src/admin/Default/box_reply_processing.php
+++ b/src/admin/Default/box_reply_processing.php
@@ -4,14 +4,14 @@ $message = trim(Request::get('message'));
 $banPoints = Request::getInt('BanPoints');
 $rewardCredits = Request::getInt('RewardCredits');
 if (Request::get('action') == 'Preview message') {
-	$container = create_container('skeleton.php', 'box_reply.php');
+	$container = Page::create('skeleton.php', 'box_reply.php');
 	$container['BanPoints'] = $banPoints;
 	$container['RewardCredits'] = $rewardCredits;
-	transfer('game_id');
-	transfer('sender_id');
-	transfer('box_type_id');
+	$container->addVar('game_id');
+	$container->addVar('sender_id');
+	$container->addVar('box_type_id');
 	$container['Preview'] = $message;
-	forward($container);
+	$container->go();
 }
 
 SmrPlayer::sendMessageFromAdmin($var['game_id'], $var['sender_id'], $message);
@@ -25,4 +25,4 @@ if ($banPoints > 0) {
 	$senderAccount->addPoints($banPoints, $account, BAN_REASON_BAD_BEHAVIOR, $suspicion);
 }
 
-forward(create_container('skeleton.php', 'box_view.php'));
+Page::create('skeleton.php', 'box_view.php')->go();

--- a/src/admin/Default/box_view.php
+++ b/src/admin/Default/box_view.php
@@ -5,12 +5,12 @@ require_once(get_file_loc('messages.inc.php'));
 if (!isset($var['box_type_id'])) {
 	$template->assign('PageTopic', 'Viewing Message Boxes');
 
-	$container = create_container('skeleton.php', 'box_view.php');
+	$container = Page::create('skeleton.php', 'box_view.php');
 	$boxes = array();
 	foreach (getAdminBoxNames() as $boxTypeID => $boxName) {
 		$container['box_type_id'] = $boxTypeID;
 		$boxes[$boxTypeID] = array(
-			'ViewHREF' => SmrSession::getNewHREF($container),
+			'ViewHREF' => $container->href(),
 			'BoxName' => $boxName,
 			'TotalMessages' => 0,
 		);
@@ -26,13 +26,13 @@ if (!isset($var['box_type_id'])) {
 	$boxName = getAdminBoxNames()[$var['box_type_id']];
 	$template->assign('PageTopic', 'Viewing ' . $boxName);
 
-	$template->assign('BackHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'box_view.php')));
+	$template->assign('BackHREF', Page::create('skeleton.php', 'box_view.php')->href());
 	$db->query('SELECT * FROM message_boxes WHERE box_type_id=' . $db->escapeNumber($var['box_type_id']) . ' ORDER BY send_time DESC');
 	$messages = array();
 	if ($db->getNumRows()) {
-		$container = create_container('box_delete_processing.php');
+		$container = Page::create('box_delete_processing.php');
 		$container['box_type_id'] = $var['box_type_id'];
-		$template->assign('DeleteHREF', SmrSession::getNewHREF($container));
+		$template->assign('DeleteHREF', $container->href());
 		while ($db->nextRecord()) {
 			$gameID = $db->getInt('game_id');
 			$validGame = $gameID > 0 && Globals::isValidGame($gameID);
@@ -51,11 +51,11 @@ if (!isset($var['box_type_id'])) {
 					$senderPlayer = SmrPlayer::getPlayer($senderID, $gameID);
 					$senderName .= ' a.k.a ' . $senderPlayer->getDisplayName();
 					if ($account->hasPermission(PERMISSION_SEND_ADMIN_MESSAGE)) {
-						$container = create_container('skeleton.php', 'box_reply.php');
+						$container = Page::create('skeleton.php', 'box_reply.php');
 						$container['sender_id'] = $senderID;
 						$container['game_id'] = $gameID;
-						transfer('box_type_id');
-						$messages[$messageID]['ReplyHREF'] = SmrSession::getNewHREF($container);
+						$container->addVar('box_type_id');
+						$messages[$messageID]['ReplyHREF'] = $container->href();
 					}
 				}
 			}

--- a/src/admin/Default/changelog.php
+++ b/src/admin/Default/changelog.php
@@ -24,7 +24,7 @@ while ($db->nextRecord()) {
 		$went_live = date(DATE_FULL_SHORT, $went_live);
 	} else {
 		if ($link_set_live) {
-			$container = create_container('changelog_set_live_processing.php');
+			$container = Page::create('changelog_set_live_processing.php');
 			$container['version_id'] = $version_id;
 			$went_live = create_link($container, 'never');
 		} else {
@@ -52,9 +52,9 @@ while ($db->nextRecord()) {
 
 	if ($first_entry) {
 		$first_entry = false;
-		$container = create_container('changelog_add_processing.php');
+		$container = Page::create('changelog_add_processing.php');
 		$container['version_id'] = $version_id;
-		$template->assign('AddHREF', SmrSession::getNewHREF($container));
+		$template->assign('AddHREF', $container->href());
 
 		if (isset($var['change_title'])) {
 			$version['changes'][] = [

--- a/src/admin/Default/changelog_add_processing.php
+++ b/src/admin/Default/changelog_add_processing.php
@@ -4,13 +4,13 @@ $change_title = Request::get('change_title');
 $change_message = Request::get('change_message');
 $affected_db = Request::get('affected_db');
 
-$container = create_container('skeleton.php', 'changelog.php');
+$container = Page::create('skeleton.php', 'changelog.php');
 
 if (Request::get('action') == 'Preview') {
 	$container['change_title'] = $change_title;
 	$container['change_message'] = $change_message;
 	$container['affected_db'] = $affected_db;
-	forward($container);
+	$container->go();
 }
 
 $db->lockTable('changelog');
@@ -31,4 +31,4 @@ $db->query('INSERT INTO changelog
 
 $db->unlock();
 
-forward($container);
+$container->go();

--- a/src/admin/Default/changelog_set_live_processing.php
+++ b/src/admin/Default/changelog_set_live_processing.php
@@ -16,4 +16,4 @@ $patch = $db->getInt('patch_level') + 1;
 $db->query('INSERT IGNORE INTO version (version_id, major_version, minor_version, patch_level, went_live) VALUES
 			('.$db->escapeNumber($versionID) . ',' . $db->escapeNumber($major) . ',' . $db->escapeNumber($minor) . ',' . $db->escapeNumber($patch) . ',0);');
 
-forward(create_container('skeleton.php', 'changelog.php'));
+Page::create('skeleton.php', 'changelog.php')->go();

--- a/src/admin/Default/db_cleanup.php
+++ b/src/admin/Default/db_cleanup.php
@@ -14,13 +14,13 @@ if (isset($var['results'])) {
 	$template->assign('DiffMB', bytesToMB($var['diffBytes']));
 	$template->assign('Action', $var['action']);
 	$template->assign('EndedGames', $var['endedGames']);
-	$container = create_container('skeleton.php', 'db_cleanup.php');
-	$template->assign('BackHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('skeleton.php', 'db_cleanup.php');
+	$template->assign('BackHREF', $container->href());
 } else {
 	// Create processing links
-	$container = create_container('db_cleanup_processing.php');
+	$container = Page::create('db_cleanup_processing.php');
 	$container['action'] = 'delete';
-	$template->assign('DeleteHREF', SmrSession::getNewHREF($container));
+	$template->assign('DeleteHREF', $container->href());
 	$container['action'] = 'preview';
-	$template->assign('PreviewHREF', SmrSession::getNewHREF($container));
+	$template->assign('PreviewHREF', $container->href());
 }

--- a/src/admin/Default/db_cleanup_processing.php
+++ b/src/admin/Default/db_cleanup_processing.php
@@ -40,9 +40,9 @@ $rowsDeleted['npc_logs'] = $db->getChangedRows();
 // Get difference in storage size
 $diffBytes = $initialBytes - $db->getDbBytes();
 
-$container = create_container('skeleton.php', 'db_cleanup.php');
+$container = Page::create('skeleton.php', 'db_cleanup.php');
 $container['results'] = $rowsDeleted;
 $container['diffBytes'] = $diffBytes;
 $container['endedGames'] = $endedGameIDs;
-transfer('action');
-forward($container);
+$container->addVar('action');
+$container->go();

--- a/src/admin/Default/enable_game.php
+++ b/src/admin/Default/enable_game.php
@@ -17,5 +17,5 @@ krsort($disabledGames);
 $template->assign('DisabledGames', $disabledGames);
 
 // Create the link to the processing file
-$linkContainer = create_container('enable_game_processing.php', '');
-$template->assign('EnableGameHREF', SmrSession::getNewHREF($linkContainer));
+$linkContainer = Page::create('enable_game_processing.php', '');
+$template->assign('EnableGameHREF', $linkContainer->href());

--- a/src/admin/Default/enable_game_processing.php
+++ b/src/admin/Default/enable_game_processing.php
@@ -6,5 +6,5 @@ $game->save(); // because next page queries database
 
 $msg = '<span class="green">SUCCESS: </span>Enabled game ' . $game->getDisplayName();
 
-forward(create_container('skeleton.php', 'enable_game.php',
-                         array('processing_msg' => $msg)));
+Page::create('skeleton.php', 'enable_game.php',
+             array('processing_msg' => $msg))->go();

--- a/src/admin/Default/form_open.php
+++ b/src/admin/Default/form_open.php
@@ -3,10 +3,10 @@
 $template->assign('PageTopic', 'Open/Close Forms');
 
 
-$container = create_container('form_open_processing.php');
+$container = Page::create('form_open_processing.php');
 $container['type'] = 'FEATURE';
 $container['is_open'] = Globals::isFeatureRequestOpen();
-$template->assign('ToggleHREF', SmrSession::getNewHREF($container));
+$template->assign('ToggleHREF', $container->href());
 
 $template->assign('Color', Globals::isFeatureRequestOpen() ? 'green' : 'red');
 $template->assign('Status', Globals::isFeatureRequestOpen() ? 'OPEN' : 'CLOSED');

--- a/src/admin/Default/form_open_processing.php
+++ b/src/admin/Default/form_open_processing.php
@@ -2,4 +2,4 @@
 
 $db->query('UPDATE open_forms SET open = ' . $db->escapeBoolean(!$var['is_open']) . ' WHERE type=' . $db->escapeString($var['type']));
 
-forward(create_container('skeleton.php', 'form_open.php'));
+Page::create('skeleton.php', 'form_open.php')->go();

--- a/src/admin/Default/game_delete.php
+++ b/src/admin/Default/game_delete.php
@@ -2,8 +2,8 @@
 
 $template->assign('PageTopic', 'Deleting A Game');
 
-$container = create_container('skeleton.php', 'game_delete_confirm.php');
-$template->assign('ConfirmHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'game_delete_confirm.php');
+$template->assign('ConfirmHREF', $container->href());
 
 $db->query('SELECT game_id, game_name FROM game ORDER BY game_id DESC');
 $games = [];

--- a/src/admin/Default/game_delete_confirm.php
+++ b/src/admin/Default/game_delete_confirm.php
@@ -5,6 +5,6 @@ $template->assign('PageTopic', 'Delete Game - Confirmation');
 SmrSession::getRequestVarInt('delete_game_id');
 $template->assign('Game', SmrGame::getGame($var['delete_game_id']));
 
-$container = create_container('game_delete_processing.php');
-transfer('delete_game_id');
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
+$container = Page::create('game_delete_processing.php');
+$container->addVar('delete_game_id');
+$template->assign('ProcessingHREF', $container->href());

--- a/src/admin/Default/game_delete_processing.php
+++ b/src/admin/Default/game_delete_processing.php
@@ -299,5 +299,4 @@ if ($action == 'Yes') {
 
 }
 $db = MySqlDatabase::getInstance();
-//forward em
-forward(create_container('skeleton.php', 'admin_tools.php'));
+Page::create('skeleton.php', 'admin_tools.php')->go();

--- a/src/admin/Default/game_status.php
+++ b/src/admin/Default/game_status.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$processingHREF = SmrSession::getNewHREF(create_container('game_status_processing.php'));
+$processingHREF = Page::create('game_status_processing.php')->href();
 $template->assign('ProcessingHREF', $processingHREF);
 
 $db->query('SELECT * FROM game_disable');

--- a/src/admin/Default/game_status_processing.php
+++ b/src/admin/Default/game_status_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php', 'admin_tools.php');
+$container = Page::create('skeleton.php', 'admin_tools.php');
 
 $action = Request::get('action');
 if ($action == 'Close') {
@@ -13,4 +13,4 @@ if ($action == 'Close') {
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have opened the server.';
 }
 
-forward($container);
+$container->go();

--- a/src/admin/Default/ip_view.php
+++ b/src/admin/Default/ip_view.php
@@ -2,4 +2,4 @@
 
 $template->assign('PageTopic', 'IP Search');
 
-$template->assign('IpFormHref', SmrSession::getNewHREF(create_container('skeleton.php', 'ip_view_results.php')));
+$template->assign('IpFormHref', Page::create('skeleton.php', 'ip_view_results.php')->href());

--- a/src/admin/Default/ip_view_results.php
+++ b/src/admin/Default/ip_view_results.php
@@ -4,11 +4,11 @@ $type = SmrSession::getRequestVar('type');
 
 $db2 = MySqlDatabase::getInstance();
 
-$container = create_container('skeleton.php', 'ip_view.php');
-$template->assign('BackHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'ip_view.php');
+$template->assign('BackHREF', $container->href());
 
-$container = create_container('account_close.php');
-$template->assign('CloseHREF', SmrSession::getNewHREF($container));
+$container = Page::create('account_close.php');
+$template->assign('CloseHREF', $container->href());
 
 $template->assign('type', $type);
 

--- a/src/admin/Default/location_edit.php
+++ b/src/admin/Default/location_edit.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$template->assign('ViewAllLocationsLink', SmrSession::getNewHREF(create_container('skeleton.php', 'location_edit.php')));
+$template->assign('ViewAllLocationsLink', Page::create('skeleton.php', 'location_edit.php')->href());
 
 if (isset($var['location_type_id'])) {
 	$location = SmrLocation::getLocation($var['location_type_id']);

--- a/src/admin/Default/log_anonymous_account.php
+++ b/src/admin/Default/log_anonymous_account.php
@@ -26,5 +26,5 @@ while ($db->nextRecord()) {
 }
 $template->assign('AnonLogs', $anon_logs);
 
-$container = create_container('skeleton.php', 'log_console.php');
-$template->assign('BackHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'log_console.php');
+$template->assign('BackHREF', $container->href());

--- a/src/admin/Default/log_console.php
+++ b/src/admin/Default/log_console.php
@@ -32,7 +32,7 @@ if ($db->getNumRows()) {
 	}
 	$template->assign('LogTypes', $logTypes);
 
-	$template->assign('LogConsoleFormHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'log_console_detail.php')));
-	$template->assign('AnonAccessHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'log_anonymous_account.php')));
+	$template->assign('LogConsoleFormHREF', Page::create('skeleton.php', 'log_console_detail.php')->href());
+	$template->assign('AnonAccessHREF', Page::create('skeleton.php', 'log_anonymous_account.php')->href());
 }
 $template->assign('LoggedAccounts', $loggedAccounts);

--- a/src/admin/Default/log_console_detail.php
+++ b/src/admin/Default/log_console_detail.php
@@ -48,9 +48,9 @@ if ($action == 'Delete') {
 	// *********************************
 	// * L o g   T y p e s
 	// *********************************
-	$container = create_container('skeleton.php', 'log_console_detail.php');
+	$container = Page::create('skeleton.php', 'log_console_detail.php');
 	$container['account_ids'] = $account_ids;
-	$template->assign('UpdateHREF', SmrSession::getNewHREF($container));
+	$template->assign('UpdateHREF', $container->href());
 
 	$logTypes = [];
 	$db->query('SELECT * FROM log_type');
@@ -70,10 +70,10 @@ if ($action == 'Delete') {
 	// *********************************
 	// * N o t e s
 	// *********************************
-	$container = create_container('log_notes_processing.php', '');
+	$container = Page::create('log_notes_processing.php', '');
 	$container['account_ids'] = $account_ids;
 	$container['log_type_ids'] = $log_type_ids;
-	$template->assign('SaveHREF', SmrSession::getNewHREF($container));
+	$template->assign('SaveHREF', $container->href());
 
 	// get notes from db
 	$log_notes = array();
@@ -114,6 +114,6 @@ if ($action == 'Delete') {
 	$template->assign('Logs', $logs);
 }
 
-$container = create_container('skeleton.php', 'log_console.php');
+$container = Page::create('skeleton.php', 'log_console.php');
 $container['account_ids'] = $account_ids;
-$template->assign('BackHREF', SmrSession::getNewHREF($container));
+$template->assign('BackHREF', $container->href());

--- a/src/admin/Default/log_notes_processing.php
+++ b/src/admin/Default/log_notes_processing.php
@@ -8,8 +8,8 @@ foreach ($var['account_ids'] as $account_id) {
 	}
 }
 
-$container = create_container('skeleton.php', 'log_console_detail.php');
-transfer('account_ids');
-transfer('log_type_ids');
+$container = Page::create('skeleton.php', 'log_console_detail.php');
+$container->addVar('account_ids');
+$container->addVar('log_type_ids');
 
-forward($container);
+$container->go();

--- a/src/admin/Default/manage_draft_leaders.php
+++ b/src/admin/Default/manage_draft_leaders.php
@@ -2,8 +2,8 @@
 
 $template->assign('PageTopic', 'Manage Draft Leaders');
 
-$container = create_container('skeleton.php', 'manage_draft_leaders.php');
-$template->assign('SelectGameHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'manage_draft_leaders.php');
+$template->assign('SelectGameHREF', $container->href());
 
 // Get the list of active Draft games ordered by reverse start date
 $activeGames = array();
@@ -46,5 +46,5 @@ if (isset($var['processing_msg'])) {
 
 // Create the link to the processing file
 // Pass entire $var so the processing file knows the selected game
-$linkContainer = create_container('manage_draft_leaders_processing.php', '', $var);
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($linkContainer));
+$linkContainer = Page::create('manage_draft_leaders_processing.php', '', $var);
+$template->assign('ProcessingHREF', $linkContainer->href());

--- a/src/admin/Default/manage_draft_leaders_processing.php
+++ b/src/admin/Default/manage_draft_leaders_processing.php
@@ -16,7 +16,7 @@ try {
 } catch (PlayerNotFoundException $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
 	SmrSession::updateVar('processing_msg', $msg);
-	forward(create_container('skeleton.php', 'manage_draft_leaders.php', $var));
+	Page::create('skeleton.php', 'manage_draft_leaders.php', $var)->go();
 }
 
 $name = $selectedPlayer->getDisplayName();
@@ -44,4 +44,4 @@ if (!empty($msg)) {
 }
 
 // Pass entire $var so that the selected game remains selected
-forward(create_container('skeleton.php', 'manage_draft_leaders.php', $var));
+Page::create('skeleton.php', 'manage_draft_leaders.php', $var)->go();

--- a/src/admin/Default/manage_post_editors.php
+++ b/src/admin/Default/manage_post_editors.php
@@ -2,8 +2,8 @@
 
 $template->assign('PageTopic', 'Manage Galactic Post Editors');
 
-$container = create_container('skeleton.php', 'manage_post_editors.php');
-$template->assign('SelectGameHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'manage_post_editors.php');
+$template->assign('SelectGameHREF', $container->href());
 
 // Get the list of active games ordered by reverse start date
 $activeGames = array();
@@ -41,5 +41,5 @@ if (isset($var['processing_msg'])) {
 
 // Create the link to the processing file
 // Pass entire $var so the processing file knows the selected game
-$linkContainer = create_container('manage_post_editors_processing.php', '', $var);
-$template->assign('PostEditorHREF', SmrSession::getNewHREF($linkContainer));
+$linkContainer = Page::create('manage_post_editors_processing.php', '', $var);
+$template->assign('PostEditorHREF', $linkContainer->href());

--- a/src/admin/Default/manage_post_editors_processing.php
+++ b/src/admin/Default/manage_post_editors_processing.php
@@ -15,7 +15,7 @@ try {
 } catch (PlayerNotFoundException $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
 	SmrSession::updateVar('processing_msg', $msg);
-	forward(create_container('skeleton.php', 'manage_post_editors.php', $var));
+	Page::create('skeleton.php', 'manage_post_editors.php', $var)->go();
 }
 
 $name = $selected_player->getDisplayName();
@@ -43,4 +43,4 @@ if (!empty($msg)) {
 }
 
 // Pass entire $var so that the selected game remains selected
-forward(create_container('skeleton.php', 'manage_post_editors.php', $var));
+Page::create('skeleton.php', 'manage_post_editors.php', $var)->go();

--- a/src/admin/Default/newsletter_send.php
+++ b/src/admin/Default/newsletter_send.php
@@ -3,7 +3,7 @@ $template->assign('PageTopic', 'Newsletter');
 
 $template->assign('CurrentEmail', $account->getEmail());
 
-$processingContainer = create_container('newsletter_send_processing.php');
+$processingContainer = Page::create('newsletter_send_processing.php');
 
 // Get the most recent newsletter text for preview
 $db = MySqlDatabase::getInstance();
@@ -21,4 +21,4 @@ if ($db->nextRecord()) {
 }
 
 // Create the form for the populated processing container
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($processingContainer));
+$template->assign('ProcessingHREF', $processingContainer->href());

--- a/src/admin/Default/newsletter_send_processing.php
+++ b/src/admin/Default/newsletter_send_processing.php
@@ -107,4 +107,4 @@ if (Request::get('to_email') == '*') {
 	}
 }
 
-forward(create_container('skeleton.php', 'newsletter_send.php'));
+Page::create('skeleton.php', 'newsletter_send.php')->go();

--- a/src/admin/Default/notify_delete_processing.php
+++ b/src/admin/Default/notify_delete_processing.php
@@ -5,4 +5,4 @@ if (!Request::has('notify_id')) {
 
 $db->query('DELETE FROM message_notify WHERE notify_id IN (' . $db->escapeArray(Request::getIntArray('notify_id')) . ')');
 
-forward(create_container('skeleton.php', 'notify_view.php'));
+Page::create('skeleton.php', 'notify_view.php')->go();

--- a/src/admin/Default/notify_reply.php
+++ b/src/admin/Default/notify_reply.php
@@ -3,11 +3,11 @@ $template->assign('PageTopic', 'Reply To Reported Messages');
 
 require_once(get_file_loc('messages.inc.php'));
 
-$container = create_container('notify_reply_processing.php');
-transfer('game_id');
-transfer('offended');
-transfer('offender');
-$template->assign('NotifyReplyFormHref', SmrSession::getNewHREF($container));
+$container = Page::create('notify_reply_processing.php');
+$container->addVar('game_id');
+$container->addVar('offended');
+$container->addVar('offender');
+$template->assign('NotifyReplyFormHref', $container->href());
 $offender = getMessagePlayer($var['offender'], $var['game_id']);
 $offended = getMessagePlayer($var['offended'], $var['game_id']);
 if (is_object($offender)) {

--- a/src/admin/Default/notify_reply_processing.php
+++ b/src/admin/Default/notify_reply_processing.php
@@ -4,16 +4,16 @@ $offenderBanPoints = Request::getInt('offenderBanPoints');
 $offendedReply = trim(Request::get('offendedReply'));
 $offendedBanPoints = Request::getInt('offendedBanPoints');
 if (Request::get('action') == 'Preview messages') {
-	$container = create_container('skeleton.php', 'notify_reply.php');
-	transfer('offender');
-	transfer('offended');
-	transfer('game_id');
-	transfer('sender_id');
+	$container = Page::create('skeleton.php', 'notify_reply.php');
+	$container->addVar('offender');
+	$container->addVar('offended');
+	$container->addVar('game_id');
+	$container->addVar('sender_id');
 	$container['PreviewOffender'] = $offenderReply;
 	$container['OffenderBanPoints'] = $offenderBanPoints;
 	$container['PreviewOffended'] = $offendedReply;
 	$container['OffendedBanPoints'] = $offendedBanPoints;
-	forward($container);
+	$container->go();
 }
 
 
@@ -39,4 +39,4 @@ if ($offendedReply != '') {
 		$offenderAccount->addPoints($offendedBanPoints, $account, BAN_REASON_BAD_BEHAVIOR, $suspicion);
 	}
 }
-forward(create_container('skeleton.php', 'notify_view.php'));
+Page::create('skeleton.php', 'notify_view.php')->go();

--- a/src/admin/Default/notify_view.php
+++ b/src/admin/Default/notify_view.php
@@ -3,8 +3,8 @@ $template->assign('PageTopic', 'Viewing Reported Messages');
 
 require_once(get_file_loc('messages.inc.php'));
 
-$container = create_container('notify_delete_processing.php');
-$template->assign('DeleteHREF', SmrSession::getNewHREF($container));
+$container = Page::create('notify_delete_processing.php');
+$template->assign('DeleteHREF', $container->href());
 
 $db->query('SELECT * FROM message_notify');
 $messages = [];
@@ -13,7 +13,7 @@ while ($db->nextRecord()) {
 	$sender = getMessagePlayer($db->getInt('from_id'), $gameID);
 	$receiver = getMessagePlayer($db->getInt('to_id'), $gameID);
 
-	$container = create_container('skeleton.php', 'notify_reply.php');
+	$container = Page::create('skeleton.php', 'notify_reply.php');
 	$container['offender'] = $db->getInt('from_id');
 	$container['offended'] = $db->getInt('to_id');
 	$container['game_id'] = $gameID;

--- a/src/admin/Default/npc_manage.php
+++ b/src/admin/Default/npc_manage.php
@@ -4,8 +4,8 @@ $template->assign('PageTopic', 'Manage NPCs');
 
 $selectedGameID = SmrSession::getRequestVarInt('selected_game_id', 0);
 
-$container = create_container('skeleton.php', 'npc_manage.php');
-$template->assign('SelectGameHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'npc_manage.php');
+$template->assign('SelectGameHREF', $container->href());
 
 $games = [];
 $db->query('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(SmrSession::getTime()) . ' AND enabled = ' . $db->escapeBoolean(true) . ' ORDER BY game_id DESC');
@@ -23,9 +23,9 @@ while ($db->nextRecord()) {
 $template->assign('Games', $games);
 $template->assign('SelectedGameID', $selectedGameID);
 
-$container = create_container('npc_manage_processing.php');
+$container = Page::create('npc_manage_processing.php');
 $container['selected_game_id'] = $selectedGameID;
-$template->assign('AddAccountHREF', SmrSession::getNewHREF($container));
+$template->assign('AddAccountHREF', $container->href());
 
 $npcs = [];
 $db->query('SELECT * FROM npc_logins JOIN account USING(login)');
@@ -42,7 +42,7 @@ while ($db->nextRecord()) {
 		'default_alliance' => htmlentities($db->getField('alliance_name')),
 		'active' => $db->getBoolean('active'),
 		'working' => $db->getBoolean('working'),
-		'href' => SmrSession::getNewHREF($container),
+		'href' => $container->href(),
 	];
 }
 

--- a/src/admin/Default/npc_manage_processing.php
+++ b/src/admin/Default/npc_manage_processing.php
@@ -50,6 +50,6 @@ if (Request::has('add_npc_account')) {
 	$db->query('INSERT INTO npc_logins (login, player_name, alliance_name) VALUES(' . $db->escapeString($login) . ',' . $db->escapeString(Request::get('default_player_name')) . ',' . $db->escapeString(Request::get('default_alliance')) . ')');
 }
 
-$container = create_container('skeleton.php', 'npc_manage.php');
-transfer('selected_game_id');
-forward($container);
+$container = Page::create('skeleton.php', 'npc_manage.php');
+$container->addVar('selected_game_id');
+$container->go();

--- a/src/admin/Default/permission_manage.php
+++ b/src/admin/Default/permission_manage.php
@@ -4,8 +4,8 @@ $admin_id = SmrSession::getRequestVarInt('admin_id', 0);
 
 $template->assign('PageTopic', 'Manage Admin Permissions');
 
-$container = create_container('skeleton.php', 'permission_manage.php');
-$selectAdminHREF = SmrSession::getNewHREF($container);
+$container = Page::create('skeleton.php', 'permission_manage.php');
+$selectAdminHREF = $container->href();
 $template->assign('SelectAdminHREF', $selectAdminHREF);
 
 $db->query('SELECT account_id, login
@@ -15,7 +15,7 @@ while ($db->nextRecord()) {
 	$accountID = $db->getInt('account_id');
 	$container['admin_id'] = $accountID;
 	$adminLinks[$accountID] = [
-		'href' => SmrSession::getNewHREF($container),
+		'href' => $container->href(),
 		'name' => $db->getField('login'),
 	];
 }
@@ -40,9 +40,9 @@ if (empty($admin_id)) {
 	$editAccount = SmrAccount::getAccount($admin_id);
 	$template->assign('EditAccount', $editAccount);
 
-	$container = create_container('permission_manage_processing.php');
+	$container = Page::create('permission_manage_processing.php');
 	$container['admin_id'] = $admin_id;
-	$processingHREF = SmrSession::getNewHREF($container);
+	$processingHREF = $container->href();
 	$template->assign('ProcessingHREF', $processingHREF);
 
 	$template->assign('PermissionCategories',

--- a/src/admin/Default/permission_manage_processing.php
+++ b/src/admin/Default/permission_manage_processing.php
@@ -30,4 +30,4 @@ if (Request::get('action') == 'Change') {
 	}
 }
 
-forward(create_container('skeleton.php', 'permission_manage.php'));
+Page::create('skeleton.php', 'permission_manage.php')->go();

--- a/src/admin/Default/ship_check.php
+++ b/src/admin/Default/ship_check.php
@@ -12,7 +12,7 @@ $db->query('SELECT * FROM ship_type_support_hardware, player, ship_has_hardware,
 
 $excessHardware = [];
 while ($db->nextRecord()) {
-	$container = create_container('ship_check_processing.php');
+	$container = Page::create('ship_check_processing.php');
 	$container['account_id'] = $db->getInt('account_id');
 	$container['hardware'] = $db->getInt('hardware_type_id');
 	$container['game_id'] = $db->getInt('game_id');
@@ -24,7 +24,7 @@ while ($db->nextRecord()) {
 		'hardware' => $db->getField('hardware_name'),
 		'amount' => $db->getInt('amount'),
 		'max_amount' => $db->getInt('max_amount'),
-		'fixHREF' => SmrSession::getNewHREF($container),
+		'fixHREF' => $container->href(),
 	];
 }
 $template->assign('ExcessHardware', $excessHardware);

--- a/src/admin/Default/ship_check_processing.php
+++ b/src/admin/Default/ship_check_processing.php
@@ -14,5 +14,5 @@ $db->query('UPDATE ship_has_hardware ' .
 				 'hardware_type_id = ' . $db->escapeNumber($hardware_id));
 
 //now erdirect back to page
-$container = create_container('skeleton.php', 'ship_check.php');
-forward($container);
+$container = Page::create('skeleton.php', 'ship_check.php');
+$container->go();

--- a/src/admin/Default/vote_create.php
+++ b/src/admin/Default/vote_create.php
@@ -2,7 +2,7 @@
 
 $template->assign('PageTopic', 'Create Vote');
 
-$template->assign('VoteFormHREF', SmrSession::getNewHREF(create_container('vote_create_processing.php', '')));
+$template->assign('VoteFormHREF', Page::create('vote_create_processing.php', '')->href());
 
 $voting = array();
 $db->query('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(SmrSession::getTime()));

--- a/src/admin/Default/vote_create_processing.php
+++ b/src/admin/Default/vote_create_processing.php
@@ -2,16 +2,16 @@
 
 $action = Request::get('action');
 if ($action == 'Preview Vote') {
-	$container = create_container('skeleton.php', 'vote_create.php');
+	$container = Page::create('skeleton.php', 'vote_create.php');
 	$container['PreviewVote'] = Request::get('question');
 	$container['Days'] = Request::getInt('days');
-	forward($container);
+	$container->go();
 }
 if ($action == 'Preview Option') {
-	$container = create_container('skeleton.php', 'vote_create.php');
+	$container = Page::create('skeleton.php', 'vote_create.php');
 	$container['PreviewOption'] = Request::get('option');
 	$container['VoteID'] = Request::getInt('vote');
-	forward($container);
+	$container->go();
 }
 
 if ($action == 'Create Vote') {
@@ -23,4 +23,4 @@ if ($action == 'Create Vote') {
 	$voteID = Request::getInt('vote');
 	$db->query('INSERT INTO voting_options (vote_id, text) VALUES(' . $db->escapeNumber($voteID) . ',' . $db->escapeString($option) . ')');
 }
-forward(create_container('skeleton.php', 'vote_create.php'));
+Page::create('skeleton.php', 'vote_create.php')->go();

--- a/src/admin/Default/word_filter.php
+++ b/src/admin/Default/word_filter.php
@@ -8,8 +8,8 @@ if (isset($var['msg'])) {
 
 $db->query('SELECT * FROM word_filter');
 if ($db->getNumRows()) {
-	$container = create_container('word_filter_del.php');
-	$template->assign('DelHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('word_filter_del.php');
+	$template->assign('DelHREF', $container->href());
 
 	$filteredWords = [];
 	while ($db->nextRecord()) {
@@ -18,5 +18,5 @@ if ($db->getNumRows()) {
 	$template->assign('FilteredWords', $filteredWords);
 }
 
-$container = create_container('word_filter_add.php');
-$template->assign('AddHREF', SmrSession::getNewHREF($container));
+$container = Page::create('word_filter_add.php');
+$template->assign('AddHREF', $container->href());

--- a/src/admin/Default/word_filter_add.php
+++ b/src/admin/Default/word_filter_add.php
@@ -3,15 +3,15 @@
 $word = strtoupper(trim(Request::get('Word')));
 $word_replacement = strtoupper(trim(Request::get('WordReplacement')));
 
-$container = create_container('skeleton.php', 'word_filter.php');
+$container = Page::create('skeleton.php', 'word_filter.php');
 
 $db->query('SELECT word_id FROM word_filter WHERE word_value=' . $db->escapeString($word) . ' LIMIT 1');
 if ($db->nextRecord()) {
 	$container['msg'] = '<span class="red bold">ERROR: </span>This word is already filtered!';
-	forward($container);
+	$container->go();
 }
 
 $db->query('INSERT INTO word_filter(word_value,word_replacement) VALUES (' . $db->escapeString($word) . ',' . $db->escapeString($word_replacement) . ')');
 
 $container['msg'] = '<span class="yellow">' . $word . '</span> will now be replaced with <span class="yellow">' . $word_replacement . '</span>.';
-forward($container);
+$container->go();

--- a/src/admin/Default/word_filter_del.php
+++ b/src/admin/Default/word_filter_del.php
@@ -4,5 +4,5 @@ if (Request::has('word_ids')) {
 	$db->query('DELETE FROM word_filter WHERE word_id IN (' . $db->escapeArray(Request::getIntArray('word_ids')) . ')');
 }
 
-$container = create_container('skeleton.php', 'word_filter.php');
-forward($container);
+$container = Page::create('skeleton.php', 'word_filter.php');
+$container->go();

--- a/src/engine/Default/album_delete_confirmation.php
+++ b/src/engine/Default/album_delete_confirmation.php
@@ -1,3 +1,3 @@
 <?php declare(strict_types=1);
 $template->assign('PageTopic', 'Delete Album Entry - Confirmation');
-$template->assign('ConfirmAlbumDeleteHref', SmrSession::getNewHREF(create_container('album_delete_processing.php', '')));
+$template->assign('ConfirmAlbumDeleteHref', Page::create('album_delete_processing.php', '')->href());

--- a/src/engine/Default/album_delete_processing.php
+++ b/src/engine/Default/album_delete_processing.php
@@ -10,11 +10,11 @@ if (Request::get('action') == 'Yes') {
 				WHERE album_id = ' . $db->escapeNumber($account->getAccountID()));
 }
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 if (!is_object($player)) {
 	$container['body'] = 'game_play.php';
 } else {
 	$container['body'] = 'current_sector.php';
 }
 
-forward($container);
+$container->go();

--- a/src/engine/Default/album_edit.php
+++ b/src/engine/Default/album_edit.php
@@ -32,8 +32,8 @@ if ($db->nextRecord()) {
 	$template->assign('AlbumEntry', $albumEntry);
 }
 
-$template->assign('AlbumEditHref', SmrSession::getNewHREF(create_container('album_edit_processing.php', '')));
-$template->assign('AlbumDeleteHref', SmrSession::getNewHREF(create_container('skeleton.php', 'album_delete_confirmation.php')));
+$template->assign('AlbumEditHref', Page::create('album_edit_processing.php', '')->href());
+$template->assign('AlbumDeleteHref', Page::create('skeleton.php', 'album_delete_confirmation.php')->href());
 
 if (isset($var['SuccessMsg'])) {
 	$template->assign('SuccessMsg', $var['SuccessMsg']);

--- a/src/engine/Default/album_edit_processing.php
+++ b/src/engine/Default/album_edit_processing.php
@@ -107,9 +107,9 @@ if (!empty($comment)) {
 	$db->unlock();
 }
 
-$container = create_container('skeleton.php', 'album_edit.php');
+$container = Page::create('skeleton.php', 'album_edit.php');
 $container['SuccessMsg'] = 'SUCCESS: Your information has been updated!';
-forward($container);
+$container->go();
 
 function php_link_check($url) {
 	/*	Purpose: Check HTTP Links

--- a/src/engine/Default/alliance_broadcast.php
+++ b/src/engine/Default/alliance_broadcast.php
@@ -3,9 +3,9 @@ $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 
-$container = create_container('message_send_processing.php');
+$container = Page::create('message_send_processing.php');
 $container['alliance_id'] = $var['alliance_id'];
-$template->assign('MessageSendFormHref', SmrSession::getNewHREF($container));
+$template->assign('MessageSendFormHref', $container->href());
 
 $template->assign('Receiver', 'Whole Alliance');
 if (isset($var['preview'])) {

--- a/src/engine/Default/alliance_create.php
+++ b/src/engine/Default/alliance_create.php
@@ -2,5 +2,5 @@
 
 $template->assign('PageTopic', 'Create Alliance');
 
-$container = create_container('alliance_create_processing.php');
-$template->assign('CreateHREF', SmrSession::getNewHREF($container));
+$container = Page::create('alliance_create_processing.php');
+$template->assign('CreateHREF', $container->href());

--- a/src/engine/Default/alliance_create_processing.php
+++ b/src/engine/Default/alliance_create_processing.php
@@ -43,4 +43,4 @@ $alliance->update();
 $player->joinAlliance($alliance->getAllianceID());
 $player->update();
 
-forward(create_container('skeleton.php', 'alliance_roster.php'));
+Page::create('skeleton.php', 'alliance_roster.php')->go();

--- a/src/engine/Default/alliance_exempt_authorize.php
+++ b/src/engine/Default/alliance_exempt_authorize.php
@@ -11,8 +11,8 @@ $db->query('SELECT * FROM alliance_bank_transactions WHERE request_exempt = 1 ' 
 			'AND alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND exempt = 0');
 $transactions = [];
 if ($db->getNumRows()) {
-	$container = create_container('bank_alliance_exempt_processing.php');
-	$template->assign('ExemptHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('bank_alliance_exempt_processing.php');
+	$template->assign('ExemptHREF', $container->href());
 
 	$players = $alliance->getMembers();
 	while ($db->nextRecord()) {

--- a/src/engine/Default/alliance_invite_accept_processing.php
+++ b/src/engine/Default/alliance_invite_accept_processing.php
@@ -28,5 +28,5 @@ $player->joinAlliance($newAlliance->getAllianceID());
 // Delete the invitation now that the player has joined
 $invite->delete();
 
-$container = create_container('skeleton.php', 'alliance_mod.php');
-forward($container);
+$container = Page::create('skeleton.php', 'alliance_mod.php');
+$container->go();

--- a/src/engine/Default/alliance_invite_cancel_processing.php
+++ b/src/engine/Default/alliance_invite_cancel_processing.php
@@ -2,4 +2,4 @@
 
 // Delete the alliance invitation
 $var['invite']->delete();
-forward(create_container('skeleton.php', 'alliance_invite_player.php'));
+Page::create('skeleton.php', 'alliance_invite_player.php')->go();

--- a/src/engine/Default/alliance_invite_player.php
+++ b/src/engine/Default/alliance_invite_player.php
@@ -9,7 +9,7 @@ Menu::alliance($alliance->getAllianceID());
 // Get list of pending invitations
 $pendingInvites = array();
 foreach (SmrInvitation::getAll($player->getAllianceID(), $player->getGameID()) as $invite) {
-	$container = create_container('alliance_invite_cancel_processing.php');
+	$container = Page::create('alliance_invite_cancel_processing.php');
 	$container['invite'] = $invite;
 
 	$invited = $invite->getReceiver();
@@ -17,7 +17,7 @@ foreach (SmrInvitation::getAll($player->getAllianceID(), $player->getGameID()) a
 		'invited' => $invited->getDisplayName(true),
 		'invited_by' => $invite->getSender()->getDisplayName(),
 		'expires' => format_time($invite->getExpires() - SmrSession::getTime(), true),
-		'cancelHREF' => SmrSession::getNewHREF($container),
+		'cancelHREF' => $container->href(),
 	);
 }
 $template->assign('PendingInvites', $pendingInvites);
@@ -46,4 +46,4 @@ $template->assign('InvitePlayers', $invitePlayers);
 
 $template->assign('ThisGame', $game);
 $template->assign('ThisAlliance', $alliance);
-$template->assign('InviteHREF', SmrSession::getNewHREF(create_container('alliance_invite_player_processing.php')));
+$template->assign('InviteHREF', Page::create('alliance_invite_player_processing.php')->href());

--- a/src/engine/Default/alliance_invite_player_processing.php
+++ b/src/engine/Default/alliance_invite_player_processing.php
@@ -27,5 +27,5 @@ if (!empty($addMessage)) {
 
 $player->sendAllianceInvitation($receiverID, $msg, $expires);
 
-$container = create_container('skeleton.php', 'alliance_invite_player.php');
-forward($container);
+$container = Page::create('skeleton.php', 'alliance_invite_player.php');
+$container->go();

--- a/src/engine/Default/alliance_join_processing.php
+++ b/src/engine/Default/alliance_join_processing.php
@@ -15,4 +15,4 @@ if (Request::get('password') != $alliance->getPassword()) {
 $player->joinAlliance($alliance->getAllianceID());
 $player->update();
 
-forward(create_container('skeleton.php', 'alliance_roster.php'));
+Page::create('skeleton.php', 'alliance_roster.php')->go();

--- a/src/engine/Default/alliance_leadership.php
+++ b/src/engine/Default/alliance_leadership.php
@@ -4,7 +4,7 @@ $alliance = $player->getAlliance();
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($player->getAllianceID());
 
-$container = create_container('alliance_leadership_processing.php');
-$template->assign('HandoverHREF', SmrSession::getNewHREF($container));
+$container = Page::create('alliance_leadership_processing.php');
+$template->assign('HandoverHREF', $container->href());
 
 $template->assign('AlliancePlayers', $alliance->getMembers());

--- a/src/engine/Default/alliance_leadership_processing.php
+++ b/src/engine/Default/alliance_leadership_processing.php
@@ -12,4 +12,4 @@ $db->query('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(
 $playerMessage = 'You are now the leader of ' . $alliance->getAllianceBBLink() . '!';
 $player->sendMessageFromAllianceCommand($leader_id, $playerMessage);
 
-forward(create_container('skeleton.php', 'alliance_roster.php'));
+Page::create('skeleton.php', 'alliance_roster.php')->go();

--- a/src/engine/Default/alliance_leave_confirm.php
+++ b/src/engine/Default/alliance_leave_confirm.php
@@ -4,9 +4,9 @@ $alliance = $player->getAlliance();
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 
-$container = create_container('alliance_leave_processing.php');
+$container = Page::create('alliance_leave_processing.php');
 $container['action'] = 'YES';
-$template->assign('YesHREF', SmrSession::getNewHREF($container));
+$template->assign('YesHREF', $container->href());
 
 $container['action'] = 'NO';
-$template->assign('NoHREF', SmrSession::getNewHREF($container));
+$template->assign('NoHREF', $container->href());

--- a/src/engine/Default/alliance_leave_processing.php
+++ b/src/engine/Default/alliance_leave_processing.php
@@ -33,5 +33,5 @@ if ($action == 'YES') {
 
 }
 
-$container = create_container('skeleton.php', 'current_sector.php');
-forward($container);
+$container = Page::create('skeleton.php', 'current_sector.php');
+$container->go();

--- a/src/engine/Default/alliance_list.php
+++ b/src/engine/Default/alliance_list.php
@@ -3,12 +3,12 @@
 $template->assign('PageTopic', 'List Of Alliances');
 
 if (!$player->hasAlliance()) {
-	$container = create_container('skeleton.php', 'alliance_create.php');
-	$template->assign('CreateAllianceHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('skeleton.php', 'alliance_create.php');
+	$template->assign('CreateAllianceHREF', $container->href());
 }
 
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 
 // get list of alliances
 $db->query('SELECT
@@ -36,7 +36,7 @@ while ($db->nextRecord()) {
 	$container['alliance_id'] = $allianceID;
 
 	$alliances[$allianceID] = array(
-		'ViewHREF' => SmrSession::getNewHREF($container),
+		'ViewHREF' => $container->href(),
 		'Name' => htmlentities($db->getField('alliance_name')),
 		'TotalExperience' => $db->getInt('alliance_xp'),
 		'AverageExperience' => $db->getInt('alliance_avg'),

--- a/src/engine/Default/alliance_message.php
+++ b/src/engine/Default/alliance_message.php
@@ -38,7 +38,7 @@ $threads = array();
 if ($db->getNumRows() > 0) {
 	$db2 = MySqlDatabase::getInstance();
 
-	$container = create_container('alliance_message_delete_processing.php');
+	$container = Page::create('alliance_message_delete_processing.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
 
 	$i = 0;
@@ -84,7 +84,7 @@ if ($db->getNumRows() > 0) {
 		$threads[$i]['CanDelete'] = $player->getAccountID() == $sender_id || $db2->getBoolean('mb_messages');
 		if ($threads[$i]['CanDelete']) {
 			$container['thread_id'] = $threadID;
-			$threads[$i]['DeleteHref'] = SmrSession::getNewHREF($container);
+			$threads[$i]['DeleteHref'] = $container->href();
 		}
 		$threads[$i]['Replies'] = $db->getInt('num_replies');
 		$thread_replies[$i] = $db->getInt('num_replies');
@@ -92,7 +92,7 @@ if ($db->getNumRows() > 0) {
 		++$i;
 	}
 
-	$container = create_container('skeleton.php', 'alliance_message_view.php');
+	$container = Page::create('skeleton.php', 'alliance_message_view.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
 	$container['thread_ids'] = $thread_ids;
 	$container['thread_topics'] = $thread_topics;
@@ -100,15 +100,15 @@ if ($db->getNumRows() > 0) {
 	$container['alliance_eyes'] = $alliance_eyes;
 	for ($j = 0; $j < $i; $j++) {
 		$container['thread_index'] = $j;
-		$threads[$j]['ViewHref'] = SmrSession::getNewHREF($container);
+		$threads[$j]['ViewHref'] = $container->href();
 	}
 }
 $template->assign('Threads', $threads);
 
 if ($mbWrite || in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
-	$container = create_container('alliance_message_add_processing.php');
+	$container = Page::create('alliance_message_add_processing.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
-	$template->assign('CreateNewThreadFormHref', SmrSession::getNewHREF($container));
+	$template->assign('CreateNewThreadFormHref', $container->href());
 }
 
 if (isset($var['preview'])) {

--- a/src/engine/Default/alliance_message_add_processing.php
+++ b/src/engine/Default/alliance_message_add_processing.php
@@ -5,7 +5,7 @@ $allEyesOnly = Request::has('allEyesOnly'); // only present for Create Thread
 
 $action = Request::get('action');
 if ($action == 'Preview Thread' || $action == 'Preview Reply') {
-	$container = create_container('skeleton.php', '', $var);
+	$container = Page::create('skeleton.php', '', $var);
 	if (!isset($var['thread_index'])) {
 		$container['body'] = 'alliance_message.php';
 	} else {
@@ -14,7 +14,7 @@ if ($action == 'Preview Thread' || $action == 'Preview Reply') {
 	$container['preview'] = $body;
 	$container['topic'] = $topic;
 	$container['AllianceEyesOnly'] = $allEyesOnly;
-	forward($container);
+	$container->go();
 }
 
 if (!isset($var['alliance_id'])) {
@@ -84,7 +84,7 @@ $db->query('REPLACE INTO player_read_thread
 			(account_id, game_id, alliance_id, thread_id, time)
 			VALUES(' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', ' . $db->escapeNumber(SmrSession::getTime() + 2) . ')');
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 $container['alliance_id'] = $alliance_id;
 if (isset($var['alliance_eyes'])) {
 	$container['alliance_eyes'] = $var['alliance_eyes'];
@@ -100,4 +100,4 @@ if (isset($var['thread_index'])) {
 	$container['body'] = 'alliance_message.php';
 }
 
-forward($container);
+$container->go();

--- a/src/engine/Default/alliance_message_delete_processing.php
+++ b/src/engine/Default/alliance_message_delete_processing.php
@@ -10,7 +10,7 @@ if (isset($var['reply_id'])) {
 				AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 				AND thread_id = ' . $db->escapeNumber($var['thread_id']) . '
 				AND reply_id = ' . $db->escapeNumber($var['reply_id']) . ' LIMIT 1');
-	forward(create_container('skeleton.php', 'alliance_message_view.php', $var));
+	Page::create('skeleton.php', 'alliance_message_view.php', $var)->go();
 } else {
 	$db->query('DELETE FROM alliance_thread
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
@@ -20,5 +20,5 @@ if (isset($var['reply_id'])) {
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 				AND thread_id = ' . $db->escapeNumber($var['thread_id']));
-	forward(create_container('skeleton.php', 'alliance_message.php'));
+	Page::create('skeleton.php', 'alliance_message.php')->go();
 }

--- a/src/engine/Default/alliance_message_view.php
+++ b/src/engine/Default/alliance_message_view.php
@@ -28,15 +28,15 @@ if ($alliance->getAllianceID() != $player->getAllianceID()) {
 	$mbWrite = $db->nextRecord();
 }
 
-$container = create_container('skeleton.php', 'alliance_message_view.php', $var);
+$container = Page::create('skeleton.php', 'alliance_message_view.php', $var);
 
 if (isset($var['thread_ids'][$thread_index - 1])) {
 	$container['thread_index'] = $thread_index - 1;
-	$template->assign('PrevThread', array('Topic' => $var['thread_topics'][$thread_index - 1], 'Href' => SmrSession::getNewHREF($container)));
+	$template->assign('PrevThread', array('Topic' => $var['thread_topics'][$thread_index - 1], 'Href' => $container->href()));
 }
 if (isset($var['thread_ids'][$thread_index + 1])) {
 	$container['thread_index'] = $thread_index + 1;
-	$template->assign('NextThread', array('Topic' => $var['thread_topics'][$thread_index + 1], 'Href' => SmrSession::getNewHREF($container)));
+	$template->assign('NextThread', array('Topic' => $var['thread_topics'][$thread_index + 1], 'Href' => $container->href()));
 }
 
 $thread = array();
@@ -66,20 +66,20 @@ ORDER BY reply_id LIMIT ' . $var['thread_replies'][$thread_index]);
 
 $thread['CanDelete'] = $db->getNumRows() > 1 && $thread['CanDelete'];
 $thread['Replies'] = array();
-$container = create_container('alliance_message_delete_processing.php', '', $var);
+$container = Page::create('alliance_message_delete_processing.php', '', $var);
 $container['thread_id'] = $thread_id;
 while ($db->nextRecord()) {
 	$thread['Replies'][$db->getInt('reply_id')] = array('Sender' => $players[$db->getInt('sender_id')], 'Message' => $db->getField('text'), 'SendTime' => $db->getInt('time'));
 	if ($thread['CanDelete']) {
 		$container['reply_id'] = $db->getInt('reply_id');
-		$thread['Replies'][$db->getInt('reply_id')]['DeleteHref'] = SmrSession::getNewHREF($container);
+		$thread['Replies'][$db->getInt('reply_id')]['DeleteHref'] = $container->href();
 	}
 }
 
 if ($mbWrite || in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
-	$container = create_container('alliance_message_add_processing.php', '', $var);
+	$container = Page::create('alliance_message_add_processing.php', '', $var);
 	$container['thread_index'] = $thread_index;
-	$thread['CreateThreadReplyFormHref'] = SmrSession::getNewHREF($container);
+	$thread['CreateThreadReplyFormHref'] = $container->href();
 }
 $template->assign('Thread', $thread);
 if (isset($var['preview'])) {

--- a/src/engine/Default/alliance_mod.php
+++ b/src/engine/Default/alliance_mod.php
@@ -22,7 +22,7 @@ if ($db->nextRecord()) {
 	$db2->query('SELECT response FROM alliance_has_op_response WHERE alliance_id=' . $db2->escapeNumber($player->getAllianceID()) . ' AND ' . $player->getSQL() . ' LIMIT 1');
 
 	$response = $db2->nextRecord() ? $db2->getField('response') : null;
-	$responseHREF = SmrSession::getNewHREF(create_container('alliance_op_response_processing.php'));
+	$responseHREF = Page::create('alliance_op_response_processing.php')->href();
 	$template->assign('OpResponseHREF', $responseHREF);
 
 	$responseInputs = array();
@@ -38,9 +38,9 @@ $role_id = $player->getAllianceRole($alliance->getAllianceID());
 $db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
 $db->requireRecord();
 if ($db->getBoolean('change_mod') || $db->getBoolean('change_pass')) {
-	$container = create_container('skeleton.php', 'alliance_stat.php');
+	$container = Page::create('skeleton.php', 'alliance_stat.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
-	$template->assign('EditHREF', SmrSession::getNewHREF($container));
+	$template->assign('EditHREF', $container->href());
 }
 
 $template->assign('DiscordServer', $alliance->getDiscordServer());

--- a/src/engine/Default/alliance_op_response_processing.php
+++ b/src/engine/Default/alliance_op_response_processing.php
@@ -4,4 +4,4 @@ $response = strtoupper(Request::get('op_response'));
 
 $db->query('REPLACE INTO alliance_has_op_response (alliance_id, game_id, account_id, response) VALUES (' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($response) . ')');
 
-forward(create_container('skeleton.php', 'alliance_mod.php'));
+Page::create('skeleton.php', 'alliance_mod.php')->go();

--- a/src/engine/Default/alliance_option.php
+++ b/src/engine/Default/alliance_option.php
@@ -10,13 +10,13 @@ Menu::alliance($alliance->getAllianceID());
 // Create an array of links with descriptions
 $links = array();
 
-$container = create_container('skeleton.php', 'alliance_leave_confirm.php');
+$container = Page::create('skeleton.php', 'alliance_leave_confirm.php');
 $links[] = array(
 	'link' => create_link($container, 'Leave Alliance'),
 	'text' => 'Leave the alliance. Alliance leaders must hand over leadership before leaving.',
 );
 
-$container = create_container('alliance_share_maps_processing.php');
+$container = Page::create('alliance_share_maps_processing.php');
 $links[] = array(
 	'link' => create_link($container, 'Share Maps'),
 	'text' => 'Share your knowledge of the universe with your alliance mates.',

--- a/src/engine/Default/alliance_remove_member.php
+++ b/src/engine/Default/alliance_remove_member.php
@@ -16,8 +16,8 @@ AND account_id != ' . $db->escapeNumber($player->getAccountID()) . '
 ORDER BY last_cpl_action DESC
 ');
 
-$container = create_container('alliance_remove_member_processing.php');
-$template->assign('BanishHREF', SmrSession::getNewHREF($container));
+$container = Page::create('alliance_remove_member_processing.php');
+$template->assign('BanishHREF', $container->href());
 
 $members = [];
 while ($db->nextRecord()) {

--- a/src/engine/Default/alliance_remove_member_processing.php
+++ b/src/engine/Default/alliance_remove_member_processing.php
@@ -21,4 +21,4 @@ foreach ($accountIDs as $accountID) {
 	$currPlayer->leaveAlliance($player);
 }
 
-forward(create_container('skeleton.php', 'alliance_roster.php'));
+Page::create('skeleton.php', 'alliance_roster.php')->go();

--- a/src/engine/Default/alliance_roles.php
+++ b/src/engine/Default/alliance_roles.php
@@ -21,7 +21,7 @@ while ($db->nextRecord()) {
 	$allianceRoles[$roleID]['EditingRole'] = isset($var['role_id']) && $var['role_id'] == $roleID;
 	$allianceRoles[$roleID]['CreatingRole'] = false;
 	if ($allianceRoles[$roleID]['EditingRole']) {
-		$container = create_container('alliance_roles_processing.php');
+		$container = Page::create('alliance_roles_processing.php');
 		$allianceRoles[$roleID]['WithdrawalLimit'] = $db->getInt('with_per_day');
 		$allianceRoles[$roleID]['PositiveBalance'] = $db->getBoolean('positive_balance');
 		$allianceRoles[$roleID]['TreatyCreated'] = $db->getBoolean('treaty_created');
@@ -36,18 +36,18 @@ while ($db->nextRecord()) {
 		$allianceRoles[$roleID]['OpLeader'] = $db->getBoolean('op_leader');
 		$allianceRoles[$roleID]['ViewBondsInPlanetList'] = $db->getBoolean('view_bonds');
 	} else {
-		$container = create_container('skeleton.php', 'alliance_roles.php');
+		$container = Page::create('skeleton.php', 'alliance_roles.php');
 	}
 	$container['role_id'] = $roleID;
 	$container['alliance_id'] = $alliance->getAllianceID();
-	$allianceRoles[$roleID]['HREF'] = SmrSession::getNewHREF($container);
+	$allianceRoles[$roleID]['HREF'] = $container->href();
 }
 $template->assign('AllianceRoles', $allianceRoles);
-$container = create_container('alliance_roles_processing.php');
+$container = Page::create('alliance_roles_processing.php');
 $container['alliance_id'] = $alliance->getAllianceID();
 
 $template->assign('CreateRole', array(
-	'HREF' => SmrSession::getNewHREF($container),
+	'HREF' => $container->href(),
 	'RoleID' => '',
 	'Name' => '',
 	'CreatingRole' => true,

--- a/src/engine/Default/alliance_roles_processing.php
+++ b/src/engine/Default/alliance_roles_processing.php
@@ -85,6 +85,6 @@ if (!isset($var['role_id'])) {
 	}
 
 }
-$container = create_container('skeleton.php', 'alliance_roles.php');
+$container = Page::create('skeleton.php', 'alliance_roles.php');
 $container['alliance_id'] = $alliance_id;
-forward($container);
+$container->go();

--- a/src/engine/Default/alliance_roles_save_processing.php
+++ b/src/engine/Default/alliance_roles_save_processing.php
@@ -5,6 +5,6 @@ foreach (Request::getIntArray('role', []) as $accountID => $roleID) {
 					VALUES (' . $db->escapeNumber($accountID) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($roleID) . ',' . $db->escapeNumber($var['alliance_id']) . ')');
 }
 
-$container = create_container('skeleton.php', 'alliance_roster.php');
+$container = Page::create('skeleton.php', 'alliance_roster.php');
 $container['action'] = 'Show Alliance Roles';
-forward($container);
+$container->go();

--- a/src/engine/Default/alliance_roster.php
+++ b/src/engine/Default/alliance_roster.php
@@ -29,9 +29,9 @@ if ($showRoles) {
 	}
 	$template->assign('Roles', $roles);
 
-	$container = create_container('alliance_roles_save_processing.php');
+	$container = Page::create('alliance_roles_save_processing.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
-	$template->assign('SaveAllianceRolesHREF', SmrSession::getNewHREF($container));
+	$template->assign('SaveAllianceRolesHREF', $container->href());
 }
 
 
@@ -51,9 +51,9 @@ $template->assign('AllianceExp', $db->getInt('alliance_xp'));
 $template->assign('AllianceAverageExp', $db->getInt('alliance_avg'));
 
 if ($account->getAccountID() == $alliance->getLeaderID() || $account->hasPermission(PERMISSION_EDIT_ALLIANCE_DESCRIPTION)) {
-	$container = create_container('skeleton.php', 'alliance_stat.php');
+	$container = Page::create('skeleton.php', 'alliance_stat.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
-	$template->assign('EditAllianceDescriptionHREF', SmrSession::getNewHREF($container));
+	$template->assign('EditAllianceDescriptionHREF', $container->href());
 }
 
 $db->query('SELECT 1 FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
@@ -67,13 +67,13 @@ $template->assign('AlliancePlayers', $alliancePlayers);
 if ($alliance->getAllianceID() == $player->getAllianceID()) {
 	// Alliance members get to see active/inactive status of members
 	$template->assign('ActiveIDs', $alliance->getActiveIDs());
-	$container = create_container('skeleton.php', 'alliance_roster.php');
+	$container = Page::create('skeleton.php', 'alliance_roster.php');
 	if ($showRoles) {
 		$container['action'] = 'Hide Alliance Roles';
 	} else {
 		$container['action'] = 'Show Alliance Roles';
 	}
-	$template->assign('ToggleRolesHREF', SmrSession::getNewHREF($container));
+	$template->assign('ToggleRolesHREF', $container->href());
 }
 
 // If the player is already in an alliance, we don't want to print
@@ -81,7 +81,7 @@ if ($alliance->getAllianceID() == $player->getAllianceID()) {
 $joinRestriction = $player->hasAlliance() ? true : $alliance->getJoinRestriction($player);
 $template->assign('JoinRestriction', $joinRestriction);
 if ($joinRestriction === false) {
-	$container = create_container('alliance_join_processing.php');
+	$container = Page::create('alliance_join_processing.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
-	$template->assign('JoinHREF', SmrSession::getNewHREF($container));
+	$template->assign('JoinHREF', $container->href());
 }

--- a/src/engine/Default/alliance_set_flagship_processing.php
+++ b/src/engine/Default/alliance_set_flagship_processing.php
@@ -6,4 +6,4 @@ $alliance = $player->getAlliance();
 $alliance->setFlagshipID($flagshipID);
 $alliance->update();
 
-forward(create_container('skeleton.php', 'alliance_set_op.php'));
+Page::create('skeleton.php', 'alliance_set_op.php')->go();

--- a/src/engine/Default/alliance_set_op.php
+++ b/src/engine/Default/alliance_set_op.php
@@ -4,7 +4,7 @@ $alliance = $player->getAlliance();
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 
-$container = create_container('alliance_set_op_processing.php');
+$container = Page::create('alliance_set_op_processing.php');
 
 // Print any error messages that may have been created
 if (!empty($var['message'])) {
@@ -24,12 +24,12 @@ if ($db->nextRecord()) {
 	$container['cancel'] = true;
 }
 
-$template->assign('OpProcessingHREF', SmrSession::getNewHREF($container));
+$template->assign('OpProcessingHREF', $container->href());
 
 
 // Stuff for designating a flagship
 $template->assign('FlagshipID', $alliance->getFlagshipID());
 $template->assign('AlliancePlayers', $alliance->getMembers());
 
-$container = create_container('alliance_set_flagship_processing.php');
-$template->assign('FlagshipHREF', SmrSession::getNewHREF($container));
+$container = Page::create('alliance_set_flagship_processing.php');
+$template->assign('FlagshipHREF', $container->href());

--- a/src/engine/Default/alliance_set_op_processing.php
+++ b/src/engine/Default/alliance_set_op_processing.php
@@ -2,7 +2,7 @@
 
 function error_on_page($error) {
 	$message = '<span class="bold red">ERROR:</span> ' . $error;
-	forward(create_container('skeleton.php', 'alliance_set_op.php', array('message' => $message)));
+	Page::create('skeleton.php', 'alliance_set_op.php', array('message' => $message))->go();
 }
 
 if (!empty($var['cancel'])) {
@@ -38,4 +38,4 @@ if (!empty($var['cancel'])) {
 	}
 }
 
-forward(create_container('skeleton.php', 'alliance_set_op.php'));
+Page::create('skeleton.php', 'alliance_set_op.php')->go();

--- a/src/engine/Default/alliance_share_maps_processing.php
+++ b/src/engine/Default/alliance_share_maps_processing.php
@@ -42,4 +42,4 @@ while ($db->nextRecord()) {
 	$cachedPort->addCachePorts($alliance_ids);
 }
 
-forward(create_container('skeleton.php', 'alliance_roster.php'));
+Page::create('skeleton.php', 'alliance_roster.php')->go();

--- a/src/engine/Default/alliance_stat.php
+++ b/src/engine/Default/alliance_stat.php
@@ -8,7 +8,7 @@ $alliance = SmrAlliance::getAlliance($alliance_id, $player->getGameID());
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance_id);
 
-$container = create_container('alliance_stat_processing.php');
+$container = Page::create('alliance_stat_processing.php');
 $container['alliance_id'] = $alliance_id;
 
 $role_id = $player->getAllianceRole($alliance->getAllianceID());
@@ -23,7 +23,7 @@ if ($db->nextRecord()) {
 }
 $change_chat = $player->getAllianceID() == $alliance_id && $player->isAllianceLeader();
 
-$template->assign('FormHREF', SmrSession::getNewHREF($container));
+$template->assign('FormHREF', $container->href());
 $template->assign('Alliance', $alliance);
 
 $template->assign('CanChangeDescription', $change_mod || $account->hasPermission(PERMISSION_EDIT_ALLIANCE_DESCRIPTION));

--- a/src/engine/Default/alliance_stat_processing.php
+++ b/src/engine/Default/alliance_stat_processing.php
@@ -63,6 +63,6 @@ if (isset($url)) {
 }
 
 $alliance->update();
-$container = create_container('skeleton.php', 'alliance_roster.php');
+$container = Page::create('skeleton.php', 'alliance_roster.php');
 $container['alliance_id'] = $alliance_id;
-forward($container);
+$container->go();

--- a/src/engine/Default/alliance_treaties.php
+++ b/src/engine/Default/alliance_treaties.php
@@ -25,13 +25,13 @@ while ($db->nextRecord()) {
 		}
 	}
 	$otherAllianceID = $db->getInt('alliance_id_1');
-	$container = create_container('alliance_treaties_processing.php', '');
+	$container = Page::create('alliance_treaties_processing.php', '');
 	$container['alliance_id_1'] = $otherAllianceID;
 	$container['aa_access'] = $db->getField('aa_access');
 	$container['accept'] = true;
-	$acceptHREF = SmrSession::getNewHREF($container);
+	$acceptHREF = $container->href();
 	$container['accept'] = false;
-	$rejectHREF = SmrSession::getNewHREF($container);
+	$rejectHREF = $container->href();
 
 	$offers[] = [
 		'Alliance' => SmrAlliance::getAlliance($otherAllianceID, $player->getGameID()),
@@ -42,5 +42,5 @@ while ($db->nextRecord()) {
 }
 $template->assign('Offers', $offers);
 
-$container = create_container('skeleton.php', 'alliance_treaties_confirm.php');
-$template->assign('SendOfferHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'alliance_treaties_confirm.php');
+$template->assign('SendOfferHREF', $container->href());

--- a/src/engine/Default/alliance_treaties_confirm.php
+++ b/src/engine/Default/alliance_treaties_confirm.php
@@ -5,9 +5,9 @@ $alliance_id_2 = $_REQUEST['proposedAlliance'];
 
 $db->query('SELECT alliance_id_1, alliance_id_2, game_id FROM alliance_treaties WHERE (alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_1 = ' . $alliance_id_2 . ') AND (alliance_id_2 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()));
 if ($db->nextRecord()) {
-	$container = create_container('skeleton.php', 'alliance_treaties.php');
+	$container = Page::create('skeleton.php', 'alliance_treaties.php');
 	$container['message'] = '<span class="red bold">ERROR:</span> There is already an outstanding treaty with that alliance.';
-	forward($container);
+	$container->go();
 }
 
 $alliance1 = SmrAlliance::getAlliance($alliance_id_1, $player->getGameID());
@@ -30,12 +30,12 @@ $terms['mb_read'] = $terms['mb_read'] || $terms['mb_write'];
 $template->assign('Terms', $terms);
 
 // Create links for yes/no response
-$container = create_container('alliance_treaties_confirm_processing.php');
+$container = Page::create('alliance_treaties_confirm_processing.php');
 $container['proposedAlliance'] = $alliance_id_2;
 foreach ($terms as $term => $value) {
 	$container[$term] = $value;
 }
-$template->assign('YesHREF', SmrSession::getNewHREF($container));
+$template->assign('YesHREF', $container->href());
 
-$container = create_container('skeleton.php', 'alliance_treaties.php');
-$template->assign('NoHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'alliance_treaties.php');
+$template->assign('NoHREF', $container->href());

--- a/src/engine/Default/alliance_treaties_confirm_processing.php
+++ b/src/engine/Default/alliance_treaties_confirm_processing.php
@@ -16,6 +16,6 @@ $leader2 = $alliance2->getLeaderID();
 $message = 'An ambassador from ' . $alliance1->getAllianceBBLink() . ' has arrived with a treaty offer.';
 
 SmrPlayer::sendMessageFromAllianceAmbassador($player->getGameID(), $leader2, $message);
-$container = create_container('skeleton.php', 'alliance_treaties.php');
+$container = Page::create('skeleton.php', 'alliance_treaties.php');
 $container['message'] = 'The treaty offer has been sent.';
-forward($container);
+$container->go();

--- a/src/engine/Default/alliance_treaties_processing.php
+++ b/src/engine/Default/alliance_treaties_processing.php
@@ -35,5 +35,5 @@ if ($var['accept']) {
 	$db->query('DELETE FROM alliance_treaties WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 }
 
-$container = create_container('skeleton.php', 'alliance_treaties.php');
-forward($container);
+$container = Page::create('skeleton.php', 'alliance_treaties.php');
+$container->go();

--- a/src/engine/Default/announcements.php
+++ b/src/engine/Default/announcements.php
@@ -22,6 +22,6 @@ while ($db->nextRecord()) {
 }
 $template->assign('Announcements', $announcements);
 
-$container = create_container('login_check_processing.php');
+$container = Page::create('login_check_processing.php');
 $container['CheckType'] = 'Updates';
-$template->assign('ContinueHREF', SmrSession::getNewHREF($container));
+$template->assign('ContinueHREF', $container->href());

--- a/src/engine/Default/bank_alliance.php
+++ b/src/engine/Default/bank_alliance.php
@@ -121,22 +121,22 @@ if ($db->getNumRows() > 0) {
 
 	$template->assign('MinValue', $minValue);
 	$template->assign('MaxValue', $maxValue);
-	$container = create_container('skeleton.php', 'bank_alliance.php');
+	$container = Page::create('skeleton.php', 'bank_alliance.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
-	$template->assign('FilterTransactionsFormHREF', SmrSession::getNewHREF($container));
+	$template->assign('FilterTransactionsFormHREF', $container->href());
 
-	$container = create_container('bank_alliance_exempt_processing.php');
+	$container = Page::create('bank_alliance_exempt_processing.php');
 	$container['minVal'] = $minValue;
 	$container['maxVal'] = $maxValue;
-	$template->assign('ExemptTransactionsFormHREF', SmrSession::getNewHREF($container));
+	$template->assign('ExemptTransactionsFormHREF', $container->href());
 
 	$template->assign('Alliance', $alliance);
 }
 
-$container = create_container('skeleton.php', 'bank_report.php');
+$container = Page::create('skeleton.php', 'bank_report.php');
 $container['alliance_id'] = $alliance->getAllianceID();
-$template->assign('BankReportHREF', SmrSession::getNewHREF($container));
+$template->assign('BankReportHREF', $container->href());
 
-$container = create_container('bank_alliance_processing.php');
+$container = Page::create('bank_alliance_processing.php');
 $container['alliance_id'] = $alliance->getAllianceID();
-$template->assign('BankTransactionFormHREF', SmrSession::getNewHREF($container));
+$template->assign('BankTransactionFormHREF', $container->href());

--- a/src/engine/Default/bank_alliance_exempt_processing.php
+++ b/src/engine/Default/bank_alliance_exempt_processing.php
@@ -16,10 +16,10 @@ if (Request::has('exempt')) {
 				AND transaction_id IN (' . $db->escapeArray($trans_ids) . ')');
 }
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 if (isset($var['minVal'])) {
 	$container['body'] = 'bank_alliance.php';
 } else {
 	$container['body'] = 'alliance_exempt_authorize.php';
 }
-forward($container);
+$container->go();

--- a/src/engine/Default/bank_alliance_processing.php
+++ b/src/engine/Default/bank_alliance_processing.php
@@ -101,6 +101,6 @@ $player->update();
 // save money for alliance
 $alliance->update();
 
-$container = create_container('skeleton.php', 'bank_alliance.php');
+$container = Page::create('skeleton.php', 'bank_alliance.php');
 $container['alliance_id'] = $alliance_id;
-forward($container);
+$container->go();

--- a/src/engine/Default/bank_anon.php
+++ b/src/engine/Default/bank_anon.php
@@ -8,8 +8,8 @@ if (!$account->isValidated()) {
 $template->assign('PageTopic', 'Anonymous Account');
 Menu::bank();
 
-$container = create_container('skeleton.php', 'bank_anon_detail.php');
-$template->assign('AccessHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'bank_anon_detail.php');
+$template->assign('AccessHREF', $container->href());
 
 $template->assign('Message', $var['message'] ?? '');
 
@@ -36,11 +36,11 @@ while ($db->nextRecord()) {
 
 	$container['account_num'] = $anon['anon_id'];
 	$container['password'] = $anon['password'];
-	$anon['href'] = SmrSession::getNewHREF($container);
+	$anon['href'] = $container->href();
 
 	$ownedAnon[] = $anon;
 }
 $template->assign('OwnedAnon', $ownedAnon);
 
-$container = create_container('skeleton.php', 'bank_anon_create.php');
-$template->assign('CreateHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'bank_anon_create.php');
+$template->assign('CreateHREF', $container->href());

--- a/src/engine/Default/bank_anon_create.php
+++ b/src/engine/Default/bank_anon_create.php
@@ -3,5 +3,5 @@
 $template->assign('PageTopic', 'Create Anonymous Account');
 Menu::bank();
 
-$container = create_container('bank_anon_create_processing.php');
-$template->assign('CreateHREF', SmrSession::getNewHREF($container));
+$container = Page::create('bank_anon_create_processing.php');
+$template->assign('CreateHREF', $container->href());

--- a/src/engine/Default/bank_anon_create_processing.php
+++ b/src/engine/Default/bank_anon_create_processing.php
@@ -12,6 +12,6 @@ if ($db->nextRecord()) {
 }
 $db->query('INSERT INTO anon_bank (game_id, anon_id, owner_id, password, amount) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($new_acc) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($password) . ', 0)');
 
-$container = create_container('skeleton.php', 'bank_anon.php');
+$container = Page::create('skeleton.php', 'bank_anon.php');
 $container['message'] = '<p>Account #' . $new_acc . ' has been opened for you.</p>';
-forward($container);
+$container->go();

--- a/src/engine/Default/bank_anon_detail.php
+++ b/src/engine/Default/bank_anon_detail.php
@@ -63,10 +63,10 @@ $db->query($query);
 if ($db->getNumRows() > 0) {
 	$template->assign('MinValue', $minValue);
 	$template->assign('MaxValue', $maxValue);
-	$container = create_container('skeleton.php', 'bank_anon_detail.php');
+	$container = Page::create('skeleton.php', 'bank_anon_detail.php');
 	$container['allowed'] = 'yes';
 	$container['account_num'] = $account_num;
-	$template->assign('ShowHREF', SmrSession::getNewHREF($container));
+	$template->assign('ShowHREF', $container->href());
 
 	$transactions = [];
 	while ($db->nextRecord()) {
@@ -83,9 +83,9 @@ if ($db->getNumRows() > 0) {
 	$template->assign('Transactions', $transactions);
 }
 
-$container = create_container('bank_anon_detail_processing.php');
+$container = Page::create('bank_anon_detail_processing.php');
 $container['account_num'] = $account_num;
-$template->assign('TransactionHREF', SmrSession::getNewHREF($container));
+$template->assign('TransactionHREF', $container->href());
 
 $template->assign('PageTopic', 'Anonymous Account #' . $account_num);
 Menu::bank();

--- a/src/engine/Default/bank_anon_detail_processing.php
+++ b/src/engine/Default/bank_anon_detail_processing.php
@@ -48,7 +48,7 @@ $db->query('INSERT INTO anon_bank_transactions (account_id, game_id, anon_id, tr
 // Log the player action
 $player->log(LOG_TYPE_BANK, $action . ' of ' . $amount . ' credits in anonymous account #' . $account_num);
 
-$container = create_container('skeleton.php', 'bank_anon_detail.php');
+$container = Page::create('skeleton.php', 'bank_anon_detail.php');
 $container['account_num'] = $account_num;
 $container['allowed'] = 'yes';
-forward($container);
+$container->go();

--- a/src/engine/Default/bank_personal.php
+++ b/src/engine/Default/bank_personal.php
@@ -9,5 +9,5 @@ $template->assign('PageTopic', 'Bank');
 
 Menu::bank();
 
-$container = create_container('bank_personal_processing.php');
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
+$container = Page::create('bank_personal_processing.php');
+$template->assign('ProcessingHREF', $container->href());

--- a/src/engine/Default/bank_personal_processing.php
+++ b/src/engine/Default/bank_personal_processing.php
@@ -25,4 +25,4 @@ if ($action == 'Deposit') {
 $player->log(LOG_TYPE_BANK, $action . ' ' . $amount . ' credits for personal account');
 
 $player->update();
-forward(create_container('skeleton.php', 'bank_personal.php'));
+Page::create('skeleton.php', 'bank_personal.php')->go();

--- a/src/engine/Default/bank_report.php
+++ b/src/engine/Default/bank_report.php
@@ -58,10 +58,10 @@ $text = '<div class="center"><br />Ending Balance: ' . number_format($balance) .
 $template->assign('BankReport', $text);
 
 if (!isset($var['sent_report'])) {
-	$container = create_container('bank_report_processing.php');
+	$container = Page::create('bank_report_processing.php');
 	$container['alliance_id'] = $alliance_id;
 	$container['text'] = $text;
-	$template->assign('SendReportHREF', SmrSession::getNewHREF($container));
+	$template->assign('SendReportHREF', $container->href());
 }
 
 $template->assign('PageTopic', 'Alliance Bank Report');

--- a/src/engine/Default/bank_report_processing.php
+++ b/src/engine/Default/bank_report_processing.php
@@ -24,7 +24,7 @@ if ($db->nextRecord()) {
 	$db->query('INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_BANK_REPORTER) . ', ' . $db->escapeNumber(SmrSession::getTime()) . ')');
 }
 
-$container = create_container('skeleton.php', 'bank_report.php');
-transfer('alliance_id');
+$container = Page::create('skeleton.php', 'bank_report.php');
+$container->addVar('alliance_id');
 $container['sent_report'] = True;
-forward($container);
+$container->go();

--- a/src/engine/Default/bar_buy_drink_processing.php
+++ b/src/engine/Default/bar_buy_drink_processing.php
@@ -87,7 +87,7 @@ if (isset($num_drinks) && $num_drinks > 15) {
 $player->increaseHOF(1, array('Bar', 'Drinks', 'Total'), HOF_PUBLIC);
 $message .= '</div>';
 
-$container = create_container('skeleton.php', 'bar_main.php');
-transfer('LocationID');
+$container = Page::create('skeleton.php', 'bar_main.php');
+$container->addVar('LocationID');
 $container['message'] = $message;
-forward($container);
+$container->go();

--- a/src/engine/Default/bar_galmap_buy.php
+++ b/src/engine/Default/bar_galmap_buy.php
@@ -39,18 +39,18 @@ if (isset($var['process'])) {
 		$port->addCachePort($player->getAccountID());
 	}
 
-	$container = create_container('skeleton.php', 'bar_main.php');
-	transfer('LocationID');
+	$container = Page::create('skeleton.php', 'bar_main.php');
+	$container->addVar('LocationID');
 	$container['message'] = '<div class="center">Galaxy maps have been added. Enjoy!</div><br />';
-	forward($container);
+	$container->go();
 } else {
 	// This is a display page!
 	$template->assign('PageTopic', 'Buy Galaxy Maps');
 	Menu::bar();
 
 	//find what gal they want
-	$container = create_container('skeleton.php', 'bar_galmap_buy.php');
-	transfer('LocationID');
+	$container = Page::create('skeleton.php', 'bar_galmap_buy.php');
+	$container->addVar('LocationID');
 	$container['process'] = true;
-	$template->assign('BuyHREF', SmrSession::getNewHREF($container));
+	$template->assign('BuyHREF', $container->href());
 }

--- a/src/engine/Default/bar_gambling_bet.php
+++ b/src/engine/Default/bar_gambling_bet.php
@@ -18,6 +18,6 @@ if ($player->hasNewbieTurns()) {
 $template->assign('MaxBet', $maxBet);
 $template->assign('MaxBetMsg', $maxBetMsg);
 
-$container = create_container('bar_gambling_processing.php');
-transfer('LocationID');
-$template->assign('PlayHREF', SmrSession::getNewHREF($container));
+$container = Page::create('bar_gambling_processing.php');
+$container->addVar('LocationID');
+$template->assign('PlayHREF', $container->href());

--- a/src/engine/Default/bar_gambling_processing.php
+++ b/src/engine/Default/bar_gambling_processing.php
@@ -195,8 +195,8 @@ if ($do == 'STAY') {
 	$win = check_for_win($dealerHand, $playerHand);
 }
 
-$container = create_container('bar_gambling_processing.php');
-transfer('LocationID');
+$container = Page::create('bar_gambling_processing.php');
+$container->addVar('LocationID');
 $container['bet'] = $bet;
 
 $message .= ('<div class="center">');
@@ -204,18 +204,18 @@ if ($playerHand->getValue() > 21) {
 	$message .= ('You have <span class="red"><b>BUSTED</b></span>');
 	$player->increaseHOF($bet, array('Blackjack', 'Money', 'Lost'), HOF_PUBLIC);
 	$player->increaseHOF(1, array('Blackjack', 'Results', 'Lost'), HOF_PUBLIC);
-	$message .= '<p><a class="submitStyle" href="' . SmrSession::getNewHREF($container) . '">Play Some More ($' . $bet . ')</a></p>';
+	$message .= '<p><a class="submitStyle" href="' . $container->href() . '">Play Some More ($' . $bet . ')</a></p>';
 	$message .= ('</div>');
 } elseif (!isset($win) && $playerHand->getValue() < 21) {
 	$container['deck'] = $deck;
 	$container['player_hand'] = $playerHand;
 	$container['player_does'] = 'HIT';
 	$container['dealer_hand'] = $dealerHand;
-	$message .= '<form method="POST" action="' . SmrSession::getNewHREF($container) . '">';
+	$message .= '<form method="POST" action="' . $container->href() . '">';
 	$message .= '<input type="submit" name="action" value="HIT" />';
 	$message .= ('<br /><small><br /></small></form>');
 	$container['player_does'] = 'STAY';
-	$message .= '<form method="POST" action="' . SmrSession::getNewHREF($container) . '">';
+	$message .= '<form method="POST" action="' . $container->href() . '">';
 	$message .= '<input type="submit" name="action" value="STAY" />';
 	$message .= ('</form></div>');
 } elseif (isset($win)) {
@@ -242,7 +242,7 @@ if ($playerHand->getValue() > 21) {
 		$player->increaseHOF($bet, array('Blackjack', 'Money', 'Lost'), HOF_PUBLIC);
 		$player->increaseHOF(1, array('Blackjack', 'Results', 'Lost'), HOF_PUBLIC);
 	}
-	$message .= '<p><a class="submitStyle" href="' . SmrSession::getNewHREF($container) . '">Play Some More ($' . $bet . ')</a></p>';
+	$message .= '<p><a class="submitStyle" href="' . $container->href() . '">Play Some More ($' . $bet . ')</a></p>';
 	$message .= ('</div>');
 } elseif ($playerHand->getValue() == 21) {
 	if ($dealerHand->getValue() != 21) {
@@ -269,13 +269,13 @@ if ($playerHand->getValue() > 21) {
 		$player->increaseHOF($bet, array('Blackjack', 'Money', 'Lost'), HOF_PUBLIC);
 		$player->increaseHOF(1, array('Blackjack', 'Results', 'Lost'), HOF_PUBLIC);
 	}
-	$message .= '<p><a class="submitStyle" href="' . SmrSession::getNewHREF($container) . '">Play Some More ($' . $bet . ')</a></p>';
+	$message .= '<p><a class="submitStyle" href="' . $container->href() . '">Play Some More ($' . $bet . ')</a></p>';
 	$message .= ('</div>');
 }
 
 $player->update();
-$container = create_container('skeleton.php', 'bar_gambling_bet.php');
-transfer('LocationID');
+$container = Page::create('skeleton.php', 'bar_gambling_bet.php');
+$container->addVar('LocationID');
 $container['message'] = $message;
 $container['AllowAjax'] = false;
-forward($container);
+$container->go();

--- a/src/engine/Default/bar_lotto_buy.php
+++ b/src/engine/Default/bar_lotto_buy.php
@@ -8,6 +8,6 @@ checkForLottoWinner($player->getGameID());
 $lottoInfo = getLottoInfo($player->getGameID());
 $template->assign('LottoInfo', $lottoInfo);
 
-$container = create_container('bar_lotto_buy_processing.php');
-transfer('LocationID');
-$template->assign('BuyTicketHREF', SmrSession::getNewHREF($container));
+$container = Page::create('bar_lotto_buy_processing.php');
+$container->addVar('LocationID');
+$template->assign('BuyTicketHREF', $container->href());

--- a/src/engine/Default/bar_lotto_buy_processing.php
+++ b/src/engine/Default/bar_lotto_buy_processing.php
@@ -25,7 +25,7 @@ $num = $db->getInt('num');
 $message = ('<div class="center">Thanks for your purchase and good luck!  You currently');
 $message .= (' own ' . $num . ' ' . pluralise('ticket', $num) . '!</div><br />');
 
-$container = create_container('skeleton.php', 'bar_main.php');
-transfer('LocationID');
+$container = Page::create('skeleton.php', 'bar_main.php');
+$container->addVar('LocationID');
 $container['message'] = $message;
-forward($container);
+$container->go();

--- a/src/engine/Default/bar_lotto_claim.php
+++ b/src/engine/Default/bar_lotto_claim.php
@@ -15,7 +15,7 @@ if ($db->nextRecord()) {
 	$db->query('DELETE FROM news WHERE type = \'lotto\' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 }
 //offer another drink and such
-$container = create_container('skeleton.php', 'bar_main.php');
-transfer('LocationID');
+$container = Page::create('skeleton.php', 'bar_main.php');
+$container->addVar('LocationID');
 $container['message'] = $message;
-forward($container);
+$container->go();

--- a/src/engine/Default/bar_main.php
+++ b/src/engine/Default/bar_main.php
@@ -23,30 +23,30 @@ $db->query('SELECT prize FROM player_has_ticket WHERE ' . $player->getSQL() . ' 
 if ($db->nextRecord()) {
 	$winningTicket = $db->getInt('prize');
 
-	$container = create_container('bar_lotto_claim.php');
-	transfer('LocationID');
-	$template->assign('LottoClaimHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('bar_lotto_claim.php');
+	$container->addVar('LocationID');
+	$template->assign('LottoClaimHREF', $container->href());
 }
 $template->assign('WinningTicket', $winningTicket);
 
 //get rid of drinks older than 30 mins
 $db->query('DELETE FROM player_has_drinks WHERE time < ' . $db->escapeNumber(SmrSession::getTime() - 1800));
 
-$container = create_container('skeleton.php', 'bar_talk_bartender.php');
-transfer('LocationID');
-$template->assign('GossipHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'bar_talk_bartender.php');
+$container->addVar('LocationID');
+$template->assign('GossipHREF', $container->href());
 
-$container = create_container('bar_buy_drink_processing.php');
-transfer('LocationID');
+$container = Page::create('bar_buy_drink_processing.php');
+$container->addVar('LocationID');
 $container['action'] = 'drink';
-$template->assign('BuyDrinkHREF', SmrSession::getNewHREF($container));
+$template->assign('BuyDrinkHREF', $container->href());
 $container['action'] = 'water';
-$template->assign('BuyWaterHREF', SmrSession::getNewHREF($container));
+$template->assign('BuyWaterHREF', $container->href());
 
-$container = create_container('skeleton.php', 'bar_ticker_buy.php');
-transfer('LocationID');
-$template->assign('BuySystemHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'bar_ticker_buy.php');
+$container->addVar('LocationID');
+$template->assign('BuySystemHREF', $container->href());
 
-$container = create_container('skeleton.php', 'bar_galmap_buy.php');
-transfer('LocationID');
-$template->assign('BuyGalMapHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'bar_galmap_buy.php');
+$container->addVar('LocationID');
+$template->assign('BuyGalMapHREF', $container->href());

--- a/src/engine/Default/bar_talk_bartender.php
+++ b/src/engine/Default/bar_talk_bartender.php
@@ -15,10 +15,10 @@ if (!isset($var['Message'])) {
 }
 $template->assign('Message', bbifyMessage($var['Message']));
 
-$container = create_container('skeleton.php', 'bar_talk_bartender.php');
-transfer('LocationID');
-$template->assign('ListenHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'bar_talk_bartender.php');
+$container->addVar('LocationID');
+$template->assign('ListenHREF', $container->href());
 
-$container = create_container('bar_talk_bartender_processing.php');
-transfer('LocationID');
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
+$container = Page::create('bar_talk_bartender_processing.php');
+$container->addVar('LocationID');
+$template->assign('ProcessingHREF', $container->href());

--- a/src/engine/Default/bar_talk_bartender_processing.php
+++ b/src/engine/Default/bar_talk_bartender_processing.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php', 'bar_talk_bartender.php');
-transfer('LocationID');
+$container = Page::create('skeleton.php', 'bar_talk_bartender.php');
+$container->addVar('LocationID');
 
 $action = Request::get('action');
 
@@ -67,4 +67,4 @@ if ($action == 'tell') {
 	}
 }
 
-forward($container);
+$container->go();

--- a/src/engine/Default/bar_ticker_buy.php
+++ b/src/engine/Default/bar_ticker_buy.php
@@ -20,6 +20,6 @@ foreach ($player->getTickers() as $ticker) {
 }
 $template->assign('Tickers', $tickers);
 
-$container = create_container('skeleton.php', 'bar_ticker_buy_processing.php');
-transfer('LocationID');
-$template->assign('BuyHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'bar_ticker_buy_processing.php');
+$container->addVar('LocationID');
+$template->assign('BuyHREF', $container->href());

--- a/src/engine/Default/bar_ticker_buy_processing.php
+++ b/src/engine/Default/bar_ticker_buy_processing.php
@@ -16,7 +16,7 @@ $db->query('REPLACE INTO player_has_ticker (game_id, account_id, type, expires) 
 $account->decreaseTotalSmrCredits(CREDITS_PER_TICKER);
 
 //offer another drink and such
-$container = create_container('skeleton.php', 'bar_main.php');
-transfer('LocationID');
+$container = Page::create('skeleton.php', 'bar_main.php');
+$container->addVar('LocationID');
 $container['message'] = '<div class="center">Your system has been added.  Enjoy!</div><br />';
-forward($container);
+$container->go();

--- a/src/engine/Default/beta_func_processing.php
+++ b/src/engine/Default/beta_func_processing.php
@@ -85,5 +85,5 @@ if ($var['func'] == 'Map') {
 	}
 }
 
-$container = create_container('skeleton.php', $var['body']);
-forward($container);
+$container = Page::create('skeleton.php', $var['body']);
+$container->go();

--- a/src/engine/Default/beta_functions.php
+++ b/src/engine/Default/beta_functions.php
@@ -6,19 +6,19 @@ if (!ENABLE_BETA) {
 $template->assign('PageTopic', 'Beta Functions');
 
 // container for all links
-$container = create_container('beta_func_processing.php', 'beta_functions.php');
+$container = Page::create('beta_func_processing.php', 'beta_functions.php');
 
 // let them map all
 $container['func'] = 'Map';
-$template->assign('MapHREF', SmrSession::getNewHREF($container));
+$template->assign('MapHREF', $container->href());
 
 // let them get money
 $container['func'] = 'Money';
-$template->assign('MoneyHREF', SmrSession::getNewHREF($container));
+$template->assign('MoneyHREF', $container->href());
 
 //next time for ship
 $container['func'] = 'Ship';
-$template->assign('ShipHREF', SmrSession::getNewHREF($container));
+$template->assign('ShipHREF', $container->href());
 $shipList = [];
 $db->query('SELECT * FROM ship_type ORDER BY ship_name');
 while ($db->nextRecord()) {
@@ -31,7 +31,7 @@ $template->assign('ShipList', $shipList);
 
 //next weapons
 $container['func'] = 'Weapon';
-$template->assign('AddWeaponHREF', SmrSession::getNewHREF($container));
+$template->assign('AddWeaponHREF', $container->href());
 $weaponList = [];
 $db->query('SELECT * FROM weapon_type ORDER BY weapon_name');
 while ($db->nextRecord()) {
@@ -44,31 +44,31 @@ $template->assign('WeaponList', $weaponList);
 
 //Remove Weapons
 $container['func'] = 'RemWeapon';
-$template->assign('RemoveWeaponsHREF', SmrSession::getNewHREF($container));
+$template->assign('RemoveWeaponsHREF', $container->href());
 
 //allow to get full hardware
 $container['func'] = 'Uno';
-$template->assign('UnoHREF', SmrSession::getNewHREF($container));
+$template->assign('UnoHREF', $container->href());
 
 //move whereever you want
 $container['func'] = 'Warp';
-$template->assign('WarpHREF', SmrSession::getNewHREF($container));
+$template->assign('WarpHREF', $container->href());
 
 //set turns
 $container['func'] = 'Turns';
-$template->assign('TurnsHREF', SmrSession::getNewHREF($container));
+$template->assign('TurnsHREF', $container->href());
 
 //set experience
 $container['func'] = 'Exp';
-$template->assign('ExperienceHREF', SmrSession::getNewHREF($container));
+$template->assign('ExperienceHREF', $container->href());
 
 //Set alignment
 $container['func'] = 'Align';
-$template->assign('AlignmentHREF', SmrSession::getNewHREF($container));
+$template->assign('AlignmentHREF', $container->href());
 
 //add any type of hardware
 $container['func'] = 'Hard_add';
-$template->assign('HardwareHREF', SmrSession::getNewHREF($container));
+$template->assign('HardwareHREF', $container->href());
 $hardware = [];
 $db->query('SELECT * FROM hardware_type ORDER BY hardware_type_id');
 while ($db->nextRecord()) {
@@ -81,23 +81,23 @@ $template->assign('Hardware', $hardware);
 
 //change personal relations
 $container['func'] = 'Relations';
-$template->assign('PersonalRelationsHREF', SmrSession::getNewHREF($container));
+$template->assign('PersonalRelationsHREF', $container->href());
 
 //change race relations
 $container['func'] = 'Race_Relations';
-$template->assign('RaceRelationsHREF', SmrSession::getNewHREF($container));
+$template->assign('RaceRelationsHREF', $container->href());
 
 //change race
 $container['func'] = 'Race';
-$template->assign('ChangeRaceHREF', SmrSession::getNewHREF($container));
+$template->assign('ChangeRaceHREF', $container->href());
 
 if ($sector->hasPlanet()) {
 	$container['func'] = 'planet_buildings';
-	$template->assign('MaxBuildingsHREF', SmrSession::getNewHREF($container));
+	$template->assign('MaxBuildingsHREF', $container->href());
 
 	$container['func'] = 'planet_defenses';
-	$template->assign('MaxDefensesHREF', SmrSession::getNewHREF($container));
+	$template->assign('MaxDefensesHREF', $container->href());
 
 	$container['func'] = 'planet_stockpile';
-	$template->assign('MaxStockpileHREF', SmrSession::getNewHREF($container));
+	$template->assign('MaxStockpileHREF', $container->href());
 }

--- a/src/engine/Default/bounty_place.php
+++ b/src/engine/Default/bounty_place.php
@@ -4,9 +4,9 @@ $template->assign('PageTopic', 'Place Bounty');
 
 Menu::headquarters();
 
-$container = create_container('bounty_place_processing.php');
-transfer('LocationID');
-$template->assign('SubmitHREF', SmrSession::getNewHREF($container));
+$container = Page::create('bounty_place_processing.php');
+$container->addVar('LocationID');
+$template->assign('SubmitHREF', $container->href());
 
 $bountyPlayers = [];
 $db->query('SELECT player_id, player_name FROM player JOIN account USING(account_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id != ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY player_name');

--- a/src/engine/Default/bounty_place_confirm.php
+++ b/src/engine/Default/bounty_place_confirm.php
@@ -11,9 +11,9 @@ $template->assign('Amount', number_format($var['amount']));
 $template->assign('SmrCredits', number_format($var['SmrCredits']));
 $template->assign('BountyPlayer', $bountyPlayer->getLinkedDisplayName());
 
-$container = create_container('bounty_place_confirm_processing.php');
+$container = Page::create('bounty_place_confirm_processing.php');
 $container['account_id'] = $bountyPlayer->getAccountID();
-transfer('amount');
-transfer('SmrCredits');
-transfer('LocationID');
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
+$container->addVar('amount');
+$container->addVar('SmrCredits');
+$container->addVar('LocationID');
+$template->assign('ProcessingHREF', $container->href());

--- a/src/engine/Default/bounty_place_confirm_processing.php
+++ b/src/engine/Default/bounty_place_confirm_processing.php
@@ -5,8 +5,8 @@ if (!$player->getSector()->hasLocation($var['LocationID'])) {
 }
 
 $location = SmrLocation::getLocation($var['LocationID']);
-$container = create_container('skeleton.php');
-transfer('LocationID');
+$container = Page::create('skeleton.php');
+$container->addVar('LocationID');
 if ($location->isHQ()) {
 	$container['body'] = 'government.php';
 	$type = 'HQ';
@@ -18,7 +18,7 @@ if ($location->isHQ()) {
 }
 // if we don't have a yes we leave immediatly
 if (Request::get('action') != 'Yes') {
-	forward($container);
+	$container->go();
 }
 
 // get values from container (validated in bounty_place_processing.php)
@@ -45,4 +45,4 @@ $placed->increaseHOF(1, array('Bounties', 'Received', 'Number'), HOF_PUBLIC);
 $player->update();
 $account->update();
 $placed->update();
-forward($container);
+$container->go();

--- a/src/engine/Default/bounty_place_processing.php
+++ b/src/engine/Default/bounty_place_processing.php
@@ -15,10 +15,10 @@ if ($amount <= 0 && $smrCredits <= 0) {
 	create_error('You must enter an amount greater than 0!');
 }
 
-$container = create_container('skeleton.php', 'bounty_place_confirm.php');
+$container = Page::create('skeleton.php', 'bounty_place_confirm.php');
 $container['amount'] = $amount;
 $container['SmrCredits'] = $smrCredits;
 $container['player_id'] = Request::getInt('player_id');
-transfer('LocationID');
+$container->addVar('LocationID');
 
-forward($container);
+$container->go();

--- a/src/engine/Default/bug_report_processing.php
+++ b/src/engine/Default/bug_report_processing.php
@@ -31,7 +31,7 @@ if (!empty(BUG_REPORT_TO_ADDRESSES)) {
 	$mail->send();
 }
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 $container['msg'] = '<span class="admin">ADMIN</span>: Bug report submitted. Thank you for helping to improve the game!';
 if (SmrSession::hasGame()) {
 	$container['body'] = 'current_sector.php';
@@ -39,4 +39,4 @@ if (SmrSession::hasGame()) {
 	$container['body'] = 'game_play.php';
 }
 
-forward($container);
+$container->go();

--- a/src/engine/Default/buy_message_notifications.php
+++ b/src/engine/Default/buy_message_notifications.php
@@ -7,7 +7,7 @@ if (isset($var['Message'])) {
 
 $template->assign('PageTopic', 'Message Notifications');
 
-$container = create_container('buy_message_notifications_processing.php');
+$container = Page::create('buy_message_notifications_processing.php');
 
 // Presently only player messages are eligible for notifications
 $notifyTypeIDs = array(MSG_PLAYER);
@@ -21,7 +21,7 @@ foreach ($notifyTypeIDs as $messageTypeID) {
 	$messageBox['MessagesPerCredit'] = MESSAGES_PER_CREDIT[$messageTypeID];
 
 	$container['MessageTypeID'] = $messageTypeID;
-	$messageBox['BuyHref'] = SmrSession::getNewHREF($container);
+	$messageBox['BuyHref'] = $container->href();
 	$messageBoxes[] = $messageBox;
 }
 $template->assign('MessageBoxes', $messageBoxes);

--- a/src/engine/Default/buy_message_notifications_processing.php
+++ b/src/engine/Default/buy_message_notifications_processing.php
@@ -8,4 +8,4 @@ $account->decreaseTotalSmrCredits(1);
 $account->increaseMessageNotifications($var['MessageTypeID'], MESSAGES_PER_CREDIT[$var['MessageTypeID']]);
 $account->update();
 
-forward(create_container('skeleton.php', 'buy_message_notifications.php', array('Message' => '<span class="green">SUCCESS</span>: You have purchased ' . MESSAGES_PER_CREDIT[$var['MessageTypeID']] . ' message notifications.')));
+Page::create('skeleton.php', 'buy_message_notifications.php', array('Message' => '<span class="green">SUCCESS</span>: You have purchased ' . MESSAGES_PER_CREDIT[$var['MessageTypeID']] . ' message notifications.'))->go();

--- a/src/engine/Default/buy_ship_name.php
+++ b/src/engine/Default/buy_ship_name.php
@@ -2,9 +2,9 @@
 
 $costs = Globals::getBuyShipNameCosts();
 
-$container = create_container('buy_ship_name_processing.php');
+$container = Page::create('buy_ship_name_processing.php');
 $container['costs'] = $costs;
 
 $template->assign('PageTopic', 'Naming Your Ship');
 $template->assign('Costs', $costs);
-$template->assign('ShipNameFormHref', SmrSession::getNewHREF($container));
+$template->assign('ShipNameFormHref', $container->href());

--- a/src/engine/Default/buy_ship_name_preview.php
+++ b/src/engine/Default/buy_ship_name_preview.php
@@ -2,9 +2,9 @@
 
 $template->assign('PageTopic', 'Naming Your Ship');
 
-$container = create_container('buy_ship_name_preview_processing.php');
-transfer('ShipName');
-transfer('cost');
-$template->assign('ContinueHREF', SmrSession::getNewHREF($container));
+$container = Page::create('buy_ship_name_preview_processing.php');
+$container->addVar('ShipName');
+$container->addVar('cost');
+$template->assign('ContinueHREF', $container->href());
 
 $template->assign('ShipName', $var['ShipName']);

--- a/src/engine/Default/buy_ship_name_preview_processing.php
+++ b/src/engine/Default/buy_ship_name_preview_processing.php
@@ -3,6 +3,6 @@
 $player->setCustomShipName($var['ShipName']);
 $account->decreaseTotalSmrCredits($var['cost']);
 
-$container = create_container('skeleton.php', 'current_sector.php');
+$container = Page::create('skeleton.php', 'current_sector.php');
 $container['msg'] = 'Thanks for your purchase! Your ship is ready!<br /><small>If your ship is found to use HTML inappropriately you may be banned. If your ship does contain inappropriate HTML, please notify an admin ASAP.</small>';
-forward($container);
+$container->go();

--- a/src/engine/Default/buy_ship_name_processing.php
+++ b/src/engine/Default/buy_ship_name_processing.php
@@ -115,16 +115,16 @@ if ($action == 'logo') {
 	} elseif ($action == 'html') {
 		checkTextShipName($name, 128);
 		checkHtmlShipName($name);
-		$container = create_container('skeleton.php', 'buy_ship_name_preview.php');
+		$container = Page::create('skeleton.php', 'buy_ship_name_preview.php');
 		$container['ShipName'] = $name;
 		$container['cost'] = $cred_cost;
-		forward($container);
+		$container->go();
 	}
 }
 
 $player->setCustomShipName($name);
 $account->decreaseTotalSmrCredits($cred_cost);
 
-$container = create_container('skeleton.php', 'current_sector.php');
+$container = Page::create('skeleton.php', 'current_sector.php');
 $container['msg'] = 'Thanks for your purchase! Your ship is ready!';
-forward($container);
+$container->go();

--- a/src/engine/Default/cargo_dump.php
+++ b/src/engine/Default/cargo_dump.php
@@ -5,14 +5,14 @@ if ($ship->hasCargo()) {
 
 	$goods = array();
 	foreach ($ship->getCargo() as $goodID => $amount) {
-		$container = create_container('cargo_dump_processing.php');
+		$container = Page::create('cargo_dump_processing.php');
 		$container['good_id'] = $goodID;
 
 		$goods[] = array(
 			'image' => Globals::getGood($goodID)['ImageLink'],
 			'name' => Globals::getGood($goodID)['Name'],
 			'amount' => $amount,
-			'dump_href' => SmrSession::getNewHREF($container),
+			'dump_href' => $container->href(),
 		);
 	}
 

--- a/src/engine/Default/cargo_dump_processing.php
+++ b/src/engine/Default/cargo_dump_processing.php
@@ -24,7 +24,7 @@ if ($sector->offersFederalProtection()) {
 	create_error('You can\'t dump cargo in a Federal Sector!');
 }
 
-$container = create_container('skeleton.php', 'current_sector.php');
+$container = Page::create('skeleton.php', 'current_sector.php');
 
 if ($player->getExperience() > 0) {
 	// If they have any experience left, lose exp
@@ -69,4 +69,4 @@ $player->takeTurns(1, 1);
 $ship->decreaseCargo($good_id, $amount);
 $player->increaseHOF($amount, array('Trade', 'Goods', 'Jettisoned'), HOF_ALLIANCE);
 
-forward($container);
+$container->go();

--- a/src/engine/Default/changelog_view.php
+++ b/src/engine/Default/changelog_view.php
@@ -3,8 +3,8 @@
 $template->assign('PageTopic', 'Change Log');
 
 if (isset($var['Since'])) {
-	$container = create_container('logged_in.php');
-	$template->assign('ContinueHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('logged_in.php');
+	$template->assign('ContinueHREF', $container->href());
 }
 
 $db2 = MySqlDatabase::getInstance();

--- a/src/engine/Default/chat_sharing.php
+++ b/src/engine/Default/chat_sharing.php
@@ -50,4 +50,4 @@ while ($db->nextRecord()) {
 $template->assign('ShareFrom', $shareFrom);
 $template->assign('ShareTo', $shareTo);
 
-$template->assign('ProcessingHREF', SmrSession::getNewHREF(create_container('chat_sharing_processing.php', '', array('share_to_ids' => array_keys($shareTo)))));
+$template->assign('ProcessingHREF', Page::create('chat_sharing_processing.php', '', array('share_to_ids' => array_keys($shareTo)))->href());

--- a/src/engine/Default/chat_sharing_processing.php
+++ b/src/engine/Default/chat_sharing_processing.php
@@ -2,7 +2,7 @@
 
 function error_on_page($message) {
 	$message = '<span class="bold red">ERROR:</span> ' . $message;
-	forward(create_container('skeleton.php', 'chat_sharing.php', array('message' => $message)));
+	Page::create('skeleton.php', 'chat_sharing.php', array('message' => $message))->go();
 }
 
 // Process adding a "share to" account
@@ -40,4 +40,4 @@ if (Request::has('remove_share_from')) {
 	$db->query('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND from_account_id=' . $db->escapeNumber(Request::getInt('remove_share_from')) . ' AND game_id=' . $db->escapeNumber(Request::getInt('game_id')));
 }
 
-forward(create_container('skeleton.php', 'chat_sharing.php'));
+Page::create('skeleton.php', 'chat_sharing.php')->go();

--- a/src/engine/Default/chess_create_processing.php
+++ b/src/engine/Default/chess_create_processing.php
@@ -3,4 +3,4 @@
 $challengePlayer = SmrPlayer::getPlayerByPlayerID(Request::getInt('player_id'), $player->getGameID());
 ChessGame::insertNewGame(SmrSession::getTime(), null, $player, $challengePlayer);
 
-forward(create_container('skeleton.php', 'chess.php'));
+Page::create('skeleton.php', 'chess.php')->go();

--- a/src/engine/Default/chess_move_processing.php
+++ b/src/engine/Default/chess_move_processing.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php', 'chess_play.php');
-transfer('ChessGameID');
+$container = Page::create('skeleton.php', 'chess_play.php');
+$container->addVar('ChessGameID');
 
 $chessGame = ChessGame::getChessGame($var['ChessGameID']);
 $x = Request::getInt('x');
@@ -30,4 +30,4 @@ if (!$chessGame->hasEnded()) {
 	$container['MoveMessage'] = 'This game is over.';
 }
 
-forward($container);
+$container->go();

--- a/src/engine/Default/chess_play.php
+++ b/src/engine/Default/chess_play.php
@@ -21,4 +21,4 @@ if (!$playerIsWhite) {
 $template->assign('FileCoords', $fileCoords);
 
 $template->assign('MoveMessage', $var['MoveMessage'] ?? '');
-$template->assign('ChessMoveHREF', SmrSession::getNewHREF(create_container('chess_move_processing.php', '', array('AJAX' => true, 'ChessGameID' => $var['ChessGameID']))));
+$template->assign('ChessMoveHREF', Page::create('chess_move_processing.php', '', array('AJAX' => true, 'ChessGameID' => $var['ChessGameID']))->href());

--- a/src/engine/Default/chess_resign_processing.php
+++ b/src/engine/Default/chess_resign_processing.php
@@ -3,11 +3,11 @@
 $chessGame = ChessGame::getChessGame($var['ChessGameID']);
 $result = $chessGame->resign($player->getAccountID());
 
-$container = create_container('skeleton.php', 'current_sector.php');
+$container = Page::create('skeleton.php', 'current_sector.php');
 
 $container['msg'] = match($result) {
 	0 => '[color=green]Success:[/color] You have resigned from [chess=' . $var['ChessGameID'] . '].',
 	1 => '[color=green]Success:[/color] [chess=' . $var['ChessGameID'] . '] has been cancelled.',
 };
 
-forward($container);
+$container->go();

--- a/src/engine/Default/combat_log_list.php
+++ b/src/engine/Default/combat_log_list.php
@@ -74,19 +74,19 @@ $logs = array();
 if ($db->getNumRows() > 0) {
 	// 'View' and 'Save' share the same form, so we use 'old_action' as a
 	// way to return to this page when we only want to save the logs.
-	$container = create_container('combat_log_list_processing.php');
+	$container = Page::create('combat_log_list_processing.php');
 	$container['old_action'] = $action;
-	$template->assign('LogFormHREF', SmrSession::getNewHREF($container));
+	$template->assign('LogFormHREF', $container->href());
 
 	// Set the links for the "view next/previous log list" buttons
-	$container = $var;
+	$container = Page::copy($var);
 	if ($page > 0) {
 		$container['page'] = $page - 1;
-		$template->assign('PreviousPage', SmrSession::getNewHREF($container));
+		$template->assign('PreviousPage', $container->href());
 	}
 	if (($page + 1) * COMBAT_LOGS_PER_PAGE < $totalLogs) {
 		$container['page'] = $page + 1;
-		$template->assign('NextPage', SmrSession::getNewHREF($container));
+		$template->assign('NextPage', $container->href());
 	}
 	// Saved logs
 	$template->assign('CanDelete', $action == COMBAT_LOG_SAVED);

--- a/src/engine/Default/combat_log_list_processing.php
+++ b/src/engine/Default/combat_log_list_processing.php
@@ -3,10 +3,10 @@
 // If here, we have hit either the 'Save', 'Delete', or 'View' form buttons.
 // Immediately return to the log list if we haven't selected any logs.
 if (!Request::has('id')) {
-	$container = create_container('skeleton.php', 'combat_log_list.php');
+	$container = Page::create('skeleton.php', 'combat_log_list.php');
 	$container['message'] = 'You must select at least one combat log!';
 	$container['action'] = $var['old_action'];
-	forward($container);
+	$container->go();
 }
 
 $submitAction = Request::get('action');
@@ -40,14 +40,14 @@ if ($submitAction == 'Save' || $submitAction == 'Delete') {
 	}
 
 	// Now that the logs have been saved/deleted, go back to the log list
-	$container = create_container('skeleton.php', 'combat_log_list.php');
+	$container = Page::create('skeleton.php', 'combat_log_list.php');
 	$container['message'] = $submitAction . 'd ' . $db->getChangedRows() . ' new logs.';
 	$container['action'] = $var['old_action'];
-	forward($container);
+	$container->go();
 } elseif ($submitAction == 'View') {
-	$container = create_container('skeleton.php', 'combat_log_viewer.php');
+	$container = Page::create('skeleton.php', 'combat_log_viewer.php');
 	$container['log_ids'] = $logIDs;
 	sort($container['log_ids']);
 	$container['current_log'] = 0;
-	forward($container);
+	$container->go();
 }

--- a/src/engine/Default/combat_log_viewer.php
+++ b/src/engine/Default/combat_log_viewer.php
@@ -20,14 +20,14 @@ $template->assign('CombatResults', $results);
 // Create a container for the next/previous log.
 // We initialize it with the current $var, then modify it to set
 // which log to view when we press the next/previous log buttons.
-$container = create_container('skeleton.php', 'combat_log_viewer.php', $var);
+$container = Page::create('skeleton.php', 'combat_log_viewer.php', $var);
 if ($var['current_log'] > 0) {
 	$container['current_log'] = $var['current_log'] - 1;
-	$template->assign('PreviousLogHREF', SmrSession::getNewHREF($container));
+	$template->assign('PreviousLogHREF', $container->href());
 }
 if ($var['current_log'] < count($container['log_ids']) - 1) {
 	$container['current_log'] = $var['current_log'] + 1;
-	$template->assign('NextLogHREF', SmrSession::getNewHREF($container));
+	$template->assign('NextLogHREF', $container->href());
 }
 
 $template->assign('PageTopic', 'Combat Logs');

--- a/src/engine/Default/combat_log_viewer_verify.php
+++ b/src/engine/Default/combat_log_viewer_verify.php
@@ -18,7 +18,7 @@ if (!$db->nextRecord()) {
 }
 
 // Player has permission, so go to the display page!
-$container = create_container('skeleton.php', 'combat_log_viewer.php');
+$container = Page::create('skeleton.php', 'combat_log_viewer.php');
 $container['log_ids'] = array($var['log_id']);
 $container['current_log'] = 0;
-forward($container);
+$container->go();

--- a/src/engine/Default/combat_simulator.php
+++ b/src/engine/Default/combat_simulator.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 $template->assign('PageTopic','Combat Simulator');
 
-$template->assign('EditDummysLink',SmrSession::getNewHREF(create_container('skeleton.php','edit_dummys.php')));
+$template->assign('EditDummysLink', Page::create('skeleton.php','edit_dummys.php')->href());
 $template->assign('DummyNames', DummyPlayer::getDummyPlayerNames());
 
 $duplicates = false;
@@ -52,7 +52,7 @@ $template->assign('Defenders',$defenders);
 
 $template->assign('Duplicates',$duplicates);
 
-$template->assign('CombatSimHREF',SmrSession::getNewHREF(create_container('skeleton.php','combat_simulator.php')));
+$template->assign('CombatSimHREF', Page::create('skeleton.php','combat_simulator.php')->href());
 
 if (!empty($realAttackers) && !empty($realDefenders)) {
 	if(isset($_REQUEST['run'])) {

--- a/src/engine/Default/configure_hardware.php
+++ b/src/engine/Default/configure_hardware.php
@@ -3,19 +3,19 @@
 $template->assign('PageTopic', 'Configure Hardware');
 
 if ($ship->hasCloak()) {
-	$container = create_container('configure_hardware_processing.php');
+	$container = Page::create('configure_hardware_processing.php');
 	if (!$ship->isCloaked()) {
 		$container['action'] = 'Enable';
 	} else {
 		$container['action'] = 'Disable';
 	}
-	$template->assign('ToggleCloakHREF', SmrSession::getNewHREF($container));
+	$template->assign('ToggleCloakHREF', $container->href());
 }
 
 if ($ship->hasIllusion()) {
-	$container = create_container('configure_hardware_processing.php');
+	$container = Page::create('configure_hardware_processing.php');
 	$container['action'] = 'Set Illusion';
-	$template->assign('SetIllusionFormHREF', SmrSession::getNewHREF($container));
+	$template->assign('SetIllusionFormHREF', $container->href());
 
 	$ships = array();
 	$db->query('SELECT ship_type_id,ship_name FROM ship_type ORDER BY ship_name');
@@ -24,11 +24,11 @@ if ($ship->hasIllusion()) {
 	}
 	$template->assign('IllusionShips', $ships);
 	$container['action'] = 'Disable Illusion';
-	$template->assign('DisableIllusionHref', SmrSession::getNewHREF($container));
+	$template->assign('DisableIllusionHref', $container->href());
 }
 
 if ($ship->hasJump()) {
-	$container = create_container('sector_jump_processing.php', '');
+	$container = Page::create('sector_jump_processing.php', '');
 	$container['target_page'] = 'current_sector.php';
-	$template->assign('JumpDriveFormLink', SmrSession::getNewHREF($container));
+	$template->assign('JumpDriveFormLink', $container->href());
 }

--- a/src/engine/Default/configure_hardware_processing.php
+++ b/src/engine/Default/configure_hardware_processing.php
@@ -15,5 +15,5 @@ if ($var['action'] == 'Enable') {
 	$ship->disableIllusion();
 }
 
-$container = create_container('skeleton.php', 'current_sector.php');
-forward($container);
+$container = Page::create('skeleton.php', 'current_sector.php');
+$container->go();

--- a/src/engine/Default/contact.php
+++ b/src/engine/Default/contact.php
@@ -2,7 +2,7 @@
 
 $template->assign('PageTopic', 'Contact Form');
 
-$container = create_container('contact_processing.php');
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
+$container = Page::create('contact_processing.php');
+$template->assign('ProcessingHREF', $container->href());
 
 $template->assign('From', $account->getLogin());

--- a/src/engine/Default/contact_processing.php
+++ b/src/engine/Default/contact_processing.php
@@ -15,11 +15,11 @@ $mail->Body =
 $mail->addAddress($receiver);
 $mail->send();
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 if (SmrSession::hasGame()) {
 	$container['body'] = 'current_sector.php';
 } else {
 	$container['body'] = 'game_play.php';
 }
 
-forward($container);
+$container->go();

--- a/src/engine/Default/council_embassy.php
+++ b/src/engine/Default/council_embassy.php
@@ -21,6 +21,6 @@ foreach ($RACES as $raceID => $raceInfo) {
 	if ($db->getNumRows() > 0) {
 		continue;
 	}
-	$voteRaces[$raceID] = SmrSession::getNewHREF(create_container('council_embassy_processing.php', '', array('race_id' => $raceID)));
+	$voteRaces[$raceID] = Page::create('council_embassy_processing.php', '', array('race_id' => $raceID))->href();
 }
 $template->assign('VoteRaceHrefs', $voteRaces);

--- a/src/engine/Default/council_embassy_processing.php
+++ b/src/engine/Default/council_embassy_processing.php
@@ -62,4 +62,4 @@ foreach ($councilMembers as $accountID) {
   }
 }
 
-forward(create_container('skeleton.php', 'council_embassy.php'));
+Page::create('skeleton.php', 'council_embassy.php')->go();

--- a/src/engine/Default/council_send_message.php
+++ b/src/engine/Default/council_send_message.php
@@ -7,6 +7,6 @@ $template->assign('PageTopic', 'Send message to Ruling Council of the ' . $raceN
 
 Menu::messages();
 
-$container = create_container('council_send_message_processing.php');
-transfer('race_id');
-$template->assign('SendHREF', SmrSession::getNewHREF($container));
+$container = Page::create('council_send_message_processing.php');
+$container->addVar('race_id');
+$template->assign('SendHREF', $container->href());

--- a/src/engine/Default/council_send_message_processing.php
+++ b/src/engine/Default/council_send_message_processing.php
@@ -12,6 +12,6 @@ foreach ($councilMembers as $accountID) {
 	$player->sendMessage($accountID, MSG_POLITICAL, $message, true, $player->getAccountID() != $accountID);
 }
 
-$container = create_container('skeleton.php', 'current_sector.php');
+$container = Page::create('skeleton.php', 'current_sector.php');
 $container['msg'] = '<span class="green">SUCCESS: </span>Your message has been sent.';
-forward($container);
+$container->go();

--- a/src/engine/Default/council_vote.php
+++ b/src/engine/Default/council_vote.php
@@ -23,9 +23,9 @@ foreach (Globals::getRaces() as $raceID => $raceInfo) {
 	if ($raceID == RACE_NEUTRAL || $raceID == $player->getRaceID()) {
 		continue;
 	}
-	$container = create_container('council_vote_processing.php', '', array('race_id' => $raceID));
+	$container = Page::create('council_vote_processing.php', '', array('race_id' => $raceID));
 	$voteRelations[$raceID] = array(
-		'HREF' => SmrSession::getNewHREF($container),
+		'HREF' => $container->href(),
 		'Increased' => $votedForRace == $raceID && $votedFor == 'INC',
 		'Decreased' => $votedForRace == $raceID && $votedFor == 'DEC',
 		'Relations' => $raceRelations[$raceID],
@@ -44,7 +44,7 @@ if ($db->getNumRows() > 0) {
 
 	while ($db->nextRecord()) {
 		$otherRaceID = $db->getInt('race_id_2');
-		$container = create_container('council_vote_processing.php', '', array('race_id' => $otherRaceID));
+		$container = Page::create('council_vote_processing.php', '', array('race_id' => $otherRaceID));
 
 		// get 'yes' votes
 		$db2->query('SELECT count(*) FROM player_votes_pact
@@ -75,7 +75,7 @@ if ($db->getNumRows() > 0) {
 		}
 
 		$voteTreaties[$otherRaceID] = array(
-			'HREF' => SmrSession::getNewHREF($container),
+			'HREF' => $container->href(),
 			'Type' => $db->getField('type'),
 			'EndTime' => $db->getInt('end_time'),
 			'For' => $votedFor == 'YES',

--- a/src/engine/Default/council_vote_processing.php
+++ b/src/engine/Default/council_vote_processing.php
@@ -42,4 +42,4 @@ if ($action == 'INC' || $action == 'DEC') {
 
 }
 
-forward(create_container('skeleton.php', 'council_vote.php'));
+Page::create('skeleton.php', 'council_vote.php')->go();

--- a/src/engine/Default/course_destination_button_processing.php
+++ b/src/engine/Default/course_destination_button_processing.php
@@ -26,6 +26,6 @@ switch ($type) {
 	break;
 }
 
-$container = create_container('skeleton.php', 'course_plot.php');
+$container = Page::create('skeleton.php', 'course_plot.php');
 
-forward($container);
+$container->go();

--- a/src/engine/Default/course_plot.php
+++ b/src/engine/Default/course_plot.php
@@ -4,20 +4,20 @@ $template->assign('PageTopic', 'Plot A Course');
 
 Menu::navigation($template, $player);
 
-$container = create_container('course_plot_processing.php');
+$container = Page::create('course_plot_processing.php');
 
-$template->assign('PlotCourseFormLink', SmrSession::getNewHREF($container));
+$template->assign('PlotCourseFormLink', $container->href());
 $container['url'] = 'course_plot_nearest_processing.php';
-$template->assign('PlotNearestFormLink', SmrSession::getNewHREF($container));
+$template->assign('PlotNearestFormLink', $container->href());
 
 if ($ship->hasJump()) {
-	$container = create_container('sector_jump_processing.php');
+	$container = Page::create('sector_jump_processing.php');
 	$container['target_page'] = 'current_sector.php';
-	$template->assign('JumpDriveFormLink', SmrSession::getNewHREF($container));
+	$template->assign('JumpDriveFormLink', $container->href());
 }
 
-$container = create_container('skeleton.php', 'course_plot.php');
-$template->assign('PlotToNearestHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'course_plot.php');
+$template->assign('PlotToNearestHREF', $container->href());
 
 $xtype = SmrSession::getRequestVar('xtype', 'Technology');
 $template->assign('XType', $xtype);
@@ -26,6 +26,6 @@ $template->assign('AllXTypes', array('Technology', 'Ships', 'Weapons', 'Location
 
 // get saved destinations
 $template->assign('StoredDestinations', $player->getStoredDestinations());
-$container = create_container('course_destination_button_processing.php');
+$container = Page::create('course_destination_button_processing.php');
 $container['target_page'] = 'course_plot.php';
-$template->assign('ManageDestination', SmrSession::getNewHREF($container));
+$template->assign('ManageDestination', $container->href());

--- a/src/engine/Default/course_plot_cancel_processing.php
+++ b/src/engine/Default/course_plot_cancel_processing.php
@@ -2,4 +2,4 @@
 
 $player->deletePlottedCourse();
 
-forward(create_container('skeleton.php', 'current_sector.php'));
+Page::create('skeleton.php', 'current_sector.php')->go();

--- a/src/engine/Default/course_plot_processing.inc.php
+++ b/src/engine/Default/course_plot_processing.inc.php
@@ -11,12 +11,12 @@ if ($player->getSectorID() == $startSectorID) {
 
 	if (!$player->isLandedOnPlanet()) {
 		// If the course can immediately be followed, display it on the current sector page
-		$container = create_container('skeleton.php', 'current_sector.php');
-		forward($container);
+		$container = Page::create('skeleton.php', 'current_sector.php');
+		$container->go();
 	}
 }
 
-$container = create_container('skeleton.php', 'course_plot_result.php');
+$container = Page::create('skeleton.php', 'course_plot_result.php');
 $container['Path'] = $path;
 $container['FullPath'] = $fullPath;
-forward($container);
+$container->go();

--- a/src/engine/Default/current_players.php
+++ b/src/engine/Default/current_players.php
@@ -72,7 +72,7 @@ if ($count_last_active > 0) {
 		$row['tr_class'] = $class;
 
 		// What should the player name be displayed as?
-		$container = create_container('skeleton.php', 'trader_search_result.php');
+		$container = Page::create('skeleton.php', 'trader_search_result.php');
 		$container['player_id'] = $curr_player->getPlayerID();
 		$name = $curr_player->getLevelName() . ' ' . $curr_player->getDisplayName();
 		$db2->query('SELECT * FROM cpl_tag WHERE account_id = ' . $db2->escapeNumber($curr_player->getAccountID()) . ' ORDER BY custom DESC');

--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -2,7 +2,7 @@
 
 // If on a planet, forward to planet_main.php
 if ($player->isLandedOnPlanet()) {
-	forward(create_container('skeleton.php', 'planet_main.php', $var));
+	Page::create('skeleton.php', 'planet_main.php', $var)->go();
 }
 
 $template->assign('SpaceView', true);

--- a/src/engine/Default/death_processing.php
+++ b/src/engine/Default/death_processing.php
@@ -3,4 +3,4 @@ $player->setDead(false);
 $player->deletePlottedCourse();
 
 $player->log(LOG_TYPE_TRADER_COMBAT, 'Player sees death screen');
-forward(create_container('skeleton.php', 'death.php'));
+Page::create('skeleton.php', 'death.php')->go();

--- a/src/engine/Default/edit_dummys.php
+++ b/src/engine/Default/edit_dummys.php
@@ -1,11 +1,11 @@
 <?php declare(strict_types=1);
 $template->assign('PageTopic', 'Edit Dummys');
 
-$template->assign('CombatSimLink', SmrSession::getNewHREF(create_container('skeleton.php', 'combat_simulator.php')));
+$template->assign('CombatSimLink', Page::create('skeleton.php', 'combat_simulator.php')->href());
 $template->assign('BaseShips', AbstractSmrShip::getAllBaseShips());
 $template->assign('Weapons', SmrWeaponType::getAllWeaponTypes());
 
-$template->assign('EditDummysLink', SmrSession::getNewHREF(create_container('skeleton.php', 'edit_dummys.php')));
+$template->assign('EditDummysLink', Page::create('skeleton.php', 'edit_dummys.php')->href());
 
 $dummyPlayer = DummyPlayer::getCachedDummyPlayer($_REQUEST['dummy_name']);
 $dummyShip = $dummyPlayer->getShip();

--- a/src/engine/Default/error.php
+++ b/src/engine/Default/error.php
@@ -5,10 +5,10 @@ if (empty($var['message']) || $var['message'] == '') {
 }
 
 if (SmrSession::hasGame() && is_object($player) && $lock) {
-	$container = create_container('skeleton.php', 'current_sector.php');
+	$container = Page::create('skeleton.php', 'current_sector.php');
 	$errorMsg = '<span class="red bold">ERROR:</span> ' . $var['message'];
 	$container['errorMsg'] = $errorMsg;
-	forward($container);
+	$container->go();
 } else {
 	$template->assign('PageTopic', 'Error');
 	$template->assign('Message', $var['message']);

--- a/src/engine/Default/feature_request.php
+++ b/src/engine/Default/feature_request.php
@@ -25,11 +25,11 @@ $categoryTable = array();
 foreach ($requestCategories as $category => $description) {
 	$status = statusFromCategory($category);
 
-	$container = $var;
+	$container = Page::copy($var);
 	$container['category'] = $category;
 	$categoryTable[$category] = array(
 		'Selected' => $category == $var['category'],
-		'HREF' => SmrSession::getNewHREF($container),
+		'HREF' => $container->href(),
 		'Count' => getFeaturesCount($status, ($category == 'New') ? NEW_REQUEST_DAYS : false),
 		'Description' => $description
 	);
@@ -57,9 +57,9 @@ $db->query('SELECT * ' .
 if ($db->getNumRows() > 0) {
 	$featureModerator = $account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST);
 	$template->assign('FeatureModerator', $featureModerator);
-	$template->assign('FeatureRequestVoteFormHREF', SmrSession::getNewHREF(create_container('feature_request_vote_processing.php', '')));
+	$template->assign('FeatureRequestVoteFormHREF', Page::create('feature_request_vote_processing.php', '')->href());
 
-	$commentsContainer = $var;
+	$commentsContainer = Page::copy($var);
 	$commentsContainer['body'] = 'feature_request_comments.php';
 	$db2 = MySqlDatabase::getInstance();
 	$featureRequests = array();
@@ -91,12 +91,12 @@ if ($db->getNumRows() > 0) {
 			$featureRequests[$featureRequestID]['Comments'] = $db2->getInt('COUNT(*)');
 		}
 		$commentsContainer['RequestID'] = $featureRequestID;
-		$featureRequests[$featureRequestID]['CommentsHREF'] = SmrSession::getNewHREF($commentsContainer);
+		$featureRequests[$featureRequestID]['CommentsHREF'] = $commentsContainer->href();
 	}
 	$template->assign('FeatureRequests', $featureRequests);
 }
 
-$template->assign('FeatureRequestFormHREF', SmrSession::getNewHREF(create_container('feature_request_processing.php', '')));
+$template->assign('FeatureRequestFormHREF', Page::create('feature_request_processing.php', '')->href());
 
 function statusFromCategory($category) {
 	return ($category == 'New' || $category == 'All Open') ? 'Opened' : $category;

--- a/src/engine/Default/feature_request_comment_processing.php
+++ b/src/engine/Default/feature_request_comment_processing.php
@@ -9,7 +9,7 @@ if (empty($comment)) {
 $db->query('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
 			VALUES(' . $db->escapeNumber($var['RequestID']) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeBoolean(Request::has('anon')) . ',' . $db->escapeString(word_filter($comment)) . ')');
 
-$container = $var;
+$container = Page::copy($var);
 $container['url'] = 'skeleton.php';
 $container['body'] = 'feature_request_comments.php';
-forward($container);
+$container->go();

--- a/src/engine/Default/feature_request_comments.php
+++ b/src/engine/Default/feature_request_comments.php
@@ -5,9 +5,9 @@ if (!Globals::isFeatureRequestOpen()) {
 
 $template->assign('PageTopic', 'Feature Request Comments');
 
-$container = $var;
+$container = Page::copy($var);
 $container['body'] = 'feature_request.php';
-$template->assign('BackHref', SmrSession::getNewHREF($container));
+$template->assign('BackHref', $container->href());
 
 $db->query('SELECT *
 			FROM feature_request
@@ -21,7 +21,7 @@ if ($db->getNumRows() > 0) {
 	// variables needed to set the status for this feature request
 	if ($featureModerator) {
 		$template->assign('FeatureRequestId', $var['RequestID']);
-		$template->assign('FeatureRequestStatusFormHREF', SmrSession::getNewHREF(create_container('feature_request_vote_processing.php')));
+		$template->assign('FeatureRequestStatusFormHREF', Page::create('feature_request_vote_processing.php')->href());
 	}
 
 	$featureRequestComments = array();
@@ -40,7 +40,7 @@ if ($db->getNumRows() > 0) {
 	$template->assign('Comments', $featureRequestComments);
 }
 
-$container = $var;
+$container = Page::copy($var);
 $container['url'] = 'feature_request_comment_processing.php';
 unset($container['body']);
-$template->assign('FeatureRequestCommentFormHREF', SmrSession::getNewHREF($container));
+$template->assign('FeatureRequestCommentFormHREF', $container->href());

--- a/src/engine/Default/feature_request_processing.php
+++ b/src/engine/Default/feature_request_processing.php
@@ -17,4 +17,4 @@ $db->query('INSERT INTO feature_request_comments (feature_request_id, poster_id,
 // vote for this feature
 $db->query('INSERT INTO account_votes_for_feature VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($featureRequestID) . ',\'YES\')');
 
-forward(create_container('skeleton.php', 'feature_request.php'));
+Page::create('skeleton.php', 'feature_request.php')->go();

--- a/src/engine/Default/feature_request_vote_processing.php
+++ b/src/engine/Default/feature_request_vote_processing.php
@@ -15,7 +15,7 @@ if ($action == 'Vote') {
 		$db->query('REPLACE INTO account_votes_for_feature VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber(Request::getInt('favourite')) . ',\'FAVOURITE\')');
 	}
 
-	forward(create_container('skeleton.php', 'feature_request.php'));
+	Page::create('skeleton.php', 'feature_request.php')->go();
 } elseif ($action == 'Set Status') {
 	if (!$account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST)) {
 		create_error('You do not have permission to do that');
@@ -54,5 +54,5 @@ if ($action == 'Vote') {
 					VALUES(' . $db->escapeNumber($featureID) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeBoolean(false) . ',' . $db->escapeString($status) . ')');
 	}
 
-	forward(create_container('skeleton.php', 'feature_request.php'));
+	Page::create('skeleton.php', 'feature_request.php')->go();
 }

--- a/src/engine/Default/forces_attack_processing.php
+++ b/src/engine/Default/forces_attack_processing.php
@@ -106,7 +106,7 @@ if ($sendMessage) {
 	$forces->ping($message, $player, true);
 }
 
-$container = create_container('skeleton.php', 'forces_attack.php');
+$container = Page::create('skeleton.php', 'forces_attack.php');
 
 // If their target is dead there is no continue attack button
 if ($forces->exists()) {
@@ -122,4 +122,4 @@ if ($player->isDead()) {
 }
 
 $container['results'] = $serializedResults;
-forward($container);
+$container->go();

--- a/src/engine/Default/forces_drop.php
+++ b/src/engine/Default/forces_drop.php
@@ -11,8 +11,8 @@ if (isset($var['owner_id'])) {
 
 $forces = SmrForce::getForce($player->getGameID(), $player->getSectorID(), $owner_id);
 
-$container = create_container('forces_drop_processing.php');
+$container = Page::create('forces_drop_processing.php');
 $container['owner_id'] = $owner_id;
 
 $template->assign('Forces', $forces);
-$template->assign('SubmitHREF', SmrSession::getNewHREF($container));
+$template->assign('SubmitHREF', $container->href());

--- a/src/engine/Default/forces_drop_processing.php
+++ b/src/engine/Default/forces_drop_processing.php
@@ -229,4 +229,4 @@ if (isset($var['referrer']) && $var['referrer'] == 'map_local.php') {
 } else {
 	$body = 'current_sector.php';
 }
-forward(create_container('skeleton.php', $body));
+Page::create('skeleton.php', $body)->go();

--- a/src/engine/Default/forces_mass_refresh.php
+++ b/src/engine/Default/forces_mass_refresh.php
@@ -12,6 +12,6 @@ foreach ($sectorForces as $sectorForce) {
 }
 
 $message = '[Force Check]'; //this notifies the CS to look for info.
-$container = create_container('skeleton.php', 'current_sector.php');
+$container = Page::create('skeleton.php', 'current_sector.php');
 $container['msg'] = $message;
-forward($container);
+$container->go();

--- a/src/engine/Default/forces_refresh_processing.php
+++ b/src/engine/Default/forces_refresh_processing.php
@@ -4,4 +4,4 @@ $forces = SmrForce::getForce($player->getGameID(), $player->getSectorID(), $var[
 
 $forces->updateExpire();
 
-forward(create_container('skeleton.php', 'current_sector.php'));
+Page::create('skeleton.php', 'current_sector.php')->go();

--- a/src/engine/Default/galactic_post.php
+++ b/src/engine/Default/galactic_post.php
@@ -9,10 +9,10 @@ Menu::galactic_post();
 
 $db2 = MySqlDatabase::getInstance();
 
-$container = create_container('skeleton.php', 'galactic_post_view_article.php');
-$template->assign('ViewArticlesHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'galactic_post_view_article.php');
+$template->assign('ViewArticlesHREF', $container->href());
 $container['body'] = 'galactic_post_make_paper.php';
-$template->assign('MakePaperHREF', SmrSession::getNewHREF($container));
+$template->assign('MakePaperHREF', $container->href());
 
 $db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
 $papers = [];
@@ -35,19 +35,19 @@ while ($db->nextRecord()) {
 
 	if (!empty($published)) {
 	} elseif ($hasEnoughArticles) {
-		$container = create_container('galactic_post_make_current.php');
+		$container = Page::create('galactic_post_make_current.php');
 		$container['id'] = $paper_id;
-		$paper['PublishHREF'] = SmrSession::getNewHREF($container);
+		$paper['PublishHREF'] = $container->href();
 	}
 
-	$container = create_container('skeleton.php', 'galactic_post_delete_confirm.php');
+	$container = Page::create('skeleton.php', 'galactic_post_delete_confirm.php');
 	$container['paper'] = 'yes';
 	$container['id'] = $paper_id;
-	$paper['DeleteHREF'] = SmrSession::getNewHREF($container);
+	$paper['DeleteHREF'] = $container->href();
 
-	$container = create_container('skeleton.php', 'galactic_post_paper_edit.php');
+	$container = Page::create('skeleton.php', 'galactic_post_paper_edit.php');
 	$container['id'] = $paper_id;
-	$paper['EditHREF'] = SmrSession::getNewHREF($container);
+	$paper['EditHREF'] = $container->href();
 
 	$papers[] = $paper;
 }

--- a/src/engine/Default/galactic_post_add_article_to_paper.php
+++ b/src/engine/Default/galactic_post_add_article_to_paper.php
@@ -7,5 +7,5 @@ if ($db->getNumRows() >= 8) {
 }
 $db->query('INSERT INTO galactic_post_paper_content (game_id, paper_id, article_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($var['paper_id']) . ', ' . $db->escapeNumber($var['id']) . ')');
 //we now have that article in the paper
-$container = create_container('skeleton.php', 'galactic_post_view_article.php');
-forward($container);
+$container = Page::create('skeleton.php', 'galactic_post_view_article.php');
+$container->go();

--- a/src/engine/Default/galactic_post_current.php
+++ b/src/engine/Default/galactic_post_current.php
@@ -7,7 +7,7 @@ if ($db->nextRecord()) {
 	$paper_id = null;
 }
 
-$container = create_container('skeleton.php', 'galactic_post_read.php');
+$container = Page::create('skeleton.php', 'galactic_post_read.php');
 $container['paper_id'] = $paper_id;
 $container['game_id'] = $player->getGameID();
-forward($container);
+$container->go();

--- a/src/engine/Default/galactic_post_delete_confirm.php
+++ b/src/engine/Default/galactic_post_delete_confirm.php
@@ -5,10 +5,10 @@ if (isset($var['article'])) {
 	$db->query('SELECT * FROM galactic_post_article WHERE article_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	$db->requireRecord();
 	$template->assign('ArticleTitle', $db->getField('title'));
-	$container = create_container('galactic_post_delete_processing.php');
-	transfer('article');
-	transfer('id');
-	$template->assign('SubmitHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('galactic_post_delete_processing.php');
+	$container->addVar('article');
+	$container->addVar('id');
+	$template->assign('SubmitHREF', $container->href());
 } else {
 	// Delete paper
 	$template->assign('PageTopic', 'Delete Paper - Confirm');
@@ -23,8 +23,8 @@ if (isset($var['article'])) {
 	}
 	$template->assign('Articles', $articles);
 
-	$container = create_container('galactic_post_delete_processing.php');
-	transfer('paper');
-	transfer('id');
-	$template->assign('SubmitHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('galactic_post_delete_processing.php');
+	$container->addVar('paper');
+	$container->addVar('id');
+	$template->assign('SubmitHREF', $container->href());
 }

--- a/src/engine/Default/galactic_post_delete_processing.php
+++ b/src/engine/Default/galactic_post_delete_processing.php
@@ -22,5 +22,5 @@ if (isset($var['article'])) {
 	}
 }
 
-$container = create_container('skeleton.php', 'galactic_post.php');
-forward($container);
+$container = Page::create('skeleton.php', 'galactic_post.php');
+$container->go();

--- a/src/engine/Default/galactic_post_make_current.php
+++ b/src/engine/Default/galactic_post_make_current.php
@@ -10,5 +10,5 @@ if ($db->nextRecord()) {
 $db->query('UPDATE galactic_post_paper SET online_since=' . $db->escapeNumber(SmrSession::getTime()) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
 
 //all done lets send back to the main GP page.
-$container = create_container('skeleton.php', 'galactic_post.php');
-forward($container);
+$container = Page::create('skeleton.php', 'galactic_post.php');
+$container->go();

--- a/src/engine/Default/galactic_post_make_paper.php
+++ b/src/engine/Default/galactic_post_make_paper.php
@@ -3,5 +3,5 @@
 $template->assign('PageTopic', 'Making A Paper');
 Menu::galactic_post();
 
-$container = create_container('galactic_post_make_paper_processing.php');
-$template->assign('SubmitHREF', SmrSession::getNewHREF($container));
+$container = Page::create('galactic_post_make_paper_processing.php');
+$template->assign('SubmitHREF', $container->href());

--- a/src/engine/Default/galactic_post_make_paper_processing.php
+++ b/src/engine/Default/galactic_post_make_paper_processing.php
@@ -9,5 +9,5 @@ if ($db->nextRecord()) {
 $title = Request::get('title');
 $db->query('INSERT INTO galactic_post_paper (game_id, paper_id, title) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($num) . ', ' . $db->escapeString($title) . ')');
 //send em back
-$container = create_container('skeleton.php', 'galactic_post_view_article.php');
-forward($container);
+$container = Page::create('skeleton.php', 'galactic_post_view_article.php');
+$container->go();

--- a/src/engine/Default/galactic_post_paper_edit.php
+++ b/src/engine/Default/galactic_post_paper_edit.php
@@ -11,13 +11,13 @@ $db->query('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article
 
 $articles = [];
 while ($db->nextRecord()) {
-	$container = create_container('galactic_post_paper_edit_processing.php');
+	$container = Page::create('galactic_post_paper_edit_processing.php');
 	$container['article_id'] = $db->getInt('article_id');
-	transfer('id');
+	$container->addVar('id');
 	$articles[] = [
 		'title' => bbifyMessage($db->getField('title')),
 		'text' => bbifyMessage($db->getField('text')),
-		'editHREF' => SmrSession::getNewHREF($container),
+		'editHREF' => $container->href(),
 	];
 }
 $template->assign('Articles', $articles);

--- a/src/engine/Default/galactic_post_paper_edit_processing.php
+++ b/src/engine/Default/galactic_post_paper_edit_processing.php
@@ -2,6 +2,6 @@
 
 $db->query('DELETE FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['article_id']));
 
-$container = create_container('skeleton.php', 'galactic_post_paper_edit.php');
-transfer('id');
-forward($container);
+$container = Page::create('skeleton.php', 'galactic_post_paper_edit.php');
+$container->addVar('id');
+$container->go();

--- a/src/engine/Default/galactic_post_past.php
+++ b/src/engine/Default/galactic_post_past.php
@@ -3,8 +3,8 @@
 $template->assign('PageTopic', 'Past <i>Galactic Post</i> Editions');
 Menu::galactic_post();
 
-$container = create_container('skeleton.php', 'galactic_post_past.php');
-$template->assign('SelectGameHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'galactic_post_past.php');
+$template->assign('SelectGameHREF', $container->href());
 
 // View past editions of current game by default
 $selectedGameID = SmrSession::getRequestVarInt('selected_game_id', $player->getGameID());
@@ -26,7 +26,7 @@ $template->assign('PublishedGames', $publishedGames);
 $db->query('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id=' . $db->escapeNumber($selectedGameID));
 $pastEditions = array();
 while ($db->nextRecord()) {
-	$container = create_container('skeleton.php', 'galactic_post_read.php');
+	$container = Page::create('skeleton.php', 'galactic_post_read.php');
 	$container['paper_id'] = $db->getInt('paper_id');
 	$container['game_id'] = $selectedGameID;
 	$container['back'] = true;
@@ -34,7 +34,7 @@ while ($db->nextRecord()) {
 	$pastEditions[] = [
 		'title' => $db->getField('title'),
 		'online_since' => $db->getInt('online_since'),
-		'href' => SmrSession::getNewHREF($container),
+		'href' => $container->href(),
 	];
 }
 $template->assign('PastEditions', $pastEditions);

--- a/src/engine/Default/galactic_post_read.php
+++ b/src/engine/Default/galactic_post_read.php
@@ -9,9 +9,9 @@ if (!empty($var['paper_id'])) {
 
 	// Create link back to past editions
 	if (isset($var['back']) && $var['back']) {
-		$container = create_container('skeleton.php', 'galactic_post_past.php');
+		$container = Page::create('skeleton.php', 'galactic_post_past.php');
 		$container['game_id'] = $var['game_id'];
-		$template->assign('BackHREF', SmrSession::getNewHREF($container));
+		$template->assign('BackHREF', $container->href());
 	}
 
 	$db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($var['game_id']) . ' AND paper_id = ' . $var['paper_id']);

--- a/src/engine/Default/galactic_post_view_article.php
+++ b/src/engine/Default/galactic_post_view_article.php
@@ -16,12 +16,12 @@ $db->query('SELECT * FROM galactic_post_article WHERE article_id NOT IN (SELECT 
 while ($db->nextRecord()) {
 	$title = stripslashes($db->getField('title'));
 	$writer = SmrPlayer::getPlayer($db->getInt('writer_id'), $player->getGameID());
-	$container = create_container('skeleton.php', 'galactic_post_view_article.php');
+	$container = Page::create('skeleton.php', 'galactic_post_view_article.php');
 	$container['id'] = $db->getInt('article_id');
 	$articles[] = [
 		'title' => $title,
 		'writer' => $writer->getDisplayName(),
-		'link' => SmrSession::getNewHREF($container),
+		'link' => $container->href(),
 	];
 }
 $template->assign('Articles', $articles);
@@ -31,14 +31,14 @@ if (isset($var['id'])) {
 	$db->query('SELECT * FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
 	$db->requireRecord();
 
-	$container = create_container('skeleton.php', 'galactic_post_write_article.php');
-	transfer('id');
-	$editHREF = SmrSession::getNewHREF($container);
+	$container = Page::create('skeleton.php', 'galactic_post_write_article.php');
+	$container->addVar('id');
+	$editHREF = $container->href();
 
-	$container = create_container('skeleton.php', 'galactic_post_delete_confirm.php');
+	$container = Page::create('skeleton.php', 'galactic_post_delete_confirm.php');
 	$container['article'] = 'yes';
-	transfer('id');
-	$deleteHREF = SmrSession::getNewHREF($container);
+	$container->addVar('id');
+	$deleteHREF = $container->href();
 
 	$selectedArticle = [
 		'title' => stripslashes($db->getField('title')),
@@ -48,30 +48,30 @@ if (isset($var['id'])) {
 	];
 	$template->assign('SelectedArticle', $selectedArticle);
 
-	$container = create_container('galactic_post_add_article_to_paper.php');
-	transfer('id');
+	$container = Page::create('galactic_post_add_article_to_paper.php');
+	$container->addVar('id');
 	$papers = [];
 	$db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
 	while ($db->nextRecord()) {
 		$container['paper_id'] = $db->getInt('paper_id');
 		$papers[] = [
 			'title' => $db->getField('title'),
-			'addHREF' => SmrSession::getNewHREF($container),
+			'addHREF' => $container->href(),
 		];
 	}
 	$template->assign('Papers', $papers);
 
 	if (empty($papers)) {
-		$container = create_container('skeleton.php', 'galactic_post_make_paper.php');
-		$template->assign('MakePaperHREF', SmrSession::getNewHREF($container));
+		$container = Page::create('skeleton.php', 'galactic_post_make_paper.php');
+		$template->assign('MakePaperHREF', $container->href());
 	}
 
 	// breaking news options
 	$template->assign('AddedToNews', $var['added_to_breaking_news'] ?? false);
 	if (empty($var['added_to_breaking_news'])) {
-		$container = create_container('skeleton.php', 'galactic_post_view_article.php');
+		$container = Page::create('skeleton.php', 'galactic_post_view_article.php');
 		$container['news'] = $selectedArticle['text'];
-		transfer('id');
-		$template->assign('AddToNewsHREF', SmrSession::getNewHREF($container));
+		$container->addVar('id');
+		$template->assign('AddToNewsHREF', $container->href());
 	}
 }

--- a/src/engine/Default/galactic_post_write_article.php
+++ b/src/engine/Default/galactic_post_write_article.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 Menu::galactic_post();
-$container = create_container('galactic_post_write_article_processing.php');
+$container = Page::create('galactic_post_write_article_processing.php');
 
 if (isset($var['id'])) {
 	$container['id'] = $var['id'];
@@ -20,4 +20,4 @@ if (isset($var['Preview'])) {
 	$template->assign('PreviewTitle', $var['PreviewTitle']);
 	$template->assign('Preview', $var['Preview']);
 }
-$template->assign('SubmitArticleHref', SmrSession::getNewHREF($container));
+$template->assign('SubmitArticleHref', $container->href());

--- a/src/engine/Default/galactic_post_write_article_processing.php
+++ b/src/engine/Default/galactic_post_write_article_processing.php
@@ -8,19 +8,19 @@ if (!$player->isGPEditor()) {
 }
 
 if (Request::get('action') == 'Preview article') {
-	$container = create_container('skeleton.php', 'galactic_post_write_article.php');
+	$container = Page::create('skeleton.php', 'galactic_post_write_article.php');
 	$container['PreviewTitle'] = $title;
 	$container['Preview'] = $message;
 	if (isset($var['id'])) {
 		$container['id'] = $var['id'];
 	}
-	forward($container);
+	$container->go();
 }
 
 if (isset($var['id'])) {
 	// Editing an article
 	$db->query('UPDATE galactic_post_article SET last_modified = ' . $db->escapeNumber(SmrSession::getTime()) . ', text = ' . $db->escapeString($message) . ', title = ' . $db->escapeString($title) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
-	forward(create_container('skeleton.php', 'galactic_post_view_article.php'));
+	Page::create('skeleton.php', 'galactic_post_view_article.php')->go();
 } else {
 	// Adding a new article
 	$message = 'Dear Galactic Post editors,<br /><br />[player=' . $player->getPlayerID() . '] has just submitted an article to the Galactic Post!';
@@ -35,5 +35,5 @@ if (isset($var['id'])) {
 	$num = $db->getInt('article_id') + 1;
 	$db->query('INSERT INTO galactic_post_article (game_id, article_id, writer_id, title, text, last_modified) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($num) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($title) . ' , ' . $db->escapeString($message) . ' , ' . $db->escapeNumber(SmrSession::getTime()) . ')');
 	$db->query('UPDATE galactic_post_writer SET last_wrote = ' . $db->escapeNumber(SmrSession::getTime()) . ' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
-	forward(create_container('skeleton.php', 'galactic_post_read.php'));
+	Page::create('skeleton.php', 'galactic_post_read.php')->go();
 }

--- a/src/engine/Default/game_join.php
+++ b/src/engine/Default/game_join.php
@@ -23,9 +23,9 @@ $template->assign('PageTopic', 'Join Game: ' . $game->getDisplayName());
 $template->assign('Game', $game);
 
 if (SmrSession::getTime() >= $game->getJoinTime()) {
-	$container = create_container('game_join_processing.php');
-	transfer('game_id');
-	$template->assign('JoinGameFormHref', SmrSession::getNewHREF($container));
+	$container = Page::create('game_join_processing.php');
+	$container->addVar('game_id');
+	$template->assign('JoinGameFormHref', $container->href());
 }
 
 $races = [];

--- a/src/engine/Default/game_join_processing.php
+++ b/src/engine/Default/game_join_processing.php
@@ -100,6 +100,6 @@ $news = '[player=' . $player->getPlayerID() . '] has joined the game!';
 $db->query('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($gameID) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
 
 // Send the player directly into the game
-$container = create_container('game_play_processing.php');
-transfer('game_id');
-forward($container);
+$container = Page::create('game_play_processing.php');
+$container->addVar('game_id');
+$container->go();

--- a/src/engine/Default/game_leave_processing.php
+++ b/src/engine/Default/game_leave_processing.php
@@ -8,4 +8,4 @@ if (SmrSession::hasGame()) {
 
 SmrSession::clearLinks();
 
-forward(create_container('skeleton.php', $var['body'], $var));
+Page::create('skeleton.php', $var['body'], $var)->go();

--- a/src/engine/Default/game_play.php
+++ b/src/engine/Default/game_play.php
@@ -33,9 +33,9 @@ if ($db->getNumRows() > 0) {
 		$games['Play'][$game_id]['EndDate'] = date(DATE_FULL_SHORT_SPLIT, $db->getInt('end_time'));
 		$games['Play'][$game_id]['Speed'] = $db->getFloat('game_speed');
 
-		$container = create_container('game_play_processing.php');
+		$container = Page::create('game_play_processing.php');
 		$container['game_id'] = $game_id;
-		$games['Play'][$game_id]['PlayGameLink'] = SmrSession::getNewHREF($container);
+		$games['Play'][$game_id]['PlayGameLink'] = $container->href();
 
 		// creates a new player object
 		$curr_player = SmrPlayer::getPlayer($account->getAccountID(), $game_id);
@@ -56,9 +56,9 @@ if ($db->getNumRows() > 0) {
 
 		// create a container that will hold next url and additional variables.
 
-		$container_game = create_container('skeleton.php', 'game_stats.php');
+		$container_game = Page::create('skeleton.php', 'game_stats.php');
 		$container_game['game_id'] = $game_id;
-		$games['Play'][$game_id]['GameStatsLink'] = SmrSession::getNewHREF($container_game);
+		$games['Play'][$game_id]['GameStatsLink'] = $container_game->href();
 		$games['Play'][$game_id]['Turns'] = $curr_player->getTurns();
 		$games['Play'][$game_id]['LastMovement'] = format_time(SmrSession::getTime() - $curr_player->getLastActive(), TRUE);
 
@@ -108,10 +108,10 @@ if ($db->getNumRows() > 0) {
 			'Credits' => $game->getCreditsNeeded(),
 		];
 		// create a container that will hold next url and additional variables.
-		$container = create_container('skeleton.php', 'game_join.php');
+		$container = Page::create('skeleton.php', 'game_join.php');
 		$container['game_id'] = $game_id;
 
-		$games['Join'][$game_id]['JoinGameLink'] = SmrSession::getNewHREF($container);
+		$games['Join'][$game_id]['JoinGameLink'] = $container->href();
 	}
 }
 
@@ -134,16 +134,16 @@ if ($db->getNumRows()) {
 		$games['Previous'][$game_id]['Type'] = SmrGame::GAME_TYPES[$db->getField('game_type')];
 		$games['Previous'][$game_id]['Speed'] = $db->getFloat('game_speed');
 		// create a container that will hold next url and additional variables.
-		$container = create_container('skeleton.php');
+		$container = Page::create('skeleton.php');
 		$container['game_id'] = $container['GameID'] = $game_id;
 		$container['game_name'] = $games['Previous'][$game_id]['Name'];
 
 		$container['body'] = 'hall_of_fame_new.php';
-		$games['Previous'][$game_id]['PreviousGameHOFLink'] = SmrSession::getNewHREF($container);
+		$games['Previous'][$game_id]['PreviousGameHOFLink'] = $container->href();
 		$container['body'] = 'news_read.php';
-		$games['Previous'][$game_id]['PreviousGameNewsLink'] = SmrSession::getNewHREF($container);
+		$games['Previous'][$game_id]['PreviousGameNewsLink'] = $container->href();
 		$container['body'] = 'game_stats.php';
-		$games['Previous'][$game_id]['PreviousGameStatsLink'] = SmrSession::getNewHREF($container);
+		$games['Previous'][$game_id]['PreviousGameStatsLink'] = $container->href();
 	}
 }
 
@@ -163,19 +163,19 @@ foreach (Globals::getHistoryDatabases() as $databaseName => $oldColumn) {
 			$games['Previous'][$index]['Type'] = $db->getField('type');
 			$games['Previous'][$index]['Speed'] = $db->getFloat('speed');
 			// create a container that will hold next url and additional variables.
-			$container = create_container('skeleton.php');
+			$container = Page::create('skeleton.php');
 			$container['view_game_id'] = $game_id;
 			$container['HistoryDatabase'] = $databaseName;
 			$container['game_name'] = $games['Previous'][$index]['Name'];
 
 			$container['body'] = 'history_games.php';
-			$games['Previous'][$index]['PreviousGameLink'] = SmrSession::getNewHREF($container);
+			$games['Previous'][$index]['PreviousGameLink'] = $container->href();
 			$container['body'] = 'history_games_hof.php';
-			$games['Previous'][$index]['PreviousGameHOFLink'] = SmrSession::getNewHREF($container);
+			$games['Previous'][$index]['PreviousGameHOFLink'] = $container->href();
 			$container['body'] = 'history_games_news.php';
-			$games['Previous'][$index]['PreviousGameNewsLink'] = SmrSession::getNewHREF($container);
+			$games['Previous'][$index]['PreviousGameNewsLink'] = $container->href();
 			$container['body'] = 'history_games_detail.php';
-			$games['Previous'][$index]['PreviousGameStatsLink'] = SmrSession::getNewHREF($container);
+			$games['Previous'][$index]['PreviousGameStatsLink'] = $container->href();
 		}
 	}
 }
@@ -186,8 +186,8 @@ $template->assign('Games', $games);
 // ***************************************
 // ** Voting
 // ***************************************
-$container = create_container('skeleton.php', 'vote.php');
-$template->assign('VotingHref', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'vote.php');
+$template->assign('VotingHref', $container->href());
 
 $db->query('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(SmrSession::getTime()) . ' ORDER BY end DESC');
 if ($db->getNumRows() > 0) {
@@ -201,9 +201,9 @@ if ($db->getNumRows() > 0) {
 	while ($db->nextRecord()) {
 		$voteID = $db->getInt('vote_id');
 		$voting[$voteID]['ID'] = $voteID;
-		$container = create_container('vote_processing.php', 'game_play.php');
+		$container = Page::create('vote_processing.php', 'game_play.php');
 		$container['vote_id'] = $voteID;
-		$voting[$voteID]['HREF'] = SmrSession::getNewHREF($container);
+		$voting[$voteID]['HREF'] = $container->href();
 		$voting[$voteID]['Question'] = $db->getField('question');
 		$voting[$voteID]['TimeRemaining'] = format_time($db->getInt('end') - SmrSession::getTime(), true);
 		$voting[$voteID]['Options'] = array();
@@ -221,6 +221,6 @@ if ($db->getNumRows() > 0) {
 // ***************************************
 // ** Announcements View
 // ***************************************
-$container = create_container('skeleton.php', 'announcements.php');
+$container = Page::create('skeleton.php', 'announcements.php');
 $container['view_all'] = 'yes';
-$template->assign('OldAnnouncementsLink', SmrSession::getNewHREF($container));
+$template->assign('OldAnnouncementsLink', $container->href());

--- a/src/engine/Default/game_play_processing.php
+++ b/src/engine/Default/game_play_processing.php
@@ -16,5 +16,5 @@ $player->update();
 // log
 $player->log(LOG_TYPE_GAME_ENTERING, 'Player entered game ' . SmrSession::getGameID());
 
-$container = create_container('skeleton.php', 'current_sector.php');
-forward($container);
+$container = Page::create('skeleton.php', 'current_sector.php');
+$container->go();

--- a/src/engine/Default/government.php
+++ b/src/engine/Default/government.php
@@ -40,7 +40,7 @@ $template->assign('AllBounties', getBounties('HQ'));
 $template->assign('MyBounties', $player->getClaimableBounties('HQ'));
 
 if ($player->getAlignment() > ALIGNMENT_EVIL && $player->getAlignment() <= ALIGNMENT_GOOD) {
-	$container = create_container('government_processing.php');
-	transfer('LocationID');
-	$template->assign('JoinHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('government_processing.php');
+	$container->addVar('LocationID');
+	$template->assign('JoinHREF', $container->href());
 }

--- a/src/engine/Default/government_processing.php
+++ b/src/engine/Default/government_processing.php
@@ -8,4 +8,4 @@ if ($location->isHQ()) {
 	$player->setAlignment(-150);
 }
 
-forward(create_container('skeleton.php', 'current_sector.php'));
+Page::create('skeleton.php', 'current_sector.php')->go();

--- a/src/engine/Default/hall_of_fame_new.php
+++ b/src/engine/Default/hall_of_fame_new.php
@@ -12,11 +12,11 @@ if (empty($game_id)) {
 }
 $template->assign('PageTopic', $topic);
 
-$container = create_container('skeleton.php', 'hall_of_fame_player_detail.php');
+$container = Page::create('skeleton.php', 'hall_of_fame_player_detail.php');
 if (isset($game_id)) {
 	$container['game_id'] = $game_id;
 }
-$template->assign('PersonalHofHREF', SmrSession::getNewHREF($container));
+$template->assign('PersonalHofHREF', $container->href());
 
 $db->query('SELECT type FROM hof_visibility WHERE visibility != ' . $db->escapeString(HOF_PRIVATE) . ' ORDER BY type');
 const DONATION_NAME = 'Money Donated To SMR';

--- a/src/engine/Default/history_alliance_detail.php
+++ b/src/engine/Default/history_alliance_detail.php
@@ -3,9 +3,9 @@
 Menu::history_games($var['selected_index']);
 
 //offer a back button
-$container = $var;
+$container = Page::copy($var);
 $container['body'] = 'history_games.php';
-$template->assign('BackHREF', SmrSession::getNewHREF($container));
+$template->assign('BackHREF', $container->href());
 
 $game_id = $var['view_game_id'];
 $id = $var['alliance_id'];

--- a/src/engine/Default/history_games.php
+++ b/src/engine/Default/history_games.php
@@ -58,7 +58,7 @@ while ($db->nextRecord()) {
 }
 $template->assign('PlayerKills', $playerKills);
 
-$container = $var;
+$container = Page::copy($var);
 $container['body'] = 'history_alliance_detail.php';
 $container['selected_index'] = 0;
 

--- a/src/engine/Default/history_games_detail.php
+++ b/src/engine/Default/history_games_detail.php
@@ -4,10 +4,12 @@ $game_id = $var['view_game_id'];
 $template->assign('PageTopic', 'Extended Stats : ' . $var['game_name']);
 Menu::history_games(1);
 
-$container = $var;
+$container = Page::copy($var);
 $container['body'] = 'history_games_detail.php';
-unset($container['action']);
-$template->assign('SelfHREF', SmrSession::getNewHREF($container));
+if (isset($container['action'])) {
+	unset($container['action']);
+}
+$template->assign('SelfHREF', $container->href());
 
 // Default page has no category (action) selected yet
 $action = SmrSession::getRequestVar('action', '');
@@ -41,7 +43,7 @@ if (!empty($action)) {
 	} else {
 		$template->assign('Name', 'Alliance');
 		$db->query('SELECT alliance_name, alliance_id, ' . $sql . ' as val FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND alliance_id > 0 GROUP BY alliance_id ORDER BY val DESC, alliance_id LIMIT 25');
-		$container = $var;
+		$container = Page::copy($var);
 		$container['body'] = 'history_alliance_detail.php';
 		$container['selected_index'] = 1;
 		while ($db->nextRecord()) {

--- a/src/engine/Default/history_games_hof.php
+++ b/src/engine/Default/history_games_hof.php
@@ -16,7 +16,7 @@ if (!isset($var['stat'])) {
 			continue;
 		}
 		$statDisplay = ucwords(str_replace('_', ' ', $stat));
-		$container = $var;
+		$container = Page::copy($var);
 		$container['stat'] = $stat;
 		$container['stat_display'] = $statDisplay;
 		$links[] = create_link($container, $statDisplay);
@@ -24,10 +24,10 @@ if (!isset($var['stat'])) {
 	$template->assign('Links', $links);
 } else {
 	// Link back to overview page
-	$container = $var;
+	$container = Page::copy($var);
 	unset($container['stat']);
 	unset($container['stat_display']);
-	$template->assign('BackHREF', SmrSession::getNewHREF($container));
+	$template->assign('BackHREF', $container->href());
 
 	$template->assign('StatName', $var['stat_display']);
 

--- a/src/engine/Default/history_games_news.php
+++ b/src/engine/Default/history_games_news.php
@@ -8,7 +8,7 @@ $max = Request::getInt('max', 50);
 $template->assign('Max', $max);
 $template->assign('Min', $min);
 
-$template->assign('ShowHREF', SmrSession::getNewHREF($var));
+$template->assign('ShowHREF', Page::copy($var)->href());
 
 $db->switchDatabases($var['HistoryDatabase']);
 $db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($var['view_game_id']) . ' AND news_id >= ' . $db->escapeNumber($min) . ' AND news_id <= ' . $db->escapeNumber($max));

--- a/src/engine/Default/invalid_email.php
+++ b/src/engine/Default/invalid_email.php
@@ -12,6 +12,6 @@ if (!$disabled || $disabled['Reason'] != CLOSE_ACCOUNT_INVALID_EMAIL_REASON) {
 // It doesn't really matter what page we link to -- the closing
 // conditional will be triggered in the loader since the account
 // is still banned, so we do the unbanning there.
-$container = create_container('skeleton.php', 'game_play.php');
+$container = Page::create('skeleton.php', 'game_play.php');
 $container['do_reopen_account'] = true;
-$template->assign('ReopenLink', SmrSession::getNewHREF($container));
+$template->assign('ReopenLink', $container->href());

--- a/src/engine/Default/invalid_email_processing.php
+++ b/src/engine/Default/invalid_email_processing.php
@@ -6,4 +6,4 @@ if (Request::get('action') == "Resend Validation Code") {
 	$account->changeEmail(Request::get('email'));
 }
 $account->update();
-forward(create_container('skeleton.php', 'validate.php'));
+Page::create('skeleton.php', 'validate.php')->go();

--- a/src/engine/Default/leave_newbie_processing.php
+++ b/src/engine/Default/leave_newbie_processing.php
@@ -6,4 +6,4 @@ if ($action == 'Yes!') {
 }
 
 $player->log(LOG_TYPE_MOVEMENT, 'Player drops newbie turns.');
-forward(create_container('skeleton.php', 'current_sector.php'));
+Page::create('skeleton.php', 'current_sector.php')->go();

--- a/src/engine/Default/logged_in.php
+++ b/src/engine/Default/logged_in.php
@@ -3,11 +3,11 @@
 // update last login time
 $account->updateLastLogin();
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 if (SmrSession::hasGame()) {
 	$container['body'] = 'current_sector.php';
 } else {
 	$container['body'] = 'game_play.php';
 }
 
-forward($container);
+$container->go();

--- a/src/engine/Default/login_check_processing.php
+++ b/src/engine/Default/login_check_processing.php
@@ -2,7 +2,7 @@
 if (!isset($var['CheckType']) || $var['CheckType'] == 'Validate') {
 	// is account validated?
 	if (!$account->isValidated()) {
-		forward(create_container('skeleton.php', 'validate.php'));
+		Page::create('skeleton.php', 'validate.php')->go();
 	} else {
 		$var['CheckType'] = 'Announcements';
 	}
@@ -15,7 +15,7 @@ if ($var['CheckType'] == 'Announcements') {
 	$db->query('SELECT 1 FROM announcement WHERE time >= ' . $db->escapeNumber($lastLogin) . ' LIMIT 1');
 	// do we have announcements?
 	if ($db->nextRecord()) {
-		forward(create_container('skeleton.php', 'announcements.php'));
+		Page::create('skeleton.php', 'announcements.php')->go();
 	} else {
 		$var['CheckType'] = 'Updates';
 	}
@@ -25,8 +25,8 @@ if ($var['CheckType'] == 'Updates') {
 	$db->query('SELECT 1 FROM version WHERE went_live >= ' . $db->escapeNumber($lastLogin) . ' LIMIT 1');
 	// do we have updates?
 	if ($db->nextRecord()) {
-		forward(create_container('skeleton.php', 'changelog_view.php', array('Since' => $lastLogin)));
+		Page::create('skeleton.php', 'changelog_view.php', array('Since' => $lastLogin))->go();
 	}
 }
 
-forward(create_container('logged_in.php'));
+Page::create('logged_in.php')->go();

--- a/src/engine/Default/map_local.php
+++ b/src/engine/Default/map_local.php
@@ -41,11 +41,11 @@ if (isset($var['ZoomDir'])) {
 	SmrSession::updateVar('ZoomDir', null);
 }
 
-$container = create_container('skeleton.php', 'map_local.php');
+$container = Page::create('skeleton.php', 'map_local.php');
 $container['ZoomDir'] = 'Expand';
-$template->assign('MapExpandHREF', SmrSession::getNewHREF($container));
+$template->assign('MapExpandHREF', $container->href());
 $container['ZoomDir'] = 'Shrink';
-$template->assign('MapShrinkHREF', SmrSession::getNewHREF($container));
+$template->assign('MapShrinkHREF', $container->href());
 
 
 $galaxy = $player->getSector()->getGalaxy();

--- a/src/engine/Default/message_blacklist.php
+++ b/src/engine/Default/message_blacklist.php
@@ -17,9 +17,9 @@ while ($db->nextRecord()) {
 $template->assign('Blacklist', $blacklist);
 
 if ($blacklist) {
-	$container = create_container('message_blacklist_del.php');
-	$template->assign('BlacklistDeleteHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('message_blacklist_del.php');
+	$template->assign('BlacklistDeleteHREF', $container->href());
 }
 
-$container = create_container('message_blacklist_add.php');
-$template->assign('BlacklistAddHREF', SmrSession::getNewHREF($container));
+$container = Page::create('message_blacklist_add.php');
+$template->assign('BlacklistAddHREF', $container->href());

--- a/src/engine/Default/message_blacklist_add.php
+++ b/src/engine/Default/message_blacklist_add.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php', 'message_blacklist.php');
+$container = Page::create('skeleton.php', 'message_blacklist.php');
 
 if (isset($var['account_id'])) {
 	$blacklisted = SmrPlayer::getPlayer($var['account_id'], $player->getGameID());
@@ -9,7 +9,7 @@ if (isset($var['account_id'])) {
 		$blacklisted = SmrPlayer::getPlayerByPlayerName(Request::get('PlayerName'), $player->getGameID());
 	} catch (PlayerNotFoundException $e) {
 		$container['msg'] = '<span class="red bold">ERROR: </span>Player does not exist.';
-		forward($container);
+		$container->go();
 	}
 }
 
@@ -17,10 +17,10 @@ $db->query('SELECT account_id FROM message_blacklist WHERE ' . $player->getSQL()
 
 if ($db->nextRecord()) {
 	$container['msg'] = '<span class="red bold">ERROR: </span>Player is already blacklisted.';
-	forward($container);
+	$container->go();
 }
 
 $db->query('INSERT INTO message_blacklist (game_id,account_id,blacklisted_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($blacklisted->getAccountID()) . ')');
 
 $container['msg'] = $blacklisted->getDisplayName() . ' has been added to your blacklist.';
-forward($container);
+$container->go();

--- a/src/engine/Default/message_blacklist_del.php
+++ b/src/engine/Default/message_blacklist_del.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php', 'message_blacklist.php');
+$container = Page::create('skeleton.php', 'message_blacklist.php');
 
 $entry_ids = Request::getIntArray('entry_ids', []);
 if (empty($entry_ids)) {
 	$container['msg'] = '<span class="red bold">ERROR: </span>No entries selected for deletion.';
-	forward($container);
+	$container->go();
 }
 
 $db->query('DELETE FROM message_blacklist WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND entry_id IN (' . $db->escapeArray($entry_ids) . ')');
-forward($container);
+$container->go();

--- a/src/engine/Default/message_box.php
+++ b/src/engine/Default/message_box.php
@@ -40,13 +40,13 @@ foreach (getMessageTypeNames() as $message_type_id => $message_type_name) {
 	$db->requireRecord();
 	$messageBox['MessageCount'] = $db->getInt('message_count');
 
-	$container = create_container('skeleton.php', 'message_view.php');
+	$container = Page::create('skeleton.php', 'message_view.php');
 	$container['folder_id'] = $message_type_id;
-	$messageBox['ViewHref'] = SmrSession::getNewHREF($container);
+	$messageBox['ViewHref'] = $container->href();
 
-	$container = create_container('message_box_delete_processing.php');
+	$container = Page::create('message_box_delete_processing.php');
 	$container['folder_id'] = $message_type_id;
-	$messageBox['DeleteHref'] = SmrSession::getNewHREF($container);
+	$messageBox['DeleteHref'] = $container->href();
 	$messageBoxes[] = $messageBox;
 }
 

--- a/src/engine/Default/message_box_delete_processing.php
+++ b/src/engine/Default/message_box_delete_processing.php
@@ -12,4 +12,4 @@ if ($var['folder_id'] == MSG_SENT) {
 					AND msg_read = ' . $db->escapeBoolean(true));
 }
 
-forward(create_container('skeleton.php', 'message_box.php'));
+Page::create('skeleton.php', 'message_box.php')->go();

--- a/src/engine/Default/message_delete_processing.php
+++ b/src/engine/Default/message_delete_processing.php
@@ -2,9 +2,9 @@
 
 // If not deleting marked messages, we are deleting entire folders
 if (Request::get('action') == 'All Messages') {
-	$container = create_container('message_box_delete_processing.php');
-	transfer('folder_id');
-	forward($container);
+	$container = Page::create('message_box_delete_processing.php');
+	$container->addVar('folder_id');
+	$container->go();
 } else {
 	if (!Request::has('message_id')) {
 		create_error('You must choose the messages you want to delete.');
@@ -34,6 +34,6 @@ if (Request::get('action') == 'All Messages') {
 	}
 }
 
-$container = create_container('skeleton.php', 'message_view.php');
-transfer('folder_id');
-forward($container);
+$container = Page::create('skeleton.php', 'message_view.php');
+$container->addVar('folder_id');
+$container->go();

--- a/src/engine/Default/message_notify_confirm.php
+++ b/src/engine/Default/message_notify_confirm.php
@@ -18,12 +18,12 @@ if (!$db->nextRecord()) {
 
 $template->assign('MessageText', $db->getField('message_text'));
 
-$container = create_container('message_notify_processing.php', '');
-transfer('folder_id');
-transfer('message_id');
-transfer('sent_time');
-transfer('notified_time');
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
+$container = Page::create('message_notify_processing.php', '');
+$container->addVar('folder_id');
+$container->addVar('message_id');
+$container->addVar('sent_time');
+$container->addVar('notified_time');
+$template->assign('ProcessingHREF', $container->href());
 
 $template->assign('PageTopic', 'Report a Message');
 Menu::messages();

--- a/src/engine/Default/message_notify_processing.php
+++ b/src/engine/Default/message_notify_processing.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php', 'message_view.php');
-transfer('folder_id');
+$container = Page::create('skeleton.php', 'message_view.php');
+$container->addVar('folder_id');
 
 if (Request::get('action') == 'No') {
-	forward($container);
+	$container->go();
 }
 
 if (empty($var['message_id'])) {
@@ -32,4 +32,4 @@ $db->query('INSERT INTO message_notify
 			(notify_id, game_id, from_id, to_id, text, sent_time, notify_time)
 			VALUES ('.$notify_id . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->getInt('sender_id') . ', ' . $db->getInt('account_id') . ', ' . $db->escapeString($db->getField('message_text')) . ', ' . $var['sent_time'] . ', ' . $var['notified_time'] . ')');
 
-forward($container);
+$container->go();

--- a/src/engine/Default/message_preference_processing.php
+++ b/src/engine/Default/message_preference_processing.php
@@ -6,6 +6,6 @@ if (Request::has('ignore_globals')) {
 	$player->setGroupScoutMessages(strtoupper(Request::get('group_scouts')));
 }
 
-$container = create_container('skeleton.php', 'message_view.php');
-transfer('folder_id');
-forward($container);
+$container = Page::create('skeleton.php', 'message_view.php');
+$container->addVar('folder_id');
+$container->go();

--- a/src/engine/Default/message_send.php
+++ b/src/engine/Default/message_send.php
@@ -4,9 +4,9 @@ $template->assign('PageTopic', 'Send Message');
 
 Menu::messages();
 
-$container = create_container('message_send_processing.php');
-transfer('receiver');
-$template->assign('MessageSendFormHref', SmrSession::getNewHREF($container));
+$container = Page::create('message_send_processing.php');
+$container->addVar('receiver');
+$template->assign('MessageSendFormHref', $container->href());
 
 if (!empty($var['receiver'])) {
 	$template->assign('Receiver', SmrPlayer::getPlayer($var['receiver'], $player->getGameID()));

--- a/src/engine/Default/message_send_processing.php
+++ b/src/engine/Default/message_send_processing.php
@@ -3,16 +3,16 @@
 $message = htmlentities(trim(Request::get('message')), ENT_COMPAT, 'utf-8');
 
 if (Request::get('action') == 'Preview message') {
-	$container = create_container('skeleton.php');
+	$container = Page::create('skeleton.php');
 	if (isset($var['alliance_id'])) {
 		$container['body'] = 'alliance_broadcast.php';
 	} else {
 		$container['body'] = 'message_send.php';
 	}
-	transfer('receiver');
-	transfer('alliance_id');
+	$container->addVar('receiver');
+	$container->addVar('alliance_id');
 	$container['preview'] = $message;
-	forward($container);
+	$container->go();
 }
 
 if (empty($message)) {
@@ -34,12 +34,12 @@ if (isset($var['alliance_id'])) {
 	$player->sendGlobalMessage($message);
 }
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 if (isset($var['alliance_id'])) {
 	$container['body'] = 'alliance_roster.php';
-	transfer('alliance_id');
+	$container->addVar('alliance_id');
 } else {
 	$container['body'] = 'current_sector.php';
 }
 $container['msg'] = '<span class="green">SUCCESS: </span>Your message has been sent.';
-forward($container);
+$container->go();

--- a/src/engine/Default/message_view.php
+++ b/src/engine/Default/message_view.php
@@ -32,14 +32,14 @@ if (isset ($var['page'])) {
 	$page = $var['page'];
 }
 
-$container = $var;
+$container = Page::copy($var);
 $container['page'] = $page - 1;
 if ($page > 0) {
-	$template->assign('PreviousPageHREF', SmrSession::getNewHREF($container));
+	$template->assign('PreviousPageHREF', $container->href());
 }
 $container['page'] = $page + 1;
 if (($page + 1) * MESSAGES_PER_PAGE < $messageBox['TotalMessages']) {
-	$template->assign('NextPageHREF', SmrSession::getNewHREF($container));
+	$template->assign('NextPageHREF', $container->href());
 }
 
 // remove entry for this folder from unread msg table
@@ -51,14 +51,14 @@ $messageBox['Name'] = getMessageTypeNames($var['folder_id']);
 $template->assign('PageTopic', 'Viewing ' . $messageBox['Name']);
 
 if ($messageBox['Type'] == MSG_GLOBAL || $messageBox['Type'] == MSG_SCOUT) {
-	$container = create_container('message_preference_processing.php');
-	transfer('folder_id');
-	$template->assign('PreferencesFormHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('message_preference_processing.php');
+	$container->addVar('folder_id');
+	$template->assign('PreferencesFormHREF', $container->href());
 }
 
-$container = create_container('message_delete_processing.php');
-transfer('folder_id');
-$messageBox['DeleteFormHref'] = SmrSession::getNewHREF($container);
+$container = Page::create('message_delete_processing.php');
+$container->addVar('folder_id');
+$messageBox['DeleteFormHref'] = $container->href();
 
 $db->query('SELECT * FROM message ' .
 			$whereClause . '
@@ -73,10 +73,10 @@ if ($var['folder_id'] == MSG_SCOUT && !isset($var['show_all']) && $messageBox['T
 	// get rid of all old scout messages (>48h)
 	$db->query('DELETE FROM message WHERE expire_time < ' . $db->escapeNumber(SmrSession::getTime()) . ' AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT));
 
-	$dispContainer = create_container('skeleton.php', 'message_view.php');
+	$dispContainer = Page::create('skeleton.php', 'message_view.php');
 	$dispContainer['folder_id'] = MSG_SCOUT;
 	$dispContainer['show_all'] = true;
-	$messageBox['ShowAllHref'] = SmrSession::getNewHREF($dispContainer);
+	$messageBox['ShowAllHref'] = $dispContainer->href();
 
 	displayScouts($messageBox, $player);
 } else {
@@ -167,25 +167,25 @@ function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $me
 		$sender = getMessagePlayer($sender_id, $player->getGameID(), $type);
 		if ($sender instanceof SmrPlayer) {
 			$message['Sender'] = $sender;
-			$container = create_container('skeleton.php', 'trader_search_result.php');
+			$container = Page::create('skeleton.php', 'trader_search_result.php');
 			$container['player_id'] = $sender->getPlayerID();
 			$message['SenderDisplayName'] = create_link($container, $sender->getDisplayName());
 
 			// Add actions that we can take on messages sent by other players.
 			if ($type != MSG_SENT) {
-				$container = create_container('skeleton.php', 'message_notify_confirm.php');
+				$container = Page::create('skeleton.php', 'message_notify_confirm.php');
 				$container['message_id'] = $message_id;
 				$container['sent_time'] = $send_time;
 				$container['folder_id'] = $type;
-				$message['ReportHref'] = SmrSession::getNewHREF($container);
+				$message['ReportHref'] = $container->href();
 
-				$container = create_container('skeleton.php', 'message_blacklist_add.php');
+				$container = Page::create('skeleton.php', 'message_blacklist_add.php');
 				$container['account_id'] = $sender_id;
-				$message['BlacklistHref'] = SmrSession::getNewHREF($container);
+				$message['BlacklistHref'] = $container->href();
 
-				$container = create_container('skeleton.php', 'message_send.php');
+				$container = Page::create('skeleton.php', 'message_send.php');
 				$container['receiver'] = $sender->getAccountID();
-				$message['ReplyHref'] = SmrSession::getNewHREF($container);
+				$message['ReplyHref'] = $container->href();
 			}
 		} else {
 			$message['SenderDisplayName'] = $sender;
@@ -194,7 +194,7 @@ function displayMessage(&$messageBox, $message_id, $receiver_id, $sender_id, $me
 
 	if ($type == MSG_SENT) {
 		$receiver = SmrPlayer::getPlayer($receiver_id, $player->getGameID());
-		$container = create_container('skeleton.php', 'trader_search_result.php');
+		$container = Page::create('skeleton.php', 'trader_search_result.php');
 		$container['player_id'] = $receiver->getPlayerID();
 		$message['ReceiverDisplayName'] = create_link($container, $receiver->getDisplayName());
 	}

--- a/src/engine/Default/mission_abandon_processing.php
+++ b/src/engine/Default/mission_abandon_processing.php
@@ -2,4 +2,4 @@
 
 $player->deleteMission($var['MissionID']);
 
-forward(create_container('skeleton.php', 'current_sector.php'));
+Page::create('skeleton.php', 'current_sector.php')->go();

--- a/src/engine/Default/mission_accept_processing.php
+++ b/src/engine/Default/mission_accept_processing.php
@@ -6,4 +6,4 @@ if (count($player->getMissions()) >= 3) {
 
 $player->addMission($var['MissionID']);
 
-forward(create_container('skeleton.php', 'current_sector.php'));
+Page::create('skeleton.php', 'current_sector.php')->go();

--- a/src/engine/Default/mission_claim_processing.php
+++ b/src/engine/Default/mission_claim_processing.php
@@ -2,4 +2,4 @@
 
 $rewardText = $player->claimMissionReward($var['MissionID']);
 
-forward(create_container('skeleton.php', 'current_sector.php', array('MissionMessage' => $rewardText)));
+Page::create('skeleton.php', 'current_sector.php', array('MissionMessage' => $rewardText))->go();

--- a/src/engine/Default/mission_decline_processing.php
+++ b/src/engine/Default/mission_decline_processing.php
@@ -2,4 +2,4 @@
 
 $player->declineMission($var['MissionID']);
 
-forward(create_container('skeleton.php', 'current_sector.php'));
+Page::create('skeleton.php', 'current_sector.php')->go();

--- a/src/engine/Default/newbie_warning_processing.php
+++ b/src/engine/Default/newbie_warning_processing.php
@@ -1,3 +1,3 @@
 <?php declare(strict_types=1);
 $player->setNewbieWarning(false);
-forward(create_container('skeleton.php', 'newbie_warning.php'));
+Page::create('skeleton.php', 'newbie_warning.php')->go();

--- a/src/engine/Default/news_read.php
+++ b/src/engine/Default/news_read.php
@@ -20,7 +20,7 @@ require_once(get_file_loc('news.inc.php'));
 doBreakingNewsAssign($gameID, $template);
 doLottoNewsAssign($gameID, $template);
 
-$template->assign('ViewNewsFormHref', SmrSession::getNewHREF(create_container('skeleton.php', 'news_read.php', array('GameID'=>$var['GameID']))));
+$template->assign('ViewNewsFormHref', Page::create('skeleton.php', 'news_read.php', array('GameID'=>$var['GameID']))->href());
 
 $db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type != \'lotto\' ORDER BY news_id DESC LIMIT ' . ($min_news - 1) . ', ' . ($max_news - $min_news + 1));
 $template->assign('NewsItems', getNewsItems($db));

--- a/src/engine/Default/news_read_advanced.php
+++ b/src/engine/Default/news_read_advanced.php
@@ -37,7 +37,7 @@ while ($db->nextRecord()) {
 }
 $template->assign('NewsAlliances', $newsAlliances);
 
-$template->assign('AdvancedNewsFormHref', SmrSession::getNewHREF(create_container('skeleton.php', 'news_read_advanced.php', $basicContainer)));
+$template->assign('AdvancedNewsFormHref', Page::create('skeleton.php', 'news_read_advanced.php', $basicContainer)->href());
 
 // No submit value when first navigating to the page
 $submit_value = SmrSession::getRequestVar('submit', '');

--- a/src/engine/Default/note_add_processing.php
+++ b/src/engine/Default/note_add_processing.php
@@ -13,4 +13,4 @@ $db->query('INSERT INTO player_has_notes (account_id,game_id,note) VALUES(' .
 		$db->escapeNumber($player->getGameID()) . ',' .
 		$db->escapeBinary(gzcompress($note)) . ')');
 
-forward(create_container('skeleton.php', 'trader_status.php'));
+Page::create('skeleton.php', 'trader_status.php')->go();

--- a/src/engine/Default/note_delete_processing.php
+++ b/src/engine/Default/note_delete_processing.php
@@ -7,4 +7,4 @@ if (!empty($note_ids)) {
 					AND note_id IN (' . $db->escapeArray($note_ids) . ')');
 }
 
-forward(create_container('skeleton.php', 'trader_status.php'));
+Page::create('skeleton.php', 'trader_status.php')->go();

--- a/src/engine/Default/planet.inc.php
+++ b/src/engine/Default/planet.inc.php
@@ -6,12 +6,12 @@ if (!$player->isLandedOnPlanet()) {
 	if (USING_AJAX) {
 		// Auto-click current sector with javascript to avoid issues with ajax
 		// updates when the display page changes.
-		$container = create_container('skeleton.php', 'current_sector.php');
+		$container = Page::create('skeleton.php', 'current_sector.php');
 		$container['msg'] = '<span class="yellow">WARNING</span>: You have been ejected from the planet!';
-		$currentSectorHREF = SmrSession::getNewHREF($container);
+		$currentSectorHREF = $container->href();
 		// json_encode the HREF as a safety precaution
 		$template->addJavascriptForAjax('EVAL', 'location.href = ' . json_encode($currentSectorHREF));
-		forward($container);
+		$container->go();
 	} else {
 		create_error('You are not on a planet!');
 	}

--- a/src/engine/Default/planet_attack_processing.php
+++ b/src/engine/Default/planet_attack_processing.php
@@ -108,7 +108,7 @@ foreach ($attackers as $attacker) {
 	}
 }
 
-$container = create_container('skeleton.php', 'planet_attack.php');
+$container = Page::create('skeleton.php', 'planet_attack.php');
 $container['sector_id'] = $planet->getSectorID();
 
 // If they died on the shot they get to see the results
@@ -117,4 +117,4 @@ if ($player->isDead()) {
 }
 
 $container['results'] = $serializedResults;
-forward($container);
+$container->go();

--- a/src/engine/Default/planet_construction_processing.php
+++ b/src/engine/Default/planet_construction_processing.php
@@ -21,4 +21,4 @@ if ($action == 'Build') {
 	$player->log(LOG_TYPE_PLANETS, 'Player cancels planet construction');
 }
 
-forward(create_container('skeleton.php', 'planet_construction.php'));
+Page::create('skeleton.php', 'planet_construction.php')->go();

--- a/src/engine/Default/planet_defense.php
+++ b/src/engine/Default/planet_defense.php
@@ -2,15 +2,15 @@
 
 require('planet.inc.php');
 
-$container = create_container('planet_defense_processing.php');
+$container = Page::create('planet_defense_processing.php');
 $container['type_id'] = 1;
-$template->assign('TransferShieldsHref', SmrSession::getNewHREF($container));
+$template->assign('TransferShieldsHref', $container->href());
 
 $container['type_id'] = 4;
-$template->assign('TransferCDsHref', SmrSession::getNewHREF($container));
+$template->assign('TransferCDsHref', $container->href());
 
 $container['type_id'] = 2;
-$template->assign('TransferArmourHref', SmrSession::getNewHREF($container));
+$template->assign('TransferArmourHref', $container->href());
 
-$container = create_container('planet_defense_weapon_processing.php');
-$template->assign('WeaponProcessingHREF', SmrSession::getNewHREF($container));
+$container = Page::create('planet_defense_weapon_processing.php');
+$template->assign('WeaponProcessingHREF', $container->href());

--- a/src/engine/Default/planet_defense_processing.php
+++ b/src/engine/Default/planet_defense_processing.php
@@ -120,4 +120,4 @@ if ($action == 'Ship') {
 	create_error('You must choose if you want to transfer to planet or to the ship!');
 }
 
-forward(create_container('skeleton.php', 'planet_defense.php'));
+Page::create('skeleton.php', 'planet_defense.php')->go();

--- a/src/engine/Default/planet_defense_weapon_processing.php
+++ b/src/engine/Default/planet_defense_weapon_processing.php
@@ -30,4 +30,4 @@ if (Request::has('transfer')) {
 	$planet->moveMountedWeaponDown(Request::getInt('move_down'));
 }
 
-forward(create_container('skeleton.php', 'planet_defense.php'));
+Page::create('skeleton.php', 'planet_defense.php')->go();

--- a/src/engine/Default/planet_financial_processing.php
+++ b/src/engine/Default/planet_financial_processing.php
@@ -38,4 +38,4 @@ elseif ($action == 'Confirm') {
 	$player->log(LOG_TYPE_BANK, 'Player bonds ' . $planet->getBonds() . ' credits at planet.');
 }
 
-forward(create_container('skeleton.php', 'planet_financial.php'));
+Page::create('skeleton.php', 'planet_financial.php')->go();

--- a/src/engine/Default/planet_kick_processing.php
+++ b/src/engine/Default/planet_kick_processing.php
@@ -15,4 +15,4 @@ $player->sendMessage($planetPlayer->getAccountID(), MSG_PLAYER, $message, false)
 $planetPlayer->setLandedOnPlanet(false);
 $planetPlayer->update();
 
-forward(create_container('skeleton.php', 'planet_main.php'));
+Page::create('skeleton.php', 'planet_main.php')->go();

--- a/src/engine/Default/planet_land_processing.php
+++ b/src/engine/Default/planet_land_processing.php
@@ -33,4 +33,4 @@ if ($player->hasAlliance()) {
 $player->setLandedOnPlanet(true);
 $player->takeTurns(1, 1);
 $player->log(LOG_TYPE_MOVEMENT, 'Player lands at planet');
-forward(create_container('skeleton.php', 'planet_main.php'));
+Page::create('skeleton.php', 'planet_main.php')->go();

--- a/src/engine/Default/planet_launch_processing.php
+++ b/src/engine/Default/planet_launch_processing.php
@@ -6,4 +6,4 @@ if (!$player->isLandedOnPlanet()) {
 $player->setLandedOnPlanet(false);
 $player->update();
 $player->log(LOG_TYPE_MOVEMENT, 'Player launches from planet');
-forward(create_container('skeleton.php', 'current_sector.php'));
+Page::create('skeleton.php', 'current_sector.php')->go();

--- a/src/engine/Default/planet_main.php
+++ b/src/engine/Default/planet_main.php
@@ -12,4 +12,4 @@ if (isset($var['msg'])) {
 
 doTickerAssigns($template, $player, $db);
 
-$template->assign('LaunchLink', SmrSession::getNewHREF(create_container('planet_launch_processing.php', '')));
+$template->assign('LaunchLink', Page::create('planet_launch_processing.php', '')->href());

--- a/src/engine/Default/planet_msg_processing.php
+++ b/src/engine/Default/planet_msg_processing.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php', 'message_view.php');
+$container = Page::create('skeleton.php', 'message_view.php');
 $container['folder_id'] = MSG_PLANET;
-forward($container);
+$container->go();

--- a/src/engine/Default/planet_ownership.php
+++ b/src/engine/Default/planet_ownership.php
@@ -2,8 +2,8 @@
 
 require('planet.inc.php');
 
-$container = create_container('planet_ownership_processing.php');
-$template->assign('ProcessingHREF', SmrSession::getNewHREF($container));
+$container = Page::create('planet_ownership_processing.php');
+$template->assign('ProcessingHREF', $container->href());
 
 $template->assign('Planet', $planet);
 $template->assign('Player', $player);

--- a/src/engine/Default/planet_ownership_processing.php
+++ b/src/engine/Default/planet_ownership_processing.php
@@ -39,4 +39,4 @@ if ($action == 'Take Ownership') {
 	$player->log(LOG_TYPE_PLANETS, 'Player sets planet password to ' . $password);
 }
 
-forward(create_container('skeleton.php', 'planet_ownership.php'));
+Page::create('skeleton.php', 'planet_ownership.php')->go();

--- a/src/engine/Default/planet_stockpile.php
+++ b/src/engine/Default/planet_stockpile.php
@@ -8,7 +8,7 @@ foreach (Globals::getGoods() as $goodID => $good) {
 		continue;
 	}
 
-	$container = create_container('planet_stockpile_processing.php');
+	$container = Page::create('planet_stockpile_processing.php');
 	$container['good_id'] = $goodID;
 
 	$goodInfo[] = array(
@@ -17,7 +17,7 @@ foreach (Globals::getGoods() as $goodID => $good) {
 		'ShipAmount' => $ship->getCargo($goodID),
 		'PlanetAmount' => $planet->getStockpile($goodID),
 		'DefaultAmount' => min($ship->getCargo($goodID), $planet->getRemainingStockpile($goodID)),
-		'HREF' => SmrSession::getNewHREF($container),
+		'HREF' => $container->href(),
 	);
 }
 

--- a/src/engine/Default/planet_stockpile_processing.php
+++ b/src/engine/Default/planet_stockpile_processing.php
@@ -50,4 +50,4 @@ if ($action == 'Ship') {
 $planet->update();
 $ship->updateCargo();
 
-forward(create_container('skeleton.php', 'planet_stockpile.php'));
+Page::create('skeleton.php', 'planet_stockpile.php')->go();

--- a/src/engine/Default/port_attack_processing.php
+++ b/src/engine/Default/port_attack_processing.php
@@ -27,7 +27,7 @@ if (!$port->exists()) {
 
 
 if ($port->isDestroyed()) {
-	forward(create_container('skeleton.php', 'port_attack.php'));
+	Page::create('skeleton.php', 'port_attack.php')->go();
 }
 
 
@@ -82,7 +82,7 @@ foreach ($attackers as $attacker) {
 	}
 }
 
-$container = create_container('skeleton.php', 'port_attack.php');
+$container = Page::create('skeleton.php', 'port_attack.php');
 
 // If they died on the shot they get to see the results
 if ($player->isDead()) {
@@ -90,4 +90,4 @@ if ($player->isDead()) {
 }
 
 $container['results'] = $serializedResults;
-forward($container);
+$container->go();

--- a/src/engine/Default/port_attack_warning.php
+++ b/src/engine/Default/port_attack_warning.php
@@ -5,10 +5,10 @@ if (!$sector->hasPort()) {
 }
 
 if ($sector->getPort()->isDestroyed()) {
-	forward(create_container('skeleton.php', 'port_attack.php'));
+	Page::create('skeleton.php', 'port_attack.php')->go();
 }
 
 $template->assign('PageTopic', 'Port Raid');
 
-$template->assign('PortAttackHREF', SmrSession::getNewHREF(create_container('port_attack_processing.php')));
+$template->assign('PortAttackHREF', Page::create('port_attack_processing.php')->href());
 $template->assign('Port', $sector->getPort());

--- a/src/engine/Default/port_claim_processing.php
+++ b/src/engine/Default/port_claim_processing.php
@@ -2,4 +2,4 @@
 $port = $player->getSectorPort();
 $port->setRaceID($player->getRaceID());
 
-forward($port->getLootHREF(true));
+$port->getLootHREF(true)->go();

--- a/src/engine/Default/port_loot_processing.php
+++ b/src/engine/Default/port_loot_processing.php
@@ -25,9 +25,9 @@ if ($player->getTurns() == 0) {
 }
 
 $player->log(LOG_TYPE_TRADING, 'Player Loots ' . $amount . ' ' . $good_name);
-$container = create_container('skeleton.php', 'port_loot.php');
+$container = Page::create('skeleton.php', 'port_loot.php');
 $ship->increaseCargo($good_id, $amount);
 $ship->updateCargo();
 $port->decreaseGoodAmount($good_id, $amount);
 $port->update();
-forward($container);
+$container->go();

--- a/src/engine/Default/port_payout_processing.php
+++ b/src/engine/Default/port_payout_processing.php
@@ -6,6 +6,6 @@ $credits = match($var['PayoutType']) {
 };
 $player->log(LOG_TYPE_TRADING, 'Player Triggers Payout: ' . $var['PayoutType']);
 $port->update();
-$container = create_container('skeleton.php', 'current_sector.php');
+$container = Page::create('skeleton.php', 'current_sector.php');
 $container['msg'] = 'You have taken <span class="creds">' . number_format($credits) . '</span> from the port.';
-forward($container);
+$container->go();

--- a/src/engine/Default/preferences.php
+++ b/src/engine/Default/preferences.php
@@ -5,11 +5,11 @@ if (isset($var['reason'])) {
 	$template->assign('Reason', $var['reason']);
 }
 
-$template->assign('PreferencesFormHREF', SmrSession::getNewHREF(create_container('preferences_processing.php', '')));
+$template->assign('PreferencesFormHREF', Page::create('preferences_processing.php', '')->href());
 
-$template->assign('PreferencesConfirmFormHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'preferences_confirm.php')));
+$template->assign('PreferencesConfirmFormHREF', Page::create('skeleton.php', 'preferences_confirm.php')->href());
 
-$template->assign('ChatSharingHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'chat_sharing.php')));
+$template->assign('ChatSharingHREF', Page::create('skeleton.php', 'chat_sharing.php')->href());
 
 $transferAccounts = array();
 $db->query('SELECT account_id,hof_name FROM account WHERE validated = ' . $db->escapeBoolean(true) . ' ORDER BY hof_name');

--- a/src/engine/Default/preferences_confirm.php
+++ b/src/engine/Default/preferences_confirm.php
@@ -14,7 +14,7 @@ $template->assign('PageTopic', 'Confirmation');
 $template->assign('Amount', $amount);
 $template->assign('HofName', SmrAccount::getAccount($account_id)->getHofDisplayName());
 
-$container = create_container('preferences_processing.php');
+$container = Page::create('preferences_processing.php');
 $container['account_id'] = $account_id;
 $container['amount'] = $amount;
-$template->assign('SubmitHREF', SmrSession::getNewHREF($container));
+$template->assign('SubmitHREF', $container->href());

--- a/src/engine/Default/preferences_processing.php
+++ b/src/engine/Default/preferences_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 if (SmrSession::hasGame()) {
 	$container['body'] = 'current_sector.php';
 } else {
@@ -284,4 +284,4 @@ if ($action == 'Save and resend validation code') {
 // Update the account in case it has changed
 $account->update();
 
-forward($container);
+$container->go();

--- a/src/engine/Default/rankings_alliance_death.php
+++ b/src/engine/Default/rankings_alliance_death.php
@@ -29,4 +29,4 @@ list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $numAlliance
 
 $template->assign('FilteredRankings', Rankings::allianceRanks('deaths', $minRank, $maxRank));
 
-$template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_death.php')));
+$template->assign('FilterRankingsHREF', Page::create('skeleton.php', 'rankings_alliance_death.php')->href());

--- a/src/engine/Default/rankings_alliance_experience.php
+++ b/src/engine/Default/rankings_alliance_experience.php
@@ -44,4 +44,4 @@ list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $numAlliance
 
 $template->assign('FilteredRankings', $expRanks($minRank, $maxRank));
 
-$template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_experience.php')));
+$template->assign('FilterRankingsHREF', Page::create('skeleton.php', 'rankings_alliance_experience.php')->href());

--- a/src/engine/Default/rankings_alliance_kills.php
+++ b/src/engine/Default/rankings_alliance_kills.php
@@ -29,4 +29,4 @@ list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $numAlliance
 
 $template->assign('FilteredRankings', Rankings::allianceRanks('kills', $minRank, $maxRank));
 
-$template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_kills.php')));
+$template->assign('FilterRankingsHREF', Page::create('skeleton.php', 'rankings_alliance_kills.php')->href());

--- a/src/engine/Default/rankings_alliance_profit.php
+++ b/src/engine/Default/rankings_alliance_profit.php
@@ -48,4 +48,4 @@ list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $numAlliance
 
 $template->assign('FilteredRankings', $profitRanks($minRank, $maxRank));
 
-$template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_alliance_profit.php')));
+$template->assign('FilterRankingsHREF', Page::create('skeleton.php', 'rankings_alliance_profit.php')->href());

--- a/src/engine/Default/rankings_alliance_vs_alliance.php
+++ b/src/engine/Default/rankings_alliance_vs_alliance.php
@@ -4,8 +4,8 @@ $template->assign('PageTopic', 'Alliance VS Alliance Rankings');
 
 Menu::rankings(1, 4);
 $db2 = MySqlDatabase::getInstance();
-$container = create_container('skeleton.php', 'rankings_alliance_vs_alliance.php');
-$template->assign('SubmitHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'rankings_alliance_vs_alliance.php');
+$template->assign('SubmitHREF', $container->href());
 
 $alliancer = SmrSession::getRequestVarIntArray('alliancer', []);
 $detailsAllianceID = SmrSession::getRequestVarInt('alliance_id', $player->getAllianceID());
@@ -40,7 +40,7 @@ foreach ($alliance_vs_ids as $curr_id) {
 	}
 	$alliance_vs[] = [
 		'ID' => $curr_id,
-		'DetailsHREF' => SmrSession::getNewHREF($container),
+		'DetailsHREF' => $container->href(),
 		'Name' => $curr_alliance->isNone() ? 'No Alliance' : $curr_alliance->getAllianceDisplayName(),
 		'Style' => $style,
 	];

--- a/src/engine/Default/rankings_player_assists.php
+++ b/src/engine/Default/rankings_player_assists.php
@@ -14,6 +14,6 @@ $template->assign('Rankings', Rankings::playerRanks('assists'));
 
 list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 
-$template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_player_assists.php')));
+$template->assign('FilterRankingsHREF', Page::create('skeleton.php', 'rankings_player_assists.php')->href());
 
 $template->assign('FilteredRankings', Rankings::playerRanks('assists', $minRank, $maxRank));

--- a/src/engine/Default/rankings_player_death.php
+++ b/src/engine/Default/rankings_player_death.php
@@ -14,6 +14,6 @@ $template->assign('Rankings', Rankings::playerRanks('deaths'));
 
 list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 
-$template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_player_death.php')));
+$template->assign('FilterRankingsHREF', Page::create('skeleton.php', 'rankings_player_death.php')->href());
 
 $template->assign('FilteredRankings', Rankings::playerRanks('deaths', $minRank, $maxRank));

--- a/src/engine/Default/rankings_player_experience.php
+++ b/src/engine/Default/rankings_player_experience.php
@@ -14,6 +14,6 @@ $template->assign('Rankings', Rankings::playerRanks('experience'));
 
 list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 
-$template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_player_experience.php')));
+$template->assign('FilterRankingsHREF', Page::create('skeleton.php', 'rankings_player_experience.php')->href());
 
 $template->assign('FilteredRankings', Rankings::playerRanks('experience', $minRank, $maxRank));

--- a/src/engine/Default/rankings_player_kills.php
+++ b/src/engine/Default/rankings_player_kills.php
@@ -14,6 +14,6 @@ $template->assign('Rankings', Rankings::playerRanks('kills'));
 
 list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 
-$template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_player_kills.php')));
+$template->assign('FilterRankingsHREF', Page::create('skeleton.php', 'rankings_player_kills.php')->href());
 
 $template->assign('FilteredRankings', Rankings::playerRanks('kills', $minRank, $maxRank));

--- a/src/engine/Default/rankings_player_profit.php
+++ b/src/engine/Default/rankings_player_profit.php
@@ -35,6 +35,6 @@ $template->assign('Rankings', $profitRanks(1, 10));
 
 list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $totalPlayers);
 
-$template->assign('FilterRankingsHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_player_profit.php')));
+$template->assign('FilterRankingsHREF', Page::create('skeleton.php', 'rankings_player_profit.php')->href());
 
 $template->assign('FilteredRankings', $profitRanks($minRank, $maxRank));

--- a/src/engine/Default/rankings_sector_kill.php
+++ b/src/engine/Default/rankings_sector_kill.php
@@ -41,8 +41,8 @@ $db->query('SELECT ranking
 $db->requireRecord();
 $ourRank = $db->getInt('ranking');
 
-$container = create_container('skeleton.php', 'rankings_sector_kill.php');
-$template->assign('SubmitHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'rankings_sector_kill.php');
+$template->assign('SubmitHREF', $container->href());
 
 list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $total_sector);
 

--- a/src/engine/Default/reopen_account.php
+++ b/src/engine/Default/reopen_account.php
@@ -16,6 +16,6 @@ $template->assign('PageTopic', 'Re-Open Account?');
 // It doesn't really matter what page we link to -- the closing
 // conditional will be triggered in the loader since the account
 // is still banned, so we do the unbanning there.
-$container = create_container('skeleton.php', 'game_play.php');
+$container = Page::create('skeleton.php', 'game_play.php');
 $container['do_reopen_account'] = true;
-$template->assign('ReopenLink', SmrSession::getNewHREF($container));
+$template->assign('ReopenLink', $container->href());

--- a/src/engine/Default/sector_jump_calculate.php
+++ b/src/engine/Default/sector_jump_calculate.php
@@ -10,7 +10,7 @@ $template->assign('Target', $targetSector->getSectorID());
 $template->assign('TurnCost', $jumpInfo['turn_cost']);
 $template->assign('MaxMisjump', $jumpInfo['max_misjump']);
 
-$container = create_container('sector_jump_processing.php');
+$container = Page::create('sector_jump_processing.php');
 $container['target'] = $targetSector->getSectorID();
 $container['target_page'] = 'current_sector.php';
-$template->assign('JumpProcessingHREF', SmrSession::getNewHREF($container));
+$template->assign('JumpProcessingHREF', $container->href());

--- a/src/engine/Default/sector_jump_processing.php
+++ b/src/engine/Default/sector_jump_processing.php
@@ -11,7 +11,7 @@ if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 	$player->setSectorID($target);
 	$player->update();
 	$sector->markVisited($player);
-	forward(create_container('skeleton.php', 'current_sector.php'));
+	Page::create('skeleton.php', 'current_sector.php')->go();
 }
 
 // you can't move while on planet
@@ -34,9 +34,9 @@ if (!SmrSector::sectorExists($player->getGameID(), $target)) {
 
 // If the Calculate Turn Cost button was pressed
 if (Request::get('action', '') == 'Calculate Turn Cost') {
-	$container = create_container('skeleton.php', 'sector_jump_calculate.php');
+	$container = Page::create('skeleton.php', 'sector_jump_calculate.php');
 	$container['target'] = $target;
-	forward($container);
+	$container->go();
 }
 
 if ($sector->hasForces()) {
@@ -102,4 +102,4 @@ $sector->enteringSector($player, MOVEMENT_JUMP);
 // If the new sector has mines...
 require('sector_mines.inc.php');
 
-forward(create_container('skeleton.php', $var['target_page']));
+Page::create('skeleton.php', $var['target_page'])->go();

--- a/src/engine/Default/sector_mines.inc.php
+++ b/src/engine/Default/sector_mines.inc.php
@@ -14,18 +14,18 @@ if ($mine_owner_id) {
 	if ($player->hasNewbieTurns() || $ship->getShipClassID() === SmrShip::SHIP_CLASS_SCOUT) {
 		$turns = $sectorForces[$mine_owner_id]->getBumpTurnCost($ship);
 		$player->takeTurns($turns, $turns);
-		$container = create_container('skeleton.php', 'current_sector.php');
+		$container = Page::create('skeleton.php', 'current_sector.php');
 		if ($player->hasNewbieTurns()) {
 			$flavor = 'Because of your newbie status you have been spared from the harsh reality of the forces';
 		} else {
 			$flavor = 'Your ship was sufficiently agile to evade them';
 		}
 		$container['msg'] = 'You have just flown past a sprinkle of mines.<br />' . $flavor . ',<br />but it has cost you <span class="red">' . $turns . ' ' . pluralise('turn', $turns) . '</span> to navigate the minefield safely.';
-		forward($container);
+		$container->go();
 	} else {
-		$container = create_container('forces_attack_processing.php');
+		$container = Page::create('forces_attack_processing.php');
 		$container['action'] = 'bump';
 		$container['owner_id'] = $mine_owner_id;
-		forward($container);
+		$container->go();
 	}
 }

--- a/src/engine/Default/sector_move_processing.php
+++ b/src/engine/Default/sector_move_processing.php
@@ -5,7 +5,7 @@ if (!$player->getGame()->hasStarted()) {
 }
 
 if ($var['target_sector'] == $player->getSectorID()) {
-	forward(create_container('skeleton.php', $var['target_page']));
+	Page::create('skeleton.php', $var['target_page'])->go();
 }
 
 if ($sector->getWarp() == $var['target_sector']) {
@@ -24,7 +24,7 @@ if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
 	// get new sector object
 	$sector = $player->getSector();
 	$sector->markVisited($player);
-	forward(create_container('skeleton.php', $var['target_page']));
+	Page::create('skeleton.php', $var['target_page'])->go();
 }
 
 // you can't move while on planet
@@ -85,4 +85,4 @@ $sector->enteringSector($player, MOVEMENT_WALK);
 require('sector_mines.inc.php');
 
 // otherwise
-forward(create_container('skeleton.php', $var['target_page']));
+Page::create('skeleton.php', $var['target_page'])->go();

--- a/src/engine/Default/shop_goods.php
+++ b/src/engine/Default/shop_goods.php
@@ -91,13 +91,13 @@ $template->assign('SearchedByFeds', $searchedByFeds);
 
 $player->setLastPort($player->getSectorID());
 
-$container = create_container('shop_goods_processing.php');
+$container = Page::create('shop_goods_processing.php');
 
 $boughtGoods = [];
 foreach ($port->getVisibleGoodsBought($player) as $goodID) {
 	$good = Globals::getGood($goodID);
 	$container['good_id'] = $goodID;
-	$good['HREF'] = SmrSession::getNewHREF($container);
+	$good['HREF'] = $container->href();
 
 	$amount = $port->getGoodAmount($goodID);
 	$good['PortAmount'] = $amount;
@@ -113,7 +113,7 @@ $soldGoods = [];
 foreach ($port->getVisibleGoodsSold($player) as $goodID) {
 	$good = Globals::getGood($goodID);
 	$container['good_id'] = $good['ID'];
-	$good['HREF'] = SmrSession::getNewHREF($container);
+	$good['HREF'] = $container->href();
 
 	$amount = $port->getGoodAmount($goodID);
 	$good['PortAmount'] = $amount;
@@ -128,5 +128,5 @@ foreach ($port->getVisibleGoodsSold($player) as $goodID) {
 $template->assign('BoughtGoods', $boughtGoods);
 $template->assign('SoldGoods', $soldGoods);
 
-$container = create_container('skeleton.php', 'current_sector.php');
-$template->assign('LeavePortHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'current_sector.php');
+$template->assign('LeavePortHREF', $container->href());

--- a/src/engine/Default/shop_goods_processing.php
+++ b/src/engine/Default/shop_goods_processing.php
@@ -98,9 +98,9 @@ if (Request::get('action') === TRADER_STEALS) {
 		$player->decreaseRelationsByTrade($amount, $port->getRaceID());
 
 		$fineMessage = '<span class="red">A Federation patrol caught you loading stolen goods onto your ship!<br />The stolen goods have been confiscated and you have been fined ' . number_format($fine) . ' credits.</span><br /><br />';
-		$container = create_container('skeleton.php', 'shop_goods.php');
+		$container = Page::create('skeleton.php', 'shop_goods.php');
 		$container['trade_msg'] = $fineMessage;
-		forward($container);
+		$container->go();
 	}
 }
 
@@ -111,9 +111,9 @@ if ($transaction === TRADER_STEALS ||
 	  ($transaction === TRADER_SELLS && $bargain_price <= $ideal_price)))) {
 
 	// the url we going to
-	$container = create_container('skeleton.php');
-	transfer('ideal_price');
-	transfer('offered_price');
+	$container = Page::create('skeleton.php');
+	$container->addVar('ideal_price');
+	$container->addVar('offered_price');
 
 	// base xp is the amount you would get for a perfect trade.
 	// this is the absolut max. the real xp can only be smaller.
@@ -194,13 +194,13 @@ if ($transaction === TRADER_STEALS ||
 
 } else {
 	// does the trader try to outsmart us?
-	$container = create_container('skeleton.php', 'shop_goods_trade.php');
-	transfer('ideal_price');
-	transfer('offered_price');
+	$container = Page::create('skeleton.php', 'shop_goods_trade.php');
+	$container->addVar('ideal_price');
+	$container->addVar('offered_price');
 	check_bargain_number($amount, $ideal_price, $offered_price, $bargain_price, $container);
 
 	// transfer values to next page
-	transfer('good_id');
+	$container->addVar('good_id');
 
 	$container['amount'] = $amount;
 	$container['bargain_price'] = $bargain_price;
@@ -212,4 +212,4 @@ if (!isset($container['number_of_bargains']) || $container['number_of_bargains']
 }
 
 // go to next page
-forward($container);
+$container->go();

--- a/src/engine/Default/shop_goods_trade.php
+++ b/src/engine/Default/shop_goods_trade.php
@@ -27,14 +27,14 @@ if ($transaction === TRADER_SELLS) {
 	$template->assign('PortAction', 'offer you');
 }
 
-$container = create_container('shop_goods_processing.php');
-transfer('amount');
-transfer('good_id');
-transfer('offered_price');
-transfer('ideal_price');
-transfer('number_of_bargains');
-transfer('overall_number_of_bargains');
-$template->assign('BargainHREF', SmrSession::getNewHREF($container));
+$container = Page::create('shop_goods_processing.php');
+$container->addVar('amount');
+$container->addVar('good_id');
+$container->addVar('offered_price');
+$container->addVar('ideal_price');
+$container->addVar('number_of_bargains');
+$container->addVar('overall_number_of_bargains');
+$template->assign('BargainHREF', $container->href());
 
 $template->assign('BargainPrice', $bargain_price);
 $template->assign('OfferedPrice', $var['offered_price']);
@@ -43,8 +43,8 @@ $template->assign('Good', $portGood);
 $template->assign('Amount', $var['amount']);
 $template->assign('Port', $port);
 
-$container = create_container('skeleton.php', 'shop_goods.php');
-$template->assign('ShopHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'shop_goods.php');
+$template->assign('ShopHREF', $container->href());
 
-$container = create_container('skeleton.php', 'current_sector.php');
-$template->assign('LeaveHREF', SmrSession::getNewHREF($container));
+$container = Page::create('skeleton.php', 'current_sector.php');
+$template->assign('LeaveHREF', $container->href());

--- a/src/engine/Default/shop_hardware.php
+++ b/src/engine/Default/shop_hardware.php
@@ -10,10 +10,10 @@ $location = SmrLocation::getLocation($var['LocationID']);
 if ($location->isHardwareSold()) {
 	$hardwareSold = $location->getHardwareSold();
 	foreach ($hardwareSold as $hardwareTypeID => $hardware) {
-		$container = create_container('shop_hardware_processing.php');
-		transfer('LocationID');
+		$container = Page::create('shop_hardware_processing.php');
+		$container->addVar('LocationID');
 		$container['hardware_id'] = $hardwareTypeID;
-		$hardwareSold[$hardwareTypeID]['HREF'] = SmrSession::getNewHREF($container);
+		$hardwareSold[$hardwareTypeID]['HREF'] = $container->href();
 	}
 	$template->assign('HardwareSold', $hardwareSold);
 }

--- a/src/engine/Default/shop_hardware_processing.php
+++ b/src/engine/Default/shop_hardware_processing.php
@@ -57,6 +57,6 @@ $player->log(LOG_TYPE_HARDWARE, 'Player ' . $action . 's ' . $amount . ' ' . $ha
 $player->update();
 $ship->updateHardware();
 
-$container = create_container('skeleton.php', 'shop_hardware.php');
-transfer('LocationID');
-forward($container);
+$container = Page::create('skeleton.php', 'shop_hardware.php');
+$container->addVar('LocationID');
+$container->go();

--- a/src/engine/Default/shop_ship.php
+++ b/src/engine/Default/shop_ship.php
@@ -19,12 +19,12 @@ foreach ($shipsSold as $shipTypeID => $shipSold) {
 $template->assign('ShipsUnavailable', $shipsUnavailable);
 
 if (!empty($shipsSold)) {
-	$container = create_container('skeleton.php', 'shop_ship.php');
-	transfer('LocationID');
+	$container = Page::create('skeleton.php', 'shop_ship.php');
+	$container->addVar('LocationID');
 
 	foreach (array_keys($shipsSold) as $shipTypeID) {
 		$container['ship_id'] = $shipTypeID;
-		$shipsSoldHREF[$shipTypeID] = SmrSession::getNewHREF($container);
+		$shipsSoldHREF[$shipTypeID] = $container->href();
 	}
 }
 $template->assign('ShipsSold', $shipsSold);
@@ -35,10 +35,10 @@ if (isset($var['ship_id'])) {
 	$compareShip['RealSpeed'] = $compareShip['Speed'] * $player->getGame()->getGameSpeed();
 	$compareShip['Turns'] = round($player->getTurns() * $compareShip['Speed'] / $ship->getSpeed());
 
-	$container = create_container('shop_ship_processing.php');
-	transfer('LocationID');
-	transfer('ship_id');
-	$compareShip['BuyHREF'] = SmrSession::getNewHREF($container);
+	$container = Page::create('shop_ship_processing.php');
+	$container->addVar('LocationID');
+	$container->addVar('ship_id');
+	$compareShip['BuyHREF'] = $container->href();
 
 	$template->assign('CompareShip', $compareShip);
 	$template->assign('TradeInValue', floor($ship->getCost() * SHIP_REFUND_PERCENT));

--- a/src/engine/Default/shop_ship_processing.php
+++ b/src/engine/Default/shop_ship_processing.php
@@ -40,6 +40,6 @@ $player->update();
 
 $player->log(LOG_TYPE_HARDWARE, 'Buys a ' . $ship->getName() . ' for ' . $cost . ' credits');
 
-$container = create_container('skeleton.php', 'current_sector.php');
-transfer('LocationID');
-forward($container);
+$container = Page::create('skeleton.php', 'current_sector.php');
+$container->addVar('LocationID');
+$container->go();

--- a/src/engine/Default/shop_weapon_processing.php
+++ b/src/engine/Default/shop_weapon_processing.php
@@ -61,6 +61,6 @@ if (!isset($var['OrderID'])) {
 
 	$player->log(LOG_TYPE_HARDWARE, 'Player Sells a ' . $weapon->getName());
 }
-$container = create_container('skeleton.php', 'shop_weapon.php');
-transfer('LocationID');
-forward($container);
+$container = Page::create('skeleton.php', 'shop_weapon.php');
+$container->addVar('LocationID');
+$container->go();

--- a/src/engine/Default/toggle_processing.php
+++ b/src/engine/Default/toggle_processing.php
@@ -11,4 +11,4 @@ if ($var['toggle'] == 'WeaponHiding') {
 }
 
 $body = $var['referrer'] ?? 'current_sector.php';
-forward(create_container('skeleton.php', $body));
+Page::create('skeleton.php', $body)->go();

--- a/src/engine/Default/trader_attack_processing.php
+++ b/src/engine/Default/trader_attack_processing.php
@@ -78,7 +78,7 @@ $account->log(LOG_TYPE_TRADER_COMBAT, 'Player attacks player, their team does ' 
 $serializedResults = serialize($results);
 $db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLAYER\',' . $db->escapeNumber($sector->getSectorID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($var['target']) . ',' . $db->escapeNumber($targetPlayer->getAllianceID()) . ',' . $db->escapeBinary(gzcompress($serializedResults)) . ')');
 
-$container = create_container('skeleton.php', 'trader_attack.php');
+$container = Page::create('skeleton.php', 'trader_attack.php');
 
 // If their target is dead there is no continue attack button
 if (!$targetPlayer->isDead()) {
@@ -94,4 +94,4 @@ if ($player->isDead()) {
 }
 
 $container['results'] = $serializedResults;
-forward($container);
+$container->go();

--- a/src/engine/Default/trader_examine.php
+++ b/src/engine/Default/trader_examine.php
@@ -4,9 +4,9 @@
 $targetPlayer = SmrPlayer::getPlayer($var['target'], $player->getGameID());
 
 if ($targetPlayer->isDead()) {
-	$container = create_container('skeleton.php', 'current_sector.php');
+	$container = Page::create('skeleton.php', 'current_sector.php');
 	$container['msg'] = '<span class="red bold">ERROR:</span> Target already dead.';
-	forward($container);
+	$container->go();
 }
 
 

--- a/src/engine/Default/trader_search.php
+++ b/src/engine/Default/trader_search.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 $template->assign('PageTopic', 'Search For Trader');
-$template->assign('TraderSearchHREF', SmrSession::getNewHREF(create_container('skeleton.php', 'trader_search_result.php')));
+$template->assign('TraderSearchHREF', Page::create('skeleton.php', 'trader_search_result.php')->href());
 
 if (isset($var['empty_result'])) {
 	$template->assign('EmptyResult', $var['empty_result'] === true);

--- a/src/engine/Default/trader_search_result.php
+++ b/src/engine/Default/trader_search_result.php
@@ -37,46 +37,46 @@ function playerLinks(SmrPlayer $curr_player) {
 	global $player;
 	$result = array('Player' => $curr_player);
 
-	$container = create_container('skeleton.php', 'trader_search_result.php');
+	$container = Page::create('skeleton.php', 'trader_search_result.php');
 	$container['player_id'] = $curr_player->getPlayerID();
-	$result['SearchHREF'] = SmrSession::getNewHREF($container);
+	$result['SearchHREF'] = $container->href();
 
-	$container = create_container('skeleton.php', 'council_list.php');
+	$container = Page::create('skeleton.php', 'council_list.php');
 	$container['race_id'] = $curr_player->getRaceID();
-	$result['RaceHREF'] = SmrSession::getNewHREF($container);
+	$result['RaceHREF'] = $container->href();
 
-	$container = create_container('skeleton.php', 'message_send.php');
+	$container = Page::create('skeleton.php', 'message_send.php');
 	$container['receiver'] = $curr_player->getAccountID();
-	$result['MessageHREF'] = SmrSession::getNewHREF($container);
+	$result['MessageHREF'] = $container->href();
 
-	$container = create_container('skeleton.php', 'bounty_view.php');
+	$container = Page::create('skeleton.php', 'bounty_view.php');
 	$container['id'] = $curr_player->getAccountID();
-	$result['BountyHREF'] = SmrSession::getNewHREF($container);
+	$result['BountyHREF'] = $container->href();
 
-	$container = create_container('skeleton.php', 'hall_of_fame_player_detail.php');
+	$container = Page::create('skeleton.php', 'hall_of_fame_player_detail.php');
 	$container['account_id'] = $curr_player->getAccountID();
 	$container['game_id'] = $curr_player->getGameID();
 	$container['sending_page'] = 'search';
-	$result['HofHREF'] = SmrSession::getNewHREF($container);
+	$result['HofHREF'] = $container->href();
 
-	$container = create_container('skeleton.php', 'news_read_advanced.php');
+	$container = Page::create('skeleton.php', 'news_read_advanced.php');
 	$container['submit'] = 'Search For Player';
 	$container['playerName'] = $curr_player->getPlayerName();
-	$result['NewsHREF'] = SmrSession::getNewHREF($container);
+	$result['NewsHREF'] = $container->href();
 
 	if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
-		$container = create_container('sector_jump_processing.php');
+		$container = Page::create('sector_jump_processing.php');
 		$container['to'] = $curr_player->getSectorID();
-		$result['JumpHREF'] = SmrSession::getNewHREF($container);
+		$result['JumpHREF'] = $container->href();
 	}
 
 	return $result;
 }
 
 if (empty($resultPlayer) && empty($similarPlayers)) {
-	$container = create_container('skeleton.php', 'trader_search.php');
+	$container = Page::create('skeleton.php', 'trader_search.php');
 	$container['empty_result'] = true;
-	forward($container);
+	$container->go();
 }
 
 if (!empty($resultPlayer)) {

--- a/src/engine/Default/trader_status.php
+++ b/src/engine/Default/trader_status.php
@@ -4,20 +4,20 @@ $template->assign('PageTopic', 'Trader Status');
 Menu::trader();
 
 if ($player->hasNewbieTurns()) {
-	$container = create_container('skeleton.php', 'leave_newbie.php');
-	$template->assign('LeaveNewbieHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('skeleton.php', 'leave_newbie.php');
+	$template->assign('LeaveNewbieHREF', $container->href());
 }
 
-$container = create_container('skeleton.php');
+$container = Page::create('skeleton.php');
 $container['body'] = 'trader_relations.php';
-$template->assign('RelationsHREF', SmrSession::getNewHREF($container));
+$template->assign('RelationsHREF', $container->href());
 
 $container['body'] = 'trader_savings.php';
-$template->assign('SavingsHREF', SmrSession::getNewHREF($container));
+$template->assign('SavingsHREF', $container->href());
 
 // Bounties
 $container['body'] = 'trader_bounties.php';
-$template->assign('BountiesHREF', SmrSession::getNewHREF($container));
+$template->assign('BountiesHREF', $container->href());
 
 $db->query('SELECT count(*) FROM bounty WHERE claimer_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
 $db->requireRecord();
@@ -25,7 +25,7 @@ $template->assign('BountiesClaimable', $db->getInt('count(*)'));
 
 // Ship
 $container['body'] = 'configure_hardware.php';
-$template->assign('HardwareHREF', SmrSession::getNewHREF($container));
+$template->assign('HardwareHREF', $container->href());
 
 $hardware = [];
 if ($ship->canHaveScanner()) {
@@ -56,10 +56,10 @@ if (!$db->nextRecord()) {
 $template->assign('NextLevelName', $db->getField('level_name'));
 
 $container['body'] = 'rankings_view.php';
-$template->assign('UserRankingsHREF', SmrSession::getNewHREF($container));
+$template->assign('UserRankingsHREF', $container->href());
 
-$container = create_container('note_delete_processing.php');
-$template->assign('NoteDeleteHREF', SmrSession::getNewHREF($container));
+$container = Page::create('note_delete_processing.php');
+$template->assign('NoteDeleteHREF', $container->href());
 
 $notes = [];
 $db->query('SELECT * FROM player_has_notes WHERE ' . $player->getSQL() . ' ORDER BY note_id DESC');
@@ -68,5 +68,5 @@ while ($db->nextRecord()) {
 }
 $template->assign('Notes', $notes);
 
-$container = create_container('note_add_processing.php');
-$template->assign('NoteAddHREF', SmrSession::getNewHREF($container));
+$container = Page::create('note_add_processing.php');
+$template->assign('NoteAddHREF', $container->href());

--- a/src/engine/Default/underground.php
+++ b/src/engine/Default/underground.php
@@ -21,7 +21,7 @@ $template->assign('AllBounties', getBounties('UG'));
 $template->assign('MyBounties', $player->getClaimableBounties('UG'));
 
 if ($player->getAlignment() < ALIGNMENT_GOOD && $player->getAlignment() >= ALIGNMENT_EVIL) {
-	$container = create_container('government_processing.php');
-	transfer('LocationID');
-	$template->assign('JoinHREF', SmrSession::getNewHREF($container));
+	$container = Page::create('government_processing.php');
+	$container->addVar('LocationID');
+	$template->assign('JoinHREF', $container->href());
 }

--- a/src/engine/Default/validate.php
+++ b/src/engine/Default/validate.php
@@ -4,4 +4,4 @@ if (isset($var['msg'])) {
 }
 
 $template->assign('PageTopic', 'Validation Reminder');
-$template->assign('ValidateFormHref', SmrSession::getNewHREF(create_container('validate_processing.php')));
+$template->assign('ValidateFormHref', Page::create('validate_processing.php')->href());

--- a/src/engine/Default/validate_processing.php
+++ b/src/engine/Default/validate_processing.php
@@ -1,18 +1,18 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php', 'validate.php');
+$container = Page::create('skeleton.php', 'validate.php');
 
 if (Request::get('action') == "resend") {
 	$account->sendValidationEmail();
 	$container['msg'] = '<span class="green">The validation code has been resent to your e-mail address!</span>';
-	forward($container);
+	$container->go();
 }
 
 // Only skip validation check if we explicitly chose to validate later
 if (Request::get('action') != "skip") {
 	if ($account->getValidationCode() != Request::get('validation_code')) {
 		$container['msg'] = '<span class="red">The validation code you entered is incorrect!</span>';
-		forward($container);
+		$container->go();
 	}
 
 	$account->setValidated(true);
@@ -24,6 +24,6 @@ if (Request::get('action') != "skip") {
 				AND notification_type = \'validation_code\'');
 }
 
-$container = create_container('login_check_processing.php');
+$container = Page::create('login_check_processing.php');
 $container['CheckType'] = 'Announcements';
-forward($container);
+$container->go();

--- a/src/engine/Default/vote.php
+++ b/src/engine/Default/vote.php
@@ -13,9 +13,9 @@ if ($db->getNumRows() > 0) {
 	while ($db->nextRecord()) {
 		$voteID = $db->getInt('vote_id');
 		$voting[$voteID]['ID'] = $voteID;
-		$container = create_container('vote.php', 'vote_processing.php');
+		$container = Page::create('vote.php', 'vote_processing.php');
 		$container['vote_id'] = $voteID;
-		$voting[$voteID]['HREF'] = SmrSession::getNewHREF($container);
+		$voting[$voteID]['HREF'] = $container->href();
 		$voting[$voteID]['Question'] = $db->getField('question');
 		if ($db->getInt('end') > SmrSession::getTime()) {
 			$voting[$voteID]['TimeRemaining'] = format_time($db->getInt('end') - SmrSession::getTime(), true);

--- a/src/engine/Default/vote_link.php
+++ b/src/engine/Default/vote_link.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$container = create_container('skeleton.php', 'current_sector.php');
+$container = Page::create('skeleton.php', 'current_sector.php');
 
 // Sanity check that we got here by means of allowing free turns
 if ($var['can_get_turns'] == true) {
@@ -15,4 +15,4 @@ if ($var['can_get_turns'] == true) {
 	}
 }
 
-forward($container);
+$container->go();

--- a/src/engine/Default/vote_processing.php
+++ b/src/engine/Default/vote_processing.php
@@ -6,4 +6,4 @@ if ($account->getAccountID() == ACCOUNT_ID_NHL) {
 
 $db->query('REPLACE INTO voting_results (account_id, vote_id, option_id) VALUES (' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber($var['vote_id']) . ',' . $db->escapeNumber(Request::getInt('vote')) . ')');
 $var['url'] = 'skeleton.php';
-forward($var);
+Page::copy($var)->go();

--- a/src/engine/Default/weapon_reorder_processing.php
+++ b/src/engine/Default/weapon_reorder_processing.php
@@ -12,4 +12,4 @@ if (isset($var['Form'])) {
 	$ship->setWeaponLocations(Request::getIntArray('weapon_reorder'));
 }
 
-forward(create_container('skeleton.php', 'weapon_reorder.php'));
+Page::create('skeleton.php', 'weapon_reorder.php')->go();

--- a/src/engine/Draft/alliance_pick.php
+++ b/src/engine/Draft/alliance_pick.php
@@ -18,7 +18,7 @@ $db->query('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($player->ge
 while ($db->nextRecord()) {
 	$pickPlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
 	$players[] = array('Player' => $pickPlayer,
-						'HREF' => SmrSession::getNewHREF(create_container('alliance_pick_processing.php', '', array('PickedAccountID'=>$pickPlayer->getAccountID()))));
+						'HREF' => Page::create('alliance_pick_processing.php', '', array('PickedAccountID'=>$pickPlayer->getAccountID()))->href());
 }
 
 $template->assign('PickPlayers', $players);

--- a/src/engine/Draft/alliance_pick_processing.php
+++ b/src/engine/Draft/alliance_pick_processing.php
@@ -39,4 +39,4 @@ $pickedPlayer->update();
 // Update the draft history
 $db->query('INSERT INTO draft_history (game_id, leader_account_id, picked_account_id, time) VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($pickedPlayer->getAccountID()) . ', ' . $db->escapeNumber(SmrSession::getTime()) . ')');
 
-forward(create_container('skeleton.php', 'alliance_pick.php'));
+Page::create('skeleton.php', 'alliance_pick.php')->go();

--- a/src/engine/Draft/alliance_remove_member_processing.php
+++ b/src/engine/Draft/alliance_remove_member_processing.php
@@ -24,4 +24,4 @@ foreach ($accountIDs as $accountID) {
 	$currPlayer->setLandedOnPlanet(false);
 }
 
-forward(create_container('skeleton.php', 'alliance_roster.php'));
+Page::create('skeleton.php', 'alliance_roster.php')->go();

--- a/src/htdocs/album/album_comment.php
+++ b/src/htdocs/album/album_comment.php
@@ -34,10 +34,10 @@ try {
 		if (!$account->hasPermission(PERMISSION_MODERATE_PHOTO_ALBUM)) {
 			create_error_offline('You do not have permission to do that!');
 		}
-		$container = create_container('skeleton.php', 'album_moderate.php');
+		$container = Page::create('skeleton.php', 'album_moderate.php');
 		$container['account_id'] = $album_id;
 
-		$href = SmrSession::getNewHREF($container, true);
+		$href = $container->href(true);
 		SmrSession::update();
 
 		header('Location: ' . $href);

--- a/src/htdocs/loader.php
+++ b/src/htdocs/loader.php
@@ -21,7 +21,6 @@ try {
 	$player = null;
 	$ship = null;
 	$sector = null;
-	$container = null;
 	$var = null;
 	$lock = false;
 	$db = MySqlDatabase::getInstance();
@@ -95,16 +94,16 @@ try {
 		if ($disabled['Reason'] == CLOSE_ACCOUNT_INVALID_EMAIL_REASON) {
 			if (isset($var['do_reopen_account'])) {
 				// The user has attempted to re-validate their e-mail
-				forward(create_container('invalid_email_processing.php'));
+				Page::create('invalid_email_processing.php')->go();
 			} else {
-				forward(create_container('skeleton.php', 'invalid_email.php'));
+				Page::create('skeleton.php', 'invalid_email.php')->go();
 			}
 		} elseif ($disabled['Reason'] == CLOSE_ACCOUNT_BY_REQUEST_REASON) {
 			if (isset($var['do_reopen_account'])) {
 				// The user has requested to reopen their account
 				$account->unbanAccount($account);
 			} else {
-				forward(create_container('skeleton.php', 'reopen_account.php'));
+				Page::create('skeleton.php', 'reopen_account.php')->go();
 			}
 		} else {
 			throw new Exception('Unexpected disabled reason');

--- a/src/htdocs/login.php
+++ b/src/htdocs/login.php
@@ -19,7 +19,7 @@ try {
 		// update last login column
 		$account->updateLastLogin();
 
-		$href = SmrSession::getNewHREF(create_container('login_check_processing.php'), true);
+		$href = Page::create('login_check_processing.php')->href(true);
 		SmrSession::update();
 
 		header('Location: ' . $href);

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -55,7 +55,7 @@ try {
 	}
 
 	// this sn identifies our container later
-	$href = SmrSession::getNewHREF(create_container('login_check_processing.php'), true);
+	$href = Page::create('login_check_processing.php')->href(true);
 	SmrSession::update();
 
 	// get this user from db

--- a/src/lib/Default/AbstractMenu.class.php
+++ b/src/lib/Default/AbstractMenu.class.php
@@ -22,12 +22,12 @@ class AbstractMenu {
 		$links[] = ['bounty_place.php', 'Place Bounty'];
 
 		$menuItems = [];
-		$container = create_container('skeleton.php');
+		$container = Page::create('skeleton.php');
 		$container['LocationID'] = $var['LocationID'];
 		foreach ($links as $link) {
 			$container['body'] = $link[0];
 			$menuItems[] = [
-				'Link' => SmrSession::getNewHREF($container),
+				'Link' => $container->href(),
 				'Text' => $link[1],
 			];
 		}
@@ -105,11 +105,11 @@ class AbstractMenu {
 	public static function galactic_post() {
 		global $template, $player;
 		$menuItems = array();
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF(create_container('galactic_post_current.php')), 'Text'=>'Current Edition');
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF(create_container('skeleton.php', 'galactic_post_past.php')), 'Text'=>'Past Editions');
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF(create_container('skeleton.php', 'galactic_post_write_article.php')), 'Text'=>'Write an article');
+		$menuItems[] = array('Link'=>Page::create('galactic_post_current.php')->href(), 'Text'=>'Current Edition');
+		$menuItems[] = array('Link'=>Page::create('skeleton.php', 'galactic_post_past.php')->href(), 'Text'=>'Past Editions');
+		$menuItems[] = array('Link'=>Page::create('skeleton.php', 'galactic_post_write_article.php')->href(), 'Text'=>'Write an article');
 		if ($player->isGPEditor()) {
-			$menuItems[] = array('Link'=>SmrSession::getNewHREF(create_container('skeleton.php', 'galactic_post.php')), 'Text'=>'Editor Options');
+			$menuItems[] = array('Link'=>Page::create('skeleton.php', 'galactic_post.php')->href(), 'Text'=>'Editor Options');
 		}
 		$template->assign('MenuItems', $menuItems);
 	}
@@ -117,27 +117,27 @@ class AbstractMenu {
 	public static function history_games($selected_index) {
 		global $template, $var;
 		$menuItems = [];
-		$container = create_container('skeleton.php', 'history_games.php');
+		$container = Page::create('skeleton.php', 'history_games.php');
 		$container['HistoryDatabase'] = $var['HistoryDatabase'];
 		$container['view_game_id'] = $var['view_game_id'];
 		$container['game_name'] = $var['game_name'];
 		$menuItems[] = [
-			'Link' => SmrSession::getNewHREF($container),
+			'Link' => $container->href(),
 			'Text' => 'Game Details',
 		];
 		$container['body'] = 'history_games_detail.php';
 		$menuItems[] = [
-			'Link' => SmrSession::getNewHREF($container),
+			'Link' => $container->href(),
 			'Text' => 'Extended Stats',
 		];
 		$container['body'] = 'history_games_hof.php';
 		$menuItems[] = [
-			'Link' => SmrSession::getNewHREF($container),
+			'Link' => $container->href(),
 			'Text' => 'Hall of Fame',
 		];
 		$container['body'] = 'history_games_news.php';
 		$menuItems[] = [
-			'Link' => SmrSession::getNewHREF($container),
+			'Link' => $container->href(),
 			'Text' => 'Game News',
 		];
 		// make the selected index bold
@@ -162,21 +162,21 @@ class AbstractMenu {
 	public static function combat_log() {
 		global $template;
 
-		$container = create_container('skeleton.php', 'combat_log_list.php');
+		$container = Page::create('skeleton.php', 'combat_log_list.php');
 		$menuItems = array();
 
 		$container['action'] = COMBAT_LOG_PERSONAL;
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF($container), 'Text'=>'Personal');
+		$menuItems[] = array('Link'=>$container->href(), 'Text'=>'Personal');
 		$container['action'] = COMBAT_LOG_ALLIANCE;
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF($container), 'Text'=>'Alliance');
+		$menuItems[] = array('Link'=>$container->href(), 'Text'=>'Alliance');
 		$container['action'] = COMBAT_LOG_FORCE;
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF($container), 'Text'=>'Force');
+		$menuItems[] = array('Link'=>$container->href(), 'Text'=>'Force');
 		$container['action'] = COMBAT_LOG_PORT;
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF($container), 'Text'=>'Port');
+		$menuItems[] = array('Link'=>$container->href(), 'Text'=>'Port');
 		$container['action'] = COMBAT_LOG_PLANET;
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF($container), 'Text'=>'Planet');
+		$menuItems[] = array('Link'=>$container->href(), 'Text'=>'Planet');
 		$container['action'] = COMBAT_LOG_SAVED;
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF($container), 'Text'=>'Saved');
+		$menuItems[] = array('Link'=>$container->href(), 'Text'=>'Saved');
 
 		$template->assign('MenuItems', $menuItems);
 	}
@@ -226,14 +226,14 @@ class AbstractMenu {
 
 		// player rankings
 		$menu_item = array();
-		$menu_item['entry'] = create_link(create_container('skeleton.php', 'rankings_player_experience.php'), 'Player Rankings', 'nav');
+		$menu_item['entry'] = create_link(Page::create('skeleton.php', 'rankings_player_experience.php'), 'Player Rankings', 'nav');
 
 		$menu_subitem = array();
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_player_experience.php'), 'Experience', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_player_profit.php'), 'Profit', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_player_kills.php'), 'Kills', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_player_death.php'), 'Deaths', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_player_assists.php'), 'Assists', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_player_experience.php'), 'Experience', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_player_profit.php'), 'Profit', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_player_kills.php'), 'Kills', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_player_death.php'), 'Deaths', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_player_assists.php'), 'Assists', 'nav');
 
 		$menu_item['submenu'] = $menu_subitem;
 
@@ -241,14 +241,14 @@ class AbstractMenu {
 
 		// alliance rankings
 		$menu_item = array();
-		$menu_item['entry'] = create_link(create_container('skeleton.php', 'rankings_alliance_experience.php'), 'Alliance Rankings', 'nav');
+		$menu_item['entry'] = create_link(Page::create('skeleton.php', 'rankings_alliance_experience.php'), 'Alliance Rankings', 'nav');
 
 		$menu_subitem = array();
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_alliance_experience.php'), 'Experience', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_alliance_profit.php'), 'Profit', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_alliance_kills.php'), 'Kills', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_alliance_death.php'), 'Deaths', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_alliance_vs_alliance.php'), 'Versus', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_alliance_experience.php'), 'Experience', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_alliance_profit.php'), 'Profit', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_alliance_kills.php'), 'Kills', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_alliance_death.php'), 'Deaths', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_alliance_vs_alliance.php'), 'Versus', 'nav');
 
 		$menu_item['submenu'] = $menu_subitem;
 
@@ -256,12 +256,12 @@ class AbstractMenu {
 
 		// racial rankings
 		$menu_item = array();
-		$menu_item['entry'] = create_link(create_container('skeleton.php', 'rankings_race.php'), 'Racial Standings', 'nav');
+		$menu_item['entry'] = create_link(Page::create('skeleton.php', 'rankings_race.php'), 'Racial Standings', 'nav');
 
 		$menu_subitem = array();
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_race.php'), 'Experience', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_race_kills.php'), 'Kills', 'nav');
-		$menu_subitem[] = create_link(create_container('skeleton.php', 'rankings_race_death.php'), 'Deaths', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_race.php'), 'Experience', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_race_kills.php'), 'Kills', 'nav');
+		$menu_subitem[] = create_link(Page::create('skeleton.php', 'rankings_race_death.php'), 'Deaths', 'nav');
 
 		$menu_item['submenu'] = $menu_subitem;
 
@@ -269,7 +269,7 @@ class AbstractMenu {
 
 		// sector rankings
 		$menu_item = array();
-		$menu_item['entry'] = create_link(create_container('skeleton.php', 'rankings_sector_kill.php'), 'Sector Kills', 'nav');
+		$menu_item['entry'] = create_link(Page::create('skeleton.php', 'rankings_sector_kill.php'), 'Sector Kills', 'nav');
 		$menu[] = $menu_item;
 
 		create_sub_menu($menu, $active_level1, $active_level2);
@@ -286,11 +286,11 @@ class AbstractMenu {
 		$links[] = ['bank_anon.php', 'Anonymous Account'];
 
 		$menuItems = [];
-		$container = create_container('skeleton.php');
+		$container = Page::create('skeleton.php');
 		foreach ($links as $link) {
 			$container['body'] = $link[0];
 			$menuItems[] = [
-				'Link' => SmrSession::getNewHREF($container),
+				'Link' => $container->href(),
 				'Text' => $link[1],
 			];
 		}
@@ -300,40 +300,40 @@ class AbstractMenu {
 	public static function council($race_id) {
 		global $player, $template;
 
-		$container = create_container('skeleton.php', 'council_list.php');
+		$container = Page::create('skeleton.php', 'council_list.php');
 		$menu_items = [];
 		$menu_items[] = [
-			'Link' => SmrSession::getNewHREF($container),
+			'Link' => $container->href(),
 			'Text' => 'View Council',
 		];
 
-		$container = create_container('skeleton.php');
+		$container = Page::create('skeleton.php');
 		$container['body'] = 'council_politics.php';
 		$container['race_id'] = $race_id;
 		$menu_items[] = [
-			'Link' => SmrSession::getNewHREF($container),
+			'Link' => $container->href(),
 			'Text' => 'Political Status',
 		];
 
 		$container['body'] = 'council_send_message.php';
 		$container['race_id'] = $race_id;
 		$menu_items[] = [
-			'Link' => SmrSession::getNewHREF($container),
+			'Link' => $container->href(),
 			'Text' => 'Send Message',
 		];
 
 		if ($player->getRaceID() == $race_id) {
 			if ($player->isOnCouncil()) {
-				$container = create_container('skeleton.php', 'council_vote.php');
+				$container = Page::create('skeleton.php', 'council_vote.php');
 				$menu_items[] = [
-					'Link' => SmrSession::getNewHREF($container),
+					'Link' => $container->href(),
 					'Text' => 'Voting Center',
 				];
 			}
 			if ($player->isPresident()) {
-				$container = create_container('skeleton.php', 'council_embassy.php');
+				$container = Page::create('skeleton.php', 'council_embassy.php');
 				$menu_items[] = [
-					'Link' => SmrSession::getNewHREF($container),
+					'Link' => $container->href(),
 					'Text' => 'Embassy',
 				];
 			}
@@ -354,10 +354,10 @@ class AbstractMenu {
 		global $var;
 		$menuItems = array();
 		if (SmrSession::getGameID() == $var['GameID']) {
-			$menuItems[] = array('Link'=>SmrSession::getNewHREF(create_container('skeleton.php', 'news_read_current.php', array('GameID'=>$var['GameID']))), 'Text'=>'Read Current News');
+			$menuItems[] = array('Link'=>Page::create('skeleton.php', 'news_read_current.php', array('GameID'=>$var['GameID']))->href(), 'Text'=>'Read Current News');
 		}
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF(create_container('skeleton.php', 'news_read.php', array('GameID'=>$var['GameID']))), 'Text'=>'Read Latest News');
-		$menuItems[] = array('Link'=>SmrSession::getNewHREF(create_container('skeleton.php', 'news_read_advanced.php', array('GameID'=>$var['GameID']))), 'Text'=>'Advanced News');
+		$menuItems[] = array('Link'=>Page::create('skeleton.php', 'news_read.php', array('GameID'=>$var['GameID']))->href(), 'Text'=>'Read Latest News');
+		$menuItems[] = array('Link'=>Page::create('skeleton.php', 'news_read_advanced.php', array('GameID'=>$var['GameID']))->href(), 'Text'=>'Advanced News');
 
 		$template->assign('MenuItems', $menuItems);
 	}

--- a/src/lib/Default/AbstractSmrAccount.class.php
+++ b/src/lib/Default/AbstractSmrAccount.class.php
@@ -1242,14 +1242,14 @@ abstract class AbstractSmrAccount {
 
 	public function getToggleAJAXHREF() : string {
 		global $var;
-		return SmrSession::getNewHREF(create_container('toggle_processing.php', '', array('toggle'=>'AJAX', 'referrer'=>$var['body'])));
+		return Page::create('toggle_processing.php', '', array('toggle'=>'AJAX', 'referrer'=>$var['body']))->href();
 	}
 
 	public function getUserRankingHREF() : string {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'rankings_view.php'));
+		return Page::create('skeleton.php', 'rankings_view.php')->href();
 	}
 
 	public function getPersonalHofHREF() : string {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'hall_of_fame_player_detail.php', array('account_id' => $this->getAccountID())));
+		return Page::create('skeleton.php', 'hall_of_fame_player_detail.php', array('account_id' => $this->getAccountID()))->href();
 	}
 }

--- a/src/lib/Default/AbstractSmrLocation.class.php
+++ b/src/lib/Default/AbstractSmrLocation.class.php
@@ -385,15 +385,15 @@ class AbstractSmrLocation {
 	}
 
 	public function getExamineHREF() : string {
-		$container = create_container('skeleton.php', $this->getAction());
+		$container = Page::create('skeleton.php', $this->getAction());
 		$container['LocationID'] = $this->getTypeID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getEditHREF() : string {
-		$container = create_container('skeleton.php', 'location_edit.php');
+		$container = Page::create('skeleton.php', 'location_edit.php');
 		$container['location_type_id'] = $this->getTypeID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function equals(SmrLocation $otherLocation) : bool {

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -3032,13 +3032,13 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function getLeaveNewbieProtectionHREF() {
-		return SmrSession::getNewHREF(create_container('leave_newbie_processing.php'));
+		return Page::create('leave_newbie_processing.php')->href();
 	}
 
 	public function getExamineTraderHREF() {
-		$container = create_container('skeleton.php', 'trader_examine.php');
+		$container = Page::create('skeleton.php', 'trader_examine.php');
 		$container['target'] = $this->getAccountID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getAttackTraderHREF() {
@@ -3046,15 +3046,15 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function getPlanetKickHREF() {
-		$container = create_container('planet_kick_processing.php', 'trader_attack_processing.php');
+		$container = Page::create('planet_kick_processing.php', 'trader_attack_processing.php');
 		$container['account_id'] = $this->getAccountID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getTraderSearchHREF() {
-		$container = create_container('skeleton.php', 'trader_search_result.php');
+		$container = Page::create('skeleton.php', 'trader_search_result.php');
 		$container['player_id'] = $this->getPlayerID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getAllianceRosterHREF() {
@@ -3062,10 +3062,10 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function getToggleWeaponHidingHREF($ajax = false) {
-		$container = create_container('toggle_processing.php');
+		$container = Page::create('toggle_processing.php');
 		$container['toggle'] = 'WeaponHiding';
 		$container['AJAX'] = $ajax;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function isDisplayWeapons() {

--- a/src/lib/Default/AbstractSmrPort.class.php
+++ b/src/lib/Default/AbstractSmrPort.class.php
@@ -1025,42 +1025,42 @@ class AbstractSmrPort {
 	}
 
 	public function getRaidWarningHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'port_attack_warning.php'));
+		return Page::create('skeleton.php', 'port_attack_warning.php')->href();
 	}
 
 	public function getAttackHREF() {
-		$container = create_container('port_attack_processing.php');
+		$container = Page::create('port_attack_processing.php');
 		$container['port_id'] = $this->getSectorID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getClaimHREF() {
-		$container = create_container('port_claim_processing.php');
+		$container = Page::create('port_claim_processing.php');
 		$container['port_id'] = $this->getSectorID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getRazeHREF($justContainer = false) {
-		$container = create_container('port_payout_processing.php');
+		$container = Page::create('port_payout_processing.php');
 		$container['PayoutType'] = 'Raze';
-		return $justContainer === false ? SmrSession::getNewHREF($container) : $container;
+		return $justContainer === false ? $container->href() : $container;
 	}
 
 	public function getLootHREF($justContainer = false) {
 		if ($this->getCredits() > 0) {
-			$container = create_container('port_payout_processing.php');
+			$container = Page::create('port_payout_processing.php');
 			$container['PayoutType'] = 'Loot';
 		} else {
-			$container = create_container('skeleton.php', 'current_sector.php');
+			$container = Page::create('skeleton.php', 'current_sector.php');
 			$container['msg'] = 'This port has already been looted.';
 		}
-		return $justContainer === false ? SmrSession::getNewHREF($container) : $container;
+		return $justContainer === false ? $container->href() : $container;
 	}
 
 	public function getLootGoodHREF($boughtGoodID) {
-		$container = create_container('port_loot_processing.php');
+		$container = Page::create('port_loot_processing.php');
 		$container['GoodID'] = $boughtGoodID;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 	public function isCachedVersion() {
 		return $this->cachedVersion;

--- a/src/lib/Default/ChessGame.class.php
+++ b/src/lib/Default/ChessGame.class.php
@@ -863,10 +863,10 @@ class ChessGame {
 	}
 
 	public function getPlayGameHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'chess_play.php', array('ChessGameID' => $this->chessGameID)));
+		return Page::create('skeleton.php', 'chess_play.php', array('ChessGameID' => $this->chessGameID))->href();
 	}
 
 	public function getResignHREF() {
-		return SmrSession::getNewHREF(create_container('chess_resign_processing.php', '', array('ChessGameID' => $this->chessGameID)));
+		return Page::create('chess_resign_processing.php', '', array('ChessGameID' => $this->chessGameID))->href();
 	}
 }

--- a/src/lib/Default/Globals.class.php
+++ b/src/lib/Default/Globals.class.php
@@ -122,7 +122,7 @@ class Globals {
 	public static function getColouredRaceName($raceID, $relations, $linked = true) {
 		$raceName = get_colored_text($relations, Globals::getRaceName($raceID));
 		if ($linked === true) {
-			$container = create_container('skeleton.php', 'council_list.php', array('race_id' => $raceID));
+			$container = Page::create('skeleton.php', 'council_list.php', array('race_id' => $raceID));
 			$raceName = create_link($container, $raceName);
 		}
 		return $raceName;
@@ -269,53 +269,53 @@ class Globals {
 	}
 
 	public static function getFeatureRequestHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'feature_request.php'));
+		return Page::create('skeleton.php', 'feature_request.php')->href();
 	}
 
 	public static function getCurrentSectorHREF() {
-		return self::$AVAILABLE_LINKS['CurrentSector'] = SmrSession::getNewHREF(create_container('skeleton.php', 'current_sector.php'));
+		return self::$AVAILABLE_LINKS['CurrentSector'] = Page::create('skeleton.php', 'current_sector.php')->href();
 	}
 
 	public static function getLocalMapHREF() {
-		return self::$AVAILABLE_LINKS['LocalMap'] = SmrSession::getNewHREF(create_container('skeleton.php', 'map_local.php'));
+		return self::$AVAILABLE_LINKS['LocalMap'] = Page::create('skeleton.php', 'map_local.php')->href();
 	}
 
 	public static function getCurrentPlayersHREF() {
-		return self::$AVAILABLE_LINKS['CurrentPlayers'] = SmrSession::getNewHREF(create_container('skeleton.php', 'current_players.php'));
+		return self::$AVAILABLE_LINKS['CurrentPlayers'] = Page::create('skeleton.php', 'current_players.php')->href();
 	}
 
 	public static function getTradeHREF() {
-		return self::$AVAILABLE_LINKS['EnterPort'] = SmrSession::getNewHREF(create_container('skeleton.php', 'shop_goods.php'));
+		return self::$AVAILABLE_LINKS['EnterPort'] = Page::create('skeleton.php', 'shop_goods.php')->href();
 	}
 
 	public static function getAttackTraderHREF($accountID) {
-		$container = create_container('trader_attack_processing.php');
+		$container = Page::create('trader_attack_processing.php');
 		$container['target'] = $accountID;
-		return self::$AVAILABLE_LINKS['AttackTrader'] = SmrSession::getNewHREF($container);
+		return self::$AVAILABLE_LINKS['AttackTrader'] = $container->href();
 	}
 
 	public static function getPodScreenHREF() {
-		return SmrSession::getNewHREF(create_container('death_processing.php'));
+		return Page::create('death_processing.php')->href();
 	}
 
 	public static function getBetaFunctionsHREF() { //BETA
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'beta_functions.php'));
+		return Page::create('skeleton.php', 'beta_functions.php')->href();
 	}
 
 	public static function getBugReportProcessingHREF() {
-		return SmrSession::getNewHREF(create_container('bug_report_processing.php'));
+		return Page::create('bug_report_processing.php')->href();
 	}
 
 	public static function getWeaponReorderHREF($weaponOrderID, $direction) {
-		$container = create_container('weapon_reorder_processing.php');
+		$container = Page::create('weapon_reorder_processing.php');
 		$container[$direction] = $weaponOrderID;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getSmrFileCreateHREF($adminCreateGameID = false) {
-		$container = create_container('skeleton.php', 'smr_file_create.php');
+		$container = Page::create('skeleton.php', 'smr_file_create.php');
 		$container['AdminCreateGameID'] = $adminCreateGameID;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getCurrentSectorMoveHREF($toSector) {
@@ -324,49 +324,49 @@ class Globals {
 
 	public static function getSectorMoveHREF($toSector, $targetPage) {
 		global $player;
-		$container = create_container('sector_move_processing.php');
+		$container = Page::create('sector_move_processing.php');
 		$container['target_page'] = $targetPage;
 		$container['target_sector'] = $toSector;
-		return self::$AVAILABLE_LINKS['Move' . $player->getSector()->getSectorDirection($toSector)] = SmrSession::getNewHREF($container);
+		return self::$AVAILABLE_LINKS['Move' . $player->getSector()->getSectorDirection($toSector)] = $container->href();
 	}
 
 	public static function getSectorScanHREF($toSector) {
 		global $player;
-		$container = create_container('skeleton.php', 'sector_scan.php');
+		$container = Page::create('skeleton.php', 'sector_scan.php');
 		$container['target_sector'] = $toSector;
-		return self::$AVAILABLE_LINKS['Scan' . $player->getSector()->getSectorDirection($toSector)] = SmrSession::getNewHREF($container);
+		return self::$AVAILABLE_LINKS['Scan' . $player->getSector()->getSectorDirection($toSector)] = $container->href();
 	}
 
 	public static function getPlotCourseHREF($fromSector = false, $toSector = false) {
 		if ($fromSector === false && $toSector === false) {
-			return self::$AVAILABLE_LINKS['PlotCourse'] = SmrSession::getNewHREF(create_container('skeleton.php', 'course_plot.php'));
+			return self::$AVAILABLE_LINKS['PlotCourse'] = Page::create('skeleton.php', 'course_plot.php')->href();
 		} else {
-			return SmrSession::getNewHREF(create_container('course_plot_processing.php', '', array('from'=>$fromSector, 'to'=>$toSector)));
+			return Page::create('course_plot_processing.php', '', array('from'=>$fromSector, 'to'=>$toSector))->href();
 		}
 	}
 
 	public static function getPlanetMainHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_main.php'));
+		return Page::create('skeleton.php', 'planet_main.php')->href();
 	}
 
 	public static function getPlanetConstructionHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_construction.php'));
+		return Page::create('skeleton.php', 'planet_construction.php')->href();
 	}
 
 	public static function getPlanetDefensesHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_defense.php'));
+		return Page::create('skeleton.php', 'planet_defense.php')->href();
 	}
 
 	public static function getPlanetOwnershipHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_ownership.php'));
+		return Page::create('skeleton.php', 'planet_ownership.php')->href();
 	}
 
 	public static function getPlanetStockpileHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_stockpile.php'));
+		return Page::create('skeleton.php', 'planet_stockpile.php')->href();
 	}
 
 	public static function getPlanetFinancesHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_financial.php'));
+		return Page::create('skeleton.php', 'planet_financial.php')->href();
 	}
 
 	public static function getAllianceHREF($allianceID = null) {
@@ -378,139 +378,139 @@ class Globals {
 	}
 
 	public static function getAllianceBankHREF($allianceID = null) {
-		$container = create_container('skeleton.php', 'bank_alliance.php');
+		$container = Page::create('skeleton.php', 'bank_alliance.php');
 		if ($allianceID != null) {
 			$container['alliance_id'] = $allianceID;
 		}
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getAllianceRosterHREF($allianceID = null) {
-		$container = create_container('skeleton.php', 'alliance_roster.php');
+		$container = Page::create('skeleton.php', 'alliance_roster.php');
 		if ($allianceID != null) {
 			$container['alliance_id'] = $allianceID;
 		}
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getAllianceListHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'alliance_list.php'));
+		return Page::create('skeleton.php', 'alliance_list.php')->href();
 	}
 
 	public static function getAllianceNewsHREF($allianceID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'news_read_advanced.php', array('allianceID'=>$allianceID, 'submit' => 'Search For Alliance')));
+		return Page::create('skeleton.php', 'news_read_advanced.php', array('allianceID'=>$allianceID, 'submit' => 'Search For Alliance'))->href();
 	}
 
 	public static function getAllianceMotdHREF($allianceID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'alliance_mod.php', array('alliance_id'=>$allianceID)));
+		return Page::create('skeleton.php', 'alliance_mod.php', array('alliance_id'=>$allianceID))->href();
 	}
 
 	public static function getAllianceMessageHREF($allianceID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'alliance_broadcast.php', array('alliance_id'=>$allianceID)));
+		return Page::create('skeleton.php', 'alliance_broadcast.php', array('alliance_id'=>$allianceID))->href();
 	}
 
 	public static function getAllianceMessageBoardHREF($allianceID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'alliance_message.php', array('alliance_id'=>$allianceID)));
+		return Page::create('skeleton.php', 'alliance_message.php', array('alliance_id'=>$allianceID))->href();
 	}
 
 	public static function getAllianceForcesHREF($allianceID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'alliance_forces.php', array('alliance_id'=>$allianceID)));
+		return Page::create('skeleton.php', 'alliance_forces.php', array('alliance_id'=>$allianceID))->href();
 	}
 
 	public static function getAllianceOptionsHREF($allianceID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'alliance_option.php', array('alliance_id'=>$allianceID)));
+		return Page::create('skeleton.php', 'alliance_option.php', array('alliance_id'=>$allianceID))->href();
 	}
 
 	public static function getPlanetListHREF($allianceID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_list.php', array('alliance_id'=>$allianceID)));
+		return Page::create('skeleton.php', 'planet_list.php', array('alliance_id'=>$allianceID))->href();
 	}
 
 	public static function getPlanetListFinancialHREF($allianceID) {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_list_financial.php', array('alliance_id'=>$allianceID)));
+		return Page::create('skeleton.php', 'planet_list_financial.php', array('alliance_id'=>$allianceID))->href();
 	}
 
 	public static function getViewMessageBoxesHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'message_box.php'));
+		return Page::create('skeleton.php', 'message_box.php')->href();
 	}
 
 	public static function getSendGlobalMessageHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'message_send.php'));
+		return Page::create('skeleton.php', 'message_send.php')->href();
 	}
 
 	public static function getManageBlacklistHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'message_blacklist.php'));
+		return Page::create('skeleton.php', 'message_blacklist.php')->href();
 	}
 
 	public static function getSendCouncilMessageHREF($raceID) {
-		$container = create_container('skeleton.php', 'council_send_message.php');
+		$container = Page::create('skeleton.php', 'council_send_message.php');
 		$container['race_id'] = $raceID;
 		$container['folder_id'] = MSG_POLITICAL;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getTraderStatusHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'trader_status.php'));
+		return Page::create('skeleton.php', 'trader_status.php')->href();
 	}
 
 	public static function getCouncilHREF($raceID = false) {
-		$container = create_container('skeleton.php', 'council_list.php');
+		$container = Page::create('skeleton.php', 'council_list.php');
 		if ($raceID !== false) {
 			$container['race_id'] = $raceID;
 		}
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getTraderRelationsHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'trader_relations.php'));
+		return Page::create('skeleton.php', 'trader_relations.php')->href();
 	}
 
 	public static function getTraderBountiesHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'trader_bounties.php'));
+		return Page::create('skeleton.php', 'trader_bounties.php')->href();
 	}
 
 	public static function getPoliticsHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'council_list.php'));
+		return Page::create('skeleton.php', 'council_list.php')->href();
 	}
 
 	public static function getCasinoHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'chess.php'));
+		return Page::create('skeleton.php', 'chess.php')->href();
 	}
 
 	public static function getChessHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'chess.php'));
+		return Page::create('skeleton.php', 'chess.php')->href();
 	}
 
 	public static function getChessCreateHREF() {
-		return SmrSession::getNewHREF(create_container('chess_create_processing.php'));
+		return Page::create('chess_create_processing.php')->href();
 	}
 
 	public static function getBarMainHREF() {
 		global $var;
-		$container = create_container('skeleton.php', 'bar_main.php');
+		$container = Page::create('skeleton.php', 'bar_main.php');
 		$container['LocationID'] = $var['LocationID'];
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getBarLottoPlayHREF() {
 		global $var;
-		$container = create_container('skeleton.php', 'bar_lotto_buy.php');
+		$container = Page::create('skeleton.php', 'bar_lotto_buy.php');
 		$container['LocationID'] = $var['LocationID'];
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getBarBlackjackHREF() {
 		global $var;
-		$container = create_container('skeleton.php', 'bar_gambling_bet.php');
+		$container = Page::create('skeleton.php', 'bar_gambling_bet.php');
 		$container['LocationID'] = $var['LocationID'];
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getBuyMessageNotificationsHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'buy_message_notifications.php'));
+		return Page::create('skeleton.php', 'buy_message_notifications.php')->href();
 	}
 
 	public static function getBuyShipNameHREF() {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'buy_ship_name.php'));
+		return Page::create('skeleton.php', 'buy_ship_name.php')->href();
 	}
 
 	public static function getBuyShipNameCosts() : array {

--- a/src/lib/Default/Mission.class.php
+++ b/src/lib/Default/Mission.class.php
@@ -3,19 +3,19 @@
 class Mission {
 
 	public static function getAcceptHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('mission_accept_processing.php', '', ['MissionID' => $missionID]));
+		return Page::create('mission_accept_processing.php', '', ['MissionID' => $missionID])->href();
 	}
 
 	public static function getDeclineHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('mission_decline_processing.php', '', ['MissionID' => $missionID]));
+		return Page::create('mission_decline_processing.php', '', ['MissionID' => $missionID])->href();
 	}
 
 	public static function getAbandonHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('mission_abandon_processing.php', '', ['MissionID' => $missionID]));
+		return Page::create('mission_abandon_processing.php', '', ['MissionID' => $missionID])->href();
 	}
 
 	public static function getClaimRewardHREF($missionID) {
-		return SmrSession::getNewHREF(create_container('mission_claim_processing.php', '', ['MissionID' => $missionID]));
+		return Page::create('mission_claim_processing.php', '', ['MissionID' => $missionID])->href();
 	}
 
 }

--- a/src/lib/Default/Page.class.php
+++ b/src/lib/Default/Page.class.php
@@ -120,7 +120,7 @@ class Page extends ArrayObject {
 	 * accompany them.
 	 */
 	public static function create($file, $body = '', array|Page $extra = [], $remainingPageLoads = null) : self {
-		if ($extra instanceof ArrayObject) {
+		if ($extra instanceof Page) {
 			// to avoid making $container a reference to $extra
 			$extra = $extra->getArrayCopy();
 		}
@@ -173,7 +173,7 @@ class Page extends ArrayObject {
 	/**
 	 * Transfer data from $var into this container.
 	 */
-	function addVar(string $what) : void {
+	public function addVar(string $what) : void {
 		global $var;
 
 		// transfer this value to next container
@@ -210,7 +210,7 @@ class Page extends ArrayObject {
 		// 'CommonID' MUST be unique to a specific action. If there will
 		// be two different outcomes from containers given the same ID then
 		// problems will likely arise.
-		$copy['CommonID'] = self::getCommonID();
+		$copy['CommonID'] = $this->getCommonID();
 		$sn = SmrSession::addLink($copy);
 
 		if ($forceFullURL === true || stripos($_SERVER['REQUEST_URI'], 'loader.php') === false) {

--- a/src/lib/Default/Page.class.php
+++ b/src/lib/Default/Page.class.php
@@ -119,7 +119,7 @@ class Page extends ArrayObject {
 	 * This is the standard method to package linked pages and the data to
 	 * accompany them.
 	 */
-	public static function create($file, $body = '', array|Page $extra = [], $remainingPageLoads = null) : self {
+	public static function create($file, $body = '', Page|array $extra = [], $remainingPageLoads = null) : self {
 		if ($extra instanceof Page) {
 			// to avoid making $container a reference to $extra
 			$extra = $extra->getArrayCopy();

--- a/src/lib/Default/Page.class.php
+++ b/src/lib/Default/Page.class.php
@@ -1,0 +1,238 @@
+<?php declare(strict_types=1);
+
+/**
+ * A container that holds data needed to create a new page.
+ *
+ * This class acts like an array, whose keys define the page properties.
+ * Then we can either create an HREF so that it can be accessed by a future
+ * http request (via the SmrSession), or forwarded to within the same request.
+ */
+class Page extends ArrayObject {
+
+	private const ALWAYS_AVAILABLE = 999999;
+
+	// Defines the number of pages that can be loaded after
+	// this page before the links on this page become invalid
+	// (i.e. before you get a back button error).
+	private const URL_DEFAULT_REMAINING_PAGE_LOADS = array(
+			'alliance_broadcast.php' => self::ALWAYS_AVAILABLE,
+			'alliance_forces.php' => self::ALWAYS_AVAILABLE,
+			'alliance_list.php' => self::ALWAYS_AVAILABLE,
+			'alliance_message_view.php' => self::ALWAYS_AVAILABLE,
+			'alliance_message.php' => self::ALWAYS_AVAILABLE,
+			'alliance_mod.php' => self::ALWAYS_AVAILABLE,
+			'alliance_option.php' => self::ALWAYS_AVAILABLE,
+			'alliance_pick.php' => self::ALWAYS_AVAILABLE,
+			'alliance_remove_member.php' => self::ALWAYS_AVAILABLE,
+			'alliance_roster.php' => self::ALWAYS_AVAILABLE,
+			'beta_functions.php' => self::ALWAYS_AVAILABLE,
+			'bug_report.php' => self::ALWAYS_AVAILABLE,
+			'cargo_dump.php' => self::ALWAYS_AVAILABLE,
+			'course_plot.php' => self::ALWAYS_AVAILABLE,
+			'changelog_view.php' => self::ALWAYS_AVAILABLE,
+			'chat_rules.php' => self::ALWAYS_AVAILABLE,
+			'chess_play.php' => self::ALWAYS_AVAILABLE,
+			'combat_log_list.php' => self::ALWAYS_AVAILABLE,
+			'combat_log_viewer.php' => self::ALWAYS_AVAILABLE,
+			'current_sector.php' => self::ALWAYS_AVAILABLE,
+			'configure_hardware.php' => self::ALWAYS_AVAILABLE,
+			'contact.php' => self::ALWAYS_AVAILABLE,
+			'council_embassy.php' => self::ALWAYS_AVAILABLE,
+			'council_list.php' => self::ALWAYS_AVAILABLE,
+			'council_politics.php' => self::ALWAYS_AVAILABLE,
+			'council_send_message.php' => self::ALWAYS_AVAILABLE,
+			'council_vote.php' => self::ALWAYS_AVAILABLE,
+			'current_players.php' => self::ALWAYS_AVAILABLE,
+			'donation.php' => self::ALWAYS_AVAILABLE,
+			'feature_request_comments.php' => self::ALWAYS_AVAILABLE,
+			'feature_request.php' => self::ALWAYS_AVAILABLE,
+			'forces_list.php' => self::ALWAYS_AVAILABLE,
+			'forces_mass_refresh.php' => self::ALWAYS_AVAILABLE,
+			'hall_of_fame_player_new.php' => self::ALWAYS_AVAILABLE,
+			'hall_of_fame_player_detail.php' => self::ALWAYS_AVAILABLE,
+			'leave_newbie.php' => self::ALWAYS_AVAILABLE,
+			'logoff.php' => self::ALWAYS_AVAILABLE,
+			'map_local.php' => self::ALWAYS_AVAILABLE,
+			'message_view.php' => self::ALWAYS_AVAILABLE,
+			'message_send.php' => self::ALWAYS_AVAILABLE,
+			'news_read_advanced.php' => self::ALWAYS_AVAILABLE,
+			'news_read_current.php' => self::ALWAYS_AVAILABLE,
+			'news_read.php' => self::ALWAYS_AVAILABLE,
+			'planet_construction.php' => self::ALWAYS_AVAILABLE,
+			'planet_defense.php' => self::ALWAYS_AVAILABLE,
+			'planet_financial.php' => self::ALWAYS_AVAILABLE,
+			'planet_main.php' => self::ALWAYS_AVAILABLE,
+			'planet_ownership.php' => self::ALWAYS_AVAILABLE,
+			'planet_stockpile.php' => self::ALWAYS_AVAILABLE,
+			'planet_list.php' => self::ALWAYS_AVAILABLE,
+			'planet_list_financial.php' => self::ALWAYS_AVAILABLE,
+			'preferences.php' => self::ALWAYS_AVAILABLE,
+			'rankings_alliance_death.php' => self::ALWAYS_AVAILABLE,
+			'rankings_alliance_experience.php' => self::ALWAYS_AVAILABLE,
+			'rankings_alliance_kills.php' => self::ALWAYS_AVAILABLE,
+			'rankings_alliance_vs_alliance.php' => self::ALWAYS_AVAILABLE,
+			'rankings_player_death.php' => self::ALWAYS_AVAILABLE,
+			'rankings_player_experience.php' => self::ALWAYS_AVAILABLE,
+			'rankings_player_kills.php' => self::ALWAYS_AVAILABLE,
+			'rankings_player_profit.php' => self::ALWAYS_AVAILABLE,
+			'rankings_race_death.php' => self::ALWAYS_AVAILABLE,
+			'rankings_race_kills.php' => self::ALWAYS_AVAILABLE,
+			'rankings_race.php' => self::ALWAYS_AVAILABLE,
+			'rankings_sector_kill.php' => self::ALWAYS_AVAILABLE,
+			'rankings_view.php' => self::ALWAYS_AVAILABLE,
+			'trader_bounties.php' => self::ALWAYS_AVAILABLE,
+			'trader_relations.php' => self::ALWAYS_AVAILABLE,
+			'trader_savings.php' => self::ALWAYS_AVAILABLE,
+			'trader_search_result.php' => self::ALWAYS_AVAILABLE,
+			'trader_search.php' => self::ALWAYS_AVAILABLE,
+			'trader_status.php' => self::ALWAYS_AVAILABLE,
+			'weapon_reorder.php' => self::ALWAYS_AVAILABLE,
+			//Processing pages
+			'alliance_message_add_processing.php' => self::ALWAYS_AVAILABLE,
+			'alliance_message_delete_processing.php' => self::ALWAYS_AVAILABLE,
+			'alliance_pick_processing.php' => self::ALWAYS_AVAILABLE,
+			'chess_move_processing.php' => self::ALWAYS_AVAILABLE,
+			'toggle_processing.php' => self::ALWAYS_AVAILABLE,
+			//Admin pages
+			'account_edit.php' => self::ALWAYS_AVAILABLE,
+			'album_moderate.php' => self::ALWAYS_AVAILABLE,
+			'box_view.php' => self::ALWAYS_AVAILABLE,
+			'changelog.php' => self::ALWAYS_AVAILABLE,
+			'comp_share.php' => self::ALWAYS_AVAILABLE,
+			'form_open.php' => self::ALWAYS_AVAILABLE,
+			'ip_view_results.php' => self::ALWAYS_AVAILABLE,
+			'ip_view.php' => self::ALWAYS_AVAILABLE,
+			'permission_manage.php' => self::ALWAYS_AVAILABLE,
+			'word_filter.php' => self::ALWAYS_AVAILABLE,
+			//Uni gen
+			'1.6/check_map.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_locations.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_planets.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_ports.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_sector_details.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_sectors.php' => self::ALWAYS_AVAILABLE,
+			'1.6/universe_create_warps.php' => self::ALWAYS_AVAILABLE,
+		);
+
+	/**
+	 * Create a new Page object.
+	 * This is the standard method to package linked pages and the data to
+	 * accompany them.
+	 */
+	public static function create($file, $body = '', array|Page $extra = [], $remainingPageLoads = null) : self {
+		if ($extra instanceof ArrayObject) {
+			// to avoid making $container a reference to $extra
+			$extra = $extra->getArrayCopy();
+		}
+		$container = new Page($extra);
+		$container['url'] = $file;
+		$container['body'] = $body;
+		if ($remainingPageLoads !== null) {
+			$container['RemainingPageLoads'] = $remainingPageLoads;
+		}
+		return $container;
+	}
+
+	/**
+	 * Create a copy of a Page object.
+	 * This may be useful for reusing a Page object without modifying the
+	 * original.
+	 */
+	public static function copy(Page $other) : self {
+		return clone $other;
+	}
+
+	/**
+	 * Use this container as the global variable $var.
+	 */
+	public function useAsGlobalVar($sn = null) {
+		global $var;
+
+		// this sn identifies our container later
+		if (!is_null($sn)) {
+			SmrSession::resetLink($this, $sn);
+		}
+
+		// Note: if problems arise, maybe $this should be cloned.
+		$var = $this;
+	}
+
+	/**
+	 * Forward to the page identified by this container.
+	 */
+	public function go() : void {
+		global $sn;
+		if (defined('OVERRIDE_FORWARD') && OVERRIDE_FORWARD === true) {
+			overrideForward($this);
+			return;
+		}
+		$this->useAsGlobalVar($sn);
+		do_voodoo();
+	}
+
+	/**
+	 * Transfer data from $var into this container.
+	 */
+	function addVar(string $what) : void {
+		global $var;
+
+		// transfer this value to next container
+		if (isset($var[$what])) {
+			$this[$what] = $var[$what];
+		}
+	}
+
+	/**
+	 * Create an HREF (based on a random SN) to link to this page.
+	 * The container is saved in the SmrSession under this SN so that on
+	 * the next request, we can grab the container out of the SmrSession.
+	 */
+	public function href(bool $forceFullURL = false) : string {
+
+		// We need to make a clone of this object for two reasons:
+		// 1. The object saved in the session is not modified if we use this
+		//    object to create more links.
+		// 2. Any additional links we create using this object do not inherit
+		//    the metadata properties that we add here, which would falsely
+		//    represent some other page.
+		// Ideally this would not be necessary, but the usage of this method
+		// would need to change globally first (no Page re-use).
+		$copy = self::copy($this);
+
+		if (!isset($copy['Expires'])) {
+			$copy['Expires'] = 0; // Lasts forever
+		}
+		if (!isset($copy['RemainingPageLoads'])) {
+			$pageURL = $copy['url'] == 'skeleton.php' ? $copy['body'] : $copy['url'];
+			$copy['RemainingPageLoads'] = self::URL_DEFAULT_REMAINING_PAGE_LOADS[$pageURL] ?? 1; // Allow refreshing
+		}
+
+		// 'CommonID' MUST be unique to a specific action. If there will
+		// be two different outcomes from containers given the same ID then
+		// problems will likely arise.
+		$copy['CommonID'] = self::getCommonID();
+		$sn = SmrSession::addLink($copy);
+
+		if ($forceFullURL === true || stripos($_SERVER['REQUEST_URI'], 'loader.php') === false) {
+			return '/loader.php?sn=' . $sn;
+		}
+		return '?sn=' . $sn;
+	}
+
+	/**
+	 * Returns a hash of the contents of the container to identify when two
+	 * containers are equivalent (apart from page-load tracking metadata, which
+	 * we strip out to prevent false differences).
+	 */
+	private function getCommonID() : string {
+		$commonContainer = $this->getArrayCopy();
+		unset($commonContainer['Expires']);
+		unset($commonContainer['RemainingPageLoads']);
+		unset($commonContainer['PreviousRequestTime']);
+		unset($commonContainer['CommonID']);
+		// NOTE: This ID will change if the order of elements in the container
+		// changes. If this causes unnecessary SN changes, sort the container!
+		return md5(serialize($commonContainer));
+	}
+
+}

--- a/src/lib/Default/SmrForce.class.php
+++ b/src/lib/Default/SmrForce.class.php
@@ -387,22 +387,22 @@ class SmrForce {
 	}
 
 	public function getExamineDropForcesHREF() {
-		$container = create_container('skeleton.php', 'forces_drop.php');
+		$container = Page::create('skeleton.php', 'forces_drop.php');
 		$container['owner_id'] = $this->getOwnerID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getAttackForcesHREF() {
-		$container = create_container('forces_attack_processing.php');
+		$container = Page::create('forces_attack_processing.php');
 		$container['action'] = 'attack';
 		$container['owner_id'] = $this->getOwnerID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getRefreshHREF() {
-		$container = create_container('forces_refresh_processing.php');
+		$container = Page::create('forces_refresh_processing.php');
 		$container['owner_id'] = $this->getOwnerID();
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	protected function getDropContainer() {
@@ -412,42 +412,42 @@ class SmrForce {
 	public function getDropSDHREF() {
 		$container = $this->getDropContainer();
 		$container['drop_scout_drones'] = 1;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getTakeSDHREF() {
 		$container = $this->getDropContainer();
 		$container['take_scout_drones'] = 1;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getDropCDHREF() {
 		$container = $this->getDropContainer();
 		$container['drop_combat_drones'] = 1;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getTakeCDHREF() {
 		$container = $this->getDropContainer();
 		$container['take_combat_drones'] = 1;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getDropMineHREF() {
 		$container = $this->getDropContainer();
 		$container['drop_mines'] = 1;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getTakeMineHREF() {
 		$container = $this->getDropContainer();
 		$container['take_mines'] = 1;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public static function getRefreshAllHREF() {
-		$container = create_container('forces_mass_refresh.php');
-		return SmrSession::getNewHREF($container);
+		$container = Page::create('forces_mass_refresh.php');
+		return $container->href();
 	}
 
 	public function shootPlayers(array $targetPlayers, $minesAreAttacker) {

--- a/src/lib/Default/SmrPlanet.class.php
+++ b/src/lib/Default/SmrPlanet.class.php
@@ -1052,37 +1052,37 @@ class SmrPlanet {
 	}
 
 	public function getExamineHREF() : string {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_examine.php'));
+		return Page::create('skeleton.php', 'planet_examine.php')->href();
 	}
 
 	public function getLandHREF() : string {
-		return SmrSession::getNewHREF(create_container('planet_land_processing.php'));
+		return Page::create('planet_land_processing.php')->href();
 	}
 
 	public function getAttackHREF() : string {
-		return SmrSession::getNewHREF(create_container('planet_attack_processing.php'));
+		return Page::create('planet_attack_processing.php')->href();
 	}
 
 	public function getBuildHREF(int $structureID) : string {
-		$container = create_container('planet_construction_processing.php');
+		$container = Page::create('planet_construction_processing.php');
 		$container['construction_id'] = $structureID;
 		$container['action'] = 'Build';
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getCancelHREF(int $structureID) : string {
-		$container = create_container('planet_construction_processing.php');
+		$container = Page::create('planet_construction_processing.php');
 		$container['construction_id'] = $structureID;
 		$container['action'] = 'Cancel';
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getFinancesHREF() : string {
-		return SmrSession::getNewHREF(create_container('planet_financial_processing.php'));
+		return Page::create('planet_financial_processing.php')->href();
 	}
 
 	public function getBondConfirmationHREF() : string {
-		return SmrSession::getNewHREF(create_container('skeleton.php', 'planet_bond_confirmation.php'));
+		return Page::create('skeleton.php', 'planet_bond_confirmation.php')->href();
 	}
 
 	public function attackedBy(AbstractSmrPlayer $trigger, array $attackers) : void {

--- a/src/lib/Default/SmrSession.class.php
+++ b/src/lib/Default/SmrSession.class.php
@@ -5,111 +5,8 @@ if (!defined('USING_AJAX')) {
 }
 
 class SmrSession {
-	const ALWAYS_AVAILABLE = 999999;
-	const TIME_BEFORE_EXPIRY = 3600;
 
-	// Defines the number of pages that can be loaded after
-	// this page before the links on this page become invalid
-	// (i.e. before you get a back button error).
-	private const URL_DEFAULT_REMAINING_PAGE_LOADS = array(
-			'alliance_broadcast.php' => self::ALWAYS_AVAILABLE,
-			'alliance_forces.php' => self::ALWAYS_AVAILABLE,
-			'alliance_list.php' => self::ALWAYS_AVAILABLE,
-			'alliance_message_view.php' => self::ALWAYS_AVAILABLE,
-			'alliance_message.php' => self::ALWAYS_AVAILABLE,
-			'alliance_mod.php' => self::ALWAYS_AVAILABLE,
-			'alliance_option.php' => self::ALWAYS_AVAILABLE,
-			'alliance_pick.php' => self::ALWAYS_AVAILABLE,
-			'alliance_remove_member.php' => self::ALWAYS_AVAILABLE,
-			'alliance_roster.php' => self::ALWAYS_AVAILABLE,
-			'beta_functions.php' => self::ALWAYS_AVAILABLE,
-			'bug_report.php' => self::ALWAYS_AVAILABLE,
-			'cargo_dump.php' => self::ALWAYS_AVAILABLE,
-			'course_plot.php' => self::ALWAYS_AVAILABLE,
-			'changelog_view.php' => self::ALWAYS_AVAILABLE,
-			'chat_rules.php' => self::ALWAYS_AVAILABLE,
-			'chess_play.php' => self::ALWAYS_AVAILABLE,
-			'combat_log_list.php' => self::ALWAYS_AVAILABLE,
-			'combat_log_viewer.php' => self::ALWAYS_AVAILABLE,
-			'current_sector.php' => self::ALWAYS_AVAILABLE,
-			'configure_hardware.php' => self::ALWAYS_AVAILABLE,
-			'contact.php' => self::ALWAYS_AVAILABLE,
-			'council_embassy.php' => self::ALWAYS_AVAILABLE,
-			'council_list.php' => self::ALWAYS_AVAILABLE,
-			'council_politics.php' => self::ALWAYS_AVAILABLE,
-			'council_send_message.php' => self::ALWAYS_AVAILABLE,
-			'council_vote.php' => self::ALWAYS_AVAILABLE,
-			'current_players.php' => self::ALWAYS_AVAILABLE,
-			'donation.php' => self::ALWAYS_AVAILABLE,
-			'feature_request_comments.php' => self::ALWAYS_AVAILABLE,
-			'feature_request.php' => self::ALWAYS_AVAILABLE,
-			'forces_list.php' => self::ALWAYS_AVAILABLE,
-			'forces_mass_refresh.php' => self::ALWAYS_AVAILABLE,
-			'hall_of_fame_player_new.php' => self::ALWAYS_AVAILABLE,
-			'hall_of_fame_player_detail.php' => self::ALWAYS_AVAILABLE,
-			'leave_newbie.php' => self::ALWAYS_AVAILABLE,
-			'logoff.php' => self::ALWAYS_AVAILABLE,
-			'map_local.php' => self::ALWAYS_AVAILABLE,
-			'message_view.php' => self::ALWAYS_AVAILABLE,
-			'message_send.php' => self::ALWAYS_AVAILABLE,
-			'news_read_advanced.php' => self::ALWAYS_AVAILABLE,
-			'news_read_current.php' => self::ALWAYS_AVAILABLE,
-			'news_read.php' => self::ALWAYS_AVAILABLE,
-			'planet_construction.php' => self::ALWAYS_AVAILABLE,
-			'planet_defense.php' => self::ALWAYS_AVAILABLE,
-			'planet_financial.php' => self::ALWAYS_AVAILABLE,
-			'planet_main.php' => self::ALWAYS_AVAILABLE,
-			'planet_ownership.php' => self::ALWAYS_AVAILABLE,
-			'planet_stockpile.php' => self::ALWAYS_AVAILABLE,
-			'planet_list.php' => self::ALWAYS_AVAILABLE,
-			'planet_list_financial.php' => self::ALWAYS_AVAILABLE,
-			'preferences.php' => self::ALWAYS_AVAILABLE,
-			'rankings_alliance_death.php' => self::ALWAYS_AVAILABLE,
-			'rankings_alliance_experience.php' => self::ALWAYS_AVAILABLE,
-			'rankings_alliance_kills.php' => self::ALWAYS_AVAILABLE,
-			'rankings_alliance_vs_alliance.php' => self::ALWAYS_AVAILABLE,
-			'rankings_player_death.php' => self::ALWAYS_AVAILABLE,
-			'rankings_player_experience.php' => self::ALWAYS_AVAILABLE,
-			'rankings_player_kills.php' => self::ALWAYS_AVAILABLE,
-			'rankings_player_profit.php' => self::ALWAYS_AVAILABLE,
-			'rankings_race_death.php' => self::ALWAYS_AVAILABLE,
-			'rankings_race_kills.php' => self::ALWAYS_AVAILABLE,
-			'rankings_race.php' => self::ALWAYS_AVAILABLE,
-			'rankings_sector_kill.php' => self::ALWAYS_AVAILABLE,
-			'rankings_view.php' => self::ALWAYS_AVAILABLE,
-			'trader_bounties.php' => self::ALWAYS_AVAILABLE,
-			'trader_relations.php' => self::ALWAYS_AVAILABLE,
-			'trader_savings.php' => self::ALWAYS_AVAILABLE,
-			'trader_search_result.php' => self::ALWAYS_AVAILABLE,
-			'trader_search.php' => self::ALWAYS_AVAILABLE,
-			'trader_status.php' => self::ALWAYS_AVAILABLE,
-			'weapon_reorder.php' => self::ALWAYS_AVAILABLE,
-			//Processing pages
-			'alliance_message_add_processing.php' => self::ALWAYS_AVAILABLE,
-			'alliance_message_delete_processing.php' => self::ALWAYS_AVAILABLE,
-			'alliance_pick_processing.php' => self::ALWAYS_AVAILABLE,
-			'chess_move_processing.php' => self::ALWAYS_AVAILABLE,
-			'toggle_processing.php' => self::ALWAYS_AVAILABLE,
-			//Admin pages
-			'account_edit.php' => self::ALWAYS_AVAILABLE,
-			'album_moderate.php' => self::ALWAYS_AVAILABLE,
-			'box_view.php' => self::ALWAYS_AVAILABLE,
-			'changelog.php' => self::ALWAYS_AVAILABLE,
-			'comp_share.php' => self::ALWAYS_AVAILABLE,
-			'form_open.php' => self::ALWAYS_AVAILABLE,
-			'ip_view_results.php' => self::ALWAYS_AVAILABLE,
-			'ip_view.php' => self::ALWAYS_AVAILABLE,
-			'permission_manage.php' => self::ALWAYS_AVAILABLE,
-			'word_filter.php' => self::ALWAYS_AVAILABLE,
-			//Uni gen
-			'1.6/check_map.php' => self::ALWAYS_AVAILABLE,
-			'1.6/universe_create_locations.php' => self::ALWAYS_AVAILABLE,
-			'1.6/universe_create_planets.php' => self::ALWAYS_AVAILABLE,
-			'1.6/universe_create_ports.php' => self::ALWAYS_AVAILABLE,
-			'1.6/universe_create_sector_details.php' => self::ALWAYS_AVAILABLE,
-			'1.6/universe_create_sectors.php' => self::ALWAYS_AVAILABLE,
-			'1.6/universe_create_warps.php' => self::ALWAYS_AVAILABLE,
-		);
+	const TIME_BEFORE_EXPIRY = 3600;
 
 	private const URL_LOAD_DELAY = array(
 		'configure_hardware.php' => .4,
@@ -356,7 +253,7 @@ class SmrSession {
 	 * Retrieve the session var for the page given by $sn.
 	 * If $sn is not specified, use the current page (i.e. self::$SN).
 	 */
-	public static function retrieveVar(string $sn = null) : array|false {
+	public static function retrieveVar(string $sn = null) : Page|false {
 		if (is_null($sn)) {
 			$sn = self::$SN;
 		}
@@ -400,7 +297,7 @@ class SmrSession {
 		return $result;
 	}
 
-	public static function resetLink(array $container, string $sn) : string {
+	public static function resetLink(Page $container, string $sn) : string {
 		//Do not allow sharing SN, useful for forwarding.
 		global $lock;
 		if (isset(self::$var[$sn]['CommonID'])) {
@@ -429,8 +326,12 @@ class SmrSession {
 	public static function updateVar(string $key, mixed $value) : void {
 		global $var;
 		if ($value === null) {
-			unset($var[$key]);
-			unset(self::$var[self::$SN][$key]);
+			if (isset($var[$key])) {
+				unset($var[$key]);
+			}
+			if (isset($var[self::$SN][$key])) {
+				unset(self::$var[self::$SN][$key]);
+			}
 		} else {
 			$var[$key] = $value;
 			self::$var[self::$SN][$key] = $value;
@@ -442,30 +343,13 @@ class SmrSession {
 		self::$commonIDs = array();
 	}
 
-	protected static function addLink(array $container, string $sn = null) : string {
-		// Container['ID'] MUST be unique to a specific action, if there will
-		// be two different outcomes from containers given the same ID then
-		// problems will likely arise.
-		if (!isset($container['Expires'])) {
-			$container['Expires'] = 0; // Lasts forever
-		}
-		if (!isset($container['RemainingPageLoads'])) {
-			$pageURL = $container['url'] == 'skeleton.php' ? $container['body'] : $container['url'];
-			$container['RemainingPageLoads'] = self::URL_DEFAULT_REMAINING_PAGE_LOADS[$pageURL] ?? 1; // Allow refreshing
-		}
-
-		if ($sn === null) {
-			$sn = self::generateSN($container);
-		} else {
-			// If we've been provided an SN to use then copy over the existing 'PreviousRequestTime'
-			$container['PreviousRequestTime'] = self::$var[$sn]['PreviousRequestTime'];
-		}
+	public static function addLink(Page $container) : string {
+		$sn = self::generateSN($container);
 		self::$var[$sn] = $container;
 		return $sn;
 	}
 
-	protected static function generateSN(array &$container) : string {
-		$container['CommonID'] = self::getCommonID($container);
+	protected static function generateSN(Page $container) : string {
 		if (isset(self::$commonIDs[$container['CommonID']])) {
 			$sn = self::$commonIDs[$container['CommonID']];
 			$container['PreviousRequestTime'] = isset(self::$var[$sn]) ? self::$var[$sn]['PreviousRequestTime'] : self::getMicroTime();
@@ -477,24 +361,6 @@ class SmrSession {
 		}
 		self::$commonIDs[$container['CommonID']] = $sn;
 		return $sn;
-	}
-
-	protected static function getCommonID(array $commonContainer) : string {
-		unset($commonContainer['Expires']);
-		unset($commonContainer['RemainingPageLoads']);
-		unset($commonContainer['PreviousRequestTime']);
-		unset($commonContainer['CommonID']);
-		// NOTE: This ID will change if the order of elements in the container
-		// changes. If this causes unnecessary SN changes, sort the container!
-		return md5(serialize($commonContainer));
-	}
-
-	public static function getNewHREF(array $container, bool $forceFullURL = false) : string {
-		$sn = self::addLink($container);
-		if ($forceFullURL === true || stripos($_SERVER['REQUEST_URI'], 'loader.php') === false) {
-			return '/loader.php?sn=' . $sn;
-		}
-		return '?sn=' . $sn;
 	}
 
 	public static function addAjaxReturns(string $element, string $contents) : bool {

--- a/src/lib/Default/SmrWeapon.class.php
+++ b/src/lib/Default/SmrWeapon.class.php
@@ -104,18 +104,18 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	}
 
 	public function getBuyHREF(SmrLocation $location) {
-		$container = create_container('shop_weapon_processing.php');
+		$container = Page::create('shop_weapon_processing.php');
 		$container['LocationID'] = $location->getTypeID();
 		$container['Weapon'] = $this;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getSellHREF(SmrLocation $location, $orderID) {
-		$container = create_container('shop_weapon_processing.php');
+		$container = Page::create('shop_weapon_processing.php');
 		$container['LocationID'] = $location->getTypeID();
 		$container['Weapon'] = $this;
 		$container['OrderID'] = $orderID;
-		return SmrSession::getNewHREF($container);
+		return $container->href();
 	}
 
 	public function getWeaponTypeID() {

--- a/src/lib/Default/VoteSite.class.php
+++ b/src/lib/Default/VoteSite.class.php
@@ -145,10 +145,10 @@ class VoteSite {
 	public function getSN($accountID, $gameID) {
 		if ($this->freeTurnsReady($accountID, $gameID)) {
 			// This page will prepare the account for the voting callback.
-			$container = create_container('vote_link.php');
+			$container = Page::create('vote_link.php');
 			$container['link_id'] = $this->linkID;
 			$container['can_get_turns'] = true;
-			return SmrSession::getNewHREF($container, true);
+			return $container->href(true);
 		} else {
 			return false;
 		}

--- a/src/lib/Default/hof.inc.php
+++ b/src/lib/Default/hof.inc.php
@@ -5,7 +5,7 @@ function getHofCategories($hofTypes, $game_id, $account_id) {
 	$categories = [];
 	foreach ($hofTypes as $type => $value) {
 		// Make each category a link to view the subcategory page
-		$container = $var;
+		$container = Page::copy($var);
 		$container['view'] = $type;
 		if (!isset($var['type'])) {
 			$container['type'] = array();
@@ -13,7 +13,7 @@ function getHofCategories($hofTypes, $game_id, $account_id) {
 		$link = create_link($container, $type);
 
 		// Make the subcategory buttons
-		$container = $var;
+		$container = Page::copy($var);
 		if (!isset($var['type'])) {
 			$container['type'] = array();
 		}
@@ -32,7 +32,6 @@ function getHofCategories($hofTypes, $game_id, $account_id) {
 				$subcategories[] = create_submit_link($container, $subType . $rankMsg);
 			}
 		} else {
-			unset($container['view']);
 			$rank = getHofRank($type, $container['type'], $account_id, $game_id);
 			$subcategories[] = create_submit_link($container, 'View (#' . $rank['Rank'] . ')');
 		}
@@ -128,7 +127,7 @@ function displayHOFRow($rank, $accountID, $amount) {
 	$return = ('<tr>');
 	$return .= ('<td ' . $bold . '>' . $rank . '</td>');
 
-	$container = create_container('skeleton.php', 'hall_of_fame_player_detail.php');
+	$container = Page::create('skeleton.php', 'hall_of_fame_player_detail.php');
 	$container['account_id'] = $accountID;
 
 	if (isset($var['game_id'])) {
@@ -148,9 +147,13 @@ function displayHOFRow($rank, $accountID, $amount) {
 }
 
 function buildBreadcrumb(&$var, &$hofTypes, $hofName) {
-	$container = $var;
-	unset($container['type']);
-	unset($container['view']);
+	$container = Page::copy($var);
+	if (isset($container['type'])) {
+		unset($container['type']);
+	}
+	if (isset($container['view'])) {
+		unset($container['view']);
+	}
 	$viewing = '<span class="bold">Currently viewing: </span>' . create_link($container, $hofName);
 	$typeList = array();
 	if (isset($var['type'])) {
@@ -163,9 +166,11 @@ function buildBreadcrumb(&$var, &$hofTypes, $hofName) {
 				$typeList[] = $type;
 			}
 			$viewing .= ' &rarr; ';
-			$container = $var;
+			$container = Page::copy($var);
 			$container['type'] = $typeList;
-			unset($container['view']);
+			if (isset($container['view'])) {
+				unset($container['view']);
+			}
 			$viewing .= create_link($container, $type);
 
 			$hofTypes = $hofTypes[$type];
@@ -177,7 +182,7 @@ function buildBreadcrumb(&$var, &$hofTypes, $hofName) {
 			$typeList[] = $var['view'];
 			$var['type'] = $typeList;
 		}
-		$container = $var;
+		$container = Page::copy($var);
 		$viewing .= create_link($container, $var['view']);
 
 		if (is_array($hofTypes[$var['view']])) {

--- a/src/lib/Default/shop_goods.inc.php
+++ b/src/lib/Default/shop_goods.inc.php
@@ -29,7 +29,7 @@ function check_bargain_number($amount, $ideal_price, $offered_price, $bargain_pr
 		$player->decreaseRelationsByTrade($amount, $port->getRaceID());
 		$player->increaseHOF(1, array('Trade', 'Results', 'Fail'), HOF_PUBLIC);
 		// transfer values
-		transfer('overall_number_of_bargains');
+		$container->addVar('overall_number_of_bargains');
 
 		// does we have enough of it?
 		if ($container['number_of_bargains'] > $container['overall_number_of_bargains']) {

--- a/src/lib/Semi Wars/Menu.class.php
+++ b/src/lib/Semi Wars/Menu.class.php
@@ -18,12 +18,12 @@ class Menu extends AbstractMenu {
 		}
 
 		$menuItems = [];
-		$container = create_container('skeleton.php');
+		$container = Page::create('skeleton.php');
 		$container['LocationID'] = $var['LocationID'];
 		foreach ($links as $link) {
 			$container['body'] = $link[0];
 			$menuItems[] = [
-				'Link' => SmrSession::getNewHREF($container),
+				'Link' => $container->href(),
 				'Text' => $link[1],
 			];
 		}

--- a/src/templates/Default/engine/Default/includes/PlottedCourse.inc.php
+++ b/src/templates/Default/engine/Default/includes/PlottedCourse.inc.php
@@ -1,8 +1,8 @@
 <?php
 if ($ThisPlayer->hasPlottedCourse()) {
 	$PlottedCourse = $ThisPlayer->getPlottedCourse();
-	$CancelCourseHREF = SmrSession::getNewHREF(create_container('course_plot_cancel_processing.php'));
-	$ReplotCourseHREF = SmrSession::getNewHREF(create_container('course_plot_processing.php', '', array('to' => $PlottedCourse->getEndSectorID(), 'from' => $ThisSector->getSectorID())));
+	$CancelCourseHREF = Page::create('course_plot_cancel_processing.php')->href();
+	$ReplotCourseHREF = Page::create('course_plot_processing.php', '', array('to' => $PlottedCourse->getEndSectorID(), 'from' => $ThisSector->getSectorID()))->href();
 	$NextSector = SmrSector::getSector($ThisPlayer->getGameID(), $PlottedCourse->getNextOnPath(), $ThisPlayer->getAccountID()); ?>
 	<table class="nobord fullwidth">
 		<tr>

--- a/src/templates/Default/engine/Default/includes/SectorMap.inc.php
+++ b/src/templates/Default/engine/Default/includes/SectorMap.inc.php
@@ -28,7 +28,7 @@
 							foreach ($MovementTypes as $MovementType) {
 								if (isset($ToggleLink)) {
 									$ToggleLink['dir'] = $MovementType; ?>
-									<a onclick="ajaxLink('<?php echo SmrSession::getNewHREF($ToggleLink); ?>')" class="lm<?php echo $MovementType; ?>"><?php
+									<a onclick="ajaxLink('<?php echo $ToggleLink->href(); ?>')" class="lm<?php echo $MovementType; ?>"><?php
 								} ?>
 								<div class="lm<?php echo $MovementType; ?> <?php if ($Sector->getLink($MovementType)) { ?>con<?php } else { ?>wall<?php } ?>"></div><?php
 								if (isset($ToggleLink)) { ?>
@@ -129,7 +129,7 @@
 						<div class="lmsector"><?php echo $Sector->getSectorID(); ?></div><?php
 						if ($UniGen) {
 							$UniGen['sector_edit'] = $Sector->getSectorID(); ?>
-							<a class="move_hack" href="<?php echo SmrSession::getNewHREF($UniGen); ?>"></a><?php
+							<a class="move_hack" href="<?php echo $UniGen->href(); ?>"></a><?php
 						} elseif ($GalaxyMap) { ?>
 							<a class="move_hack" href="<?php echo $Sector->getGalaxyMapHREF(); ?>"></a><?php
 						} elseif ($isLinkedSector) { ?>

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -148,10 +148,10 @@ function NPCStuff() {
 				debug('Some evil person killed us, let\'s move on now.');
 				$previousContainer = null; //We died, we don't care what we were doing beforehand.
 				$TRADE_ROUTE =& changeRoute($TRADE_ROUTES); //Change route
-				processContainer(create_container('death_processing.php'));
+				processContainer(Page::create('death_processing.php'));
 			}
 			if ($player->getNewbieTurns() <= NEWBIE_TURNS_WARNING_LIMIT && $player->getNewbieWarning()) {
-				processContainer(create_container('newbie_warning_processing.php'));
+				processContainer(Page::create('newbie_warning_processing.php'));
 			}
 
 			$fedContainer = null;
@@ -338,7 +338,7 @@ function processContainer($container) {
 	debug('Executing container', $container);
 	// The next "page request" must occur at an updated time.
 	SmrSession::updateTime();
-	resetContainer($container);
+	$container->useAsGlobalVar();
 	acquire_lock($player->getSectorID()); // Lock now to skip var update in do_voodoo
 	do_voodoo();
 }
@@ -480,7 +480,7 @@ function doUNO($hardwareID, $amount) {
 		'amount' => $amount,
 		'action' => 'Buy',
 	];
-	return create_container('shop_hardware_processing.php', '', array('hardware_id'=>$hardwareID));
+	return Page::create('shop_hardware_processing.php', '', array('hardware_id'=>$hardwareID));
 }
 
 function tradeGoods($goodID, AbstractSmrPlayer $player, SmrPort $port) {
@@ -500,7 +500,7 @@ function tradeGoods($goodID, AbstractSmrPlayer $player, SmrPort $port) {
 	$offeredPrice = $port->getOfferPrice($idealPrice, $relations, $transaction);
 
 	$_REQUEST = ['action' => $transaction];
-	return create_container('shop_goods_processing.php', '', array('offered_price'=>$offeredPrice, 'ideal_price'=>$idealPrice, 'amount'=>$amount, 'good_id'=>$goodID, 'bargain_price'=>$offeredPrice));
+	return Page::create('shop_goods_processing.php', '', array('offered_price'=>$offeredPrice, 'ideal_price'=>$idealPrice, 'amount'=>$amount, 'good_id'=>$goodID, 'bargain_price'=>$offeredPrice));
 }
 
 function dumpCargo($player) {
@@ -509,13 +509,13 @@ function dumpCargo($player) {
 	debug('Ship Cargo', $cargo);
 	foreach ($cargo as $goodID => $amount) {
 		if ($amount > 0) {
-			return create_container('cargo_dump_processing.php', '', array('good_id'=>$goodID, 'amount'=>$amount));
+			return Page::create('cargo_dump_processing.php', '', array('good_id'=>$goodID, 'amount'=>$amount));
 		}
 	}
 }
 
 function plotToSector($player, $sectorID) {
-	return create_container('course_plot_processing.php', '', array('from'=>$player->getSectorID(), 'to'=>$sectorID));
+	return Page::create('course_plot_processing.php', '', array('from'=>$player->getSectorID(), 'to'=>$sectorID));
 }
 
 function plotToFed($player, $plotToHQ = false) {
@@ -544,11 +544,11 @@ function plotToNearest(AbstractSmrPlayer $player, $realX) {
 		return true;
 	}
 
-	return create_container('course_plot_nearest_processing.php', '', array('RealX'=>$realX));
+	return Page::create('course_plot_nearest_processing.php', '', array('RealX'=>$realX));
 }
 function moveToSector($player, $targetSector) {
 	debug('Moving from #' . $player->getSectorID() . ' to #' . $targetSector);
-	return create_container('sector_move_processing.php', '', array('target_sector'=>$targetSector, 'target_page'=>''));
+	return Page::create('sector_move_processing.php', '', array('target_sector'=>$targetSector, 'target_page'=>''));
 }
 
 function checkForShipUpgrade(AbstractSmrPlayer $player) {
@@ -571,7 +571,7 @@ function doShipUpgrade(AbstractSmrPlayer $player, $upgradeShipID) {
 
 	if ($plotNearest == true) { //We're already there!
 		//TODO: We're going to want to UNO after upgrading
-		return create_container('shop_ship_processing.php', '', array('ship_id'=>$upgradeShipID));
+		return Page::create('shop_ship_processing.php', '', array('ship_id'=>$upgradeShipID));
 	} //Otherwise return the plot
 	return $plotNearest;
 }

--- a/test/SmrTest/lib/DefaultGame/PageIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/PageIntegrationTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use Page;
+
+/**
+ * This is an integration test, but does not need to extend BaseIntegrationTest
+ * since we are not (or should not be!) writing any data.
+ * @covers Page
+ */
+class PageIntegrationTest extends \PHPUnit\Framework\TestCase {
+
+	public function test_create() {
+		// Test create with $extra as array
+		$page = Page::create('file', 'body', ['extra' => 'data']);
+		// Check that the expected keys of the ArrayObject are set
+		$expected = ['extra' => 'data', 'url' => 'file', 'body' => 'body'];
+		self::assertSame($expected, $page->getArrayCopy());
+
+		// Test create with $extra as a Page object
+		$page2 = Page::create('file2', extra: $page);
+		// Check that the expected keys of the ArrayObject are set
+		$expected2 = ['extra' => 'data', 'url' => 'file2', 'body' => ''];
+		self::assertSame($expected2, $page2->getArrayCopy());
+
+		// Make sure they are not references to the same underlying object
+		self::assertNotSame($page, $page2);
+		// Make sure passing $page to create didn't modify the original
+		self::assertSame($expected, $page->getArrayCopy());
+
+		// Test create when setting $remainingPageLoads
+		$page3 = Page::create('file', remainingPageLoads: 2);
+		self::assertSame(2, $page3['RemainingPageLoads']);
+	}
+
+	public function test_copy() {
+		// Create an arbitrary Page
+		$page = Page::create('file');
+		// The copy should be equal, but not the same
+		$copy = Page::copy($page);
+		self::assertNotSame($page, $copy);
+		self::assertEquals($page, $copy);
+	}
+
+	public function test_useAsGlobalVar() {
+		// Create an arbitrary Page
+		$page = Page::create('file');
+
+		// Unset the global $var in case it has been set elsewhere
+		global $var;
+		$var = null;
+
+		// The global $var should be the same object as $page
+		$page->useAsGlobalVar();
+		self::assertSame($var, $page);
+	}
+
+	public function test_href() {
+		// Create an arbitrary Page
+		$page = Page::create('file');
+
+		// The Page should not be modified when href() is called
+		$expected = $page->getArrayCopy();
+		srand(0); // for a deterministic SN
+		$_SERVER['REQUEST_URI'] = 'loader.php'; // prevent "Undefined array key"
+		$href = $page->href();
+		self::assertSame('?sn=qpbqzr', $href);
+		self::assertSame($expected, $page->getArrayCopy());
+	}
+
+}


### PR DESCRIPTION
The container mechanism for creating links and forwarding to new pages
originally used arrays. Now we use the Page class, which inherits from
ArrayObject. Since Objects (including ArrayObject) behave differently
for copying and references than arrays, this first stage of refactoring
only attempts to recover the old behavior without modifying the _logic_
of container usage everywhere in the code. Further stages may attempt
to treat containers as Objects from the ground up.

In particular, since we often reuse containers to make multiple HREFs,
we need to do a lot of (otherwise unnecessary) copying of the data in
the ArrayObject to prevent overwriting the data from prior usage.

The new interface maps fairly directly to the previous one:

* `create_container(...)` ➞ `Page::create(...)`
* `$container = $var` ➞ `$container = Page::copy($var)`
* `SmrSession::getNewHREF($container)` ➞ `$container->href()`
* `forward($container)` ➞ `$container->go()`
* `resetContainer($container)` ➞ `$container->useAsGlobalVar()`
* `transfer(...)` ➞ `$container->addVar(...)`

There are a number of subtle considerations in this refactoring. Here
is a mostly comprehensive list of them:

* Some of the container manipulation performed in SmrSession methods
  is now performed in the Page class (such as generating the CommonID
  and setting the ReaminingPageLoads.

* Functions that had container arguments can now be type-hinted as
  `Page` instead of the much more ambiguous `array`.

* We no longer use `$container` as a global variable. It's not clear
  why or if this was needed in the past, but it did not appear to be
  needed before or after this refactoring.

* Using `Page::copy($var)` as a static function instead of using a
  method (e.g. `$var->copy()`) will enable better static analysis,
  because the analyis will be able to infer the return type (whereas
  it doesn't know the type of the global variable `$var`).

* An undocumented difference between arrays and ArrayObjects is that
  `unset($var['non-existent key'])` emits an "Undefined array key" for
  ArrayObject, but not array. As a result, there were some places where
  `isset` checks needed to be performed where they weren't before.