### PR TITLE
Remove unused gameTypeID constructor arguments

### DIFF
--- a/src/lib/Default/AbstractSmrCombatWeapon.class.php
+++ b/src/lib/Default/AbstractSmrCombatWeapon.class.php
@@ -6,7 +6,6 @@ abstract class AbstractSmrCombatWeapon {
 	 */
 	const PLANET_DAMAGE_MOD = 0.2;
 
-	protected $gameTypeID;
 	protected $name;
 	protected $maxDamage;
 	protected $shieldDamage;

--- a/src/lib/Default/AbstractSmrPort.class.php
+++ b/src/lib/Default/AbstractSmrPort.class.php
@@ -1222,7 +1222,7 @@ class AbstractSmrPort {
 			}
 		}
 		if ($this->hasCDs()) {
-			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs(), true);
+			$thisCDs = new SmrCombatDrones($this->getCDs(), true);
 			$results['Drones'] = $thisCDs->shootPlayerAsPort($this, array_rand_value($targetPlayers));
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 			$results['TotalDamagePerTargetPlayer'][$results['Drones']['TargetPlayer']->getAccountID()] += $results['Drones']['ActualDamage']['TotalDamage'];

--- a/src/lib/Default/AbstractSmrShip.class.php
+++ b/src/lib/Default/AbstractSmrShip.class.php
@@ -890,7 +890,7 @@ class AbstractSmrShip {
 			}
 		}
 		if ($this->hasCDs()) {
-			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs());
+			$thisCDs = new SmrCombatDrones($this->getCDs());
 			$results['Drones'] = $thisCDs->shootPlayer($thisPlayer, array_rand_value($targetPlayers));
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}
@@ -922,7 +922,7 @@ class AbstractSmrShip {
 			}
 		}
 		if ($this->hasCDs()) {
-			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs());
+			$thisCDs = new SmrCombatDrones($this->getCDs());
 			$results['Drones'] = $thisCDs->shootForces($thisPlayer, $forces);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 			$thisPlayer->increaseHOF($results['Drones']['ActualDamage']['NumMines'], array('Combat', 'Forces', 'Mines', 'Killed'), HOF_PUBLIC);
@@ -954,7 +954,7 @@ class AbstractSmrShip {
 			}
 		}
 		if ($this->hasCDs()) {
-			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs());
+			$thisCDs = new SmrCombatDrones($this->getCDs());
 			$results['Drones'] = $thisCDs->shootPort($thisPlayer, $port);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}
@@ -992,7 +992,7 @@ class AbstractSmrShip {
 			}
 		}
 		if ($this->hasCDs()) {
-			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs());
+			$thisCDs = new SmrCombatDrones($this->getCDs());
 			$results['Drones'] = $thisCDs->shootPlanet($thisPlayer, $planet, $delayed);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}

--- a/src/lib/Default/SmrCombatDrones.class.php
+++ b/src/lib/Default/SmrCombatDrones.class.php
@@ -4,8 +4,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 	const MAX_CDS_RAND = 54;
 	protected $numberOfCDs;
 
-	public function __construct($gameTypeID, $numberOfCDs, $portPlanetDrones = false) {
-		$this->gameTypeID = $gameTypeID;
+	public function __construct($numberOfCDs, $portPlanetDrones = false) {
 		$this->numberOfCDs = $numberOfCDs;
 		$this->name = 'Combat Drones';
 		if ($portPlanetDrones === false) {

--- a/src/lib/Default/SmrForce.class.php
+++ b/src/lib/Default/SmrForce.class.php
@@ -461,20 +461,20 @@ class SmrForce {
 		$results['DeadBeforeShot'] = false;
 
 		if ($this->hasMines()) {
-			$thisMines = new SmrMines($this->getGameID(), $this->getMines());
+			$thisMines = new SmrMines($this->getMines());
 			$results['Results']['Mines'] = $thisMines->shootPlayerAsForce($this, array_rand_value($targetPlayers), $minesAreAttacker);
 			$results['TotalDamage'] += $results['Results']['Mines']['ActualDamage']['TotalDamage'];
 		}
 
 		if ($this->hasCDs()) {
-			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs());
+			$thisCDs = new SmrCombatDrones($this->getCDs());
 			$results['Results']['Drones'] = $thisCDs->shootPlayerAsForce($this, array_rand_value($targetPlayers));
 			$results['TotalDamage'] += $results['Results']['Drones']['ActualDamage']['TotalDamage'];
 		}
 
 		if (!$minesAreAttacker) {
 			if ($this->hasSDs()) {
-				$thisSDs = new SmrScoutDrones($this->getGameID(), $this->getSDs());
+				$thisSDs = new SmrScoutDrones($this->getSDs());
 				$results['Results']['Scouts'] = $thisSDs->shootPlayerAsForce($this, array_rand_value($targetPlayers));
 				$results['TotalDamage'] += $results['Results']['Scouts']['ActualDamage']['TotalDamage'];
 			}

--- a/src/lib/Default/SmrMines.class.php
+++ b/src/lib/Default/SmrMines.class.php
@@ -6,8 +6,7 @@ class SmrMines extends AbstractSmrCombatWeapon {
 	const DCS_DAMAGE_MODIFIER = .75;
 	protected $numberOfMines;
 
-	public function __construct($gameTypeID, $numberOfMines) {
-		$this->gameTypeID = $gameTypeID;
+	public function __construct($numberOfMines) {
 		$this->numberOfMines = $numberOfMines;
 		$this->name = 'Mines';
 		$this->maxDamage = 20;

--- a/src/lib/Default/SmrPlanet.class.php
+++ b/src/lib/Default/SmrPlanet.class.php
@@ -1190,7 +1190,7 @@ class SmrPlanet {
 			}
 		}
 		if ($this->hasCDs()) {
-			$thisCDs = new SmrCombatDrones($this->getGameID(), $this->getCDs(), true);
+			$thisCDs = new SmrCombatDrones($this->getCDs(), true);
 			$results['Drones'] = $thisCDs->shootPlayerAsPlanet($this, array_rand_value($targetPlayers));
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 			$results['TotalDamagePerTargetPlayer'][$results['Drones']['TargetPlayer']->getAccountID()] += $results['Drones']['ActualDamage']['TotalDamage'];

--- a/src/lib/Default/SmrScoutDrones.class.php
+++ b/src/lib/Default/SmrScoutDrones.class.php
@@ -3,8 +3,7 @@
 class SmrScoutDrones extends AbstractSmrCombatWeapon {
 	protected $numberOfSDs;
 
-	public function __construct($gameTypeID, $numberOfSDs) {
-		$this->gameTypeID = $gameTypeID;
+	public function __construct($numberOfSDs) {
 		$this->numberOfSDs = $numberOfSDs;
 		$this->name = 'Scout Drones';
 		$this->maxDamage = 20;


### PR DESCRIPTION
Affects the Smr{CombatDrones,ScoutDrones,Mines} classes.

The argument is written as `$gameTypeID`, but we were always passing
a game ID instead. Also, it was completely unused.

The same change was made to SmrWeapon in 0b1af16a0c.