### PR TITLE
Move engine processing from do_voodoo to Page class

### DIFF
--- a/src/lib/Default/Page.class.php
+++ b/src/lib/Default/Page.class.php
@@ -235,4 +235,19 @@ class Page extends ArrayObject {
 		return md5(serialize($commonContainer));
 	}
 
+	/**
+	 * Process this page by executing the 'url' and 'body' files.
+	 * Global variables are included here for convenience (and should be
+	 * synchronized with `do_voodoo`).
+	 */
+	public function process() : void {
+		global $lock, $var, $player, $ship, $sector, $account, $db, $template;
+		if ($this['url'] != 'skeleton.php') {
+			require(get_file_loc($this['url']));
+		}
+		if ($this['body']) {
+			require(get_file_loc($this['body']));
+		}
+	}
+
 }

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -382,16 +382,9 @@ function do_voodoo() {
 	// Initialize the template
 	$template = new Template();
 
-	if ($var['url'] != 'skeleton.php') {
-		require(get_file_loc($var['url']));
-	}
-	if ($var['body']) {
-		if ($var['body'] == 'error.php') { // infinite includes for error pages
-			require(get_file_loc($var['body']));
-		} else {
-			require_once(get_file_loc($var['body']));
-		}
-	}
+	// Execute the engine files.
+	// This is where the majority of the page-specific work is performed.
+	$var->process();
 
 	if (SmrSession::hasGame()) {
 		$template->assign('UnderAttack', $player->removeUnderAttack());


### PR DESCRIPTION
Add function `Page::process` that performs the processing of engine
pages. This helps to ensure a sanitized namespace that only has the
global variables in it that we expect to find. The goal is to remove
all of these global variables eventually (if for no other reason than
to improve static analysis of engine files).

Also remove special handling of error.php. We can use `require` for
every page instead of `require_once`.