### PR TITLE
Use MySqlDatabase::{get,escape}Object

### DIFF
--- a/db/patches/V1_6_66_14__ajax_returns_default_null.sql
+++ b/db/patches/V1_6_66_14__ajax_returns_default_null.sql
@@ -1,0 +1,2 @@
+-- Add null default for active_session.ajax_returns
+ALTER TABLE `active_session` MODIFY `ajax_returns` mediumblob DEFAULT NULL;

--- a/src/engine/Default/combat_log_viewer.php
+++ b/src/engine/Default/combat_log_viewer.php
@@ -13,7 +13,7 @@ if (!$db->nextRecord()) {
 }
 $template->assign('CombatLogSector', $db->getInt('sector_id'));
 $template->assign('CombatLogTimestamp', date(DATE_FULL_SHORT, $db->getInt('timestamp')));
-$results = unserialize(gzuncompress($db->getField('result')));
+$results = $db->getObject('result', true);
 $template->assign('CombatResultsType', $db->getField('type'));
 $template->assign('CombatResults', $results);
 

--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -169,7 +169,7 @@ function checkForAttackMessage(&$msg) {
 			$db->query('SELECT sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($msg) . ' LIMIT 1');
 			if ($db->nextRecord()) {
 				if ($player->getSectorID() == $db->getInt('sector_id')) {
-					$results = unserialize(gzuncompress($db->getField('result')));
+					$results = $db->getObject('result', true);
 					$template->assign('AttackResultsType', $db->getField('type'));
 					$template->assign('AttackResults', $results);
 					$template->assign('AttackLogLink', linkCombatLog($msg));

--- a/src/engine/Default/forces_attack.php
+++ b/src/engine/Default/forces_attack.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
-$results = unserialize($var['results']);
-$template->assign('FullForceCombatResults', $results);
+$template->assign('FullForceCombatResults', $var['results']);
 
 if ($var['owner_id'] > 0) {
 	$template->assign('Target', SmrForce::getForce($player->getGameID(), $player->getSectorID(), $var['owner_id']));

--- a/src/engine/Default/forces_attack_processing.php
+++ b/src/engine/Default/forces_attack_processing.php
@@ -97,8 +97,7 @@ if (!$bump) {
 }
 
 // Add this log to the `combat_logs` database table
-$serializedResults = serialize($results);
-$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'FORCE\',' . $db->escapeNumber($forces->getSectorID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($forceOwner->getAccountID()) . ',' . $db->escapeNumber($forceOwner->getAllianceID()) . ',' . $db->escapeBinary(gzcompress($serializedResults)) . ')');
+$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'FORCE\',' . $db->escapeNumber($forces->getSectorID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($forceOwner->getAccountID()) . ',' . $db->escapeNumber($forceOwner->getAllianceID()) . ',' . $db->escapeObject($results, true) . ')');
 $logId = $db->getInsertID();
 
 if ($sendMessage) {
@@ -121,5 +120,5 @@ if ($player->isDead()) {
 	$container['owner_id'] = 0;
 }
 
-$container['results'] = $serializedResults;
+$container['results'] = $results;
 $container->go();

--- a/src/engine/Default/planet_attack.php
+++ b/src/engine/Default/planet_attack.php
@@ -1,8 +1,7 @@
 <?php declare(strict_types=1);
 
 if (isset($var['results'])) {
-	$results = unserialize($var['results']);
-	$template->assign('FullPlanetCombatResults', $results);
+	$template->assign('FullPlanetCombatResults', $var['results']);
 	$template->assign('AlreadyDestroyed', false);
 } else {
 	$template->assign('AlreadyDestroyed', true);

--- a/src/engine/Default/planet_attack_processing.php
+++ b/src/engine/Default/planet_attack_processing.php
@@ -77,8 +77,7 @@ $results['Planet'] = $planet->shootPlayers($attackers);
 $account->log(LOG_TYPE_PLANET_BUSTING, 'Player attacks planet, the planet does ' . $results['Planet']['TotalDamage'] . ', their team does ' . $results['Attackers']['TotalDamage'] . ' and downgrades: ' . var_export($results['Attackers']['Downgrades'], true), $planet->getSectorID());
 
 // Add this log to the `combat_logs` database table
-$serializedResults = serialize($results);
-$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLANET\',' . $planet->getSectorID() . ',' . SmrSession::getTime() . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $planetOwner->getAccountID() . ',' . $planetOwner->getAllianceID() . ',' . $db->escapeBinary(gzcompress($serializedResults)) . ')');
+$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLANET\',' . $planet->getSectorID() . ',' . SmrSession::getTime() . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $planetOwner->getAccountID() . ',' . $planetOwner->getAllianceID() . ',' . $db->escapeObject($results, true) . ')');
 $logId = $db->getInsertID();
 
 if ($planet->isDestroyed()) {
@@ -116,5 +115,5 @@ if ($player->isDead()) {
 	$container['override_death'] = TRUE;
 }
 
-$container['results'] = $serializedResults;
+$container['results'] = $results;
 $container->go();

--- a/src/engine/Default/port_attack.php
+++ b/src/engine/Default/port_attack.php
@@ -1,8 +1,7 @@
 <?php declare(strict_types=1);
 
 if (isset($var['results'])) {
-	$results = unserialize($var['results']);
-	$template->assign('FullPortCombatResults', $results);
+	$template->assign('FullPortCombatResults', $var['results']);
 	$template->assign('AlreadyDestroyed', false);
 } else {
 	$template->assign('AlreadyDestroyed', true);

--- a/src/engine/Default/port_attack_processing.php
+++ b/src/engine/Default/port_attack_processing.php
@@ -73,8 +73,7 @@ $account->log(LOG_TYPE_PORT_RAIDING, 'Player attacks port, the port does ' . $re
 
 $port->update();
 
-$serializedResults = serialize($results);
-$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PORT\',' . $db->escapeNumber($port->getSectorID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber(ACCOUNT_ID_PORT) . ',' . $db->escapeNumber(PORT_ALLIANCE_ID) . ',' . $db->escapeBinary(gzcompress($serializedResults)) . ')');
+$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PORT\',' . $db->escapeNumber($port->getSectorID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber(ACCOUNT_ID_PORT) . ',' . $db->escapeNumber(PORT_ALLIANCE_ID) . ',' . $db->escapeObject($results, true) . ')');
 $logId = $db->escapeString('[ATTACK_RESULTS]' . $db->getInsertID());
 foreach ($attackers as $attacker) {
 	if (!$player->equals($attacker)) {
@@ -89,5 +88,5 @@ if ($player->isDead()) {
 	$container['override_death'] = TRUE;
 }
 
-$container['results'] = $serializedResults;
+$container['results'] = $results;
 $container->go();

--- a/src/engine/Default/trader_attack.php
+++ b/src/engine/Default/trader_attack.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
-$results = unserialize($var['results']);
-$template->assign('TraderCombatResults', $results);
+
+$template->assign('TraderCombatResults', $var['results']);
 if ($var['target']) {
 	$template->assign('Target', SmrPlayer::getPlayer($var['target'], $player->getGameID()));
 }

--- a/src/engine/Default/trader_attack_processing.php
+++ b/src/engine/Default/trader_attack_processing.php
@@ -75,8 +75,7 @@ $results = [
 
 $account->log(LOG_TYPE_TRADER_COMBAT, 'Player attacks player, their team does ' . $results['Attackers']['TotalDamage'] . ' and the other team does ' . $results['Defenders']['TotalDamage'], $sector->getSectorID());
 
-$serializedResults = serialize($results);
-$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLAYER\',' . $db->escapeNumber($sector->getSectorID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($var['target']) . ',' . $db->escapeNumber($targetPlayer->getAllianceID()) . ',' . $db->escapeBinary(gzcompress($serializedResults)) . ')');
+$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLAYER\',' . $db->escapeNumber($sector->getSectorID()) . ',' . $db->escapeNumber(SmrSession::getTime()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($var['target']) . ',' . $db->escapeNumber($targetPlayer->getAllianceID()) . ',' . $db->escapeObject($results, true) . ')');
 
 $container = Page::create('skeleton.php', 'trader_attack.php');
 
@@ -93,5 +92,5 @@ if ($player->isDead()) {
 	$container['target'] = 0;
 }
 
-$container['results'] = $serializedResults;
+$container['results'] = $results;
 $container->go();

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -1595,7 +1595,7 @@ abstract class AbstractSmrPlayer {
 
 			if ($this->db->nextRecord()) {
 				// get the course back
-				$this->plottedCourse = unserialize($this->db->getField('course'));
+				$this->plottedCourse = $this->db->getObject('course');
 			} else {
 				$this->plottedCourse = false;
 			}
@@ -1624,7 +1624,7 @@ abstract class AbstractSmrPlayer {
 		if ($this->plottedCourse->getTotalSectors() > 0) {
 			$this->db->query('REPLACE INTO player_plotted_course
 				(account_id, game_id, course)
-				VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeBinary(serialize($this->plottedCourse)) . ')');
+				VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeObject($this->plottedCourse) . ')');
 		} elseif ($hadPlottedCourse) {
 			$this->deletePlottedCourse();
 		}

--- a/src/lib/Default/AbstractSmrPort.class.php
+++ b/src/lib/Default/AbstractSmrPort.class.php
@@ -1084,7 +1084,7 @@ class AbstractSmrPort {
 	}
 	public function addCachePorts(array $accountIDs) {
 		if (count($accountIDs) > 0 && $this->exists()) {
-			$cache = $this->db->escapeBinary(gzcompress(serialize($this)));
+			$cache = $this->db->escapeObject($this, true);
 			$cacheHash = $this->db->escapeString(md5($cache));
 			//give them the port info
 			$query = 'INSERT IGNORE INTO player_visited_port ' .
@@ -1119,7 +1119,7 @@ class AbstractSmrPort {
 							AND sector_id = ' . $db->escapeNumber($sectorID) . ' LIMIT 1');
 
 			if ($db->nextRecord()) {
-				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID] = unserialize(gzuncompress($db->getField('port_info')));
+				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID] = $db->getObject('port_info', true);
 				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID]->setCachedTime($db->getInt('visited'));
 			} else {
 				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID] = false;

--- a/src/lib/Default/DummyPlayer.class.php
+++ b/src/lib/Default/DummyPlayer.class.php
@@ -72,12 +72,10 @@ class DummyPlayer extends AbstractSmrPlayer {
 
 	public function cacheDummyPlayer() {
 		$this->getShip()->cacheDummyShip();
-		$cache = serialize($this);
 		$db = MySqlDatabase::getInstance();
 		$db->query('REPLACE INTO cached_dummys ' .
 					'(type, id, info) ' .
-					'VALUES (\'DummyPlayer\', '.$db->escapeString($this->getPlayerName()).', '.$db->escapeString($cache).')');
-		 unserialize($cache);
+					'VALUES (\'DummyPlayer\', '.$db->escapeString($this->getPlayerName()).', '.$db->escapeObject($this).')');
 	}
 
 	public static function &getCachedDummyPlayer($name) {
@@ -86,7 +84,7 @@ class DummyPlayer extends AbstractSmrPlayer {
 					WHERE type = \'DummyPlayer\'
 						AND id = ' . $db->escapeString($name) . ' LIMIT 1');
 		if($db->nextRecord()) {
-			$return = unserialize($db->getField('info'));
+			$return = $db->getObject('info');
 			return $return;
 		}
 		else {

--- a/src/lib/Default/DummyShip.class.php
+++ b/src/lib/Default/DummyShip.class.php
@@ -9,10 +9,9 @@ class DummyShip extends AbstractSmrShip {
 	}
 
 	public function cacheDummyShip() {
-		$cache = serialize($this);
 		$db = MySqlDatabase::getInstance();
 		$db->query('REPLACE INTO cached_dummys (type, id, info)
-					VALUES (\'DummyShip\', ' . $db->escapeString($this->getPlayer()->getPlayerName()) . ', ' . $db->escapeString($cache) . ')');
+					VALUES (\'DummyShip\', ' . $db->escapeString($this->getPlayer()->getPlayerName()) . ', ' . $db->escapeObject($this) . ')');
 	}
 
 	public static function getCachedDummyShip(AbstractSmrPlayer $player) {
@@ -24,7 +23,7 @@ class DummyShip extends AbstractSmrShip {
 			$db->query('SELECT info FROM cached_dummys WHERE type = \'DummyShip\'
 						AND id = ' . $db->escapeString($player->getPlayerName()) . ' LIMIT 1');
 			if ($db->nextRecord()) {
-				$cachedShip = unserialize($db->getField('info'));
+				$cachedShip = $db->getObject('info');
 				foreach ($cachedShip->getWeapons() as $weapon) {
 					$ship->addWeapon($weapon);
 				}

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -622,7 +622,7 @@ function &findRoutes($player) {
 	$db = MySqlDatabase::getInstance();
 	$db->query('SELECT routes FROM route_cache WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND max_ports=' . $db->escapeNumber($maxNumberOfPorts) . ' AND goods_allowed=' . $db->escapeObject($tradeGoods) . ' AND races_allowed=' . $db->escapeObject($tradeRaces) . ' AND start_sector_id=' . $db->escapeNumber($startSectorID) . ' AND end_sector_id=' . $db->escapeNumber($endSectorID) . ' AND routes_for_port=' . $db->escapeNumber($routesForPort) . ' AND max_distance=' . $db->escapeNumber($maxDistance));
 	if ($db->nextRecord()) {
-		$routes = unserialize(gzuncompress($db->getField('routes')));
+		$routes = $db->getObject('routes', true);
 		debug('Using Cached Routes: #' . count($routes));
 		return $routes;
 	} else {

--- a/src/tools/reserializeCombatLogs.php
+++ b/src/tools/reserializeCombatLogs.php
@@ -22,5 +22,5 @@ $db2 = MySqlDatabase::getInstance();
 
 $db->query('SELECT result,log_id FROM combat_logs');
 while ($db->nextRecord()) {
-	$db2->query('UPDATE combat_logs SET result=' . $db2->escapeBinary(gzcompress(serialize(unserialize(gzuncompress($db->getField('result')))))) . ' WHERE log_id=' . $db->getField('log_id'));
+	$db2->query('UPDATE combat_logs SET result=' . $db2->escapeObject($db->getObject('result', true), true) . ' WHERE log_id=' . $db->getField('log_id'));
 }


### PR DESCRIPTION
These methods are a wrapper around serialize and gzcompress for
database escaping and querying. Use them, where applicable, instead
of getting the raw strings and manually (un)serializing/compressing
them.

For the various attack pages, we can store the combat results in the
global `$var` in its raw form. Serializing them only to unserialize
them later just creates extra work.

This also includes two simplifications in SmrSession:

1. We always specify `active_session.session_var` on insertion, and
   `self::$var` is always set to an array; therefore, we know that
   the `session_var` can be safely extracted with `getObject`, rather
   than getting the raw string and verifying that it is not empty.

2. Since we don't always specify `active_session.ajax_returns`, it
   now has a default value of null. This allows us to use `getObject`
   without first checking if the raw string is the empty string.

(Note that the empty raw string is what you get when you have a column
default of `None`, but omit the field on insertion, which is not legal
in strict sql mode. We do not use this mode, but may in the future.)