### PR TITLE
SmrShip: replace base ship with SmrShipType class

### DIFF
--- a/src/admin/Default/edit_dummys.php
+++ b/src/admin/Default/edit_dummys.php
@@ -5,7 +5,7 @@ $template = Smr\Template::getInstance();
 $template->assign('PageTopic', 'Edit Dummys');
 
 $template->assign('CombatSimLink', Page::create('skeleton.php', 'combat_simulator.php')->href());
-$template->assign('BaseShips', AbstractSmrShip::getAllBaseShips());
+$template->assign('ShipTypes', SmrShipType::getAll());
 $template->assign('Weapons', SmrWeaponType::getAllWeaponTypes());
 
 $template->assign('SelectDummysLink', Page::create('skeleton.php', 'edit_dummys.php')->href());

--- a/src/admin/Default/edit_dummys_processing.php
+++ b/src/admin/Default/edit_dummys_processing.php
@@ -4,7 +4,7 @@ $name = Request::get('dummy_name');
 $dummyPlayer = DummyPlayer::getCachedDummyPlayer($name);
 $dummyPlayer->setPlayerName($name);
 $dummyPlayer->setExperience(Request::getInt('exp'));
-$dummyPlayer->setShipTypeID(Request::getInt('ship_id'));
+$dummyPlayer->setShipTypeID(Request::getInt('ship_type_id'));
 $dummyShip = $dummyPlayer->getShip();
 $dummyShip->removeAllWeapons();
 foreach (Request::getIntArray('weapons', []) as $weaponTypeID) {

--- a/src/admin/Default/location_edit.php
+++ b/src/admin/Default/location_edit.php
@@ -43,7 +43,7 @@ if (isset($var['location_type_id'])) {
 
 
 	$template->assign('Location', $location);
-	$template->assign('Ships', AbstractSmrShip::getAllBaseShips());
+	$template->assign('ShipTypes', SmrShipType::getAll());
 	$template->assign('Weapons', SmrWeaponType::getAllWeaponTypes());
 
 

--- a/src/engine/Default/beta_func_processing.php
+++ b/src/engine/Default/beta_func_processing.php
@@ -23,12 +23,12 @@ if ($var['func'] == 'Map') {
 } elseif ($var['func'] == 'Money') {
 	$player->setCredits(50000000);
 } elseif ($var['func'] == 'Ship') {
-	$ship_id = Request::getInt('ship_id');
-	if ($ship_id <= 75 && $ship_id != 68) {
+	$shipTypeID = Request::getInt('ship_type_id');
+	if ($shipTypeID <= 75 && $shipTypeID != 68) {
 		// assign the new ship
 		$ship->decloak();
 		$ship->disableIllusion();
-		$ship->setShipTypeID($ship_id);
+		$ship->setTypeID($shipTypeID);
 		$ship->setHardwareToMax();
 	}
 } elseif ($var['func'] == 'Weapon') {

--- a/src/engine/Default/beta_functions.php
+++ b/src/engine/Default/beta_functions.php
@@ -24,27 +24,20 @@ $template->assign('MoneyHREF', $container->href());
 $container['func'] = 'Ship';
 $template->assign('ShipHREF', $container->href());
 $shipList = [];
-$db = Smr\Database::getInstance();
-$db->query('SELECT * FROM ship_type ORDER BY ship_name');
-while ($db->nextRecord()) {
-	$shipList[] = [
-		'ID' => $db->getInt('ship_type_id'),
-		'Name' => $db->getField('ship_name'),
-	];
+foreach (SmrShipType::getAll() as $shipTypeID => $shipType) {
+	$shipList[$shipTypeID] = $shipType->getName();
 }
+asort($shipList); // sort by name
 $template->assign('ShipList', $shipList);
 
 //next weapons
 $container['func'] = 'Weapon';
 $template->assign('AddWeaponHREF', $container->href());
 $weaponList = [];
-$db->query('SELECT * FROM weapon_type ORDER BY weapon_name');
-while ($db->nextRecord()) {
-	$weaponList[] = [
-		'ID' => $db->getInt('weapon_type_id'),
-		'Name' => $db->getField('weapon_name'),
-	];
+foreach (SmrWeaponType::getAllWeaponTypes() as $weaponTypeID => $weaponType) {
+	$weaponList[$weaponTypeID] = $weaponType->getName();
 }
+asort($weaponList); // sort by name
 $template->assign('WeaponList', $weaponList);
 
 //Remove Weapons
@@ -75,12 +68,8 @@ $template->assign('AlignmentHREF', $container->href());
 $container['func'] = 'Hard_add';
 $template->assign('HardwareHREF', $container->href());
 $hardware = [];
-$db->query('SELECT * FROM hardware_type ORDER BY hardware_type_id');
-while ($db->nextRecord()) {
-	$hardware[] = [
-		'ID' => $db->getInt('hardware_type_id'),
-		'Name' => $db->getField('hardware_name'),
-	];
+foreach (Globals::getHardwareTypes() as $hardwareTypeID => $hardwareType) {
+	$hardware[$hardwareTypeID] = $hardwareType['Name'];
 }
 $template->assign('Hardware', $hardware);
 

--- a/src/engine/Default/configure_hardware_processing.php
+++ b/src/engine/Default/configure_hardware_processing.php
@@ -16,7 +16,7 @@ if ($var['action'] == 'Enable') {
 } elseif ($var['action'] == 'Disable') {
 	$ship->decloak();
 } elseif ($var['action'] == 'Set Illusion') {
-	$ship->setIllusion(Request::getInt('ship_id'), Request::getInt('attack'), Request::getInt('defense'));
+	$ship->setIllusion(Request::getInt('ship_type_id'), Request::getInt('attack'), Request::getInt('defense'));
 } elseif ($var['action'] == 'Disable Illusion') {
 	$ship->disableIllusion();
 }

--- a/src/engine/Default/shop_hardware_processing.php
+++ b/src/engine/Default/shop_hardware_processing.php
@@ -24,7 +24,7 @@ if ($action == 'Buy') {
 	}
 
 	// chec for max. we can hold!
-	if ($amount > $ship->getMaxHardware($hardware_id) - $ship->getHardware($hardware_id)) {
+	if ($amount > $ship->getType()->getMaxHardware($hardware_id) - $ship->getHardware($hardware_id)) {
 		create_error('You can\'t buy more ' . $hardware_name . ' than you can transport!');
 	}
 

--- a/src/engine/Default/shop_ship_processing.php
+++ b/src/engine/Default/shop_ship_processing.php
@@ -5,19 +5,19 @@ $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 $ship = $player->getShip();
 
-$shipID = $var['ship_id'];
-$newShip = AbstractSmrShip::getBaseShip($shipID);
-$cost = $ship->getCostToUpgrade($shipID);
+$shipTypeID = $var['ship_type_id'];
+$newShipType = SmrShipType::get($shipTypeID);
+$cost = $ship->getCostToUpgrade($shipTypeID);
 
-if ($newShip['AlignRestriction'] == BUYER_RESTRICTION_EVIL && $player->getAlignment() > ALIGNMENT_EVIL) {
+if ($newShipType->getRestriction() == BUYER_RESTRICTION_EVIL && $player->getAlignment() > ALIGNMENT_EVIL) {
 	create_error('You can\'t buy smuggler ships!');
 }
 
-if ($newShip['AlignRestriction'] == BUYER_RESTRICTION_GOOD && $player->getAlignment() < ALIGNMENT_GOOD) {
+if ($newShipType->getRestriction() == BUYER_RESTRICTION_GOOD && $player->getAlignment() < ALIGNMENT_GOOD) {
 	create_error('You can\'t buy federal ships!');
 }
 
-if ($newShip['RaceID'] != RACE_NEUTRAL && $player->getRaceID() != $newShip['RaceID']) {
+if ($newShipType->getRaceID() != RACE_NEUTRAL && $player->getRaceID() != $newShipType->getRaceID()) {
 	create_error('You can\'t buy other race\'s ships!');
 }
 
@@ -36,10 +36,9 @@ if ($cost > 0) {
 // assign the new ship
 $ship->decloak();
 $ship->disableIllusion();
-$ship->setShipTypeID($shipID);
+$ship->setTypeID($shipTypeID);
 
-
-$player->log(LOG_TYPE_HARDWARE, 'Buys a ' . $ship->getName() . ' for ' . $cost . ' credits');
+$player->log(LOG_TYPE_HARDWARE, 'Buys a ' . $newShipType->getName() . ' for ' . $cost . ' credits');
 
 $container = Page::create('skeleton.php', 'current_sector.php');
 $container->addVar('LocationID');

--- a/src/engine/Default/smr_file_create.php
+++ b/src/engine/Default/smr_file_create.php
@@ -45,16 +45,16 @@ foreach ($hardwares as $hardware) {
 $file .= '[Ships]
 ; Name = Race,Cost,TPH,Hardpoints,Power,Class,+Equipment (Optional),+Restrictions(Optional)
 ; Restrictions:Align(Integer)' . EOL;
-foreach (AbstractSmrShip::getAllBaseShips() as $ship) {
-	$file .= inify($ship['Name']) . '=' . Globals::getRaceName($ship['RaceID']) . ',' . $ship['Cost'] . ',' . $ship['Speed'] . ',' . $ship['Hardpoint'] . ',' . $ship['MaxPower'] . ',' . Smr\ShipClass::getName($ship['ShipClassID']);
-	if ($ship['MaxHardware'] > 0) {
-		$shipEquip = ',ShipEquipment=';
-		foreach ($ship['MaxHardware'] as $hardwareID => $maxHardware) {
-			$shipEquip .= $hardwares[$hardwareID]['Name'] . '=' . $maxHardware . ';';
-		}
-		$file .= substr($shipEquip, 0, -1);
-		$file .= ',Restrictions=' . $ship['AlignRestriction'];
+foreach (SmrShipType::getAll() as $ship) {
+	$file .= inify($ship->getName()) . '=' . inify($ship->getRaceName()) . ',' . $ship->getCost() . ',' . $ship->getSpeed() . ',' . $ship->getHardpoints() . ',' . $ship->getMaxPower() . ',' . Smr\ShipClass::getName($ship->getClassID());
+	$shipEquip = [];
+	foreach ($ship->getAllMaxHardware() as $hardwareID => $maxHardware) {
+		$shipEquip[] = $hardwares[$hardwareID]['Name'] . '=' . $maxHardware;
 	}
+	if (!empty($shipEquip)) {
+		$file .= ',ShipEquipment=' . join(';', $shipEquip);
+	}
+	$file .= ',Restrictions=' . $ship->getRestriction();
 	$file .= EOL;
 }
 
@@ -80,7 +80,7 @@ foreach (SmrLocation::getAllLocations() as $location) {
 	if ($location->isShipSold()) {
 		$locSells .= 'Ships=';
 		foreach ($location->getShipsSold() as $locShip) {
-			$locSells .= $locShip['Name'] . ';';
+			$locSells .= $locShip->getName() . ';';
 		}
 		$locSells = substr($locSells, 0, -1) . ',';
 	}

--- a/src/engine/Default/trader_status.php
+++ b/src/engine/Default/trader_status.php
@@ -3,7 +3,6 @@
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
-$ship = $player->getShip();
 
 $template->assign('PageTopic', 'Trader Status');
 
@@ -35,20 +34,21 @@ $container['body'] = 'configure_hardware.php';
 $template->assign('HardwareHREF', $container->href());
 
 $hardware = [];
-if ($ship->canHaveScanner()) {
-	$hardware[] = 'Scanner';
+$shipType = $player->getShip()->getType();
+if ($shipType->canHaveScanner()) {
+	$hardware[] = Globals::getHardwareTypes(HARDWARE_SCANNER)['Name'];
 }
-if ($ship->canHaveIllusion()) {
-	$hardware[] = 'Illusion Generator';
+if ($shipType->canHaveIllusion()) {
+	$hardware[] = Globals::getHardwareTypes(HARDWARE_ILLUSION)['Name'];
 }
-if ($ship->canHaveCloak()) {
-	$hardware[] = 'Cloaking Device';
+if ($shipType->canHaveCloak()) {
+	$hardware[] = Globals::getHardwareTypes(HARDWARE_CLOAK)['Name'];
 }
-if ($ship->canHaveJump()) {
-	$hardware[] = 'Jump Drive';
+if ($shipType->canHaveJump()) {
+	$hardware[] = Globals::getHardwareTypes(HARDWARE_JUMP)['Name'];
 }
-if ($ship->canHaveDCS()) {
-	$hardware[] = 'Drone Scrambler';
+if ($shipType->canHaveDCS()) {
+	$hardware[] = Globals::getHardwareTypes(HARDWARE_DCS)['Name'];
 }
 if (empty($hardware)) {
 	$hardware[] = 'none';

--- a/src/htdocs/ship_list.php
+++ b/src/htdocs/ship_list.php
@@ -5,8 +5,8 @@ try {
 	$template = Smr\Template::getInstance();
 
 	$shipArray = [];
-	foreach (SmrShip::getAllBaseShips() as $ship) {
-		$shipArray[] = buildShipStats($ship);
+	foreach (SmrShipType::getAll() as $shipType) {
+		$shipArray[] = buildShipStats($shipType);
 	}
 	$template->assign('shipArray', $shipArray);
 
@@ -28,7 +28,7 @@ try {
 
 function buildShipStats($ship) {
 	//we want to put them all in an array so we dont have to have 15 td rows
-	$restriction = match($ship['AlignRestriction']) {
+	$restriction = match($ship->getRestriction()) {
 		BUYER_RESTRICTION_NONE => '',
 		BUYER_RESTRICTION_GOOD => '<span class="dgreen">Good</span>',
 		BUYER_RESTRICTION_EVIL => '<span class="red">Evil</span>',
@@ -37,24 +37,24 @@ function buildShipStats($ship) {
 
 	// Array key is the td class (sort key), and array value is the data value
 	$stat = [
-		'name' => $ship['Name'],
-		'race race' . $ship['RaceID'] => Globals::getRaceName($ship['RaceID']),
-		'class_' => Smr\ShipClass::getName($ship['ShipClassID']),
-		'cost' => number_format($ship['Cost']),
-		'speed' => $ship['Speed'],
-		'hardpoint' => $ship['Hardpoint'],
+		'name' => $ship->getName(),
+		'race race' . $ship->getRaceID() => Globals::getRaceName($ship->getRaceID()),
+		'class_' => Smr\ShipClass::getName($ship->getClassID()),
+		'cost' => number_format($ship->getCost()),
+		'speed' => $ship->getSpeed(),
+		'hardpoint' => $ship->getHardpoints(),
 		'restriction' => $restriction,
-		'shields' => $ship['MaxHardware'][HARDWARE_SHIELDS],
-		'armour' => $ship['MaxHardware'][HARDWARE_ARMOUR],
-		'cargo' => $ship['MaxHardware'][HARDWARE_CARGO],
-		'cds' => $ship['MaxHardware'][HARDWARE_COMBAT],
-		'scouts' => $ship['MaxHardware'][HARDWARE_SCOUT],
-		'mines' => $ship['MaxHardware'][HARDWARE_MINE],
-		'scanner' => $ship['MaxHardware'][HARDWARE_SCANNER] == 1 ? 'Yes' : '',
-		'cloak' => $ship['MaxHardware'][HARDWARE_CLOAK] == 1 ? 'Yes' : '',
-		'illusion' => $ship['MaxHardware'][HARDWARE_ILLUSION] == 1 ? 'Yes' : '',
-		'jump' => $ship['MaxHardware'][HARDWARE_JUMP] == 1 ? 'Yes' : '',
-		'scrambler' => $ship['MaxHardware'][HARDWARE_DCS] == 1 ? 'Yes' : '',
+		'shields' => $ship->getMaxHardware(HARDWARE_SHIELDS),
+		'armour' => $ship->getMaxHardware(HARDWARE_ARMOUR),
+		'cargo' => $ship->getMaxHardware(HARDWARE_CARGO),
+		'cds' => $ship->getMaxHardware(HARDWARE_COMBAT),
+		'scouts' => $ship->getMaxHardware(HARDWARE_SCOUT),
+		'mines' => $ship->getMaxHardware(HARDWARE_MINE),
+		'scanner' => $ship->canHaveScanner() ? 'Yes' : '',
+		'cloak' => $ship->canHaveCloak() ? 'Yes' : '',
+		'illusion' => $ship->canHaveIllusion() ? 'Yes' : '',
+		'jump' => $ship->canHaveJump() ? 'Yes' : '',
+		'scrambler' => $ship->canHaveDCS() ? 'Yes' : '',
 	];
 	return $stat;
 }

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -436,7 +436,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	/**
-	 * Do not call directly. Use SmrShip::setShipTypeID instead.
+	 * Do not call directly. Use SmrShip::setTypeID instead.
 	 */
 	public function setShipTypeID(int $shipID) : void {
 		if ($this->shipID == $shipID) {

--- a/src/lib/Default/Plotter.class.php
+++ b/src/lib/Default/Plotter.class.php
@@ -26,7 +26,7 @@ class Plotter {
 
 		return match($xType) {
 			'Technology' => Globals::getHardwareTypes($X),
-			'Ships' => AbstractSmrShip::getBaseShip($X),
+			'Ships' => SmrShipType::get($X),
 			'Weapons' => SmrWeaponType::getWeaponType($X),
 			'Locations' => SmrLocation::getLocation($X),
 			'Sell Goods', 'Buy Goods' => $getGoodWithTransaction($X),

--- a/src/lib/Default/SmrSector.class.php
+++ b/src/lib/Default/SmrSector.class.php
@@ -1016,7 +1016,7 @@ class SmrSector {
 		}
 
 		//Check if it's possible for location to have X, hacky but nice performance gains
-		if ($x instanceof SmrWeaponType || (is_array($x) && ($x['Type'] == 'Ship' || $x['Type'] == 'Hardware')) || (is_string($x) && ($x == 'Bank' || $x == 'Bar' || $x == 'Fed' || $x == 'SafeFed' || $x == 'HQ' || $x == 'UG' || $x == 'Hardware' || $x == 'Ship' || $x == 'Weapon'))) {
+		if ($x instanceof SmrWeaponType || $x instanceof SmrShipType || (is_array($x) && $x['Type'] == 'Hardware') || (is_string($x) && ($x == 'Bank' || $x == 'Bar' || $x == 'Fed' || $x == 'SafeFed' || $x == 'HQ' || $x == 'UG' || $x == 'Hardware' || $x == 'Ship' || $x == 'Weapon'))) {
 			foreach ($this->getLocations() as $loc) {
 				if ($loc->hasX($x, $player)) {
 					return true;

--- a/src/lib/Default/SmrShip.class.php
+++ b/src/lib/Default/SmrShip.class.php
@@ -55,7 +55,7 @@ class SmrShip extends AbstractSmrShip {
 		$this->updateCargo();
 		$this->updateCloak();
 		$this->updateIllusion();
-		// note: SmrShip::setShipTypeID updates the SmrPlayer only
+		// note: SmrShip::setTypeID updates the SmrPlayer only
 		$this->getPlayer()->update();
 	}
 

--- a/src/lib/Default/SmrShipType.class.php
+++ b/src/lib/Default/SmrShipType.class.php
@@ -1,0 +1,181 @@
+<?php declare(strict_types=1);
+
+/**
+ * Defines the base ship types
+ */
+class SmrShipType {
+	use Traits\RaceID;
+
+	private static array $CACHE_SHIP_TYPES = [];
+
+	private string $name;
+	private int $typeID;
+	private int $classID;
+	private int $hardpoints;
+	private int $speed;
+	private int $cost;
+	private int $restriction;
+	private int $levelNeeded;
+
+	private int $maxPower = 0;
+	private array $maxHardware = [];
+	private int $baseManeuverability;
+
+	public static function get(int $shipTypeID, Smr\Database $db = null) : self {
+		if (!isset(self::$CACHE_SHIP_TYPES[$shipTypeID])) {
+			if ($db === null) {
+				$db = Smr\Database::getInstance();
+				$db->query('SELECT * FROM ship_type WHERE ship_type_id = ' . $db->escapeNumber($shipTypeID));
+				$db->requireRecord();
+			} elseif ($shipTypeID !== $db->getInt('ship_type_id')) {
+				throw new Exception('Database result mismatch');
+			}
+			self::$CACHE_SHIP_TYPES[$shipTypeID] = new self($db);
+		}
+		return self::$CACHE_SHIP_TYPES[$shipTypeID];
+	}
+
+	public static function getAll() : array {
+		$db = Smr\Database::getInstance();
+		$db->query('SELECT * FROM ship_type ORDER BY ship_type_id ASC');
+		while ($db->nextRecord()) {
+			// populate the cache
+			self::get($db->getInt('ship_type_id'), $db);
+		}
+		return self::$CACHE_SHIP_TYPES;
+	}
+
+	protected function __construct(Smr\Database $db) {
+		$this->name = $db->getField('ship_name');
+		$this->typeID = $db->getInt('ship_type_id');
+		$this->classID = $db->getInt('ship_class_id');
+		$this->raceID = $db->getInt('race_id');
+		$this->hardpoints = $db->getInt('hardpoint');
+		$this->speed = $db->getInt('speed');
+		$this->cost = $db->getInt('cost');
+		$this->restriction = $db->getInt('buyer_restriction');
+		$this->levelNeeded = $db->getInt('lvl_needed');
+
+		$maxPower = 0;
+		switch ($this->hardpoints) {
+			default:
+				$maxPower += 1 * $this->hardpoints - 10;
+			case 10:
+				$maxPower += 2;
+			case 9:
+				$maxPower += 2;
+			case 8:
+				$maxPower += 2;
+			case 7:
+				$maxPower += 2;
+			case 6:
+				$maxPower += 3;
+			case 5:
+				$maxPower += 3;
+			case 4:
+				$maxPower += 3;
+			case 3:
+				$maxPower += 4;
+			case 2:
+				$maxPower += 4;
+			case 1:
+				$maxPower += 5;
+			case 0:
+				$maxPower += 0;
+		}
+		$this->maxPower = $maxPower;
+
+
+		// get supported hardware from db
+		$db2 = Smr\Database::getInstance();
+		$db2->query('SELECT hardware_type_id, max_amount FROM ship_type_support_hardware ' .
+			'WHERE ship_type_id = ' . $db2->escapeNumber($this->typeID) . ' ORDER BY hardware_type_id');
+
+		while ($db2->nextRecord()) {
+			// adding hardware to array
+			$this->maxHardware[$db2->getInt('hardware_type_id')] = $db2->getInt('max_amount');
+		}
+
+		$this->baseManeuverability = IRound(
+								700 -
+								(
+									(
+										$this->maxHardware[HARDWARE_SHIELDS]
+										+ $this->maxHardware[HARDWARE_ARMOUR]
+										+ $this->maxHardware[HARDWARE_COMBAT] * 3
+									) / 25
+									+ $this->maxHardware[HARDWARE_CARGO] / 100
+									- $this->speed * 5
+									+ $this->hardpoints * 5
+									+ $this->maxHardware[HARDWARE_COMBAT] / 5
+								)
+							);
+	}
+
+	public function getTypeID() : int {
+		return $this->typeID;
+	}
+
+	public function getClassID() : int {
+		return $this->classID;
+	}
+
+	public function getName() : string {
+		return $this->name;
+	}
+
+	public function getCost() : int {
+		return $this->cost;
+	}
+
+	public function getRestriction() : int {
+		return $this->restriction;
+	}
+
+	/**
+	 * Return the base ship speed (unmodified by the game speed)
+	 */
+	public function getSpeed() : int {
+		return $this->speed;
+	}
+
+	public function getHardpoints() : int {
+		return $this->hardpoints;
+	}
+
+	/**
+	 * Return the maximum weapon power
+	 */
+	public function getMaxPower() : int {
+		return $this->maxPower;
+	}
+
+	public function getMaxHardware(int $hardwareTypeID) : int {
+		return $this->maxHardware[$hardwareTypeID];
+	}
+
+	public function getAllMaxHardware() : array {
+		return $this->maxHardware;
+	}
+
+	public function canHaveJump() : bool {
+		return $this->getMaxHardware(HARDWARE_JUMP) > 0;
+	}
+
+	public function canHaveDCS() : bool {
+		return $this->getMaxHardware(HARDWARE_DCS) > 0;
+	}
+
+	public function canHaveScanner() : bool {
+		return $this->getMaxHardware(HARDWARE_SCANNER) > 0;
+	}
+
+	public function canHaveCloak() : bool {
+		return $this->getMaxHardware(HARDWARE_CLOAK) > 0;
+	}
+
+	public function canHaveIllusion() : bool {
+		return $this->getMaxHardware(HARDWARE_ILLUSION) > 0;
+	}
+
+}

--- a/src/lib/HunterWars/SmrLocation.class.php
+++ b/src/lib/HunterWars/SmrLocation.class.php
@@ -12,7 +12,7 @@ class SmrLocation extends AbstractSmrLocation {
 			                    AND ship_type_id != ' . $this->db->escapeNumber(SHIP_TYPE_PLANETARY_SUPER_FREIGHTER));
 			while ($this->db->nextRecord()) {
 				$shipTypeID = $this->db->getInt('ship_type_id');
-				$this->shipsSold[$shipTypeID] = AbstractSmrShip::getBaseShip($shipTypeID);
+				$this->shipsSold[$shipTypeID] = SmrShipType::get($shipTypeID, $this->db);
 			}
 		}
 		return $this->shipsSold;

--- a/src/templates/Default/admin/Default/edit_dummys.php
+++ b/src/templates/Default/admin/Default/edit_dummys.php
@@ -23,9 +23,9 @@
 					} ?>
 				</select>
 				Ship:
-				<select name="ship_id"><?php
-					foreach ($BaseShips as $BaseShip) {
-						?><option value="<?php echo $BaseShip['ShipTypeID']; ?>"<?php if ($BaseShip['ShipTypeID'] == $DummyPlayer->getShipTypeID()) { ?> selected="selected"<?php } ?>><?php echo $BaseShip['Name']; ?></option><?php
+				<select name="ship_type_id"><?php
+					foreach ($ShipTypes as $ShipType) {
+						?><option value="<?php echo $ShipType->getTypeID(); ?>"<?php if ($ShipType->getTypeID() == $DummyPlayer->getShipTypeID()) { ?> selected="selected"<?php } ?>><?php echo $ShipType->getName(); ?></option><?php
 					} ?>
 				</select><br /><?php
 

--- a/src/templates/Default/admin/Default/includes/ViewLocations.inc.php
+++ b/src/templates/Default/admin/Default/includes/ViewLocations.inc.php
@@ -16,7 +16,7 @@ foreach ($Locations as $Location) { ?>
 	</td>
 	<td><?php
 		foreach ($Location->getShipsSold() as $Ship) {
-			echo $Ship['Name'] ?><br /><?php
+			echo $Ship->getName() ?><br /><?php
 		} ?>
 	</td>
 	<td>

--- a/src/templates/Default/admin/Default/location_edit.php
+++ b/src/templates/Default/admin/Default/location_edit.php
@@ -52,10 +52,10 @@ if (isset($Locations)) {
 		</td>
 		<td>
 			<table><?php
-			foreach ($Location->getShipsSold() as $Ship) { ?>
+			foreach ($Location->getShipsSold() as $ShipTypeSold) { ?>
 					<tr>
-						<td><?php echo $Ship['Name'] ?></td>
-						<td><input type="checkbox" name="remove_ships[]" value="<?php echo $Ship['ShipTypeID']; ?>" /></td>
+						<td><?php echo $ShipTypeSold->getName(); ?></td>
+						<td><input type="checkbox" name="remove_ships[]" value="<?php echo $ShipTypeSold->getTypeID(); ?>" /></td>
 					</tr><?php
 				} ?>
 				<tr>
@@ -63,8 +63,8 @@ if (isset($Locations)) {
 					<td>
 						<select name="add_ship_id">
 							<option value="0">None</option><?php
-							foreach ($Ships as $Ship) { ?>
-								<option value="<?php echo $Ship['ShipTypeID']; ?>"><?php echo $Ship['Name']; ?></option><?php
+							foreach ($ShipTypes as $ShipType) { ?>
+								<option value="<?php echo $ShipType->getTypeID(); ?>"><?php echo $ShipType->getName(); ?></option><?php
 							} ?>
 					</select>
 					</td>

--- a/src/templates/Default/engine/Default/beta_functions.php
+++ b/src/templates/Default/engine/Default/beta_functions.php
@@ -17,7 +17,7 @@
 <br />
 
 <form method="POST" action="<?php echo $ShipHREF; ?>">
-	<select name="ship_id"><?php
+	<select name="ship_type_id"><?php
 		foreach ($ShipList as $ship) { ?>
 			<option value="<?php echo $ship['ID']; ?>"><?php echo $ship['Name']; ?></option><?php
 		} ?>

--- a/src/templates/Default/engine/Default/beta_functions.php
+++ b/src/templates/Default/engine/Default/beta_functions.php
@@ -8,8 +8,8 @@
 <form method="POST" action="<?php echo $AddWeaponHREF; ?>">
 	<input type="number" name="amount" value="1" style="width:75px" />&nbsp;
 	<select name="weapon_id"><?php
-		foreach ($WeaponList as $weapon) { ?>
-			<option value="<?php echo $weapon['ID']; ?>"><?php echo $weapon['Name']; ?></option><?php
+		foreach ($WeaponList as $weaponTypeID => $weaponName) { ?>
+			<option value="<?php echo $weaponTypeID; ?>"><?php echo $weaponName; ?></option><?php
 		} ?>
 	</select>&nbsp;&nbsp;
 	<input type="submit" value="Add Weapon(s)" />
@@ -18,8 +18,8 @@
 
 <form method="POST" action="<?php echo $ShipHREF; ?>">
 	<select name="ship_type_id"><?php
-		foreach ($ShipList as $ship) { ?>
-			<option value="<?php echo $ship['ID']; ?>"><?php echo $ship['Name']; ?></option><?php
+		foreach ($ShipList as $shipTypeID => $shipName) { ?>
+			<option value="<?php echo $shipTypeID; ?>"><?php echo $shipName; ?></option><?php
 		} ?>
 	</select>&nbsp;&nbsp;
 	<input type="submit" value="Change Ship" />
@@ -29,8 +29,8 @@
 <form method="POST" action="<?php echo $HardwareHREF; ?>">
 	<input type="number" name="amount_hard" value="0" style="width:75px" />&nbsp;
 	<select name="type_hard"><?php
-		foreach ($Hardware as $item) { ?>
-			<option value="<?php echo $item['ID']; ?>"><?php echo $item['Name']; ?></option><?php
+		foreach ($Hardware as $hardwareTypeID => $hardwareName) { ?>
+			<option value="<?php echo $hardwareTypeID; ?>"><?php echo $hardwareName; ?></option><?php
 		} ?>
 	</select>&nbsp;&nbsp;
 	<input type="submit" value="Set Hardware" />

--- a/src/templates/Default/engine/Default/configure_hardware.php
+++ b/src/templates/Default/engine/Default/configure_hardware.php
@@ -16,8 +16,8 @@ if (!$ThisShip->hasCloak() && !$ThisShip->hasIllusion() && !$ThisShip->hasJump()
 				<tr>
 					<td>Ship:</td>
 					<td>
-						<select name="ship_id" size="1"><?php
-							$CurrentShipID = $ThisShip->hasActiveIllusion() ? $ThisShip->getIllusionShipID() : $ThisShip->getShipTypeID();
+						<select name="ship_type_id" size="1"><?php
+							$CurrentShipID = $ThisShip->hasActiveIllusion() ? $ThisShip->getIllusionShipID() : $ThisShip->getTypeID();
 							foreach ($IllusionShips as $ShipTypeID => $ShipName) {
 								?><option value="<?php echo $ShipTypeID; ?>"<?php if ($CurrentShipID == $ShipTypeID) { ?> selected="selected"<?php } ?>><?php echo $ShipName; ?></option><?php
 							} ?>

--- a/src/templates/Default/engine/Default/course_plot.php
+++ b/src/templates/Default/engine/Default/course_plot.php
@@ -38,10 +38,10 @@ if (isset($XType)) { ?>
 					}
 				break;
 				case 'Ships':
-					$Ships = AbstractSmrShip::getAllBaseShips();
-					Sorter::sortByNumElement($Ships, 'Name');
+					$Ships = SmrShipType::getAll();
+					Sorter::sortByNumMethod($Ships, 'getName');
 					foreach ($Ships as $Ship) {
-						?><option value="<?php echo $Ship['ShipTypeID']; ?>"><?php echo $Ship['Name']; ?></option><?php
+						?><option value="<?php echo $Ship->getTypeID(); ?>"><?php echo $Ship->getName(); ?></option><?php
 					}
 				break;
 				case 'Weapons':

--- a/src/templates/Default/engine/Default/includes/RightPanelShip.inc.php
+++ b/src/templates/Default/engine/Default/includes/RightPanelShip.inc.php
@@ -84,7 +84,7 @@ if (isset($GameID)) { ?>
 	} ?>
 	Open : <?php echo $ThisShip->getOpenWeaponSlots(); ?><br />
 	Total Damage: (<?php echo $ThisShip->getTotalShieldDamage(); ?>/<?php echo $ThisShip->getTotalArmourDamage(); ?>)<br />
-	Power Used: <?php echo $ThisShip->getPowerUsed(); ?>/<?php echo $ThisShip->getMaxPower(); ?><br /><br /><?php
+	Power Used: <?php echo $ThisShip->getPowerUsed(); ?>/<?php echo $ThisShip->getType()->getMaxPower(); ?><br /><br /><?php
 	if (ENABLE_BETA) {
 		?><a href="<?php echo Globals::getBetaFunctionsHREF(); ?>"><span class="bold">Beta Functions</span></a><?php
 	}

--- a/src/templates/Default/engine/Default/shop_hardware.php
+++ b/src/templates/Default/engine/Default/shop_hardware.php
@@ -10,7 +10,7 @@ if (isset($HardwareSold)) { ?>
 			<th>Action</th>
 		</tr><?php
 		foreach ($HardwareSold as $HardwareTypeID => $Hardware) {
-			$AmountToBuy = $ThisShip->getMaxHardware($HardwareTypeID) - $ThisShip->getHardware($HardwareTypeID); ?>
+			$AmountToBuy = $ThisShip->getType()->getMaxHardware($HardwareTypeID) - $ThisShip->getHardware($HardwareTypeID); ?>
 
 			<tr>
 				<td><?php echo $Hardware['Name']; ?></td>

--- a/src/templates/Default/engine/Default/shop_ship.php
+++ b/src/templates/Default/engine/Default/shop_ship.php
@@ -8,13 +8,13 @@ if (count($ShipsSold) > 0) { ?>
 			<th>Cost</th>
 			<th>Action</th>
 		</tr><?php
-		foreach ($ShipsSold as $ShipSold) { ?>
+		foreach ($ShipsSold as $ShipTypeID => $ShipType) { ?>
 			<tr>
-				<td><?php echo $ShipSold['Name']; ?></td>
-				<td class="center"><?php echo number_format($ShipSold['Cost']); ?></td>
+				<td><?php echo $ShipType->getName(); ?></td>
+				<td class="center"><?php echo number_format($ShipType->getCost()); ?></td>
 				<td>
 					<div class="buttonA">
-						<a class="buttonA" href="<?php echo $ShipsSoldHREF[$ShipSold['ShipTypeID']]; ?>">View Details</a>
+						<a class="buttonA" href="<?php echo $ShipsSoldHREF[$ShipTypeID]; ?>">View Details</a>
 					</div>
 				</td>
 			</tr><?php
@@ -46,35 +46,17 @@ if (isset($CompareShip)) { ?>
 		<tr>
 			<th>&nbsp;</th>
 			<th><?php echo $ThisShip->getName(); ?></th>
-			<th><?php echo $CompareShip['Name']; ?></th>
+			<th><?php echo $CompareShip->getName(); ?></th>
 			<th>Change</th>
 		</tr><?php
-		foreach (Globals::getHardwareTypes() as $HardwareTypeID => $Hardware) { ?>
+		foreach ($ShipDiffs as $Label => $Diff) { ?>
 			<tr class="center">
-				<td class="left"><?php echo $Hardware['Name']; ?></td>
-				<td><?php echo $ThisShip->getMaxHardware($HardwareTypeID); ?></td>
-				<td><?php echo $CompareShip['MaxHardware'][$HardwareTypeID]; ?></td>
-				<td><?php echo number_colour_format($CompareShip['MaxHardware'][$HardwareTypeID] - $ThisShip->getMaxHardware($HardwareTypeID)); ?></td>
+				<td class="left"><?php echo $Label; ?></td>
+				<td><?php echo $Diff['Old']; ?></td>
+				<td><?php echo $Diff['New']; ?></td>
+				<td><?php echo number_colour_format($Diff['New'] - $Diff['Old']); ?></td>
 			</tr><?php
 		} ?>
-		<tr class="center">
-			<td class="left">Hardpoints</td>
-			<td><?php echo $ThisShip->getHardpoints(); ?></td>
-			<td><?php echo $CompareShip['Hardpoint']; ?></td>
-			<td><?php echo number_colour_format($CompareShip['Hardpoint'] - $ThisShip->getHardpoints()); ?></td>
-		</tr>
-		<tr class="center">
-			<td class="left">Speed</td>
-			<td><?php echo $ThisShip->getRealSpeed(); ?></td>
-			<td><?php echo $CompareShip['RealSpeed']; ?></td>
-			<td><?php echo number_colour_format($CompareShip['RealSpeed'] - $ThisShip->getRealSpeed()); ?></td>
-		</tr>
-		<tr class="center">
-			<td class="left">Turns</td>
-			<td><?php echo $ThisPlayer->getTurns() ?></td>
-			<td><?php echo $CompareShip['Turns']; ?></td>
-			<td><?php echo number_colour_format($CompareShip['Turns'] - $ThisPlayer->getTurns()); ?></td>
-		</tr>
 	</table><br />
 
 	<table class="nobord">
@@ -82,8 +64,8 @@ if (isset($CompareShip)) { ?>
 			<td colspan="2"><hr style="width:200px"></td>
 		</tr>
 		<tr>
-			<td class="right"><?php echo $CompareShip['Name']; ?> Cost</td>
-			<td class="right red"><?php echo number_format($CompareShip['Cost']); ?></td>
+			<td class="right"><?php echo $CompareShip->getName(); ?> Cost</td>
+			<td class="right red"><?php echo number_format($CompareShip->getCost()); ?></td>
 		</tr>
 		<tr>
 			<td class="right"><?php echo $ThisShip->getName(); ?> Trade-In</td>
@@ -107,7 +89,7 @@ if (isset($CompareShip)) { ?>
 		<tr>
 			<td class="right" colspan="2">
 				<div class="buttonA">
-					<a class="buttonA" href="<?php echo $CompareShip['BuyHREF']; ?>">Buy</a>
+					<a class="buttonA" href="<?php echo $BuyHREF; ?>">Buy</a>
 				</div>
 			</td>
 		</tr>

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -465,7 +465,7 @@ function canWeUNO(AbstractSmrPlayer $player, $oppurtunisticOnly) {
 				}
 			}
 			if (isset($hardwareID)) {
-				$amount = min($ship->getMaxHardware($hardwareID) - $ship->getHardware($hardwareID), $amount);
+				$amount = min($ship->getType()->getMaxHardware($hardwareID) - $ship->getHardware($hardwareID), $amount);
 				return doUNO($hardwareID, $amount, $sector->getSectorID());
 			}
 		}
@@ -584,11 +584,11 @@ function checkForShipUpgrade(AbstractSmrPlayer $player) {
 }
 
 function doShipUpgrade(AbstractSmrPlayer $player, $upgradeShipID) {
-	$plotNearest = plotToNearest($player, AbstractSmrShip::getBaseShip($upgradeShipID));
+	$plotNearest = plotToNearest($player, SmrShipType::get($upgradeShipID));
 
 	if ($plotNearest == true) { //We're already there!
 		//TODO: We're going to want to UNO after upgrading
-		return Page::create('shop_ship_processing.php', '', array('ship_id'=>$upgradeShipID));
+		return Page::create('shop_ship_processing.php', '', ['ship_type_id' => $upgradeShipID]);
 	} //Otherwise return the plot
 	return $plotNearest;
 }

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrShipTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrShipTest.php
@@ -32,10 +32,10 @@ class AbstractSmrShipTest extends \PHPUnit\Framework\TestCase {
 	public function test_base_ship_properties_are_set_correctly() {
 		$ship = new AbstractSmrShip($this->player);
 		self::assertSame('Demonica', $ship->getName());
-		self::assertSame(SHIP_TYPE_DEMONICA, $ship->getShipTypeID());
-		self::assertSame(ShipClass::HUNTER, $ship->getShipClassID());
+		self::assertSame(SHIP_TYPE_DEMONICA, $ship->getTypeID());
+		self::assertSame(ShipClass::HUNTER, $ship->getClassID());
 		self::assertSame(6, $ship->getHardpoints());
-		self::assertSame(10, $ship->getSpeed());
+		self::assertSame(10, $ship->getType()->getSpeed());
 		self::assertSame(0, $ship->getCost());
 	}
 
@@ -153,31 +153,31 @@ class AbstractSmrShipTest extends \PHPUnit\Framework\TestCase {
 		self::assertSame(5, $ship->getSDs());
 
 		// Cloak
-		self::assertTrue($ship->canHaveCloak());
+		self::assertTrue($ship->getType()->canHaveCloak());
 		self::assertFalse($ship->hasCloak());
 		$ship->increaseHardware(HARDWARE_CLOAK, 1);
 		self::assertTrue($ship->hasCloak());
 
 		// Illusion
-		self::assertTrue($ship->canHaveIllusion());
+		self::assertTrue($ship->getType()->canHaveIllusion());
 		self::assertFalse($ship->hasIllusion());
 		$ship->increaseHardware(HARDWARE_ILLUSION, 1);
 		self::assertTrue($ship->hasIllusion());
 
 		// Jump
-		self::assertTrue($ship->canHaveJump());
+		self::assertTrue($ship->getType()->canHaveJump());
 		self::assertFalse($ship->hasJump());
 		$ship->increaseHardware(HARDWARE_JUMP, 1);
 		self::assertTrue($ship->hasJump());
 
 		// Scanner
-		self::assertTrue($ship->canHaveScanner());
+		self::assertTrue($ship->getType()->canHaveScanner());
 		self::assertFalse($ship->hasScanner());
 		$ship->increaseHardware(HARDWARE_SCANNER, 1);
 		self::assertTrue($ship->hasScanner());
 
 		// DCs
-		self::assertTrue($ship->canHaveDCs());
+		self::assertTrue($ship->getType()->canHaveDCs());
 		self::assertFalse($ship->hasDCs());
 		$ship->increaseHardware(HARDWARE_DCS, 1);
 		self::assertTrue($ship->hasDCs());

--- a/test/SmrTest/lib/DefaultGame/SmrShipIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrShipIntegrationTest.php
@@ -38,7 +38,7 @@ class SmrShipIntegrationTest extends BaseIntegrationSpec {
 		$original = SmrShip::getShip($this->player);
 		self::assertSame($this->player->getAccountID(), $original->getAccountID());
 		self::assertSame($this->player->getGameID(), $original->getGameID());
-		self::assertSame($this->player->getShipTypeID(), $original->getShipTypeID());
+		self::assertSame($this->player->getShipTypeID(), $original->getTypeID());
 
 		// Check that we get the exact same object if we get it again
 		$forceUpdate = false;

--- a/test/SmrTest/lib/DefaultGame/SmrShipTypeTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrShipTypeTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use SmrShipType;
+use Smr\ShipClass;
+
+/**
+ * @covers SmrShipType
+ */
+class SmrShipTypeTest extends \PHPUnit\Framework\TestCase {
+
+	public function test_one_ship_properties() {
+		// Test all properties of one particular ship (Fed Ult)
+		$shipType = SmrShipType::get(SHIP_TYPE_FEDERAL_ULTIMATUM);
+
+		$this->assertSame(SHIP_TYPE_FEDERAL_ULTIMATUM, $shipType->getTypeID());
+		$this->assertSame(ShipClass::RAIDER, $shipType->getClassID());
+		$this->assertSame('Federal Ultimatum', $shipType->getName());
+		$this->assertSame(38675738, $shipType->getCost());
+		$this->assertSame(BUYER_RESTRICTION_GOOD, $shipType->getRestriction());
+		$this->assertSame(8, $shipType->getSpeed());
+		$this->assertSame(7, $shipType->getHardpoints());
+		$this->assertSame(24, $shipType->getMaxPower());
+
+		$hardware = [
+			HARDWARE_SHIELDS => 700,
+			HARDWARE_ARMOUR => 600,
+			HARDWARE_CARGO => 120,
+			HARDWARE_COMBAT => 120,
+			HARDWARE_SCOUT => 15,
+			HARDWARE_MINE => 0,
+			HARDWARE_SCANNER => 1,
+			HARDWARE_CLOAK => 0,
+			HARDWARE_ILLUSION => 0,
+			HARDWARE_JUMP => 1,
+			HARDWARE_DCS => 0,
+		];
+		$this->assertSame($hardware, $shipType->getAllMaxHardware());
+		foreach ($hardware as $hardwareID => $amount) {
+			$this->assertSame($amount, $shipType->getMaxHardware($hardwareID));
+		}
+	}
+
+	public function test_getAll_matches_get() {
+		// Check that we get the same ship type from get and getAll
+		$shipType1 = SmrShipType::get(SHIP_TYPE_GALACTIC_SEMI);
+		$shipType2 = SmrShipType::getAll()[SHIP_TYPE_GALACTIC_SEMI];
+		$this->assertSame($shipType1, $shipType2);
+	}
+
+	public function test_can_have_special_hardware() {
+		// Demonica has all special hardware
+		$shipType = SmrShipType::get(SHIP_TYPE_DEMONICA);
+		$this->assertTrue($shipType->canHaveJump());
+		$this->assertTrue($shipType->canHaveDCS());
+		$this->assertTrue($shipType->canHaveScanner());
+		$this->assertTrue($shipType->canHaveCloak());
+		$this->assertTrue($shipType->canHaveIllusion());
+
+		// Galactic Semi has no special hardware
+		$shipType = SmrShipType::get(SHIP_TYPE_GALACTIC_SEMI);
+		$this->assertFalse($shipType->canHaveJump());
+		$this->assertFalse($shipType->canHaveDCS());
+		$this->assertFalse($shipType->canHaveScanner());
+		$this->assertFalse($shipType->canHaveCloak());
+		$this->assertFalse($shipType->canHaveIllusion());
+	}
+
+}


### PR DESCRIPTION
The `baseShip` property of SmrShip was just an array, which made it
difficult to validate. As a separate class, SmrShipType does not have
such a limitation.

In variable names, try to make it clearer when data is a ship versus
a ship type (e.g. `ship_id` -> `ship_type_id`).

The class structure is very similar to SmrWeaponType.

We provide an interface to get many ships in a single database query,
which is used in, e.g. SmrLocation::getShipsSold.

The following SmrShip methods have been modified:

* SmrShip::buildBaseShip -> SmrShipType::get
* SmrShip::getAllBaseShips -> SmrShipType::getAll
* SmrShip::{regenerateBaseShip -> regenerateShipType}
* SmrShip::{setShipTypeID -> setTypeID}
* SmrShip::{getShipTypeID -> getTypeID}
* SmrShip::{getShipClassID -> getClassID}
* SmrShip::getRefundValue (added)
* SmrShip::getMaxPower (moved to SmrShipType)
* SmrShip::getMaxHardware (moved to SmrShipType)
* SmrShip::canHave* (moved to SmrShipType)
