### PR TITLE
Remove quasi-global date format constants

### DIFF
--- a/src/admin/Default/album_moderate.php
+++ b/src/admin/Default/album_moderate.php
@@ -2,6 +2,7 @@
 
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
+$account = $session->getAccount();
 
 $template->assign('PageTopic', 'Moderate Photo Album');
 
@@ -83,7 +84,7 @@ $comments = array();
 while ($db->nextRecord()) {
 	$comments[] = [
 		'id' => $db->getInt('comment_id'),
-		'date' => date(DATE_FULL_SHORT, $db->getInt('time')),
+		'date' => date($account->getDateTimeFormat(), $db->getInt('time')),
 		'postee' => get_album_nick($db->getInt('post_id')),
 		'msg' => stripslashes($db->getField('msg')),
 	];

--- a/src/admin/Default/box_view.php
+++ b/src/admin/Default/box_view.php
@@ -75,7 +75,7 @@ if (!isset($var['box_type_id'])) {
 				$messages[$messageID]['GameName'] = SmrGame::getGame($gameID)->getDisplayName();
 			}
 
-			$messages[$messageID]['SendTime'] = date(DATE_FULL_SHORT, $db->getInt('send_time'));
+			$messages[$messageID]['SendTime'] = date($account->getDateTimeFormat(), $db->getInt('send_time'));
 			$messages[$messageID]['Message'] = bbifyMessage(htmliseMessage($db->getField('message_text')));
 		}
 		$template->assign('Messages', $messages);

--- a/src/admin/Default/changelog.php
+++ b/src/admin/Default/changelog.php
@@ -3,6 +3,7 @@
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
+$account = $session->getAccount();
 
 $template->assign('PageTopic', 'Change Log');
 
