### PR TITLE
Make SmrSession non-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ There are two common usages of this:
 - $container = Page::create('skeleton.php', $displayOnlyPage) with $displayOnlyPage being something such as 'current_sector.php'
 - $container = Page::create($processingPage) with $processingPage being something such as 'sector_move_processing.php'.
 
-You can then call $container->href() to get a HREF which will load the given page or SmrSession::generateSN($container) to get just the sn.
+You can then call $container->href() to get a HREF which will load the given page or Smr\Session::generateSN($container) to get just the sn.
 Along with this you can also assign extra values to $container which will be available on the next page under $var
 
 ```php
@@ -150,7 +150,7 @@ simultaneously (doing so will cause database errors).
 
 ### $var
 $var contains all information passed using the $container from the previous page.
-This *can* be assigned to, but only using SmrSession::updateVar($name, $value)
+This *can* be assigned to, but only using Smr\Session::updateVar($name, $value)
 
 ### $template
 The global instance of the Template class should be the _only_ instance, and
@@ -173,7 +173,7 @@ be assigned to.
 
 
 ## Request variables
-For any page which takes input through POST or GET (or other forms?) they should store these values in $var using SmrSession::updateVar() and only access via $var, this is required as when auto-refresh updates the page it will *not* resend these inputs but still requires them to render the page correctly.
+For any page which takes input through POST or GET (or other forms?) they should store these values in $var using Smr\Session::updateVar() and only access via $var, this is required as when auto-refresh updates the page it will *not* resend these inputs but still requires them to render the page correctly.
 
 ## Abstract vs normal classes
 This initially started out to be used in the "standard" way for NPCs but that idea has since been discarded.

--- a/src/admin/Default/1.6/universe_create_galaxies.php
+++ b/src/admin/Default/1.6/universe_create_galaxies.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-$numGals = SmrSession::getRequestVarInt('num_gals', 12);
+$session = SmrSession::getInstance();
+
+$numGals = $session->getRequestVarInt('num_gals', 12);
 
 $game = SmrGame::getGame($var['game_id']);
 $template->assign('PageTopic', 'Create Galaxies : ' . $game->getDisplayName());

--- a/src/admin/Default/1.6/universe_create_galaxies.php
+++ b/src/admin/Default/1.6/universe_create_galaxies.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $numGals = $session->getRequestVarInt('num_gals', 12);
 

--- a/src/admin/Default/1.6/universe_create_locations.php
+++ b/src/admin/Default/1.6/universe_create_locations.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-SmrSession::getRequestVarInt('gal_on');
+$session = SmrSession::getInstance();
+
+$session->getRequestVarInt('gal_on');
 $template->assign('Galaxies', SmrGalaxy::getGameGalaxies($var['game_id']));
 
 $container = Page::create('skeleton.php', '1.6/universe_create_locations.php');

--- a/src/admin/Default/1.6/universe_create_locations.php
+++ b/src/admin/Default/1.6/universe_create_locations.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $session->getRequestVarInt('gal_on');
 $template->assign('Galaxies', SmrGalaxy::getGameGalaxies($var['game_id']));

--- a/src/admin/Default/1.6/universe_create_planets.php
+++ b/src/admin/Default/1.6/universe_create_planets.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-SmrSession::getRequestVarInt('gal_on');
+$session = SmrSession::getInstance();
+
+$session->getRequestVarInt('gal_on');
 $template->assign('Galaxies', SmrGalaxy::getGameGalaxies($var['game_id']));
 
 $container = Page::create('skeleton.php', '1.6/universe_create_planets.php');

--- a/src/admin/Default/1.6/universe_create_planets.php
+++ b/src/admin/Default/1.6/universe_create_planets.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $session->getRequestVarInt('gal_on');
 $template->assign('Galaxies', SmrGalaxy::getGameGalaxies($var['game_id']));

--- a/src/admin/Default/1.6/universe_create_ports.php
+++ b/src/admin/Default/1.6/universe_create_ports.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-SmrSession::getRequestVarInt('gal_on');
+$session = SmrSession::getInstance();
+
+$session->getRequestVarInt('gal_on');
 $template->assign('Galaxies', SmrGalaxy::getGameGalaxies($var['game_id']));
 
 $container = Page::create('skeleton.php', '1.6/universe_create_ports.php');

--- a/src/admin/Default/1.6/universe_create_ports.php
+++ b/src/admin/Default/1.6/universe_create_ports.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $session->getRequestVarInt('gal_on');
 $template->assign('Galaxies', SmrGalaxy::getGameGalaxies($var['game_id']));

--- a/src/admin/Default/1.6/universe_create_save_processing.php
+++ b/src/admin/Default/1.6/universe_create_save_processing.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $submit = Request::getVar('submit');
-SmrSession::updateVar('submit', null);
+$session->updateVar('submit', null);
 
 if ($submit == 'Create Galaxies') {
 	for ($i = 1; $i <= $var['num_gals']; $i++) {

--- a/src/admin/Default/1.6/universe_create_save_processing.php
+++ b/src/admin/Default/1.6/universe_create_save_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $submit = Request::getVar('submit');
 $session->updateVar('submit', null);

--- a/src/admin/Default/1.6/universe_create_sector_details.php
+++ b/src/admin/Default/1.6/universe_create_sector_details.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-$editSectorID = SmrSession::getRequestVarInt('sector_edit');
+$session = SmrSession::getInstance();
+
+$editSectorID = $session->getRequestVarInt('sector_edit');
 $editSector = SmrSector::getSector($var['game_id'], $editSectorID);
 $template->assign('PageTopic', 'Edit Sector #' . $editSector->getSectorID() . ' (' . $editSector->getGalaxy()->getDisplayName() . ')');
 $template->assign('EditSector', $editSector);

--- a/src/admin/Default/1.6/universe_create_sector_details.php
+++ b/src/admin/Default/1.6/universe_create_sector_details.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $editSectorID = $session->getRequestVarInt('sector_edit');
 $editSector = SmrSector::getSector($var['game_id'], $editSectorID);

--- a/src/admin/Default/1.6/universe_create_sectors.php
+++ b/src/admin/Default/1.6/universe_create_sectors.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $session->getRequestVarInt('game_id');
 $session->getRequestVarInt('gal_on', 1);

--- a/src/admin/Default/1.6/universe_create_sectors.php
+++ b/src/admin/Default/1.6/universe_create_sectors.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
-SmrSession::getRequestVarInt('game_id');
-SmrSession::getRequestVarInt('gal_on', 1);
-$focusSector = SmrSession::getRequestVarInt('focus_sector_id', 0);
+$session = SmrSession::getInstance();
+
+$session->getRequestVarInt('game_id');
+$session->getRequestVarInt('gal_on', 1);
+$focusSector = $session->getRequestVarInt('focus_sector_id', 0);
 
 $galaxies = SmrGalaxy::getGameGalaxies($var['game_id']);
 if (empty($galaxies)) {
@@ -41,7 +43,7 @@ $template->assign('LastSector', $lastSector);
 
 if (isset($var['message'])) {
 	$template->assign('Message', $var['message']);
-	SmrSession::updateVar('message', null); // Only show message once
+	$session->updateVar('message', null); // Only show message once
 }
 
 $container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');

--- a/src/admin/Default/1.6/universe_create_warps.php
+++ b/src/admin/Default/1.6/universe_create_warps.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 if (isset($var['message'])) {
 	$template->assign('Message', $var['message']);
-	SmrSession::updateVar('message', null); // Only show message once
+	$session->updateVar('message', null); // Only show message once
 }
 
 $galaxies = SmrGalaxy::getGameGalaxies($var['game_id']);

--- a/src/admin/Default/1.6/universe_create_warps.php
+++ b/src/admin/Default/1.6/universe_create_warps.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (isset($var['message'])) {
 	$template->assign('Message', $var['message']);

--- a/src/admin/Default/admin_message_send.php
+++ b/src/admin/Default/admin_message_send.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Send Admin Message');
 
-$gameID = SmrSession::getRequestVarInt('SendGameID');
+$gameID = $session->getRequestVarInt('SendGameID');
 $container = Page::create('admin_message_send_processing.php');
 $container['SendGameID'] = $gameID;
 $template->assign('AdminMessageSendFormHref', $container->href());

--- a/src/admin/Default/admin_message_send.php
+++ b/src/admin/Default/admin_message_send.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Send Admin Message');
 

--- a/src/admin/Default/album_moderate.php
+++ b/src/admin/Default/album_moderate.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Moderate Photo Album');
 

--- a/src/admin/Default/album_moderate.php
+++ b/src/admin/Default/album_moderate.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Moderate Photo Album');
 
 require_once(LIB . 'Album/album_functions.php');
 
-$account_id = SmrSession::getRequestVarInt('account_id');
+$account_id = $session->getRequestVarInt('account_id');
 
 // check if the given account really has an entry
 $db->query('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account_id) . ' AND Approved = \'YES\'');

--- a/src/admin/Default/anon_acc_view.php
+++ b/src/admin/Default/anon_acc_view.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 //view anon acct activity.
 $template->assign('PageTopic', 'View Anonymous Account Info');

--- a/src/admin/Default/anon_acc_view.php
+++ b/src/admin/Default/anon_acc_view.php
@@ -1,13 +1,15 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 //view anon acct activity.
 $template->assign('PageTopic', 'View Anonymous Account Info');
 
 $container = Page::create('skeleton.php', 'anon_acc_view_select.php');
 $template->assign('BackHREF', $container->href());
 
-$anonID = SmrSession::getRequestVarInt('anon_account');
-$gameID = SmrSession::getRequestVarInt('view_game_id');
+$anonID = $session->getRequestVarInt('anon_account');
+$gameID = $session->getRequestVarInt('view_game_id');
 
 $db->query('SELECT *
 			FROM anon_bank_transactions

--- a/src/admin/Default/game_delete_confirm.php
+++ b/src/admin/Default/game_delete_confirm.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Delete Game - Confirmation');
 

--- a/src/admin/Default/game_delete_confirm.php
+++ b/src/admin/Default/game_delete_confirm.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Delete Game - Confirmation');
 
-SmrSession::getRequestVarInt('delete_game_id');
+$session->getRequestVarInt('delete_game_id');
 $template->assign('Game', SmrGame::getGame($var['delete_game_id']));
 
 $container = Page::create('game_delete_processing.php');

--- a/src/admin/Default/ip_view_results.php
+++ b/src/admin/Default/ip_view_results.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
-$variable = SmrSession::getRequestVar('variable');
-$type = SmrSession::getRequestVar('type');
+
+$session = SmrSession::getInstance();
+
+$variable = $session->getRequestVar('variable');
+$type = $session->getRequestVar('type');
 
 $db2 = MySqlDatabase::getInstance();
 

--- a/src/admin/Default/ip_view_results.php
+++ b/src/admin/Default/ip_view_results.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $variable = $session->getRequestVar('variable');
 $type = $session->getRequestVar('type');

--- a/src/admin/Default/log_console_detail.php
+++ b/src/admin/Default/log_console_detail.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Log Console - Detail');
 

--- a/src/admin/Default/log_console_detail.php
+++ b/src/admin/Default/log_console_detail.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Log Console - Detail');
 
 // get the account_ids from last form
-$account_ids = SmrSession::getRequestVarIntArray('account_ids');
+$account_ids = $session->getRequestVarIntArray('account_ids');
 
 // get the log_type_ids for log types to be displayed
-$log_type_ids = SmrSession::getRequestVarIntArray('log_type_ids');
+$log_type_ids = $session->getRequestVarIntArray('log_type_ids');
 
 // nothing marked?
 if (count($account_ids) == 0) {
@@ -14,7 +16,7 @@ if (count($account_ids) == 0) {
 }
 $account_list = $db->escapeArray($account_ids);
 
-$action = SmrSession::getRequestVar('action');
+$action = $session->getRequestVar('action');
 $template->assign('Action', $action);
 if ($action == 'Delete') {
 

--- a/src/admin/Default/manage_draft_leaders.php
+++ b/src/admin/Default/manage_draft_leaders.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Manage Draft Leaders');
 
 $container = Page::create('skeleton.php', 'manage_draft_leaders.php');
@@ -18,7 +20,7 @@ $template->assign('ActiveGames', $activeGames);
 
 if ($activeGames) {
 	// Set the selected game (or the first in the list if not selected yet)
-	$selectedGameID = SmrSession::getRequestVarInt('selected_game_id', $activeGames[0]['game_id']);
+	$selectedGameID = $session->getRequestVarInt('selected_game_id', $activeGames[0]['game_id']);
 	$template->assign('SelectedGame', $selectedGameID);
 
 	// Get the list of current draft leaders for the selected game
@@ -37,7 +39,7 @@ if ($activeGames) {
 
 // If we are selecting a different game, clear the processing message.
 if (Request::has('selected_game_id')) {
-	SmrSession::updateVar('processing_msg', null);
+	$session->updateVar('processing_msg', null);
 }
 // If we have just forwarded from the processing file, pass its message.
 if (isset($var['processing_msg'])) {

--- a/src/admin/Default/manage_draft_leaders.php
+++ b/src/admin/Default/manage_draft_leaders.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Manage Draft Leaders');
 

--- a/src/admin/Default/manage_draft_leaders_processing.php
+++ b/src/admin/Default/manage_draft_leaders_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 // Get the selected game
 $gameId = $var['selected_game_id'];

--- a/src/admin/Default/manage_draft_leaders_processing.php
+++ b/src/admin/Default/manage_draft_leaders_processing.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 // Get the selected game
 $gameId = $var['selected_game_id'];
 
 // Clear any messages from prior processing
-SmrSession::updateVar('processing_msg', null);
+$session->updateVar('processing_msg', null);
 
 // Get the POST variables
 $playerId = Request::getInt('player_id');
@@ -15,7 +17,7 @@ try {
 	$selectedPlayer = SmrPlayer::getPlayerByPlayerID($playerId, $gameId);
 } catch (PlayerNotFoundException $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
-	SmrSession::updateVar('processing_msg', $msg);
+	$session->updateVar('processing_msg', $msg);
 	Page::create('skeleton.php', 'manage_draft_leaders.php', $var)->go();
 }
 
@@ -40,7 +42,7 @@ if ($action == "Assign") {
 }
 
 if (!empty($msg)) {
-	SmrSession::updateVar('processing_msg', $msg);
+	$session->updateVar('processing_msg', $msg);
 }
 
 // Pass entire $var so that the selected game remains selected

--- a/src/admin/Default/manage_post_editors.php
+++ b/src/admin/Default/manage_post_editors.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Manage Galactic Post Editors');
 

--- a/src/admin/Default/manage_post_editors.php
+++ b/src/admin/Default/manage_post_editors.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Manage Galactic Post Editors');
 
 $container = Page::create('skeleton.php', 'manage_post_editors.php');
@@ -18,7 +20,7 @@ $template->assign('ActiveGames', $activeGames);
 
 if ($activeGames) {
 	// Set the selected game (or the first in the list if not selected yet)
-	$selectedGameID = SmrSession::getRequestVarInt('selected_game_id', $activeGames[0]['game_id']);
+	$selectedGameID = $session->getRequestVarInt('selected_game_id', $activeGames[0]['game_id']);
 	$template->assign('SelectedGame', $selectedGameID);
 
 	// Get the list of current editors for the selected game
@@ -32,7 +34,7 @@ if ($activeGames) {
 
 // If we are selecting a different game, clear the processing message.
 if (Request::has('game_id')) {
-	SmrSession::updateVar('processing_msg', null);
+	$session->updateVar('processing_msg', null);
 }
 // If we have just forwarded from the processing file, pass its message.
 if (isset($var['processing_msg'])) {

--- a/src/admin/Default/manage_post_editors_processing.php
+++ b/src/admin/Default/manage_post_editors_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 // Get the selected game
 $game_id = $var['selected_game_id'];

--- a/src/admin/Default/manage_post_editors_processing.php
+++ b/src/admin/Default/manage_post_editors_processing.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 // Get the selected game
 $game_id = $var['selected_game_id'];
 
 // Clear any messages from prior processing
-SmrSession::updateVar('processing_msg', null);
+$session->updateVar('processing_msg', null);
 
 // Get the POST variables
 $player_id = Request::getInt('player_id');
@@ -14,7 +16,7 @@ try {
 	$selected_player = SmrPlayer::getPlayerByPlayerID($player_id, $game_id);
 } catch (PlayerNotFoundException $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
-	SmrSession::updateVar('processing_msg', $msg);
+	$session->updateVar('processing_msg', $msg);
 	Page::create('skeleton.php', 'manage_post_editors.php', $var)->go();
 }
 
@@ -39,7 +41,7 @@ if ($action == "Assign") {
 }
 
 if (!empty($msg)) {
-	SmrSession::updateVar('processing_msg', $msg);
+	$session->updateVar('processing_msg', $msg);
 }
 
 // Pass entire $var so that the selected game remains selected

--- a/src/admin/Default/npc_manage.php
+++ b/src/admin/Default/npc_manage.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Manage NPCs');
 

--- a/src/admin/Default/npc_manage.php
+++ b/src/admin/Default/npc_manage.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Manage NPCs');
 
-$selectedGameID = SmrSession::getRequestVarInt('selected_game_id', 0);
+$selectedGameID = $session->getRequestVarInt('selected_game_id', 0);
 
 $container = Page::create('skeleton.php', 'npc_manage.php');
 $template->assign('SelectGameHREF', $container->href());

--- a/src/admin/Default/permission_manage.php
+++ b/src/admin/Default/permission_manage.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-$admin_id = SmrSession::getRequestVarInt('admin_id', 0);
+$session = SmrSession::getInstance();
+
+$admin_id = $session->getRequestVarInt('admin_id', 0);
 
 $template->assign('PageTopic', 'Manage Admin Permissions');
 

--- a/src/admin/Default/permission_manage.php
+++ b/src/admin/Default/permission_manage.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $admin_id = $session->getRequestVarInt('admin_id', 0);
 

--- a/src/engine/Default/alliance_forces.php
+++ b/src/engine/Default/alliance_forces.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/alliance_forces.php
+++ b/src/engine/Default/alliance_forces.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());

--- a/src/engine/Default/alliance_message.php
+++ b/src/engine/Default/alliance_message.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/alliance_message.php
+++ b/src/engine/Default/alliance_message.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());

--- a/src/engine/Default/alliance_message_add_processing.php
+++ b/src/engine/Default/alliance_message_add_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $body = htmlentities(trim(Request::get('body')), ENT_COMPAT, 'utf-8');
 $topic = Request::get('topic', ''); // only present for Create Thread

--- a/src/engine/Default/alliance_message_add_processing.php
+++ b/src/engine/Default/alliance_message_add_processing.php
@@ -1,4 +1,7 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 $body = htmlentities(trim(Request::get('body')), ENT_COMPAT, 'utf-8');
 $topic = Request::get('topic', ''); // only present for Create Thread
 $allEyesOnly = Request::has('allEyesOnly'); // only present for Create Thread
@@ -18,7 +21,7 @@ if ($action == 'Preview Thread' || $action == 'Preview Reply') {
 }
 
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 $alliance_id = $var['alliance_id'];
 

--- a/src/engine/Default/alliance_message_delete_processing.php
+++ b/src/engine/Default/alliance_message_delete_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/alliance_message_delete_processing.php
+++ b/src/engine/Default/alliance_message_delete_processing.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 $alliance_id = $var['alliance_id'];
 

--- a/src/engine/Default/alliance_message_view.php
+++ b/src/engine/Default/alliance_message_view.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/alliance_message_view.php
+++ b/src/engine/Default/alliance_message_view.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());

--- a/src/engine/Default/alliance_mod.php
+++ b/src/engine/Default/alliance_mod.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/alliance_mod.php
+++ b/src/engine/Default/alliance_mod.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());

--- a/src/engine/Default/alliance_option.php
+++ b/src/engine/Default/alliance_option.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/alliance_option.php
+++ b/src/engine/Default/alliance_option.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());

--- a/src/engine/Default/alliance_roles.php
+++ b/src/engine/Default/alliance_roles.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/alliance_roles.php
+++ b/src/engine/Default/alliance_roles.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());

--- a/src/engine/Default/alliance_roster.php
+++ b/src/engine/Default/alliance_roster.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());

--- a/src/engine/Default/alliance_roster.php
+++ b/src/engine/Default/alliance_roster.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/alliance_stat.php
+++ b/src/engine/Default/alliance_stat.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/alliance_stat.php
+++ b/src/engine/Default/alliance_stat.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 $alliance_id = $var['alliance_id'];
 

--- a/src/engine/Default/alliance_stat_processing.php
+++ b/src/engine/Default/alliance_stat_processing.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 $alliance_id = $var['alliance_id'];
 if (Request::has('description')) {

--- a/src/engine/Default/alliance_stat_processing.php
+++ b/src/engine/Default/alliance_stat_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/bank_alliance.php
+++ b/src/engine/Default/bank_alliance.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 // ********************************
 // *
 // * V a l i d a t e d ?
@@ -12,7 +14,7 @@ if (!$account->isValidated()) {
 }
 
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
@@ -71,8 +73,8 @@ if ($db->getBoolean('positive_balance')) {
 	$template->assign('TotalWithdrawn', $totalWithdrawn);
 }
 
-$maxValue = SmrSession::getRequestVarInt('maxValue', 0);
-$minValue = SmrSession::getRequestVarInt('minValue', 0);
+$maxValue = $session->getRequestVarInt('maxValue', 0);
+$minValue = $session->getRequestVarInt('minValue', 0);
 
 if ($maxValue <= 0) {
 	$db->query('SELECT MAX(transaction_id) FROM alliance_bank_transactions

--- a/src/engine/Default/bank_alliance.php
+++ b/src/engine/Default/bank_alliance.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 // ********************************
 // *

--- a/src/engine/Default/bank_alliance_processing.php
+++ b/src/engine/Default/bank_alliance_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/bank_alliance_processing.php
+++ b/src/engine/Default/bank_alliance_processing.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 $alliance_id = $var['alliance_id'];
 

--- a/src/engine/Default/bank_anon_detail.php
+++ b/src/engine/Default/bank_anon_detail.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
-$account_num = SmrSession::getRequestVarInt('account_num');
-SmrSession::getRequestVarInt('maxValue', 0);
-SmrSession::getRequestVarInt('minValue', 0);
+$session = SmrSession::getInstance();
+
+$account_num = $session->getRequestVarInt('account_num');
+$session->getRequestVarInt('maxValue', 0);
+$session->getRequestVarInt('minValue', 0);
 
 $db->query('SELECT *
 			FROM anon_bank
@@ -12,7 +14,7 @@ $db->query('SELECT *
 // if they didn't come from the creation screen we need to check if the pw is correct
 if ($db->nextRecord()) {
 	if (!isset($var['allowed']) || $var['allowed'] != 'yes') {
-		SmrSession::getRequestVar('password');
+		$session->getRequestVar('password');
 		if ($db->getField('password') != $var['password']) {
 			create_error('Invalid password!');
 		}

--- a/src/engine/Default/bank_anon_detail.php
+++ b/src/engine/Default/bank_anon_detail.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $account_num = $session->getRequestVarInt('account_num');
 $session->getRequestVarInt('maxValue', 0);

--- a/src/engine/Default/bank_report.php
+++ b/src/engine/Default/bank_report.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['alliance_id'])) {
 	$session->updateVar('alliance_id', $player->getAllianceID());

--- a/src/engine/Default/bank_report.php
+++ b/src/engine/Default/bank_report.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['alliance_id'])) {
-	SmrSession::updateVar('alliance_id', $player->getAllianceID());
+	$session->updateVar('alliance_id', $player->getAllianceID());
 }
 $alliance_id = $var['alliance_id'];
 const WITHDRAW = 0;

--- a/src/engine/Default/bar_talk_bartender.php
+++ b/src/engine/Default/bar_talk_bartender.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Talk to Bartender');
 Menu::bar();

--- a/src/engine/Default/bar_talk_bartender.php
+++ b/src/engine/Default/bar_talk_bartender.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Talk to Bartender');
 Menu::bar();
 
@@ -11,7 +13,7 @@ if (!isset($var['Message'])) {
 	} else {
 		$message = 'I havent heard anything recently... got anything to tell me?';
 	}
-	SmrSession::updateVar('Message', $message);
+	$session->updateVar('Message', $message);
 }
 $template->assign('Message', bbifyMessage($var['Message']));
 

--- a/src/engine/Default/bounty_claim.php
+++ b/src/engine/Default/bounty_claim.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Bounty Payout');
 
 Menu::headquarters();
@@ -46,6 +48,6 @@ if (!isset($var['ClaimText'])) {
 		$claimText .= ('You have no claimable bounties<br /><br />');
 	}
 
-	SmrSession::updateVar('ClaimText', $claimText);
+	$session->updateVar('ClaimText', $claimText);
 }
 $template->assign('ClaimText', $var['ClaimText']);

--- a/src/engine/Default/bounty_claim.php
+++ b/src/engine/Default/bounty_claim.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Bounty Payout');
 

--- a/src/engine/Default/bug_report_processing.php
+++ b/src/engine/Default/bug_report_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $steps = Request::get('steps');
 $subject = Request::get('subject');

--- a/src/engine/Default/bug_report_processing.php
+++ b/src/engine/Default/bug_report_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $steps = Request::get('steps');
 $subject = Request::get('subject');
 $error_msg = Request::get('error_msg');
@@ -33,7 +35,7 @@ if (!empty(BUG_REPORT_TO_ADDRESSES)) {
 
 $container = Page::create('skeleton.php');
 $container['msg'] = '<span class="admin">ADMIN</span>: Bug report submitted. Thank you for helping to improve the game!';
-if (SmrSession::hasGame()) {
+if ($session->hasGame()) {
 	$container['body'] = 'current_sector.php';
 } else {
 	$container['body'] = 'game_play.php';

--- a/src/engine/Default/combat_log_list.php
+++ b/src/engine/Default/combat_log_list.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Combat Logs');
 Menu::combat_log();
 
@@ -10,7 +12,7 @@ if (isset($var['message'])) {
 
 // $var['action'] is the page log type
 if (!isset($var['action'])) {
-	SmrSession::updateVar('action', COMBAT_LOG_PERSONAL);
+	$session->updateVar('action', COMBAT_LOG_PERSONAL);
 }
 $action = $var['action'];
 

--- a/src/engine/Default/combat_log_list.php
+++ b/src/engine/Default/combat_log_list.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Combat Logs');
 Menu::combat_log();

--- a/src/engine/Default/contact_processing.php
+++ b/src/engine/Default/contact_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $receiver = Request::get('receiver');
 $subject = Request::get('subject');
 $msg = Request::get('msg');
@@ -16,7 +18,7 @@ $mail->addAddress($receiver);
 $mail->send();
 
 $container = Page::create('skeleton.php');
-if (SmrSession::hasGame()) {
+if ($session->hasGame()) {
 	$container['body'] = 'current_sector.php';
 } else {
 	$container['body'] = 'game_play.php';

--- a/src/engine/Default/contact_processing.php
+++ b/src/engine/Default/contact_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $receiver = Request::get('receiver');
 $subject = Request::get('subject');

--- a/src/engine/Default/council_list.php
+++ b/src/engine/Default/council_list.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['race_id'])) {
 	$session->updateVar('race_id', $player->getRaceID());

--- a/src/engine/Default/council_list.php
+++ b/src/engine/Default/council_list.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 if (!isset($var['race_id'])) {
-	SmrSession::updateVar('race_id', $player->getRaceID());
+	$session->updateVar('race_id', $player->getRaceID());
 }
 $raceID = $var['race_id'];
 

--- a/src/engine/Default/council_politics.php
+++ b/src/engine/Default/council_politics.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['race_id'])) {
 	$session->updateVar('race_id', $player->getRaceID());

--- a/src/engine/Default/council_politics.php
+++ b/src/engine/Default/council_politics.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 if (!isset($var['race_id'])) {
-	SmrSession::updateVar('race_id', $player->getRaceID());
+	$session->updateVar('race_id', $player->getRaceID());
 }
 $raceID = $var['race_id'];
 

--- a/src/engine/Default/course_plot.php
+++ b/src/engine/Default/course_plot.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Plot A Course');
 

--- a/src/engine/Default/course_plot.php
+++ b/src/engine/Default/course_plot.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Plot A Course');
 
 Menu::navigation($template, $player);
@@ -19,7 +21,7 @@ if ($ship->hasJump()) {
 $container = Page::create('skeleton.php', 'course_plot.php');
 $template->assign('PlotToNearestHREF', $container->href());
 
-$xtype = SmrSession::getRequestVar('xtype', 'Technology');
+$xtype = $session->getRequestVar('xtype', 'Technology');
 $template->assign('XType', $xtype);
 $template->assign('AllXTypes', array('Technology', 'Ships', 'Weapons', 'Locations', 'Sell Goods', 'Buy Goods', 'Galaxies'));
 

--- a/src/engine/Default/current_players.php
+++ b/src/engine/Default/current_players.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Current Players');
 $db->query('DELETE FROM cpl_tag WHERE expires > 0 AND expires < ' . $db->escapeNumber(Smr\Epoch::time()));
 $db->query('SELECT count(*) count FROM active_session
@@ -9,7 +11,7 @@ $count_real_last_active = 0;
 if ($db->nextRecord()) {
 	$count_real_last_active = $db->getInt('count');
 }
-if (SmrSession::$last_accessed < Smr\Epoch::time() - 600) {
+if ($session->getLastAccessed() < Smr\Epoch::time() - 600) {
 	++$count_real_last_active;
 }
 

--- a/src/engine/Default/current_players.php
+++ b/src/engine/Default/current_players.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Current Players');
 $db->query('DELETE FROM cpl_tag WHERE expires > 0 AND expires < ' . $db->escapeNumber(Smr\Epoch::time()));

--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 // If on a planet, forward to planet_main.php
 if ($player->isLandedOnPlanet()) {
@@ -166,7 +166,7 @@ function checkForAttackMessage(&$msg) {
 	$msg = str_replace('[ATTACK_RESULTS]', '', $msg, $contains);
 	if ($contains > 0) {
 		// $msg now contains only the log_id, if there is one
-		SmrSession::getInstance()->updateVar('AttackMessage', '[ATTACK_RESULTS]' . $msg);
+		Smr\Session::getInstance()->updateVar('AttackMessage', '[ATTACK_RESULTS]' . $msg);
 		if (!$template->hasTemplateVar('AttackResults')) {
 			$db->query('SELECT sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($msg) . ' LIMIT 1');
 			if ($db->nextRecord()) {

--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 // If on a planet, forward to planet_main.php
 if ($player->isLandedOnPlanet()) {
 	Page::create('skeleton.php', 'planet_main.php', $var)->go();
@@ -52,7 +54,7 @@ doTickerAssigns($template, $player, $db);
 
 if (!isset($var['UnreadMissions'])) {
 	$unreadMissions = $player->markMissionsRead();
-	SmrSession::updateVar('UnreadMissions', $unreadMissions);
+	$session->updateVar('UnreadMissions', $unreadMissions);
 }
 $template->assign('UnreadMissions', $var['UnreadMissions']);
 
@@ -164,7 +166,7 @@ function checkForAttackMessage(&$msg) {
 	$msg = str_replace('[ATTACK_RESULTS]', '', $msg, $contains);
 	if ($contains > 0) {
 		// $msg now contains only the log_id, if there is one
-		SmrSession::updateVar('AttackMessage', '[ATTACK_RESULTS]' . $msg);
+		SmrSession::getInstance()->updateVar('AttackMessage', '[ATTACK_RESULTS]' . $msg);
 		if (!$template->hasTemplateVar('AttackResults')) {
 			$db->query('SELECT sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($msg) . ' LIMIT 1');
 			if ($db->nextRecord()) {

--- a/src/engine/Default/error.php
+++ b/src/engine/Default/error.php
@@ -4,7 +4,7 @@ if (empty($var['message']) || $var['message'] == '') {
 	$var['message'] = 'File not found';
 }
 
-if (SmrSession::getInstance()->hasGame() && is_object($player) && $lock) {
+if (Smr\Session::getInstance()->hasGame() && is_object($player) && $lock) {
 	$container = Page::create('skeleton.php', 'current_sector.php');
 	$errorMsg = '<span class="red bold">ERROR:</span> ' . $var['message'];
 	$container['errorMsg'] = $errorMsg;

--- a/src/engine/Default/error.php
+++ b/src/engine/Default/error.php
@@ -4,7 +4,7 @@ if (empty($var['message']) || $var['message'] == '') {
 	$var['message'] = 'File not found';
 }
 
-if (SmrSession::hasGame() && is_object($player) && $lock) {
+if (SmrSession::getInstance()->hasGame() && is_object($player) && $lock) {
 	$container = Page::create('skeleton.php', 'current_sector.php');
 	$errorMsg = '<span class="red bold">ERROR:</span> ' . $var['message'];
 	$container['errorMsg'] = $errorMsg;

--- a/src/engine/Default/feature_request.php
+++ b/src/engine/Default/feature_request.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!Globals::isFeatureRequestOpen()) {
 	create_error('Feature requests are currently not being accepted.');

--- a/src/engine/Default/feature_request.php
+++ b/src/engine/Default/feature_request.php
@@ -1,10 +1,13 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!Globals::isFeatureRequestOpen()) {
 	create_error('Feature requests are currently not being accepted.');
 }
 
 if (!isset($var['category'])) {
-	SmrSession::updateVar('category', 'New');
+	$session->updateVar('category', 'New');
 }
 $thisStatus = statusFromCategory($var['category']);
 

--- a/src/engine/Default/galactic_post_past.php
+++ b/src/engine/Default/galactic_post_past.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Past <i>Galactic Post</i> Editions');
 Menu::galactic_post();

--- a/src/engine/Default/galactic_post_past.php
+++ b/src/engine/Default/galactic_post_past.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Past <i>Galactic Post</i> Editions');
 Menu::galactic_post();
 
@@ -7,7 +9,7 @@ $container = Page::create('skeleton.php', 'galactic_post_past.php');
 $template->assign('SelectGameHREF', $container->href());
 
 // View past editions of current game by default
-$selectedGameID = SmrSession::getRequestVarInt('selected_game_id', $player->getGameID());
+$selectedGameID = $session->getRequestVarInt('selected_game_id', $player->getGameID());
 $template->assign('SelectedGame', $selectedGameID);
 
 // Get the list of games with published papers

--- a/src/engine/Default/galactic_post_view_article.php
+++ b/src/engine/Default/galactic_post_view_article.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Viewing Articles');
 Menu::galactic_post();

--- a/src/engine/Default/galactic_post_view_article.php
+++ b/src/engine/Default/galactic_post_view_article.php
@@ -1,4 +1,7 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Viewing Articles');
 Menu::galactic_post();
 
@@ -6,8 +9,8 @@ if (isset($var['news'])) {
 	$db->query('INSERT INTO news (game_id, time, news_message, type) ' .
 		'VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeString($var['news']) . ', \'BREAKING\')');
 	// avoid multiple insertion on ajax updates
-	SmrSession::updateVar('news', null);
-	SmrSession::updateVar('added_to_breaking_news', true);
+	$session->updateVar('news', null);
+	$session->updateVar('added_to_breaking_news', true);
 }
 
 // Get the articles that are not already in a paper

--- a/src/engine/Default/galactic_post_write_article.php
+++ b/src/engine/Default/galactic_post_write_article.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 Menu::galactic_post();
 $container = Page::create('galactic_post_write_article_processing.php');
 
@@ -9,8 +11,8 @@ if (isset($var['id'])) {
 	if (!isset($var['Preview'])) {
 		$db->query('SELECT title, text FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']) . ' LIMIT 1');
 		if ($db->nextRecord()) {
-			SmrSession::updateVar('PreviewTitle', $db->getField('title'));
-			SmrSession::updateVar('Preview', $db->getField('text'));
+			$session->updateVar('PreviewTitle', $db->getField('title'));
+			$session->updateVar('Preview', $db->getField('text'));
 		}
 	}
 } else {

--- a/src/engine/Default/galactic_post_write_article.php
+++ b/src/engine/Default/galactic_post_write_article.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 Menu::galactic_post();
 $container = Page::create('galactic_post_write_article_processing.php');

--- a/src/engine/Default/game_leave_processing.php
+++ b/src/engine/Default/game_leave_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 // Reset the game ID if necessary
 if ($session->hasGame()) {

--- a/src/engine/Default/game_leave_processing.php
+++ b/src/engine/Default/game_leave_processing.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 // Reset the game ID if necessary
-if (SmrSession::hasGame()) {
-	$account->log(LOG_TYPE_GAME_ENTERING, 'Player left game ' . SmrSession::getGameID());
-	SmrSession::updateGame(0);
+if ($session->hasGame()) {
+	$account->log(LOG_TYPE_GAME_ENTERING, 'Player left game ' . $session->getGameID());
+	$session->updateGame(0);
 }
 
-SmrSession::clearLinks();
+$session->clearLinks();
 
 Page::create('skeleton.php', $var['body'], $var)->go();

--- a/src/engine/Default/game_play_processing.php
+++ b/src/engine/Default/game_play_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 // register game_id
 $session->updateGame($var['game_id']);

--- a/src/engine/Default/game_play_processing.php
+++ b/src/engine/Default/game_play_processing.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 // register game_id
-SmrSession::updateGame($var['game_id']);
+$session->updateGame($var['game_id']);
 
 $player = SmrPlayer::getPlayer($account->getAccountID(), $var['game_id']);
 $player->updateLastCPLAction();
@@ -14,7 +16,7 @@ $player->deletePlottedCourse();
 $player->update();
 
 // log
-$player->log(LOG_TYPE_GAME_ENTERING, 'Player entered game ' . SmrSession::getGameID());
+$player->log(LOG_TYPE_GAME_ENTERING, 'Player entered game ' . $player->getGameID());
 
 $container = Page::create('skeleton.php', 'current_sector.php');
 $container->go();

--- a/src/engine/Default/history_games_detail.php
+++ b/src/engine/Default/history_games_detail.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $game_id = $var['view_game_id'];
 $template->assign('PageTopic', 'Extended Stats : ' . $var['game_name']);
 Menu::history_games(1);
@@ -12,7 +14,7 @@ if (isset($container['action'])) {
 $template->assign('SelfHREF', $container->href());
 
 // Default page has no category (action) selected yet
-$action = SmrSession::getRequestVar('action', '');
+$action = $session->getRequestVar('action', '');
 if (!empty($action)) {
 	if ($action == 'Top Mined Sectors') {
 		$sql = 'mines'; $from = 'sector'; $dis = 'Mines';

--- a/src/engine/Default/history_games_detail.php
+++ b/src/engine/Default/history_games_detail.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $game_id = $var['view_game_id'];
 $template->assign('PageTopic', 'Extended Stats : ' . $var['game_name']);

--- a/src/engine/Default/logged_in.php
+++ b/src/engine/Default/logged_in.php
@@ -4,7 +4,7 @@
 $account->updateLastLogin();
 
 $container = Page::create('skeleton.php');
-if (SmrSession::getInstance()->hasGame()) {
+if (Smr\Session::getInstance()->hasGame()) {
 	$container['body'] = 'current_sector.php';
 } else {
 	$container['body'] = 'game_play.php';

--- a/src/engine/Default/logged_in.php
+++ b/src/engine/Default/logged_in.php
@@ -4,7 +4,7 @@
 $account->updateLastLogin();
 
 $container = Page::create('skeleton.php');
-if (SmrSession::hasGame()) {
+if (SmrSession::getInstance()->hasGame()) {
 	$container['body'] = 'current_sector.php';
 } else {
 	$container['body'] = 'game_play.php';

--- a/src/engine/Default/logoff.php
+++ b/src/engine/Default/logoff.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $account->log(LOG_TYPE_LOGIN, 'logged off from ' . getIpAddress());
 

--- a/src/engine/Default/logoff.php
+++ b/src/engine/Default/logoff.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $account->log(LOG_TYPE_LOGIN, 'logged off from ' . getIpAddress());
 
 // Remove the lock if we're holding one (ie logged off from game screen)
 if ($lock) {
 	release_lock();
 }
-SmrSession::destroy();
+$session->destroy();
 
 // Send the player back to the login screen
 $msg = 'You have successfully logged off!';

--- a/src/engine/Default/map_local.php
+++ b/src/engine/Default/map_local.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if ($player->isLandedOnPlanet()) {
 	create_error('You are on a planet!');

--- a/src/engine/Default/map_local.php
+++ b/src/engine/Default/map_local.php
@@ -1,10 +1,6 @@
 <?php declare(strict_types=1);
-////////////////////////////////////////////////////////////
-//
-//	Script:		map_local.php
-//	Purpose:	Displays Local Map
-//
-////////////////////////////////////////////////////////////
+
+$session = SmrSession::getInstance();
 
 if ($player->isLandedOnPlanet()) {
 	create_error('You are on a planet!');
@@ -38,7 +34,7 @@ if (isset($var['ZoomDir'])) {
 		$player->increaseZoom(1);
 	}
 	// Unset so that refreshing doesn't zoom again
-	SmrSession::updateVar('ZoomDir', null);
+	$session->updateVar('ZoomDir', null);
 }
 
 $container = Page::create('skeleton.php', 'map_local.php');

--- a/src/engine/Default/message_notify_confirm.php
+++ b/src/engine/Default/message_notify_confirm.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['notified_time'])) {
 	$session->updateVar('notified_time', Smr\Epoch::time());

--- a/src/engine/Default/message_notify_confirm.php
+++ b/src/engine/Default/message_notify_confirm.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 if (!isset($var['notified_time'])) {
-	SmrSession::updateVar('notified_time', Smr\Epoch::time());
+	$session->updateVar('notified_time', Smr\Epoch::time());
 }
 
 if (empty($var['message_id'])) {

--- a/src/engine/Default/military_payment_claim.php
+++ b/src/engine/Default/military_payment_claim.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Military Payment Center');
 
 Menu::headquarters();
@@ -21,7 +23,7 @@ if (!isset($var['ClaimText'])) {
 		$claimText = ('You have done nothing worthy of military payment.');
 	}
 
-	SmrSession::updateVar('ClaimText', $claimText);
+	$session->updateVar('ClaimText', $claimText);
 }
 
 $template->assign('ClaimText', $var['ClaimText']);

--- a/src/engine/Default/military_payment_claim.php
+++ b/src/engine/Default/military_payment_claim.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Military Payment Center');
 

--- a/src/engine/Default/news_read.php
+++ b/src/engine/Default/news_read.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['GameID'])) {
-	SmrSession::updateVar('GameID', $player->getGameID());
+	$session->updateVar('GameID', $player->getGameID());
 }
 $gameID = $var['GameID'];
 

--- a/src/engine/Default/news_read.php
+++ b/src/engine/Default/news_read.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['GameID'])) {
 	$session->updateVar('GameID', $player->getGameID());

--- a/src/engine/Default/news_read_advanced.php
+++ b/src/engine/Default/news_read_advanced.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['GameID'])) {
 	$session->updateVar('GameID', $player->getGameID());

--- a/src/engine/Default/news_read_advanced.php
+++ b/src/engine/Default/news_read_advanced.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['GameID'])) {
-	SmrSession::updateVar('GameID', $player->getGameID());
+	$session->updateVar('GameID', $player->getGameID());
 }
 $gameID = $var['GameID'];
 
@@ -40,10 +43,10 @@ $template->assign('NewsAlliances', $newsAlliances);
 $template->assign('AdvancedNewsFormHref', Page::create('skeleton.php', 'news_read_advanced.php', $basicContainer)->href());
 
 // No submit value when first navigating to the page
-$submit_value = SmrSession::getRequestVar('submit', '');
+$submit_value = $session->getRequestVar('submit', '');
 
 if ($submit_value == 'Search For Player') {
-	$p_name = SmrSession::getRequestVar('playerName');
+	$p_name = $session->getRequestVar('playerName');
 	$template->assign('ResultsFor', $p_name);
 	$db->query('SELECT * FROM player WHERE player_name LIKE ' . $db->escapeString('%' . $p_name . '%') . ' AND game_id = ' . $db->escapeNumber($gameID));
 	$IDs = array(0);
@@ -52,12 +55,12 @@ if ($submit_value == 'Search For Player') {
 	}
 	$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND (killer_id IN (' . $db->escapeArray($IDs) . ') OR dead_id IN (' . $db->escapeArray($IDs) . ')) ORDER BY news_id DESC');
 } elseif ($submit_value == 'Search For Alliance') {
-	$allianceID = SmrSession::getRequestVarInt('allianceID');
+	$allianceID = $session->getRequestVarInt('allianceID');
 	$template->assign('ResultsFor', $newsAlliances[$allianceID]['Name']);
 	$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND ((killer_alliance = ' . $db->escapeNumber($allianceID) . ' AND killer_id != ' . $db->escapeNumber(ACCOUNT_ID_PORT) . ') OR (dead_alliance = ' . $db->escapeNumber($allianceID) . ' AND dead_id != ' . $db->escapeNumber(ACCOUNT_ID_PORT) . ')) ORDER BY news_id DESC');
 } elseif ($submit_value == 'Search For Players') {
-	$player1 = SmrSession::getRequestVar('player1');
-	$player2 = SmrSession::getRequestVar('player2');
+	$player1 = $session->getRequestVar('player1');
+	$player2 = $session->getRequestVar('player2');
 	$template->assign('ResultsFor', $player1 . ' vs. ' . $player2);
 	$db->query('SELECT * FROM player WHERE player_name LIKE ' . $db->escapeString('%' . $player1 . '%') . ' AND game_id = ' . $db->escapeNumber($gameID));
 	$IDs = array(0);
@@ -77,8 +80,8 @@ if ($submit_value == 'Search For Player') {
 						(killer_id IN (' . $db->escapeArray($IDs2) . ') AND dead_id IN (' . $db->escapeArray($IDs) . '))
 					) ORDER BY news_id DESC');
 } elseif ($submit_value == 'Search For Alliances') {
-	$allianceID1 = SmrSession::getRequestVar('alliance1');
-	$allianceID2 = SmrSession::getRequestVar('alliance2');
+	$allianceID1 = $session->getRequestVar('alliance1');
+	$allianceID2 = $session->getRequestVar('alliance2');
 	$template->assign('ResultsFor', $newsAlliances[$allianceID1]['Name'] . ' vs. ' . $newsAlliances[$allianceID2]['Name']);
 	$db->query('SELECT * FROM news
 				WHERE game_id = ' . $db->escapeNumber($gameID) . '

--- a/src/engine/Default/news_read_current.php
+++ b/src/engine/Default/news_read_current.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
+
+$session = SmrSession::getInstance();
+
 if (!isset($var['GameID'])) {
-	SmrSession::updateVar('GameID', $player->getGameID());
+	$session->updateVar('GameID', $player->getGameID());
 }
 $gameID = $var['GameID'];
 
@@ -13,7 +16,7 @@ doLottoNewsAssign($gameID, $template);
 
 
 if (!isset($var['LastNewsUpdate'])) {
-	SmrSession::updateVar('LastNewsUpdate', $player->getLastNewsUpdate());
+	$session->updateVar('LastNewsUpdate', $player->getLastNewsUpdate());
 }
 
 $db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND time > ' . $db->escapeNumber($var['LastNewsUpdate']) . ' AND type != \'lotto\' ORDER BY news_id DESC');

--- a/src/engine/Default/news_read_current.php
+++ b/src/engine/Default/news_read_current.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 if (!isset($var['GameID'])) {
 	$session->updateVar('GameID', $player->getGameID());

--- a/src/engine/Default/preferences_confirm.php
+++ b/src/engine/Default/preferences_confirm.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $amount = $session->getRequestVarInt('amount');
 $account_id = $session->getRequestVarInt('account_id');

--- a/src/engine/Default/preferences_confirm.php
+++ b/src/engine/Default/preferences_confirm.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
-$amount = SmrSession::getRequestVarInt('amount');
-$account_id = SmrSession::getRequestVarInt('account_id');
+$session = SmrSession::getInstance();
+
+$amount = $session->getRequestVarInt('amount');
+$account_id = $session->getRequestVarInt('account_id');
 if ($amount <= 0) {
 	create_error('You can only tranfer a positive amount!');
 }

--- a/src/engine/Default/preferences_processing.php
+++ b/src/engine/Default/preferences_processing.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $container = Page::create('skeleton.php');
-if (SmrSession::hasGame()) {
+if ($session->hasGame()) {
 	$container['body'] = 'current_sector.php';
 } else {
 	$container['body'] = 'game_play.php';

--- a/src/engine/Default/preferences_processing.php
+++ b/src/engine/Default/preferences_processing.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $container = Page::create('skeleton.php');
 if ($session->hasGame()) {

--- a/src/engine/Default/rankings_alliance_vs_alliance.php
+++ b/src/engine/Default/rankings_alliance_vs_alliance.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Alliance VS Alliance Rankings');
 

--- a/src/engine/Default/rankings_alliance_vs_alliance.php
+++ b/src/engine/Default/rankings_alliance_vs_alliance.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Alliance VS Alliance Rankings');
 
 Menu::rankings(1, 4);
@@ -7,8 +9,8 @@ $db2 = MySqlDatabase::getInstance();
 $container = Page::create('skeleton.php', 'rankings_alliance_vs_alliance.php');
 $template->assign('SubmitHREF', $container->href());
 
-$alliancer = SmrSession::getRequestVarIntArray('alliancer', []);
-$detailsAllianceID = SmrSession::getRequestVarInt('alliance_id', $player->getAllianceID());
+$alliancer = $session->getRequestVarIntArray('alliancer', []);
+$detailsAllianceID = $session->getRequestVarInt('alliance_id', $player->getAllianceID());
 
 // Get list of alliances that have kills or deaths
 $activeAlliances = [];

--- a/src/engine/Default/rankings_view.php
+++ b/src/engine/Default/rankings_view.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $template->assign('PageTopic', 'Extended User Rankings');
 if ($session->hasGame()) {

--- a/src/engine/Default/rankings_view.php
+++ b/src/engine/Default/rankings_view.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
+$session = SmrSession::getInstance();
+
 $template->assign('PageTopic', 'Extended User Rankings');
-if (SmrSession::hasGame()) {
+if ($session->hasGame()) {
 	Menu::trader();
 }

--- a/src/engine/Default/shop_goods_processing.php
+++ b/src/engine/Default/shop_goods_processing.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 require_once(LIB . 'Default/shop_goods.inc.php');
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $amount = Request::getVarInt('amount');
 // no negative amounts are allowed

--- a/src/engine/Default/shop_goods_processing.php
+++ b/src/engine/Default/shop_goods_processing.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 require_once(LIB . 'Default/shop_goods.inc.php');
 
+$session = SmrSession::getInstance();
+
 $amount = Request::getVarInt('amount');
 // no negative amounts are allowed
 if ($amount <= 0) {
@@ -64,12 +66,12 @@ if ($transaction === TRADER_BUYS && $player->getCredits() < $bargain_price) {
 $relations = $player->getRelation($port->getRaceID());
 
 if (!isset($var['ideal_price'])) {
-	SmrSession::updateVar('ideal_price', $port->getIdealPrice($good_id, $transaction, $amount, $relations));
+	$session->updateVar('ideal_price', $port->getIdealPrice($good_id, $transaction, $amount, $relations));
 }
 $ideal_price = $var['ideal_price'];
 
 if (!isset($var['offered_price'])) {
-	SmrSession::updateVar('offered_price', $port->getOfferPrice($ideal_price, $relations, $transaction));
+	$session->updateVar('offered_price', $port->getOfferPrice($ideal_price, $relations, $transaction));
 }
 $offered_price = $var['offered_price'];
 

--- a/src/engine/Default/trader_search_result.php
+++ b/src/engine/Default/trader_search_result.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
-$player_id = SmrSession::getRequestVarInt('player_id');
+$session = SmrSession::getInstance();
+
+$player_id = $session->getRequestVarInt('player_id');
 // When clicking on a player name, only the 'player_id' is supplied
-$player_name = SmrSession::getRequestVar('player_name', '');
+$player_name = $session->getRequestVar('player_name', '');
 
 if (empty($player_name) && empty($player_id)) {
 	create_error('You must specify either a player name or ID!');

--- a/src/engine/Default/trader_search_result.php
+++ b/src/engine/Default/trader_search_result.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-$session = SmrSession::getInstance();
+$session = Smr\Session::getInstance();
 
 $player_id = $session->getRequestVarInt('player_id');
 // When clicking on a player name, only the 'player_id' is supplied

--- a/src/htdocs/album/album_comment.php
+++ b/src/htdocs/album/album_comment.php
@@ -10,7 +10,7 @@ try {
 	require_once(LIB . 'Default/smr.inc.php');
 	require_once(LIB . 'Album/album_functions.php');
 
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 
 	if (!$session->hasAccount()) {
 		create_error_offline('You need to logged in to post comments!');

--- a/src/htdocs/album/album_comment.php
+++ b/src/htdocs/album/album_comment.php
@@ -10,7 +10,9 @@ try {
 	require_once(LIB . 'Default/smr.inc.php');
 	require_once(LIB . 'Album/album_functions.php');
 
-	if (!SmrSession::hasAccount()) {
+	$session = SmrSession::getInstance();
+
+	if (!$session->hasAccount()) {
 		create_error_offline('You need to logged in to post comments!');
 	}
 
@@ -28,7 +30,7 @@ try {
 		create_error_offline('Picture ID has to be positive!');
 	}
 
-	$account = SmrSession::getAccount();
+	$account = $session->getAccount();
 
 	if (isset($_GET['action']) && $_GET['action'] == 'Moderate') {
 		if (!$account->hasPermission(PERMISSION_MODERATE_PHOTO_ALBUM)) {
@@ -38,7 +40,7 @@ try {
 		$container['account_id'] = $album_id;
 
 		$href = $container->href(true);
-		SmrSession::update();
+		$session->update();
 
 		header('Location: ' . $href);
 		exit;

--- a/src/htdocs/loader.php
+++ b/src/htdocs/loader.php
@@ -35,7 +35,7 @@ try {
 	//echo '<pre>';echo_r($session);echo'</pre>';
 	//exit;
 	// do we have a session?
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 	if (!$session->hasAccount()) {
 		header('Location: /login.php');
 		exit;
@@ -70,7 +70,7 @@ try {
 	}
 
 	// Determine where to load game scripts from (in case we need a special
-	// game script from outside the current SmrSession game).
+	// game script from outside the current Smr\Session game).
 	// Must not call `get_file_loc` until after we have set $overrideGameID
 	// (unless we're exiting immediately with an error, as above).
 	$overrideGameID = 0;

--- a/src/htdocs/loader.php
+++ b/src/htdocs/loader.php
@@ -35,7 +35,8 @@ try {
 	//echo '<pre>';echo_r($session);echo'</pre>';
 	//exit;
 	// do we have a session?
-	if (!SmrSession::hasAccount()) {
+	$session = SmrSession::getInstance();
+	if (!$session->hasAccount()) {
 		header('Location: /login.php');
 		exit;
 	}
@@ -59,7 +60,7 @@ try {
 	}
 
 	// do we have such a container object in the db?
-	if (!($var = SmrSession::retrieveVar($sn))) {
+	if (!($var = $session->retrieveVar($sn))) {
 		if (!USING_AJAX) {
 			require_once(get_file_loc('smr.inc.php'));
 			create_error('Please avoid using the back button!');
@@ -80,17 +81,17 @@ try {
 		$overrideGameID = $var['GameID'];
 	}
 	if ($overrideGameID == 0) {
-		$overrideGameID = SmrSession::getGameID();
+		$overrideGameID = $session->getGameID();
 	}
 
 	require_once(get_file_loc('smr.inc.php'));
 
-	$account = SmrSession::getAccount();
+	$account = $session->getAccount();
 	// get reason for disabled user
 	require_once(LIB . 'Default/login_processing.inc.php');
 	if (($disabled = redirectIfDisabled($account)) !== false) {
 		// save session (incase we forward)
-		SmrSession::update();
+		$session->update();
 		if ($disabled['Reason'] == CLOSE_ACCOUNT_INVALID_EMAIL_REASON) {
 			if (isset($var['do_reopen_account'])) {
 				// The user has attempted to re-validate their e-mail

--- a/src/htdocs/login.php
+++ b/src/htdocs/login.php
@@ -11,7 +11,7 @@ try {
 	// *
 	// ********************************
 
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 	if ($session->hasAccount()) {
 		// update last login column
 		$session->getAccount()->updateLastLogin();

--- a/src/htdocs/login.php
+++ b/src/htdocs/login.php
@@ -11,16 +11,13 @@ try {
 	// *
 	// ********************************
 
-
-	if (SmrSession::hasAccount()) {
-		// creates a new user account object
-		$account = SmrSession::getAccount();
-
+	$session = SmrSession::getInstance();
+	if ($session->hasAccount()) {
 		// update last login column
-		$account->updateLastLogin();
+		$session->getAccount()->updateLastLogin();
 
 		$href = Page::create('login_check_processing.php')->href(true);
-		SmrSession::update();
+		$session->update();
 
 		header('Location: ' . $href);
 		exit;

--- a/src/htdocs/login_create_processing.php
+++ b/src/htdocs/login_create_processing.php
@@ -4,7 +4,7 @@ try {
 	require_once('../bootstrap.php');
 	require_once(LIB . 'Default/smr.inc.php');
 
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 
 	if ($session->hasAccount()) {
 		$msg = 'You\'re already logged in! Creating multis is against the rules!';

--- a/src/htdocs/login_create_processing.php
+++ b/src/htdocs/login_create_processing.php
@@ -4,7 +4,9 @@ try {
 	require_once('../bootstrap.php');
 	require_once(LIB . 'Default/smr.inc.php');
 
-	if (SmrSession::hasAccount()) {
+	$session = SmrSession::getInstance();
+
+	if ($session->hasAccount()) {
 		$msg = 'You\'re already logged in! Creating multis is against the rules!';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
@@ -159,7 +161,7 @@ try {
 	}
 
 	// register session
-	SmrSession::setAccount($account);
+	$session->setAccount($account);
 
 	// save ip
 	$account->updateIP();

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -10,7 +10,8 @@ try {
 	// *
 	// ********************************
 
-	if (!SmrSession::hasAccount()) {
+	$session = SmrSession::getInstance();
+	if (!$session->hasAccount()) {
 		if (Request::has('loginType')) {
 			$socialLogin = Smr\SocialLogin\SocialLogin::get(Request::get('loginType'))->login();
 			if (!$socialLogin->isValid()) {
@@ -21,7 +22,7 @@ try {
 			$account = SmrAccount::getAccountBySocialLogin($socialLogin);
 			if (!is_null($account)) {
 				// register session and continue to login
-				SmrSession::setAccount($account);
+				$session->setAccount($account);
 			} else {
 				// Let them create an account or link to existing
 				if (session_status() === PHP_SESSION_NONE) {
@@ -45,7 +46,7 @@ try {
 
 			$account = SmrAccount::getAccountByName($login);
 			if (is_object($account) && $account->checkPassword($password)) {
-				SmrSession::setAccount($account);
+				$session->setAccount($account);
 			} else {
 				$msg = 'Password is incorrect!';
 				header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
@@ -56,10 +57,10 @@ try {
 
 	// this sn identifies our container later
 	$href = Page::create('login_check_processing.php')->href(true);
-	SmrSession::update();
+	$session->update();
 
 	// get this user from db
-	$account = SmrSession::getAccount();
+	$account = $session->getAccount();
 
 	// If linking a social login to an existing account
 	if (Request::has('social')) {

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -10,7 +10,7 @@ try {
 	// *
 	// ********************************
 
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 	if (!$session->hasAccount()) {
 		if (Request::has('loginType')) {
 			$socialLogin = Smr\SocialLogin\SocialLogin::get(Request::get('loginType'))->login();

--- a/src/htdocs/map_galaxy.php
+++ b/src/htdocs/map_galaxy.php
@@ -17,7 +17,7 @@ try {
 	// ********************************
 
 	// do we have a session?
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 	if (!$session->hasAccount() || !$session->hasGame()) {
 		header('Location: /login.php');
 		exit;

--- a/src/htdocs/map_galaxy.php
+++ b/src/htdocs/map_galaxy.php
@@ -16,9 +16,9 @@ try {
 	// *
 	// ********************************
 
-
 	// do we have a session?
-	if (!SmrSession::hasAccount() || !SmrSession::hasGame()) {
+	$session = SmrSession::getInstance();
+	if (!$session->hasAccount() || !$session->hasGame()) {
 		header('Location: /login.php');
 		exit;
 	}
@@ -26,7 +26,7 @@ try {
 	if (Request::has('sector_id')) {
 		$sectorID = Request::getInt('sector_id');
 		try {
-			$galaxy = SmrGalaxy::getGalaxyContaining(SmrSession::getGameID(), $sectorID);
+			$galaxy = SmrGalaxy::getGalaxyContaining($session->getGameID(), $sectorID);
 		} catch (SectorNotFoundException $e) {
 			header('location: /error.php?msg=Invalid sector ID');
 			exit;
@@ -34,15 +34,15 @@ try {
 	} elseif (Request::has('galaxy_id')) {
 		$galaxyID = Request::getInt('galaxy_id');
 		try {
-			$galaxy = SmrGalaxy::getGalaxy(SmrSession::getGameID(), $galaxyID);
+			$galaxy = SmrGalaxy::getGalaxy($session->getGameID(), $galaxyID);
 		} catch (Exception $e) {
 			header('location: /error.php?msg=Invalid galaxy ID');
 			exit;
 		}
 	}
 
-	$account = SmrSession::getAccount();
-	$player = SmrPlayer::getPlayer($account->getAccountID(), SmrSession::getGameID());
+	$player = SmrPlayer::getPlayer($session->getAccountID(), $session->getGameID());
+	$account = $player->getAccount();
 
 	// Create a session to store temporary display options
 	// Garbage collect here often, since the page is slow anyways (see map_local.php)
@@ -67,7 +67,7 @@ try {
 	}
 
 	if (!isset($galaxyID) && !isset($sectorID)) {
-		$galaxy = SmrGalaxy::getGalaxyContaining(SmrSession::getGameID(), $player->getSectorID());
+		$galaxy = SmrGalaxy::getGalaxyContaining($player->getGameID(), $player->getSectorID());
 		if ($account->isCenterGalaxyMapOnPlayer()) {
 			$sectorID = $player->getSectorID();
 		}

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -2,7 +2,7 @@
 try {
 	require_once('../bootstrap.php');
 
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 
 	$gameID = Request::getInt('game');
 	if (!$session->hasAccount() || !Globals::isValidGame($gameID)) {

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -2,13 +2,15 @@
 try {
 	require_once('../bootstrap.php');
 
+	$session = SmrSession::getInstance();
+
 	$gameID = Request::getInt('game');
-	if (!SmrSession::hasAccount() || !Globals::isValidGame($gameID)) {
+	if (!$session->hasAccount() || !Globals::isValidGame($gameID)) {
 		header('Location: /login.php');
 		exit;
 	}
 
-	$account = SmrSession::getAccount();
+	$account = $session->getAccount();
 	if (!SmrGame::getGame($gameID)->isEnabled() && !$account->hasPermission(PERMISSION_UNI_GEN)) {
 		header('location: /error.php?msg=You do not have permission to view this map!');
 		exit;

--- a/src/lib/Album/album_functions.php
+++ b/src/lib/Album/album_functions.php
@@ -60,13 +60,13 @@ function main_page() {
 }
 
 function album_entry($album_id) {
-	// database object
 	$db = MySqlDatabase::getInstance();
+	$session = SmrSession::getInstance();
 
 	// list of all first letter nicks
 	create_link_list();
 
-	if (SmrSession::hasAccount() && $album_id != SmrSession::getAccountID()) {
+	if ($session->hasAccount() && $album_id != $session->getAccountID()) {
 		$db->query('UPDATE album
 				SET page_views = page_views + 1
 				WHERE account_id = '.$db->escapeNumber($album_id) . ' AND
@@ -205,17 +205,17 @@ function album_entry($album_id) {
 		echo('<span style="font-size:85%;">[' . date(defined('DATE_FULL_SHORT') ?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $time) . '] &lt;' . $postee . '&gt; ' . $msg . '</span><br />');
 	}
 
-	if (SmrSession::hasAccount()) {
+	if ($session->hasAccount()) {
 		echo('<form action="album_comment.php">');
 		echo('<input type="hidden" name="album_id" value="' . $album_id . '">');
 		echo('<table>');
 		echo('<tr>');
-		echo('<td style="color:green; font-size:70%;">Nick:<br /><input type="text" size="10" name="nick" value="' . htmlspecialchars(get_album_nick(SmrSession::getAccountID())) . '" readonly></td>');
+		echo('<td style="color:green; font-size:70%;">Nick:<br /><input type="text" size="10" name="nick" value="' . htmlspecialchars(get_album_nick($session->getAccountID())) . '" readonly></td>');
 		echo('<td style="color:green; font-size:70%;">Comment:<br /><input type="text" size="50" name="comment"></td>');
 		echo('<td style="color:green; font-size:70%;"><br /><input type="submit" value="Send"></td>');
 		$db->query('SELECT *
 					FROM account_has_permission
-					WHERE account_id = '.$db->escapeNumber(SmrSession::getAccountID()) . ' AND
+					WHERE account_id = '.$db->escapeNumber($session->getAccountID()) . ' AND
 						permission_id = '.$db->escapeNumber(PERMISSION_MODERATE_PHOTO_ALBUM));
 		if ($db->nextRecord()) {
 			echo('<td style="color:green; font-size:70%;"><br /><input type="submit" name="action" value="Moderate"></td>');

--- a/src/lib/Album/album_functions.php
+++ b/src/lib/Album/album_functions.php
@@ -61,7 +61,7 @@ function main_page() {
 
 function album_entry($album_id) {
 	$db = MySqlDatabase::getInstance();
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 
 	// list of all first letter nicks
 	create_link_list();

--- a/src/lib/Default/AbstractMenu.class.php
+++ b/src/lib/Default/AbstractMenu.class.php
@@ -353,7 +353,7 @@ class AbstractMenu {
 	public static function news(Template $template) {
 		global $var;
 		$menuItems = array();
-		if (SmrSession::getGameID() == $var['GameID']) {
+		if (SmrSession::getInstance()->getGameID() == $var['GameID']) {
 			$menuItems[] = array('Link'=>Page::create('skeleton.php', 'news_read_current.php', array('GameID'=>$var['GameID']))->href(), 'Text'=>'Read Current News');
 		}
 		$menuItems[] = array('Link'=>Page::create('skeleton.php', 'news_read.php', array('GameID'=>$var['GameID']))->href(), 'Text'=>'Read Latest News');

--- a/src/lib/Default/AbstractMenu.class.php
+++ b/src/lib/Default/AbstractMenu.class.php
@@ -353,7 +353,7 @@ class AbstractMenu {
 	public static function news(Template $template) {
 		global $var;
 		$menuItems = array();
-		if (SmrSession::getInstance()->getGameID() == $var['GameID']) {
+		if (Smr\Session::getInstance()->getGameID() == $var['GameID']) {
 			$menuItems[] = array('Link'=>Page::create('skeleton.php', 'news_read_current.php', array('GameID'=>$var['GameID']))->href(), 'Text'=>'Read Current News');
 		}
 		$menuItems[] = array('Link'=>Page::create('skeleton.php', 'news_read.php', array('GameID'=>$var['GameID']))->href(), 'Text'=>'Read Latest News');

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -2176,7 +2176,7 @@ abstract class AbstractSmrPlayer {
 		}
 		$underAttack = $this->isUnderAttack();
 		if ($underAttack && !USING_AJAX) {
-			SmrSession::updateVar('UnderAttack', $underAttack); //Remember we are under attack for AJAX
+			SmrSession::getInstance()->updateVar('UnderAttack', $underAttack); //Remember we are under attack for AJAX
 		}
 		$this->setUnderAttack(false);
 		return $underAttack;

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -709,7 +709,7 @@ abstract class AbstractSmrPlayer {
 		$db->query('SELECT account_id
 					FROM active_session
 					JOIN player USING (game_id, account_id)
-					WHERE active_session.last_accessed >= ' . $db->escapeNumber(Smr\Epoch::time() - SmrSession::TIME_BEFORE_EXPIRY) . '
+					WHERE active_session.last_accessed >= ' . $db->escapeNumber(Smr\Epoch::time() - Smr\Session::TIME_BEFORE_EXPIRY) . '
 						AND game_id = ' . $db->escapeNumber($this->getGameID()) . '
 						AND ignore_globals = \'FALSE\'
 						AND account_id != ' . $db->escapeNumber($this->getAccountID()));
@@ -2176,7 +2176,7 @@ abstract class AbstractSmrPlayer {
 		}
 		$underAttack = $this->isUnderAttack();
 		if ($underAttack && !USING_AJAX) {
-			SmrSession::getInstance()->updateVar('UnderAttack', $underAttack); //Remember we are under attack for AJAX
+			Smr\Session::getInstance()->updateVar('UnderAttack', $underAttack); //Remember we are under attack for AJAX
 		}
 		$this->setUnderAttack(false);
 		return $underAttack;

--- a/src/lib/Default/Page.class.php
+++ b/src/lib/Default/Page.class.php
@@ -199,9 +199,6 @@ class Page extends ArrayObject {
 		// would need to change globally first (no Page re-use).
 		$copy = self::copy($this);
 
-		if (!isset($copy['Expires'])) {
-			$copy['Expires'] = 0; // Lasts forever
-		}
 		if (!isset($copy['RemainingPageLoads'])) {
 			$pageURL = $copy['url'] == 'skeleton.php' ? $copy['body'] : $copy['url'];
 			$copy['RemainingPageLoads'] = self::URL_DEFAULT_REMAINING_PAGE_LOADS[$pageURL] ?? 1; // Allow refreshing
@@ -226,7 +223,6 @@ class Page extends ArrayObject {
 	 */
 	private function getCommonID() : string {
 		$commonContainer = $this->getArrayCopy();
-		unset($commonContainer['Expires']);
 		unset($commonContainer['RemainingPageLoads']);
 		unset($commonContainer['PreviousRequestTime']);
 		unset($commonContainer['CommonID']);

--- a/src/lib/Default/Page.class.php
+++ b/src/lib/Default/Page.class.php
@@ -150,7 +150,7 @@ class Page extends ArrayObject {
 
 		// this sn identifies our container later
 		if (!is_null($sn)) {
-			SmrSession::resetLink($this, $sn);
+			SmrSession::getInstance()->resetLink($this, $sn);
 		}
 
 		// Note: if problems arise, maybe $this should be cloned.
@@ -211,7 +211,7 @@ class Page extends ArrayObject {
 		// be two different outcomes from containers given the same ID then
 		// problems will likely arise.
 		$copy['CommonID'] = $this->getCommonID();
-		$sn = SmrSession::addLink($copy);
+		$sn = SmrSession::getInstance()->addLink($copy);
 
 		if ($forceFullURL === true || stripos($_SERVER['REQUEST_URI'], 'loader.php') === false) {
 			return '/loader.php?sn=' . $sn;

--- a/src/lib/Default/Page.class.php
+++ b/src/lib/Default/Page.class.php
@@ -5,7 +5,7 @@
  *
  * This class acts like an array, whose keys define the page properties.
  * Then we can either create an HREF so that it can be accessed by a future
- * http request (via the SmrSession), or forwarded to within the same request.
+ * http request (via the Smr\Session), or forwarded to within the same request.
  */
 class Page extends ArrayObject {
 
@@ -150,7 +150,7 @@ class Page extends ArrayObject {
 
 		// this sn identifies our container later
 		if (!is_null($sn)) {
-			SmrSession::getInstance()->resetLink($this, $sn);
+			Smr\Session::getInstance()->resetLink($this, $sn);
 		}
 
 		// Note: if problems arise, maybe $this should be cloned.
@@ -184,8 +184,8 @@ class Page extends ArrayObject {
 
 	/**
 	 * Create an HREF (based on a random SN) to link to this page.
-	 * The container is saved in the SmrSession under this SN so that on
-	 * the next request, we can grab the container out of the SmrSession.
+	 * The container is saved in the Smr\Session under this SN so that on
+	 * the next request, we can grab the container out of the Smr\Session.
 	 */
 	public function href(bool $forceFullURL = false) : string {
 
@@ -211,7 +211,7 @@ class Page extends ArrayObject {
 		// be two different outcomes from containers given the same ID then
 		// problems will likely arise.
 		$copy['CommonID'] = $this->getCommonID();
-		$sn = SmrSession::getInstance()->addLink($copy);
+		$sn = Smr\Session::getInstance()->addLink($copy);
 
 		if ($forceFullURL === true || stripos($_SERVER['REQUEST_URI'], 'loader.php') === false) {
 			return '/loader.php?sn=' . $sn;

--- a/src/lib/Default/Rankings.class.php
+++ b/src/lib/Default/Rankings.class.php
@@ -104,8 +104,9 @@ class Rankings {
 
 	public static function calculateMinMaxRanks($ourRank, $totalRanks) {
 		global $var, $template;
-		$minRank = SmrSession::getRequestVarInt('min_rank', $ourRank - 5);
-		$maxRank = SmrSession::getRequestVarInt('max_rank', $ourRank + 5);
+		$session = SmrSession::getInstance();
+		$minRank = $session->getRequestVarInt('min_rank', $ourRank - 5);
+		$maxRank = $session->getRequestVarInt('max_rank', $ourRank + 5);
 
 		if ($minRank <= 0 || $minRank > $totalRanks) {
 			$minRank = 1;

--- a/src/lib/Default/Rankings.class.php
+++ b/src/lib/Default/Rankings.class.php
@@ -104,7 +104,7 @@ class Rankings {
 
 	public static function calculateMinMaxRanks($ourRank, $totalRanks) {
 		global $var, $template;
-		$session = SmrSession::getInstance();
+		$session = Smr\Session::getInstance();
 		$minRank = $session->getRequestVarInt('min_rank', $ourRank - 5);
 		$maxRank = $session->getRequestVarInt('max_rank', $ourRank + 5);
 

--- a/src/lib/Default/Request.class.php
+++ b/src/lib/Default/Request.class.php
@@ -2,7 +2,7 @@
 
 /**
  * Should be used for getting request data for processing pages.
- * For display pages, see SmrSession::getRequestVar.
+ * For display pages, see Smr\Session::getRequestVar.
  */
 class Request {
 
@@ -84,7 +84,7 @@ class Request {
 	 * This is useful for processing pages that need to handle data both from
 	 * posted form inputs and from container variables.
 	 *
-	 * Note that this does not save the result in $var (see SmrSession).
+	 * Note that this does not save the result in $var (see Smr\Session).
 	 */
 	public static function getVar(string $index, string $default = null) : string {
 		return self::getVarX($index, $default, 'get');

--- a/src/lib/Default/SmrSession.class.php
+++ b/src/lib/Default/SmrSession.class.php
@@ -21,54 +21,63 @@ class SmrSession {
 		'trader_examine.php' => .75
 	);
 
-	protected static MySqlDatabase $db;
+	protected MySqlDatabase $db;
 
-	private static ?string $session_id;
-	private static int $game_id;
-	private static array $var;
-	private static array $commonIDs = [];
-	private static bool $generate;
-	private static string $SN = '';
-	private static string $lastSN;
-	private static int $account_id;
-	public static int $last_accessed;
+	private string $sessionID;
+	private int $gameID;
+	private array $var;
+	private array $commonIDs = [];
+	private bool $generate;
+	private string $SN = '';
+	private string $lastSN;
+	private int $accountID;
+	public int $lastAccessed;
 
-	protected static ?array $previousAjaxReturns;
-	protected static array $ajaxReturns = array();
+	protected ?array $previousAjaxReturns;
+	protected array $ajaxReturns = array();
 
-	public static function init() : void {
-		// Return immediately if the SmrSession is already initialized
-		if (isset(self::$session_id)) {
-			return;
-		}
+	/**
+	 * Return the SmrSession in the DI container.
+	 * If one does not exist yet, it will be created.
+	 * This is the intended way to construct this class.
+	 */
+	public static function getInstance() : self {
+		return Smr\Container\DiContainer::get(self::class);
+	}
 
-		// Initialize the db connector here, since `init` is always called
-		self::$db = MySqlDatabase::getInstance();
+	/**
+	 * SmrSession constructor.
+	 * Not intended to be constructed by hand. Use SmrSession::getInstance().
+	 */
+	public function __construct() {
+
+		// Initialize the db connector here
+		$this->db = MySqlDatabase::getInstance();
 
 		// now try the cookie
 		if (isset($_COOKIE['session_id']) && strlen($_COOKIE['session_id']) === 32) {
-			self::$session_id = $_COOKIE['session_id'];
+			$this->sessionID = $_COOKIE['session_id'];
 		} else {
 			// create a new session id
 			do {
-				self::$session_id = md5(uniqid(strval(rand())));
-				self::$db->query('SELECT 1 FROM active_session WHERE session_id = ' . self::$db->escapeString(self::$session_id) . ' LIMIT 1');
-			} while (self::$db->nextRecord()); //Make sure we haven't somehow clashed with someone else's session.
+				$this->sessionID = md5(uniqid(strval(rand())));
+				$this->db->query('SELECT 1 FROM active_session WHERE session_id = ' . $this->db->escapeString($this->sessionID) . ' LIMIT 1');
+			} while ($this->db->nextRecord()); //Make sure we haven't somehow clashed with someone else's session.
 
 			// This is a minor hack to make sure that setcookie is not called
 			// for CLI programs and tests (to avoid "headers already sent").
 			if (headers_sent() === false) {
-				setcookie('session_id', self::$session_id);
+				setcookie('session_id', $this->sessionID);
 			}
 		}
 
 		// try to get current session
-		self::$db->query('DELETE FROM active_session WHERE last_accessed < ' . self::$db->escapeNumber(time() - self::TIME_BEFORE_EXPIRY));
-		self::fetchVarInfo();
+		$this->db->query('DELETE FROM active_session WHERE last_accessed < ' . $this->db->escapeNumber(time() - self::TIME_BEFORE_EXPIRY));
+		$this->fetchVarInfo();
 
 		$sn = Request::get('sn', '');
-		if (!USING_AJAX && !empty($sn) && !empty(self::$var[$sn])) {
-			$var = self::$var[$sn];
+		if (!USING_AJAX && !empty($sn) && !empty($this->var[$sn])) {
+			$var = $this->var[$sn];
 			$currentPage = $var['url'] == 'skeleton.php' ? $var['body'] : $var['url'];
 			$loadDelay = self::URL_LOAD_DELAY[$currentPage] ?? 0;
 			$initialTimeBetweenLoads = microtime(true) - $var['PreviousRequestTime'];
@@ -78,154 +87,158 @@ class SmrSession {
 				usleep($sleepTime);
 			}
 			if (ENABLE_DEBUG) {
-				self::$db->query('INSERT INTO debug VALUES (' . self::$db->escapeString('Delay: ' . $currentPage) . ',' . self::$db->escapeNumber(self::$account_id) . ',' . self::$db->escapeNumber($initialTimeBetweenLoads) . ',' . self::$db->escapeNumber($timeBetweenLoads) . ')');
+				$this->db->query('INSERT INTO debug VALUES (' . $this->db->escapeString('Delay: ' . $currentPage) . ',' . $this->db->escapeNumber($this->accountID) . ',' . $this->db->escapeNumber($initialTimeBetweenLoads) . ',' . $this->db->escapeNumber($timeBetweenLoads) . ')');
 			}
 		}
 	}
 
-	public static function fetchVarInfo() : void {
-		self::$db->query('SELECT * FROM active_session WHERE session_id = ' . self::$db->escapeString(self::$session_id) . ' LIMIT 1');
-		if (self::$db->nextRecord()) {
-			self::$generate = false;
-			self::$session_id = self::$db->getField('session_id');
-			self::$account_id = self::$db->getInt('account_id');
-			self::$game_id = self::$db->getInt('game_id');
-			self::$last_accessed = self::$db->getInt('last_accessed');
-			self::$lastSN = self::$db->getField('last_sn');
+	public function fetchVarInfo() : void {
+		$this->db->query('SELECT * FROM active_session WHERE session_id = ' . $this->db->escapeString($this->sessionID) . ' LIMIT 1');
+		if ($this->db->nextRecord()) {
+			$this->generate = false;
+			$this->sessionID = $this->db->getField('session_id');
+			$this->accountID = $this->db->getInt('account_id');
+			$this->gameID = $this->db->getInt('game_id');
+			$this->lastAccessed = $this->db->getInt('last_accessed');
+			$this->lastSN = $this->db->getField('last_sn');
 			// We may not have ajax_returns if ajax was disabled
-			self::$previousAjaxReturns = self::$db->getObject('ajax_returns', true, true);
+			$this->previousAjaxReturns = $this->db->getObject('ajax_returns', true, true);
 
-			self::$var = self::$db->getObject('session_var', true);
+			$this->var = $this->db->getObject('session_var', true);
 
-			foreach (self::$var as $key => $value) {
+			foreach ($this->var as $key => $value) {
 				if ($value['Expires'] > 0 && $value['Expires'] <= Smr\Epoch::time()) { // Use 0 for infinity
 					//This link is no longer valid
-					unset(self::$var[$key]);
+					unset($this->var[$key]);
 				} elseif ($value['RemainingPageLoads'] < 0) {
 					//This link is no longer valid
-					unset(self::$var[$key]);
+					unset($this->var[$key]);
 				} else {
-					--self::$var[$key]['RemainingPageLoads'];
+					$this->var[$key]['RemainingPageLoads'] -= 1;
 					if (isset($value['CommonID'])) {
-						self::$commonIDs[$value['CommonID']] = $key;
+						$this->commonIDs[$value['CommonID']] = $key;
 					}
 				}
 			}
 		} else {
-			self::$generate = true;
-			self::$account_id = 0;
-			self::$game_id = 0;
-			self::$var = array();
+			$this->generate = true;
+			$this->accountID = 0;
+			$this->gameID = 0;
+			$this->var = array();
 		}
 	}
 
-	public static function update() : void {
-		foreach (self::$var as $key => $value) {
+	public function update() : void {
+		foreach ($this->var as $key => $value) {
 			if ($value['RemainingPageLoads'] <= 0) {
 				//This link was valid this load but will not be in the future, removing it now saves database space and data transfer.
-				unset(self::$var[$key]);
+				unset($this->var[$key]);
 			}
 		}
-		if (!self::$generate) {
-			self::$db->query('UPDATE active_session SET account_id=' . self::$db->escapeNumber(self::$account_id) . ',game_id=' . self::$db->escapeNumber(self::$game_id) . (!USING_AJAX ? ',last_accessed=' . self::$db->escapeNumber(Smr\Epoch::time()) : '') . ',session_var=' . self::$db->escapeObject(self::$var, true) .
-					',last_sn=' . self::$db->escapeString(self::$SN) .
-					' WHERE session_id=' . self::$db->escapeString(self::$session_id) . (USING_AJAX ? ' AND last_sn=' . self::$db->escapeString(self::$lastSN) : '') . ' LIMIT 1');
+		if (!$this->generate) {
+			$this->db->query('UPDATE active_session SET account_id=' . $this->db->escapeNumber($this->accountID) . ',game_id=' . $this->db->escapeNumber($this->gameID) . (!USING_AJAX ? ',last_accessed=' . $this->db->escapeNumber(Smr\Epoch::time()) : '') . ',session_var=' . $this->db->escapeObject($this->var, true) .
+					',last_sn=' . $this->db->escapeString($this->SN) .
+					' WHERE session_id=' . $this->db->escapeString($this->sessionID) . (USING_AJAX ? ' AND last_sn=' . $this->db->escapeString($this->lastSN) : '') . ' LIMIT 1');
 		} else {
-			self::$db->query('DELETE FROM active_session WHERE account_id = ' . self::$db->escapeNumber(self::$account_id) . ' AND game_id = ' . self::$db->escapeNumber(self::$game_id));
-			self::$db->query('INSERT INTO active_session (session_id, account_id, game_id, last_accessed, session_var) VALUES(' . self::$db->escapeString(self::$session_id) . ',' . self::$db->escapeNumber(self::$account_id) . ',' . self::$db->escapeNumber(self::$game_id) . ',' . self::$db->escapeNumber(Smr\Epoch::time()) . ',' . self::$db->escapeObject(self::$var, true) . ')');
-			self::$generate = false;
+			$this->db->query('DELETE FROM active_session WHERE account_id = ' . $this->db->escapeNumber($this->accountID) . ' AND game_id = ' . $this->db->escapeNumber($this->gameID));
+			$this->db->query('INSERT INTO active_session (session_id, account_id, game_id, last_accessed, session_var) VALUES(' . $this->db->escapeString($this->sessionID) . ',' . $this->db->escapeNumber($this->accountID) . ',' . $this->db->escapeNumber($this->gameID) . ',' . $this->db->escapeNumber(Smr\Epoch::time()) . ',' . $this->db->escapeObject($this->var, true) . ')');
+			$this->generate = false;
 		}
 	}
 
 	/**
 	 * Returns the Game ID associated with the session.
 	 */
-	public static function getGameID() : int {
-		return self::$game_id;
+	public function getGameID() : int {
+		return $this->gameID;
 	}
 
 	/**
 	 * Returns true if the session is inside a game, false otherwise.
 	 */
-	public static function hasGame() : bool {
-		return self::$game_id != 0;
+	public function hasGame() : bool {
+		return $this->gameID != 0;
 	}
 
-	public static function hasAccount() : bool {
-		return self::$account_id > 0;
+	public function hasAccount() : bool {
+		return $this->accountID > 0;
 	}
 
-	public static function getAccountID() : int {
-		return self::$account_id;
+	public function getAccountID() : int {
+		return $this->accountID;
 	}
 
-	public static function getAccount() : SmrAccount {
-		return SmrAccount::getAccount(self::$account_id);
+	public function getAccount() : SmrAccount {
+		return SmrAccount::getAccount($this->accountID);
 	}
 
 	/**
-	 * Sets the `account_id` attribute of this session.
+	 * Sets the `accountID` attribute of this session.
 	 */
-	public static function setAccount(AbstractSmrAccount $account) : void {
-		self::$account_id = $account->getAccountID();
+	public function setAccount(AbstractSmrAccount $account) : void {
+		$this->accountID = $account->getAccountID();
 	}
 
 	/**
-	 * Updates the `game_id` attribute of the session and deletes any other
+	 * Updates the `gameID` attribute of the session and deletes any other
 	 * active sessions in this game for this account.
 	 */
-	public static function updateGame(int $gameID) : void {
-		if (self::$game_id == $gameID) {
+	public function updateGame(int $gameID) : void {
+		if ($this->gameID == $gameID) {
 			return;
 		}
-		self::$game_id = $gameID;
-		self::$db->query('DELETE FROM active_session WHERE account_id = ' . self::$db->escapeNumber(self::$account_id) . ' AND game_id = ' . self::$game_id);
-		self::$db->query('UPDATE active_session SET game_id=' . self::$db->escapeNumber(self::$game_id) . ' WHERE session_id=' . self::$db->escapeString(self::$session_id));
+		$this->gameID = $gameID;
+		$this->db->query('DELETE FROM active_session WHERE account_id = ' . $this->db->escapeNumber($this->accountID) . ' AND game_id = ' . $this->gameID);
+		$this->db->query('UPDATE active_session SET game_id=' . $this->db->escapeNumber($this->gameID) . ' WHERE session_id=' . $this->db->escapeString($this->sessionID));
 	}
 
 	/**
 	 * Returns true if the current SN is different than the previous SN.
 	 */
-	public static function hasChangedSN() : bool {
-		return self::$SN != self::$lastSN;
+	public function hasChangedSN() : bool {
+		return $this->SN != $this->lastSN;
 	}
 
-	private static function updateSN() : void {
+	private function updateSN() : void {
 		if (!USING_AJAX) {
-			self::$db->query('UPDATE active_session SET last_sn=' . self::$db->escapeString(self::$SN) .
-				' WHERE session_id=' . self::$db->escapeString(self::$session_id) . ' LIMIT 1');
+			$this->db->query('UPDATE active_session SET last_sn=' . $this->db->escapeString($this->SN) .
+				' WHERE session_id=' . $this->db->escapeString($this->sessionID) . ' LIMIT 1');
 		}
 	}
 
-	public static function destroy() : void {
-		self::$db->query('DELETE FROM active_session WHERE session_id = ' . self::$db->escapeString(self::$session_id));
-		self::$session_id = null;
-		self::$account_id = 0;
-		self::$game_id = 0;
+	public function destroy() : void {
+		$this->db->query('DELETE FROM active_session WHERE session_id = ' . $this->db->escapeString($this->sessionID));
+		unset($this->sessionID);
+		unset($this->accountID);
+		unset($this->gameID);
+	}
+
+	public function getLastAccessed() : int {
+		return $this->lastAccessed;
 	}
 
 	/**
 	 * Retrieve the session var for the page given by $sn.
-	 * If $sn is not specified, use the current page (i.e. self::$SN).
+	 * If $sn is not specified, use the current page (i.e. $this->SN).
 	 */
-	public static function retrieveVar(string $sn = null) : Page|false {
+	public function retrieveVar(string $sn = null) : Page|false {
 		if (is_null($sn)) {
-			$sn = self::$SN;
+			$sn = $this->SN;
 		}
-		if (empty(self::$var[$sn])) {
+		if (empty($this->var[$sn])) {
 			return false;
 		}
-		self::$SN = $sn;
-		SmrSession::updateSN();
-		if (isset(self::$var[$sn]['body']) && isset(self::$var[$sn]['CommonID'])) {
-//			if(preg_match('/processing/',self::$var[$sn]['body']))
-			unset(self::$commonIDs[self::$var[$sn]['CommonID']]); //Do not store common id for current page
-			unset(self::$var[$sn]['CommonID']);
+		$this->SN = $sn;
+		$this->updateSN();
+		if (isset($this->var[$sn]['body']) && isset($this->var[$sn]['CommonID'])) {
+//			if(preg_match('/processing/',$this->var[$sn]['body']))
+			unset($this->commonIDs[$this->var[$sn]['CommonID']]); //Do not store common id for current page
+			unset($this->var[$sn]['CommonID']);
 		}
 
-		self::$var[$sn]['RemainingPageLoads'] += 1; // Allow refreshing
-		self::$var[$sn]['Expires'] = 0; // Allow refreshing forever
-		return self::$var[$sn];
+		$this->var[$sn]['RemainingPageLoads'] += 1; // Allow refreshing
+		$this->var[$sn]['Expires'] = 0; // Allow refreshing forever
+		return $this->var[$sn];
 	}
 
 	/**
@@ -234,31 +247,31 @@ class SmrSession {
 	 * This is the recommended way to get $_REQUEST data for display pages.
 	 * For processing pages, see the Request class.
 	 */
-	public static function getRequestVar(string $varName, string $default = null) : string {
+	public function getRequestVar(string $varName, string $default = null) : string {
 		$result = Request::getVar($varName, $default);
-		self::updateVar($varName, $result);
+		$this->updateVar($varName, $result);
 		return $result;
 	}
 
-	public static function getRequestVarInt(string $varName, int $default = null) : int {
+	public function getRequestVarInt(string $varName, int $default = null) : int {
 		$result = Request::getVarInt($varName, $default);
-		self::updateVar($varName, $result);
+		$this->updateVar($varName, $result);
 		return $result;
 	}
 
-	public static function getRequestVarIntArray(string $varName, array $default = null) : array {
+	public function getRequestVarIntArray(string $varName, array $default = null) : array {
 		$result = Request::getVarIntArray($varName, $default);
-		self::updateVar($varName, $result);
+		$this->updateVar($varName, $result);
 		return $result;
 	}
 
-	public static function resetLink(Page $container, string $sn) : string {
+	public function resetLink(Page $container, string $sn) : string {
 		//Do not allow sharing SN, useful for forwarding.
 		global $lock;
-		if (isset(self::$var[$sn]['CommonID'])) {
-			unset(self::$commonIDs[self::$var[$sn]['CommonID']]); //Do not store common id for reset page, to allow refreshing to always give the same page in response
+		if (isset($this->var[$sn]['CommonID'])) {
+			unset($this->commonIDs[$this->var[$sn]['CommonID']]); //Do not store common id for reset page, to allow refreshing to always give the same page in response
 		}
-		self::$SN = $sn;
+		$this->SN = $sn;
 		if (!isset($container['Expires'])) {
 			$container['Expires'] = 0; // Lasts forever
 		}
@@ -266,70 +279,68 @@ class SmrSession {
 			$container['RemainingPageLoads'] = 1; // Allow refreshing
 		}
 		if (!isset($container['PreviousRequestTime'])) {
-			if (isset(self::$var[$sn]['PreviousRequestTime'])) {
-				$container['PreviousRequestTime'] = self::$var[$sn]['PreviousRequestTime']; // Copy across the previous request time if not explicitly set.
+			if (isset($this->var[$sn]['PreviousRequestTime'])) {
+				$container['PreviousRequestTime'] = $this->var[$sn]['PreviousRequestTime']; // Copy across the previous request time if not explicitly set.
 			}
 		}
 
-		self::$var[$sn] = $container;
+		$this->var[$sn] = $container;
 		if (!$lock && !USING_AJAX) {
-			self::update();
+			$this->update();
 		}
 		return $sn;
 	}
 
-	public static function updateVar(string $key, mixed $value) : void {
+	public function updateVar(string $key, mixed $value) : void {
 		global $var;
 		if ($value === null) {
 			if (isset($var[$key])) {
 				unset($var[$key]);
 			}
-			if (isset($var[self::$SN][$key])) {
-				unset(self::$var[self::$SN][$key]);
+			if (isset($var[$this->SN][$key])) {
+				unset($this->var[$this->SN][$key]);
 			}
 		} else {
 			$var[$key] = $value;
-			self::$var[self::$SN][$key] = $value;
+			$this->var[$this->SN][$key] = $value;
 		}
 	}
 
-	public static function clearLinks() : void {
-		self::$var = array(self::$SN => self::$var[self::$SN]);
-		self::$commonIDs = array();
+	public function clearLinks() : void {
+		$this->var = array($this->SN => $this->var[$this->SN]);
+		$this->commonIDs = array();
 	}
 
-	public static function addLink(Page $container) : string {
-		$sn = self::generateSN($container);
-		self::$var[$sn] = $container;
+	public function addLink(Page $container) : string {
+		$sn = $this->generateSN($container);
+		$this->var[$sn] = $container;
 		return $sn;
 	}
 
-	protected static function generateSN(Page $container) : string {
-		if (isset(self::$commonIDs[$container['CommonID']])) {
-			$sn = self::$commonIDs[$container['CommonID']];
-			$container['PreviousRequestTime'] = isset(self::$var[$sn]) ? self::$var[$sn]['PreviousRequestTime'] : Smr\Epoch::microtime();
+	protected function generateSN(Page $container) : string {
+		if (isset($this->commonIDs[$container['CommonID']])) {
+			$sn = $this->commonIDs[$container['CommonID']];
+			$container['PreviousRequestTime'] = isset($this->var[$sn]) ? $this->var[$sn]['PreviousRequestTime'] : Smr\Epoch::microtime();
 		} else {
 			do {
 				$sn = random_alphabetic_string(6);
-			} while (isset(self::$var[$sn]));
+			} while (isset($this->var[$sn]));
 			$container['PreviousRequestTime'] = Smr\Epoch::microtime();
 		}
-		self::$commonIDs[$container['CommonID']] = $sn;
+		$this->commonIDs[$container['CommonID']] = $sn;
 		return $sn;
 	}
 
-	public static function addAjaxReturns(string $element, string $contents) : bool {
-		self::$ajaxReturns[$element] = $contents;
-		return isset(self::$previousAjaxReturns[$element]) && self::$previousAjaxReturns[$element] == $contents;
+	public function addAjaxReturns(string $element, string $contents) : bool {
+		$this->ajaxReturns[$element] = $contents;
+		return isset($this->previousAjaxReturns[$element]) && $this->previousAjaxReturns[$element] == $contents;
 	}
 
-	public static function saveAjaxReturns() : void {
-		if (empty(self::$ajaxReturns)) {
+	public function saveAjaxReturns() : void {
+		if (empty($this->ajaxReturns)) {
 			return;
 		}
-		self::$db->query('UPDATE active_session SET ajax_returns=' . self::$db->escapeObject(self::$ajaxReturns, true) .
-				' WHERE session_id=' . self::$db->escapeString(self::$session_id) . ' LIMIT 1');
+		$this->db->query('UPDATE active_session SET ajax_returns=' . $this->db->escapeObject($this->ajaxReturns, true) .
+				' WHERE session_id=' . $this->db->escapeString($this->sessionID) . ' LIMIT 1');
 	}
 }
-
-SmrSession::init();

--- a/src/lib/Default/SmrSession.class.php
+++ b/src/lib/Default/SmrSession.class.php
@@ -1,9 +1,5 @@
 <?php declare(strict_types=1);
 
-if (!defined('USING_AJAX')) {
-	define('USING_AJAX', false);
-}
-
 class SmrSession {
 
 	const TIME_BEFORE_EXPIRY = 3600;

--- a/src/lib/Default/Template.class.php
+++ b/src/lib/Default/Template.class.php
@@ -58,7 +58,8 @@ class Template {
 				/* Left out for size: <?xml version="1.0" encoding="ISO-8859-1"?>*/
 				$output = '<all>' . $ajaxXml . '</all>';
 			}
-			SmrSession::saveAjaxReturns();
+			$session = SmrSession::getInstance();
+			$session->saveAjaxReturns();
 		}
 
 		// Now that we are completely done processing, we can output
@@ -82,8 +83,9 @@ class Template {
 			$templateDir .= 'Default/';
 		}
 
-		if (SmrSession::hasGame()) {
-			$gameDir = Globals::getGameType(SmrSession::getGameID()) . '/';
+		$session = SmrSession::getInstance();
+		if ($session->hasGame()) {
+			$gameDir = Globals::getGameType($session->getGameID()) . '/';
 		} else {
 			$gameDir = 'Default/';
 		}
@@ -177,7 +179,8 @@ class Template {
 	}
 
 	protected function addJavascriptAlert($string) {
-		if (!SmrSession::addAjaxReturns('ALERT:' . $string, $string)) {
+		$session = SmrSession::getInstance();
+		if (!$session->addAjaxReturns('ALERT:' . $string, $string)) {
 			$this->jsAlerts[] = $string;
 		}
 	}
@@ -193,6 +196,8 @@ class Template {
 		if (empty($str)) {
 			return '';
 		}
+
+		$session = SmrSession::getInstance();
 
 		// To get inner html, we need to construct a separate DOMDocument.
 		// See PHP Bug #76285.
@@ -216,7 +221,7 @@ class Template {
 			foreach ($matchNodes as $node) {
 				$id = $node->getAttribute('id');
 				$inner = $getInnerHTML($node);
-				if (!SmrSession::addAjaxReturns($id, $inner) && $returnXml) {
+				if (!$session->addAjaxReturns($id, $inner) && $returnXml) {
 					$xml .= '<' . $id . '>' . xmlify($inner) . '</' . $id . '>';
 				}
 			}
@@ -246,7 +251,7 @@ class Template {
 				$inner = $getInnerHTML($mid);
 				if (!$this->checkDisableAJAX($inner)) {
 					$id = $mid->getAttribute('id');
-					if (!SmrSession::addAjaxReturns($id, $inner) && $returnXml) {
+					if (!$session->addAjaxReturns($id, $inner) && $returnXml) {
 						$xml .= '<' . $id . '>' . xmlify($inner) . '</' . $id . '>';
 					}
 				}
@@ -255,7 +260,7 @@ class Template {
 
 		$js = '';
 		foreach ($this->ajaxJS as $varName => $JSON) {
-			if (!SmrSession::addAjaxReturns('JS:' . $varName, $JSON) && $returnXml) {
+			if (!$session->addAjaxReturns('JS:' . $varName, $JSON) && $returnXml) {
 				$js .= '<' . $varName . '>' . xmlify($JSON) . '</' . $varName . '>';
 			}
 		}

--- a/src/lib/Default/Template.class.php
+++ b/src/lib/Default/Template.class.php
@@ -58,7 +58,7 @@ class Template {
 				/* Left out for size: <?xml version="1.0" encoding="ISO-8859-1"?>*/
 				$output = '<all>' . $ajaxXml . '</all>';
 			}
-			$session = SmrSession::getInstance();
+			$session = Smr\Session::getInstance();
 			$session->saveAjaxReturns();
 		}
 
@@ -83,7 +83,7 @@ class Template {
 			$templateDir .= 'Default/';
 		}
 
-		$session = SmrSession::getInstance();
+		$session = Smr\Session::getInstance();
 		if ($session->hasGame()) {
 			$gameDir = Globals::getGameType($session->getGameID()) . '/';
 		} else {
@@ -179,7 +179,7 @@ class Template {
 	}
 
 	protected function addJavascriptAlert($string) {
-		$session = SmrSession::getInstance();
+		$session = Smr\Session::getInstance();
 		if (!$session->addAjaxReturns('ALERT:' . $string, $string)) {
 			$this->jsAlerts[] = $string;
 		}
@@ -197,7 +197,7 @@ class Template {
 			return '';
 		}
 
-		$session = SmrSession::getInstance();
+		$session = Smr\Session::getInstance();
 
 		// To get inner html, we need to construct a separate DOMDocument.
 		// See PHP Bug #76285.

--- a/src/lib/Default/gov.inc.php
+++ b/src/lib/Default/gov.inc.php
@@ -5,7 +5,7 @@
  */
 function getBounties($type) {
 	$db = MySqlDatabase::getInstance();
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 	$db->query('SELECT * FROM bounty WHERE game_id = ' . $db->escapeNumber($session->getGameID()) . ' AND type =' . $db->escapeString($type) . ' AND claimer_id = 0 ORDER BY amount DESC');
 	$bounties = [];
 	while ($db->nextRecord()) {

--- a/src/lib/Default/gov.inc.php
+++ b/src/lib/Default/gov.inc.php
@@ -5,11 +5,12 @@
  */
 function getBounties($type) {
 	$db = MySqlDatabase::getInstance();
-	$db->query('SELECT * FROM bounty WHERE game_id = ' . $db->escapeNumber(SmrSession::getGameID()) . ' AND type =' . $db->escapeString($type) . ' AND claimer_id = 0 ORDER BY amount DESC');
+	$session = SmrSession::getInstance();
+	$db->query('SELECT * FROM bounty WHERE game_id = ' . $db->escapeNumber($session->getGameID()) . ' AND type =' . $db->escapeString($type) . ' AND claimer_id = 0 ORDER BY amount DESC');
 	$bounties = [];
 	while ($db->nextRecord()) {
 		$bounties[] = [
-			'player' => SmrPlayer::getPlayer($db->getInt('account_id'), SmrSession::getGameID()),
+			'player' => SmrPlayer::getPlayer($db->getInt('account_id'), $session->getGameID()),
 			'credits' => $db->getInt('amount'),
 			'smr_credits' => $db->getInt('smr_credits')
 		];

--- a/src/lib/Default/login_processing.inc.php
+++ b/src/lib/Default/login_processing.inc.php
@@ -22,8 +22,8 @@ function redirectIfDisabled(SmrAccount $account) {
 	}
 	$msg .= '.<br />Please contact an admin for further information.';
 
-	// Destroy the SmrSession, since there is no way to "log off" from the login page
-	SmrSession::getInstance()->destroy();
+	// Destroy the Smr\Session, since there is no way to "log off" from the login page
+	Smr\Session::getInstance()->destroy();
 
 	// Store the message in a session to avoid URL length restrictions
 	if (session_status() === PHP_SESSION_NONE) {
@@ -48,7 +48,7 @@ function redirectIfOffline(SmrAccount $account) : void {
 
 	// We need to destroy the session so that the login page doesn't
 	// redirect to the in-game loader (bypassing the server closure).
-	SmrSession::getInstance()->destroy();
+	Smr\Session::getInstance()->destroy();
 
 	// Store the message in a session to avoid URL length restrictions
 	if (session_status() === PHP_SESSION_NONE) {

--- a/src/lib/Default/login_processing.inc.php
+++ b/src/lib/Default/login_processing.inc.php
@@ -23,7 +23,7 @@ function redirectIfDisabled(SmrAccount $account) {
 	$msg .= '.<br />Please contact an admin for further information.';
 
 	// Destroy the SmrSession, since there is no way to "log off" from the login page
-	SmrSession::destroy();
+	SmrSession::getInstance()->destroy();
 
 	// Store the message in a session to avoid URL length restrictions
 	if (session_status() === PHP_SESSION_NONE) {
@@ -48,7 +48,7 @@ function redirectIfOffline(SmrAccount $account) : void {
 
 	// We need to destroy the session so that the login page doesn't
 	// redirect to the in-game loader (bypassing the server closure).
-	SmrSession::destroy();
+	SmrSession::getInstance()->destroy();
 
 	// Store the message in a session to avoid URL length restrictions
 	if (session_status() === PHP_SESSION_NONE) {

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -28,7 +28,7 @@ function linkCombatLog($logID) {
  */
 function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagContent) {
 	global $overrideGameID, $disableBBLinks, $player, $account, $var;
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 	try {
 		switch ($tagName) {
 			case 'combatlog':
@@ -311,7 +311,7 @@ function do_voodoo() {
 		define('AJAX_CONTAINER', isset($var['AJAX']) && $var['AJAX'] === true);
 	}
 
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 	if (!AJAX_CONTAINER && USING_AJAX && $session->hasChangedSN()) {
 		exit;
 	}
@@ -455,7 +455,7 @@ function acquire_lock($sector) {
 	}
 
 	// Insert ourselves into the queue.
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 	$db->query('INSERT INTO locks_queue (game_id,account_id,sector_id,timestamp) VALUES(' . $db->escapeNumber($session->getGameID()) . ',' . $db->escapeNumber($session->getAccountID()) . ',' . $db->escapeNumber($sector) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 	$lock = $db->getInsertID();
 
@@ -530,7 +530,7 @@ function doTickerAssigns($template, $player, $db) {
 }
 
 function doSkeletonAssigns($template, $player, $ship, $sector, $db, $account, $var) {
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 
 	$template->assign('CSSLink', $account->getCssUrl());
 	$template->assign('CSSColourLink', $account->getCssColourUrl());

--- a/src/lib/Smr/Container/DiContainer.php
+++ b/src/lib/Smr/Container/DiContainer.php
@@ -9,6 +9,7 @@ use MySqlDatabase;
 use mysqli;
 use Smr\MySqlProperties;
 use Smr\Epoch;
+use SmrSession;
 use function DI\autowire;
 
 /**
@@ -45,7 +46,8 @@ class DiContainer {
 			// the compiled container feature for a performance boost
 			Epoch::class => autowire(),
 			MySqlProperties::class => autowire(),
-			MySqlDatabase::class => autowire()
+			MySqlDatabase::class => autowire(),
+			SmrSession::class => autowire(),
 		];
 	}
 

--- a/src/lib/Smr/Container/DiContainer.php
+++ b/src/lib/Smr/Container/DiContainer.php
@@ -9,7 +9,7 @@ use MySqlDatabase;
 use mysqli;
 use Smr\MySqlProperties;
 use Smr\Epoch;
-use SmrSession;
+use Smr\Session;
 use function DI\autowire;
 
 /**
@@ -47,7 +47,7 @@ class DiContainer {
 			Epoch::class => autowire(),
 			MySqlProperties::class => autowire(),
 			MySqlDatabase::class => autowire(),
-			SmrSession::class => autowire(),
+			Session::class => autowire(),
 		];
 	}
 

--- a/src/lib/Smr/Session.php
+++ b/src/lib/Smr/Session.php
@@ -113,10 +113,7 @@ class Session {
 			$this->var = $this->db->getObject('session_var', true);
 
 			foreach ($this->var as $key => $value) {
-				if ($value['Expires'] > 0 && $value['Expires'] <= Epoch::time()) { // Use 0 for infinity
-					//This link is no longer valid
-					unset($this->var[$key]);
-				} elseif ($value['RemainingPageLoads'] < 0) {
+				if ($value['RemainingPageLoads'] < 0) {
 					//This link is no longer valid
 					unset($this->var[$key]);
 				} else {

--- a/src/templates/Default/engine/Default/buy_message_notifications.php
+++ b/src/templates/Default/engine/Default/buy_message_notifications.php
@@ -5,7 +5,7 @@ if (isset($Message)) {
 }
 ?>
 
-<span class="red">WARNING:</span> Message notifications will only be received when you are logged out, therefore when logging out you will have to either have to click the logout link on the left or wait <?php echo format_time(SmrSession::TIME_BEFORE_EXPIRY); ?> for your session to time out.<br />
+<span class="red">WARNING:</span> Message notifications will only be received when you are logged out, therefore when logging out you will have to either have to click the logout link on the left or wait <?php echo format_time(Smr\Session::TIME_BEFORE_EXPIRY); ?> for your session to time out.<br />
 Messages will be sent to your currently validated email, so make sure that is the email address to which you wish to receive emails.<br />
 <br />
 <?php

--- a/src/templates/Default/engine/Default/includes/VoteLinks.inc.php
+++ b/src/templates/Default/engine/Default/includes/VoteLinks.inc.php
@@ -1,5 +1,5 @@
 <?php
-if (SmrSession::getInstance()->hasGame()) { ?>
+if (Smr\Session::getInstance()->hasGame()) { ?>
 	<div>Get <b><u>FREE TURNS</u></b> for voting if you see the star, available <span id="v"><?php echo $TimeToNextVote ?></span>.</div><?php
 } ?>
 <span id="vote_links"><?php

--- a/src/templates/Default/engine/Default/includes/VoteLinks.inc.php
+++ b/src/templates/Default/engine/Default/includes/VoteLinks.inc.php
@@ -1,5 +1,5 @@
 <?php
-if (SmrSession::hasGame()) { ?>
+if (SmrSession::getInstance()->hasGame()) { ?>
 	<div>Get <b><u>FREE TURNS</u></b> for voting if you see the star, available <span id="v"><?php echo $TimeToNextVote ?></span>.</div><?php
 } ?>
 <span id="vote_links"><?php

--- a/src/templates/Default/engine/Default/rankings_view.php
+++ b/src/templates/Default/engine/Default/rankings_view.php
@@ -21,7 +21,7 @@ foreach ($ThisAccount->getIndividualScores() as $statScore) {
 	echo join(' - ', $statScore['Stat']); ?>, has a stat of <?php echo number_format($ThisAccount->getHOF($statScore['Stat'])); ?> and a score of <span class="green"><?php echo number_format(round($statScore['Score'])); ?></span><br /><?php
 }
 
-if (SmrSession::getInstance()->hasGame()) { ?>
+if (Smr\Session::getInstance()->hasGame()) { ?>
 	<br />
 	<b>Current Game Extended Stats</b>
 	<br /><?php

--- a/src/templates/Default/engine/Default/rankings_view.php
+++ b/src/templates/Default/engine/Default/rankings_view.php
@@ -21,7 +21,7 @@ foreach ($ThisAccount->getIndividualScores() as $statScore) {
 	echo join(' - ', $statScore['Stat']); ?>, has a stat of <?php echo number_format($ThisAccount->getHOF($statScore['Stat'])); ?> and a score of <span class="green"><?php echo number_format(round($statScore['Score'])); ?></span><br /><?php
 }
 
-if (SmrSession::hasGame()) { ?>
+if (SmrSession::getInstance()->hasGame()) { ?>
 	<br />
 	<b>Current Game Extended Stats</b>
 	<br /><?php

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -102,7 +102,7 @@ function NPCStuff() {
 	$underAttack = false;
 	$actions = -1;
 
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 
 	while (true) {
 		// Clear the $_REQUEST global, in case we had set it, to avoid
@@ -351,7 +351,7 @@ function sleepNPC() {
 
 // Releases an NPC when it is done working
 function releaseNPC() {
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 	if (!$session->hasAccount()) {
 		debug('releaseNPC: no NPC to release');
 		return;
@@ -396,7 +396,7 @@ function changeNPCLogin() {
 	static $availableNpcs = null;
 
 	$db = MySqlDatabase::getInstance();
-	$session = SmrSession::getInstance();
+	$session = Smr\Session::getInstance();
 
 	if (is_null($availableNpcs)) {
 		// Make sure to select NPCs from active games only

--- a/src/tools/rerunChessGames.php
+++ b/src/tools/rerunChessGames.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 require_once('../bootstrap.php');
 
-SmrSession::getInstance()->updateGame(44);
+Smr\Session::getInstance()->updateGame(44);
 
 $db = MySqlDatabase::getInstance();
 $db->query('DELETE FROM player_hof WHERE type LIKE \'Chess%\'');

--- a/src/tools/rerunChessGames.php
+++ b/src/tools/rerunChessGames.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 require_once('../bootstrap.php');
 
-SmrSession::updateGame(44);
+SmrSession::getInstance()->updateGame(44);
 
 $db = MySqlDatabase::getInstance();
 $db->query('DELETE FROM player_hof WHERE type LIKE \'Chess%\'');

--- a/test/SmrTest/lib/DefaultGame/PageIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/PageIntegrationTest.php
@@ -60,10 +60,10 @@ class PageIntegrationTest extends \PHPUnit\Framework\TestCase {
 		// Create an arbitrary Page
 		$page = Page::create('file');
 
-		// Pre-initialize the SmrSession, since it uses 'rand', and we don't
+		// Pre-initialize the Smr\Session, since it uses 'rand', and we don't
 		// want it to interfere with our rand seed when we call `href`, which
-		// internally requires an SmrSession.
-		\SmrSession::getInstance();
+		// internally requires an Smr\Session.
+		\Smr\Session::getInstance();
 
 		// The Page should not be modified when href() is called
 		$expected = $page->getArrayCopy();

--- a/test/SmrTest/lib/DefaultGame/PageIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/PageIntegrationTest.php
@@ -63,7 +63,7 @@ class PageIntegrationTest extends \PHPUnit\Framework\TestCase {
 		// Pre-initialize the SmrSession, since it uses 'rand', and we don't
 		// want it to interfere with our rand seed when we call `href`, which
 		// internally requires an SmrSession.
-		\SmrSession::init();
+		\SmrSession::getInstance();
 
 		// The Page should not be modified when href() is called
 		$expected = $page->getArrayCopy();

--- a/test/SmrTest/lib/DefaultGame/SessionIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SessionIntegrationTest.php
@@ -2,21 +2,21 @@
 
 namespace SmrTest\lib\DefaultGame;
 
-use SmrSession;
+use Smr\Session;
 use SmrTest\BaseIntegrationSpec;
 
 /**
- * @covers SmrSession
+ * @covers Smr\Session
  */
-class SmrSessionIntegrationTest extends BaseIntegrationSpec {
+class SessionIntegrationTest extends BaseIntegrationSpec {
 
-	private SmrSession $session;
+	private Session $session;
 
 	protected function setUp() : void {
-		// Start each test with a fresh container (and SmrSession).
+		// Start each test with a fresh container (and Smr\Session).
 		// This ensures the independence of each test.
 		\Smr\Container\DiContainer::initializeContainer();
-		$this->session = SmrSession::getInstance();
+		$this->session = Session::getInstance();
 	}
 
 	public function test_game() {

--- a/test/SmrTest/lib/DefaultGame/SmrSessionIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrSessionIntegrationTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use SmrSession;
+use SmrTest\BaseIntegrationSpec;
+
+/**
+ * @covers SmrSession
+ */
+class SmrSessionIntegrationTest extends BaseIntegrationSpec {
+
+	private SmrSession $session;
+
+	protected function setUp() : void {
+		// Start each test with a fresh container (and SmrSession).
+		// This ensures the independence of each test.
+		\Smr\Container\DiContainer::initializeContainer();
+		$this->session = SmrSession::getInstance();
+	}
+
+	public function test_game() {
+		// Sessions are initialized with no game
+		self::assertFalse($this->session->hasGame());
+		self::assertSame(0, $this->session->getGameID());
+
+		// Now update the game
+		$gameID = 3;
+		$this->session->updateGame($gameID);
+		self::assertTrue($this->session->hasGame());
+		self::assertSame($gameID, $this->session->getGameID());
+	}
+
+	public function test_account() {
+		// Sessions are initialized with no account
+		self::assertFalse($this->session->hasAccount());
+		self::assertSame(0, $this->session->getAccountID());
+
+		// Now update the account
+		$account = $this->createMock(\AbstractSmrAccount::class);
+		$account
+			->method('getAccountID')
+			->willReturn(7);
+		$this->session->setAccount($account);
+		self::assertTrue($this->session->hasAccount());
+		self::assertSame(7, $this->session->getAccountID());
+	}
+
+}


### PR DESCRIPTION
Static classes are an anti-pattern, and so we instead put the session
in the DI Container. When we want to access the session, we call
`SmrSession::getInstance`. (Note that this always returns the original
instance, unlike `MySqlDatabase::getInstance`, which returns a new
instance each call.)

Since the DI Container is responsible for constructing the SmrSession,
we no longer need to call `SmrSession::init` in SmrSession.class.php
outside the scope of the class definition.

Also add `Page::process` for handling the processing of engine files.
