### PR TITLE
Switch constant tables from database to PHP class

### DIFF
--- a/db/patches/V1_6_66_16__drop_ship_class.sql
+++ b/db/patches/V1_6_66_16__drop_ship_class.sql
@@ -1,0 +1,2 @@
+-- This constant table is replaced with the PHP class ShipClass
+DROP TABLE `ship_class`;

--- a/db/patches/V1_6_66_17__drop_user_rankings.sql
+++ b/db/patches/V1_6_66_17__drop_user_rankings.sql
@@ -1,0 +1,2 @@
+-- This constant table is replaced with the PHP class UserRanking
+DROP TABLE `user_rankings`;

--- a/src/engine/Default/sector_mines.inc.php
+++ b/src/engine/Default/sector_mines.inc.php
@@ -12,7 +12,7 @@ foreach ($sectorForces as $forces) {
 
 if ($mine_owner_id) {
 	$ship = $player->getShip();
-	if ($player->hasNewbieTurns() || $ship->getShipClassID() === SmrShip::SHIP_CLASS_SCOUT) {
+	if ($player->hasNewbieTurns() || $ship->getShipClassID() === Smr\ShipClass::SCOUT) {
 		$turns = $sectorForces[$mine_owner_id]->getBumpTurnCost($ship);
 		$player->takeTurns($turns, $turns);
 		$container = Page::create('skeleton.php', 'current_sector.php');

--- a/src/engine/Default/shop_ship.php
+++ b/src/engine/Default/shop_ship.php
@@ -15,7 +15,7 @@ $shipsSold = $location->getShipsSold();
 $timeUntilUnlock = $player->getGame()->timeUntilShipUnlock();
 $shipsUnavailable = [];
 foreach ($shipsSold as $shipTypeID => $shipSold) {
-	if ($timeUntilUnlock > 0 && ($shipSold['ShipClassID'] == SmrShip::SHIP_CLASS_RAIDER || $shipSold['ShipTypeID'] == SHIP_TYPE_PLANETARY_SUPER_FREIGHTER)) {
+	if ($timeUntilUnlock > 0 && ($shipSold['ShipClassID'] == Smr\ShipClass::RAIDER || $shipSold['ShipTypeID'] == SHIP_TYPE_PLANETARY_SUPER_FREIGHTER)) {
 		$shipSold['TimeUntilUnlock'] = $timeUntilUnlock;
 		$shipsUnavailable[] = $shipSold;
 		unset($shipsSold[$shipTypeID]);

--- a/src/engine/Default/smr_file_create.php
+++ b/src/engine/Default/smr_file_create.php
@@ -46,7 +46,7 @@ $file .= '[Ships]
 ; Name = Race,Cost,TPH,Hardpoints,Power,Class,+Equipment (Optional),+Restrictions(Optional)
 ; Restrictions:Align(Integer)' . EOL;
 foreach (AbstractSmrShip::getAllBaseShips() as $ship) {
-	$file .= inify($ship['Name']) . '=' . Globals::getRaceName($ship['RaceID']) . ',' . $ship['Cost'] . ',' . $ship['Speed'] . ',' . $ship['Hardpoint'] . ',' . $ship['MaxPower'] . ',' . Globals::getShipClass($ship['ShipClassID']);
+	$file .= inify($ship['Name']) . '=' . Globals::getRaceName($ship['RaceID']) . ',' . $ship['Cost'] . ',' . $ship['Speed'] . ',' . $ship['Hardpoint'] . ',' . $ship['MaxPower'] . ',' . Smr\ShipClass::getName($ship['ShipClassID']);
 	if ($ship['MaxHardware'] > 0) {
 		$shipEquip = ',ShipEquipment=';
 		foreach ($ship['MaxHardware'] as $hardwareID => $maxHardware) {

--- a/src/htdocs/ship_list.php
+++ b/src/htdocs/ship_list.php
@@ -39,7 +39,7 @@ function buildShipStats($ship) {
 	$stat = [
 		'name' => $ship['Name'],
 		'race race' . $ship['RaceID'] => Globals::getRaceName($ship['RaceID']),
-		'class_' => Globals::getShipClass($ship['ShipClassID']),
+		'class_' => Smr\ShipClass::getName($ship['ShipClassID']),
 		'cost' => number_format($ship['Cost']),
 		'speed' => $ship['Speed'],
 		'hardpoint' => $ship['Hardpoint'],

--- a/src/lib/Default/AbstractSmrAccount.class.php
+++ b/src/lib/Default/AbstractSmrAccount.class.php
@@ -4,9 +4,8 @@
 class AccountNotFoundException extends Exception {}
 
 abstract class AbstractSmrAccount {
+
 	const USER_RANKINGS_EACH_STAT_POW = .9;
-	const USER_RANKINGS_TOTAL_SCORE_POW = .3;
-	const USER_RANKINGS_RANK_BOUNDARY = 5.2;
 	protected const USER_RANKINGS_SCORE = array(
 		// [Stat, a, b]
 		// Used as: pow(Stat * a, USER_RANKINGS_EACH_STAT_POW) * b
@@ -413,12 +412,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function getRankName() : string {
-		$rankings = Globals::getUserRanking();
-		if (isset($rankings[$this->getRank()])) {
-			return $rankings[$this->getRank()];
-		} else {
-			return end($rankings);
-		}
+		return Smr\UserRanking::getName($this->getRank());
 	}
 
 	public function getScore() : int {
@@ -452,10 +446,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function getRank() : int {
-		$rank = ICeil(pow($this->getScore(), self::USER_RANKINGS_TOTAL_SCORE_POW) / self::USER_RANKINGS_RANK_BOUNDARY);
-		if ($rank < 1) {
-			$rank = 1;
-		}
+		$rank = Smr\UserRanking::getRankFromScore($this->getScore());
 		if ($rank > $this->maxRankAchieved) {
 			$this->updateMaxRankAchieved($rank);
 		}

--- a/src/lib/Default/AbstractSmrShip.class.php
+++ b/src/lib/Default/AbstractSmrShip.class.php
@@ -7,10 +7,6 @@
 class AbstractSmrShip {
 	protected static array $CACHE_BASE_SHIPS = [];
 
-	const SHIP_CLASS_HUNTER = 1;
-	const SHIP_CLASS_RAIDER = 3;
-	const SHIP_CLASS_SCOUT = 4;
-
 	// Player exp gained for each point of damage done
 	const EXP_PER_DAMAGE_PLAYER = 0.375;
 	const EXP_PER_DAMAGE_PLANET = 1.0; // note that planet damage is reduced

--- a/src/lib/Default/Globals.class.php
+++ b/src/lib/Default/Globals.class.php
@@ -9,7 +9,6 @@ class Globals {
 	protected static bool $FEATURE_REQUEST_OPEN;
 	protected static array $RACE_RELATIONS;
 	protected static array $USER_RANKINGS;
-	protected static array $SHIP_CLASSES;
 	protected static array $AVAILABLE_LINKS = [];
 	protected static Smr\Database $db;
 
@@ -222,24 +221,6 @@ class Globals {
 			}
 		}
 		return self::$RACE_RELATIONS[$gameID][$raceID];
-	}
-
-	/**
-	 * If specified, returns the Ship Class Name associated with the given ID.
-	 * Otherwise, returns an array of all Ship Class Names.
-	 */
-	public static function getShipClass(int $shipClassID = null) : array|string {
-		if (!isset(self::$SHIP_CLASSES)) {
-			self::initialiseDatabase();
-			self::$db->query('SELECT * FROM ship_class');
-			while (self::$db->nextRecord()) {
-				self::$SHIP_CLASSES[self::$db->getInt('ship_class_id')] = self::$db->getField('ship_class_name');
-			}
-		}
-		if (is_null($shipClassID)) {
-			return self::$SHIP_CLASSES;
-		}
-		return self::$SHIP_CLASSES[$shipClassID];
 	}
 
 	public static function getUserRanking() : array {

--- a/src/lib/Default/Globals.class.php
+++ b/src/lib/Default/Globals.class.php
@@ -8,7 +8,6 @@ class Globals {
 	protected static array $HARDWARE_TYPES;
 	protected static bool $FEATURE_REQUEST_OPEN;
 	protected static array $RACE_RELATIONS;
-	protected static array $USER_RANKINGS;
 	protected static array $AVAILABLE_LINKS = [];
 	protected static Smr\Database $db;
 
@@ -221,18 +220,6 @@ class Globals {
 			}
 		}
 		return self::$RACE_RELATIONS[$gameID][$raceID];
-	}
-
-	public static function getUserRanking() : array {
-		if (!isset(self::$USER_RANKINGS)) {
-			self::initialiseDatabase();
-			self::$USER_RANKINGS = array();
-			self::$db->query('SELECT `rank`, rank_name FROM user_rankings ORDER BY `rank`');
-			while (self::$db->nextRecord()) {
-				self::$USER_RANKINGS[self::$db->getInt('rank')] = self::$db->getField('rank_name');
-			}
-		}
-		return self::$USER_RANKINGS;
 	}
 
 	public static function getFeatureRequestHREF() : string {

--- a/src/lib/HunterWars/SmrLocation.class.php
+++ b/src/lib/HunterWars/SmrLocation.class.php
@@ -8,7 +8,7 @@ class SmrLocation extends AbstractSmrLocation {
 			$this->db->query('SELECT * FROM location_sells_ships
 			                  JOIN ship_type USING (ship_type_id)
 			                  WHERE ' . $this->SQL . '
-			                    AND ship_class_id != ' . $this->db->escapeNumber(SmrShip::SHIP_CLASS_RAIDER) . '
+			                    AND ship_class_id != ' . $this->db->escapeNumber(Smr\ShipClass::RAIDER) . '
 			                    AND ship_type_id != ' . $this->db->escapeNumber(SHIP_TYPE_PLANETARY_SUPER_FREIGHTER));
 			while ($this->db->nextRecord()) {
 				$shipTypeID = $this->db->getInt('ship_type_id');

--- a/src/lib/Smr/ShipClass.php
+++ b/src/lib/Smr/ShipClass.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Smr;
+
+/**
+ * Categorization of ship types.
+ */
+class ShipClass {
+
+	const HUNTER = 1;
+	const TRADER = 2;
+	const RAIDER = 3;
+	const SCOUT = 4;
+	const STARTER = 5;
+
+	const NAMES = [
+		self::HUNTER => 'Hunter',
+		self::TRADER => 'Trader',
+		self::RAIDER => 'Raider',
+		self::SCOUT => 'Scout',
+		self::STARTER => 'Starter',
+	];
+
+	public static function getName(int $shipClassID) : string {
+		return self::NAMES[$shipClassID];
+	}
+
+	public static function getAllNames() : array {
+		return self::NAMES;
+	}
+
+}

--- a/src/lib/Smr/UserRanking.php
+++ b/src/lib/Smr/UserRanking.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Smr;
+
+/**
+ * User ranking titles
+ */
+class UserRanking {
+
+	const NAMES = [
+		1 => 'Newbie',
+		2 => 'Beginner',
+		3 => 'Fledgling',
+		4 => 'Average',
+		5 => 'Adept',
+		6 => 'Expert',
+		7 => 'Elite',
+		8 => 'Master',
+		9 => 'Grandmaster',
+	];
+
+	const MIN_RANK = 1;
+	const MAX_RANK = 9;
+
+	const SCORE_POW = .3;
+	const SCORE_POW_RANK_INCREMENT = 5.2;
+
+	/**
+	 * Given a score, return the associated rank
+	 */
+	public static function getRankFromScore(int $score) : int {
+		$rank = ICeil(pow($score, self::SCORE_POW) / self::SCORE_POW_RANK_INCREMENT);
+		$rank = min(max($rank, self::MIN_RANK), self::MAX_RANK);
+		return $rank;
+	}
+
+	/**
+	 * Given a rank, return the minimum score needed to achieve it
+	 * (this is an inversion of getRankFromScore)
+	 */
+	public static function getMinScoreForRank(int $rank) : int {
+		return ICeil(pow(($rank - 1) * self::SCORE_POW_RANK_INCREMENT, 1 / self::SCORE_POW));
+	}
+
+	/**
+	 * Return the title associated with the given rank
+	 */
+	public static function getName(int $rank) : string {
+		return self::NAMES[$rank];
+	}
+
+	public static function getAllNames() : array {
+		return self::NAMES;
+	}
+
+}

--- a/src/templates/Default/engine/Default/rankings_view.php
+++ b/src/templates/Default/engine/Default/rankings_view.php
@@ -6,10 +6,10 @@ You are ranked as a <span style="font-size: 125%; color: greenyellow;"><?php ech
 		<th>Points Required</th>
 	</tr>
 	<?php
-	foreach (Globals::getUserRanking() as $rankID => $rankName) { ?>
+	foreach (Smr\UserRanking::getAllNames() as $rank => $rankName) { ?>
 		<tr>
 			<td><?php echo $rankName; ?></td>
-			<td class="center"><?php echo ceil(pow((max(0, $rankID - 1)) * SmrAccount::USER_RANKINGS_RANK_BOUNDARY, 1 / SmrAccount::USER_RANKINGS_TOTAL_SCORE_POW)); ?></td>
+			<td class="center"><?php echo Smr\UserRanking::getMinScoreForRank($rank); ?></td>
 		</tr><?php
 	} ?>
 </table>

--- a/src/templates/Default/ship_list.php
+++ b/src/templates/Default/ship_list.php
@@ -42,7 +42,7 @@
 							<span class="sort" data-sort="class_">Class</span><br />
 							<select onchange="filterSelect(this)">
 								<option value="All">All</option><?php
-								foreach (Globals::getShipClass() as $shipClass) { ?>
+								foreach (Smr\ShipClass::getAllNames() as $shipClass) { ?>
 									<option><?php echo $shipClass; ?></option><?php
 								} ?>
 							</select>

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrShipTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrShipTest.php
@@ -4,6 +4,7 @@ namespace SmrTest\lib\DefaultGame;
 
 use AbstractSmrShip;
 use AbstractSmrPlayer;
+use Smr\ShipClass;
 
 /**
  * This test is expected to not make any changes to the database.
@@ -32,7 +33,7 @@ class AbstractSmrShipTest extends \PHPUnit\Framework\TestCase {
 		$ship = new AbstractSmrShip($this->player);
 		self::assertSame('Demonica', $ship->getName());
 		self::assertSame(SHIP_TYPE_DEMONICA, $ship->getShipTypeID());
-		self::assertSame(AbstractSmrShip::SHIP_CLASS_HUNTER, $ship->getShipClassID());
+		self::assertSame(ShipClass::HUNTER, $ship->getShipClassID());
 		self::assertSame(6, $ship->getHardpoints());
 		self::assertSame(10, $ship->getSpeed());
 		self::assertSame(0, $ship->getCost());

--- a/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
@@ -187,12 +187,12 @@ class DatabaseIntegrationTest extends TestCase {
 
 	public function test_lockTable_allows_read() {
 		$db = Database::getInstance();
-		$db->lockTable('ship_class');
+		$db->lockTable('good');
 
 		// Perform a query on the locked table
-		$db->query('SELECT ship_class_name FROM ship_class WHERE ship_class_id = 1');
+		$db->query('SELECT good_name FROM good WHERE good_id = 1');
 		$db->requireRecord();
-		self::assertSame(['ship_class_name' => 'Hunter'], $db->getRow());
+		self::assertSame(['good_name' => 'Wood'], $db->getRow());
 
 		// After unlock we can access other tables again
 		$db->unlock();
@@ -227,7 +227,7 @@ class DatabaseIntegrationTest extends TestCase {
 	public function test_nextRecord_no_result() {
 		$db = Database::getInstance();
 		// Construct a query that has an empty result set
-		$db->query('SELECT 1 FROM ship_class WHERE ship_class_id = 0');
+		$db->query('SELECT 1 FROM good WHERE good_id = 0');
 		self::assertFalse($db->nextRecord());
 	}
 

--- a/test/SmrTest/lib/DefaultGame/ShipClassTest.php
+++ b/test/SmrTest/lib/DefaultGame/ShipClassTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use Smr\ShipClass;
+
+/**
+ * @covers Smr\ShipClass
+ */
+class ShipClassTest extends \PHPUnit\Framework\TestCase {
+
+	public function test_getName() {
+		$this->assertSame('Trader', ShipClass::getName(2));
+	}
+
+	public function test_getAllNames() {
+		$this->assertSame('Trader', ShipClass::getAllNames()[2]);
+	}
+
+}

--- a/test/SmrTest/lib/DefaultGame/UserRankingTest.php
+++ b/test/SmrTest/lib/DefaultGame/UserRankingTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use Smr\UserRanking;
+
+/**
+ * @covers Smr\UserRanking
+ */
+class UserRankingTest extends \PHPUnit\Framework\TestCase {
+
+	public function test_getName() {
+		$this->assertSame('Expert', UserRanking::getName(6));
+	}
+
+	public function test_getAllNames() {
+		$this->assertSame('Expert', UserRanking::getAllNames()[6]);
+	}
+
+	public function test_rank_limits() {
+		$ranks = array_keys(UserRanking::getAllNames());
+		$this->assertSame(UserRanking::MIN_RANK, min($ranks));
+		$this->assertSame(UserRanking::MAX_RANK, max($ranks));
+	}
+
+	public function test_score_limits() {
+		// test the lowest possible score
+		$rank = UserRanking::getRankFromScore(0);
+		$this->assertSame(UserRanking::MIN_RANK, $rank);
+		// test an absurdly high score
+		$rank = UserRanking::getRankFromScore(PHP_INT_MAX);
+		$this->assertSame(UserRanking::MAX_RANK, $rank);
+	}
+
+	public function test_getMinScoreForRank() {
+		// test all ranks
+		foreach (UserRanking::getAllNames() as $rank => $name) {
+			$minScore = UserRanking::getMinScoreForRank($rank);
+			// make sure the given min score is still the same rank
+			$rankFromScore = UserRanking::getRankFromScore($minScore);
+			$this->assertSame($rank, $rankFromScore);
+		}
+	}
+
+}


### PR DESCRIPTION
The database should be reserved for data that changes over time,
especially because database queries are the slowest way to retrieve
data (whereas loading a PHP class is significantly faster).

The following table -> class replacements are made:
* `user_rankings` -> `UserRanking`
* `ship_class` -> `ShipClass`