@@ -26,7 +27,7 @@ while ($db->nextRecord()) {
 		$link_set_live = false;
 
 		// get human readable format for date
-		$went_live = date(DATE_FULL_SHORT, $went_live);
+		$went_live = date($account->getDateTimeFormat(), $went_live);
 	} else {
 		if ($link_set_live) {
 			$container = Page::create('changelog_set_live_processing.php');

--- a/src/admin/Default/comp_share.php
+++ b/src/admin/Default/comp_share.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 $template = Smr\Template::getInstance();
+$session = Smr\Session::getInstance();
+$account = $session->getAccount();
 
 $template->assign('PageTopic', 'Computer Sharing');
 
@@ -72,7 +74,7 @@ while ($db->nextRecord()) {
 			$email = $db2->getField('email');
 			$valid = $db2->getBoolean('validated') ? 'Valid' : 'Invalid';
 			$common_ip = $db2->getField('common_ip');
-			$last_login = date(DATE_FULL_SHORT, $db2->getInt('last_login'));
+			$last_login = date($account->getDateTimeFormat(), $db2->getInt('last_login'));
 
 			$db2->query('SELECT * FROM account_is_closed WHERE account_id = ' . $db2->escapeNumber($currLinkAccId));
 			$isDisabled = $db2->nextRecord();

--- a/src/admin/Default/ip_view_results.php
+++ b/src/admin/Default/ip_view_results.php
@@ -2,6 +2,7 @@
 
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
+$account = $session->getAccount();
 
 $variable = $session->getRequestVar('variable');
 $type = $session->getRequestVar('type');
@@ -118,7 +119,7 @@ if ($type == 'comp_share') {
 	while ($db->nextRecord()) {
 		$rows[] = [
 			'ip' => $db->getField('ip'),
-			'date' => date(DATE_FULL_SHORT, $db->getInt('time')),
+			'date' => date($account->getDateTimeFormat(), $db->getInt('time')),
 			'host' => $db->getField('host'),
 		];
 	}
@@ -232,7 +233,7 @@ if ($type == 'comp_share') {
 		$rows[] = [
 			'account_id' => $id,
 			'login' => $acc->getLogin(),
-			'date' => date(DATE_FULL_SHORT, $time),
+			'date' => date($account->getDateTimeFormat(), $time),
 			'ip' => $ip,
 			'host' => $host,
 			'names' => implode(', ', array_unique($names)),

--- a/src/admin/Default/log_anonymous_account.php
+++ b/src/admin/Default/log_anonymous_account.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 $template = Smr\Template::getInstance();
+$session = Smr\Session::getInstance();
+$account = $session->getAccount();
 
 $template->assign('PageTopic', 'Anonymous Account Access');
 
@@ -22,7 +24,7 @@ while ($db->nextRecord()) {
 	$anon_logs[$db->getInt('game_id')][$db->getInt('anon_id')][] = [
 		'login' => $db->getField('login'),
 		'amount' => number_format($db->getInt('amount')),
-		'date' => date(DATE_FULL_SHORT, $db->getInt('time')),
+		'date' => date($account->getDateTimeFormat(), $db->getInt('time')),
 		'type' => $transaction,
 		'color' => $transaction == 'payment' ? 'tomato' : 'green',
 	];

--- a/src/admin/Default/notify_view.php
+++ b/src/admin/Default/notify_view.php
@@ -52,8 +52,8 @@ while ($db->nextRecord()) {
 		'senderName' => $getName($sender),
 		'receiverName' => $getName($receiver),
 		'gameName' => $gameName,
-		'sentDate' => date(DATE_FULL_SHORT, $db->getInt('sent_time')),
-		'reportDate' => date(DATE_FULL_SHORT, $db->getInt('notify_time')),
+		'sentDate' => date($account->getDateTimeFormat(), $db->getInt('sent_time')),
+		'reportDate' => date($account->getDateTimeFormat(), $db->getInt('notify_time')),
 		'text' => bbifyMessage($db->getField('text')),
 	];
 }

--- a/src/config.php
+++ b/src/config.php
@@ -76,13 +76,12 @@ const DISCORD_URL = 'https://discord.me/smrealms';
 const DISCORD_SERVER_ID = '376433706916642826';
 
 /*
- * Localisations
+ * Default date formatting specifiers
  */
-const DEFAULT_DATE_DATE_SHORT = 'j/n/Y';
-const DEFAULT_DATE_TIME_SHORT = 'g:i:s A';
-const DEFAULT_DATE_FULL_SHORT = DEFAULT_DATE_DATE_SHORT . ' ' . DEFAULT_DATE_TIME_SHORT;
-const DEFAULT_DATE_FULL_SHORT_SPLIT = DEFAULT_DATE_DATE_SHORT . '\<b\r /\>' . DEFAULT_DATE_TIME_SHORT;
-const DEFAULT_DATE_FULL_LONG = 'l F jS Y ' . DEFAULT_DATE_TIME_SHORT;
+const DEFAULT_DATE_FORMAT = 'j/n/Y';
+const DEFAULT_TIME_FORMAT = 'g:i:s A';
+const DEFAULT_DATE_TIME_FORMAT = DEFAULT_DATE_FORMAT . ' ' . DEFAULT_TIME_FORMAT;
+const DEFAULT_DATE_TIME_FORMAT_SPLIT = DEFAULT_DATE_FORMAT . '\<b\r /\>' . DEFAULT_TIME_FORMAT;
 
 /*
  * Buyer restrictions for ships and weapons

--- a/src/engine/Default/alliance_remove_member.php
+++ b/src/engine/Default/alliance_remove_member.php
@@ -2,6 +2,7 @@
 
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
+$account = $session->getAccount();
 $player = $session->getPlayer();
 $alliance = $player->getAlliance();
 
@@ -29,7 +30,7 @@ $members = [];
 while ($db->nextRecord()) {
 	// get the amount of time since last_active
 	$diff = 864000 + max(-864000, $db->getInt('last_cpl_action') - Smr\Epoch::time());
-	$lastActive = get_colored_text_range($diff, 864000, date(DATE_FULL_SHORT, $db->getInt('last_cpl_action')));
+	$lastActive = get_colored_text_range($diff, 864000, date($account->getDateTimeFormat(), $db->getInt('last_cpl_action')));
 
 	$members[] = [
 		'last_active' => $lastActive,

--- a/src/engine/Default/alliance_set_op.php
+++ b/src/engine/Default/alliance_set_op.php
@@ -3,6 +3,7 @@
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
+$account = $session->getAccount();
 $player = $session->getPlayer();
 $alliance = $player->getAlliance();
 
@@ -23,7 +24,7 @@ $db->query('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNu
 if ($db->nextRecord()) {
 	// An op is already scheduled, so get the time
 	$time = $db->getInt('time');
-	$template->assign('OpDate', date(DATE_FULL_SHORT, $time));
+	$template->assign('OpDate', date($account->getDateTimeFormat(), $time));
 	$template->assign('OpCountdown', format_time($time - Smr\Epoch::time()));
 
 	// Add a cancel button

--- a/src/engine/Default/alliance_set_op_processing.php
+++ b/src/engine/Default/alliance_set_op_processing.php
@@ -3,6 +3,7 @@
 $db = Smr\Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
+$account = $session->getAccount();
 $player = $session->getPlayer();
 
 function error_on_page($error) {
@@ -37,7 +38,7 @@ if (!empty($var['cancel'])) {
 
 	// Send an alliance message that expires at the time of the op.
 	// Since the message is procedural, don't exclude this player.
-	$message = $player->getBBLink() . ' has scheduled an operation for ' . date(DATE_FULL_SHORT, $time) . '. Navigate to your Alliance console to respond!';
+	$message = $player->getBBLink() . ' has scheduled an operation for ' . date($account->getDateTimeFormat(), $time) . '. Navigate to your Alliance console to respond!';
 	foreach ($player->getAlliance()->getMemberIDs() as $memberAccountID) {
 		$player->sendMessageFromOpAnnounce($memberAccountID, $message, $time);
 	}

--- a/src/engine/Default/bank_anon.php
+++ b/src/engine/Default/bank_anon.php
@@ -35,7 +35,7 @@ while ($db->nextRecord()) {
 				WHERE game_id=' . $db2->escapeNumber($player->getGameID()) . '
 				AND anon_id=' . $db2->escapeNumber($db->getInt('anon_id')) . ' LIMIT 1');
 	if ($db2->nextRecord() && $db2->getInt('MAX(time)')) {
-		$anon['last_transaction'] = date(DATE_FULL_SHORT, $db2->getInt('MAX(time)'));
+		$anon['last_transaction'] = date($account->getDateTimeFormat(), $db2->getInt('MAX(time)'));
 	} else {
 		$anon['last_transaction'] = 'No transactions';
 	}

--- a/src/engine/Default/bank_anon_detail.php
+++ b/src/engine/Default/bank_anon_detail.php
@@ -3,6 +3,7 @@
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
+$account = $session->getAccount();
 $player = $session->getPlayer();
 
 $account_num = $session->getRequestVarInt('account_num');
@@ -80,7 +81,7 @@ if ($db->getNumRows() > 0) {
 		$transaction = $db->getField('transaction');
 		$amount = number_format($db->getInt('amount'));
 		$transactions[$db->getInt('transaction_id')] = [
-			'date' => date(DATE_FULL_SHORT_SPLIT, $db->getInt('time')),
+			'date' => date($account->getDateTimeFormatSplit(), $db->getInt('time')),
 			'payment' => $transaction == 'Payment' ? $amount : '',
 			'deposit' => $transaction == 'Deposit' ? $amount : '',
 			'link' => $transactionPlayer->getLinkedDisplayName(),

--- a/src/engine/Default/changelog_view.php
+++ b/src/engine/Default/changelog_view.php
@@ -3,6 +3,7 @@
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
+$account = $session->getAccount();
 
 $template->assign('PageTopic', 'Change Log');
 
@@ -27,7 +28,7 @@ while ($db->nextRecord()) {
 
 	// get human readable format for date
 	if ($went_live > 0) {
-		$went_live = date(DATE_FULL_SHORT, $went_live);
+		$went_live = date($account->getDateTimeFormat(), $went_live);
 	} else {
 		$went_live = 'never';
 	}

--- a/src/engine/Default/combat_log_viewer.php
+++ b/src/engine/Default/combat_log_viewer.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
 $template = Smr\Template::getInstance();
-$var = Smr\Session::getInstance()->getCurrentVar();
+$session = Smr\Session::getInstance();
+$var = $session->getCurrentVar();
+$account = $session->getAccount();
 
 if (!isset($var['log_ids']) && !isset($var['current_log'])) {
 	create_error('You must select a combat log to view');
@@ -16,7 +18,7 @@ if (!$db->nextRecord()) {
 	create_error('Combat log not found');
 }
 $template->assign('CombatLogSector', $db->getInt('sector_id'));
-$template->assign('CombatLogTimestamp', date(DATE_FULL_SHORT, $db->getInt('timestamp')));
+$template->assign('CombatLogTimestamp', date($account->getDateTimeFormat(), $db->getInt('timestamp')));
 $results = $db->getObject('result', true);
 $template->assign('CombatResultsType', $db->getField('type'));
 $template->assign('CombatResults', $results);

--- a/src/engine/Default/feature_request_comments.php
+++ b/src/engine/Default/feature_request_comments.php
@@ -36,7 +36,7 @@ if ($db->getNumRows() > 0) {
 		$featureRequestComments[$commentID] = array(
 								'CommentID' => $commentID,
 								'Message' => $db->getField('text'),
-								'Time' => date(DATE_FULL_SHORT, $db->getInt('posting_time')),
+								'Time' => date($account->getDateTimeFormat(), $db->getInt('posting_time')),
 								'Anonymous' => $db->getBoolean('anonymous')
 		);
 		if ($featureModerator || !$db->getBoolean('anonymous')) {

--- a/src/engine/Default/game_play.php
+++ b/src/engine/Default/game_play.php
@@ -37,7 +37,7 @@ if ($db->getNumRows() > 0) {
 		$games['Play'][$game_id]['ID'] = $game_id;
 		$games['Play'][$game_id]['Name'] = $db->getField('game_name');
 		$games['Play'][$game_id]['Type'] = SmrGame::GAME_TYPES[$db->getInt('game_type')];
-		$games['Play'][$game_id]['EndDate'] = date(DATE_FULL_SHORT_SPLIT, $db->getInt('end_time'));
+		$games['Play'][$game_id]['EndDate'] = date($account->getDateTimeFormatSplit(), $db->getInt('end_time'));
 		$games['Play'][$game_id]['Speed'] = $db->getFloat('game_speed');
 
 		$container = Page::create('game_play_processing.php');
@@ -107,8 +107,8 @@ if ($db->getNumRows() > 0) {
 			'ID' => $game_id,
 			'Name' => $game->getName(),
 			'JoinTime' => $game->getJoinTime(),
-			'StartDate' => date(DATE_FULL_SHORT_SPLIT, $game->getStartTime()),
-			'EndDate' => date(DATE_FULL_SHORT_SPLIT, $game->getEndTime()),
+			'StartDate' => date($account->getDateTimeFormatSplit(), $game->getStartTime()),
+			'EndDate' => date($account->getDateTimeFormatSplit(), $game->getEndTime()),
 			'Players' => $game->getTotalPlayers(),
 			'Type' => $game->getGameType(),
 			'Speed' => $game->getGameSpeed(),
@@ -136,8 +136,8 @@ if ($db->getNumRows()) {
 		$game_id = $db->getInt('game_id');
 		$games['Previous'][$game_id]['ID'] = $game_id;
 		$games['Previous'][$game_id]['Name'] = $db->getField('game_name');
-		$games['Previous'][$game_id]['StartDate'] = date(DATE_DATE_SHORT, $db->getInt('start_time'));
-		$games['Previous'][$game_id]['EndDate'] = date(DATE_DATE_SHORT, $db->getInt('end_time'));
+		$games['Previous'][$game_id]['StartDate'] = date($account->getDateFormat(), $db->getInt('start_time'));
+		$games['Previous'][$game_id]['EndDate'] = date($account->getDateFormat(), $db->getInt('end_time'));
 		$games['Previous'][$game_id]['Type'] = SmrGame::GAME_TYPES[$db->getField('game_type')];
 		$games['Previous'][$game_id]['Speed'] = $db->getFloat('game_speed');
 		// create a container that will hold next url and additional variables.
@@ -165,8 +165,8 @@ foreach (Globals::getHistoryDatabases() as $databaseName => $oldColumn) {
 			$index = $databaseName . $game_id;
 			$games['Previous'][$index]['ID'] = $game_id;
 			$games['Previous'][$index]['Name'] = $db->getField('game_name');
-			$games['Previous'][$index]['StartDate'] = date(DATE_DATE_SHORT, $db->getInt('start_date'));
-			$games['Previous'][$index]['EndDate'] = date(DATE_DATE_SHORT, $db->getInt('end_date'));
+			$games['Previous'][$index]['StartDate'] = date($account->getDateFormat(), $db->getInt('start_date'));
+			$games['Previous'][$index]['EndDate'] = date($account->getDateFormat(), $db->getInt('end_date'));
 			$games['Previous'][$index]['Type'] = $db->getField('type');
 			$games['Previous'][$index]['Speed'] = $db->getFloat('speed');
 			// create a container that will hold next url and additional variables.

--- a/src/engine/Default/history_games.php
+++ b/src/engine/Default/history_games.php
@@ -20,8 +20,8 @@ $db->query('SELECT start_date, type, end_date, game_name, speed, game_id ' .
            'FROM game WHERE game_id = ' . $db->escapeNumber($game_id));
 $db->requireRecord();
 $template->assign('GameName', $game_name);
-$template->assign('Start', date(DATE_DATE_SHORT, $db->getInt('start_date')));
-$template->assign('End', date(DATE_DATE_SHORT, $db->getInt('end_date')));
+$template->assign('Start', date($account->getDateFormat(), $db->getInt('start_date')));
+$template->assign('End', date($account->getDateFormat(), $db->getInt('end_date')));
 $template->assign('Type', $db->getField('type'));
 $template->assign('Speed', $db->getFloat('speed'));
 

--- a/src/engine/Default/history_games_news.php
+++ b/src/engine/Default/history_games_news.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
 $template = Smr\Template::getInstance();
-$var = Smr\Session::getInstance()->getCurrentVar();
+$session = Smr\Session::getInstance();
+$var = $session->getCurrentVar();
+$account = $session->getAccount();
 
 $template->assign('PageTopic', 'Game News : ' . $var['game_name']);
 Menu::history_games(3);
@@ -19,7 +21,7 @@ $db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($var['view_
 $rows = [];
 while ($db->nextRecord()) {
 	$rows[] = [
-		'time' => date(DATE_FULL_SHORT, $db->getInt('time')),
+		'time' => date($account->getDateTimeFormat(), $db->getInt('time')),
 		'news' => $db->getField('message'),
 	];
 }

--- a/src/engine/Default/preferences_processing.php
+++ b/src/engine/Default/preferences_processing.php
@@ -146,8 +146,8 @@ if ($action == 'Save and resend validation code') {
 	$db->query('UPDATE account SET offset = ' . $db->escapeNumber($timez) . ' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your time offset.';
 } elseif ($action == 'Change Date Formats') {
-	$account->setShortDateFormat(Request::get('dateformat'));
-	$account->setShortTimeFormat(Request::get('timeformat'));
+	$account->setDateFormat(Request::get('dateformat'));
+	$account->setTimeFormat(Request::get('timeformat'));
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your date formats.';
 } elseif ($action == 'Change Images') {
 	$account->setDisplayShipImages(Request::get('images') == 'Yes');

--- a/src/engine/Default/smr_file_create.php
+++ b/src/engine/Default/smr_file_create.php
@@ -24,7 +24,7 @@ if (isset($var['AdminCreateGameID']) && $var['AdminCreateGameID'] !== false) {
 // make sure to update the SMR_FILE_VERSION!
 
 $file = ';SMR1.6 Sectors File v' . SMR_FILE_VERSION . '
-; Created on ' . date(DEFAULT_DATE_FULL_SHORT) . '
+; Created on ' . date(DEFAULT_DATE_TIME_FORMAT) . '
 [Races]
 ; Name = ID' . EOL;
 foreach (Globals::getRaces() as $race) {

--- a/src/engine/Default/vote.php
+++ b/src/engine/Default/vote.php
@@ -26,7 +26,7 @@ if ($db->getNumRows() > 0) {
 		if ($db->getInt('end') > Smr\Epoch::time()) {
 			$voting[$voteID]['TimeRemaining'] = format_time($db->getInt('end') - Smr\Epoch::time(), true);
 		} else {
-			$voting[$voteID]['EndDate'] = date(DATE_DATE_SHORT, $db->getInt('end'));
+			$voting[$voteID]['EndDate'] = date($account->getDateFormat(), $db->getInt('end'));
 		}
 		$voting[$voteID]['Options'] = array();
 		$db2->query('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = ' . $db2->escapeNumber($db->getInt('vote_id')) . ' GROUP BY option_id');

--- a/src/htdocs/login.php
+++ b/src/htdocs/login.php
@@ -41,7 +41,7 @@ try {
 	while ($db->nextRecord()) {
 		$overrideGameID = $db->getInt('game_id'); //for bbifyMessage
 		$gameNews[] = [
-			'Time' => date(DEFAULT_DATE_FULL_SHORT_SPLIT, $db->getInt('time')),
+			'Time' => date(DEFAULT_DATE_TIME_FORMAT_SPLIT, $db->getInt('time')),
 			'Message' => bbifyMessage($db->getField('news_message')),
 		];
 	}

--- a/src/lib/Album/album_functions.php
+++ b/src/lib/Album/album_functions.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
 function main_page() {
-	// database object
 	$db = Smr\Database::getInstance();
+	$session = Smr\Session::getInstance();
 
 	// list of all first letter nicks
 	create_link_list();
@@ -40,6 +40,7 @@ function main_page() {
 	}
 
 	// latest picture
+	$dateFormat = $session->hasAccount() ? $session->getAccount()->getDateTimeFormat() : DEFAULT_DATE_TIME_FORMAT;
 	echo('<p><u>Latest Picture</u><br /><br />');
 	$db->query('SELECT *
 				FROM album
@@ -51,7 +52,7 @@ function main_page() {
 			$created = $db->getInt('created');
 			$nick = get_album_nick($db->getInt('account_id'));
 
-			echo('<span style="font-size:85%;"><b>[' . date(defined('DATE_FULL_SHORT') ?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $created) . ']</b> Picture of <a href="?nick=' . urlencode($nick) . '">' . $nick . '</a> added</span><br />');
+			echo('<span style="font-size:85%;"><b>[' . date($dateFormat, $created) . ']</b> Picture of <a href="?nick=' . urlencode($nick) . '">' . $nick . '</a> added</span><br />');
 		}
 	} else {
 		echo('<span style="font-size:85%;">no entries</span>');
@@ -194,6 +195,7 @@ function album_entry($album_id) {
 	echo('<td colspan="2">');
 	echo('<u>Comments</u><br /><br />');
 
+	$dateFormat = $session->hasAccount() ? $session->getAccount()->getDateTimeFormat() : DEFAULT_DATE_TIME_FORMAT;
 	$db->query('SELECT *
 				FROM album_has_comments
 				WHERE album_id = '.$db->escapeNumber($album_id));
@@ -202,7 +204,7 @@ function album_entry($album_id) {
 		$postee = get_album_nick($db->getInt('post_id'));
 		$msg = stripslashes($db->getField('msg'));
 
-		echo('<span style="font-size:85%;">[' . date(defined('DATE_FULL_SHORT') ?DATE_FULL_SHORT:DEFAULT_DATE_FULL_SHORT, $time) . '] &lt;' . $postee . '&gt; ' . $msg . '</span><br />');
+		echo('<span style="font-size:85%;">[' . date($dateFormat, $time) . '] &lt;' . $postee . '&gt; ' . $msg . '</span><br />');
 	}
 
 	if ($session->hasAccount()) {

--- a/src/lib/Default/AbstractSmrAccount.class.php
+++ b/src/lib/Default/AbstractSmrAccount.class.php
@@ -69,8 +69,8 @@ abstract class AbstractSmrAccount {
 	protected int $referrerID;
 	protected int $credits; // SMR credits
 	protected int $rewardCredits; // SMR reward credits
-	protected string $dateShort;
-	protected string $timeShort;
+	protected string $dateFormat;
+	protected string $timeFormat;
 	protected string $template;
 	protected string $colourScheme;
 	protected array $hotkeys;
@@ -233,8 +233,8 @@ abstract class AbstractSmrAccount {
 			$this->discordId = $this->db->getField('discord_id');
 			$this->ircNick = $this->db->getField('irc_nick');
 
-			$this->dateShort = $this->db->getField('date_short');
-			$this->timeShort = $this->db->getField('time_short');
+			$this->dateFormat = $this->db->getField('date_short');
+			$this->timeFormat = $this->db->getField('time_short');
 
 			$this->template = $this->db->getField('template');
 			$this->colourScheme = $this->db->getField('colour_scheme');
@@ -288,8 +288,8 @@ abstract class AbstractSmrAccount {
 			', hotkeys=' . $this->db->escapeObject($this->hotkeys) .
 			', last_login = ' . $this->db->escapeNumber($this->last_login) .
 			', logging = ' . $this->db->escapeBoolean($this->logging) .
-			', time_short = ' . $this->db->escapeString($this->timeShort) .
-			', date_short = ' . $this->db->escapeString($this->dateShort) .
+			', time_short = ' . $this->db->escapeString($this->timeFormat) .
+			', date_short = ' . $this->db->escapeString($this->dateFormat) .
 			', discord_id = ' . $this->db->escapeString($this->discordId, true) .
 			', irc_nick = ' . $this->db->escapeString($this->ircNick, true) .
 			', hof_name = ' . $this->db->escapeString($this->hofName) .
@@ -825,27 +825,43 @@ abstract class AbstractSmrAccount {
 		return URL . '/login_create.php?ref=' . $this->getAccountID();
 	}
 
-	public function getShortDateFormat() : string {
-		return $this->dateShort;
+	/**
+	 * Get the epoch format string including both date and time.
+	 */
+	public function getDateTimeFormat() : string {
+		return $this->getDateFormat() . ' ' . $this->getTimeFormat();
 	}
 
-	public function setShortDateFormat(string $format) : void {
-		if ($this->dateShort === $format) {
+	/**
+	 * Get the (HTML-only) epoch format string including both date and time,
+	 * split across two lines.
+	 */
+	public function getDateTimeFormatSplit() : string {
+		// We need to escape 'r' because it is a format specifier
+		return $this->getDateFormat() . '\<b\r /\>' . $this->getTimeFormat();
+	}
+
+	public function getDateFormat() : string {
+		return $this->dateFormat;
+	}
+
+	public function setDateFormat(string $format) : void {
+		if ($this->dateFormat === $format) {
 			return;
 		}
-		$this->dateShort = $format;
+		$this->dateFormat = $format;
 		$this->hasChanged = true;
 	}
 
-	public function getShortTimeFormat() : string {
-		return $this->timeShort;
+	public function getTimeFormat() : string {
+		return $this->timeFormat;
 	}
 
-	public function setShortTimeFormat(string $format) : void {
-		if ($this->timeShort === $format) {
+	public function setTimeFormat(string $format) : void {
+		if ($this->timeFormat === $format) {
 			return;
 		}
-		$this->timeShort = $format;
+		$this->timeFormat = $format;
 		$this->hasChanged = true;
 	}
 

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -677,7 +677,7 @@ abstract class AbstractSmrPlayer {
 					$mail = setupMailer();
 					$mail->Subject = 'Message Notification';
 					$mail->setFrom('notifications@smrealms.de', 'SMR Notifications');
-					$bbifiedMessage = 'From: ' . $sender . ' Date: ' . date($receiverAccount->getShortDateFormat() . ' ' . $receiverAccount->getShortTimeFormat(), Smr\Epoch::time()) . "<br/>\r\n<br/>\r\n" . bbifyMessage($message, true);
+					$bbifiedMessage = 'From: ' . $sender . ' Date: ' . date($receiverAccount->getDateTimeFormat(), Smr\Epoch::time()) . "<br/>\r\n<br/>\r\n" . bbifyMessage($message, true);
 					$mail->msgHTML($bbifiedMessage);
 					$mail->AltBody = strip_tags($bbifiedMessage);
 					$mail->addAddress($receiverAccount->getEmail(), $receiverAccount->getHofName());

--- a/src/lib/Default/login_processing.inc.php
+++ b/src/lib/Default/login_processing.inc.php
@@ -16,7 +16,7 @@ function redirectIfDisabled(SmrAccount $account) {
 	// Otherwise, we redirect to the login page with a message
 	$msg = '<span class="red">Your account is disabled!</span><br />Reason: ' . $disabled['Reason'] . '<br /><br />It is set to ';
 	if ($disabled['Time'] > 0) {
-		$msg .= 'reopen on ' . date(DEFAULT_DATE_FULL_LONG, $disabled['Time']);
+		$msg .= 'reopen on ' . date($account->getDateTimeFormat(), $disabled['Time']);
 	} else {
 		$msg .= 'never reopen';
 	}

--- a/src/lib/Default/news.inc.php
+++ b/src/lib/Default/news.inc.php
@@ -4,6 +4,9 @@
  * Takes a populated query and returns the news items.
  */
 function getNewsItems(Smr\Database $db) {
+	$session = Smr\Session::getInstance();
+	$account = $session->getAccount();
+
 	$newsItems = [];
 	while ($db->nextRecord()) {
 		$message = bbifyMessage($db->getField('news_message'));
@@ -11,7 +14,7 @@ function getNewsItems(Smr\Database $db) {
 			$message = '<span class="admin">ADMIN </span>' . $message;
 		}
 		$newsItems[] = [
-			'Date' => date(DATE_FULL_SHORT_SPLIT, $db->getInt('time')),
+			'Date' => date($account->getDateTimeFormatSplit(), $db->getInt('time')),
 			'Message' => $message,
 		];
 	}

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -88,10 +88,8 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 				}
 				$timeString = $default;
 				if ($timeString != '' && ($time = strtotime($timeString)) !== false) {
-					if ($session->hasAccount()) {
-						$time += $session->getAccount()->getOffset() * 3600;
-					}
-					return date(DATE_FULL_SHORT, $time);
+					$time += $session->getAccount()->getOffset() * 3600;
+					return date($session->getAccount()->getDateTimeFormat(), $time);
 				}
 			break;
 			case 'chess':
@@ -319,19 +317,6 @@ function do_voodoo() {
 	// create account object
 	$account = $session->getAccount();
 
-	if (!defined('DATE_DATE_SHORT')) {
-		define('DATE_DATE_SHORT', $account->getShortDateFormat());
-	}
-	if (!defined('DATE_TIME_SHORT')) {
-		define('DATE_TIME_SHORT', $account->getShortTimeFormat());
-	}
-	if (!defined('DATE_FULL_SHORT')) {
-		define('DATE_FULL_SHORT', DATE_DATE_SHORT . ' ' . DATE_TIME_SHORT);
-	}
-	if (!defined('DATE_FULL_SHORT_SPLIT')) {
-		define('DATE_FULL_SHORT_SPLIT', DATE_DATE_SHORT . '\<b\r /\>' . DATE_TIME_SHORT);
-	}
-
 	$db = Smr\Database::getInstance();
 
 	if ($session->hasGame()) {
@@ -503,11 +488,12 @@ function doTickerAssigns($template, $player, $db) {
 	if ($player->hasTickers()) {
 		$ticker = array();
 		$max = Smr\Epoch::time() - 60;
+		$dateFormat = $player->getAccount()->getDateTimeFormat();
 		if ($player->hasTicker('NEWS')) {
 			//get recent news (5 mins)
 			$db->query('SELECT time,news_message FROM news WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND time >= ' . $max . ' ORDER BY time DESC LIMIT 4');
 			while ($db->nextRecord()) {
-				$ticker[] = array('Time' => date(DATE_FULL_SHORT, $db->getInt('time')),
+				$ticker[] = array('Time' => date($dateFormat, $db->getInt('time')),
 								'Message'=>$db->getField('news_message'));
 			}
 		}
@@ -521,7 +507,7 @@ function doTickerAssigns($template, $player, $db) {
 						ORDER BY send_time DESC
 						LIMIT 4');
 			while ($db->nextRecord()) {
-				$ticker[] = array('Time' => date(DATE_FULL_SHORT, $db->getInt('send_time')),
+				$ticker[] = array('Time' => date($dateFormat, $db->getInt('send_time')),
 								'Message'=>$db->getField('message_text'));
 			}
 		}
@@ -537,7 +523,7 @@ function doSkeletonAssigns($template, $db) {
 	$template->assign('CSSColourLink', $account->getCssColourUrl());
 
 	$template->assign('FontSize', $account->getFontSize() - 20);
-	$template->assign('timeDisplay', date(DATE_FULL_SHORT_SPLIT, Smr\Epoch::time()));
+	$template->assign('timeDisplay', date($account->getDateTimeFormatSplit(), Smr\Epoch::time()));
 
 	$container = Page::create('skeleton.php');
 

--- a/src/templates/Default/admin/Default/1.6/universe_create_sector_details.php
+++ b/src/templates/Default/admin/Default/1.6/universe_create_sector_details.php
@@ -9,7 +9,7 @@
 		} ?>
 	</select><br /><?php
 	if ($SelectedPlanetType) { ?>
-		<b>Habitable: </b><?php echo date(DATE_FULL_SHORT, $Planet->getInhabitableTime()); ?><br /><?php
+		<b>Habitable: </b><?php echo date($ThisAccount->getDateTimeFormat(), $Planet->getInhabitableTime()); ?><br /><?php
 	} ?>
 	<br />
 

--- a/src/templates/Default/admin/Default/account_edit.php
+++ b/src/templates/Default/admin/Default/account_edit.php
@@ -33,7 +33,7 @@
 					<span class="red">CLOSED</span> (<?php echo $Disabled['Reason']; ?>)<br />
 					The account is set to <?php
 					if ($Disabled['Time'] > 0) { ?>
-						reopen on <?php echo date(DEFAULT_DATE_FULL_LONG, $Disabled['Time']); ?>.<?php
+						reopen on <?php echo date($ThisAccount->getDateTimeFormat(), $Disabled['Time']); ?>.<?php
 					} else { ?>
 						never reopen.<?php
 					}
@@ -206,7 +206,7 @@
 			<td><?php
 				if (count($ClosingHistory) > 0) {
 					foreach ($ClosingHistory as $Action) {
-						echo date(DATE_FULL_SHORT, $Action['Time']); ?> - <?php echo $Action['Action']; ?> by <?php echo $Action['AdminName']; ?><br /><?php
+						echo date($ThisAccount->getDateTimeFormat(), $Action['Time']); ?> - <?php echo $Action['Action']; ?> by <?php echo $Action['AdminName']; ?><br /><?php
 					}
 				} else { ?>
 					No activity.<?php
@@ -271,7 +271,7 @@
 					<table id="recentIPs" style="display:none"><?php
 						foreach ($RecentIPs as $RecentIP) { ?>
 							<tr>
-								<td><?php echo date(DATE_FULL_SHORT, $RecentIP['Time']); ?></td>
+								<td><?php echo date($ThisAccount->getDateTimeFormat(), $RecentIP['Time']); ?></td>
 								<td>&nbsp;</td>
 								<td><?php echo $RecentIP['IP']; ?></td>
 								<td>&nbsp;</td>

--- a/src/templates/Default/engine/Default/alliance_forces.php
+++ b/src/templates/Default/engine/Default/alliance_forces.php
@@ -57,7 +57,7 @@ if (empty($Forces)) { ?>
 			<td class="sort_cds center"><?php echo $Force->getCDs(); ?></td>
 			<td class="sort_sds center"><?php echo $Force->getSDs(); ?></td>
 			<td class="sort_mines center"><?php echo $Force->getMines(); ?></td>
-			<td class="sort_expire noWrap" data-expire="<?php echo $Force->getExpire(); ?>"><?php echo date(DATE_FULL_SHORT, $Force->getExpire()); ?></td>
+			<td class="sort_expire noWrap" data-expire="<?php echo $Force->getExpire(); ?>"><?php echo date($ThisAccount->getDateTimeFormat(), $Force->getExpire()); ?></td>
 		</tr><?php
 	} ?>
 	</table>

--- a/src/templates/Default/engine/Default/alliance_message.php
+++ b/src/templates/Default/engine/Default/alliance_message.php
@@ -28,7 +28,7 @@ if (count($Threads) > 0) { ?>
 						} ?>
 					</td>
 					<td class="sort_replies center"><?php echo $Thread['Replies']; ?></td>
-					<td class="sort_lastReply noWrap" data-lastReply="<?php echo $Thread['SendTime']; ?>"><?php echo date(DATE_FULL_SHORT, $Thread['SendTime']); ?></td>
+					<td class="sort_lastReply noWrap" data-lastReply="<?php echo $Thread['SendTime']; ?>"><?php echo date($ThisAccount->getDateTimeFormat(), $Thread['SendTime']); ?></td>
 				</tr><?php
 			} ?>
 		</tbody>

--- a/src/templates/Default/engine/Default/alliance_message_view.php
+++ b/src/templates/Default/engine/Default/alliance_message_view.php
@@ -40,7 +40,7 @@ if (isset($PrevThread) || isset($NextThread)) { ?>
 			<tr>
 				<td class="shrink noWrap top"><?php echo $Reply['Sender']; ?></td>
 				<td><?php echo bbifyMessage($Reply['Message']); ?></td>
-				<td class="shrink noWrap top"><?php echo date(DATE_FULL_SHORT, $Reply['SendTime']); ?></td><?php
+				<td class="shrink noWrap top"><?php echo date($ThisAccount->getDateTimeFormat(), $Reply['SendTime']); ?></td><?php
 				if ($Thread['CanDelete']) {
 					?><td class="shrink noWrap top"><a href="<?php echo $Reply['DeleteHref']; ?>"><img src="images/silk/cross.png" width="16" height="16" alt="Delete" title="Delete Post"/></a></td><?php
 				} ?>

--- a/src/templates/Default/engine/Default/alliance_mod.php
+++ b/src/templates/Default/engine/Default/alliance_mod.php
@@ -4,7 +4,7 @@
 if (isset($OpTime)) { ?>
 	<table class="center nobord opResponse">
 		<tr><th>ENCRYPTED ALLIANCE TELEGRAM</th></tr>
-		<tr><td>Your leader has scheduled an important alliance operation for <?php echo date(DATE_FULL_SHORT, $OpTime); ?></td></tr>
+		<tr><td>Your leader has scheduled an important alliance operation for <?php echo date($ThisAccount->getDateTimeFormat(), $OpTime); ?></td></tr>
 		<tr><td><span id="countdown"><?php echo ucfirst(format_time($OpTime - Smr\Epoch::time())); ?></span></td></tr>
 		<tr><td><b>Will you join the operation?</b></td></tr>
 		<tr><td>

--- a/src/templates/Default/engine/Default/alliance_pick.php
+++ b/src/templates/Default/engine/Default/alliance_pick.php
@@ -92,7 +92,7 @@ if (count($History) > 0) { ?>
 			<tr>
 				<td class="center"><?php echo $i + 1; ?></td>
 				<td><?php echo $Pick['Leader']->getDisplayName(); ?></td>
-				<td><?php echo date(DATE_FULL_SHORT, $Pick['Time']); ?></td>
+				<td><?php echo date($ThisAccount->getDateTimeFormat(), $Pick['Time']); ?></td>
 				<td><?php echo $Pick['Player']->getDisplayName(); ?></td>
 				<td><?php echo $Pick['Player']->getRaceName(); ?></td>
 				<td><?php echo $Pick['Player']->getAccount()->getHofDisplayName(true); ?></td>

--- a/src/templates/Default/engine/Default/alliance_roster.php
+++ b/src/templates/Default/engine/Default/alliance_roster.php
@@ -99,7 +99,7 @@ if ($ShowRoles && $CanChangeRoles) { ?>
 							if (in_array($AlliancePlayer->getAccountID(), $ActiveIDs)) { ?>
 								<span class="green">Online</span><?php
 							} elseif ($ThisPlayer->getAccountID() == $Alliance->getLeaderID() && $Disabled = SmrAccount::getAccount($AlliancePlayer->getAccountID())->isDisabled()) { ?>
-								<span class="red">Banned Until:<br/><?php echo date(DATE_FULL_SHORT_SPLIT, $Disabled['Time']); ?></span><?php
+								<span class="red">Banned Until:<br/><?php echo date($ThisAccount->getDateTimeFormatSplit(), $Disabled['Time']); ?></span><?php
 							} else { ?>
 								<span class="red">Offline</span><?php
 							} ?>

--- a/src/templates/Default/engine/Default/announcements.php
+++ b/src/templates/Default/engine/Default/announcements.php
@@ -8,7 +8,7 @@
 	foreach ($Announcements as $Announcement) { ?>
 		<tr>
 			<td class="shrink top noWrap">
-				<?php echo date(DATE_FULL_SHORT_SPLIT, $Announcement['Time']); ?>
+				<?php echo date($ThisAccount->getDateTimeFormatSplit(), $Announcement['Time']); ?>
 			</td>
 			<td class="top">
 				<?php echo bbifyMessage($Announcement['Msg']); ?>

--- a/src/templates/Default/engine/Default/bank_alliance.php
+++ b/src/templates/Default/engine/Default/bank_alliance.php
@@ -57,7 +57,7 @@ if (!empty($BankTransactions)) { ?>
 				foreach ($BankTransactions as $TransactionID => $BankTransaction) { ?>
 					<tr>
 						<td><?php echo number_format($TransactionID); ?></td>
-						<td class="noWrap"><?php echo date(DATE_FULL_SHORT_SPLIT, $BankTransaction['Time']); ?></td>
+						<td class="noWrap"><?php echo date($ThisAccount->getDateTimeFormatSplit(), $BankTransaction['Time']); ?></td>
 						<td class="left"><?php
 							if ($BankTransaction['Exempt']) {
 								?>Alliance Funds c/o<br /><?php

--- a/src/templates/Default/engine/Default/combat_log_list.php
+++ b/src/templates/Default/engine/Default/combat_log_list.php
@@ -48,7 +48,7 @@ if (isset($Message)) {?>
 							<td class="center">
 								<input type="checkbox" value="on" name="id[<?php echo $LogID; ?>]">
 							</td>
-							<td class="sort_date noWrap"><?php echo date(DATE_FULL_SHORT, $Log['Time']); ?></td>
+							<td class="sort_date noWrap"><?php echo date($ThisAccount->getDateTimeFormat(), $Log['Time']); ?></td>
 							<td class="sort_sectorid center"><?php echo $Log['Sector']; ?></td>
 							<td class="sort_attacker"><?php echo $Log['Attacker']; ?></td>
 							<td class="sort_defender"><?php echo $Log['Defender']; ?></td>

--- a/src/templates/Default/engine/Default/council_vote.php
+++ b/src/templates/Default/engine/Default/council_vote.php
@@ -37,7 +37,7 @@ if (!$VoteTreaties) { ?>
 				</form>
 			</td>
 			<td><?php echo $VoteInfo['YesVotes']; ?> / <?php echo $VoteInfo['NoVotes']; ?></td>
-			<td class="noWrap"><?php echo date(DATE_FULL_SHORT_SPLIT, $VoteInfo['EndTime']); ?></td>
+			<td class="noWrap"><?php echo date($ThisAccount->getDateTimeFormatSplit(), $VoteInfo['EndTime']); ?></td>
 		</tr><?php
 	} ?>
 	</table><?php

--- a/src/templates/Default/engine/Default/forces_list.php
+++ b/src/templates/Default/engine/Default/forces_list.php
@@ -26,7 +26,7 @@ if (empty($Forces)) { ?>
 				<td class="sort_cds center"><?php echo $Force->getCDs(); ?></td>
 				<td class="sort_sds center"><?php echo $Force->getSDs(); ?></td>
 				<td class="sort_mines center"><?php echo $Force->getMines(); ?></td>
-				<td class="sort_expire noWrap" data-expire="<?php echo $Force->getExpire(); ?>"><?php echo date(DATE_FULL_SHORT, $Force->getExpire()); ?></td>
+				<td class="sort_expire noWrap" data-expire="<?php echo $Force->getExpire(); ?>"><?php echo date($ThisAccount->getDateTimeFormat(), $Force->getExpire()); ?></td>
 			</tr><?php
 		} ?>
 		</tbody>

--- a/src/templates/Default/engine/Default/game_join.php
+++ b/src/templates/Default/engine/Default/game_join.php
@@ -19,8 +19,8 @@ if ($Game->getDescription()) { ?>
 		<th>View Warp Chart</th>
 	</tr>
 	<tr class="center">
-		<td width="12%"><?php echo date(DATE_FULL_SHORT_SPLIT, $Game->getStartTime()); ?></td>
-		<td width="12%"><?php echo date(DATE_FULL_SHORT_SPLIT, $Game->getEndTime()); ?></td>
+		<td width="12%"><?php echo date($ThisAccount->getDateTimeFormatSplit(), $Game->getStartTime()); ?></td>
+		<td width="12%"><?php echo date($ThisAccount->getDateTimeFormatSplit(), $Game->getEndTime()); ?></td>
 		<td><?php echo $Game->getMaxTurns(); ?></td>
 		<td><?php echo $Game->getStartTurnHours(); ?></td>
 		<td><?php echo $Game->getMaxPlayers(); ?></td>

--- a/src/templates/Default/engine/Default/game_stats.php
+++ b/src/templates/Default/engine/Default/game_stats.php
@@ -19,12 +19,12 @@
 					<tr>
 						<td class="right">Start Date</td>
 						<td>&nbsp;</td>
-						<td><?php echo date(DATE_FULL_SHORT, $StatsGame->getStartTime()); ?></td>
+						<td><?php echo date($ThisAccount->getDateTimeFormat(), $StatsGame->getStartTime()); ?></td>
 					</tr>
 					<tr>
 						<td class="right">End Date</td>
 						<td>&nbsp;</td>
-						<td><?php echo date(DATE_FULL_SHORT, $StatsGame->getEndTime()); ?></td>
+						<td><?php echo date($ThisAccount->getDateTimeFormat(), $StatsGame->getEndTime()); ?></td>
 					</tr>
 					<tr>
 						<td class="right">Max Turns</td>

--- a/src/templates/Default/engine/Default/includes/CommonNews.inc.php
+++ b/src/templates/Default/engine/Default/includes/CommonNews.inc.php
@@ -1,13 +1,13 @@
 <?php
 if (isset($BreakingNews)) {
-	?><b>MAJOR NEWS! - <?php echo date(DATE_FULL_SHORT, $BreakingNews['Time']); ?></b><br />
+	?><b>MAJOR NEWS! - <?php echo date($ThisAccount->getDateTimeFormat(), $BreakingNews['Time']); ?></b><br />
 	<table class="standard">
 		<tr>
 			<th><span class="lgreen">Time</span></th>
 			<th><span class="lgreen">Breaking News</span></th>
 		</tr>
 		<tr>
-			<td class="center"><?php echo date(DATE_FULL_SHORT, $BreakingNews['Time']); ?></td>
+			<td class="center"><?php echo date($ThisAccount->getDateTimeFormat(), $BreakingNews['Time']); ?></td>
 			<td class="left"><?php echo $BreakingNews['Message']; ?></td>
 		</tr>
 	</table>
@@ -22,7 +22,7 @@ if (isset($LottoNews)) { ?>
 		    <th><span class="lgreen">Message</span></th>
 	    </tr>
 	    <tr>
-		    <td class="center"><?php echo date(DATE_FULL_SHORT, $LottoNews['Time']); ?></td>
+		    <td class="center"><?php echo date($ThisAccount->getDateTimeFormat(), $LottoNews['Time']); ?></td>
 		    <td class="left"><?php echo $LottoNews['Message']; ?></td>
 	    </tr>
     </table>

--- a/src/templates/Default/engine/Default/includes/SectorForces.inc.php
+++ b/src/templates/Default/engine/Default/includes/SectorForces.inc.php
@@ -53,7 +53,7 @@
 						</td>
 						<td class="shrink noWrap center"><?php
 							if ($SharedForceAlliance) {
-								?><span class="green"><?php echo date(DATE_FULL_SHORT, $Force->getExpire()); ?></span><?php
+								?><span class="green"><?php echo date($ThisAccount->getDateTimeFormat(), $Force->getExpire()); ?></span><?php
 							} else {
 								?><span class="red">WAR</span><?php
 							} ?>

--- a/src/templates/Default/engine/Default/preferences.php
+++ b/src/templates/Default/engine/Default/preferences.php
@@ -237,7 +237,7 @@ if (isset($GameID)) { ?>
 				$time = Smr\Epoch::time();
 				$offset = $ThisAccount->getOffset();
 				for ($i = -12; $i <= 11; $i++) {
-					?><option value="<?php echo $i; ?>"<?php if ($offset == $i) { ?> selected="selected"<?php } ?>><?php echo date(DATE_TIME_SHORT, $time + $i * 3600); ?></option><?php
+					?><option value="<?php echo $i; ?>"<?php if ($offset == $i) { ?> selected="selected"<?php } ?>><?php echo date($ThisAccount->getTimeFormat(), $time + $i * 3600); ?></option><?php
 				} ?>
 				</select>
 			</td>
@@ -254,12 +254,12 @@ if (isset($GameID)) { ?>
 
 		<tr>
 			<td>Date Format:</td>
-			<td><input type="text" name="dateformat" value="<?php echo htmlspecialchars($ThisAccount->getShortDateFormat()); ?>" /><br />(Default: '<?php echo DEFAULT_DATE_DATE_SHORT; ?>')</td>
+			<td><input type="text" name="dateformat" value="<?php echo htmlspecialchars($ThisAccount->getDateFormat()); ?>" /><br />(Default: '<?php echo DEFAULT_DATE_FORMAT; ?>')</td>
 		</tr>
 
 		<tr>
 			<td>Time Format:</td>
-			<td><input type="text" name="timeformat" value="<?php echo htmlspecialchars($ThisAccount->getShortTimeFormat()); ?>" /><br />(Default: '<?php echo DEFAULT_DATE_TIME_SHORT; ?>')</td>
+			<td><input type="text" name="timeformat" value="<?php echo htmlspecialchars($ThisAccount->getTimeFormat()); ?>" /><br />(Default: '<?php echo DEFAULT_TIME_FORMAT; ?>')</td>
 		</tr>
 
 		<tr>

--- a/src/templates/Default/login/login_create.php
+++ b/src/templates/Default/login/login_create.php
@@ -31,7 +31,7 @@
 					<select name="timez" class="InputFields"><?php
 						$time = Smr\Epoch::time();
 						for ($i = -12; $i <= 11; $i++) {
-							?><option value="<?php echo $i; ?>"><?php echo date(DEFAULT_DATE_TIME_SHORT, $time + $i * 3600); ?></option><?php
+							?><option value="<?php echo $i; ?>"><?php echo date(DEFAULT_TIME_FORMAT, $time + $i * 3600); ?></option><?php
 						} ?>
 					</select>
 				</td>

--- a/src/templates/Default/login/login_social_create.php
+++ b/src/templates/Default/login/login_social_create.php
@@ -53,7 +53,7 @@
 							<?php
 							$time = Smr\Epoch::time();
 								for ($i = -12; $i <= 11; $i++) {
-									echo('<option value="' . $i . '">' . date(DEFAULT_DATE_TIME_SHORT, $time + $i * 3600));
+									echo('<option value="' . $i . '">' . date(DEFAULT_TIME_FORMAT, $time + $i * 3600));
 								}
 							?>
 						</select>

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
@@ -230,4 +230,27 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 		$this->assertNull($account);
 	}
 
+	public function test_date_format_methods() {
+		$account = AbstractSmrAccount::createAccount('test', 'test', 'test@test.com', 9, 0);
+
+		// Arbitrary epoch for testing (Sat, 24 Apr 2021 01:39:51 GMT)
+		$epoch = 1619228391;
+
+		// Test default formats
+		self::assertSame('24/4/2021', date($account->getDateFormat(), $epoch));
+		self::assertSame('1:39:51 AM', date($account->getTimeFormat(), $epoch));
+
+		// Test combined formats
+		self::assertSame('24/4/2021 1:39:51 AM', date($account->getDateTimeFormat(), $epoch));
+		self::assertSame('24/4/2021<br />1:39:51 AM', date($account->getDateTimeFormatSplit(), $epoch));
+
+		// Now modify the formats
+		$account->setDateFormat('Y M D');
+		$account->setTimeFormat('H i s');
+
+		// Test the modified formats
+		self::assertSame('2021 Apr Sat', date($account->getDateFormat(), $epoch));
+		self::assertSame('01 39 51', date($account->getTimeFormat(), $epoch));
+	}
+
 }


### PR DESCRIPTION
Instead of defining some account-dependent date format constants in
`do_voodoo`, just use SmrAccount methods instead. This is much more
straightforward, and we can be sure that they actually exist when
we use them.

The replacements are as follows:

* DATE_DATE_SHORT -> SmrAccount::getDateFormat
* DATE_TIME_SHORT -> SmrAccount::getTimeFormat
* DATE_FULL_SHORT -> SmrAccount::getDateTimeFormat
* DATE_FULL_SHORT_SPLIT -> SmrAccount::getDateTimeFormatSplit

Note that while `getDateTimeFormat` and `getDateTimeFormatSplit` are
new, the others are existing methods that have been renamed:

* {get,set}ShortDateFormat -> {get,set}DateFormat
* {get,set}ShortTimeFormat -> {get,set}TimeFormat

The reason for this is that we don't need the "Short" qualifier since
we are also removing any notion of "Long" date formats, i.e we remove
`DEFAULT_DATE_FULL_LONG` (this was the only "Long" format and was used
sparsely anyway).

As such, we also rename the "DEFAULT" format constants. Here again we
have removed the "FULL" qualifier in favor of the more explicit name
"DATE_TIME" (as we did in the SmrAccount methods):

* DEFAULT_DATE_DATE_SHORT -> DEFAULT_DATE_FORMAT
* DEFAULT_DATE_TIME_SHORT -> DEFAULT_TIME_FORMAT
* DEFAULT_DATE_FULL_SHORT -> DEFAULT_DATE_TIME_FORMAT
* DEFAULT_DATE_FULL_SHORT_SPLIT -> DEFAULT_DATE_TIME_FORMAT_SPLIT