### PR TITLE
Fix combat logs

### DIFF
--- a/src/lib/Default/AbstractSmrCombatWeapon.class.php
+++ b/src/lib/Default/AbstractSmrCombatWeapon.class.php
@@ -7,7 +7,6 @@ abstract class AbstractSmrCombatWeapon {
 	const PLANET_DAMAGE_MOD = 0.2;
 
 	protected string $name;
-	protected int $maxDamage;
 	protected int $shieldDamage;
 	protected int $armourDamage;
 	protected int $accuracy;
@@ -21,8 +20,11 @@ abstract class AbstractSmrCombatWeapon {
 		return $this->name;
 	}
 
+	/**
+	 * Return the max weapon damage possible in a single round.
+	 */
 	public function getMaxDamage() : int {
-		return $this->maxDamage;
+		return max($this->getShieldDamage(), $this->getArmourDamage());
 	}
 
 	public function getShieldDamage() : int {

--- a/src/lib/Default/AbstractSmrCombatWeapon.class.php
+++ b/src/lib/Default/AbstractSmrCombatWeapon.class.php
@@ -6,19 +6,7 @@ abstract class AbstractSmrCombatWeapon {
 	 */
 	const PLANET_DAMAGE_MOD = 0.2;
 
-	protected string $name;
-	protected int $shieldDamage;
-	protected int $armourDamage;
-	protected int $accuracy;
 	protected bool $damageRollover;
-
-	public function getBaseAccuracy() : int {
-		return $this->accuracy;
-	}
-
-	public function getName() : string {
-		return $this->name;
-	}
 
 	/**
 	 * Return the max weapon damage possible in a single round.
@@ -27,13 +15,10 @@ abstract class AbstractSmrCombatWeapon {
 		return max($this->getShieldDamage(), $this->getArmourDamage());
 	}
 
-	public function getShieldDamage() : int {
-		return $this->shieldDamage;
-	}
-
-	public function getArmourDamage() : int {
-		return $this->armourDamage;
-	}
+	abstract public function getBaseAccuracy() : int;
+	abstract public function getName() : string;
+	abstract public function getShieldDamage() : int;
+	abstract public function getArmourDamage() : int;
 
 	public function isDamageRollover() : bool {
 		return $this->damageRollover;

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -31,7 +31,7 @@ abstract class AbstractSmrPlayer {
 	protected int $lastSectorID;
 	protected int $newbieTurns;
 	protected bool $dead;
-	protected bool $npc;
+	protected bool $npc = false; // initialized for legacy combat logs
 	protected bool $newbieStatus;
 	protected bool $newbieWarning;
 	protected bool $landedOnPlanet;
@@ -1669,7 +1669,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function __sleep() {
-		return array('accountID', 'gameID', 'sectorID', 'alignment', 'playerID', 'playerName');
+		return array('accountID', 'gameID', 'sectorID', 'alignment', 'playerID', 'playerName', 'npc');
 	}
 
 	public function &getStoredDestinations() : array {

--- a/src/lib/Default/SmrCombatDrones.class.php
+++ b/src/lib/Default/SmrCombatDrones.class.php
@@ -8,11 +8,9 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 		$this->numberOfCDs = $numberOfCDs;
 		$this->name = 'Combat Drones';
 		if ($portPlanetDrones === false) {
-			$this->maxDamage = 2;
 			$this->shieldDamage = 2;
 			$this->armourDamage = 2;
 		} else {
-			$this->maxDamage = 1;
 			$this->shieldDamage = 1;
 			$this->armourDamage = 1;
 		}

--- a/src/lib/Default/SmrCombatDrones.class.php
+++ b/src/lib/Default/SmrCombatDrones.class.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 class SmrCombatDrones extends AbstractSmrCombatWeapon {
+	use Traits\CombatWeaponForce;
+
 	const MAX_CDS_RAND = 54;
 	protected int $numberOfCDs;
 

--- a/src/lib/Default/SmrCombatDrones.class.php
+++ b/src/lib/Default/SmrCombatDrones.class.php
@@ -4,10 +4,9 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 	use Traits\CombatWeaponForce;
 
 	const MAX_CDS_RAND = 54;
-	protected int $numberOfCDs;
 
 	public function __construct(int $numberOfCDs, bool $portPlanetDrones = false) {
-		$this->numberOfCDs = $numberOfCDs;
+		$this->amount = $numberOfCDs;
 		$this->name = 'Combat Drones';
 		if ($portPlanetDrones === false) {
 			$this->shieldDamage = 2;
@@ -18,10 +17,6 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 		}
 		$this->accuracy = 3;
 		$this->damageRollover = true;
-	}
-
-	public function getNumberOfCDs() : int {
-		return $this->numberOfCDs;
 	}
 
 	public function getModifiedAccuracy() : float {
@@ -106,7 +101,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		}
 		$damage = $this->getDamage();
-		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstForces($weaponPlayer, $forces) / 100);
+		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedAccuracyAgainstForces($weaponPlayer, $forces) / 100);
 		$damage['Kamikaze'] = 0;
 		if ($weaponPlayer->isCombatDronesKamikazeOnMines()) { // If kamikaze then damage is same as MINE_ARMOUR
 			$damage['Kamikaze'] = min($damage['Launched'], $forces->getMines());
@@ -130,7 +125,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		}
 		$damage = $this->getDamage();
-		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPort($weaponPlayer, $port) / 100);
+		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedAccuracyAgainstPort($weaponPlayer, $port) / 100);
 		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
 		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
 		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
@@ -144,7 +139,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			return array('MaxDamage' => 0, 'Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover());
 		}
 		$damage = $this->getDamage();
-		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPlanet($weaponPlayer, $planet) / 100);
+		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedAccuracyAgainstPlanet($weaponPlayer, $planet) / 100);
 		$planetMod = self::PLANET_DAMAGE_MOD;
 		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage'] * $planetMod);
 		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield'] * $planetMod);
@@ -164,7 +159,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			$damage['Shield'] *= DCS_PLAYER_DAMAGE_DECIMAL_PERCENT;
 			$damage['Armour'] *= DCS_PLAYER_DAMAGE_DECIMAL_PERCENT;
 		}
-		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedAccuracyAgainstPlayer($weaponPlayer, $targetPlayer) / 100);
+		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedAccuracyAgainstPlayer($weaponPlayer, $targetPlayer) / 100);
 		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
 		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
 		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
@@ -184,7 +179,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			$damage['Armour'] *= DCS_FORCE_DAMAGE_DECIMAL_PERCENT;
 		}
 
-		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer) / 100);
+		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer) / 100);
 		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
 		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
 		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
@@ -203,7 +198,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			$damage['Shield'] *= DCS_PORT_DAMAGE_DECIMAL_PERCENT;
 			$damage['Armour'] *= DCS_PORT_DAMAGE_DECIMAL_PERCENT;
 		}
-		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedPortAccuracyAgainstPlayer($port, $targetPlayer) / 100);
+		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedPortAccuracyAgainstPlayer($port, $targetPlayer) / 100);
 		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
 		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
 		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);
@@ -222,7 +217,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 			$damage['Shield'] *= DCS_PLANET_DAMAGE_DECIMAL_PERCENT;
 			$damage['Armour'] *= DCS_PLANET_DAMAGE_DECIMAL_PERCENT;
 		}
-		$damage['Launched'] = ICeil($this->getNumberOfCDs() * $this->getModifiedPlanetAccuracyAgainstPlayer($planet, $targetPlayer) / 100);
+		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedPlanetAccuracyAgainstPlayer($planet, $targetPlayer) / 100);
 		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
 		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
 		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);

--- a/src/lib/Default/SmrMines.class.php
+++ b/src/lib/Default/SmrMines.class.php
@@ -6,19 +6,14 @@ class SmrMines extends AbstractSmrCombatWeapon {
 	const TOTAL_ENEMY_MINES_MODIFIER = 25;
 	const FED_SHIP_DAMAGE_MODIFIER = .5;
 	const DCS_DAMAGE_MODIFIER = .75;
-	protected int $numberOfMines;
 
 	public function __construct(int $numberOfMines) {
-		$this->numberOfMines = $numberOfMines;
+		$this->amount = $numberOfMines;
 		$this->name = 'Mines';
 		$this->shieldDamage = 20;
 		$this->armourDamage = 20;
 		$this->accuracy = 100;
 		$this->damageRollover = false;
-	}
-
-	public function getNumberOfMines() : int {
-		return $this->numberOfMines;
 	}
 
 	public function getModifiedAccuracy() : float {
@@ -95,7 +90,7 @@ class SmrMines extends AbstractSmrCombatWeapon {
 			$damage['Shield'] = IRound($damage['Shield'] * self::DCS_DAMAGE_MODIFIER);
 			$damage['Armour'] = IRound($damage['Armour'] * self::DCS_DAMAGE_MODIFIER);
 		}
-		$damage['Launched'] = ICeil($this->getNumberOfMines() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer, $minesAreAttacker) / 100);
+		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer, $minesAreAttacker) / 100);
 		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
 		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
 		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);

--- a/src/lib/Default/SmrMines.class.php
+++ b/src/lib/Default/SmrMines.class.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 class SmrMines extends AbstractSmrCombatWeapon {
+	use Traits\CombatWeaponForce;
+
 	const TOTAL_ENEMY_MINES_MODIFIER = 25;
 	const FED_SHIP_DAMAGE_MODIFIER = .5;
 	const DCS_DAMAGE_MODIFIER = .75;

--- a/src/lib/Default/SmrMines.class.php
+++ b/src/lib/Default/SmrMines.class.php
@@ -9,7 +9,6 @@ class SmrMines extends AbstractSmrCombatWeapon {
 	public function __construct(int $numberOfMines) {
 		$this->numberOfMines = $numberOfMines;
 		$this->name = 'Mines';
-		$this->maxDamage = 20;
 		$this->shieldDamage = 20;
 		$this->armourDamage = 20;
 		$this->accuracy = 100;

--- a/src/lib/Default/SmrScoutDrones.class.php
+++ b/src/lib/Default/SmrScoutDrones.class.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 class SmrScoutDrones extends AbstractSmrCombatWeapon {
+	use Traits\CombatWeaponForce;
+
 	protected int $numberOfSDs;
 
 	public function __construct(int $numberOfSDs) {

--- a/src/lib/Default/SmrScoutDrones.class.php
+++ b/src/lib/Default/SmrScoutDrones.class.php
@@ -6,7 +6,6 @@ class SmrScoutDrones extends AbstractSmrCombatWeapon {
 	public function __construct(int $numberOfSDs) {
 		$this->numberOfSDs = $numberOfSDs;
 		$this->name = 'Scout Drones';
-		$this->maxDamage = 20;
 		$this->shieldDamage = 20;
 		$this->armourDamage = 20;
 		$this->accuracy = 100;

--- a/src/lib/Default/SmrScoutDrones.class.php
+++ b/src/lib/Default/SmrScoutDrones.class.php
@@ -3,19 +3,13 @@
 class SmrScoutDrones extends AbstractSmrCombatWeapon {
 	use Traits\CombatWeaponForce;
 
-	protected int $numberOfSDs;
-
 	public function __construct(int $numberOfSDs) {
-		$this->numberOfSDs = $numberOfSDs;
+		$this->amount = $numberOfSDs;
 		$this->name = 'Scout Drones';
 		$this->shieldDamage = 20;
 		$this->armourDamage = 20;
 		$this->accuracy = 100;
 		$this->damageRollover = false;
-	}
-
-	public function getNumberOfSDs() : int {
-		return $this->numberOfSDs;
 	}
 
 	public function getModifiedAccuracy() : float {
@@ -70,7 +64,7 @@ class SmrScoutDrones extends AbstractSmrCombatWeapon {
 			return $return;
 		}
 		$damage = $this->getDamage();
-		$damage['Launched'] = ICeil($this->getNumberOfSDs() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer) / 100);
+		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer) / 100);
 		$damage['MaxDamage'] = ICeil($damage['Launched'] * $damage['MaxDamage']);
 		$damage['Shield'] = ICeil($damage['Launched'] * $damage['Shield']);
 		$damage['Armour'] = ICeil($damage['Launched'] * $damage['Armour']);

--- a/src/lib/Default/SmrWeapon.class.php
+++ b/src/lib/Default/SmrWeapon.class.php
@@ -96,13 +96,6 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 		return $armourDamage;
 	}
 
-	/**
-	 * (Override) Return the max weapon damage possible in a single round.
-	 */
-	public function getMaxDamage() : int {
-		return max($this->getShieldDamage(), $this->getArmourDamage());
-	}
-
 	public function getBuyHREF(SmrLocation $location) : string {
 		$container = Page::create('shop_weapon_processing.php');
 		$container['LocationID'] = $location->getTypeID();

--- a/src/lib/Default/SmrWeapon.class.php
+++ b/src/lib/Default/SmrWeapon.class.php
@@ -24,7 +24,6 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	protected function __construct(int $weaponTypeID, Smr\Database $db = null) {
 		$this->weaponType = SmrWeaponType::getWeaponType($weaponTypeID, $db);
 		$this->weaponTypeID = $weaponTypeID;
-		$this->name = $this->weaponType->getName();
 		$this->raceID = $this->weaponType->getRaceID();
 	}
 
@@ -53,18 +52,19 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	}
 
 	/**
-	 * (Override) Return weapon name suitable for HTML display.
+	 * Return weapon name suitable for HTML display.
 	 * The name is displayed in green with pluses if enhancements are present.
 	 */
 	public function getName() : string {
+		$name = $this->weaponType->getName();
 		if ($this->hasEnhancements()) {
-			return '<span class="green">' . $this->name . str_repeat('+', $this->getNumberOfEnhancements()) . '</span>';
+			$name = '<span class="green">' . $name . str_repeat('+', $this->getNumberOfEnhancements()) . '</span>';
 		}
-		return $this->name;
+		return $name;
 	}
 
 	/**
-	 * (Override) Return the weapon base accuracy.
+	 * Return the weapon base accuracy.
 	 */
 	public function getBaseAccuracy() : int {
 		$baseAccuracy = $this->weaponType->getAccuracy();
@@ -75,7 +75,7 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	}
 
 	/**
-	 * (Override) Return the weapon shield damage.
+	 * Return the weapon shield damage.
 	 */
 	public function getShieldDamage() : int {
 		$shieldDamage = $this->weaponType->getShieldDamage();
@@ -86,7 +86,7 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	}
 
 	/**
-	 * (Override) Return the weapon armour damage.
+	 * Return the weapon armour damage.
 	 */
 	public function getArmourDamage() : int {
 		$armourDamage = $this->weaponType->getArmourDamage();

--- a/src/lib/Default/Traits/CombatWeaponForce.class.php
+++ b/src/lib/Default/Traits/CombatWeaponForce.class.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Traits;
+
+/**
+ * Common interface used by the subset of AbstractSmrCombatWeapon classes
+ * that are used for forces (mines, combat drones, and scout drones).
+ */
+trait CombatWeaponForce {
+
+	protected string $name;
+	protected int $shieldDamage;
+	protected int $armourDamage;
+	protected int $accuracy;
+
+	public function getBaseAccuracy() : int {
+		return $this->accuracy;
+	}
+
+	public function getName() : string {
+		return $this->name;
+	}
+
+	public function getShieldDamage() : int {
+		return $this->shieldDamage;
+	}
+
+	public function getArmourDamage() : int {
+		return $this->armourDamage;
+	}
+
+}

--- a/src/lib/Default/Traits/CombatWeaponForce.class.php
+++ b/src/lib/Default/Traits/CombatWeaponForce.class.php
@@ -12,6 +12,7 @@ trait CombatWeaponForce {
 	protected int $shieldDamage;
 	protected int $armourDamage;
 	protected int $accuracy;
+	protected int $amount;
 
 	public function getBaseAccuracy() : int {
 		return $this->accuracy;
@@ -27,6 +28,13 @@ trait CombatWeaponForce {
 
 	public function getArmourDamage() : int {
 		return $this->armourDamage;
+	}
+
+	/**
+	 * Returns the amount of this type of force.
+	 */
+	public function getAmount() : int {
+		return $this->amount;
 	}
 
 }

--- a/test/SmrTest/lib/DefaultGame/SmrCombatDronesTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrCombatDronesTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use SmrCombatDrones;
+
+/**
+ * @covers SmrCombatDrones
+ */
+class SmrCombatDronesTest extends \PHPUnit\Framework\TestCase {
+
+	public function test_getMaxDamage() {
+		// regular drones
+		$drones = new SmrCombatDrones(100); // doesn't matter how many
+		$this->assertSame(2, $drones->getMaxDamage());
+		// port/planet drones
+		$drones = new SmrCombatDrones(100, true);
+		$this->assertSame(1, $drones->getMaxDamage());
+	}
+
+}

--- a/test/SmrTest/lib/DefaultGame/SmrMinesTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrMinesTest.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use SmrMines;
+
+/**
+ * @covers SmrMines
+ */
+class SmrMinesTest extends \PHPUnit\Framework\TestCase {
+
+	public function test_getMaxDamage() {
+		$mines = new SmrMines(100); // doesn't matter how many
+		$this->assertSame(20, $mines->getMaxDamage());
+	}
+
+}

--- a/test/SmrTest/lib/DefaultGame/SmrScoutDronesTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrScoutDronesTest.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use SmrScoutDrones;
+
+/**
+ * @covers SmrScoutDrones
+ */
+class SmrScoutDronesTest extends \PHPUnit\Framework\TestCase {
+
+	public function test_getMaxDamage() {
+		$sds = new SmrScoutDrones(100); // doesn't matter how many
+		$this->assertSame(20, $sds->getMaxDamage());
+	}
+
+}


### PR DESCRIPTION
The typed properties introduced in #1072 caused an issue with the deserialization of some classes when viewing old combat logs. See commit messages for details.