### PR TITLE
Refactor Database

### DIFF
--- a/db/patches/V1_6_66_19__alliance_name_not_null.sql
+++ b/db/patches/V1_6_66_19__alliance_name_not_null.sql
@@ -1,0 +1,2 @@
+-- Make alliance.alliance_name not null with no default
+ALTER TABLE `alliance` MODIFY `alliance_name` varchar(36) NOT NULL;

--- a/src/admin/Default/1.6/galaxies_edit_processing.php
+++ b/src/admin/Default/1.6/galaxies_edit_processing.php
@@ -86,7 +86,7 @@ foreach ($galaxies as $i => $galaxy) {
 				// Remove this sector and everything in it
 				$delSector = SmrSector::getSector($gameID, $oldID);
 				$delSector->removeAllFixtures();
-				$db->query('DELETE FROM sector WHERE ' . $delSector->getSQL());
+				$db->write('DELETE FROM sector WHERE ' . $delSector->getSQL());
 			}
 		}
 	}
@@ -102,7 +102,7 @@ foreach ($galaxies as $galaxy) {
 		}
 	}
 }
-$db->query('UPDATE sector SET warp = 0 WHERE game_id = ' . $db->escapeNumber($gameID));
+$db->write('UPDATE sector SET warp = 0 WHERE game_id = ' . $db->escapeNumber($gameID));
 
 // Many sectors will have their IDs shifted up or down, so we need to modify
 // the primary keys for the sector table as well as planets, ports, etc.
@@ -132,22 +132,22 @@ while ($needsUpdate) {
 		$SQL = 'SET sector_id = ' . $db->escapeNumber($newID) . ' WHERE ' . $oldSector->getSQL();
 
 		if ($oldSector->hasPlanet()) {
-			$db->query('UPDATE planet ' . $SQL);
-			$db->query('UPDATE planet_has_building ' . $SQL);
-			$db->query('UPDATE planet_has_cargo ' . $SQL);
-			$db->query('UPDATE planet_has_weapon ' . $SQL);
+			$db->write('UPDATE planet ' . $SQL);
+			$db->write('UPDATE planet_has_building ' . $SQL);
+			$db->write('UPDATE planet_has_cargo ' . $SQL);
+			$db->write('UPDATE planet_has_weapon ' . $SQL);
 		}
 
 		if ($oldSector->hasPort()) {
-			$db->query('UPDATE port ' . $SQL);
-			$db->query('UPDATE port_has_goods ' . $SQL);
+			$db->write('UPDATE port ' . $SQL);
+			$db->write('UPDATE port_has_goods ' . $SQL);
 		}
 
 		if ($oldSector->hasLocation()) {
-			$db->query('UPDATE location ' . $SQL);
+			$db->write('UPDATE location ' . $SQL);
 		}
 
-		$db->query('UPDATE sector ' . $SQL);
+		$db->write('UPDATE sector ' . $SQL);
 		unset($needsUpdate[$newID]);
 	}
 }

--- a/src/admin/Default/1.6/game_create.php
+++ b/src/admin/Default/1.6/game_create.php
@@ -38,11 +38,11 @@ $template->assign('SubmitValue', 'Create Game');
 
 $games = array();
 if ($canEditStartedGames) {
-	$db->query('SELECT game_id FROM game ORDER BY end_time DESC');
+	$dbResult = $db->read('SELECT game_id FROM game ORDER BY end_time DESC');
 } else {
-	$db->query('SELECT game_id FROM game WHERE join_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY end_time DESC');
+	$dbResult = $db->read('SELECT game_id FROM game WHERE join_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY end_time DESC');
 }
-while ($db->nextRecord()) {
-	$games[] = SmrGame::getGame($db->getInt('game_id'));
+foreach ($dbResult->records() as $dbRecord) {
+	$games[] = SmrGame::getGame($dbRecord->getInt('game_id'));
 }
 $template->assign('EditGames', $games);

--- a/src/admin/Default/1.6/game_create_processing.php
+++ b/src/admin/Default/1.6/game_create_processing.php
@@ -3,14 +3,14 @@
 $db = Smr\Database::getInstance();
 
 //first create the game
-$db->query('SELECT game_id FROM game WHERE game_name=' . $db->escapeString(Request::get('game_name')) . ' LIMIT 1');
-if ($db->nextRecord()) {
+$dbResult = $db->read('SELECT 1 FROM game WHERE game_name=' . $db->escapeString(Request::get('game_name')) . ' LIMIT 1');
+if ($dbResult->hasRecord()) {
 	create_error('That game name is already taken.');
 }
 
-$db->query('SELECT game_id FROM game ORDER BY game_id DESC LIMIT 1');
-if ($db->nextRecord()) {
-	$newID = $db->getInt('game_id') + 1;
+$dbResult = $db->read('SELECT game_id FROM game ORDER BY game_id DESC LIMIT 1');
+if ($dbResult->hasRecord()) {
+	$newID = $dbResult->record()->getInt('game_id') + 1;
 } else {
 	$newID = 1;
 }
@@ -62,7 +62,7 @@ function createNHA(int $gameID) : void {
 	$db = Smr\Database::getInstance();
 
 	// create the Newbie Help Alliance
-	$db->query('REPLACE INTO alliance (alliance_id, game_id, alliance_name, alliance_description, alliance_password, leader_id, `mod`, recruiting) VALUES
+	$db->write('REPLACE INTO alliance (alliance_id, game_id, alliance_name, alliance_description, alliance_password, leader_id, `mod`, recruiting) VALUES
 				(' . $db->escapeNumber(NHA_ID) . ',' . $db->escapeNumber($gameID) . ',\'Newbie Help Alliance\',\'Newbie Help Alliance\',\'\',' . $db->escapeNumber(ACCOUNT_ID_NHL) . ',\'Alliance message board includes tips and FAQs.\', \'FALSE\')');
 
 	$alliance = SmrAlliance::getAlliance(NHA_ID, $gameID);
@@ -72,7 +72,7 @@ function createNHA(int $gameID) : void {
 
 	// NHA default topics
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 1, \'Read this first!\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 1, \'Read this first!\')');
 	$text = 'This alliance message board contains pretty much everything you need to know to get going in the game, and hopefully learn some of the skills you will need to do well and stay alive. Here are some basic tips that you should start thinking about right from the start, all of which are dealt with in more detail elsewhere on the message board:<br />
 	<br />
 	1) When you log off, always make sure you are safe, current sector will have a message if you are protected.<br />
@@ -84,9 +84,9 @@ function createNHA(int $gameID) : void {
 	7) Contact Newbie Help Leader for help, advice or with any questions you have.<br />
 	<br />
 	8) Most of all - have fun out there!';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 1, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 1, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 2, \'What the Newbie Help Alliance (NHA) can do for you\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 2, \'What the Newbie Help Alliance (NHA) can do for you\')');
 	$text = 'There are a number of ways this alliance can help you as a new player, and you are welcome to make use of as many or as few of these as you wish:<br />
 	<br />
 	1) Access to one or more experienced veteran players who will give you accurate and unbiased advice. Most players in SMR will help you if you need it, but the veterans in this alliance are here specifically to help you.<br />
@@ -98,17 +98,17 @@ function createNHA(int $gameID) : void {
 	4) If you stay in NHA, stay active, try to learn, and keep in touch with the Newbie Help Leader then this alliance can be a stepping stone to the more established alliances. Every game I get alliance leaders asking me to recommend newbies who are active and have potential.<br />
 	<br />
 	5) Newbie Help Leader will work with each of you individually on specific questions and game goals if you want. If resources allow it (I am dependent on my own trading income for cash) I try to reward players for achieving the game goals they work towards. I also try to make sure that members have at least a mid-level tradeship after they have been killed, although I try to make sure that they have learned from their mistakes before buying replacement ships (to be fair to the rest of the players in the game, you can no longer get cash or new ships after reaching fledgling status, although you are welcome to stay in the alliance as long as you like).';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 2, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 2, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 3, \'Turns\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 3, \'Turns\')');
 	$text = 'Many of the basic actions performed in SMR cost turns, the most common examples being moving, trading &amp; attacking. One of the keys to success in the game is good turn management, no matter what you are busing the turns to accomplish. If you are a trader, you want to get as much cash and xp as possible per turn used. If you are a hunter, you want to spend as many turns as possible efficiently locating targets and getting kills, and as few as possible chasing traders around without getting the final trigger shot off. In an alliance, you will often be expected to save turns for op\'s, where it is often crucial to have plenty of alliance members show up with plenty of turns.<br />
 	<br />
 	Turns are accumulated constantly, whether you are logged in or not, and are a product of ship speed and game speed. When you click the Trader link on the left of your screen, one of the things you will see is how many turns you get per hour in the ship you are in, and also the maximum number of turns you can accumulate in the current game. It is important to manage your turns carefully - make sure to always leave yourself enough turns to get back to somewhere you can park safely (preferably with some to spare in case you run into trouble on the way). It can sometimes be a good idea to save up a large number of turns so you can use them all in one session, but be aware that this is not always possible or even ideal. You should try to avoid reaching the maximum number of turns, since you will then stop getting more and will basically be wasting the turns you would usually have accumulated.<br />
 	<br />
 	A good way to get a few extra turns and help the game at the same time is to click on the voting links at the bottom of your screen. Voting for SMR helps our rankings, which brings more players to the game - making it better for all of us.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 3, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 3, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 4, \'How to trade\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 4, \'How to trade\')');
 	$text = 'In SMR, trading is the easiest and most fundamental way to accumulate both cash and experience points. The basic principles of trading are easy, but getting really good at it takes time and experience.<br />
 	<br />
 	The basic idea of trading is that you buy goods from a port that sells them, transport them to a reciprocal port that buys them, and sell them there for a profit. If you make a good trade, you will also accumulate experience points for the trades. Reciprocal ports for a trade good are ones which can be matched up to create a trade route; for example if a port sells wood then all ports that buy wood are reciprocal ports and can potentially be used to create a "wood" traderoute. A good traderoute is one which can be traded in both directions (different goods of course), and one which makes good profits and/or experience. More on that later.<br />
@@ -120,9 +120,9 @@ function createNHA(int $gameID) : void {
 	The experience you get from a trade depends on your relations with that race, and on how good a deal you make. With perfect relations (1000) you will automatically be offered the best possible deal by a port and will not need to bargain at all. At less than 1000 relations, you get experience depending on how well you bargain, where bargaining means offering a little less than the port asks for when you are buying and asking for a little more than the port is offering when you are selling. relations go up with successful trades, and they go down when a port refuses the bargain you offer them. If you are trading with your own race, it is often a good idea not to worry too much about making the best bargains at first and try to get maximum relations as quickly as possible.<br />
 	<br />
 	One of the major contributing factors to how well you can trade is the ship you are using. Profit and experience depend on the number of goods you are able to trade which depends in turn on the number of cargo holds you have and the speed of your ship. A general guide to how efficient a tradeship is is to multiply the number of holds by the ship speed to give you the trade potential. It is important to note, however, that trade potential is not the only important factor in choosing a tradeship. For example, the planetary super freighter is a very efficient trader with good defenses but is very slow and therefore very inefficient if you have to travel a lot between traderoutes and parking spots; whereas the Interstellar trader has pretty good trade potential and a jump drive to allow you to travel easily but has very weak defenses and is easily killed.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 4, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 4, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 5, \'Safe trading\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 5, \'Safe trading\')');
 	$text = 'This topic is extensive, and there is no substitute for playing the game, probably dying a few times, and learning through experience. However, it doesn\'t hurt to keep a few tips and tricks in mind:<br />
 	<br />
 	1) Choose your route. The best routes are also likely to be the least safe, since that is where most hunters will look for their targets. It is sometimes better to trade a slightly less lucrative route and stay alive, especially if you know there are hunters online in the area or you have seen a lot of deaths in the news on the better routes.<br />
@@ -136,9 +136,9 @@ function createNHA(int $gameID) : void {
 	4) Watch the CPL. Before and during trading, keep an eye on the current player list and the news, and look for hunters who you think may come for you. It is sometimes better to leave trading for another time, but at least stay alive.<br />
 	<br />
 	5) Use local map. It can sometimes be useful to enter your port sectors using local map, especially if you suspect there may be trouble close by. This allows you to see ships sitting in neighbouring sectors waiting to ambush you, but it only works if you have a scanner.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 5, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 5, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 6, \'Get a scanner\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 6, \'Get a scanner\')');
 	$text = ' 	If your ship can equip with a scanner, then get one and learn how to use it. Scanners are very useful for moving around safely and for gathering information about local sectors. Some examples:<br />
 	<br />
 	Scanners can warn you of nearby ships on local map (see safe trading thread).<br />
@@ -146,49 +146,49 @@ function createNHA(int $gameID) : void {
 	Scanners can warn you of cloaked ships. Scanning a sector (from a neighbouring sector) will give you a reading on the number of ships there. Enemy ships scan as their defensive value x 10. For example, if you scan a sector and get a reading of 300, then enter and see only a planetary super freighter there (def value of 15) then you know there is a 150 scan unaccounted for, which means a cloaked ship. At this point, you will probably want to get out of there fast! (Note that ship scans can sometimes also be off due to Illusion generator ships pretending to be something they are not).<br />
 	<br />
 	Scanners will give you force readings. Scanning a neighbouring sector will tell you the total number of forces in the sector (scouts scan as 1, drones as 2, mines as 3). This allows you to avoid sectors with heavy force scans (which usually means a lot of mines) when navigating.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 6, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 6, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 7, \'Logging off safely\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 7, \'Logging off safely\')');
 	$text = 'Before logging off, it is very important to ALWAYS check that your are as safe as you can be. Until you join a major alliance, you should all be parking safely in federally protected space every time you log off (sectors with a "Federal Beacon"). Before leaving SMR, ALWAYS check your main screen protection message and/or click the "Trader" link to make sure you are in fact protected.<br />
 	<br />
 	The two things that can prevent you from having federal protection are carrying illegal goods (slaves, weapons or narcotics) or having an attack rating that is too high. At neutral alignment, that is +/-149, you can park safely with an attack rating of 3 or less. The attack rating you can park with increases with increasing alignment and decreases with decreasing alignment.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 7, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 7, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 8, \'Merchant\\\'s Guide to the Universe\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 8, \'Merchant\\\'s Guide to the Universe\')');
 	$text = 'MGU, as everyone calls it, is an extremely valuable tool to use alongside SMR. Details on how to get the software (as well as instructions and discussions) can be found on the SMR Wiki at https://wiki.smrealms.de/tools/mgu.<br />
 	<br />
 	Basically, after you have installed MGU, you need to download your game maps using the link on the left side of the SMR page, and save them into your MGU directory. From MGU, you can then open the game maps and access the map information to do may useful things. MGU functions include things like finding traderoutes (listed by experience or cash), finding locations, plotting arming routes, finding safe course plots, etc.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 8, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 8, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
 // remove newbie gals
-//	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 9, \'Racial galaxies\')');
+//	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 9, \'Racial galaxies\')');
 //	$text = ' 	As long as you are ranked newbie or beginner, players ranked fledgling or above cannot see you in the racial galaxies. This makes these galaxies considerably safer for you, and I recommend avoiding too much time spent outside them.';
-//	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 9, 1, '.$db->escapeString($text).', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+//	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 9, 1, '.$db->escapeString($text).', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 10, \'Respect for other players\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 10, \'Respect for other players\')');
 	$text = 'SMR has a very active and social player community, and one thing that will get noticed is how you treat your fellow players. If you send polite messages to other players asking for advice or just to make some contacts, they\'ll remember your name, maybe mention you to their teammates, and you have taken the first step to becoming a respected player. However, if you, for example, react to being killed (it happens to everyone, get used to it) by sending an abusive and angry message then you will quickly lose the respect of your fellow players.<br />
 	<br />
 	If you do get killed, it can be useful to politely message your killer and ask what you did wrong - most veteran players will be more than happy to advise you on how to avoid the same thing happening again, plus it shows them that you want to learn how to improve at the game. If you get a kill, it is considered impolite to send messages gloating over the fact, although some veteran players will sometimes message newbies they have killed with offers of cash to get them back on their feet or advice on how to avoid the same thing happening again.<br />
 	<br />
 	There are all kinds of ways to play and enjoy this game, different players choose to emphasize different aspects of gameplay - but whatever choices you make, the bottom line is that if you treat your fellow players (both allies and enemies) with respect, then they will respect you.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 10, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 10, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 11, \'Talk to the players\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 11, \'Talk to the players\')');
 	$text = 'SMR has a very active community, and it is always a good idea to talk to the other players. You can do this in the #smr chatroom, or by messaging them ingame. Most players will be happy to talk to you or help you if you send them polite messages.<br />
 	<br />
 	It is also a good idea to talk to veteran players, especially alliance leaders, about their alliances and what they look for in their team members. You probably won\'t be asked to join a major alliance right away, but many of them have training alliances and they are always looking for active players who are willing to learn and contribute to an alliance.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 11, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 11, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 12, \'The Webboard\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 12, \'The Webboard\')');
 	$text = 'The SMR webboard (often referred to simply as the WB) is full of all kinds of advice and discussions, and I recommend stopping by to take a look every so often. It will all seem a bit much at first, but start with the sections that seem most useful to you and you will quickly learn to recognize what is important and what is not.<br />
 	<br />
 	You should also contribute to the webboard if you have an opinion or something you feel needs discussed, but please use the search function before starting new topics to make sure you are not repeating what someone else has posted somewhere else.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 12, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 12, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
 
 
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 13, \'Alignment\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 13, \'Alignment\')');
 	$text = ' 	Alignment has a couple of functions, the main ones being for trading purposes and determining which restricted ships and weapons you can buy.<br />
 	<br />
 	If you are evil (alignment -100 or lower) you can trade evil goods, buy underground ships (Thief, Assassin, Death Cruiser which are all cloaked) and buy the underground level 5 weapon (nuke). If you are neutral (between -99 and 99 alignment) you can become evil by signing up as a gang member at Underground HQ. Evil players cannot enter federal (racial) HQ\'s.<br />
@@ -196,25 +196,25 @@ function createNHA(int $gameID) : void {
 	If you are good (alignment 100 or higher) you can buy federal ships (Federal Discovery, Warrant and Ultimatum which all have jump drive and take half damage from forces) and buy the federal level 5 weapon (holy hand grenade). If you are neutral (between -99 and 99 alignment) you can become good by deputizing at any racial HQ. Good players cannot enter the underground HQ.<br />
 	<br />
 	Alignment also affects the attack ratings you can have and still be federally protected in fed space. At neutral alignment you can park with an attack rating of 3, and the protected rating goes up 1 for every +150 alignment and down 1 for every -150 alignment. You are always protected with an attack rating of zero.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 13, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 13, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 14, \'Watching the news and CPL\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 14, \'Watching the news and CPL\')');
 	$text = 'Whether you are a trader or a hunter, it is very valuable to know as much as possible about who is currently active in the game, and where they might be. Two of the resources you need to learn to use, but also know the limitations of, are the news and the current player list (CPL).<br />
 	<br />
 	Reading the news before you trade can be valuable in letting you know which hunters are currently active in the game, even if they don\'t show on the CPL. If there has been a recent kill near your traderoute, or a hunter that knows where you like to trade has recently been active, it is often a good idea to wait and trade another time.<br />
 	<br />
 	The CPL will let you know who has recently accessed the database, and also how many players are "lurking" (logged into the game, but not moving). It is a good idea to check the CPL for hunters you believe are a threat to you before you trade, and also every so often while you trade (especially if you are trading over a scout drone).';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 14, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 14, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 15, \'IRC chat\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 15, \'IRC chat\')');
 	$text = ' 	It is very helpful to learn to use IRC chat often while playing this game. The first step is to simply use the IRC chat link on the left of your screen and just spend some time in the #smr room getting to know some of the players. This is also a good time to ask questions - not just about technical or tactical aspects of the game, but about what the players like about the game, about the alliances, about pretty much anything. Getting to know the players and the community is part of getting to know SMR.<br />
 	<br />
 	When you end up in an alliance, playing with a team, you will find that they pretty much all use dedicated alliance chatrooms that they use for conducting alliance operations. These rooms are also a place to simply hang out and chat, which is a great way to get to know your teammates.<br />
 	<br />
 	In time, if you are able to do so, it is useful to install an IRC client on the computer(s) you use. mIRC is free and works well. If you have trouble getting your IRC client to work, there are instructions and help to be found on the webboard.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 15, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 15, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 16, \'Avoiding mines\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 16, \'Avoiding mines\')');
 	$text = 'Enemy mines are something you will encounter on a regular basis in SMR, and there are a couple of things that can help prevent you dying to them.<br />
 	<br />
 	1) If you hit a mined sector, you always have a safe way out. Going back the way you came to your green highlighted sector will spare you from hitting any more mines.<br />
@@ -224,27 +224,27 @@ function createNHA(int $gameID) : void {
 	3) Work from UNO. If you are travelling a long way, it is often a very good idea not to plot your route directly from A to B, but to plan it so that you pass UNO shops along the way - this will allow you to refill your defenses as you go if you take some damage. This is especially important when travelling through large neutral galaxies.<br />
 	<br />
 	4) Use your maps. If you encounter heavily mined sectors, retreat to safety, then take the time to look carefully at your maps to see if the area you were in is close to something an alliance would want to protect (usually a galaxy warp or a Combat Accessories shop). Then plan a new route avoiding this area.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 16, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 16, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 17, \'Port raiding\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 17, \'Port raiding\')');
 	$text = 'It\'s simple - don\'t do it! Raiding small ports will gain you nothing and will often get you killed, and raiding big ports is impossible without a well-armed fleet of warships.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 17, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 17, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 18, \'Operations guide\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 18, \'Operations guide\')');
 	$text = ' 	http://smrcnn.smrealms.de/viewtopic.php?t=3922<br />
 	<br />
 	Once you graduate to alliances that are more active in the bigger picture of a game, you will want to take part in alliance operations. SMR op\'s come in all kinds of shapes &amp; sizes and flavours, and involve things like territory wars, planet busts, port raids and fleet battles.<br />
 	<br />
 	The link I posted here is a rough guide to what you might expect, and what will be expected of you, in alliance op\'s.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 18, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 18, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 19, \'Multiple accounts\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 19, \'Multiple accounts\')');
 	$text = 'Multiple accounts are NOT permitted in SMR. The game has admins who actively look for multiple accounts and suspicious activity. If you are caught playing more than one account, you risk losing all your accumulated stats and being banned from the game.<br />
 	<br />
 	One of the results of this strict policy on multiple accounts is that you should try to avoid logging into your account from any computer also used by other SMR players. Even though you are not actually playing more than one account, it can seem as though you are when the connection logs are checked.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 19, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 19, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 20, \'Moving on to a new alliance\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 20, \'Moving on to a new alliance\')');
 	$text = 'When you feel you are ready to move on from this alliance to a new one, it is a good idea to take the time to talk to the alliance leaders out there, When you do, don\'t be afraid to talk to the major alliances as well as the small ones - they probably won\'t offer you a spot right away, but they can give good advice and it also puts your name on their radar for future games.<br />
 	<br />
 	There are a number of things it is a good idea to ask alliance leaders about, to give you an idea what they look for in a member and (more importantly) to help you decide what kind of alliance you want to join.<br />
@@ -256,9 +256,9 @@ function createNHA(int $gameID) : void {
 	5) Since you are still learning, what can you expect to learn from flying with a given alliance.<br />
 	<br />
 	There is no right time to leave this alliance and join a new one, but I recommend that you do not jump hastily or blindly into a random small alliance. Apart from anything else, some of the small ones are made up of new players who have as little game knowledge as you and are not doing anything remotely organized or coordinated.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 20, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 20, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 21, \'Experience\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 21, \'Experience\')');
 	$text = 'There are many ways to play SMR, and many different aspects of the game to enjoy - but experience points are important whether you play with a high ranking as a goal in itself, or whether you see it as just another tool to help achieve other goals.<br />
 	<br />
 	Experience (xp) is gained through both trading and combat, but trading is by far the most effective and efficient way to accumulate experience (especially early in a game). Refer to the trading section on this message board for details, but the best way to get lots of experience fast is to trade long routes with perfect trading relations. This is not always possible, and often dangerous (and you lose significant amounts of xp when you die), so it is often a good idea to look for decent traderoutes but stay off the best ones.<br />
@@ -267,9 +267,9 @@ function createNHA(int $gameID) : void {
 	1) Higher weapon accuracy when you fire, and lower weapon accuracy for your opponents.<br />
 	2) The ability to cloak from lower ranked players.<br />
 	3) Demonstrating the ability to accumulate and keep a good experience level. This last benefit is especially important for new players since climbing the rankings and avoiding too many deaths will get you noticed.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 21, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 21, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 22, \'Ships\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 22, \'Ships\')');
 	$text = 'Everything you do in SMR is done while you are flying some kind of ship - it can be anything from an escape pod to a huge IkThorne mothership, but you are always the pilot of something. In addition to the neutral ships, each race also has unique ships that only race members can purchase. You can find the SMR shiplist <a href="ship_list.php" target="_blank"><b><u>here</u></b></a>.<br />
 	Additional information relating to ships can be found in the <a href="' . WIKI_URL . '" target="_blank">SMR wiki</a><br />
 	<br />
@@ -294,9 +294,9 @@ function createNHA(int $gameID) : void {
 	- Speed. Ship speed determines how fast your ship will accumulate turns. Faster ships gain more turns per hour and vice versa.<br />
 	- Hardware. Most ships can use one or more hardware items, each of which adds certain capabilities to the ship. These are Scanners (see scanner thread), Cloaks (invisibility from lower ranked traders when activated), Illusion Generators (the ability to disguise your ship), Jump Drives (allows you to jump from place to place without travelling through the sectors between), and Drone Scramblers (improved defense against combat drones).<br />
 	- Restricted ships. There are restrictions on who can buy certain ships. These include racial restrictions, top racial restrictions (the top racial ships cannot be purchased until you reach fledgling status), and alignment restrictions (Underground and Federal ships require you to be evil or good respectively, Federal ships also take half damage from forces).';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 22, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 22, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 23, \'Weapons\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 23, \'Weapons\')');
 	$text = 'SMR has a wide variety of weapons with which to arm your ships, and information on weapon capabilities can be found <a href="weapon_list.php" target="_blank"><b><u>here</b></u></a>.<br />
 	<br />
 	There are a few things to consider when choosing weapons, and the weapon combination that works for one player may not be suited to the style or the needs of another.<br />
@@ -306,9 +306,9 @@ function createNHA(int $gameID) : void {
 	- Accuracy. Weapon accuracy (modified by trader level) determines how likely it is that your weapon will hit your target on any shot. In ship to ship combat, higher ranked traders get accuracy benefits over their lower ranked opponents. There is (and always has been since the dawn of this game) an ongoing debate about when it is better to use either high accuracy low damage weapons or low accuracy high damage weapons.<br />
 	- Rating. There are restrictions on how many weapons of certain ratings you are allowed to arm yourself with. Weapon rating is determined by accuracy and damage, and higher is better. You are allowed up to one level 5 weapon, up to 2 level 4 weapons, and up to 3 level 3 weapons.<br />
 	- Availability.Weapon choice when arming is sometimes determined by the availability of certain weapons. Racial weapons are only available to the owner race or races that have peaceful relations with them; weapons may be sold at weapon shops that are not safely accessible; or the number of turns it would take to acquire all the weapons you would like may be too high.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 23, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 23, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
-	$db->query('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 24, \'Planets and Territory\')');
+	$db->write('REPLACE INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 24, \'Planets and Territory\')');
 	$text = 'Except for your ship and what it carries, a planet is the only thing in SMR that you can claim for yourself or your alliance. This means that planets and planet galaxies are often the main focus of the rivalries and wars between alliances.<br />
 	<br />
 	At the beginning of every game planets are weak and planet galaxies are easily accessible, but as a game progresses planets become stronger (the strongest planets will regularly kill attacking warships even when being attacked by a full fleet) and some galaxies (alliance territory) become heavily fortified by minefields. Planets become parking spots for fully armed warships as well as being used to generate cash, and therefore become attractive targets for enemy alliances.<br />
@@ -316,5 +316,5 @@ function createNHA(int $gameID) : void {
 	Kill counts and experience are important measures of success, but many veteran players feel that the only true measure of success in alliance wars is the ability to hold and/or take territory from enemy alliances.<br />
 	<br />
 	It is important to note that weakly defended planets should NOT be considered safe parking spots.';
-	$db->query('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 24, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('REPLACE INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(NHA_ID) . ', 24, 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 }

--- a/src/admin/Default/1.6/universe_create_warps.php
+++ b/src/admin/Default/1.6/universe_create_warps.php
@@ -26,10 +26,10 @@ foreach ($galaxies as $gal1) {
 }
 
 //get totals
-$db->query('SELECT sector_id, warp FROM sector WHERE warp != 0 AND game_id=' . $db->escapeNumber($var['game_id']));
-while ($db->nextRecord()) {
-	$warp1 = SmrSector::getSector($var['game_id'], $db->getInt('sector_id'));
-	$warp2 = SmrSector::getSector($var['game_id'], $db->getInt('warp'));
+$dbResult = $db->read('SELECT sector_id, warp FROM sector WHERE warp != 0 AND game_id=' . $db->escapeNumber($var['game_id']));
+foreach ($dbResult->records() as $dbRecord) {
+	$warp1 = SmrSector::getSector($var['game_id'], $dbRecord->getInt('sector_id'));
+	$warp2 = SmrSector::getSector($var['game_id'], $dbRecord->getInt('warp'));
 	if ($warp1->getGalaxyID() == $warp2->getGalaxyID()) {
 		// For warps within the same galaxy, even though there will be two
 		// sectors with warps, we still consider this as "one warp" (pair).

--- a/src/admin/Default/account_edit.php
+++ b/src/admin/Default/account_edit.php
@@ -14,55 +14,55 @@ $template->assign('EditFormHREF', Page::create('account_edit_processing.php', ''
 $template->assign('ResetFormHREF', Page::create('skeleton.php', 'account_edit_search.php')->href());
 
 $editingPlayers = array();
-$db->query('SELECT * FROM player WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY game_id ASC');
-while ($db->nextRecord()) {
-	$editingPlayers[] = SmrPlayer::getPlayer($curr_account->getAccountID(), $db->getInt('game_id'), false, $db);
+$dbResult = $db->read('SELECT * FROM player WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY game_id ASC');
+foreach ($dbResult->records() as $dbRecord) {
+	$editingPlayers[] = SmrPlayer::getPlayer($curr_account->getAccountID(), $dbRecord->getInt('game_id'), false, $dbRecord);
 }
 $template->assign('EditingPlayers', $editingPlayers);
 
 $template->assign('Disabled', $curr_account->isDisabled());
 
 $banReasons = array();
-$db->query('SELECT * FROM closing_reason');
-while ($db->nextRecord()) {
-	$reason = $db->getField('reason');
+$dbResult = $db->read('SELECT * FROM closing_reason');
+foreach ($dbResult->records() as $dbRecord) {
+	$reason = $dbRecord->getField('reason');
 	if (strlen($reason) > 61) {
 		$reason = substr($reason, 0, 61) . '...';
 	}
-	$banReasons[$db->getInt('reason_id')] = $reason;
+	$banReasons[$dbRecord->getInt('reason_id')] = $reason;
 }
 $template->assign('BanReasons', $banReasons);
 
 $closingHistory = array();
-$db->query('SELECT * FROM account_has_closing_history WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY time DESC');
-while ($db->nextRecord()) {
+$dbResult = $db->read('SELECT * FROM account_has_closing_history WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY time DESC');
+foreach ($dbResult->records() as $dbRecord) {
 	// if an admin did it we get his/her name
-	$admin_id = $db->getInt('admin_id');
+	$admin_id = $dbRecord->getInt('admin_id');
 	if ($admin_id > 0) {
 		$admin = SmrAccount::getAccount($admin_id)->getLogin();
 	} else {
 		$admin = 'System';
 	}
 	$closingHistory[] = array(
-		'Time' => $db->getInt('time'),
-		'Action' => $db->getField('action'),
+		'Time' => $dbRecord->getInt('time'),
+		'Action' => $dbRecord->getField('action'),
 		'AdminName' => $admin
 	);
 }
 $template->assign('ClosingHistory', $closingHistory);
 
-$db->query('SELECT * FROM account_exceptions WHERE account_id = ' . $curr_account->getAccountID());
-if ($db->nextRecord()) {
-	$template->assign('Exception', $db->getField('reason'));
+$dbResult = $db->read('SELECT * FROM account_exceptions WHERE account_id = ' . $curr_account->getAccountID());
+if ($dbResult->hasRecord()) {
+	$template->assign('Exception', $dbResult->record()->getField('reason'));
 }
 
 $recentIPs = array();
-$db->query('SELECT ip, time, host FROM account_has_ip WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY time DESC');
-while ($db->nextRecord()) {
+$dbResult = $db->read('SELECT ip, time, host FROM account_has_ip WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY time DESC');
+foreach ($dbResult->records() as $dbRecord) {
 	$recentIPs[] = array(
-		'IP' => $db->getField('ip'),
-		'Time' => $db->getField('time'),
-		'Host' => $db->getField('host')
+		'IP' => $dbRecord->getField('ip'),
+		'Time' => $dbRecord->getField('time'),
+		'Host' => $dbRecord->getField('host')
 	);
 }
 $template->assign('RecentIPs', $recentIPs);

--- a/src/admin/Default/account_edit.php
+++ b/src/admin/Default/account_edit.php
@@ -25,7 +25,7 @@ $template->assign('Disabled', $curr_account->isDisabled());
 $banReasons = array();
 $dbResult = $db->read('SELECT * FROM closing_reason');
 foreach ($dbResult->records() as $dbRecord) {
-	$reason = $dbRecord->getField('reason');
+	$reason = $dbRecord->getString('reason');
 	if (strlen($reason) > 61) {
 		$reason = substr($reason, 0, 61) . '...';
 	}

--- a/src/admin/Default/account_edit_search.php
+++ b/src/admin/Default/account_edit_search.php
@@ -8,10 +8,10 @@ $template->assign('PageTopic', 'Edit Account');
 
 $games = [];
 $db = Smr\Database::getInstance();
-$db->query('SELECT game_id, game_name FROM game WHERE enabled = \'TRUE\' ORDER BY game_id DESC');
-while ($db->nextRecord()) {
-	$gameID = $db->getInt('game_id');
-	$games[$gameID] = $db->getField('game_name') . ' (' . $gameID . ')';
+$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE enabled = \'TRUE\' ORDER BY game_id DESC');
+foreach ($dbResult->records() as $dbRecord) {
+	$gameID = $dbRecord->getInt('game_id');
+	$games[$gameID] = $dbRecord->getField('game_name') . ' (' . $gameID . ')';
 }
 $template->assign('Games', $games);
 $template->assign('SearchHREF', Page::create('account_edit_search_processing.php')->href());

--- a/src/admin/Default/account_edit_search_processing.php
+++ b/src/admin/Default/account_edit_search_processing.php
@@ -8,29 +8,29 @@ $searchGameID = Request::getInt('game_id');
 
 if (!empty($player_name)) {
 	$gameIDClause = $searchGameID != 0 ? ' AND game_id = ' . $db->escapeNumber($searchGameID) . ' ' : '';
-	$db->query('SELECT account_id FROM player
+	$dbResult = $db->read('SELECT account_id FROM player
 					WHERE player_name = ' . $db->escapeString($player_name) . $gameIDClause . '
 					ORDER BY game_id DESC LIMIT 1');
-	if ($db->nextRecord()) {
-		$account_id = $db->getInt('account_id');
+	if ($dbResult->hasRecord()) {
+		$account_id = $dbResult->record()->getInt('account_id');
 	} else {
-		$db->query('SELECT * FROM player
-						WHERE player_name LIKE ' . $db->escapeString($player_name . '%') . $gameIDClause);
-		if ($db->nextRecord()) {
-			$account_id = $db->getInt('account_id');
+		$dbResult = $db->read('SELECT * FROM player
+						WHERE player_name LIKE ' . $db->escapeString($player_name . '%') . $gameIDClause . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$account_id = $dbResult->record()->getInt('account_id');
 		}
 	}
 }
 
 // get account from db
-$db->query('SELECT account_id FROM account WHERE account_id = ' . $db->escapeNumber($account_id) . ' OR ' .
+$dbResult = $db->read('SELECT account_id FROM account WHERE account_id = ' . $db->escapeNumber($account_id) . ' OR ' .
 									   'login LIKE ' . $db->escapeString(Request::get('login')) . ' OR ' .
 									   'email LIKE ' . $db->escapeString(Request::get('email')) . ' OR ' .
 									   'hof_name LIKE ' . $db->escapeString(Request::get('hofname')) . ' OR ' .
-									   'validation_code LIKE ' . $db->escapeString(Request::get('val_code')));
-if ($db->nextRecord()) {
+									   'validation_code LIKE ' . $db->escapeString(Request::get('val_code')) . ' LIMIT 1');
+if ($dbResult->hasRecord()) {
 	$container = Page::create('skeleton.php', 'account_edit.php');
-	$container['account_id'] = $db->getInt('account_id');
+	$container['account_id'] = $dbResult->record()->getInt('account_id');
 } else {
 	$container = Page::create('skeleton.php', 'account_edit_search.php');
 	$container['errorMsg'] = 'No matching accounts were found!';

--- a/src/admin/Default/admin_message_send.php
+++ b/src/admin/Default/admin_message_send.php
@@ -17,11 +17,11 @@ if ($gameID != 20000) {
 	$game = SmrGame::getGame($gameID);
 	$gamePlayers = [['AccountID' => 0, 'Name' => 'All Players (' . $game->getName() . ')']];
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT account_id,player_id,player_name FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY player_name');
-	while ($db->nextRecord()) {
+	$dbResult = $db->read('SELECT account_id,player_id,player_name FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY player_name');
+	foreach ($dbResult->records() as $dbRecord) {
 		$gamePlayers[] = [
-			'AccountID' => $db->getInt('account_id'),
-			'Name' => $db->getField('player_name') . ' (' . $db->getInt('player_id') . ')',
+			'AccountID' => $dbRecord->getInt('account_id'),
+			'Name' => $dbRecord->getField('player_name') . ' (' . $dbRecord->getInt('player_id') . ')',
 		];
 	}
 	$template->assign('GamePlayers', $gamePlayers);

--- a/src/admin/Default/admin_message_send_processing.php
+++ b/src/admin/Default/admin_message_send_processing.php
@@ -33,18 +33,18 @@ $receivers = [];
 if ($game_id != ALL_GAMES_ID) {
 	if ($account_id == 0) {
 		// Send to all players in the requested game
-		$db->query('SELECT account_id FROM player WHERE game_id = ' . $db->escapeNumber($game_id));
-		while ($db->nextRecord()) {
-			$receivers[] = [$game_id, $db->getInt('account_id')];
+		$dbResult = $db->read('SELECT account_id FROM player WHERE game_id = ' . $db->escapeNumber($game_id));
+		foreach ($dbResult->records() as $dbRecord) {
+			$receivers[] = [$game_id, $dbRecord->getInt('account_id')];
 		}
 	} else {
 		$receivers[] = [$game_id, $account_id];
 	}
 } else {
 	//send to all players in games that haven't ended yet
-	$db->query('SELECT game_id,account_id FROM player JOIN game USING(game_id) WHERE end_time > ' . $db->escapeNumber(Smr\Epoch::time()));
-	while ($db->nextRecord()) {
-		$receivers[] = [$db->getInt('game_id'), $db->getInt('account_id')];
+	$dbResult = $db->read('SELECT game_id,account_id FROM player JOIN game USING(game_id) WHERE end_time > ' . $db->escapeNumber(Smr\Epoch::time()));
+	foreach ($dbResult->records() as $dbRecord) {
+		$receivers[] = [$dbRecord->getInt('game_id'), $dbRecord->getInt('account_id')];
 	}
 }
 // Send the messages

--- a/src/admin/Default/admin_message_send_select.php
+++ b/src/admin/Default/admin_message_send_select.php
@@ -9,8 +9,8 @@ $template->assign('AdminMessageChooseGameFormHref', Page::create('skeleton.php',
 // Get a list of all games that have not yet ended
 $activeGames = array();
 $db = Smr\Database::getInstance();
-$db->query('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY end_time DESC');
-while ($db->nextRecord()) {
-	$activeGames[] = SmrGame::getGame($db->getInt('game_id'));
+$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY end_time DESC');
+foreach ($dbResult->records() as $dbRecord) {
+	$activeGames[] = SmrGame::getGame($dbRecord->getInt('game_id'));
 }
 $template->assign('ActiveGames', $activeGames);

--- a/src/admin/Default/album_approve.php
+++ b/src/admin/Default/album_approve.php
@@ -22,14 +22,14 @@ $dbResult = $db->read('SELECT *
 if ($dbResult->hasRecord()) {
 	$dbRecord = $dbResult->record();
 	$album_id = $dbRecord->getInt('account_id');
-	$location = stripslashes($dbRecord->getField('location'));
-	$email = stripslashes($dbRecord->getField('email'));
-	$website = stripslashes($dbRecord->getField('website'));
-	$day = $dbRecord->getField('day');
-	$month = $dbRecord->getField('month');
-	$year = $dbRecord->getField('year');
-	$other = nl2br(stripslashes($dbRecord->getField('other')));
-	$last_changed = $dbRecord->getField('last_changed');
+	$location = $dbRecord->getField('location');
+	$email = $dbRecord->getField('email');
+	$website = $dbRecord->getField('website');
+	$day = $dbRecord->getInt('day');
+	$month = $dbRecord->getInt('month');
+	$year = $dbRecord->getInt('year');
+	$other = nl2br($dbRecord->getString('other'));
+	$last_changed = $dbRecord->getInt('last_changed');
 	$disabled = $dbRecord->getBoolean('disabled');
 
 	if (empty($location)) {

--- a/src/admin/Default/album_approve.php
+++ b/src/admin/Default/album_approve.php
@@ -13,24 +13,24 @@ $template = Smr\Template::getInstance();
 $template->assign('PageTopic', 'Approve Album Entries');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT *
+$dbResult = $db->read('SELECT *
 			FROM album
 			WHERE approved = \'TBC\'
 			ORDER BY last_changed
 			LIMIT 1');
 
-if ($db->nextRecord()) {
-
-	$album_id = $db->getInt('account_id');
-	$location = stripslashes($db->getField('location'));
-	$email = stripslashes($db->getField('email'));
-	$website = stripslashes($db->getField('website'));
-	$day = $db->getField('day');
-	$month = $db->getField('month');
-	$year = $db->getField('year');
-	$other = nl2br(stripslashes($db->getField('other')));
-	$last_changed = $db->getField('last_changed');
-	$disabled = $db->getBoolean('disabled');
+if ($dbResult->hasRecord()) {
+	$dbRecord = $dbResult->record();
+	$album_id = $dbRecord->getInt('account_id');
+	$location = stripslashes($dbRecord->getField('location'));
+	$email = stripslashes($dbRecord->getField('email'));
+	$website = stripslashes($dbRecord->getField('website'));
+	$day = $dbRecord->getField('day');
+	$month = $dbRecord->getField('month');
+	$year = $dbRecord->getField('year');
+	$other = nl2br(stripslashes($dbRecord->getField('other')));
+	$last_changed = $dbRecord->getField('last_changed');
+	$disabled = $dbRecord->getBoolean('disabled');
 
 	if (empty($location)) {
 		$location = 'N/A';

--- a/src/admin/Default/album_approve_processing.php
+++ b/src/admin/Default/album_approve_processing.php
@@ -5,7 +5,7 @@ $var = Smr\Session::getInstance()->getCurrentVar();
 $approved = $var['approved'] ? 'YES' : 'NO';
 
 $db = Smr\Database::getInstance();
-$db->query('UPDATE album
+$db->write('UPDATE album
 			SET approved = '.$db->escapeString($approved) . '
 			WHERE account_id = ' . $db->escapeNumber($var['album_id']));
 

--- a/src/admin/Default/album_moderate.php
+++ b/src/admin/Default/album_moderate.php
@@ -12,17 +12,17 @@ $account_id = $session->getRequestVarInt('account_id');
 
 // check if the given account really has an entry
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account_id) . ' AND Approved = \'YES\'');
-$db->requireRecord();
+$dbResult = $db->read('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account_id) . ' AND Approved = \'YES\'');
+$dbRecord = $dbResult->record();
 
-$disabled = $db->getBoolean('disabled');
-$location = stripslashes($db->getField('location'));
-$email = stripslashes($db->getField('email'));
-$website = stripslashes($db->getField('website'));
-$day = $db->getField('day');
-$month = $db->getField('month');
-$year = $db->getField('year');
-$other = nl2br(stripslashes($db->getField('other')));
+$disabled = $dbRecord->getBoolean('disabled');
+$location = stripslashes($dbRecord->getField('location'));
+$email = stripslashes($dbRecord->getField('email'));
+$website = stripslashes($dbRecord->getField('website'));
+$day = $dbRecord->getField('day');
+$month = $dbRecord->getField('month');
+$year = $dbRecord->getField('year');
+$other = nl2br(stripslashes($dbRecord->getField('other')));
 
 if (!empty($day) && !empty($month) && !empty($year)) {
 	$birthdate = $month . ' / ' . $day . ' / ' . $year;
@@ -75,16 +75,16 @@ $default_email = 'Dear Photo Album User,' . EOL . EOL .
 				 'Admin Team';
 $template->assign('DisableEmail', $default_email);
 
-$db->query('SELECT *
+$dbResult = $db->read('SELECT *
 			FROM album_has_comments
 			WHERE album_id = '.$db->escapeNumber($account_id));
 $comments = array();
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$comments[] = [
-		'id' => $db->getInt('comment_id'),
-		'date' => date($account->getDateTimeFormat(), $db->getInt('time')),
-		'postee' => get_album_nick($db->getInt('post_id')),
-		'msg' => stripslashes($db->getField('msg')),
+		'id' => $dbRecord->getInt('comment_id'),
+		'date' => date($account->getDateTimeFormat(), $dbRecord->getInt('time')),
+		'postee' => get_album_nick($dbRecord->getInt('post_id')),
+		'msg' => stripslashes($dbRecord->getField('msg')),
 	];
 }
 $template->assign('Comments', $comments);

--- a/src/admin/Default/album_moderate.php
+++ b/src/admin/Default/album_moderate.php
@@ -16,13 +16,13 @@ $dbResult = $db->read('SELECT * FROM album WHERE account_id = ' . $db->escapeNum
 $dbRecord = $dbResult->record();
 
 $disabled = $dbRecord->getBoolean('disabled');
-$location = stripslashes($dbRecord->getField('location'));
-$email = stripslashes($dbRecord->getField('email'));
-$website = stripslashes($dbRecord->getField('website'));
-$day = $dbRecord->getField('day');
-$month = $dbRecord->getField('month');
-$year = $dbRecord->getField('year');
-$other = nl2br(stripslashes($dbRecord->getField('other')));
+$location = $dbRecord->getField('location');
+$email = $dbRecord->getField('email');
+$website = $dbRecord->getField('website');
+$day = $dbRecord->getInt('day');
+$month = $dbRecord->getInt('month');
+$year = $dbRecord->getInt('year');
+$other = nl2br($dbRecord->getString('other'));
 
 if (!empty($day) && !empty($month) && !empty($year)) {
 	$birthdate = $month . ' / ' . $day . ' / ' . $year;
@@ -84,7 +84,7 @@ foreach ($dbResult->records() as $dbRecord) {
 		'id' => $dbRecord->getInt('comment_id'),
 		'date' => date($account->getDateTimeFormat(), $dbRecord->getInt('time')),
 		'postee' => get_album_nick($dbRecord->getInt('post_id')),
-		'msg' => stripslashes($dbRecord->getField('msg')),
+		'msg' => $dbRecord->getString('msg'),
 	];
 }
 $template->assign('Comments', $comments);

--- a/src/admin/Default/album_moderate_processing.php
+++ b/src/admin/Default/album_moderate_processing.php
@@ -9,17 +9,17 @@ $account_id = $var['account_id'];
 // check for each task
 if ($var['task'] == 'reset_image') {
 	$email_txt = Request::get('email_txt');
-	$db->query('UPDATE album SET disabled = \'TRUE\' WHERE account_id = ' . $db->escapeNumber($account_id));
+	$db->write('UPDATE album SET disabled = \'TRUE\' WHERE account_id = ' . $db->escapeNumber($account_id));
 
 	$db->lockTable('album_has_comments');
-	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($account_id));
-	if ($db->nextRecord()) {
-		$comment_id = $db->getInt('MAX(comment_id)') + 1;
+	$dbResult = $db->read('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($account_id));
+	if ($dbResult->hasRecord()) {
+		$comment_id = $dbResult->record()->getInt('MAX(comment_id)') + 1;
 	} else {
 		$comment_id = 1;
 	}
 
-	$db->query('INSERT INTO album_has_comments
+	$db->write('INSERT INTO album_has_comments
 				(album_id, comment_id, time, post_id, msg)
 				VALUES ('.$db->escapeNumber($account_id) . ', ' . $db->escapeNumber($comment_id) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', 0, ' . $db->escapeString('<span class="green">*** Picture disabled by an admin</span>') . ')');
 	$db->unlock();
@@ -36,19 +36,19 @@ if ($var['task'] == 'reset_image') {
 	}
 
 } elseif ($var['task'] == 'reset_location') {
-	$db->query('UPDATE album SET location = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
+	$db->write('UPDATE album SET location = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
 } elseif ($var['task'] == 'reset_email') {
-	$db->query('UPDATE album SET email = \'\' WHERE account_id =' . $db->escapeNumber($account_id));
+	$db->write('UPDATE album SET email = \'\' WHERE account_id =' . $db->escapeNumber($account_id));
 } elseif ($var['task'] == 'reset_website') {
-	$db->query('UPDATE album SET website = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
+	$db->write('UPDATE album SET website = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
 } elseif ($var['task'] == 'reset_birthdate') {
-	$db->query('UPDATE album SET day = 0, month = 0, year = 0 WHERE account_id = ' . $db->escapeNumber($account_id));
+	$db->write('UPDATE album SET day = 0, month = 0, year = 0 WHERE account_id = ' . $db->escapeNumber($account_id));
 } elseif ($var['task'] == 'reset_other') {
-	$db->query('UPDATE album SET other = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
+	$db->write('UPDATE album SET other = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
 } elseif ($var['task'] == 'delete_comment') {
 	// we just ignore if nothing was set
 	if (Request::has('comment_ids')) {
-		$db->query('DELETE
+		$db->write('DELETE
 					FROM album_has_comments
 					WHERE album_id = '.$db->escapeNumber($account_id) . ' AND
 						  comment_id IN ('.$db->escapeArray(Request::getIntArray('comment_ids')) . ')');

--- a/src/admin/Default/album_moderate_select.php
+++ b/src/admin/Default/album_moderate_select.php
@@ -11,10 +11,10 @@ $template->assign('ModerateHREF', $moderateHREF);
 
 // Get all accounts that are eligible for moderation
 $db = Smr\Database::getInstance();
-$db->query('SELECT account_id FROM album WHERE Approved = \'YES\'');
+$dbResult = $db->read('SELECT account_id FROM album WHERE Approved = \'YES\'');
 $approved = array();
-while ($db->nextRecord()) {
-	$accountId = $db->getInt('account_id');
+foreach ($dbResult->records() as $dbRecord) {
+	$accountId = $dbRecord->getInt('account_id');
 	$approved[$accountId] = get_album_nick($accountId);
 }
 $template->assign('Approved', $approved);

--- a/src/admin/Default/announcement_create_processing.php
+++ b/src/admin/Default/announcement_create_processing.php
@@ -12,6 +12,6 @@ if (Request::get('action') == 'Preview announcement') {
 
 // put the msg into the database
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO announcement (time, admin_id, msg) VALUES(' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($message) . ')');
+$db->write('INSERT INTO announcement (time, admin_id, msg) VALUES(' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($message) . ')');
 
 Page::create('skeleton.php', 'admin_tools.php')->go();

--- a/src/admin/Default/anon_acc_view.php
+++ b/src/admin/Default/anon_acc_view.php
@@ -13,18 +13,18 @@ $anonID = $session->getRequestVarInt('anon_account');
 $gameID = $session->getRequestVarInt('view_game_id');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT *
+$dbResult = $db->read('SELECT *
 			FROM anon_bank_transactions
 			JOIN player USING(account_id, game_id)
 			WHERE anon_id = '.$db->escapeNumber($anonID) . '
 				AND game_id = '.$db->escapeNumber($gameID) . '
 			ORDER BY transaction_id');
 $rows = [];
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$rows[] = [
-		'player_name' => $db->getField('player_name'),
-		'transaction' => $db->getField('transaction'),
-		'amount' => $db->getInt('amount'),
+		'player_name' => $dbRecord->getField('player_name'),
+		'transaction' => $dbRecord->getField('transaction'),
+		'amount' => $dbRecord->getInt('amount'),
 	];
 }
 if (!$rows) {

--- a/src/admin/Default/box_delete_processing.php
+++ b/src/admin/Default/box_delete_processing.php
@@ -10,13 +10,13 @@ if ($action == 'Marked Messages') {
 	}
 
 	foreach (Request::getIntArray('message_id') as $id) {
-		$db->query('DELETE FROM message_boxes WHERE message_id = ' . $db->escapeNumber($id));
+		$db->write('DELETE FROM message_boxes WHERE message_id = ' . $db->escapeNumber($id));
 	}
 } elseif ($action == 'All Messages') {
 	if (!isset($var['box_type_id'])) {
 		create_error('No box selected.');
 	}
-	$db->query('DELETE FROM message_boxes WHERE box_type_id = ' . $db->escapeNumber($var['box_type_id']));
+	$db->write('DELETE FROM message_boxes WHERE box_type_id = ' . $db->escapeNumber($var['box_type_id']));
 }
 
 Page::create('skeleton.php', 'box_view.php')->go();

--- a/src/admin/Default/box_view.php
+++ b/src/admin/Default/box_view.php
@@ -21,11 +21,11 @@ if (!isset($var['box_type_id'])) {
 			'TotalMessages' => 0,
 		);
 	}
-	$db->query('SELECT count(message_id), box_type_id
+	$dbResult = $db->read('SELECT count(message_id), box_type_id
 				FROM message_boxes
 				GROUP BY box_type_id');
-	while ($db->nextRecord()) {
-		$boxes[$db->getInt('box_type_id')]['TotalMessages'] = $db->getInt('count(message_id)');
+	foreach ($dbResult->records() as $dbRecord) {
+		$boxes[$dbRecord->getInt('box_type_id')]['TotalMessages'] = $dbRecord->getInt('count(message_id)');
 	}
 	$template->assign('Boxes', $boxes);
 } else {
@@ -33,21 +33,21 @@ if (!isset($var['box_type_id'])) {
 	$template->assign('PageTopic', 'Viewing ' . $boxName);
 
 	$template->assign('BackHREF', Page::create('skeleton.php', 'box_view.php')->href());
-	$db->query('SELECT * FROM message_boxes WHERE box_type_id=' . $db->escapeNumber($var['box_type_id']) . ' ORDER BY send_time DESC');
+	$dbResult = $db->read('SELECT * FROM message_boxes WHERE box_type_id=' . $db->escapeNumber($var['box_type_id']) . ' ORDER BY send_time DESC');
 	$messages = array();
-	if ($db->getNumRows()) {
+	if ($dbResult->hasRecord()) {
 		$container = Page::create('box_delete_processing.php');
 		$container->addVar('box_type_id');
 		$template->assign('DeleteHREF', $container->href());
-		while ($db->nextRecord()) {
-			$gameID = $db->getInt('game_id');
+		foreach ($dbResult->records() as $dbRecord) {
+			$gameID = $dbRecord->getInt('game_id');
 			$validGame = $gameID > 0 && Globals::isValidGame($gameID);
-			$messageID = $db->getInt('message_id');
+			$messageID = $dbRecord->getInt('message_id');
 			$messages[$messageID] = array(
 				'ID' => $messageID
 			);
 
-			$senderID = $db->getInt('sender_id');
+			$senderID = $dbRecord->getInt('sender_id');
 			if ($senderID == 0) {
 				$senderName = 'User not logged in';
 			} else {
@@ -75,8 +75,8 @@ if (!isset($var['box_type_id'])) {
 				$messages[$messageID]['GameName'] = SmrGame::getGame($gameID)->getDisplayName();
 			}
 
-			$messages[$messageID]['SendTime'] = date($account->getDateTimeFormat(), $db->getInt('send_time'));
-			$messages[$messageID]['Message'] = bbifyMessage(htmliseMessage($db->getField('message_text')));
+			$messages[$messageID]['SendTime'] = date($account->getDateTimeFormat(), $dbRecord->getInt('send_time'));
+			$messages[$messageID]['Message'] = bbifyMessage(htmliseMessage($dbRecord->getField('message_text')));
 		}
 		$template->assign('Messages', $messages);
 	}

--- a/src/admin/Default/box_view.php
+++ b/src/admin/Default/box_view.php
@@ -76,7 +76,7 @@ if (!isset($var['box_type_id'])) {
 			}
 
 			$messages[$messageID]['SendTime'] = date($account->getDateTimeFormat(), $dbRecord->getInt('send_time'));
-			$messages[$messageID]['Message'] = bbifyMessage(htmliseMessage($dbRecord->getField('message_text')));
+			$messages[$messageID]['Message'] = bbifyMessage(htmliseMessage($dbRecord->getString('message_text')));
 		}
 		$template->assign('Messages', $messages);
 	}

--- a/src/admin/Default/changelog.php
+++ b/src/admin/Default/changelog.php
@@ -11,18 +11,17 @@ $template->assign('ChangeTitle', $var['change_title'] ?? '');
 $template->assign('ChangeMessage', $var['change_message'] ?? '');
 $template->assign('AffectedDb', $var['affected_db'] ?? '');
 
-$db2 = Smr\Database::getInstance();
 $first_entry = true;
 $link_set_live = true;
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM version ORDER BY version_id DESC');
+$dbResult = $db->read('SELECT * FROM version ORDER BY version_id DESC');
 
 $versions = [];
-while ($db->nextRecord()) {
-	$version_id = $db->getInt('version_id');
-	$version = $db->getInt('major_version') . '.' . $db->getInt('minor_version') . '.' . $db->getInt('patch_level');
-	$went_live = $db->getInt('went_live');
+foreach ($dbResult->records() as $dbRecord) {
+	$version_id = $dbRecord->getInt('version_id');
+	$version = $dbRecord->getInt('major_version') . '.' . $dbRecord->getInt('minor_version') . '.' . $dbRecord->getInt('patch_level');
+	$went_live = $dbRecord->getInt('went_live');
 	if ($went_live > 0) {
 		// from this point on we don't create links to set a version to live
 		$link_set_live = false;
@@ -39,15 +38,15 @@ while ($db->nextRecord()) {
 		}
 	}
 
-	$db2->query('SELECT *
+	$dbResult2 = $db->read('SELECT *
 				FROM changelog
 				WHERE version_id = '.$db->escapeNumber($version_id) . '
 				ORDER BY changelog_id');
 	$changes = [];
-	while ($db2->nextRecord()) {
+	foreach ($dbResult2->records() as $dbRecord2) {
 		$changes[] = [
-			'title' => $db2->getField('change_title'),
-			'message' => $db2->getField('change_message'),
+			'title' => $dbRecord2->getField('change_title'),
+			'message' => $dbRecord2->getField('change_message'),
 		];
 	}
 

--- a/src/admin/Default/changelog_add_processing.php
+++ b/src/admin/Default/changelog_add_processing.php
@@ -18,17 +18,17 @@ if (Request::get('action') == 'Preview') {
 $db = Smr\Database::getInstance();
 $db->lockTable('changelog');
 
-$db->query('SELECT MAX(changelog_id)
+$dbResult = $db->read('SELECT MAX(changelog_id)
 			FROM changelog
 			WHERE version_id = ' . $db->escapeNumber($var['version_id'])
 		   );
-if ($db->nextRecord()) {
-	$changelog_id = $db->getInt('MAX(changelog_id)') + 1;
+if ($dbResult->hasRecord()) {
+	$changelog_id = $dbResult->record()->getInt('MAX(changelog_id)') + 1;
 } else {
 	$changelog_id = 1;
 }
 
-$db->query('INSERT INTO changelog
+$db->write('INSERT INTO changelog
 			(version_id, changelog_id, change_title, change_message, affected_db)
 			VALUES (' . $db->escapeNumber($var['version_id']) . ', ' . $db->escapeNumber($changelog_id) . ', ' . $db->escapeString($change_title) . ', ' . $db->escapeString($change_message) . ', ' . $db->escapeString($affected_db) . ')');
 

--- a/src/admin/Default/changelog_set_live_processing.php
+++ b/src/admin/Default/changelog_set_live_processing.php
@@ -3,20 +3,20 @@
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 $db = Smr\Database::getInstance();
-$db->query('UPDATE version
+$db->write('UPDATE version
 			SET went_live = ' . $db->escapeNumber(Smr\Epoch::time()) . '
 			WHERE version_id = ' . $db->escapeNumber($var['version_id'])
 		   );
 
 // Initialize the next version (since the version set live is not always the
 // last one, we INSERT IGNORE to skip this step in this case).
-$db->query('SELECT * FROM version WHERE version_id = ' . $db->escapeNumber($var['version_id']));
-$db->requireRecord();
-$versionID = $db->getInt('version_id') + 1;
-$major = $db->getInt('major_version');
-$minor = $db->getInt('minor_version');
-$patch = $db->getInt('patch_level') + 1;
-$db->query('INSERT IGNORE INTO version (version_id, major_version, minor_version, patch_level, went_live) VALUES
+$dbResult = $db->read('SELECT * FROM version WHERE version_id = ' . $db->escapeNumber($var['version_id']));
+$dbRecord = $dbResult->record();
+$versionID = $dbRecord->getInt('version_id') + 1;
+$major = $dbRecord->getInt('major_version');
+$minor = $dbRecord->getInt('minor_version');
+$patch = $dbRecord->getInt('patch_level') + 1;
+$db->write('INSERT IGNORE INTO version (version_id, major_version, minor_version, patch_level, went_live) VALUES
 			('.$db->escapeNumber($versionID) . ',' . $db->escapeNumber($major) . ',' . $db->escapeNumber($minor) . ',' . $db->escapeNumber($patch) . ',0);');
 
 Page::create('skeleton.php', 'changelog.php')->go();

--- a/src/admin/Default/comp_share.php
+++ b/src/admin/Default/comp_share.php
@@ -19,7 +19,7 @@ $dbResult = $db->read('SELECT * FROM multi_checking_cookie WHERE `use` = \'TRUE\
 $tables = [];
 foreach ($dbResult->records() as $dbRecord) {
 	//get info about linked IDs
-	$accountIDs = explode('-', $dbRecord->getField('array'));
+	$accountIDs = explode('-', $dbRecord->getString('array'));
 
 	//make sure this is good data.
 	$cookieVersion = array_shift($accountIDs);

--- a/src/admin/Default/comp_share.php
+++ b/src/admin/Default/comp_share.php
@@ -11,17 +11,15 @@ $skipUnusedAccs = true;
 $skipClosedAccs = false;
 $skipExceptions = false;
 
-//extra db object and other vars
-$db2 = Smr\Database::getInstance();
 $used = array();
 
 //check the db and get the info we need
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM multi_checking_cookie WHERE `use` = \'TRUE\'');
+$dbResult = $db->read('SELECT * FROM multi_checking_cookie WHERE `use` = \'TRUE\'');
 $tables = [];
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	//get info about linked IDs
-	$accountIDs = explode('-', $db->getField('array'));
+	$accountIDs = explode('-', $dbRecord->getField('array'));
 
 	//make sure this is good data.
 	$cookieVersion = array_shift($accountIDs);
@@ -32,7 +30,7 @@ while ($db->nextRecord()) {
 	//how many are they linked to?
 	$rows = count($accountIDs);
 
-	$currTabAccId = $db->getInt('account_id');
+	$currTabAccId = $dbRecord->getInt('account_id');
 
 	//if this account was listed with another we can skip it.
 	if (isset($used[$currTabAccId])) {
@@ -40,48 +38,55 @@ while ($db->nextRecord()) {
 	}
 
 	if ($rows > 1) {
-		$db2->query('SELECT account_id, login FROM account WHERE account_id =' . $db2->escapeNumber($currTabAccId) . ($skipUnusedAccs ? ' AND last_login > ' . $db2->escapeNumber(Smr\Epoch::time() - 86400 * 30) : '') . ' LIMIT 1');
-		if ($db2->nextRecord()) {
-			$currTabAccLogin = $db2->getField('login');
-		} else {
+		$dbResult2 = $db->read('SELECT login FROM account WHERE account_id =' . $db->escapeNumber($currTabAccId) . ($skipUnusedAccs ? ' AND last_login > ' . $db->escapeNumber(Smr\Epoch::time() - 86400 * 30) : '') . ' LIMIT 1');
+		if (!$dbResult2->hasRecord()) {
 			continue;
 		}
+		$currTabAccLogin = $dbResult2->record()->getField('login');
 
 		if ($skipClosedAccs) {
-			$db2->query('SELECT * FROM account_is_closed WHERE account_id = ' . $db2->escapeNumber($currTabAccId));
-			if ($db2->nextRecord()) {
+			$dbResult2 = $db->read('SELECT 1 FROM account_is_closed WHERE account_id = ' . $db->escapeNumber($currTabAccId));
+			if ($dbResult2->hasRecord()) {
 				continue;
 			}
 		}
 
 		if ($skipExceptions) {
-			$db2->query('SELECT * FROM account_exceptions WHERE account_id = ' . $db2->escapeNumber($currTabAccId));
-			if ($db2->nextRecord()) {
+			$dbResult2 = $db->read('SELECT 1 FROM account_exceptions WHERE account_id = ' . $db->escapeNumber($currTabAccId));
+			if ($dbResult2->hasRecord()) {
 				continue;
 			}
 		}
 
 		$rows = [];
 		foreach ($accountIDs as $currLinkAccId) {
-			$db2->query('SELECT account_id, login, email, validated, last_login, (SELECT ip FROM account_has_ip WHERE account_id = account.account_id GROUP BY ip ORDER BY COUNT(ip) DESC LIMIT 1) common_ip FROM account WHERE account_id = ' . $db2->escapeNumber($currLinkAccId) . ($skipUnusedAccs ? ' AND last_login > ' . $db2->escapeNumber(Smr\Epoch::time() - 86400 * 30) : ''));
-			if ($db2->nextRecord()) {
-				$currLinkAccLogin = $db2->getField('login');
-			} else {
+			$dbResult2 = $db->read('SELECT account_id, login, email, validated, last_login, (SELECT ip FROM account_has_ip WHERE account_id = account.account_id GROUP BY ip ORDER BY COUNT(ip) DESC LIMIT 1) common_ip FROM account WHERE account_id = ' . $db->escapeNumber($currLinkAccId) . ($skipUnusedAccs ? ' AND last_login > ' . $db->escapeNumber(Smr\Epoch::time() - 86400 * 30) : ''));
+			if (!$dbResult2->hasRecord()) {
 				continue;
 			}
+			$dbRecord2 = $dbResult2->record();
+			$currLinkAccLogin = $dbRecord->getField('login');
 
-			$style = $db2->getBoolean('validated') ? '' : ' style="text-decoration:line-through;"';
-			$email = $db2->getField('email');
-			$valid = $db2->getBoolean('validated') ? 'Valid' : 'Invalid';
-			$common_ip = $db2->getField('common_ip');
-			$last_login = date($account->getDateTimeFormat(), $db2->getInt('last_login'));
+			$style = $dbRecord2->getBoolean('validated') ? '' : ' style="text-decoration:line-through;"';
+			$email = $dbRecord2->getField('email');
+			$valid = $dbRecord2->getBoolean('validated') ? 'Valid' : 'Invalid';
+			$common_ip = $dbRecord2->getField('common_ip');
+			$last_login = date($account->getDateTimeFormat(), $dbRecord2->getInt('last_login'));
 
-			$db2->query('SELECT * FROM account_is_closed WHERE account_id = ' . $db2->escapeNumber($currLinkAccId));
-			$isDisabled = $db2->nextRecord();
-			$suspicion = $db2->getField('suspicion');
+			$dbResult2 = $db->read('SELECT * FROM account_is_closed WHERE account_id = ' . $db->escapeNumber($currLinkAccId));
+			$isDisabled = $dbResult2->hasRecord();
+			if ($isDisabled) {
+				$suspicion = $dbResult2->record()->getField('suspicion');
+			} else {
+				$suspicion = '';
+			}
 
-			$db2->query('SELECT * FROM account_exceptions WHERE account_id = ' . $db2->escapeNumber($currLinkAccId));
-			$exception = $db2->nextRecord() ? $db2->getField('reason') : '';
+			$dbResult2 = $db->read('SELECT * FROM account_exceptions WHERE account_id = ' . $db->escapeNumber($currLinkAccId));
+			if ($dbResult2->hasRecord()) {
+				$exception = $dbResult2->record()->getField('reason');
+			} else {
+				$exception = '';
+			}
 
 			$used[$currLinkAccId] = TRUE;
 

--- a/src/admin/Default/enable_game.php
+++ b/src/admin/Default/enable_game.php
@@ -13,10 +13,10 @@ if (isset($var['processing_msg'])) {
 
 // Get the list of disabled games
 $db = Smr\Database::getInstance();
-$db->query('SELECT game_name, game_id FROM game WHERE enabled=' . $db->escapeBoolean(false));
+$dbResult = $db->read('SELECT game_name, game_id FROM game WHERE enabled=' . $db->escapeBoolean(false));
 $disabledGames = array();
-while ($db->nextRecord()) {
-	$disabledGames[$db->getInt('game_id')] = $db->getField('game_name');
+foreach ($dbResult->records() as $dbRecord) {
+	$disabledGames[$dbRecord->getInt('game_id')] = $dbRecord->getField('game_name');
 }
 krsort($disabledGames);
 $template->assign('DisabledGames', $disabledGames);

--- a/src/admin/Default/form_open_processing.php
+++ b/src/admin/Default/form_open_processing.php
@@ -3,6 +3,6 @@
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 $db = Smr\Database::getInstance();
-$db->query('UPDATE open_forms SET open = ' . $db->escapeBoolean(!$var['is_open']) . ' WHERE type=' . $db->escapeString($var['type']));
+$db->write('UPDATE open_forms SET open = ' . $db->escapeBoolean(!$var['is_open']) . ' WHERE type=' . $db->escapeString($var['type']));
 
 Page::create('skeleton.php', 'form_open.php')->go();

--- a/src/admin/Default/game_delete.php
+++ b/src/admin/Default/game_delete.php
@@ -8,11 +8,11 @@ $container = Page::create('skeleton.php', 'game_delete_confirm.php');
 $template->assign('ConfirmHREF', $container->href());
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT game_id, game_name FROM game ORDER BY game_id DESC');
+$dbResult = $db->read('SELECT game_id, game_name FROM game ORDER BY game_id DESC');
 $games = [];
-while ($db->nextRecord()) {
-	$name = $db->getField('game_name');
-	$game_id = $db->getInt('game_id');
+foreach ($dbResult->records() as $dbRecord) {
+	$name = $dbRecord->getField('game_name');
+	$game_id = $dbRecord->getInt('game_id');
 	$games[] = [
 		'game_id' => $game_id,
 		'display' => '(' . $game_id . ') ' . $name,

--- a/src/admin/Default/game_delete_processing.php
+++ b/src/admin/Default/game_delete_processing.php
@@ -2,9 +2,7 @@
 
 create_error('Deleting games is disabled!');
 
-// additional db objects
 $db = Smr\Database::getInstance();
-$db2 = Smr\Database::getInstance();
 
 $smr_db_sql = array();
 $history_db_sql = array();
@@ -22,27 +20,27 @@ if ($action == 'Yes') {
 	$game_id = $var['delete_game_id'];
 
 	if ($save) {
-		$db->query('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id));
+		$dbResult = $db->read('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id));
 
-		while ($db->nextRecord()) {
-			$id = $db->getInt('alliance_id');
+		foreach ($dbResult->records() as $dbRecord) {
+			$id = $dbRecord->getInt('alliance_id');
 			//we need info for forces
 			//populate alliance list
-			$db2->query('SELECT * FROM player
-						WHERE alliance_id = '.$db2->escapeNumber($id) . '
-							AND game_id = '.$db2->escapeNumber($game_id));
+			$dbResult2 = $db->read('SELECT * FROM player
+						WHERE alliance_id = '.$db->escapeNumber($id) . '
+							AND game_id = '.$db->escapeNumber($game_id));
 			$list = array(0);
-			while ($db2->nextRecord()) {
-				$list[] = $db2->getInt('account_id');
+			foreach ($dbResult2->records() as $dbRecord2) {
+				$list[] = $dbRecord2->getInt('account_id');
 			}
-			$db2->query('SELECT sum(mines) as sum_m, sum(combat_drones) as cds, sum(scout_drones) as sds
+			$dbResult2 = $db->read('SELECT sum(mines) as sum_m, sum(combat_drones) as cds, sum(scout_drones) as sds
 						FROM sector_has_forces
-						WHERE owner_id IN ('.$db2->escapeArray($list) . ') AND game_id = ' . $db2->escapeNumber($game_id));
-			if ($db2->nextRecord()) {
-
-				$mines = $db2->getInt('sum_m');
-				$cds = $db2->getInt('cds');
-				$sds = $db2->getInt('sds');
+						WHERE owner_id IN ('.$db->escapeArray($list) . ') AND game_id = ' . $db->escapeNumber($game_id));
+			if ($dbResult2->hasRecord()) {
+				$dbRecord2 = $dbResult2->record();
+				$mines = $dbRecord2->getInt('sum_m');
+				$cds = $dbRecord2->getInt('cds');
+				$sds = $dbRecord2->getInt('sds');
 			} else {
 				$mines = 0;
 				$cds = 0;
@@ -50,10 +48,10 @@ if ($action == 'Yes') {
 			}
 
 			// get info we want
-			$name = $db->getField('alliance_name');
-			$leader = $db->getInt('leader_id');
-			$kills = $db->getInt('alliance_kills');
-			$deaths = $db->getInt('alliance_deaths');
+			$name = $dbRecord->getField('alliance_name');
+			$leader = $dbRecord->getInt('leader_id');
+			$kills = $dbRecord->getInt('alliance_kills');
+			$deaths = $dbRecord->getInt('alliance_deaths');
 			// insert into history db
 			$history_db_sql[] = 'INSERT INTO alliance (game_id, alliance_id, leader_id, kills, deaths, alliance_name, mines, cds, sds) ' .
 								'VALUES (' . $db->escapeNumber($game_id) . ', ' . $db->escapeNumber($id) . ', ' . $db->escapeNumber($leader) . ', ' . $db->escapeNumber($kills) . ', ' . $db->escapeNumber($deaths) . ', ' . $db->escapeString($name) . ', ' . $db->escapeNumber($mines) . ', ' . $db->escapeNumber($cds) . ', ' . $db->escapeNumber($sds) . ')';
@@ -74,12 +72,12 @@ if ($action == 'Yes') {
 
 	if ($save) {
 
-		$db->query('SELECT * FROM alliance_vs_alliance WHERE game_id = ' . $db->escapeNumber($game_id));
-		while ($db->nextRecord()) {
+		$dbResult = $db->read('SELECT * FROM alliance_vs_alliance WHERE game_id = ' . $db->escapeNumber($game_id));
+		foreach ($dbResult->records() as $dbRecord) {
 
-			$alliance_1 = $db->getInt('alliance_id_1');
-			$alliance_2 = $db->getInt('alliance_id_2');
-			$kills = $db->getInt('kills');
+			$alliance_1 = $dbRecord->getInt('alliance_id_1');
+			$alliance_2 = $dbRecord->getInt('alliance_id_2');
+			$kills = $dbRecord->getInt('kills');
 			$history_db_sql[] = 'INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) ' .
 								'VALUES (' . $game_id . ', ' . $alliance_1 . ', ' . $alliance_2 . ', ' . $kills . ')';
 
@@ -114,14 +112,14 @@ if ($action == 'Yes') {
 
 	if ($save) {
 
-		$db->query('SELECT * FROM news WHERE game_id = ' . $game_id . ' AND type = \'regular\'');
+		$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $game_id . ' AND type = \'regular\'');
 		$id = 1;
 
-		while ($db->nextRecord()) {
+		foreach ($dbResult->records() as $dbRecord) {
 
 			// get info we want
-			$time = $db->getInt('time');
-			$msg = $db->getField('news_message');
+			$time = $dbRecord->getInt('time');
+			$msg = $dbRecord->getField('news_message');
 
 			// insert into history db
 			$history_db_sql[] = 'INSERT INTO news (game_id, news_id, time, message) VALUES (' . $game_id . ', ' . $id . ', ' . $time . ', ' . $db->escapeString($msg) . ')';
@@ -134,25 +132,34 @@ if ($action == 'Yes') {
 
 	if ($save) {
 
-		$db->query('SELECT * FROM planet WHERE game_id = ' . $db->escapeNumber($game_id));
+		$dbResult = $db->read('SELECT * FROM planet WHERE game_id = ' . $db->escapeNumber($game_id));
 
-		while ($db->nextRecord()) {
+		foreach ($dbResult->records() as $dbRecord) {
 
 			// get info we want
-			$sector = $db->getInt('sector_id');
-			$owner = $db->getInt('owner_id');
+			$sector = $dbRecord->getInt('sector_id');
+			$owner = $dbRecord->getInt('owner_id');
 
-			$db2->query('SELECT * FROM planet_has_building WHERE game_id = ' . $game_id . ' AND sector_id = ' . $sector . ' AND construction_id = 1');
-			if ($db2->nextRecord()) $gens = $db2->getInt('amount');
-			else $gens = 0;
+			$dbResult2 = $db->read('SELECT * FROM planet_has_building WHERE game_id = ' . $game_id . ' AND sector_id = ' . $sector . ' AND construction_id = 1');
+			if ($dbResult2->hasRecord()) {
+				$gens = $dbResult2->record()->getInt('amount');
+			} else {
+				$gens = 0;
+			}
 
-			$db2->query('SELECT * FROM planet_has_building WHERE game_id = ' . $game_id . ' AND sector_id = ' . $sector . ' AND construction_id = 2');
-			if ($db2->nextRecord()) $hangs = $db2->getInt('amount');
-			else $hangs = 0;
+			$dbResult2 = $db->read('SELECT * FROM planet_has_building WHERE game_id = ' . $game_id . ' AND sector_id = ' . $sector . ' AND construction_id = 2');
+			if ($dbResult2->hasRecord()) {
+				$hangs = $dbResult2->record()->getInt('amount');
+			} else {
+				$hangs = 0;
+			}
 
-			$db2->query('SELECT * FROM planet_has_building WHERE game_id = ' . $game_id . ' AND sector_id = ' . $sector . ' AND construction_id = 3');
-			if ($db2->nextRecord()) $turs = $db2->getInt('amount');
-			else $turs = 0;
+			$dbResult2 = $db->read('SELECT * FROM planet_has_building WHERE game_id = ' . $game_id . ' AND sector_id = ' . $sector . ' AND construction_id = 3');
+			if ($dbResult2->hasRecord()) {
+				$turs = $dbResult2->record()->getInt('amount');
+			} else {
+				$turs = 0;
+			}
 
 			// insert into history db
 			$history_db_sql[] = 'INSERT INTO planet (game_id, sector_id, owner_id, generators, hangers, turrets) VALUES ' .
@@ -169,34 +176,37 @@ if ($action == 'Yes') {
 
 	if ($save) {
 
-		$db->query('SELECT * FROM player WHERE game_id = ' . $game_id);
+		$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $game_id);
 
-		while ($db->nextRecord()) {
+		foreach ($dbResult->records() as $dbRecord) {
 
 			// get info we want
-			$acc_id = $db->getInt('account_id');
-			$name = stripslashes($db->getField('player_name'));
-			$id = $db->getInt('player_id');
-			$exp = $db->getInt('experience');
-			$ship = $db->getInt('ship_type_id');
-			$race = $db->getInt('race_id');
-			$align = $db->getInt('alignment');
-			$alli = $db->getInt('alliance_id');
-			$kills = $db->getInt('kills');
-			$deaths = $db->getInt('deaths');
+			$acc_id = $dbRecord->getInt('account_id');
+			$name = stripslashes($dbRecord->getField('player_name'));
+			$id = $dbRecord->getInt('player_id');
+			$exp = $dbRecord->getInt('experience');
+			$ship = $dbRecord->getInt('ship_type_id');
+			$race = $dbRecord->getInt('race_id');
+			$align = $dbRecord->getInt('alignment');
+			$alli = $dbRecord->getInt('alliance_id');
+			$kills = $dbRecord->getInt('kills');
+			$deaths = $dbRecord->getInt('deaths');
 
 			$amount = 0;
 			$smrCredits = 0;
-			$db2->query('SELECT sum(amount) as bounty_am, sum(smr_credits) as bounty_cred FROM bounty WHERE game_id = ' . $game_id . ' AND account_id = ' . $acc_id . ' AND claimer_id = 0');
-			if ($db2->nextRecord()) {
-				if (is_int($db2->getField('bounty_am'))) $amount = $db2->getInt('bounty_am');
-				if (is_int($db2->getField('bounty_cred'))) $smrCredits = $db2->getInt('bounty_cred');
-
+			$dbResult2 = $db->read('SELECT sum(amount) as bounty_am, sum(smr_credits) as bounty_cred FROM bounty WHERE game_id = ' . $game_id . ' AND account_id = ' . $acc_id . ' AND claimer_id = 0');
+			if ($dbResult2->hasRecord()) {
+				$dbRecord2 = $dbResult2->record();
+				$amount = $dbRecord2->getInt('bounty_am');
+				$smrCredits = $dbRecord2->getInt('bounty_cred');
 			}
 
-			$db2->query('SELECT * FROM ship_has_name WHERE game_id = ' . $game_id . ' AND account_id = ' . $acc_id);
-			if ($db2->nextRecord()) $ship_name = $db2->getField('ship_name');
-			else $ship_name = 'None';
+			$dbResult2 = $db->read('SELECT * FROM ship_has_name WHERE game_id = ' . $game_id . ' AND account_id = ' . $acc_id);
+			if ($dbResult2->hasRecord()) {
+				$ship_name = $dbResult2->record()->getField('ship_name');
+			} else {
+				$ship_name = 'None';
+			}
 
 			// insert into history db
 			$history_db_sql[] = 'INSERT INTO player (account_id, game_id, player_name, player_id, experience, ship, race, alignment, alliance_id, kills, deaths, bounty, bounty_cred, ship_name) ' .
@@ -228,31 +238,23 @@ if ($action == 'Yes') {
 
 	if ($save) {
 
-		$db->query('SELECT * FROM sector WHERE game_id = ' . $game_id);
+		$dbResult = $db->read('SELECT * FROM sector WHERE game_id = ' . $game_id);
 
-		while ($db->nextRecord()) {
+		foreach ($dbResult->records() as $dbRecord) {
 
 			// get info we want
-			$sector = $db->getInt('sector_id');
-			$kills = $db->getInt('battles');
-			$gal_id = $db->getInt('galaxy_id');
+			$sector = $dbRecord->getInt('sector_id');
+			$kills = $dbRecord->getInt('battles');
+			$gal_id = $dbRecord->getInt('galaxy_id');
 
-			$db2->query('SELECT sum(mines) as sum_mines, sum(combat_drones) as cds, sum(scout_drones) as sds FROM sector_has_forces ' .
+			$dbResult2 = $db->read('SELECT sum(mines) as sum_mines, sum(combat_drones) as cds, sum(scout_drones) as sds FROM sector_has_forces ' .
 						'WHERE sector_id = ' . $sector . ' AND game_id = ' . $game_id . ' GROUP BY sector_id');
-			if ($db2->nextRecord()) {
+			if ($dbResult2->hasRecord()) {
 
-				$mines = $db2->getInt('sum_mines');
-				$cds = $db2->getInt('cds');
-				$sds = $db2->getInt('sds');
-				if (!is_numeric($mines)) {
-					$mines = 0;
-				}
-				if (!is_numeric($cds)) {
-					$cds = 0;
-				}
-				if (!is_numeric($sds)) {
-					$sds = 0;
-				}
+				$dbRecord2 = $dbResult2->record();
+				$mines = $dbRecord2->getInt('sum_mines');
+				$cds = $dbRecord2->getInt('cds');
+				$sds = $dbRecord2->getInt('sds');
 
 			} else {
 
@@ -284,14 +286,14 @@ if ($action == 'Yes') {
 	// now do the sql stuff
 	foreach ($smr_db_sql as $sql) {
 
-		$db->query($sql);
+		$db->write($sql);
 
 	}
 
 	$db = new SmrHistoryMySqlDatabase();
 	foreach ($history_db_sql as $sql) {
 
-		$db->query($sql);
+		$db->write($sql);
 
 	}
 

--- a/src/admin/Default/game_delete_processing.php
+++ b/src/admin/Default/game_delete_processing.php
@@ -182,7 +182,7 @@ if ($action == 'Yes') {
 
 			// get info we want
 			$acc_id = $dbRecord->getInt('account_id');
-			$name = stripslashes($dbRecord->getField('player_name'));
+			$name = $dbRecord->getString('player_name');
 			$id = $dbRecord->getInt('player_id');
 			$exp = $dbRecord->getInt('experience');
 			$ship = $dbRecord->getInt('ship_type_id');

--- a/src/admin/Default/game_status.php
+++ b/src/admin/Default/game_status.php
@@ -6,8 +6,8 @@ $processingHREF = Page::create('game_status_processing.php')->href();
 $template->assign('ProcessingHREF', $processingHREF);
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM game_disable');
-if (!$db->getNumRows()) {
+$dbResult = $db->read('SELECT 1 FROM game_disable');
+if (!$dbResult->hasRecord()) {
 	$template->assign('PageTopic', 'Close Server');
 	$template->assign('ServerIsOpen', true);
 } else {

--- a/src/admin/Default/game_status_processing.php
+++ b/src/admin/Default/game_status_processing.php
@@ -7,11 +7,11 @@ $container = Page::create('skeleton.php', 'admin_tools.php');
 $action = Request::get('action');
 if ($action == 'Close') {
 	$reason = Request::get('close_reason');
-	$db->query('REPLACE INTO game_disable (reason) VALUES (' . $db->escapeString($reason) . ');');
-	$db->query('DELETE FROM active_session;');
+	$db->write('REPLACE INTO game_disable (reason) VALUES (' . $db->escapeString($reason) . ');');
+	$db->write('DELETE FROM active_session;');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have closed the server. You will now be logged out!';
 } elseif ($action == 'Open') {
-	$db->query('DELETE FROM game_disable;');
+	$db->write('DELETE FROM game_disable;');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have opened the server.';
 }
 

--- a/src/admin/Default/ip_view_results.php
+++ b/src/admin/Default/ip_view_results.php
@@ -8,7 +8,6 @@ $variable = $session->getRequestVar('variable');
 $type = $session->getRequestVar('type');
 
 $db = Smr\Database::getInstance();
-$db2 = Smr\Database::getInstance();
 
 $container = Page::create('skeleton.php', 'ip_view.php');
 $template->assign('BackHREF', $container->href());
@@ -29,13 +28,13 @@ if ($type == 'comp_share') {
 	//=========================================================
 
 	//we are listing ALL IPs
-	$db->query('SELECT * FROM account_has_ip GROUP BY ip, account_id ORDER BY ip');
+	$dbResult = $db->read('SELECT * FROM account_has_ip GROUP BY ip, account_id ORDER BY ip');
 	$ip_array = array();
 	//make sure we have enough but not too mant to reduce lag
-	while ($db->nextRecord()) {
-		$id = $db->getInt('account_id');
-		$ip = $db->getField('ip');
-		$host = $db->getField('host');
+	foreach ($dbResult->records() as $dbRecord) {
+		$id = $dbRecord->getInt('account_id');
+		$ip = $dbRecord->getField('ip');
+		$host = $dbRecord->getField('host');
 		$ip_array[] = array('ip' => $ip, 'id' => $id, 'host' => $host);
 	}
 
@@ -67,9 +66,9 @@ if ($type == 'comp_share') {
 		$row['matches'] = $matches;
 
 		if ($matches) {
-			$db2->query('SELECT * FROM account_exceptions WHERE account_id = ' . $db2->escapeNumber($account_id));
-			if ($db2->nextRecord()) {
-				$ex = $db2->getField('reason');
+			$dbResult2 = $db->read('SELECT * FROM account_exceptions WHERE account_id = ' . $db->escapeNumber($account_id));
+			if ($dbResult2->hasRecord()) {
+				$ex = $dbResult2->record()->getField('reason');
 			} else {
 				$ex = '';
 			}
@@ -104,9 +103,9 @@ if ($type == 'comp_share') {
 	$template->assign('BanAccountID', $accountID);
 	$summary = 'Account ' . $accountID . ' has had the following IPs at the following times.';
 	$template->assign('Summary', $summary);
-	$db2->query('SELECT * FROM account_exceptions WHERE account_id = ' . $db->escapeNumber($variable));
-	if ($db2->nextRecord()) {
-		$ex = $db2->getField('reason');
+	$dbResult = $db->read('SELECT * FROM account_exceptions WHERE account_id = ' . $db->escapeNumber($variable));
+	if ($dbResult->hasRecord()) {
+		$ex = $dbResult->record()->getField('reason');
 		$template->assign('Exception', $ex);
 	}
 	$viewAccount = SmrAccount::getAccount($accountID);
@@ -115,12 +114,12 @@ if ($type == 'comp_share') {
 		$template->assign('CloseReason', $disabled['Reason']);
 	}
 	$rows = [];
-	$db->query('SELECT * FROM account_has_ip WHERE account_id = ' . $db->escapeNumber($variable) . ' ORDER BY time');
-	while ($db->nextRecord()) {
+	$dbResult = $db->read('SELECT * FROM account_has_ip WHERE account_id = ' . $db->escapeNumber($variable) . ' ORDER BY time');
+	foreach ($dbResult->records() as $dbRecord) {
 		$rows[] = [
-			'ip' => $db->getField('ip'),
-			'date' => date($account->getDateTimeFormat(), $db->getInt('time')),
-			'host' => $db->getField('host'),
+			'ip' => $dbRecord->getField('ip'),
+			'date' => date($account->getDateTimeFormat(), $dbRecord->getInt('time')),
+			'host' => $dbRecord->getField('host'),
 		];
 	}
 	$template->assign('Rows', $rows);
@@ -137,7 +136,7 @@ if ($type == 'comp_share') {
 			$host = 'unknown';
 		}
 		$summary = 'The following accounts have the IP address ' . $ip . ' (' . $host . ')';
-		$db->query('SELECT * FROM account_has_ip WHERE ip = ' . $db->escapeString($ip) . ' ORDER BY account_id');
+		$dbResult = $db->read('SELECT * FROM account_has_ip WHERE ip = ' . $db->escapeString($ip) . ' ORDER BY account_id');
 
 	} elseif ($type == 'alliance_ips') {
 		//=========================================================
@@ -150,21 +149,21 @@ if ($type == 'comp_share') {
 		$allianceID = (int)$allianceID;
 		$gameID = (int)$gameID;
 		$name = SmrAlliance::getAlliance($allianceID, $gameID)->getAllianceDisplayName();
-		$db->query('SELECT ip.* FROM account_has_ip ip JOIN player USING(account_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND alliance_id = ' . $db->escapeNumber($allianceID) . ' ORDER BY ip');
+		$dbResult = $db->read('SELECT ip.* FROM account_has_ip ip JOIN player USING(account_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND alliance_id = ' . $db->escapeNumber($allianceID) . ' ORDER BY ip');
 		$summary = 'Listing all IPs for alliance ' . $name . ' in game with ID ' . $gameID;
 
 	} elseif ($type == 'wild_log') {
 		//=========================================================
 		// List all IPs for a wildcard login name
 		//=========================================================
-		$db->query('SELECT ip.* FROM account_has_ip ip JOIN account USING(account_id) WHERE login LIKE ' . $db->escapeString($variable) . ' ORDER BY login, ip');
+		$dbResult = $db->read('SELECT ip.* FROM account_has_ip ip JOIN account USING(account_id) WHERE login LIKE ' . $db->escapeString($variable) . ' ORDER BY login, ip');
 		$summary = 'Listing all IPs for login names LIKE ' . $variable;
 
 	} elseif ($type == 'wild_in') {
 		//=========================================================
 		// List all IPs for a wildcard ingame name
 		//=========================================================
-		$db->query('SELECT ip.* FROM account_has_ip ip JOIN player USING(account_id) WHERE player_name LIKE ' . $db->escapeString($variable) . ' ORDER BY player_name, ip');
+		$dbResult = $db->read('SELECT ip.* FROM account_has_ip ip JOIN player USING(account_id) WHERE player_name LIKE ' . $db->escapeString($variable) . ' ORDER BY player_name, ip');
 		$summary = 'Listing all IPs for ingame names LIKE ' . $variable;
 
 	} elseif ($type == 'compare') {
@@ -172,7 +171,7 @@ if ($type == 'comp_share') {
 		// List all IPs for specified players
 		//=========================================================
 		$list = preg_split('/[,]+[\s]/', $variable);
-		$db->query('SELECT ip.* FROM account_has_ip ip JOIN player USING(account_id) WHERE player_name IN (' . $db->escapeArray($list) . ') ORDER BY ip');
+		$dbResult = $db->read('SELECT ip.* FROM account_has_ip ip JOIN player USING(account_id) WHERE player_name IN (' . $db->escapeArray($list) . ') ORDER BY ip');
 		$summary = 'Listing all IPs for ingame names ' . $variable;
 
 	} elseif ($type == 'compare_log') {
@@ -180,22 +179,24 @@ if ($type == 'comp_share') {
 		// List all IPs for specified logins
 		//=========================================================
 		$list = preg_split('/[,]+[\s]/', $variable);
-		$db->query('SELECT ip.* FROM account_has_ip ip JOIN account USING(account_id) WHERE login IN (' . $db->escapeArray($list) . ') ORDER BY ip');
+		$dbResult = $db->read('SELECT ip.* FROM account_has_ip ip JOIN account USING(account_id) WHERE login IN (' . $db->escapeArray($list) . ') ORDER BY ip');
 		$summary = 'Listing all IPs for logins ' . $variable;
 
 	} elseif ($type == 'wild_ip') {
 		//=========================================================
 		// Wildcard IP search
 		//=========================================================
-		$db->query('SELECT * FROM account_has_ip WHERE ip LIKE ' . $db->escapeString($variable) . ' GROUP BY account_id, ip ORDER BY time DESC, ip');
+		$dbResult = $db->read('SELECT * FROM account_has_ip WHERE ip LIKE ' . $db->escapeString($variable) . ' GROUP BY account_id, ip ORDER BY time DESC, ip');
 		$summary = 'Listing all IPs LIKE ' . $variable;
 
 	} elseif ($type == 'wild_host') {
 		//=========================================================
 		// Wildcard host search
 		//=========================================================
-		$db->query('SELECT * FROM account_has_ip WHERE host LIKE ' . $db->escapeString($variable) . ' GROUP BY account_id, ip ORDER BY time, ip');
+		$dbResult = $db->read('SELECT * FROM account_has_ip WHERE host LIKE ' . $db->escapeString($variable) . ' GROUP BY account_id, ip ORDER BY time, ip');
 		$summary = 'Listing all hosts LIKE ' . $variable;
+	} else {
+		throw new Exception('Unknown type: ' . $type);
 	}
 	$template->assign('Summary', $summary);
 
@@ -204,11 +205,11 @@ if ($type == 'comp_share') {
 	$last_ip = null;
 
 	$rows = [];
-	while ($db->nextRecord()) {
-		$id = $db->getInt('account_id');
-		$time = $db->getInt('time');
-		$ip = $db->getField('ip');
-		$host = $db->getField('host');
+	foreach ($dbResult->records() as $dbRecord) {
+		$id = $dbRecord->getInt('account_id');
+		$time = $dbRecord->getInt('time');
+		$ip = $dbRecord->getField('ip');
+		$host = $dbRecord->getField('host');
 
 		if ($id == $last_id && $ip == $last_ip) {
 			continue;
@@ -216,14 +217,14 @@ if ($type == 'comp_share') {
 		$acc = SmrAccount::getAccount($id);
 		$disabled = $acc->isDisabled();
 		$close_reason = $disabled ? $disabled['Reason'] : '';
-		$db2->query('SELECT * FROM player WHERE account_id = ' . $db2->escapeNumber($id));
+		$dbResult2 = $db->read('SELECT * FROM player WHERE account_id = ' . $db->escapeNumber($id));
 		$names = array();
-		while ($db2->nextRecord()) {
-			$names[] = stripslashes($db2->getField('player_name'));
+		foreach ($dbResult2->records() as $dbRecord2) {
+			$names[] = stripslashes($dbRecord2->getField('player_name'));
 		}
-		$db2->query('SELECT * FROM account_exceptions WHERE account_id = ' . $db2->escapeNumber($id));
-		if ($db2->nextRecord()) {
-			$ex = $db2->getField('reason');
+		$dbResult2 = $db->read('SELECT * FROM account_exceptions WHERE account_id = ' . $db->escapeNumber($id));
+		if ($dbResult2->hasRecord()) {
+			$ex = $dbResult2->record()->getField('reason');
 		} else {
 			$ex = '';
 		}

--- a/src/admin/Default/ip_view_results.php
+++ b/src/admin/Default/ip_view_results.php
@@ -211,7 +211,7 @@ if ($type == 'comp_share') {
 		$ip = $dbRecord->getField('ip');
 		$host = $dbRecord->getField('host');
 
-		if ($id == $last_id && $ip == $last_ip) {
+		if ($id === $last_id && $ip === $last_ip) {
 			continue;
 		}
 		$acc = SmrAccount::getAccount($id);
@@ -220,7 +220,7 @@ if ($type == 'comp_share') {
 		$dbResult2 = $db->read('SELECT * FROM player WHERE account_id = ' . $db->escapeNumber($id));
 		$names = array();
 		foreach ($dbResult2->records() as $dbRecord2) {
-			$names[] = stripslashes($dbRecord2->getField('player_name'));
+			$names[] = $dbRecord2->getString('player_name');
 		}
 		$dbResult2 = $db->read('SELECT * FROM account_exceptions WHERE account_id = ' . $db->escapeNumber($id));
 		if ($dbResult2->hasRecord()) {

--- a/src/admin/Default/location_edit.php
+++ b/src/admin/Default/location_edit.php
@@ -41,20 +41,10 @@ if (isset($var['location_type_id'])) {
 		$location->setUG(isset($_REQUEST['ug']));
 	}
 
-
 	$template->assign('Location', $location);
 	$template->assign('ShipTypes', SmrShipType::getAll());
 	$template->assign('Weapons', SmrWeaponType::getAllWeaponTypes());
-
-
-	$db = Smr\Database::getInstance();
-	$db->query('SELECT * FROM hardware_type');
-	$hardware = array();
-	while ($db->nextRecord()) {
-		$hardware[$db->getInt('hardware_type_id')] = array('ID' => $db->getInt('hardware_type_id'),
-														'Name' => $db->getField('hardware_name'));
-	}
-	$template->assign('AllHardware', $hardware);
+	$template->assign('AllHardware', Globals::getHardwareTypes());
 } else {
 	$template->assign('Locations', SmrLocation::getAllLocations());
 }

--- a/src/admin/Default/log_anonymous_account.php
+++ b/src/admin/Default/log_anonymous_account.php
@@ -20,7 +20,7 @@ $dbResult = $db->read('SELECT * FROM anon_bank_transactions
             ORDER BY game_id DESC, anon_id ASC');
 $anon_logs = [];
 foreach ($dbResult->records() as $dbRecord) {
-	$transaction = strtolower($dbRecord->getField('transaction'));
+	$transaction = strtolower($dbRecord->getString('transaction'));
 	$anon_logs[$dbRecord->getInt('game_id')][$dbRecord->getInt('anon_id')][] = [
 		'login' => $dbRecord->getField('login'),
 		'amount' => number_format($dbRecord->getInt('amount')),

--- a/src/admin/Default/log_anonymous_account.php
+++ b/src/admin/Default/log_anonymous_account.php
@@ -7,24 +7,24 @@ $account = $session->getAccount();
 $template->assign('PageTopic', 'Anonymous Account Access');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT account_id FROM account_has_logs GROUP BY account_id');
+$dbResult = $db->read('SELECT account_id FROM account_has_logs GROUP BY account_id');
 $log_account_ids = [];
-while ($db->nextRecord()) {
-	$log_account_ids[] = $db->getInt('account_id');
+foreach ($dbResult->records() as $dbRecord) {
+	$log_account_ids[] = $dbRecord->getInt('account_id');
 }
 
 // get all anon bank transactions that are logged in an array
-$db->query('SELECT * FROM anon_bank_transactions
+$dbResult = $db->read('SELECT * FROM anon_bank_transactions
             JOIN account USING(account_id)
             WHERE account_id IN ('.$db->escapeArray($log_account_ids) . ')
             ORDER BY game_id DESC, anon_id ASC');
 $anon_logs = [];
-while ($db->nextRecord()) {
-	$transaction = strtolower($db->getField('transaction'));
-	$anon_logs[$db->getInt('game_id')][$db->getInt('anon_id')][] = [
-		'login' => $db->getField('login'),
-		'amount' => number_format($db->getInt('amount')),
-		'date' => date($account->getDateTimeFormat(), $db->getInt('time')),
+foreach ($dbResult->records() as $dbRecord) {
+	$transaction = strtolower($dbRecord->getField('transaction'));
+	$anon_logs[$dbRecord->getInt('game_id')][$dbRecord->getInt('anon_id')][] = [
+		'login' => $dbRecord->getField('login'),
+		'amount' => number_format($dbRecord->getInt('amount')),
+		'date' => date($account->getDateTimeFormat(), $dbRecord->getInt('time')),
 		'type' => $transaction,
 		'color' => $transaction == 'payment' ? 'tomato' : 'green',
 	];

--- a/src/admin/Default/log_console.php
+++ b/src/admin/Default/log_console.php
@@ -25,7 +25,7 @@ foreach ($dbResult->records() as $dbRecord) {
 
 	$dbResult2 = $db->read('SELECT notes FROM log_has_notes WHERE account_id = ' . $db->escapeNumber($accountID));
 	if ($dbResult2->hasRecord()) {
-		$loggedAccounts[$accountID]['Notes'] = nl2br($dbResult2->record()->getField('notes'));
+		$loggedAccounts[$accountID]['Notes'] = nl2br($dbResult2->record()->getString('notes'));
 	}
 }
 $template->assign('LoggedAccounts', $loggedAccounts);

--- a/src/admin/Default/log_console_detail.php
+++ b/src/admin/Default/log_console_detail.php
@@ -101,7 +101,7 @@ if ($action == 'Delete') {
 	foreach ($dbResult->records() as $dbRecord) {
 		$account_id = $dbRecord->getInt('account_id');
 		$microtime = $dbRecord->getMicrotime('microtime');
-		$message = stripslashes($dbRecord->getField('message'));
+		$message = $dbRecord->getString('message');
 		$log_type_id = $dbRecord->getInt('log_type_id');
 		$sector_id = $dbRecord->getInt('sector_id');
 

--- a/src/admin/Default/log_console_detail.php
+++ b/src/admin/Default/log_console_detail.php
@@ -23,8 +23,8 @@ $template->assign('Action', $action);
 if ($action == 'Delete') {
 
 	// get rid of all entries
-	$db->query('DELETE FROM account_has_logs WHERE account_id IN (' . $account_list . ')');
-	$db->query('DELETE FROM log_has_notes WHERE account_id IN (' . $account_list . ')');
+	$db->write('DELETE FROM account_has_logs WHERE account_id IN (' . $account_list . ')');
+	$db->write('DELETE FROM log_has_notes WHERE account_id IN (' . $account_list . ')');
 
 } else {
 	// *********************************
@@ -39,10 +39,10 @@ if ($action == 'Delete') {
 		// assign it a color
 		$color = $avail_colors[$i % count($avail_colors)];
 
-		$db->query('SELECT login FROM account WHERE account_id = ' . $db->escapeNumber($id));
-		if ($db->nextRecord()) {
+		$dbResult = $db->read('SELECT login FROM account WHERE account_id = ' . $db->escapeNumber($id));
+		if ($dbResult->hasRecord()) {
 			$colors[$id] = [
-				'name' => $db->getField('login'),
+				'name' => $dbResult->record()->getField('login'),
 				'color' => $color,
 			];
 		}
@@ -57,9 +57,9 @@ if ($action == 'Delete') {
 	$template->assign('UpdateHREF', $container->href());
 
 	$logTypes = [];
-	$db->query('SELECT * FROM log_type');
-	while ($db->nextRecord()) {
-		$logTypes[$db->getInt('log_type_id')] = $db->getField('log_type_entry');
+	$dbResult = $db->read('SELECT * FROM log_type');
+	foreach ($dbResult->records() as $dbRecord) {
+		$logTypes[$dbRecord->getInt('log_type_id')] = $dbRecord->getField('log_type_entry');
 	}
 	$template->assign('LogTypes', $logTypes);
 
@@ -81,9 +81,9 @@ if ($action == 'Delete') {
 
 	// get notes from db
 	$log_notes = array();
-	$db->query('SELECT * FROM log_has_notes WHERE account_id IN (' . $account_list . ')');
-	while ($db->nextRecord()) {
-		$log_notes[] = $db->getField('notes');
+	$dbResult = $db->read('SELECT * FROM log_has_notes WHERE account_id IN (' . $account_list . ')');
+	foreach ($dbResult->records() as $dbRecord) {
+		$log_notes[] = $dbRecord->getField('notes');
 	}
 
 	// get rid of double values
@@ -97,13 +97,13 @@ if ($action == 'Delete') {
 	// * L o g   T a b l e
 	// *********************************
 	$logs = [];
-	$db->query('SELECT * FROM account_has_logs WHERE account_id IN (' . $account_list . ') AND log_type_id IN (' . $db->escapeArray($log_type_id_list) . ') ORDER BY microtime DESC');
-	while ($db->nextRecord()) {
-		$account_id = $db->getInt('account_id');
-		$microtime = $db->getMicrotime('microtime');
-		$message = stripslashes($db->getField('message'));
-		$log_type_id = $db->getInt('log_type_id');
-		$sector_id = $db->getInt('sector_id');
+	$dbResult = $db->read('SELECT * FROM account_has_logs WHERE account_id IN (' . $account_list . ') AND log_type_id IN (' . $db->escapeArray($log_type_id_list) . ') ORDER BY microtime DESC');
+	foreach ($dbResult->records() as $dbRecord) {
+		$account_id = $dbRecord->getInt('account_id');
+		$microtime = $dbRecord->getMicrotime('microtime');
+		$message = stripslashes($dbRecord->getField('message'));
+		$log_type_id = $dbRecord->getInt('log_type_id');
+		$sector_id = $dbRecord->getInt('sector_id');
 
 		$date = DateTime::createFromFormat("U.u", $microtime)->format('Y-m-d H:i:s.u');
 

--- a/src/admin/Default/log_notes_processing.php
+++ b/src/admin/Default/log_notes_processing.php
@@ -5,9 +5,9 @@ $var = Smr\Session::getInstance()->getCurrentVar();
 
 foreach ($var['account_ids'] as $account_id) {
 	if (empty(Request::get('notes'))) {
-		$db->query('DELETE FROM log_has_notes WHERE account_id = ' . $db->escapeNumber($account_id));
+		$db->write('DELETE FROM log_has_notes WHERE account_id = ' . $db->escapeNumber($account_id));
 	} else {
-		$db->query('REPLACE INTO log_has_notes (account_id, notes) VALUES(' . $db->escapeNumber($account_id) . ', ' . $db->escapeString(Request::get('notes')) . ')');
+		$db->write('REPLACE INTO log_has_notes (account_id, notes) VALUES(' . $db->escapeNumber($account_id) . ', ' . $db->escapeString(Request::get('notes')) . ')');
 	}
 }
 

--- a/src/admin/Default/manage_draft_leaders.php
+++ b/src/admin/Default/manage_draft_leaders.php
@@ -12,11 +12,11 @@ $template->assign('SelectGameHREF', $container->href());
 // Get the list of active Draft games ordered by reverse start date
 $activeGames = array();
 $db = Smr\Database::getInstance();
-$db->query('SELECT game_id, game_name FROM game WHERE game_type=' . $db->escapeNumber(SmrGame::GAME_TYPE_DRAFT) . ' AND join_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY start_time DESC');
-while ($db->nextRecord()) {
+$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE game_type=' . $db->escapeNumber(SmrGame::GAME_TYPE_DRAFT) . ' AND join_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY start_time DESC');
+foreach ($dbResult->records() as $dbRecord) {
 	$activeGames[] = [
-		'game_name' => $db->getField('game_name'),
-		'game_id' => $db->getInt('game_id'),
+		'game_name' => $dbRecord->getField('game_name'),
+		'game_id' => $dbRecord->getInt('game_id'),
 	];
 }
 $template->assign('ActiveGames', $activeGames);
@@ -28,10 +28,10 @@ if ($activeGames) {
 
 	// Get the list of current draft leaders for the selected game
 	$currentLeaders = array();
-	$db->query('SELECT account_id, home_sector_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($selectedGameID));
-	while ($db->nextRecord()) {
-		$homeSectorID = $db->getInt('home_sector_id');
-		$leader = SmrPlayer::getPlayer($db->getInt('account_id'), $selectedGameID);
+	$dbResult = $db->read('SELECT account_id, home_sector_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($selectedGameID));
+	foreach ($dbResult->records() as $dbRecord) {
+		$homeSectorID = $dbRecord->getInt('home_sector_id');
+		$leader = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $selectedGameID);
 		$currentLeaders[] = [
 			'Name' => $leader->getDisplayName(),
 			'HomeSectorID' => $homeSectorID === 0 ? 'None' : $homeSectorID,

--- a/src/admin/Default/manage_draft_leaders_processing.php
+++ b/src/admin/Default/manage_draft_leaders_processing.php
@@ -31,13 +31,13 @@ if ($action == "Assign") {
 	if ($selectedPlayer->isDraftLeader()) {
 		$msg = "<span class='red'>ERROR: </span>$name is already a draft leader in game $game!";
 	} else {
-		$db->query('INSERT INTO draft_leaders (account_id, game_id, home_sector_id) VALUES (' . $db->escapeNumber($accountId) . ', ' . $db->escapeNumber($gameId) . ', ' . $db->escapeNumber($homeSectorID) . ')');
+		$db->write('INSERT INTO draft_leaders (account_id, game_id, home_sector_id) VALUES (' . $db->escapeNumber($accountId) . ', ' . $db->escapeNumber($gameId) . ', ' . $db->escapeNumber($homeSectorID) . ')');
 	}
 } elseif ($action == "Remove") {
 	if (!$selectedPlayer->isDraftLeader()) {
 		$msg = "<span class='red'>ERROR: </span>$name is not a draft leader in game $game!";
 	} else {
-		$db->query('DELETE FROM draft_leaders WHERE ' . $selectedPlayer->getSQL());
+		$db->write('DELETE FROM draft_leaders WHERE ' . $selectedPlayer->getSQL());
 	}
 } else {
 	$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";

--- a/src/admin/Default/manage_post_editors.php
+++ b/src/admin/Default/manage_post_editors.php
@@ -12,11 +12,11 @@ $template->assign('SelectGameHREF', $container->href());
 // Get the list of active games ordered by reverse start date
 $activeGames = array();
 $db = Smr\Database::getInstance();
-$db->query('SELECT game_id, game_name FROM game WHERE join_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY start_time DESC');
-while ($db->nextRecord()) {
+$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE join_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY start_time DESC');
+foreach ($dbResult->records() as $dbRecord) {
 	$activeGames[] = [
-		'game_name' => $db->getField('game_name'),
-		'game_id' => $db->getInt('game_id'),
+		'game_name' => $dbRecord->getField('game_name'),
+		'game_id' => $dbRecord->getInt('game_id'),
 	];
 }
 $template->assign('ActiveGames', $activeGames);

--- a/src/admin/Default/manage_post_editors_processing.php
+++ b/src/admin/Default/manage_post_editors_processing.php
@@ -30,13 +30,13 @@ if ($action == "Assign") {
 	if ($selected_player->isGPEditor()) {
 		$msg = "<span class='red'>ERROR: </span>$name is already an editor in game $game!";
 	} else {
-		$db->query('INSERT INTO galactic_post_writer (account_id, game_id) VALUES (' . $db->escapeNumber($account_id) . ', ' . $db->escapeNumber($game_id) . ')');
+		$db->write('INSERT INTO galactic_post_writer (account_id, game_id) VALUES (' . $db->escapeNumber($account_id) . ', ' . $db->escapeNumber($game_id) . ')');
 	}
 } elseif ($action == "Remove") {
 	if (!$selected_player->isGPEditor()) {
 		$msg = "<span class='red'>ERROR: </span>$name is not an editor in game $game!";
 	} else {
-		$db->query('DELETE FROM galactic_post_writer WHERE ' . $selected_player->getSQL());
+		$db->write('DELETE FROM galactic_post_writer WHERE ' . $selected_player->getSQL());
 	}
 } else {
 	$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";

--- a/src/admin/Default/newsletter_send.php
+++ b/src/admin/Default/newsletter_send.php
@@ -12,17 +12,18 @@ $processingContainer = Page::create('newsletter_send_processing.php');
 
 // Get the most recent newsletter text for preview
 $db = Smr\Database::getInstance();
-$db->query('SELECT newsletter_id, newsletter_html, newsletter_text FROM newsletter ORDER BY newsletter_id DESC LIMIT 1');
-if ($db->nextRecord()) {
-	$id = $db->getInt('newsletter_id');
+$dbResult = $db->read('SELECT newsletter_id, newsletter_html, newsletter_text FROM newsletter ORDER BY newsletter_id DESC LIMIT 1');
+if ($dbResult->hasRecord()) {
+	$dbRecord = $dbResult->record();
+	$id = $dbRecord->getInt('newsletter_id');
 	$template->assign('NewsletterId', $id);
 	$template->assign('DefaultSubject', 'Space Merchant Realms Newsletter #' . $id);
 
 	// Give both the template and processing container access to the message
-	$processingContainer['newsletter_html'] = $db->getField('newsletter_html');
-	$processingContainer['newsletter_text'] = $db->getField('newsletter_text');
-	$template->assign('NewsletterHtml', $db->getField('newsletter_html'));
-	$template->assign('NewsletterText', $db->getField('newsletter_text'));
+	$processingContainer['newsletter_html'] = $dbRecord->getField('newsletter_html');
+	$processingContainer['newsletter_text'] = $dbRecord->getField('newsletter_text');
+	$template->assign('NewsletterHtml', $dbRecord->getField('newsletter_html'));
+	$template->assign('NewsletterText', $dbRecord->getField('newsletter_text'));
 }
 
 // Create the form for the populated processing container

--- a/src/admin/Default/newsletter_send_processing.php
+++ b/src/admin/Default/newsletter_send_processing.php
@@ -48,9 +48,9 @@ if (Request::get('to_email') == '*') {
 
 	// Skip all smrealms.de addresses (NPC, multi) to avoid spamming ourselves.
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT account_id, email, login FROM account WHERE validated="TRUE" AND email NOT LIKE "%@smrealms.de" AND NOT(EXISTS(SELECT account_id FROM account_is_closed WHERE account_is_closed.account_id=account.account_id))');
+	$dbResult = $db->read('SELECT account_id, email, login FROM account WHERE validated="TRUE" AND email NOT LIKE "%@smrealms.de" AND NOT(EXISTS(SELECT account_id FROM account_is_closed WHERE account_is_closed.account_id=account.account_id))');
 
-	$total = $db->getNumRows();
+	$total = $dbResult->getNumRecords();
 	echo 'Will send ' . $total . ' mails...<br /><br />';
 
 	// counter
@@ -61,11 +61,11 @@ if (Request::get('to_email') == '*') {
 	// --enable-safe-mode). However, you may hit a browser or HTTP timeout.
 	set_time_limit(0);
 
-	while ($db->nextRecord()) {
+	foreach ($dbResult->records() as $dbRecord) {
 		// get account data
-		$account_id = $db->getInt('account_id');
-		$to_email = $db->getField('email');
-		$to_name = $db->getField('login');
+		$account_id = $dbRecord->getInt('account_id');
+		$to_email = $dbRecord->getField('email');
+		$to_name = $dbRecord->getField('login');
 
 		// Reset the message body with personalized salutation, if requested
 		$salutation = trim(Request::get('salutation'));

--- a/src/admin/Default/notify_delete_processing.php
+++ b/src/admin/Default/notify_delete_processing.php
@@ -4,6 +4,6 @@ if (!Request::has('notify_id')) {
 }
 
 $db = Smr\Database::getInstance();
-$db->query('DELETE FROM message_notify WHERE notify_id IN (' . $db->escapeArray(Request::getIntArray('notify_id')) . ')');
+$db->write('DELETE FROM message_notify WHERE notify_id IN (' . $db->escapeArray(Request::getIntArray('notify_id')) . ')');
 
 Page::create('skeleton.php', 'notify_view.php')->go();

--- a/src/admin/Default/notify_view.php
+++ b/src/admin/Default/notify_view.php
@@ -51,7 +51,7 @@ foreach ($dbResult->records() as $dbRecord) {
 		'gameName' => $gameName,
 		'sentDate' => date($account->getDateTimeFormat(), $dbRecord->getInt('sent_time')),
 		'reportDate' => date($account->getDateTimeFormat(), $dbRecord->getInt('notify_time')),
-		'text' => bbifyMessage($dbRecord->getField('text')),
+		'text' => bbifyMessage($dbRecord->getString('text')),
 	];
 }
 $template->assign('Messages', $messages);

--- a/src/admin/Default/notify_view.php
+++ b/src/admin/Default/notify_view.php
@@ -12,16 +12,16 @@ $container = Page::create('notify_delete_processing.php');
 $template->assign('DeleteHREF', $container->href());
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM message_notify');
+$dbResult = $db->read('SELECT * FROM message_notify');
 $messages = [];
-while ($db->nextRecord()) {
-	$gameID = $db->getInt('game_id');
-	$sender = getMessagePlayer($db->getInt('from_id'), $gameID);
-	$receiver = getMessagePlayer($db->getInt('to_id'), $gameID);
+foreach ($dbResult->records() as $dbRecord) {
+	$gameID = $dbRecord->getInt('game_id');
+	$sender = getMessagePlayer($dbRecord->getInt('from_id'), $gameID);
+	$receiver = getMessagePlayer($dbRecord->getInt('to_id'), $gameID);
 
 	$container = Page::create('skeleton.php', 'notify_reply.php');
-	$container['offender'] = $db->getInt('from_id');
-	$container['offended'] = $db->getInt('to_id');
+	$container['offender'] = $dbRecord->getInt('from_id');
+	$container['offended'] = $dbRecord->getInt('to_id');
 	$container['game_id'] = $gameID;
 
 	$getName = function(SmrPlayer|string $messagePlayer) use ($container, $account) : string {
@@ -45,13 +45,13 @@ while ($db->nextRecord()) {
 	}
 
 	$messages[] = [
-		'notifyID' => $db->getInt('notify_id'),
+		'notifyID' => $dbRecord->getInt('notify_id'),
 		'senderName' => $getName($sender),
 		'receiverName' => $getName($receiver),
 		'gameName' => $gameName,
-		'sentDate' => date($account->getDateTimeFormat(), $db->getInt('sent_time')),
-		'reportDate' => date($account->getDateTimeFormat(), $db->getInt('notify_time')),
-		'text' => bbifyMessage($db->getField('text')),
+		'sentDate' => date($account->getDateTimeFormat(), $dbRecord->getInt('sent_time')),
+		'reportDate' => date($account->getDateTimeFormat(), $dbRecord->getInt('notify_time')),
+		'text' => bbifyMessage($dbRecord->getField('text')),
 	];
 }
 $template->assign('Messages', $messages);

--- a/src/admin/Default/npc_manage.php
+++ b/src/admin/Default/npc_manage.php
@@ -42,8 +42,8 @@ foreach ($dbResult->records() as $dbRecord) {
 
 	$npcs[$accountID] = [
 		'login' => $login,
-		'default_player_name' => htmlentities($dbRecord->getField('player_name')),
-		'default_alliance' => htmlentities($dbRecord->getField('alliance_name')),
+		'default_player_name' => htmlentities($dbRecord->getString('player_name')),
+		'default_alliance' => htmlentities($dbRecord->getString('alliance_name')),
 		'active' => $dbRecord->getBoolean('active'),
 		'working' => $dbRecord->getBoolean('working'),
 		'href' => $container->href(),

--- a/src/admin/Default/npc_manage.php
+++ b/src/admin/Default/npc_manage.php
@@ -12,9 +12,9 @@ $template->assign('SelectGameHREF', $container->href());
 
 $games = [];
 $db = Smr\Database::getInstance();
-$db->query('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND enabled = ' . $db->escapeBoolean(true) . ' ORDER BY game_id DESC');
-while ($db->nextRecord()) {
-	$gameID = $db->getInt('game_id');
+$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND enabled = ' . $db->escapeBoolean(true) . ' ORDER BY game_id DESC');
+foreach ($dbResult->records() as $dbRecord) {
+	$gameID = $dbRecord->getInt('game_id');
 	if (empty($selectedGameID)) {
 		$selectedGameID = $gameID;
 	}
@@ -32,20 +32,20 @@ $container['selected_game_id'] = $selectedGameID;
 $template->assign('AddAccountHREF', $container->href());
 
 $npcs = [];
-$db->query('SELECT * FROM npc_logins JOIN account USING(login)');
-while ($db->nextRecord()) {
-	$accountID = $db->getInt('account_id');
-	$login = $db->getField('login');
+$dbResult = $db->read('SELECT * FROM npc_logins JOIN account USING(login)');
+foreach ($dbResult->records() as $dbRecord) {
+	$accountID = $dbRecord->getInt('account_id');
+	$login = $dbRecord->getField('login');
 
 	$container['login'] = $login;
 	$container['accountID'] = $accountID;
 
 	$npcs[$accountID] = [
 		'login' => $login,
-		'default_player_name' => htmlentities($db->getField('player_name')),
-		'default_alliance' => htmlentities($db->getField('alliance_name')),
-		'active' => $db->getBoolean('active'),
-		'working' => $db->getBoolean('working'),
+		'default_player_name' => htmlentities($dbRecord->getField('player_name')),
+		'default_alliance' => htmlentities($dbRecord->getField('alliance_name')),
+		'active' => $dbRecord->getBoolean('active'),
+		'working' => $dbRecord->getBoolean('working'),
 		'href' => $container->href(),
 	];
 }
@@ -55,10 +55,10 @@ $nextNpcID = count($npcs) + 1;
 $template->assign('NextLogin', 'npc' . $nextNpcID);
 
 // Get the existing NPC players for the selected game
-$db->query('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($selectedGameID) . ' AND npc=' . $db->escapeBoolean(true));
-while ($db->nextRecord()) {
-	$accountID = $db->getInt('account_id');
-	$npcs[$accountID]['player'] = SmrPlayer::getPlayer($accountID, $selectedGameID, false, $db);
+$dbResult = $db->read('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($selectedGameID) . ' AND npc=' . $db->escapeBoolean(true));
+foreach ($dbResult->records() as $dbRecord) {
+	$accountID = $dbRecord->getInt('account_id');
+	$npcs[$accountID]['player'] = SmrPlayer::getPlayer($accountID, $selectedGameID, false, $dbRecord);
 }
 
 $template->assign('Npcs', $npcs);

--- a/src/admin/Default/npc_manage_processing.php
+++ b/src/admin/Default/npc_manage_processing.php
@@ -7,7 +7,7 @@ $var = Smr\Session::getInstance()->getCurrentVar();
 if (Request::has('active-submit')) {
 	// Toggle the activity of this NPC
 	$active = Request::has('active');
-	$db->query('UPDATE npc_logins SET active=' . $db->escapeBoolean($active) . ' WHERE login=' . $db->escapeString($var['login']));
+	$db->write('UPDATE npc_logins SET active=' . $db->escapeBoolean($active) . ' WHERE login=' . $db->escapeString($var['login']));
 }
 
 // Create a new NPC player in a selected game
@@ -50,7 +50,7 @@ if (Request::has('add_npc_account')) {
 	$npcAccount = SmrAccount::createAccount($login, '', 'NPC@smrealms.de', 0, 0);
 	$npcAccount->setValidated(true);
 	$npcAccount->update();
-	$db->query('INSERT INTO npc_logins (login, player_name, alliance_name) VALUES(' . $db->escapeString($login) . ',' . $db->escapeString(Request::get('default_player_name')) . ',' . $db->escapeString(Request::get('default_alliance')) . ')');
+	$db->write('INSERT INTO npc_logins (login, player_name, alliance_name) VALUES(' . $db->escapeString($login) . ',' . $db->escapeString(Request::get('default_player_name')) . ',' . $db->escapeString(Request::get('default_alliance')) . ')');
 }
 
 $container = Page::create('skeleton.php', 'npc_manage.php');

--- a/src/admin/Default/permission_manage.php
+++ b/src/admin/Default/permission_manage.php
@@ -13,15 +13,15 @@ $template->assign('SelectAdminHREF', $selectAdminHREF);
 
 $adminLinks = [];
 $db = Smr\Database::getInstance();
-$db->query('SELECT account_id, login
+$dbResult = $db->read('SELECT account_id, login
 			FROM account_has_permission JOIN account USING(account_id)
 			GROUP BY account_id');
-while ($db->nextRecord()) {
-	$accountID = $db->getInt('account_id');
+foreach ($dbResult->records() as $dbRecord) {
+	$accountID = $dbRecord->getInt('account_id');
 	$container['admin_id'] = $accountID;
 	$adminLinks[$accountID] = [
 		'href' => $container->href(),
-		'name' => $db->getField('login'),
+		'name' => $dbRecord->getField('login'),
 	];
 }
 $template->assign('AdminLinks', $adminLinks);
@@ -29,14 +29,14 @@ $template->assign('AdminLinks', $adminLinks);
 if (empty($admin_id)) {
 	// If we don't have an account_id here display an account list
 	$validatedAccounts = [];
-	$db->query('SELECT account_id, login
+	$dbResult = $db->read('SELECT account_id, login
 				FROM account
 				WHERE validated = '.$db->escapeBoolean(true) . '
 				ORDER BY login');
-	while ($db->nextRecord()) {
-		$accountID = $db->getInt('account_id');
+	foreach ($dbResult->records() as $dbRecord) {
+		$accountID = $dbRecord->getInt('account_id');
 		if (!array_key_exists($accountID, $adminLinks)) {
-			$validatedAccounts[$accountID] = $db->getField('login');
+			$validatedAccounts[$accountID] = $dbRecord->getField('login');
 		}
 	}
 	$template->assign('ValidatedAccounts', $validatedAccounts);

--- a/src/admin/Default/permission_manage_processing.php
+++ b/src/admin/Default/permission_manage_processing.php
@@ -8,14 +8,14 @@ if (Request::get('action') == 'Change') {
 
 	// delete everything first
 	$db = Smr\Database::getInstance();
-	$db->query('DELETE
+	$db->write('DELETE
 				FROM account_has_permission
 				WHERE account_id = ' . $db->escapeNumber($var['admin_id']));
 
 	// Grant permissions
 	$permissions = Request::getIntArray('permission_ids', []);
 	foreach ($permissions as $permission_id) {
-		$db->query('REPLACE
+		$db->write('REPLACE
 						INTO account_has_permission
 						(account_id, permission_id)
 						VALUES (' . $db->escapeNumber($var['admin_id']) . ', ' . $db->escapeNumber($permission_id) . ')');
@@ -25,11 +25,11 @@ if (Request::get('action') == 'Change') {
 	if (in_array(PERMISSION_DISPLAY_ADMIN_TAG, $permissions)) {
 		// This might overwrite an existing unrelated tag.
 		$tag = '<span class="blue">Admin</span>';
-		$db->query('REPLACE INTO cpl_tag (account_id, tag, custom) VALUES (' . $db->escapeNumber($var['admin_id']) . ',' . $db->escapeString($tag) . ',0)');
+		$db->write('REPLACE INTO cpl_tag (account_id, tag, custom) VALUES (' . $db->escapeNumber($var['admin_id']) . ',' . $db->escapeString($tag) . ',0)');
 	} elseif ($hadAdminTag) {
 		// Only delete the tag if they previously had an admin tag;
 		// otherwise we might accidentally delete an unrelated tag.
-		$db->query('DELETE FROM cpl_tag WHERE custom=0 AND account_id=' . $db->escapeNumber($var['admin_id']));
+		$db->write('DELETE FROM cpl_tag WHERE custom=0 AND account_id=' . $db->escapeNumber($var['admin_id']));
 	}
 }
 

--- a/src/admin/Default/ship_check.php
+++ b/src/admin/Default/ship_check.php
@@ -5,7 +5,7 @@ $template = Smr\Template::getInstance();
 $template->assign('PageTopic', 'Ship Integrity Check');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM ship_type_support_hardware, player, ship_has_hardware, hardware_type ' .
+$dbResult = $db->read('SELECT * FROM ship_type_support_hardware, player, ship_has_hardware, hardware_type ' .
 		   'WHERE ship_type_support_hardware.ship_type_id = player.ship_type_id AND ' .
 				 'player.account_id = ship_has_hardware.account_id AND ' .
 				 'player.game_id = ship_has_hardware.game_id AND ' .
@@ -14,19 +14,19 @@ $db->query('SELECT * FROM ship_type_support_hardware, player, ship_has_hardware,
 				 'amount > max_amount');
 
 $excessHardware = [];
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$container = Page::create('ship_check_processing.php');
-	$container['account_id'] = $db->getInt('account_id');
-	$container['hardware'] = $db->getInt('hardware_type_id');
-	$container['game_id'] = $db->getInt('game_id');
-	$container['max_amount'] = $db->getInt('max_amount');
+	$container['account_id'] = $dbRecord->getInt('account_id');
+	$container['hardware'] = $dbRecord->getInt('hardware_type_id');
+	$container['game_id'] = $dbRecord->getInt('game_id');
+	$container['max_amount'] = $dbRecord->getInt('max_amount');
 
 	$excessHardware[] = [
-		'player' => htmlentities($db->getField('player_name')),
-		'game_id' => $db->getInt('game_id'),
-		'hardware' => $db->getField('hardware_name'),
-		'amount' => $db->getInt('amount'),
-		'max_amount' => $db->getInt('max_amount'),
+		'player' => htmlentities($dbRecord->getField('player_name')),
+		'game_id' => $dbRecord->getInt('game_id'),
+		'hardware' => $dbRecord->getField('hardware_name'),
+		'amount' => $dbRecord->getInt('amount'),
+		'max_amount' => $dbRecord->getInt('max_amount'),
 		'fixHREF' => $container->href(),
 	];
 }

--- a/src/admin/Default/ship_check.php
+++ b/src/admin/Default/ship_check.php
@@ -22,7 +22,7 @@ foreach ($dbResult->records() as $dbRecord) {
 	$container['max_amount'] = $dbRecord->getInt('max_amount');
 
 	$excessHardware[] = [
-		'player' => htmlentities($dbRecord->getField('player_name')),
+		'player' => htmlentities($dbRecord->getString('player_name')),
 		'game_id' => $dbRecord->getInt('game_id'),
 		'hardware' => $dbRecord->getField('hardware_name'),
 		'amount' => $dbRecord->getInt('amount'),

--- a/src/admin/Default/ship_check_processing.php
+++ b/src/admin/Default/ship_check_processing.php
@@ -10,7 +10,7 @@ $account_id = $var['account_id'];
 
 //update it so they arent cheating
 $db = Smr\Database::getInstance();
-$db->query('UPDATE ship_has_hardware ' .
+$db->write('UPDATE ship_has_hardware ' .
 		   'SET amount = ' . $db->escapeNumber($max_amount) . ' ' .
 		   'WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND ' .
 				 'account_id = ' . $db->escapeNumber($account_id) . ' AND ' .

--- a/src/admin/Default/vote_create.php
+++ b/src/admin/Default/vote_create.php
@@ -10,11 +10,11 @@ $template->assign('VoteFormHREF', Page::create('vote_create_processing.php', '')
 
 $voting = array();
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(Smr\Epoch::time()));
-while ($db->nextRecord()) {
-	$voteID = $db->getInt('vote_id');
+$dbResult = $db->read('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(Smr\Epoch::time()));
+foreach ($dbResult->records() as $dbRecord) {
+	$voteID = $dbRecord->getInt('vote_id');
 	$voting[$voteID]['ID'] = $voteID;
-	$voting[$voteID]['Question'] = $db->getField('question');
+	$voting[$voteID]['Question'] = $dbRecord->getField('question');
 }
 $template->assign('CurrentVotes', $voting);
 if (isset($var['PreviewVote'])) {

--- a/src/admin/Default/vote_create_processing.php
+++ b/src/admin/Default/vote_create_processing.php
@@ -18,10 +18,10 @@ $db = Smr\Database::getInstance();
 if ($action == 'Create Vote') {
 	$question = trim(Request::get('question'));
 	$end = Smr\Epoch::time() + 86400 * Request::getInt('days');
-	$db->query('INSERT INTO voting (question, end) VALUES(' . $db->escapeString($question) . ',' . $db->escapeNumber($end) . ')');
+	$db->write('INSERT INTO voting (question, end) VALUES(' . $db->escapeString($question) . ',' . $db->escapeNumber($end) . ')');
 } elseif ($action == 'Add Option') {
 	$option = trim(Request::get('option'));
 	$voteID = Request::getInt('vote');
-	$db->query('INSERT INTO voting_options (vote_id, text) VALUES(' . $db->escapeNumber($voteID) . ',' . $db->escapeString($option) . ')');
+	$db->write('INSERT INTO voting_options (vote_id, text) VALUES(' . $db->escapeNumber($voteID) . ',' . $db->escapeString($option) . ')');
 }
 Page::create('skeleton.php', 'vote_create.php')->go();

--- a/src/admin/Default/word_filter.php
+++ b/src/admin/Default/word_filter.php
@@ -11,14 +11,14 @@ if (isset($var['msg'])) {
 }
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM word_filter');
-if ($db->getNumRows()) {
+$dbResult = $db->read('SELECT * FROM word_filter');
+if ($dbResult->hasRecord()) {
 	$container = Page::create('word_filter_del.php');
 	$template->assign('DelHREF', $container->href());
 
 	$filteredWords = [];
-	while ($db->nextRecord()) {
-		$filteredWords[] = $db->getRow();
+	foreach ($dbResult->records() as $dbRecord) {
+		$filteredWords[] = $dbRecord->getRow();
 	}
 	$template->assign('FilteredWords', $filteredWords);
 }

--- a/src/admin/Default/word_filter_add.php
+++ b/src/admin/Default/word_filter_add.php
@@ -6,13 +6,13 @@ $word_replacement = strtoupper(trim(Request::get('WordReplacement')));
 $container = Page::create('skeleton.php', 'word_filter.php');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT word_id FROM word_filter WHERE word_value=' . $db->escapeString($word) . ' LIMIT 1');
-if ($db->nextRecord()) {
+$dbResult = $db->read('SELECT 1 FROM word_filter WHERE word_value=' . $db->escapeString($word) . ' LIMIT 1');
+if ($dbResult->hasRecord()) {
 	$container['msg'] = '<span class="red bold">ERROR: </span>This word is already filtered!';
 	$container->go();
 }
 
-$db->query('INSERT INTO word_filter(word_value,word_replacement) VALUES (' . $db->escapeString($word) . ',' . $db->escapeString($word_replacement) . ')');
+$db->write('INSERT INTO word_filter(word_value,word_replacement) VALUES (' . $db->escapeString($word) . ',' . $db->escapeString($word_replacement) . ')');
 
 $container['msg'] = '<span class="yellow">' . $word . '</span> will now be replaced with <span class="yellow">' . $word_replacement . '</span>.';
 $container->go();

--- a/src/admin/Default/word_filter_del.php
+++ b/src/admin/Default/word_filter_del.php
@@ -2,7 +2,7 @@
 
 if (Request::has('word_ids')) {
 	$db = Smr\Database::getInstance();
-	$db->query('DELETE FROM word_filter WHERE word_id IN (' . $db->escapeArray(Request::getIntArray('word_ids')) . ')');
+	$db->write('DELETE FROM word_filter WHERE word_id IN (' . $db->escapeArray(Request::getIntArray('word_ids')) . ')');
 }
 
 $container = Page::create('skeleton.php', 'word_filter.php');

--- a/src/engine/Default/album_delete_processing.php
+++ b/src/engine/Default/album_delete_processing.php
@@ -5,11 +5,11 @@ $account = $session->getAccount();
 
 if (Request::get('action') == 'Yes') {
 	$db = Smr\Database::getInstance();
-	$db->query('DELETE
+	$db->write('DELETE
 				FROM album
 				WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
 
-	$db->query('DELETE
+	$db->write('DELETE
 				FROM album_has_comments
 				WHERE album_id = ' . $db->escapeNumber($account->getAccountID()));
 }

--- a/src/engine/Default/album_edit.php
+++ b/src/engine/Default/album_edit.php
@@ -8,25 +8,26 @@ $account = $session->getAccount();
 $template->assign('PageTopic', 'Edit Photo');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
-if ($db->nextRecord()) {
-	$day = $db->getInt('day');
-	$month = $db->getInt('month');
-	$year = $db->getInt('year');
-	$albumEntry['Location'] = stripslashes($db->getField('location'));
-	$albumEntry['Email'] = stripslashes($db->getField('email'));
-	$albumEntry['Website'] = stripslashes($db->getField('website'));
+$dbResult = $db->read('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+if ($dbResult->hasRecord()) {
+	$dbRecord = $dbResult->record();
+	$day = $dbRecord->getInt('day');
+	$month = $dbRecord->getInt('month');
+	$year = $dbRecord->getInt('year');
+	$albumEntry['Location'] = stripslashes($dbRecord->getField('location'));
+	$albumEntry['Email'] = stripslashes($dbRecord->getField('email'));
+	$albumEntry['Website'] = stripslashes($dbRecord->getField('website'));
 	$albumEntry['Day'] = $day > 0 ? $day : '';
 	$albumEntry['Month'] = $month > 0 ? $month : '';
 	$albumEntry['Year'] = $year > 0 ? $year : '';
-	$albumEntry['Other'] = stripslashes($db->getField('other'));
-	$approved = $db->getField('approved');
+	$albumEntry['Other'] = stripslashes($dbRecord->getField('other'));
+	$approved = $dbRecord->getField('approved');
 
 	if ($approved == 'TBC') {
 		$albumEntry['Status'] = ('<span style="color:orange;">Waiting approval</span>');
 	} elseif ($approved == 'NO') {
 		$albumEntry['Status'] = ('<span class="red">Approval denied</span>');
-	} elseif ($db->getBoolean('disabled')) {
+	} elseif ($dbRecord->getBoolean('disabled')) {
 		$albumEntry['Status'] = ('<span class="red">Disabled</span>');
 	} elseif ($approved == 'YES') {
 		$albumEntry['Status'] = ('<a href="album/?nick=' . urlencode($account->getHofName()) . '" class="dgreen">Online</a>');

--- a/src/engine/Default/album_edit.php
+++ b/src/engine/Default/album_edit.php
@@ -14,13 +14,13 @@ if ($dbResult->hasRecord()) {
 	$day = $dbRecord->getInt('day');
 	$month = $dbRecord->getInt('month');
 	$year = $dbRecord->getInt('year');
-	$albumEntry['Location'] = stripslashes($dbRecord->getField('location'));
-	$albumEntry['Email'] = stripslashes($dbRecord->getField('email'));
-	$albumEntry['Website'] = stripslashes($dbRecord->getField('website'));
+	$albumEntry['Location'] = $dbRecord->getField('location');
+	$albumEntry['Email'] = $dbRecord->getField('email');
+	$albumEntry['Website'] = $dbRecord->getField('website');
 	$albumEntry['Day'] = $day > 0 ? $day : '';
 	$albumEntry['Month'] = $month > 0 ? $month : '';
 	$albumEntry['Year'] = $year > 0 ? $year : '';
-	$albumEntry['Other'] = stripslashes($dbRecord->getField('other'));
+	$albumEntry['Other'] = $dbRecord->getField('other');
 	$approved = $dbRecord->getField('approved');
 
 	if ($approved == 'TBC') {

--- a/src/engine/Default/album_edit_processing.php
+++ b/src/engine/Default/album_edit_processing.php
@@ -61,14 +61,14 @@ if ($_FILES['photo']['error'] == UPLOAD_ERR_OK) {
 
 // check if we had a album entry so far
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
-if ($db->nextRecord()) {
+$dbResult = $db->read('SELECT 1 FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+if ($dbResult->hasRecord()) {
 	if (!$noPicture) {
 		$comment = '<span class="green">*** Picture changed</span>';
 	}
 
 	// change album entry
-	$db->query('UPDATE album
+	$db->write('UPDATE album
 				SET location = ' . $db->escapeString($location) . ',
 					email = ' . $db->escapeString($email) . ',
 					website= ' . $db->escapeString($website) . ',
@@ -90,7 +90,7 @@ if ($db->nextRecord()) {
 	$comment = '<span class="green">*** Picture added</span>';
 
 	// add album entry
-	$db->query('INSERT INTO album (account_id, location, email, website, day, month, year, other, created, last_changed, approved)
+	$db->write('INSERT INTO album (account_id, location, email, website, day, month, year, other, created, last_changed, approved)
 				VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($location) . ', ' . $db->escapeString($email) . ', ' . $db->escapeString($website) . ', ' . $db->escapeNumber($day) . ', ' . $db->escapeNumber($month) . ', ' . $db->escapeNumber($year) . ', ' . $db->escapeString($other) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', \'TBC\')');
 }
 
@@ -98,14 +98,14 @@ if (!empty($comment)) {
 	// check if we have comments for this album already
 	$db->lockTable('album_has_comments');
 
-	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($account->getAccountID()));
-	if ($db->nextRecord()) {
-		$comment_id = $db->getInt('MAX(comment_id)') + 1;
+	$dbResult = $db->read('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($account->getAccountID()));
+	if ($dbResult->hasRecord()) {
+		$comment_id = $dbResult->record()->getInt('MAX(comment_id)') + 1;
 	} else {
 		$comment_id = 1;
 	}
 
-	$db->query('INSERT INTO album_has_comments
+	$db->write('INSERT INTO album_has_comments
 				(album_id, comment_id, time, post_id, msg)
 				VALUES (' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($comment_id) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', 0, ' . $db->escapeString($comment) . ')');
 	$db->unlock();

--- a/src/engine/Default/alliance_exempt_authorize.php
+++ b/src/engine/Default/alliance_exempt_authorize.php
@@ -10,24 +10,24 @@ Menu::alliance($alliance->getAllianceID());
 
 //get rid of already approved entries
 $db = Smr\Database::getInstance();
-$db->query('UPDATE alliance_bank_transactions SET request_exempt = 0 WHERE exempt = 1');
+$db->write('UPDATE alliance_bank_transactions SET request_exempt = 0 WHERE exempt = 1');
 
 
-$db->query('SELECT * FROM alliance_bank_transactions WHERE request_exempt = 1 ' .
+$dbResult = $db->read('SELECT * FROM alliance_bank_transactions WHERE request_exempt = 1 ' .
 			'AND alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND exempt = 0');
 $transactions = [];
-if ($db->getNumRows()) {
+if ($dbResult->hasRecord()) {
 	$container = Page::create('bank_alliance_exempt_processing.php');
 	$template->assign('ExemptHREF', $container->href());
 
 	$players = $alliance->getMembers();
-	while ($db->nextRecord()) {
+	foreach ($dbResult->records() as $dbRecord) {
 		$transactions[] = [
-			'type' => $db->getField('transaction') == 'Payment' ? 'Withdraw' : 'Deposit',
-			'player' => $players[$db->getInt('payee_id')]->getDisplayName(),
-			'reason' => $db->getField('reason'),
-			'amount' => number_format($db->getInt('amount')),
-			'transactionID' => $db->getInt('transaction_id'),
+			'type' => $dbRecord->getField('transaction') == 'Payment' ? 'Withdraw' : 'Deposit',
+			'player' => $players[$dbRecord->getInt('payee_id')]->getDisplayName(),
+			'reason' => $dbRecord->getField('reason'),
+			'amount' => number_format($dbRecord->getInt('amount')),
+			'transactionID' => $dbRecord->getInt('transaction_id'),
 		];
 	}
 }

--- a/src/engine/Default/alliance_invite_player.php
+++ b/src/engine/Default/alliance_invite_player.php
@@ -30,13 +30,13 @@ $template->assign('PendingInvites', $pendingInvites);
 $invitePlayers = array();
 if ($alliance->getNumMembers() < $game->getAllianceMaxPlayers()) {
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT account_id FROM player
+	$dbResult = $db->read('SELECT * FROM player
 	            WHERE game_id = '.$db->escapeNumber($player->getGameID()) . '
 	              AND alliance_id != '.$db->escapeNumber($alliance->getAllianceID()) . '
 	              AND npc = '.$db->escapeBoolean(false) . '
 	            ORDER BY player_id DESC');
-	while ($db->nextRecord()) {
-		$invitePlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID());
+	foreach ($dbResult->records() as $dbRecord) {
+		$invitePlayer = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), false, $dbRecord);
 		if (array_key_exists($invitePlayer->getAccountID(), $pendingInvites)) {
 			// Don't display players we've already invited
 			continue;

--- a/src/engine/Default/alliance_invite_player_processing.php
+++ b/src/engine/Default/alliance_invite_player_processing.php
@@ -12,10 +12,10 @@ $expires = Smr\Epoch::time() + 86400 * $expireDays;
 
 // If sender is mail banned or blacklisted by receiver, omit the custom message
 $db = Smr\Database::getInstance();
-$db->query('SELECT 1 FROM message_blacklist
+$dbResult = $db->read('SELECT 1 FROM message_blacklist
             WHERE account_id='.$db->escapeNumber($receiverID) . '
               AND blacklisted_id='.$db->escapeNumber($player->getAccountID()));
-if ($db->nextRecord() || $account->isMailBanned()) {
+if ($dbResult->hasRecord() || $account->isMailBanned()) {
 	$addMessage = '';
 }
 

--- a/src/engine/Default/alliance_leadership_processing.php
+++ b/src/engine/Default/alliance_leadership_processing.php
@@ -9,8 +9,8 @@ $alliance->setLeaderID($leader_id);
 $alliance->update();
 
 $db = Smr\Database::getInstance();
-$db->query('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ' WHERE ' . $player->getSQL() . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
-$db->query('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ' WHERE account_id = ' . $db->escapeNumber($leader_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
+$db->write('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ' WHERE ' . $player->getSQL() . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
+$db->write('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ' WHERE account_id = ' . $db->escapeNumber($leader_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
 
 // Notify the new leader
 $playerMessage = 'You are now the leader of ' . $alliance->getAllianceBBLink() . '!';

--- a/src/engine/Default/alliance_leave_processing.php
+++ b/src/engine/Default/alliance_leave_processing.php
@@ -17,19 +17,19 @@ if ($action == 'YES') {
 	if ($alliance->getNumMembers() == 1 && $alliance->getAllianceID() != NHA_ID) {
 		// Retain the alliance, but delete some auxilliary info
 		$db = Smr\Database::getInstance();
-		$db->query('DELETE FROM alliance_bank_transactions
+		$db->write('DELETE FROM alliance_bank_transactions
 		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
-		$db->query('DELETE FROM alliance_thread
+		$db->write('DELETE FROM alliance_thread
 		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
-		$db->query('DELETE FROM alliance_thread_topic
+		$db->write('DELETE FROM alliance_thread_topic
 		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
-		$db->query('DELETE FROM alliance_has_roles
+		$db->write('DELETE FROM alliance_has_roles
 		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
-		$db->query('UPDATE alliance SET leader_id = 0, discord_channel = NULL
+		$db->write('UPDATE alliance SET leader_id = 0, discord_channel = NULL
 		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 		            AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	}

--- a/src/engine/Default/alliance_list.php
+++ b/src/engine/Default/alliance_list.php
@@ -16,7 +16,7 @@ $container = Page::create('skeleton.php');
 
 // get list of alliances
 $db = Smr\Database::getInstance();
-$db->query('SELECT
+$dbResult = $db->read('SELECT
 count(account_id) as alliance_member_count,
 sum(experience) as alliance_xp,
 floor(avg(experience)) as alliance_avg,
@@ -31,21 +31,21 @@ ORDER BY alliance_name ASC'
 );
 
 $alliances = array();
-while ($db->nextRecord()) {
-	if ($db->getInt('alliance_id') != $player->getAllianceID()) {
+foreach ($dbResult->records() as $dbRecord) {
+	if ($dbRecord->getInt('alliance_id') != $player->getAllianceID()) {
 		$container['body'] = 'alliance_roster.php';
 	} else {
 		$container['body'] = 'alliance_mod.php';
 	}
-	$allianceID = $db->getInt('alliance_id');
+	$allianceID = $dbRecord->getInt('alliance_id');
 	$container['alliance_id'] = $allianceID;
 
 	$alliances[$allianceID] = array(
 		'ViewHREF' => $container->href(),
-		'Name' => htmlentities($db->getField('alliance_name')),
-		'TotalExperience' => $db->getInt('alliance_xp'),
-		'AverageExperience' => $db->getInt('alliance_avg'),
-		'Members' => $db->getInt('alliance_member_count'),
+		'Name' => htmlentities($dbRecord->getField('alliance_name')),
+		'TotalExperience' => $dbRecord->getInt('alliance_xp'),
+		'AverageExperience' => $dbRecord->getInt('alliance_avg'),
+		'Members' => $dbRecord->getInt('alliance_member_count'),
 	);
 }
 $template->assign('Alliances', $alliances);

--- a/src/engine/Default/alliance_list.php
+++ b/src/engine/Default/alliance_list.php
@@ -42,7 +42,7 @@ foreach ($dbResult->records() as $dbRecord) {
 
 	$alliances[$allianceID] = array(
 		'ViewHREF' => $container->href(),
-		'Name' => htmlentities($dbRecord->getField('alliance_name')),
+		'Name' => htmlentities($dbRecord->getString('alliance_name')),
 		'TotalExperience' => $dbRecord->getInt('alliance_xp'),
 		'AverageExperience' => $dbRecord->getInt('alliance_avg'),
 		'Members' => $dbRecord->getInt('alliance_member_count'),

--- a/src/engine/Default/alliance_message_add_processing.php
+++ b/src/engine/Default/alliance_message_add_processing.php
@@ -40,11 +40,11 @@ if (empty($body)) {
 // if we don't have a thread id
 if (!isset($var['thread_index'])) {
 	// get one
-	$db->query('SELECT max(thread_id) FROM alliance_thread
+	$dbResult = $db->read('SELECT max(thread_id) FROM alliance_thread
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND alliance_id = ' . $db->escapeNumber($alliance_id));
-	if ($db->nextRecord()) {
-		$thread_id = $db->getInt('max(thread_id)') + 1;
+	if ($dbResult->hasRecord()) {
+		$thread_id = $dbResult->record()->getInt('max(thread_id)') + 1;
 	}
 } else {
 	$thread_index = $var['thread_index'];
@@ -52,12 +52,12 @@ if (!isset($var['thread_index'])) {
 }
 
 // now get the next reply id
-$db->query('SELECT max(reply_id) FROM alliance_thread
+$dbResult = $db->read('SELECT max(reply_id) FROM alliance_thread
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 			AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 			AND thread_id = ' . $db->escapeNumber($thread_id));
-if ($db->nextRecord()) {
-	$reply_id = $db->getInt('max(reply_id)') + 1;
+if ($dbResult->hasRecord()) {
+	$reply_id = $dbResult->record()->getInt('max(reply_id)') + 1;
 }
 
 // only add the topic if it's the first reply
@@ -71,22 +71,22 @@ if ($reply_id == 1) {
 	}
 
 	// test if this topic already exists
-	$db->query('SELECT 1 FROM alliance_thread_topic
+	$dbResult = $db->read('SELECT 1 FROM alliance_thread_topic
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 				AND topic = ' . $db->escapeString($topic));
-	if ($db->getNumRows() > 0) {
+	if ($dbResult->hasRecord()) {
 		create_error('This topic exist already!');
 	}
 
-	$db->query('INSERT INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic, alliance_only)
+	$db->write('INSERT INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic, alliance_only)
 				VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', ' . $db->escapeString($topic) . ', ' . $db->escapeBoolean($allEyesOnly) . ')');
 }
 
 // and the body
-$db->query('INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time)
+$db->write('INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time)
 			VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', ' . $db->escapeNumber($reply_id) . ', ' . $db->escapeString($body) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
-$db->query('REPLACE INTO player_read_thread
+$db->write('REPLACE INTO player_read_thread
 			(account_id, game_id, alliance_id, thread_id, time)
 			VALUES(' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', ' . $db->escapeNumber(Smr\Epoch::time() + 2) . ')');
 

--- a/src/engine/Default/alliance_message_delete_processing.php
+++ b/src/engine/Default/alliance_message_delete_processing.php
@@ -11,18 +11,18 @@ if (!isset($var['alliance_id'])) {
 $alliance_id = $var['alliance_id'];
 
 if (isset($var['reply_id'])) {
-	$db->query('DELETE FROM alliance_thread
+	$db->write('DELETE FROM alliance_thread
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 				AND thread_id = ' . $db->escapeNumber($var['thread_id']) . '
 				AND reply_id = ' . $db->escapeNumber($var['reply_id']) . ' LIMIT 1');
 	Page::create('skeleton.php', 'alliance_message_view.php', $var)->go();
 } else {
-	$db->query('DELETE FROM alliance_thread
+	$db->write('DELETE FROM alliance_thread
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 				AND thread_id = ' . $db->escapeNumber($var['thread_id']));
-	$db->query('DELETE FROM alliance_thread_topic
+	$db->write('DELETE FROM alliance_thread_topic
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 				AND thread_id = ' . $db->escapeNumber($var['thread_id']));

--- a/src/engine/Default/alliance_mod.php
+++ b/src/engine/Default/alliance_mod.php
@@ -20,15 +20,14 @@ Menu::alliance($alliance->getAllianceID());
 // Check to see if an alliance op is scheduled
 // Display it for 1 hour past start time (late arrivals, etc.)
 $db = Smr\Database::getInstance();
-$db->query('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND time > ' . $db->escapeNumber(Smr\Epoch::time() - 3600) . ' LIMIT 1');
-if ($db->nextRecord()) {
-	$template->assign('OpTime', $db->getInt('time'));
+$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND time > ' . $db->escapeNumber(Smr\Epoch::time() - 3600) . ' LIMIT 1');
+if ($dbResult->hasRecord()) {
+	$template->assign('OpTime', $dbResult->record()->getInt('time'));
 
 	// Has player responded yet?
-	$db2 = Smr\Database::getInstance();
-	$db2->query('SELECT response FROM alliance_has_op_response WHERE alliance_id=' . $db2->escapeNumber($player->getAllianceID()) . ' AND ' . $player->getSQL() . ' LIMIT 1');
+	$dbResult2 = $db->read('SELECT response FROM alliance_has_op_response WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND ' . $player->getSQL() . ' LIMIT 1');
 
-	$response = $db2->nextRecord() ? $db2->getField('response') : null;
+	$response = $dbResult2->hasRecord() ? $dbResult2->record()->getField('response') : null;
 	$responseHREF = Page::create('alliance_op_response_processing.php')->href();
 	$template->assign('OpResponseHREF', $responseHREF);
 
@@ -42,9 +41,9 @@ if ($db->nextRecord()) {
 
 // Does the player have edit permission?
 $role_id = $player->getAllianceRole($alliance->getAllianceID());
-$db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
-$db->requireRecord();
-if ($db->getBoolean('change_mod') || $db->getBoolean('change_pass')) {
+$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
+$dbRecord = $dbResult->record();
+if ($dbRecord->getBoolean('change_mod') || $dbRecord->getBoolean('change_pass')) {
 	$container = Page::create('skeleton.php', 'alliance_stat.php');
 	$container['alliance_id'] = $alliance->getAllianceID();
 	$template->assign('EditHREF', $container->href());

--- a/src/engine/Default/alliance_op_response_processing.php
+++ b/src/engine/Default/alliance_op_response_processing.php
@@ -6,6 +6,6 @@ $player = $session->getPlayer();
 $response = strtoupper(Request::get('op_response'));
 
 $db = Smr\Database::getInstance();
-$db->query('REPLACE INTO alliance_has_op_response (alliance_id, game_id, account_id, response) VALUES (' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($response) . ')');
+$db->write('REPLACE INTO alliance_has_op_response (alliance_id, game_id, account_id, response) VALUES (' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($response) . ')');
 
 Page::create('skeleton.php', 'alliance_mod.php')->go();

--- a/src/engine/Default/alliance_option.php
+++ b/src/engine/Default/alliance_option.php
@@ -31,20 +31,20 @@ $links[] = array(
 $role_id = $player->getAllianceRole($alliance->getAllianceID());
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
-$db->requireRecord();
+$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
+$dbRecord = $dbResult->record();
 
 $container['url'] = 'skeleton.php';
 $container['alliance_id'] = $alliance->getAllianceID();
 
-if ($db->getBoolean('change_pass')) {
+if ($dbRecord->getBoolean('change_pass')) {
 	$container['body'] = 'alliance_invite_player.php';
 	$links[] = array(
 		'link' => create_link($container, 'Invite Player'),
 		'text' => 'Invite a player to the alliance.',
 	);
 }
-if ($db->getBoolean('remove_member')) {
+if ($dbRecord->getBoolean('remove_member')) {
 	$container['body'] = 'alliance_remove_member.php';
 	$links[] = array(
 		'link' => create_link($container, 'Remove Member'),
@@ -58,35 +58,35 @@ if ($player->isAllianceLeader()) {
 		'text' => 'Hand over leadership of the alliance to an alliance mate.',
 	);
 }
-if ($db->getBoolean('change_pass') || $db->getBoolean('change_mod')) {
+if ($dbRecord->getBoolean('change_pass') || $dbRecord->getBoolean('change_mod')) {
 	$container['body'] = 'alliance_stat.php';
 	$links[] = array(
 		'link' => create_link($container, 'Change Alliance Stats'),
 		'text' => 'Change the password, description or message of the day for the alliance.',
 	);
 }
-if ($db->getBoolean('change_roles')) {
+if ($dbRecord->getBoolean('change_roles')) {
 	$container['body'] = 'alliance_roles.php';
 	$links[] = array(
 		'link' => create_link($container, 'Define Alliance Roles'),
 		'text' => 'Each member in your alliance can fit into a specific role, a task. Here you can define the roles that you can assign to them.',
 	);
 }
-if ($db->getBoolean('exempt_with')) {
+if ($dbRecord->getBoolean('exempt_with')) {
 	$container['body'] = 'alliance_exempt_authorize.php';
 	$links[] = array(
 		'link' => create_link($container, 'Exempt Bank Transactions'),
 		'text' => 'Here you can set certain alliance account transactions as exempt. This makes them not count against, or for, the player making the transaction in the bank report.',
 	);
 }
-if ($db->getBoolean('treaty_entry')) {
+if ($dbRecord->getBoolean('treaty_entry')) {
 	$container['body'] = 'alliance_treaties.php';
 	$links[] = array(
 		'link' => create_link($container, 'Negotiate Treaties'),
 		'text' => 'Negotitate treaties with other alliances.',
 	);
 }
-if ($db->getBoolean('op_leader')) {
+if ($dbRecord->getBoolean('op_leader')) {
 	$container['body'] = 'alliance_set_op.php';
 	$links[] = array(
 		'link' => create_link($container, 'Schedule Operation'),

--- a/src/engine/Default/alliance_roles.php
+++ b/src/engine/Default/alliance_roles.php
@@ -14,34 +14,34 @@ $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT *
+$dbResult = $db->read('SELECT *
 FROM alliance_has_roles
 WHERE game_id=' . $db->escapeNumber($alliance->getGameID()) . '
 AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
 ORDER BY role_id
 ');
 $allianceRoles = array();
-while ($db->nextRecord()) {
-	$roleID = $db->getInt('role_id');
+foreach ($dbResult->records() as $dbRecord) {
+	$roleID = $dbRecord->getInt('role_id');
 	$allianceRoles[$roleID]['RoleID'] = $roleID;
-	$allianceRoles[$roleID]['Name'] = $db->getField('role');
+	$allianceRoles[$roleID]['Name'] = $dbRecord->getField('role');
 	$allianceRoles[$roleID]['EditingRole'] = isset($var['role_id']) && $var['role_id'] == $roleID;
 	$allianceRoles[$roleID]['CreatingRole'] = false;
 	if ($allianceRoles[$roleID]['EditingRole']) {
 		$container = Page::create('alliance_roles_processing.php');
-		$allianceRoles[$roleID]['WithdrawalLimit'] = $db->getInt('with_per_day');
-		$allianceRoles[$roleID]['PositiveBalance'] = $db->getBoolean('positive_balance');
-		$allianceRoles[$roleID]['TreatyCreated'] = $db->getBoolean('treaty_created');
-		$allianceRoles[$roleID]['RemoveMember'] = $db->getBoolean('remove_member');
-		$allianceRoles[$roleID]['ChangePass'] = $db->getBoolean('change_pass');
-		$allianceRoles[$roleID]['ChangeMod'] = $db->getBoolean('change_mod');
-		$allianceRoles[$roleID]['ChangeRoles'] = $db->getBoolean('change_roles');
-		$allianceRoles[$roleID]['PlanetAccess'] = $db->getBoolean('planet_access');
-		$allianceRoles[$roleID]['ModerateMessageboard'] = $db->getBoolean('mb_messages');
-		$allianceRoles[$roleID]['ExemptWithdrawals'] = $db->getBoolean('exempt_with');
-		$allianceRoles[$roleID]['SendAllianceMessage'] = $db->getBoolean('send_alliance_msg');
-		$allianceRoles[$roleID]['OpLeader'] = $db->getBoolean('op_leader');
-		$allianceRoles[$roleID]['ViewBondsInPlanetList'] = $db->getBoolean('view_bonds');
+		$allianceRoles[$roleID]['WithdrawalLimit'] = $dbRecord->getInt('with_per_day');
+		$allianceRoles[$roleID]['PositiveBalance'] = $dbRecord->getBoolean('positive_balance');
+		$allianceRoles[$roleID]['TreatyCreated'] = $dbRecord->getBoolean('treaty_created');
+		$allianceRoles[$roleID]['RemoveMember'] = $dbRecord->getBoolean('remove_member');
+		$allianceRoles[$roleID]['ChangePass'] = $dbRecord->getBoolean('change_pass');
+		$allianceRoles[$roleID]['ChangeMod'] = $dbRecord->getBoolean('change_mod');
+		$allianceRoles[$roleID]['ChangeRoles'] = $dbRecord->getBoolean('change_roles');
+		$allianceRoles[$roleID]['PlanetAccess'] = $dbRecord->getBoolean('planet_access');
+		$allianceRoles[$roleID]['ModerateMessageboard'] = $dbRecord->getBoolean('mb_messages');
+		$allianceRoles[$roleID]['ExemptWithdrawals'] = $dbRecord->getBoolean('exempt_with');
+		$allianceRoles[$roleID]['SendAllianceMessage'] = $dbRecord->getBoolean('send_alliance_msg');
+		$allianceRoles[$roleID]['OpLeader'] = $dbRecord->getBoolean('op_leader');
+		$allianceRoles[$roleID]['ViewBondsInPlanetList'] = $dbRecord->getBoolean('view_bonds');
 	} else {
 		$container = Page::create('skeleton.php', 'alliance_roles.php');
 	}

--- a/src/engine/Default/alliance_roles_processing.php
+++ b/src/engine/Default/alliance_roles_processing.php
@@ -43,15 +43,15 @@ if (!isset($var['role_id'])) {
 	$db->lockTable('alliance_has_roles');
 
 	// get last id
-	$db->query('SELECT MAX(role_id)
+	$dbResult = $db->read('SELECT MAX(role_id)
 				FROM alliance_has_roles
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND alliance_id = ' . $db->escapeNumber($alliance_id));
-	if ($db->nextRecord()) {
-		$role_id = $db->getInt('MAX(role_id)') + 1;
+	if ($dbResult->hasRecord()) {
+		$role_id = $dbResult->record()->getInt('MAX(role_id)') + 1;
 	}
 
-	$db->query('INSERT INTO alliance_has_roles
+	$db->write('INSERT INTO alliance_has_roles
 				(alliance_id, game_id, role_id, role, with_per_day, positive_balance, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds)
 				VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($role_id) . ', ' . $db->escapeString(Request::get('role')) . ', ' . $db->escapeNumber($withPerDay) . ',' . $db->escapeBoolean($positiveBalance) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 
@@ -64,13 +64,13 @@ if (!isset($var['role_id'])) {
 		} elseif ($var['role_id'] == ALLIANCE_ROLE_NEW_MEMBER) {
 			create_error('You cannot delete the new member role.');
 		}
-		$db->query('DELETE FROM alliance_has_roles
+		$db->write('DELETE FROM alliance_has_roles
 					WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 					AND role_id = ' . $db->escapeNumber($var['role_id']));
 	// otherwise we update it
 	} else {
-		$db->query('UPDATE alliance_has_roles
+		$db->write('UPDATE alliance_has_roles
 					SET role = ' . $db->escapeString(Request::get('role')) . ',
 					with_per_day = ' . $db->escapeNumber($withPerDay) . ',
 					positive_balance = ' . $db->escapeBoolean($positiveBalance) . ',

--- a/src/engine/Default/alliance_roles_save_processing.php
+++ b/src/engine/Default/alliance_roles_save_processing.php
@@ -6,7 +6,7 @@ $player = $session->getPlayer();
 
 foreach (Request::getIntArray('role', []) as $accountID => $roleID) {
 	$db = Smr\Database::getInstance();
-	$db->query('REPLACE INTO player_has_alliance_role
+	$db->write('REPLACE INTO player_has_alliance_role
 					(account_id, game_id, role_id, alliance_id)
 					VALUES (' . $db->escapeNumber($accountID) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($roleID) . ',' . $db->escapeNumber($var['alliance_id']) . ')');
 }

--- a/src/engine/Default/alliance_roster.php
+++ b/src/engine/Default/alliance_roster.php
@@ -26,13 +26,13 @@ if ($showRoles) {
 	$roles = array();
 
 	// get all roles from db for faster access later
-	$db->query('SELECT role_id, role
+	$dbResult = $db->read('SELECT role_id, role
 				FROM alliance_has_roles
 				WHERE game_id=' . $db->escapeNumber($alliance->getGameID()) . '
 				AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
 				ORDER BY role_id');
-	while ($db->nextRecord()) {
-		$roles[$db->getInt('role_id')] = $db->getField('role');
+	foreach ($dbResult->records() as $dbRecord) {
+		$roles[$dbRecord->getInt('role_id')] = $dbRecord->getField('role');
 	}
 	$template->assign('Roles', $roles);
 
@@ -44,7 +44,7 @@ if ($showRoles) {
 
 // If the alliance is the player's alliance they get live information
 // Otherwise it comes from the cache.
-$db->query('SELECT
+$dbResult = $db->read('SELECT
 	SUM(experience) AS alliance_xp,
 	FLOOR(AVG(experience)) AS alliance_avg
 	FROM player
@@ -52,10 +52,10 @@ $db->query('SELECT
 	AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
 	GROUP BY alliance_id'
 );
+$dbRecord = $dbResult->record();
 
-$db->requireRecord();
-$template->assign('AllianceExp', $db->getInt('alliance_xp'));
-$template->assign('AllianceAverageExp', $db->getInt('alliance_avg'));
+$template->assign('AllianceExp', $dbRecord->getInt('alliance_xp'));
+$template->assign('AllianceAverageExp', $dbRecord->getInt('alliance_avg'));
 
 if ($account->getAccountID() == $alliance->getLeaderID() || $account->hasPermission(PERMISSION_EDIT_ALLIANCE_DESCRIPTION)) {
 	$container = Page::create('skeleton.php', 'alliance_stat.php');
@@ -63,9 +63,9 @@ if ($account->getAccountID() == $alliance->getLeaderID() || $account->hasPermiss
 	$template->assign('EditAllianceDescriptionHREF', $container->href());
 }
 
-$db->query('SELECT 1 FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
+$dbResult = $db->read('SELECT 1 FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
 			AND role_id = ' . $db->escapeNumber($player->getAllianceRole()) . ' AND change_roles = \'TRUE\'');
-$allowed = $db->nextRecord();
+$allowed = $dbResult->hasRecord();
 $template->assign('CanChangeRoles', $allowed);
 
 $alliancePlayers = $alliance->getMembers();

--- a/src/engine/Default/alliance_set_op.php
+++ b/src/engine/Default/alliance_set_op.php
@@ -19,11 +19,11 @@ if (!empty($var['message'])) {
 
 // get the op from db
 $db = Smr\Database::getInstance();
-$db->query('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND  game_id=' . $db->escapeNumber($player->getGameID()));
+$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND  game_id=' . $db->escapeNumber($player->getGameID()));
 
-if ($db->nextRecord()) {
+if ($dbResult->hasRecord()) {
 	// An op is already scheduled, so get the time
-	$time = $db->getInt('time');
+	$time = $dbResult->record()->getInt('time');
 	$template->assign('OpDate', date($account->getDateTimeFormat(), $time));
 	$template->assign('OpCountdown', format_time($time - Smr\Epoch::time()));
 

--- a/src/engine/Default/alliance_set_op_processing.php
+++ b/src/engine/Default/alliance_set_op_processing.php
@@ -13,11 +13,11 @@ function error_on_page(string $error) : void {
 
 if (!empty($var['cancel'])) {
 	// just get rid of op
-	$db->query('DELETE FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
-	$db->query('DELETE FROM alliance_has_op_response WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
+	$db->write('DELETE FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
+	$db->write('DELETE FROM alliance_has_op_response WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
 
 	// Delete the announcement from alliance members message boxes
-	$db->query('DELETE FROM message WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND sender_id=' . $db->escapeNumber(ACCOUNT_ID_OP_ANNOUNCE) . ' AND account_id IN (' . $db->escapeArray($player->getAlliance()->getMemberIDs()) . ')');
+	$db->write('DELETE FROM message WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND sender_id=' . $db->escapeNumber(ACCOUNT_ID_OP_ANNOUNCE) . ' AND account_id IN (' . $db->escapeArray($player->getAlliance()->getMemberIDs()) . ')');
 
 	// NOTE: for simplicity we don't touch `player_has_unread_messages` here,
 	// so they may get an errant alliance message icon if logged in.
@@ -34,7 +34,7 @@ if (!empty($var['cancel'])) {
 	}
 
 	// add op to db
-	$db->query('INSERT INTO alliance_has_op (alliance_id, game_id, time) VALUES (' . $db->escapeNumber($player->getAllianceID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($time) . ')');
+	$db->write('INSERT INTO alliance_has_op (alliance_id, game_id, time) VALUES (' . $db->escapeNumber($player->getAllianceID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($time) . ')');
 
 	// Send an alliance message that expires at the time of the op.
 	// Since the message is procedural, don't exclude this player.

--- a/src/engine/Default/alliance_stat.php
+++ b/src/engine/Default/alliance_stat.php
@@ -21,10 +21,11 @@ $container['alliance_id'] = $alliance_id;
 $role_id = $player->getAllianceRole($alliance->getAllianceID());
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
-if ($db->nextRecord()) {
-	$change_mod = $db->getBoolean('change_mod');
-	$change_pass = $db->getBoolean('change_pass');
+$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
+if ($dbResult->hasRecord()) {
+	$dbRecord = $dbResult->record();
+	$change_mod = $dbRecord->getBoolean('change_mod');
+	$change_pass = $dbRecord->getBoolean('change_pass');
 } else {
 	$change_mod = false;
 	$change_pass = false;

--- a/src/engine/Default/alliance_stat_processing.php
+++ b/src/engine/Default/alliance_stat_processing.php
@@ -50,8 +50,8 @@ if (isset($discordChannel)) {
 	} else {
 		// no duplicates in a given game
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT * FROM alliance WHERE discord_channel =' . $db->escapeString($discordChannel) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($alliance->getAllianceID()) . ' LIMIT 1');
-		if ($db->nextRecord()) {
+		$dbResult = $db->read('SELECT 1 FROM alliance WHERE discord_channel =' . $db->escapeString($discordChannel) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($alliance->getAllianceID()) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
 			create_error('Another alliance is already using that Discord Channel ID!');
 		}
 

--- a/src/engine/Default/alliance_treaties.php
+++ b/src/engine/Default/alliance_treaties.php
@@ -11,9 +11,9 @@ Menu::alliance($alliance->getAllianceID());
 
 $alliances = [];
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($player->getAllianceID()) . ' ORDER BY alliance_name');
-while ($db->nextRecord()) {
-	$alliances[$db->getInt('alliance_id')] = htmlentities($db->getField('alliance_name'));
+$dbResult = $db->read('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($player->getAllianceID()) . ' ORDER BY alliance_name');
+foreach ($dbResult->records() as $dbRecord) {
+	$alliances[$dbRecord->getInt('alliance_id')] = htmlentities($dbRecord->getField('alliance_name'));
 }
 $template->assign('Alliances', $alliances);
 
@@ -22,18 +22,18 @@ if (isset($var['message'])) {
 }
 
 $offers = [];
-$db->query('SELECT * FROM alliance_treaties WHERE alliance_id_2 = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND official = \'FALSE\'');
-while ($db->nextRecord()) {
+$dbResult = $db->read('SELECT * FROM alliance_treaties WHERE alliance_id_2 = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND official = \'FALSE\'');
+foreach ($dbResult->records() as $dbRecord) {
 	$offerTerms = [];
 	foreach (array_keys(SmrTreaty::TYPES) as $term) {
-		if ($db->getBoolean($term)) {
+		if ($dbRecord->getBoolean($term)) {
 			$offerTerms[] = $term;
 		}
 	}
-	$otherAllianceID = $db->getInt('alliance_id_1');
+	$otherAllianceID = $dbRecord->getInt('alliance_id_1');
 	$container = Page::create('alliance_treaties_processing.php', '');
 	$container['alliance_id_1'] = $otherAllianceID;
-	$container['aa_access'] = $db->getField('aa_access');
+	$container['aa_access'] = $dbRecord->getField('aa_access');
 	$container['accept'] = true;
 	$acceptHREF = $container->href();
 	$container['accept'] = false;

--- a/src/engine/Default/alliance_treaties.php
+++ b/src/engine/Default/alliance_treaties.php
@@ -13,7 +13,7 @@ $alliances = [];
 $db = Smr\Database::getInstance();
 $dbResult = $db->read('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($player->getAllianceID()) . ' ORDER BY alliance_name');
 foreach ($dbResult->records() as $dbRecord) {
-	$alliances[$dbRecord->getInt('alliance_id')] = htmlentities($dbRecord->getField('alliance_name'));
+	$alliances[$dbRecord->getInt('alliance_id')] = htmlentities($dbRecord->getString('alliance_name'));
 }
 $template->assign('Alliances', $alliances);
 

--- a/src/engine/Default/alliance_treaties_confirm.php
+++ b/src/engine/Default/alliance_treaties_confirm.php
@@ -8,8 +8,8 @@ $alliance_id_1 = $player->getAllianceID();
 $alliance_id_2 = $_REQUEST['proposedAlliance'];
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT alliance_id_1, alliance_id_2, game_id FROM alliance_treaties WHERE (alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_1 = ' . $alliance_id_2 . ') AND (alliance_id_2 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()));
-if ($db->nextRecord()) {
+$dbResult = $db->read('SELECT 1 FROM alliance_treaties WHERE (alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_1 = ' . $alliance_id_2 . ') AND (alliance_id_2 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()));
+if ($dbResult->hasRecord()) {
 	$container = Page::create('skeleton.php', 'alliance_treaties.php');
 	$container['message'] = '<span class="red bold">ERROR:</span> There is already an outstanding treaty with that alliance.';
 	$container->go();

--- a/src/engine/Default/alliance_treaties_confirm_processing.php
+++ b/src/engine/Default/alliance_treaties_confirm_processing.php
@@ -11,7 +11,7 @@ $alliance_id_1 = $alliance1->getAllianceID();
 $alliance_id_2 = $alliance2->getAllianceID();
 
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO alliance_treaties (alliance_id_1,alliance_id_2,game_id,trader_assist,trader_defend,trader_nap,raid_assist,planet_land,planet_nap,forces_nap,aa_access,mb_read,mb_write,mod_read,official)
+$db->write('INSERT INTO alliance_treaties (alliance_id_1,alliance_id_2,game_id,trader_assist,trader_defend,trader_nap,raid_assist,planet_land,planet_nap,forces_nap,aa_access,mb_read,mb_write,mod_read,official)
 			VALUES (' . $db->escapeNumber($alliance_id_1) . ', ' . $db->escapeNumber($alliance_id_2) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeBoolean($var['trader_assist']) . ', ' .
 			$db->escapeBoolean($var['trader_defend']) . ', ' . $db->escapeBoolean($var['trader_nap']) . ', ' . $db->escapeBoolean($var['raid_assist']) . ', ' . $db->escapeBoolean($var['planet_land']) . ', ' . $db->escapeBoolean($var['planet_nap']) . ', ' .
 			$db->escapeBoolean($var['forces_nap']) . ', ' . $db->escapeBoolean($var['aa_access']) . ', ' . $db->escapeBoolean($var['mb_read']) . ', ' . $db->escapeBoolean($var['mb_write']) . ', ' . $db->escapeBoolean($var['mod_read']) . ', \'FALSE\')');

--- a/src/engine/Default/alliance_treaties_processing.php
+++ b/src/engine/Default/alliance_treaties_processing.php
@@ -13,7 +13,7 @@ $alliance_id_2 = $player->getAllianceID();
 
 $db = Smr\Database::getInstance();
 if ($var['accept']) {
-	$db->query('UPDATE alliance_treaties SET official = \'TRUE\' WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->write('UPDATE alliance_treaties SET official = \'TRUE\' WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 
 	if ($var['aa_access']) {
 		//make an AA role for both alliances, use treaty_created column
@@ -23,21 +23,21 @@ if ($var['accept']) {
 		];
 		foreach ($pairs as $alliance_id_A => $alliance_id_B) {
 			// get last id
-			$db->query('SELECT MAX(role_id)
+			$dbResult = $db->read('SELECT MAX(role_id)
 						FROM alliance_has_roles
 						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 							AND alliance_id = ' . $db->escapeNumber($alliance_id_A));
-			if ($db->nextRecord()) {
-				$role_id = $db->getInt('MAX(role_id)') + 1;
+			if ($dbResult->hasRecord()) {
+				$role_id = $dbResult->record()->getInt('MAX(role_id)') + 1;
 			}
 			$allianceName = SmrAlliance::getAlliance($alliance_id_B, $player->getGameID())->getAllianceName();
-			$db->query('INSERT INTO alliance_has_roles
+			$db->write('INSERT INTO alliance_has_roles
 				(alliance_id, game_id, role_id, role, treaty_created)
 				VALUES (' . $db->escapeNumber($alliance_id_A) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($role_id) . ', ' . $db->escapeString($allianceName) . ',1)');
 		}
 	}
 } else {
-	$db->query('DELETE FROM alliance_treaties WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->write('DELETE FROM alliance_treaties WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 }
 
 $container = Page::create('skeleton.php', 'alliance_treaties.php');

--- a/src/engine/Default/announcements.php
+++ b/src/engine/Default/announcements.php
@@ -11,21 +11,21 @@ if (!isset($var['view_all'])) {
 	$session = Smr\Session::getInstance();
 	$account = $session->getAccount();
 
-	$db->query('SELECT time, msg
+	$dbResult = $db->read('SELECT time, msg
 				FROM announcement
 				WHERE time > ' . $db->escapeNumber($account->getLastLogin()) . '
 				ORDER BY time DESC');
 } else {
-	$db->query('SELECT time, msg
+	$dbResult = $db->read('SELECT time, msg
 				FROM announcement
 				ORDER BY time DESC');
 }
 
 $announcements = [];
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$announcements[] = [
-		'Time' => $db->getInt('time'),
-		'Msg' => htmlentities($db->getField('msg')),
+		'Time' => $dbRecord->getInt('time'),
+		'Msg' => htmlentities($dbRecord->getField('msg')),
 	];
 }
 $template->assign('Announcements', $announcements);

--- a/src/engine/Default/announcements.php
+++ b/src/engine/Default/announcements.php
@@ -25,7 +25,7 @@ $announcements = [];
 foreach ($dbResult->records() as $dbRecord) {
 	$announcements[] = [
 		'Time' => $dbRecord->getInt('time'),
-		'Msg' => htmlentities($dbRecord->getField('msg')),
+		'Msg' => htmlentities($dbRecord->getString('msg')),
 	];
 }
 $template->assign('Announcements', $announcements);

--- a/src/engine/Default/bank_alliance.php
+++ b/src/engine/Default/bank_alliance.php
@@ -27,28 +27,22 @@ $template->assign('PageTopic', 'Bank');
 Menu::bank();
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM alliance_treaties WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
+$dbResult = $db->read('SELECT * FROM alliance_treaties WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 			AND (alliance_id_1 = ' . $db->escapeNumber($player->getAllianceID()) . ' OR alliance_id_2 = ' . $db->escapeNumber($player->getAllianceID()) . ')
 			AND aa_access = 1 AND official = \'TRUE\'');
 $alliedAllianceBanks = array();
-if ($db->getNumRows() > 0) {
-	$alliedAllianceBanks[$player->getAllianceID()] = $player->getAlliance();
-	while ($db->nextRecord()) {
-		if ($db->getInt('alliance_id_1') == $player->getAllianceID()) {
-			$alliedAllianceBanks[$db->getInt('alliance_id_2')] = SmrAlliance::getAlliance($db->getInt('alliance_id_2'), $alliance->getGameID());
-		} else {
-			$alliedAllianceBanks[$db->getInt('alliance_id_1')] = SmrAlliance::getAlliance($db->getInt('alliance_id_1'), $alliance->getGameID());
-		}
-	}
+foreach ($dbResult->records() as $dbRecord) {
+	$alliedAllianceBanks[$dbRecord->getInt('alliance_id_2')] = SmrAlliance::getAlliance($dbRecord->getInt('alliance_id_2'), $alliance->getGameID());
+	$alliedAllianceBanks[$dbRecord->getInt('alliance_id_1')] = SmrAlliance::getAlliance($dbRecord->getInt('alliance_id_1'), $alliance->getGameID());
 }
 $template->assign('AlliedAllianceBanks', $alliedAllianceBanks);
 
-$db->query('SELECT transaction, sum(amount) as total FROM alliance_bank_transactions
+$dbResult = $db->read('SELECT transaction, sum(amount) as total FROM alliance_bank_transactions
 			WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . '
 			GROUP BY transaction');
 $playerTrans = array('Deposit' => 0, 'Payment' => 0);
-while ($db->nextRecord()) {
-	$playerTrans[$db->getField('transaction')] = $db->getInt('total');
+foreach ($dbResult->records() as $dbRecord) {
+	$playerTrans[$dbRecord->getField('transaction')] = $dbRecord->getInt('total');
 }
 
 if ($alliance->getAllianceID() == $player->getAllianceID()) {
@@ -58,20 +52,20 @@ if ($alliance->getAllianceID() == $player->getAllianceID()) {
 	$query = 'role = ' . $db->escapeString($player->getAlliance()->getAllianceName());
 }
 
-$db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND ' . $query);
-$db->requireRecord();
-$template->assign('CanExempt', $db->getBoolean('exempt_with'));
-$withdrawalPerDay = $db->getInt('with_per_day');
+$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND ' . $query);
+$dbRecord = $dbResult->record();
+$template->assign('CanExempt', $dbRecord->getBoolean('exempt_with'));
+$withdrawalPerDay = $dbRecord->getInt('with_per_day');
 
-if ($db->getBoolean('positive_balance')) {
+if ($dbRecord->getBoolean('positive_balance')) {
 	$template->assign('PositiveWithdrawal', $withdrawalPerDay + $playerTrans['Deposit'] - $playerTrans['Payment']);
 } elseif ($withdrawalPerDay == ALLIANCE_BANK_UNLIMITED) {
 	$template->assign('UnlimitedWithdrawal', true);
 } else {
-	$db->query('SELECT sum(amount) as total FROM alliance_bank_transactions WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
+	$dbResult = $db->read('SELECT sum(amount) as total FROM alliance_bank_transactions WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
 				AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND transaction = \'Payment\' AND exempt = 0 AND time > ' . $db->escapeNumber(Smr\Epoch::time() - 86400));
-	if ($db->nextRecord()) {
-		$totalWithdrawn = $db->getInt('total');
+	if ($dbResult->hasRecord()) {
+		$totalWithdrawn = $dbResult->record()->getInt('total');
 	}
 	$template->assign('WithdrawalPerDay', $withdrawalPerDay);
 	$template->assign('RemainingWithdrawal', $withdrawalPerDay - $totalWithdrawn);
@@ -82,11 +76,11 @@ $maxValue = $session->getRequestVarInt('maxValue', 0);
 $minValue = $session->getRequestVarInt('minValue', 0);
 
 if ($maxValue <= 0) {
-	$db->query('SELECT MAX(transaction_id) FROM alliance_bank_transactions
+	$dbResult = $db->read('SELECT MAX(transaction_id) FROM alliance_bank_transactions
 				WHERE game_id=' . $db->escapeNumber($alliance->getGameID()) . '
 				AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()));
-	if ($db->nextRecord()) {
-		$maxValue = $db->getInt('MAX(transaction_id)');
+	if ($dbResult->hasRecord()) {
+		$maxValue = $dbResult->record()->getInt('MAX(transaction_id)');
 	}
 }
 
@@ -108,20 +102,20 @@ if ($maxValue > 0 && $minValue > 0) {
 	$query .= ' ORDER BY time LIMIT 10';
 }
 
-$db->query($query);
+$dbResult = $db->read($query);
 
 // only if we have at least one result
-if ($db->getNumRows() > 0) {
+if ($dbResult->hasRecord()) {
 	$bankTransactions = array();
-	while ($db->nextRecord()) {
-		$bankTransactions[$db->getInt('transaction_id')] = array(
-			'Time' => $db->getInt('time'),
-			'Player' => SmrPlayer::getPlayer($db->getInt('payee_id'), $player->getGameID()),
-			'Reason' => $db->getField('reason'),
-			'TransactionType' => $db->getField('transaction'),
-			'Withdrawal' => $db->getField('transaction') == 'Payment' ? $db->getInt('amount') : '',
-			'Deposit' => $db->getField('transaction') == 'Deposit' ? $db->getInt('amount') : '',
-			'Exempt' => $db->getInt('exempt') == 1
+	foreach ($dbResult->records() as $dbRecord) {
+		$bankTransactions[$dbRecord->getInt('transaction_id')] = array(
+			'Time' => $dbRecord->getInt('time'),
+			'Player' => SmrPlayer::getPlayer($dbRecord->getInt('payee_id'), $player->getGameID()),
+			'Reason' => $dbRecord->getField('reason'),
+			'TransactionType' => $dbRecord->getField('transaction'),
+			'Withdrawal' => $dbRecord->getField('transaction') == 'Payment' ? $dbRecord->getInt('amount') : '',
+			'Deposit' => $dbRecord->getField('transaction') == 'Deposit' ? $dbRecord->getInt('amount') : '',
+			'Exempt' => $dbRecord->getInt('exempt') == 1
 		);
 	}
 	$template->assign('BankTransactions', $bankTransactions);

--- a/src/engine/Default/bank_alliance_exempt_processing.php
+++ b/src/engine/Default/bank_alliance_exempt_processing.php
@@ -7,13 +7,13 @@ $player = $session->getPlayer();
 
 //only if we are coming from the bank screen do we unexempt selection first
 if (isset($var['minVal'])) {
-	$db->query('UPDATE alliance_bank_transactions SET exempt = 0 WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
+	$db->write('UPDATE alliance_bank_transactions SET exempt = 0 WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 				AND transaction_id BETWEEN ' . $db->escapeNumber($var['minVal']) . ' AND ' . $db->escapeNumber($var['maxVal']));
 }
 
 if (Request::has('exempt')) {
 	$trans_ids = array_keys(Request::getArray('exempt'));
-	$db->query('UPDATE alliance_bank_transactions SET exempt = 1, request_exempt = 0 WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
+	$db->write('UPDATE alliance_bank_transactions SET exempt = 1, request_exempt = 0 WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 				AND transaction_id IN (' . $db->escapeArray($trans_ids) . ')');
 }
 

--- a/src/engine/Default/bank_alliance_processing.php
+++ b/src/engine/Default/bank_alliance_processing.php
@@ -47,33 +47,32 @@ if ($action == 'Deposit') {
 		// Alliance treaties create new roles with alliance names
 		$query = 'role = ' . $db->escapeString($player->getAlliance()->getAllianceName());
 	}
-	$db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND ' . $query);
-	$db->requireRecord();
-	$withdrawalPerDay = $db->getInt('with_per_day');
-	if ($db->getBoolean('positive_balance')) {
-		$db->query('SELECT transaction, sum(amount) as total FROM alliance_bank_transactions
+	$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND ' . $query);
+	$dbRecord = $dbResult->record();
+	$withdrawalPerDay = $dbRecord->getInt('with_per_day');
+	if ($dbRecord->getBoolean('positive_balance')) {
+		$dbResult = $db->read('SELECT transaction, sum(amount) as total FROM alliance_bank_transactions
 			WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . '
 			GROUP BY transaction');
 		$playerTrans = array('Deposit' => 0, 'Payment' => 0);
-		while ($db->nextRecord()) {
-			$playerTrans[$db->getField('transaction')] = $db->getInt('total');
+		foreach ($dbResult->records() as $dbRecord) {
+			$playerTrans[$dbRecord->getField('transaction')] = $dbRecord->getInt('total');
 		}
 		$allowedWithdrawal = $withdrawalPerDay + $playerTrans['Deposit'] - $playerTrans['Payment'];
 		if ($allowedWithdrawal - $amount < 0) {
 			create_error('Your alliance won\'t allow you to take so much with how little you\'ve given!');
 		}
 	} elseif ($withdrawalPerDay >= 0) {
-		$db->query('SELECT sum(amount) as total FROM alliance_bank_transactions
+		$dbResult = $db->read('SELECT sum(amount) as total FROM alliance_bank_transactions
 					WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . '
 						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 						AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . '
 						AND transaction = \'Payment\'
 						AND exempt = 0
 						AND time > ' . $db->escapeNumber(Smr\Epoch::time() - 86400));
-		if ($db->nextRecord() && !is_null($db->getInt('total'))) {
-			$total = $db->getInt('total');
-		} else {
-			$total = 0;
+		$total = 0;
+		if ($dbResult->hasRecord()) {
+			$total = $dbResult->record()->getInt('total');
 		}
 		if ($total + $amount > $withdrawalPerDay) {
 			create_error('Your alliance doesn\'t allow you to take that much cash this often!');
@@ -88,16 +87,16 @@ if ($action == 'Deposit') {
 $player->log(LOG_TYPE_BANK, $action . ' ' . $amount . ' credits for alliance account of ' . $alliance->getAllianceName());
 
 // get next transaction id
-$db->query('SELECT MAX(transaction_id) as next_id FROM alliance_bank_transactions
+$dbResult = $db->read('SELECT MAX(transaction_id) as next_id FROM alliance_bank_transactions
 			WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . '
 				AND game_id = ' . $db->escapeNumber($player->getGameID()));
-if ($db->nextRecord()) {
-	$next_id = $db->getInt('next_id') + 1;
+if ($dbResult->hasRecord()) {
+	$next_id = $dbResult->record()->getInt('next_id') + 1;
 }
 
 // save log
 $requestExempt = Request::has('requestExempt') ? 1 : 0;
-$db->query('INSERT INTO alliance_bank_transactions
+$db->write('INSERT INTO alliance_bank_transactions
 			(alliance_id, game_id, transaction_id, time, payee_id, reason, transaction, amount, request_exempt)
 			VALUES(' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($next_id) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($message) . ', ' . $db->escapeString($action) . ', ' . $db->escapeNumber($amount) . ', ' . $db->escapeNumber($requestExempt) . ')');
 

--- a/src/engine/Default/bank_anon.php
+++ b/src/engine/Default/bank_anon.php
@@ -19,23 +19,22 @@ $template->assign('AccessHREF', $container->href());
 $template->assign('Message', $var['message'] ?? '');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM anon_bank
+$dbResult = $db->read('SELECT * FROM anon_bank
 			WHERE owner_id=' . $db->escapeNumber($player->getAccountID()) . '
 			AND game_id=' . $db->escapeNumber($player->getGameID()));
 
 $ownedAnon = [];
-$db2 = Smr\Database::getInstance();
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$anon = [];
-	$anon['anon_id'] = $db->getInt('anon_id');
-	$anon['password'] = $db->getField('password');
-	$anon['amount'] = $db->getInt('amount');
+	$anon['anon_id'] = $dbRecord->getInt('anon_id');
+	$anon['password'] = $dbRecord->getField('password');
+	$anon['amount'] = $dbRecord->getInt('amount');
 
-	$db2->query('SELECT MAX(time) FROM anon_bank_transactions
-				WHERE game_id=' . $db2->escapeNumber($player->getGameID()) . '
-				AND anon_id=' . $db2->escapeNumber($db->getInt('anon_id')) . ' LIMIT 1');
-	if ($db2->nextRecord() && $db2->getInt('MAX(time)')) {
-		$anon['last_transaction'] = date($account->getDateTimeFormat(), $db2->getInt('MAX(time)'));
+	$dbResult2 = $db->read('SELECT MAX(time) FROM anon_bank_transactions
+				WHERE game_id=' . $db->escapeNumber($player->getGameID()) . '
+				AND anon_id=' . $db->escapeNumber($dbRecord->getInt('anon_id')) . ' LIMIT 1');
+	if ($dbResult2->hasRecord()) {
+		$anon['last_transaction'] = date($account->getDateTimeFormat(), $dbResult2->record()->getInt('MAX(time)'));
 	} else {
 		$anon['last_transaction'] = 'No transactions';
 	}

--- a/src/engine/Default/bank_anon_create_processing.php
+++ b/src/engine/Default/bank_anon_create_processing.php
@@ -10,11 +10,11 @@ if (empty($password)) {
 }
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT MAX(anon_id) FROM anon_bank WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
-if ($db->nextRecord()) {
-	$new_acc = $db->getInt('MAX(anon_id)') + 1;
+$dbResult = $db->read('SELECT MAX(anon_id) FROM anon_bank WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
+if ($dbResult->hasRecord()) {
+	$new_acc = $dbResult->record()->getInt('MAX(anon_id)') + 1;
 }
-$db->query('INSERT INTO anon_bank (game_id, anon_id, owner_id, password, amount) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($new_acc) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($password) . ', 0)');
+$db->write('INSERT INTO anon_bank (game_id, anon_id, owner_id, password, amount) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($new_acc) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($password) . ', 0)');
 
 $container = Page::create('skeleton.php', 'bank_anon.php');
 $container['message'] = '<p>Account #' . $new_acc . ' has been opened for you.</p>';

--- a/src/engine/Default/bank_anon_detail_processing.php
+++ b/src/engine/Default/bank_anon_detail_processing.php
@@ -18,9 +18,9 @@ if ($amount <= 0) {
 
 // Get the next transaction ID for this anon bank
 $db = Smr\Database::getInstance();
-$db->query('SELECT transaction_id FROM anon_bank_transactions WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num) . ' ORDER BY transaction_id DESC LIMIT 1');
-if ($db->nextRecord()) {
-	$trans_id = $db->getInt('transaction_id') + 1;
+$dbResult = $db->read('SELECT transaction_id FROM anon_bank_transactions WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num) . ' ORDER BY transaction_id DESC LIMIT 1');
+if ($dbResult->hasRecord()) {
+	$trans_id = $dbResult->record()->getInt('transaction_id') + 1;
 } else {
 	$trans_id = 1;
 }
@@ -33,22 +33,21 @@ if ($action == 'Deposit') {
 
 	// Does not handle overflow!
 	$player->decreaseCredits($amount);
-	$db->query('UPDATE anon_bank SET amount = amount + ' . $db->escapeNumber($amount) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num));
+	$db->write('UPDATE anon_bank SET amount = amount + ' . $db->escapeNumber($amount) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num));
 } else {
-	$db->query('SELECT * FROM anon_bank WHERE anon_id = ' . $db->escapeNumber($account_num) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db->requireRecord();
-	if ($db->getInt('amount') < $amount) {
+	$dbResult = $db->read('SELECT * FROM anon_bank WHERE anon_id = ' . $db->escapeNumber($account_num) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	if ($dbResult->record()->getInt('amount') < $amount) {
 		create_error('You don\'t have that much money on your account!');
 	}
 
 	$amount = $player->increaseCredits($amount); // handles overflow
-	$db->query('UPDATE anon_bank SET amount = amount - ' . $db->escapeNumber($amount) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num));
+	$db->write('UPDATE anon_bank SET amount = amount - ' . $db->escapeNumber($amount) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num));
 }
 
 $player->update();
 
 // Log the bank transaction
-$db->query('INSERT INTO anon_bank_transactions (account_id, game_id, anon_id, transaction_id, transaction, amount, time)
+$db->write('INSERT INTO anon_bank_transactions (account_id, game_id, anon_id, transaction_id, transaction, amount, time)
 			VALUES (' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($account_num) . ', ' . $db->escapeNumber($trans_id) . ', ' . $db->escapeString($action) . ', ' . $db->escapeNumber($amount) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
 // Log the player action

--- a/src/engine/Default/bank_report.php
+++ b/src/engine/Default/bank_report.php
@@ -39,7 +39,7 @@ arsort($totals, SORT_NUMERIC);
 $dbResult = $db->read('SELECT * FROM player WHERE account_id IN (' . $db->escapeArray($playerIDs) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY player_name');
 $players[0] = 'Alliance Funds';
 foreach ($dbResult->records() as $dbRecord) {
-	$players[$dbRecord->getInt('account_id')] = htmlentities($dbRecord->getField('player_name'));
+	$players[$dbRecord->getInt('account_id')] = htmlentities($dbRecord->getString('player_name'));
 }
 
 //format it this way so its easy to send to the alliance MB if requested.

--- a/src/engine/Default/bank_report.php
+++ b/src/engine/Default/bank_report.php
@@ -14,19 +14,19 @@ const DEPOSIT = 1;
 
 //get all transactions
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM alliance_bank_transactions WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-if (!$db->getNumRows()) {
+$dbResult = $db->read('SELECT * FROM alliance_bank_transactions WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+if (!$dbResult->hasRecord()) {
 	create_error('Your alliance has no recorded transactions.');
 }
 $trans = array();
-while ($db->nextRecord()) {
-	$transType = ($db->getField('transaction') == 'Payment') ? WITHDRAW : DEPOSIT;
-	$payeeId = ($db->getInt('exempt')) ? 0 : $db->getInt('payee_id');
+foreach ($dbResult->records() as $dbRecord) {
+	$transType = ($dbRecord->getField('transaction') == 'Payment') ? WITHDRAW : DEPOSIT;
+	$payeeId = ($dbRecord->getInt('exempt')) ? 0 : $dbRecord->getInt('payee_id');
 	// initialize payee if necessary
 	if (!isset($trans[$payeeId])) {
 		$trans[$payeeId] = array(WITHDRAW => 0, DEPOSIT => 0);
 	}
-	$trans[$payeeId][$transType] += $db->getInt('amount');
+	$trans[$payeeId][$transType] += $dbRecord->getInt('amount');
 }
 
 //ordering
@@ -36,10 +36,10 @@ foreach ($trans as $accId => $transArray) {
 	$totals[$accId] = $transArray[DEPOSIT] - $transArray[WITHDRAW];
 }
 arsort($totals, SORT_NUMERIC);
-$db->query('SELECT * FROM player WHERE account_id IN (' . $db->escapeArray($playerIDs) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY player_name');
+$dbResult = $db->read('SELECT * FROM player WHERE account_id IN (' . $db->escapeArray($playerIDs) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY player_name');
 $players[0] = 'Alliance Funds';
-while ($db->nextRecord()) {
-	$players[$db->getInt('account_id')] = htmlentities($db->getField('player_name'));
+foreach ($dbResult->records() as $dbRecord) {
+	$players[$dbRecord->getInt('account_id')] = htmlentities($dbRecord->getField('player_name'));
 }
 
 //format it this way so its easy to send to the alliance MB if requested.

--- a/src/engine/Default/bank_report_processing.php
+++ b/src/engine/Default/bank_report_processing.php
@@ -10,23 +10,23 @@ $text = $var['text'];
 
 // Check if the "Bank Statement" thread exists yet
 $db = Smr\Database::getInstance();
-$db->query('SELECT thread_id FROM alliance_thread_topic WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND topic = \'Bank Statement\' LIMIT 1');
+$dbResult = $db->read('SELECT thread_id FROM alliance_thread_topic WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND topic = \'Bank Statement\' LIMIT 1');
 
-if ($db->nextRecord()) {
+if ($dbResult->hasRecord()) {
 	// Update the existing "Bank Statement" thread
-	$thread_id = $db->getInt('thread_id');
-	$db->query('UPDATE alliance_thread SET time = ' . $db->escapeNumber(Smr\Epoch::time()) . ', text = ' . $db->escapeString($text) . ' WHERE thread_id = ' . $db->escapeNumber($thread_id) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND reply_id = 1');
-	$db->query('DELETE FROM player_read_thread WHERE thread_id = ' . $db->escapeNumber($thread_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id));
+	$thread_id = $dbResult->record()->getInt('thread_id');
+	$db->write('UPDATE alliance_thread SET time = ' . $db->escapeNumber(Smr\Epoch::time()) . ', text = ' . $db->escapeString($text) . ' WHERE thread_id = ' . $db->escapeNumber($thread_id) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND reply_id = 1');
+	$db->write('DELETE FROM player_read_thread WHERE thread_id = ' . $db->escapeNumber($thread_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id));
 } else {
 	// There is no "Bank Statement" thread yet
-	$db->query('SELECT thread_id FROM alliance_thread_topic WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' ORDER BY thread_id DESC LIMIT 1');
-	if ($db->nextRecord()) {
-		$thread_id = $db->getInt('thread_id') + 1;
+	$dbResult = $db->read('SELECT thread_id FROM alliance_thread_topic WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' ORDER BY thread_id DESC LIMIT 1');
+	if ($dbResult->hasRecord()) {
+		$thread_id = $dbResult->record()->getInt('thread_id') + 1;
 	} else {
 		$thread_id = 1;
 	}
-	$db->query('INSERT INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', \'Bank Statement\')');
-	$db->query('INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_BANK_REPORTER) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('INSERT INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', \'Bank Statement\')');
+	$db->write('INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_BANK_REPORTER) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 }
 
 $container = Page::create('skeleton.php', 'bank_report.php');

--- a/src/engine/Default/bar_galmap_buy.php
+++ b/src/engine/Default/bar_galmap_buy.php
@@ -27,8 +27,8 @@ if (isset($var['process'])) {
 
 	// Have they already got this map? (Are there any unexplored sectors?
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT * FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND ' . $player->getSQL() . ' LIMIT 1');
-	if (!$db->nextRecord()) {
+	$dbResult = $db->read('SELECT 1 FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND ' . $player->getSQL() . ' LIMIT 1');
+	if (!$dbResult->hasRecord()) {
 		create_error('You already have maps of this galaxy!');
 	}
 
@@ -38,7 +38,7 @@ if (isset($var['process'])) {
 	//now give maps
 
 	// delete all entries from the player_visited_sector/port table
-	$db->query('DELETE FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND ' . $player->getSQL());
+	$db->write('DELETE FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND ' . $player->getSQL());
 	//start section
 
 	// add port infos

--- a/src/engine/Default/bar_lotto_buy_processing.php
+++ b/src/engine/Default/bar_lotto_buy_processing.php
@@ -11,21 +11,20 @@ if ($player->getCredits() < 1000000) {
 $time = Smr\Epoch::time();
 while (true) {
 	//avoid double entries (since table is unique on game,account,time)
-	$db->query('SELECT 1 FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
+	$dbResult = $db->read('SELECT 1 FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND time = ' . $db->escapeNumber($time));
-	if (!$db->getNumRows()) {
+	if (!$dbResult->hasRecord()) {
 		break;
 	}
 	$time++;
 }
 
-$db->query('INSERT INTO player_has_ticket (game_id, account_id, time) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($time) . ')');
+$db->write('INSERT INTO player_has_ticket (game_id, account_id, time) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($time) . ')');
 $player->decreaseCredits(1000000);
 $player->increaseHOF(1000000, array('Bar', 'Lotto', 'Money', 'Spent'), HOF_PUBLIC);
 $player->increaseHOF(1, array('Bar', 'Lotto', 'Tickets Bought'), HOF_PUBLIC);
-$db->query('SELECT count(*) as num FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0 GROUP BY account_id');
-$db->requireRecord();
-$num = $db->getInt('num');
+$dbResult = $db->read('SELECT count(*) as num FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0 GROUP BY account_id');
+$num = $dbResult->record()->getInt('num');
 $message = ('<div class="center">Thanks for your purchase and good luck!  You currently');
 $message .= (' own ' . $num . ' ' . pluralise('ticket', $num) . '!</div><br />');
 

--- a/src/engine/Default/bar_lotto_claim.php
+++ b/src/engine/Default/bar_lotto_claim.php
@@ -6,17 +6,17 @@ $player = $session->getPlayer();
 $message = '';
 //check if we really are a winner
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
-if ($db->nextRecord()) {
-	$prize = $db->getInt('prize');
+$dbResult = $db->read('SELECT * FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
+if ($dbResult->hasRecord()) {
+	$prize = $dbResult->record()->getInt('prize');
 	$NHLAmount = ($prize - 1000000) / 9;
-	$db->query('UPDATE player SET bank = bank + ' . $db->escapeNumber($NHLAmount) . ' WHERE account_id = ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->write('UPDATE player SET bank = bank + ' . $db->escapeNumber($NHLAmount) . ' WHERE account_id = ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	$player->increaseCredits($prize);
 	$player->increaseHOF($prize, array('Bar', 'Lotto', 'Money', 'Claimed'), HOF_PUBLIC);
 	$player->increaseHOF(1, array('Bar', 'Lotto', 'Results', 'Claims'), HOF_PUBLIC);
 	$message .= '<div class="center">You have claimed <span class="red">$' . number_format($prize) . '</span>!<br /></div><br />';
-	$db->query('DELETE FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND prize = ' . $db->escapeNumber($prize) . ' AND time = 0 LIMIT 1');
-	$db->query('DELETE FROM news WHERE type = \'lotto\' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->write('DELETE FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND prize = ' . $db->escapeNumber($prize) . ' AND time = 0 LIMIT 1');
+	$db->write('DELETE FROM news WHERE type = \'lotto\' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 }
 //offer another drink and such
 $container = Page::create('skeleton.php', 'bar_main.php');

--- a/src/engine/Default/bar_main.php
+++ b/src/engine/Default/bar_main.php
@@ -25,9 +25,9 @@ if (isset($var['message'])) {
 $winningTicket = false;
 //check for winner
 $db = Smr\Database::getInstance();
-$db->query('SELECT prize FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0 LIMIT 1');
-if ($db->nextRecord()) {
-	$winningTicket = $db->getInt('prize');
+$dbResult = $db->read('SELECT prize FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0 LIMIT 1');
+if ($dbResult->hasRecord()) {
+	$winningTicket = $dbResult->record()->getInt('prize');
 
 	$container = Page::create('bar_lotto_claim.php');
 	$container->addVar('LocationID');
@@ -36,7 +36,7 @@ if ($db->nextRecord()) {
 $template->assign('WinningTicket', $winningTicket);
 
 //get rid of drinks older than 30 mins
-$db->query('DELETE FROM player_has_drinks WHERE time < ' . $db->escapeNumber(Smr\Epoch::time() - 1800));
+$db->write('DELETE FROM player_has_drinks WHERE time < ' . $db->escapeNumber(Smr\Epoch::time() - 1800));
 
 $container = Page::create('skeleton.php', 'bar_talk_bartender.php');
 $container->addVar('LocationID');

--- a/src/engine/Default/bar_talk_bartender.php
+++ b/src/engine/Default/bar_talk_bartender.php
@@ -13,7 +13,7 @@ if (!isset($var['Message'])) {
 	$db = Smr\Database::getInstance();
 	$dbResult = $db->read('SELECT message FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY rand() LIMIT 1');
 	if ($dbResult->hasRecord()) {
-		$message = 'I heard... ' . htmlentities(word_filter($dbResult->record()->getField('message'))) . '<br /><br />Got anything else to tell me?';
+		$message = 'I heard... ' . htmlentities(word_filter($dbResult->record()->getString('message'))) . '<br /><br />Got anything else to tell me?';
 	} else {
 		$message = 'I havent heard anything recently... got anything to tell me?';
 	}

--- a/src/engine/Default/bar_talk_bartender.php
+++ b/src/engine/Default/bar_talk_bartender.php
@@ -11,9 +11,9 @@ Menu::bar();
 // We save the displayed message in session since it is randomized
 if (!isset($var['Message'])) {
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT * FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY rand() LIMIT 1');
-	if ($db->nextRecord()) {
-		$message = 'I heard... ' . htmlentities(word_filter($db->getField('message'))) . '<br /><br />Got anything else to tell me?';
+	$dbResult = $db->read('SELECT message FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY rand() LIMIT 1');
+	if ($dbResult->hasRecord()) {
+		$message = 'I heard... ' . htmlentities(word_filter($dbResult->record()->getField('message'))) . '<br /><br />Got anything else to tell me?';
 	} else {
 		$message = 'I havent heard anything recently... got anything to tell me?';
 	}

--- a/src/engine/Default/bar_talk_bartender_processing.php
+++ b/src/engine/Default/bar_talk_bartender_processing.php
@@ -12,14 +12,14 @@ if ($action == 'tell') {
 	$gossip = Request::get('gossip_tell');
 	if (!empty($gossip)) {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT message_id FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY message_id DESC LIMIT 1');
-		if ($db->nextRecord()) {
-			$amount = $db->getInt('message_id') + 1;
+		$dbResult = $db->read('SELECT message_id FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY message_id DESC LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$amount = $dbResult->record()->getInt('message_id') + 1;
 		} else {
 			$amount = 1;
 		}
 
-		$db->query('INSERT INTO bar_tender (game_id, message_id, message) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($amount) . ',  ' . $db->escapeString($gossip) . ' )');
+		$db->write('INSERT INTO bar_tender (game_id, message_id, message) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($amount) . ',  ' . $db->escapeString($gossip) . ' )');
 		SmrAccount::doMessageSendingToBox($player->getAccountID(), BOX_BARTENDER, $gossip, $player->getGameID());
 
 		$container['Message'] = 'Huh, that\'s news to me...<br /><br />Got anything else to tell me?';

--- a/src/engine/Default/bar_ticker_buy_processing.php
+++ b/src/engine/Default/bar_ticker_buy_processing.php
@@ -16,7 +16,7 @@ if ($ticker !== false) {
 $expires += 5 * 86400;
 
 $db = Smr\Database::getInstance();
-$db->query('REPLACE INTO player_has_ticker (game_id, account_id, type, expires) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($type) . ', ' . $db->escapeNumber($expires) . ')');
+$db->write('REPLACE INTO player_has_ticker (game_id, account_id, type, expires) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($type) . ', ' . $db->escapeNumber($expires) . ')');
 
 //take credits
 $account->decreaseTotalSmrCredits(CREDITS_PER_TICKER);

--- a/src/engine/Default/beta_func_processing.php
+++ b/src/engine/Default/beta_func_processing.php
@@ -11,12 +11,12 @@ if ($var['func'] == 'Map') {
 	$game_id = $player->getGameID();
 	// delete all entries from the player_visited_sector/port table
 	$db = Smr\Database::getInstance();
-	$db->query('DELETE FROM player_visited_sector WHERE ' . $player->getSQL());
+	$db->write('DELETE FROM player_visited_sector WHERE ' . $player->getSQL());
 
 	// add port infos
-	$db->query('SELECT * FROM port WHERE game_id = ' . $db->escapeNumber($game_id));
-	while ($db->nextRecord()) {
-		$port = SmrPort::getPort($game_id, $db->getInt('sector_id'), false, $db);
+	$dbResult = $db->read('SELECT * FROM port WHERE game_id = ' . $db->escapeNumber($game_id));
+	foreach ($dbResult->records() as $dbRecord) {
+		$port = SmrPort::getPort($game_id, $dbRecord->getInt('sector_id'), false, $dbRecord);
 		$port->addCachePort($account_id);
 	}
 
@@ -71,8 +71,8 @@ if ($var['func'] == 'Map') {
 		create_error('You cannot change race relations with your own race.');
 	}
 	$db = Smr\Database::getInstance();
-	$db->query('UPDATE race_has_relation SET relation = ' . $db->escapeNumber($amount) . ' WHERE race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . ' AND race_id_2 = ' . $db->escapeNumber($race) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db->query('UPDATE race_has_relation SET relation = ' . $db->escapeNumber($amount) . ' WHERE race_id_1 = ' . $db->escapeNumber($race) . ' AND race_id_2 = ' . $db->escapeNumber($player->getRaceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->write('UPDATE race_has_relation SET relation = ' . $db->escapeNumber($amount) . ' WHERE race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . ' AND race_id_2 = ' . $db->escapeNumber($race) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->write('UPDATE race_has_relation SET relation = ' . $db->escapeNumber($amount) . ' WHERE race_id_1 = ' . $db->escapeNumber($race) . ' AND race_id_2 = ' . $db->escapeNumber($player->getRaceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 } elseif ($var['func'] == 'Race') {
 	$race = Request::getInt('race');
 	$player->setRaceID($race);

--- a/src/engine/Default/bounty_claim.php
+++ b/src/engine/Default/bounty_claim.php
@@ -44,7 +44,7 @@ if (!isset($var['ClaimText'])) {
 			$player->increaseHOF($smrCredits, array('Bounties', 'Claimed', 'SMR Credits'), HOF_PUBLIC);
 
 			// delete bounty
-			$db->query('DELETE FROM bounty
+			$db->write('DELETE FROM bounty
 						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 							AND claimer_id = ' . $db->escapeNumber($player->getAccountID()) . '
 							AND bounty_id = ' . $db->escapeNumber($bounty['bounty_id']));

--- a/src/engine/Default/bounty_place.php
+++ b/src/engine/Default/bounty_place.php
@@ -16,6 +16,6 @@ $bountyPlayers = [];
 $db = Smr\Database::getInstance();
 $dbResult = $db->read('SELECT player_id, player_name FROM player JOIN account USING(account_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id != ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY player_name');
 foreach ($dbResult->records() as $dbRecord) {
-	$bountyPlayers[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getField('player_name'));
+	$bountyPlayers[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getString('player_name'));
 }
 $template->assign('BountyPlayers', $bountyPlayers);

--- a/src/engine/Default/bounty_place.php
+++ b/src/engine/Default/bounty_place.php
@@ -14,8 +14,8 @@ $template->assign('SubmitHREF', $container->href());
 
 $bountyPlayers = [];
 $db = Smr\Database::getInstance();
-$db->query('SELECT player_id, player_name FROM player JOIN account USING(account_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id != ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY player_name');
-while ($db->nextRecord()) {
-	$bountyPlayers[$db->getInt('player_id')] = htmlentities($db->getField('player_name'));
+$dbResult = $db->read('SELECT player_id, player_name FROM player JOIN account USING(account_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id != ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY player_name');
+foreach ($dbResult->records() as $dbRecord) {
+	$bountyPlayers[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getField('player_name'));
 }
 $template->assign('BountyPlayers', $bountyPlayers);

--- a/src/engine/Default/changelog_view.php
+++ b/src/engine/Default/changelog_view.php
@@ -13,18 +13,17 @@ if (isset($var['Since'])) {
 }
 
 $db = Smr\Database::getInstance();
-$db2 = Smr\Database::getInstance();
 
-$db->query('SELECT *
+$dbResult = $db->read('SELECT *
 			FROM version
 			WHERE went_live > ' . (isset($var['Since']) ? $db->escapeNumber($var['Since']) : '0') . '
 			ORDER BY version_id DESC');
 
 $versions = [];
-while ($db->nextRecord()) {
-	$version_id = $db->getInt('version_id');
-	$version = $db->getInt('major_version') . '.' . $db->getInt('minor_version') . '.' . $db->getInt('patch_level');
-	$went_live = $db->getInt('went_live');
+foreach ($dbResult->records() as $dbRecord) {
+	$version_id = $dbRecord->getInt('version_id');
+	$version = $dbRecord->getInt('major_version') . '.' . $dbRecord->getInt('minor_version') . '.' . $dbRecord->getInt('patch_level');
+	$went_live = $dbRecord->getInt('went_live');
 
 	// get human readable format for date
 	if ($went_live > 0) {
@@ -33,15 +32,15 @@ while ($db->nextRecord()) {
 		$went_live = 'never';
 	}
 
-	$db2->query('SELECT *
+	$dbResult2 = $db->read('SELECT *
 				FROM changelog
-				WHERE version_id = ' . $db2->escapeNumber($version_id) . '
+				WHERE version_id = ' . $db->escapeNumber($version_id) . '
 				ORDER BY changelog_id');
 	$changes = [];
-	while ($db2->nextRecord()) {
+	foreach ($dbResult2->records() as $dbRecord2) {
 		$changes[] = [
-			'title' => $db2->getField('change_title'),
-			'message' => $db2->getField('change_message'),
+			'title' => $dbRecord2->getField('change_title'),
+			'message' => $dbRecord2->getField('change_message'),
 		];
 	}
 

--- a/src/engine/Default/chat_sharing.php
+++ b/src/engine/Default/chat_sharing.php
@@ -13,10 +13,10 @@ if (isset($var['message'])) {
 
 $shareFrom = array();
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($player->getGameID()) . ')');
-while ($db->nextRecord()) {
-	$fromAccountId = $db->getInt('from_account_id');
-	$gameId = $db->getInt('game_id');
+$dbResult = $db->read('SELECT * FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($player->getGameID()) . ')');
+foreach ($dbResult->records() as $dbRecord) {
+	$fromAccountId = $dbRecord->getInt('from_account_id');
+	$gameId = $dbRecord->getInt('game_id');
 	try {
 		$otherPlayer = SmrPlayer::getPlayer($fromAccountId, $player->getGameID());
 	} catch (PlayerNotFoundException $e) {
@@ -34,10 +34,10 @@ while ($db->nextRecord()) {
 }
 
 $shareTo = array();
-$db->query('SELECT * FROM account_shares_info WHERE from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($player->getGameID()) . ')');
-while ($db->nextRecord()) {
-	$gameId = $db->getInt('game_id');
-	$toAccountId = $db->getInt('to_account_id');
+$dbResult = $db->read('SELECT * FROM account_shares_info WHERE from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($player->getGameID()) . ')');
+foreach ($dbResult->records() as $dbRecord) {
+	$gameId = $dbRecord->getInt('game_id');
+	$toAccountId = $dbRecord->getInt('to_account_id');
 	try {
 		$otherPlayer = SmrPlayer::getPlayer($toAccountId, $player->getGameID());
 	} catch (PlayerNotFoundException $e) {

--- a/src/engine/Default/chat_sharing_processing.php
+++ b/src/engine/Default/chat_sharing_processing.php
@@ -32,17 +32,17 @@ if (Request::has('add')) {
 	}
 
 	$gameId = Request::has('all_games') ? '0' : $player->getGameID();
-	$db->query('INSERT INTO account_shares_info (to_account_id, from_account_id, game_id) VALUES (' . $db->escapeNumber($accountId) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($gameId) . ')');
+	$db->write('INSERT INTO account_shares_info (to_account_id, from_account_id, game_id) VALUES (' . $db->escapeNumber($accountId) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($gameId) . ')');
 }
 
 // Process removing a "share to" account
 if (Request::has('remove_share_to')) {
-	$db->query('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber(Request::getInt('remove_share_to')) . ' AND from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber(Request::getInt('game_id')));
+	$db->write('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber(Request::getInt('remove_share_to')) . ' AND from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber(Request::getInt('game_id')));
 }
 
 // Process removing a "share from" account
 if (Request::has('remove_share_from')) {
-	$db->query('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND from_account_id=' . $db->escapeNumber(Request::getInt('remove_share_from')) . ' AND game_id=' . $db->escapeNumber(Request::getInt('game_id')));
+	$db->write('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND from_account_id=' . $db->escapeNumber(Request::getInt('remove_share_from')) . ' AND game_id=' . $db->escapeNumber(Request::getInt('game_id')));
 }
 
 Page::create('skeleton.php', 'chat_sharing.php')->go();

--- a/src/engine/Default/chess.php
+++ b/src/engine/Default/chess.php
@@ -18,7 +18,7 @@ $players = array();
 $db = Smr\Database::getInstance();
 $dbResult = $db->read('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) WHERE npc = ' . $db->escapeBoolean(false) . ' AND validated = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
 foreach ($dbResult->records() as $dbRecord) {
-	$players[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getField('player_name'));
+	$players[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getString('player_name'));
 }
 $template->assign('PlayerList', $players);
 
@@ -26,7 +26,7 @@ if (ENABLE_NPCS_CHESS) {
 	$npcs = array();
 	$dbResult = $db->read('SELECT player_id, player.player_name FROM player WHERE npc = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
 	foreach ($dbResult->records() as $dbRecord) {
-		$npcs[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getField('player_name'));
+		$npcs[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getString('player_name'));
 	}
 	$template->assign('NPCList', $npcs);
 }

--- a/src/engine/Default/chess.php
+++ b/src/engine/Default/chess.php
@@ -16,17 +16,17 @@ foreach ($chessGames as $chessGame) {
 
 $players = array();
 $db = Smr\Database::getInstance();
-$db->query('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) WHERE npc = ' . $db->escapeBoolean(false) . ' AND validated = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
-while ($db->nextRecord()) {
-	$players[$db->getInt('player_id')] = htmlentities($db->getField('player_name'));
+$dbResult = $db->read('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) WHERE npc = ' . $db->escapeBoolean(false) . ' AND validated = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
+foreach ($dbResult->records() as $dbRecord) {
+	$players[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getField('player_name'));
 }
 $template->assign('PlayerList', $players);
 
 if (ENABLE_NPCS_CHESS) {
 	$npcs = array();
-	$db->query('SELECT player_id, player.player_name FROM player WHERE npc = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
-	while ($db->nextRecord()) {
-		$npcs[$db->getInt('player_id')] = htmlentities($db->getField('player_name'));
+	$dbResult = $db->read('SELECT player_id, player.player_name FROM player WHERE npc = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
+	foreach ($dbResult->records() as $dbRecord) {
+		$npcs[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getField('player_name'));
 	}
 	$template->assign('NPCList', $npcs);
 }

--- a/src/engine/Default/combat_log_list_processing.php
+++ b/src/engine/Default/combat_log_list_processing.php
@@ -21,7 +21,7 @@ if ($submitAction == 'Save' || $submitAction == 'Delete') {
 	if ($submitAction == 'Save') {
 		//save the logs we checked
 		// Query means people can only save logs that they are allowd to view.
-		$db->query('INSERT IGNORE INTO player_saved_combat_logs (account_id, game_id, log_id)
+		$db->write('INSERT IGNORE INTO player_saved_combat_logs (account_id, game_id, log_id)
 					SELECT ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', log_id
 					FROM combat_logs
 					WHERE log_id IN (' . $db->escapeArray($logIDs) . ')
@@ -36,7 +36,7 @@ if ($submitAction == 'Save' || $submitAction == 'Delete') {
 						)
 					LIMIT ' . count($logIDs));
 	} elseif ($submitAction == 'Delete') {
-		$db->query('DELETE FROM player_saved_combat_logs
+		$db->write('DELETE FROM player_saved_combat_logs
 					WHERE log_id IN (' . $db->escapeArray($logIDs) . ')
 						AND account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '

--- a/src/engine/Default/combat_log_viewer.php
+++ b/src/engine/Default/combat_log_viewer.php
@@ -12,15 +12,16 @@ if (!isset($var['log_ids']) && !isset($var['current_log'])) {
 // Set properties for the current display page
 $display_id = $var['log_ids'][$var['current_log']];
 $db = Smr\Database::getInstance();
-$db->query('SELECT timestamp,sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($display_id) . ' LIMIT 1');
+$dbResult = $db->read('SELECT timestamp,sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($display_id) . ' LIMIT 1');
 
-if (!$db->nextRecord()) {
+if (!$dbResult->hasRecord()) {
 	create_error('Combat log not found');
 }
-$template->assign('CombatLogSector', $db->getInt('sector_id'));
-$template->assign('CombatLogTimestamp', date($account->getDateTimeFormat(), $db->getInt('timestamp')));
-$results = $db->getObject('result', true);
-$template->assign('CombatResultsType', $db->getField('type'));
+$dbRecord = $dbResult->record();
+$template->assign('CombatLogSector', $dbRecord->getInt('sector_id'));
+$template->assign('CombatLogTimestamp', date($account->getDateTimeFormat(), $dbRecord->getInt('timestamp')));
+$results = $dbRecord->getObject('result', true);
+$template->assign('CombatResultsType', $dbRecord->getField('type'));
 $template->assign('CombatResults', $results);
 
 // Create a container for the next/previous log.

--- a/src/engine/Default/combat_log_viewer_verify.php
+++ b/src/engine/Default/combat_log_viewer_verify.php
@@ -9,16 +9,16 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$query = 'SELECT log_id FROM combat_logs WHERE log_id=' . $db->escapeNumber($var['log_id']) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND ';
+$query = 'SELECT 1 FROM combat_logs WHERE log_id=' . $db->escapeNumber($var['log_id']) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND ';
 if ($player->hasAlliance()) {
 	$query .= '(attacker_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' OR defender_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ')';
 } else {
 	$query .= '(attacker_id=' . $db->escapeNumber($player->getAccountID()) . ' OR defender_id=' . $db->escapeNumber($player->getAccountID()) . ')';
 }
-$db->query($query . ' LIMIT 1');
+$dbResult = $db->read($query . ' LIMIT 1');
 
 // Error if qualifications are not met
-if (!$db->nextRecord()) {
+if (!$dbResult->hasRecord()) {
 	create_error('You do not have permission to view this combat log!');
 }
 

--- a/src/engine/Default/configure_hardware.php
+++ b/src/engine/Default/configure_hardware.php
@@ -23,9 +23,9 @@ if ($ship->hasIllusion()) {
 
 	$ships = array();
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT ship_type_id,ship_name FROM ship_type ORDER BY ship_name');
-	while ($db->nextRecord()) {
-		$ships[$db->getInt('ship_type_id')] = $db->getField('ship_name');
+	$dbResult = $db->read('SELECT ship_type_id,ship_name FROM ship_type ORDER BY ship_name');
+	foreach ($dbResult->records() as $dbRecord) {
+		$ships[$dbRecord->getInt('ship_type_id')] = $dbRecord->getField('ship_name');
 	}
 	$template->assign('IllusionShips', $ships);
 	$container['action'] = 'Disable Illusion';

--- a/src/engine/Default/council_embassy.php
+++ b/src/engine/Default/council_embassy.php
@@ -19,11 +19,11 @@ foreach ($RACES as $raceID => $raceInfo) {
 	if ($raceID == RACE_NEUTRAL || $raceID == $player->getRaceID()) {
 		continue;
 	}
-	$db->query('SELECT 1 FROM race_has_voting
+	$dbResult = $db->read('SELECT 1 FROM race_has_voting
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . '
 				AND race_id_2 = ' . $db->escapeNumber($raceID));
-	if ($db->getNumRows() > 0) {
+	if ($dbResult->hasRecord()) {
 		continue;
 	}
 	$voteRaces[$raceID] = Page::create('council_embassy_processing.php', '', array('race_id' => $raceID))->href();

--- a/src/engine/Default/council_embassy_processing.php
+++ b/src/engine/Default/council_embassy_processing.php
@@ -13,29 +13,29 @@ $type = strtoupper(Request::get('action'));
 $time = Smr\Epoch::time() + TIME_FOR_COUNCIL_VOTE;
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT count(*) FROM race_has_voting
+$dbResult = $db->read('SELECT count(*) FROM race_has_voting
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 			AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()));
-if ($db->nextRecord() && $db->getInt('count(*)') > 2) {
+if ($dbResult->record()->getInt('count(*)') > 2) {
 	create_error('You can\'t initiate more than 3 votes at a time!');
 }
 
 if ($type == 'PEACE') {
-	$db->query('SELECT 1 FROM race_has_voting
+	$dbResult = $db->read('SELECT 1 FROM race_has_voting
 				WHERE race_id_1='.$db->escapeNumber($race_id) . ' AND race_id_2=' . $db->escapeNumber($player->getRaceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	if ($db->nextRecord()) {
+	if ($dbResult->hasRecord()) {
 		create_error('You cannot start a vote with that race.');
 	}
 }
 
 // Create the vote for the player's race
-$db->query('REPLACE INTO race_has_voting
+$db->write('REPLACE INTO race_has_voting
 			(game_id, race_id_1, race_id_2, type, end_time)
 			VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getRaceID()) . ', ' . $db->escapeNumber($race_id) . ', ' . $db->escapeString($type) . ', ' . $db->escapeNumber($time) . ')');
 
 // If voting for peace, the other race also has to vote
 if ($type == 'PEACE') {
-	$db->query('REPLACE INTO race_has_voting
+	$db->write('REPLACE INTO race_has_voting
 				(game_id, race_id_1, race_id_2, type, end_time)
 				VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $race_id . ', ' . $db->escapeNumber($player->getRaceID()) . ', ' . $db->escapeString($type) . ', ' . $time . ')');
 }

--- a/src/engine/Default/council_vote_processing.php
+++ b/src/engine/Default/council_vote_processing.php
@@ -20,28 +20,28 @@ if ($action == 'INCREASE') {
 $race_id = $var['race_id'];
 
 if ($action == 'INC' || $action == 'DEC') {
-	$db->query('REPLACE INTO player_votes_relation
+	$db->write('REPLACE INTO player_votes_relation
 				(account_id, game_id, race_id_1, race_id_2, action, time)
 				VALUES(' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getRaceID()) . ', ' . $db->escapeNumber($race_id) . ', ' . $db->escapeString($action) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 } elseif ($action == 'YES' || $action == 'NO') {
-	$db->query('REPLACE INTO player_votes_pact
+	$db->write('REPLACE INTO player_votes_pact
 			(account_id, game_id, race_id_1, race_id_2, vote)
 			VALUES(' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getRaceID()) . ', ' . $db->escapeNumber($race_id) . ', ' . $db->escapeString($action) . ')');
 } elseif ($action == 'VETO') {
 	// try to cancel both votings
-	$db->query('DELETE FROM race_has_voting ' .
+	$db->write('DELETE FROM race_has_voting ' .
 			'WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . '
 				AND race_id_2 = '.$db->escapeNumber($race_id));
-	$db->query('DELETE FROM player_votes_pact ' .
+	$db->write('DELETE FROM player_votes_pact ' .
 			'WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . '
 				AND race_id_2 = '.$db->escapeNumber($race_id));
-	$db->query('DELETE FROM race_has_voting ' .
+	$db->write('DELETE FROM race_has_voting ' .
 			'WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND race_id_1 = '.$db->escapeNumber($race_id) . '
 				AND race_id_2 = ' . $db->escapeNumber($player->getRaceID()));
-	$db->query('DELETE FROM player_votes_pact ' .
+	$db->write('DELETE FROM player_votes_pact ' .
 			'WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND race_id_1 = '.$db->escapeNumber($race_id) . '
 				AND race_id_2 = ' . $db->escapeNumber($player->getRaceID()));

--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -35,9 +35,9 @@ $links['Warp'] = array('ID'=>$sector->getWarp());
 $unvisited = array();
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT sector_id FROM player_visited_sector WHERE sector_id IN (' . $db->escapeArray($links) . ') AND ' . $player->getSQL());
-while ($db->nextRecord()) {
-	$unvisited[$db->getInt('sector_id')] = TRUE;
+$dbResult = $db->read('SELECT sector_id FROM player_visited_sector WHERE sector_id IN (' . $db->escapeArray($links) . ') AND ' . $player->getSQL());
+foreach ($dbResult->records() as $dbRecord) {
+	$unvisited[$dbRecord->getInt('sector_id')] = TRUE;
 }
 
 foreach ($links as $key => $linkArray) {
@@ -100,10 +100,10 @@ if (!empty($protectionMessage)) {
 
 //enableProtectionDependantRefresh($template,$player);
 
-$db->query('SELECT * FROM sector_message WHERE ' . $player->getSQL());
-if ($db->nextRecord()) {
-	$msg = $db->getField('message');
-	$db->query('DELETE FROM sector_message WHERE ' . $player->getSQL());
+$dbResult = $db->read('SELECT * FROM sector_message WHERE ' . $player->getSQL());
+if ($dbResult->hasRecord()) {
+	$msg = $dbResult->record()->getField('message');
+	$db->write('DELETE FROM sector_message WHERE ' . $player->getSQL());
 	checkForForceRefreshMessage($msg);
 	checkForAttackMessage($msg);
 }
@@ -155,11 +155,11 @@ function checkForForceRefreshMessage(string &$msg) : void {
 			$player = Smr\Session::getInstance()->getPlayer();
 
 			$forceRefreshMessage = '';
-			$db->query('SELECT refresh_at FROM sector_has_forces WHERE refresh_at >= ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND sector_id = ' . $db->escapeNumber($player->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND refresher = ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY refresh_at DESC LIMIT 1');
-			if ($db->nextRecord()) {
-				$remainingTime = $db->getInt('refresh_at') - Smr\Epoch::time();
+			$dbResult = $db->read('SELECT refresh_at FROM sector_has_forces WHERE refresh_at >= ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND sector_id = ' . $db->escapeNumber($player->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND refresher = ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY refresh_at DESC LIMIT 1');
+			if ($dbResult->hasRecord()) {
+				$remainingTime = $dbResult->record()->getInt('refresh_at') - Smr\Epoch::time();
 				$forceRefreshMessage = '<span class="green">REFRESH</span>: All forces will be refreshed in ' . $remainingTime . ' seconds.';
-				$db->query('REPLACE INTO sector_message (game_id, account_id, message) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', \'[Force Check]\')');
+				$db->write('REPLACE INTO sector_message (game_id, account_id, message) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', \'[Force Check]\')');
 			} else {
 				$forceRefreshMessage = '<span class="green">REFRESH</span>: All forces have finished refreshing.';
 			}
@@ -184,12 +184,13 @@ function checkForAttackMessage(string &$msg) : void {
 		$template = Smr\Template::getInstance();
 		if (!$template->hasTemplateVar('AttackResults')) {
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($logID) . ' LIMIT 1');
-			if ($db->nextRecord()) {
+			$dbResult = $db->read('SELECT sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($logID) . ' LIMIT 1');
+			if ($dbResult->hasRecord()) {
+				$dbRecord = $dbResult->record();
 				$player = $session->getPlayer();
-				if ($player->getSectorID() == $db->getInt('sector_id')) {
-					$results = $db->getObject('result', true);
-					$template->assign('AttackResultsType', $db->getField('type'));
+				if ($player->getSectorID() == $dbRecord->getInt('sector_id')) {
+					$results = $dbRecord->getObject('result', true);
+					$template->assign('AttackResultsType', $dbRecord->getField('type'));
 					$template->assign('AttackResults', $results);
 					$template->assign('AttackLogLink', linkCombatLog($logID));
 				}

--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -102,7 +102,7 @@ if (!empty($protectionMessage)) {
 
 $dbResult = $db->read('SELECT * FROM sector_message WHERE ' . $player->getSQL());
 if ($dbResult->hasRecord()) {
-	$msg = $dbResult->record()->getField('message');
+	$msg = $dbResult->record()->getString('message');
 	$db->write('DELETE FROM sector_message WHERE ' . $player->getSQL());
 	checkForForceRefreshMessage($msg);
 	checkForAttackMessage($msg);

--- a/src/engine/Default/donation.php
+++ b/src/engine/Default/donation.php
@@ -4,7 +4,7 @@ $template = Smr\Template::getInstance();
 
 $template->assign('PageTopic', 'Donations');
 $db = Smr\Database::getInstance();
-$db->query('SELECT SUM(amount) as total_donation FROM account_donated WHERE time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' - (86400 * 90)');
-if ($db->nextRecord()) {
-	$template->assign('TotalDonation', $db->getInt('total_donation'));
+$dbResult = $db->read('SELECT SUM(amount) as total_donation FROM account_donated WHERE time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' - (86400 * 90)');
+if ($dbResult->hasRecord()) {
+	$template->assign('TotalDonation', $dbResult->record()->getInt('total_donation'));
 }

--- a/src/engine/Default/feature_request_comment_processing.php
+++ b/src/engine/Default/feature_request_comment_processing.php
@@ -11,7 +11,7 @@ if (empty($comment)) {
 
 // add this feature comment
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
+$db->write('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
 			VALUES(' . $db->escapeNumber($var['RequestID']) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeBoolean(Request::has('anon')) . ',' . $db->escapeString(word_filter($comment)) . ')');
 
 $container = Page::copy($var);

--- a/src/engine/Default/feature_request_comments.php
+++ b/src/engine/Default/feature_request_comments.php
@@ -15,12 +15,12 @@ $container['body'] = 'feature_request.php';
 $template->assign('BackHref', $container->href());
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT *
+$dbResult = $db->read('SELECT *
 			FROM feature_request
 			JOIN feature_request_comments USING(feature_request_id)
 			WHERE feature_request_id = ' . $db->escapeNumber($var['RequestID']) . '
 			ORDER BY comment_id ASC');
-if ($db->getNumRows() > 0) {
+if ($dbResult->hasRecord()) {
 	$featureModerator = $account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST);
 	$template->assign('FeatureModerator', $featureModerator);
 
@@ -31,16 +31,16 @@ if ($db->getNumRows() > 0) {
 	}
 
 	$featureRequestComments = array();
-	while ($db->nextRecord()) {
-		$commentID = $db->getInt('comment_id');
+	foreach ($dbResult->records() as $dbRecord) {
+		$commentID = $dbRecord->getInt('comment_id');
 		$featureRequestComments[$commentID] = array(
 								'CommentID' => $commentID,
-								'Message' => $db->getField('text'),
-								'Time' => date($account->getDateTimeFormat(), $db->getInt('posting_time')),
-								'Anonymous' => $db->getBoolean('anonymous')
+								'Message' => $dbRecord->getField('text'),
+								'Time' => date($account->getDateTimeFormat(), $dbRecord->getInt('posting_time')),
+								'Anonymous' => $dbRecord->getBoolean('anonymous')
 		);
-		if ($featureModerator || !$db->getBoolean('anonymous')) {
-			$featureRequestComments[$commentID]['PosterAccount'] = SmrAccount::getAccount($db->getInt('poster_id'));
+		if ($featureModerator || !$dbRecord->getBoolean('anonymous')) {
+			$featureRequestComments[$commentID]['PosterAccount'] = SmrAccount::getAccount($dbRecord->getInt('poster_id'));
 		}
 	}
 	$template->assign('Comments', $featureRequestComments);

--- a/src/engine/Default/feature_request_processing.php
+++ b/src/engine/Default/feature_request_processing.php
@@ -13,12 +13,12 @@ if (strlen($feature) > 500) {
 
 // add this feature to db
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO feature_request (feature_request_id) VALUES (NULL)');
+$db->write('INSERT INTO feature_request (feature_request_id) VALUES (NULL)');
 $featureRequestID = $db->getInsertID();
-$db->query('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text) ' .
+$db->write('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text) ' .
 								'VALUES(' . $db->escapeNumber($featureRequestID) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeBoolean(Request::has('anon')) . ',' . $db->escapeString(word_filter($feature)) . ')');
 
 // vote for this feature
-$db->query('INSERT INTO account_votes_for_feature VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($featureRequestID) . ',\'YES\')');
+$db->write('INSERT INTO account_votes_for_feature VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($featureRequestID) . ',\'YES\')');
 
 Page::create('skeleton.php', 'feature_request.php')->go();

--- a/src/engine/Default/feature_request_vote_processing.php
+++ b/src/engine/Default/feature_request_vote_processing.php
@@ -14,10 +14,10 @@ if ($action == 'Vote') {
 		foreach (Request::getArray('vote') as $requestID => $vote) {
 			$query .= '(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($requestID) . ',' . $db->escapeString($vote) . '),';
 		}
-		$db->query(substr($query, 0, -1));
+		$db->write(substr($query, 0, -1));
 	}
 	if (Request::has('favourite')) {
-		$db->query('REPLACE INTO account_votes_for_feature VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber(Request::getInt('favourite')) . ',\'FAVOURITE\')');
+		$db->write('REPLACE INTO account_votes_for_feature VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber(Request::getInt('favourite')) . ',\'FAVOURITE\')');
 	}
 
 	Page::create('skeleton.php', 'feature_request.php')->go();
@@ -34,7 +34,7 @@ if ($action == 'Vote') {
 	}
 	$setStatusIDs = Request::getIntArray('set_status_ids');
 
-	$db->query('UPDATE feature_request fr SET status = ' . $db->escapeString($status) . '
+	$db->write('UPDATE feature_request fr SET status = ' . $db->escapeString($status) . '
 			, fav = (
 				SELECT COUNT(feature_request_id)
 				FROM account_votes_for_feature
@@ -55,7 +55,7 @@ if ($action == 'Vote') {
 			)
 			WHERE feature_request_id IN (' . $db->escapeArray($setStatusIDs) . ')');
 	foreach ($setStatusIDs as $featureID) {
-		$db->query('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
+		$db->write('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
 					VALUES(' . $db->escapeNumber($featureID) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeBoolean(false) . ',' . $db->escapeString($status) . ')');
 	}
 

--- a/src/engine/Default/forces_attack_processing.php
+++ b/src/engine/Default/forces_attack_processing.php
@@ -100,7 +100,7 @@ if (!$bump) {
 
 // Add this log to the `combat_logs` database table
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'FORCE\',' . $db->escapeNumber($forces->getSectorID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($forceOwner->getAccountID()) . ',' . $db->escapeNumber($forceOwner->getAllianceID()) . ',' . $db->escapeObject($results, true) . ')');
+$db->write('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'FORCE\',' . $db->escapeNumber($forces->getSectorID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($forceOwner->getAccountID()) . ',' . $db->escapeNumber($forceOwner->getAllianceID()) . ',' . $db->escapeObject($results, true) . ')');
 $logId = $db->getInsertID();
 
 if ($sendMessage) {

--- a/src/engine/Default/forces_list.php
+++ b/src/engine/Default/forces_list.php
@@ -7,7 +7,7 @@ $player = $session->getPlayer();
 $template->assign('PageTopic', 'View Forces');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT *
+$dbResult = $db->read('SELECT *
 			FROM sector_has_forces
 			WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . '
 			AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
@@ -15,7 +15,7 @@ $db->query('SELECT *
 			ORDER BY sector_id ASC');
 
 $forces = array();
-while ($db->nextRecord()) {
-	$forces[] = SmrForce::getForce($player->getGameID(), $db->getInt('sector_id'), $db->getInt('owner_id'), false, $db);
+foreach ($dbResult->records() as $dbRecord) {
+	$forces[] = SmrForce::getForce($player->getGameID(), $dbRecord->getInt('sector_id'), $dbRecord->getInt('owner_id'), false, $dbRecord);
 }
 $template->assign('Forces', $forces);

--- a/src/engine/Default/galactic_post.php
+++ b/src/engine/Default/galactic_post.php
@@ -12,27 +12,25 @@ $template->assign('PageTopic', 'Galactic Post');
 Menu::galactic_post();
 
 $db = Smr\Database::getInstance();
-$db2 = Smr\Database::getInstance();
 
 $container = Page::create('skeleton.php', 'galactic_post_view_article.php');
 $template->assign('ViewArticlesHREF', $container->href());
 $container['body'] = 'galactic_post_make_paper.php';
 $template->assign('MakePaperHREF', $container->href());
 
-$db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
+$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
 $papers = [];
-while ($db->nextRecord()) {
-	$paper_name = $db->getField('title');
-	$paper_id = $db->getInt('paper_id');
-	$published = $db->getInt('online_since');
+foreach ($dbResult->records() as $dbRecord) {
+	$paper_name = $dbRecord->getField('title');
+	$paper_id = $dbRecord->getInt('paper_id');
+	$published = $dbRecord->getInt('online_since');
 
-	$db2->query('SELECT count(*) FROM galactic_post_paper_content WHERE paper_id = ' . $db2->escapeNumber($paper_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db2->nextRecord();
-	$numArticles = $db2->getInt('count(*)');
+	$dbResult2 = $db->read('SELECT count(*) FROM galactic_post_paper_content WHERE paper_id = ' . $db->escapeNumber($paper_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$numArticles = $dbResult2->record()->getInt('count(*)');
 	$hasEnoughArticles = $numArticles > 2 && $numArticles < 9;
 
 	$paper = [
-		'title' => $db->getField('title'),
+		'title' => $dbRecord->getField('title'),
 		'num_articles' => $numArticles,
 		'color' => $hasEnoughArticles ? 'green' : 'red',
 		'published' => !empty($published) && $published > 0,

--- a/src/engine/Default/galactic_post_add_article_to_paper.php
+++ b/src/engine/Default/galactic_post_add_article_to_paper.php
@@ -6,11 +6,11 @@ $player = $session->getPlayer();
 
 //limit 4 per paper...make sure we arent over that
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['paper_id']));
-if ($db->getNumRows() >= 8) {
+$dbResult = $db->read('SELECT 1 FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['paper_id']));
+if ($dbResult->getNumRecords() >= 8) {
 	create_error('You can only have 8 articles per paper.');
 }
-$db->query('INSERT INTO galactic_post_paper_content (game_id, paper_id, article_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($var['paper_id']) . ', ' . $db->escapeNumber($var['id']) . ')');
+$db->write('INSERT INTO galactic_post_paper_content (game_id, paper_id, article_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($var['paper_id']) . ', ' . $db->escapeNumber($var['id']) . ')');
 //we now have that article in the paper
 $container = Page::create('skeleton.php', 'galactic_post_view_article.php');
 $container->go();

--- a/src/engine/Default/galactic_post_current.php
+++ b/src/engine/Default/galactic_post_current.php
@@ -4,9 +4,9 @@ $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY online_since DESC LIMIT 1');
-if ($db->nextRecord()) {
-	$paper_id = $db->getInt('paper_id');
+$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY online_since DESC LIMIT 1');
+if ($dbResult->hasRecord()) {
+	$paper_id = $dbResult->record()->getInt('paper_id');
 } else {
 	$paper_id = null;
 }

--- a/src/engine/Default/galactic_post_delete_confirm.php
+++ b/src/engine/Default/galactic_post_delete_confirm.php
@@ -8,9 +8,8 @@ $player = $session->getPlayer();
 
 if (isset($var['article'])) {
 	$template->assign('PageTopic', 'Delete Article - Confirm');
-	$db->query('SELECT * FROM galactic_post_article WHERE article_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db->requireRecord();
-	$template->assign('ArticleTitle', $db->getField('title'));
+	$dbResult = $db->read('SELECT title FROM galactic_post_article WHERE article_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$template->assign('ArticleTitle', $dbResult->record()->getField('title'));
 	$container = Page::create('galactic_post_delete_processing.php');
 	$container->addVar('article');
 	$container->addVar('id');
@@ -18,14 +17,13 @@ if (isset($var['article'])) {
 } else {
 	// Delete paper
 	$template->assign('PageTopic', 'Delete Paper - Confirm');
-	$db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
-	$db->requireRecord();
-	$template->assign('PaperTitle', $db->getField('title'));
+	$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
+	$template->assign('PaperTitle', $dbResult->record()->getField('title'));
 
 	$articles = [];
-	$db->query('SELECT title FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
-	while ($db->nextRecord()) {
-		$articles[] = bbifyMessage($db->getField('title'));
+	$dbResult = $db->read('SELECT title FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
+	foreach ($dbResult->records() as $dbRecord) {
+		$articles[] = bbifyMessage($dbRecord->getField('title'));
 	}
 	$template->assign('Articles', $articles);
 

--- a/src/engine/Default/galactic_post_delete_confirm.php
+++ b/src/engine/Default/galactic_post_delete_confirm.php
@@ -9,7 +9,7 @@ $player = $session->getPlayer();
 if (isset($var['article'])) {
 	$template->assign('PageTopic', 'Delete Article - Confirm');
 	$dbResult = $db->read('SELECT title FROM galactic_post_article WHERE article_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$template->assign('ArticleTitle', $dbResult->record()->getField('title'));
+	$template->assign('ArticleTitle', $dbResult->record()->getString('title'));
 	$container = Page::create('galactic_post_delete_processing.php');
 	$container->addVar('article');
 	$container->addVar('id');
@@ -18,12 +18,12 @@ if (isset($var['article'])) {
 	// Delete paper
 	$template->assign('PageTopic', 'Delete Paper - Confirm');
 	$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
-	$template->assign('PaperTitle', $dbResult->record()->getField('title'));
+	$template->assign('PaperTitle', $dbResult->record()->getString('title'));
 
 	$articles = [];
 	$dbResult = $db->read('SELECT title FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
 	foreach ($dbResult->records() as $dbRecord) {
-		$articles[] = bbifyMessage($dbRecord->getField('title'));
+		$articles[] = bbifyMessage($dbRecord->getString('title'));
 	}
 	$template->assign('Articles', $articles);
 

--- a/src/engine/Default/galactic_post_delete_processing.php
+++ b/src/engine/Default/galactic_post_delete_processing.php
@@ -5,10 +5,9 @@ $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
 $db = Smr\Database::getInstance();
-$db2 = Smr\Database::getInstance();
 if (isset($var['article'])) {
 	if (Request::get('action') == 'Yes') {
-		$db->query('DELETE FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
+		$db->write('DELETE FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
 	}
 } else {
 	// Should we delete this paper?
@@ -16,15 +15,15 @@ if (isset($var['article'])) {
 
 		// Should the articles associated with the paper be deleted as well?
 		if (Request::get('delete_articles') == 'Yes') {
-			$db->query('SELECT * FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
-			while ($db->nextRecord()) {
-				$db2->query('DELETE FROM galactic_post_article WHERE article_id = ' . $db->escapeNumber($db->getInt('article_id')) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+			$dbResult = $db->read('SELECT * FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
+			foreach ($dbResult->records() as $dbRecord) {
+				$db->write('DELETE FROM galactic_post_article WHERE article_id = ' . $db->escapeNumber($dbRecord->getInt('article_id')) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 			}
 		}
 
 		// Delete the paper and the article associations
-		$db->query('DELETE FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
-		$db->query('DELETE FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
+		$db->write('DELETE FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
+		$db->write('DELETE FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
 	}
 }
 

--- a/src/engine/Default/galactic_post_make_current.php
+++ b/src/engine/Default/galactic_post_make_current.php
@@ -6,13 +6,13 @@ $player = $session->getPlayer();
 
 // Make sure this paper hasn't been published before
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
-if ($db->nextRecord()) {
+$dbResult = $db->read('SELECT 1 FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
+if ($dbResult->hasRecord()) {
 	create_error("Cannot publish a paper that has previously been published!");
 }
 
 // Update the online_since column
-$db->query('UPDATE galactic_post_paper SET online_since=' . $db->escapeNumber(Smr\Epoch::time()) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
+$db->write('UPDATE galactic_post_paper SET online_since=' . $db->escapeNumber(Smr\Epoch::time()) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
 
 //all done lets send back to the main GP page.
 $container = Page::create('skeleton.php', 'galactic_post.php');

--- a/src/engine/Default/galactic_post_make_paper_processing.php
+++ b/src/engine/Default/galactic_post_make_paper_processing.php
@@ -4,14 +4,14 @@ $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY paper_id DESC');
-if ($db->nextRecord()) {
-	$num = $db->getInt('paper_id') + 1;
+$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY paper_id DESC');
+if ($dbResult->hasRecord()) {
+	$num = $dbResult->record()->getInt('paper_id') + 1;
 } else {
 	$num = 1;
 }
 $title = Request::get('title');
-$db->query('INSERT INTO galactic_post_paper (game_id, paper_id, title) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($num) . ', ' . $db->escapeString($title) . ')');
+$db->write('INSERT INTO galactic_post_paper (game_id, paper_id, title) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($num) . ', ' . $db->escapeString($title) . ')');
 //send em back
 $container = Page::create('skeleton.php', 'galactic_post_view_article.php');
 $container->go();

--- a/src/engine/Default/galactic_post_paper_edit.php
+++ b/src/engine/Default/galactic_post_paper_edit.php
@@ -10,7 +10,7 @@ Menu::galactic_post();
 
 $db = Smr\Database::getInstance();
 $dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE paper_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-$template->assign('PaperTitle', bbifyMessage($dbResult->record()->getField('title')));
+$template->assign('PaperTitle', bbifyMessage($dbResult->record()->getString('title')));
 
 $dbResult = $db->read('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE paper_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 
@@ -20,8 +20,8 @@ foreach ($dbResult->records() as $dbRecord) {
 	$container['article_id'] = $dbRecord->getInt('article_id');
 	$container->addVar('id');
 	$articles[] = [
-		'title' => bbifyMessage($dbRecord->getField('title')),
-		'text' => bbifyMessage($dbRecord->getField('text')),
+		'title' => bbifyMessage($dbRecord->getString('title')),
+		'text' => bbifyMessage($dbRecord->getString('text')),
 		'editHREF' => $container->href(),
 	];
 }

--- a/src/engine/Default/galactic_post_paper_edit.php
+++ b/src/engine/Default/galactic_post_paper_edit.php
@@ -9,20 +9,19 @@ $template->assign('PageTopic', 'Edit Paper');
 Menu::galactic_post();
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM galactic_post_paper WHERE paper_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-$db->requireRecord();
-$template->assign('PaperTitle', bbifyMessage($db->getField('title')));
+$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE paper_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+$template->assign('PaperTitle', bbifyMessage($dbResult->record()->getField('title')));
 
-$db->query('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE paper_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+$dbResult = $db->read('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE paper_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 
 $articles = [];
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$container = Page::create('galactic_post_paper_edit_processing.php');
-	$container['article_id'] = $db->getInt('article_id');
+	$container['article_id'] = $dbRecord->getInt('article_id');
 	$container->addVar('id');
 	$articles[] = [
-		'title' => bbifyMessage($db->getField('title')),
-		'text' => bbifyMessage($db->getField('text')),
+		'title' => bbifyMessage($dbRecord->getField('title')),
+		'text' => bbifyMessage($dbRecord->getField('text')),
 		'editHREF' => $container->href(),
 	];
 }

--- a/src/engine/Default/galactic_post_paper_edit_processing.php
+++ b/src/engine/Default/galactic_post_paper_edit_processing.php
@@ -5,7 +5,7 @@ $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
 $db = Smr\Database::getInstance();
-$db->query('DELETE FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['article_id']));
+$db->write('DELETE FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['article_id']));
 
 $container = Page::create('skeleton.php', 'galactic_post_paper_edit.php');
 $container->addVar('id');

--- a/src/engine/Default/galactic_post_past.php
+++ b/src/engine/Default/galactic_post_past.php
@@ -17,28 +17,28 @@ $template->assign('SelectedGame', $selectedGameID);
 // Get the list of games with published papers
 // Add the current game to this list no matter what
 $db = Smr\Database::getInstance();
-$db->query('SELECT game_name, game_id FROM game WHERE game_id IN (SELECT DISTINCT game_id FROM galactic_post_paper WHERE online_since IS NOT NULL) OR game_id=' . $db->escapeNumber($player->getGameID()) . ' ORDER BY game_id DESC');
+$dbResult = $db->read('SELECT game_name, game_id FROM game WHERE game_id IN (SELECT DISTINCT game_id FROM galactic_post_paper WHERE online_since IS NOT NULL) OR game_id=' . $db->escapeNumber($player->getGameID()) . ' ORDER BY game_id DESC');
 $publishedGames = array();
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$publishedGames[] = [
-		'game_name' => $db->getField('game_name'),
-		'game_id' => $db->getInt('game_id'),
+		'game_name' => $dbRecord->getField('game_name'),
+		'game_id' => $dbRecord->getInt('game_id'),
 	];
 }
 $template->assign('PublishedGames', $publishedGames);
 
 // Get the list of published papers for the selected game
-$db->query('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id=' . $db->escapeNumber($selectedGameID));
+$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id=' . $db->escapeNumber($selectedGameID));
 $pastEditions = array();
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$container = Page::create('skeleton.php', 'galactic_post_read.php');
-	$container['paper_id'] = $db->getInt('paper_id');
+	$container['paper_id'] = $dbRecord->getInt('paper_id');
 	$container['game_id'] = $selectedGameID;
 	$container['back'] = true;
 
 	$pastEditions[] = [
-		'title' => $db->getField('title'),
-		'online_since' => $db->getInt('online_since'),
+		'title' => $dbRecord->getField('title'),
+		'online_since' => $dbRecord->getInt('online_since'),
 		'href' => $container->href(),
 	];
 }

--- a/src/engine/Default/galactic_post_read.php
+++ b/src/engine/Default/galactic_post_read.php
@@ -19,19 +19,18 @@ if (!empty($var['paper_id'])) {
 	}
 
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($var['game_id']) . ' AND paper_id = ' . $var['paper_id']);
-	$db->requireRecord();
-	$paper_name = bbifyMessage($db->getField('title'));
+	$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($var['game_id']) . ' AND paper_id = ' . $var['paper_id']);
+	$paper_name = bbifyMessage($dbResult->record()->getField('title'));
 	$template->assign('PageTopic', 'Reading <i>Galactic Post</i> Edition : ' . $paper_name);
 
 	//now get the articles in this paper.
-	$db->query('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING(game_id, article_id) WHERE paper_id = ' . $db->escapeNumber($var['paper_id']) . ' AND game_id = ' . $db->escapeNumber($var['game_id']));
+	$dbResult = $db->read('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING(game_id, article_id) WHERE paper_id = ' . $db->escapeNumber($var['paper_id']) . ' AND game_id = ' . $db->escapeNumber($var['game_id']));
 
 	$articles = [];
-	while ($db->nextRecord()) {
+	foreach ($dbResult->records() as $dbRecord) {
 		$articles[] = [
-			'title' => $db->getField('title'),
-			'text' => $db->getField('text'),
+			'title' => $dbRecord->getField('title'),
+			'text' => $dbRecord->getField('text'),
 		];
 	}
 

--- a/src/engine/Default/galactic_post_read.php
+++ b/src/engine/Default/galactic_post_read.php
@@ -20,7 +20,7 @@ if (!empty($var['paper_id'])) {
 
 	$db = Smr\Database::getInstance();
 	$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($var['game_id']) . ' AND paper_id = ' . $var['paper_id']);
-	$paper_name = bbifyMessage($dbResult->record()->getField('title'));
+	$paper_name = bbifyMessage($dbResult->record()->getString('title'));
 	$template->assign('PageTopic', 'Reading <i>Galactic Post</i> Edition : ' . $paper_name);
 
 	//now get the articles in this paper.
@@ -29,8 +29,8 @@ if (!empty($var['paper_id'])) {
 	$articles = [];
 	foreach ($dbResult->records() as $dbRecord) {
 		$articles[] = [
-			'title' => $dbRecord->getField('title'),
-			'text' => $dbRecord->getField('text'),
+			'title' => $dbRecord->getString('title'),
+			'text' => $dbRecord->getString('text'),
 		];
 	}
 

--- a/src/engine/Default/galactic_post_view_article.php
+++ b/src/engine/Default/galactic_post_view_article.php
@@ -10,7 +10,7 @@ $template->assign('PageTopic', 'Viewing Articles');
 Menu::galactic_post();
 
 if (isset($var['news'])) {
-	$db->query('INSERT INTO news (game_id, time, news_message, type) ' .
+	$db->write('INSERT INTO news (game_id, time, news_message, type) ' .
 		'VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeString($var['news']) . ', \'BREAKING\')');
 	// avoid multiple insertion on ajax updates
 	$session->updateVar('news', null);
@@ -19,12 +19,12 @@ if (isset($var['news'])) {
 
 // Get the articles that are not already in a paper
 $articles = [];
-$db->query('SELECT * FROM galactic_post_article WHERE article_id NOT IN (SELECT article_id FROM galactic_post_paper_content) AND game_id = ' . $db->escapeNumber($player->getGameID()));
-while ($db->nextRecord()) {
-	$title = stripslashes($db->getField('title'));
-	$writer = SmrPlayer::getPlayer($db->getInt('writer_id'), $player->getGameID());
+$dbResult = $db->read('SELECT * FROM galactic_post_article WHERE article_id NOT IN (SELECT article_id FROM galactic_post_paper_content) AND game_id = ' . $db->escapeNumber($player->getGameID()));
+foreach ($dbResult->records() as $dbRecord) {
+	$title = stripslashes($dbRecord->getField('title'));
+	$writer = SmrPlayer::getPlayer($dbRecord->getInt('writer_id'), $player->getGameID());
 	$container = Page::create('skeleton.php', 'galactic_post_view_article.php');
-	$container['id'] = $db->getInt('article_id');
+	$container['id'] = $dbRecord->getInt('article_id');
 	$articles[] = [
 		'title' => $title,
 		'writer' => $writer->getDisplayName(),
@@ -35,8 +35,8 @@ $template->assign('Articles', $articles);
 
 // Details about a selected article
 if (isset($var['id'])) {
-	$db->query('SELECT * FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
-	$db->requireRecord();
+	$dbResult = $db->read('SELECT * FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
+	$dbRecord = $dbResult->record();
 
 	$container = Page::create('skeleton.php', 'galactic_post_write_article.php');
 	$container->addVar('id');
@@ -48,8 +48,8 @@ if (isset($var['id'])) {
 	$deleteHREF = $container->href();
 
 	$selectedArticle = [
-		'title' => stripslashes($db->getField('title')),
-		'text' => stripslashes($db->getField('text')),
+		'title' => stripslashes($dbRecord->getField('title')),
+		'text' => stripslashes($dbRecord->getField('text')),
 		'editHREF' => $editHREF,
 		'deleteHREF' => $deleteHREF,
 	];
@@ -58,11 +58,11 @@ if (isset($var['id'])) {
 	$container = Page::create('galactic_post_add_article_to_paper.php');
 	$container->addVar('id');
 	$papers = [];
-	$db->query('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
-	while ($db->nextRecord()) {
-		$container['paper_id'] = $db->getInt('paper_id');
+	$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
+	foreach ($dbResult->records() as $dbRecord) {
+		$container['paper_id'] = $dbRecord->getInt('paper_id');
 		$papers[] = [
-			'title' => $db->getField('title'),
+			'title' => $dbRecord->getField('title'),
 			'addHREF' => $container->href(),
 		];
 	}

--- a/src/engine/Default/galactic_post_view_article.php
+++ b/src/engine/Default/galactic_post_view_article.php
@@ -21,7 +21,7 @@ if (isset($var['news'])) {
 $articles = [];
 $dbResult = $db->read('SELECT * FROM galactic_post_article WHERE article_id NOT IN (SELECT article_id FROM galactic_post_paper_content) AND game_id = ' . $db->escapeNumber($player->getGameID()));
 foreach ($dbResult->records() as $dbRecord) {
-	$title = stripslashes($dbRecord->getField('title'));
+	$title = $dbRecord->getString('title');
 	$writer = SmrPlayer::getPlayer($dbRecord->getInt('writer_id'), $player->getGameID());
 	$container = Page::create('skeleton.php', 'galactic_post_view_article.php');
 	$container['id'] = $dbRecord->getInt('article_id');
@@ -48,8 +48,8 @@ if (isset($var['id'])) {
 	$deleteHREF = $container->href();
 
 	$selectedArticle = [
-		'title' => stripslashes($dbRecord->getField('title')),
-		'text' => stripslashes($dbRecord->getField('text')),
+		'title' => $dbRecord->getString('title'),
+		'text' => $dbRecord->getString('text'),
 		'editHREF' => $editHREF,
 		'deleteHREF' => $deleteHREF,
 	];

--- a/src/engine/Default/galactic_post_write_article.php
+++ b/src/engine/Default/galactic_post_write_article.php
@@ -13,10 +13,11 @@ if (isset($var['id'])) {
 	$template->assign('PageTopic', 'Editing An Article');
 	if (!isset($var['Preview'])) {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT title, text FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			$session->updateVar('PreviewTitle', $db->getField('title'));
-			$session->updateVar('Preview', $db->getField('text'));
+		$dbResult = $db->read('SELECT title, text FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			$session->updateVar('PreviewTitle', $dbRecord->getField('title'));
+			$session->updateVar('Preview', $dbRecord->getField('text'));
 		}
 	}
 } else {

--- a/src/engine/Default/galactic_post_write_article_processing.php
+++ b/src/engine/Default/galactic_post_write_article_processing.php
@@ -24,7 +24,7 @@ if (Request::get('action') == 'Preview article') {
 $db = Smr\Database::getInstance();
 if (isset($var['id'])) {
 	// Editing an article
-	$db->query('UPDATE galactic_post_article SET last_modified = ' . $db->escapeNumber(Smr\Epoch::time()) . ', text = ' . $db->escapeString($message) . ', title = ' . $db->escapeString($title) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
+	$db->write('UPDATE galactic_post_article SET last_modified = ' . $db->escapeNumber(Smr\Epoch::time()) . ', text = ' . $db->escapeString($message) . ', title = ' . $db->escapeString($title) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
 	Page::create('skeleton.php', 'galactic_post_view_article.php')->go();
 } else {
 	// Adding a new article
@@ -35,10 +35,10 @@ if (isset($var['id'])) {
 		}
 	}
 
-	$db->query('SELECT MAX(article_id) article_id FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' LIMIT 1');
-	$db->requireRecord();
-	$num = $db->getInt('article_id') + 1;
-	$db->query('INSERT INTO galactic_post_article (game_id, article_id, writer_id, title, text, last_modified) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($num) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($title) . ' , ' . $db->escapeString($message) . ' , ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
-	$db->query('UPDATE galactic_post_writer SET last_wrote = ' . $db->escapeNumber(Smr\Epoch::time()) . ' WHERE account_id = ' . $db->escapeNumber($player->getAccountID()));
+	$dbResult = $db->read('SELECT MAX(article_id) article_id FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' LIMIT 1');
+	$num = $dbResult->record()->getInt('article_id') + 1;
+
+	$db->write('INSERT INTO galactic_post_article (game_id, article_id, writer_id, title, text, last_modified) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($num) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($title) . ' , ' . $db->escapeString($message) . ' , ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->write('UPDATE galactic_post_writer SET last_wrote = ' . $db->escapeNumber(Smr\Epoch::time()) . ' WHERE account_id = ' . $db->escapeNumber($player->getAccountID()));
 	Page::create('skeleton.php', 'galactic_post_read.php')->go();
 }

--- a/src/engine/Default/game_join.php
+++ b/src/engine/Default/game_join.php
@@ -37,15 +37,14 @@ $races = [];
 $db = Smr\Database::getInstance();
 foreach ($game->getPlayableRaceIDs() as $raceID) {
 	// get number of traders in game
-	$db->query('SELECT count(*) as number_of_race FROM player WHERE race_id = ' . $db->escapeNumber($raceID) . ' AND game_id = ' . $db->escapeNumber($var['game_id']));
-	$db->requireRecord();
+	$dbResult = $db->read('SELECT count(*) as number_of_race FROM player WHERE race_id = ' . $db->escapeNumber($raceID) . ' AND game_id = ' . $db->escapeNumber($var['game_id']));
 
 	$race = Globals::getRaces()[$raceID];
 	$races[$raceID] = [
 		'ID' => $raceID,
 		'Name' => $race['Race Name'],
 		'Description' => $race['Description'],
-		'NumberOfPlayers' => $db->getInt('number_of_race'),
+		'NumberOfPlayers' => $dbResult->record()->getInt('number_of_race'),
 		'Selected' => false,
 	];
 }

--- a/src/engine/Default/game_join_processing.php
+++ b/src/engine/Default/game_join_processing.php
@@ -77,7 +77,7 @@ $player->giveStartingRelations();
 // The `player_visited_sector` table holds *unvisited* sectors, so that once
 // all sectors are visited (the majority of the game), the table is empty.
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO player_visited_sector (account_id, game_id, sector_id)
+$db->write('INSERT INTO player_visited_sector (account_id, game_id, sector_id)
             SELECT ' . $db->escapeNumber($account->getAccountID()) . ', game_id, sector_id
               FROM sector WHERE game_id = ' . $db->escapeNumber($gameID));
 
@@ -102,7 +102,7 @@ $player->getShip()->update();
 
 // Announce the player joining in the news
 $news = '[player=' . $player->getPlayerID() . '] has joined the game!';
-$db->query('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($gameID) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
+$db->write('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($gameID) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
 
 // Send the player directly into the game
 $container = Page::create('game_play_processing.php');

--- a/src/engine/Default/game_play.php
+++ b/src/engine/Default/game_play.php
@@ -25,51 +25,47 @@ $games = array();
 $games['Play'] = array();
 $game_id_list = array();
 $db = Smr\Database::getInstance();
-$db->query('SELECT end_time, game_id, game_name, game_speed, game_type
+$dbResult = $db->read('SELECT end_time, game_id, game_name, game_speed, game_type
 			FROM game JOIN player USING (game_id)
 			WHERE account_id = '.$db->escapeNumber($account->getAccountID()) . '
 				AND enabled = \'TRUE\'
 				AND end_time >= ' . $db->escapeNumber(Smr\Epoch::time()) . '
 			ORDER BY start_time, game_id DESC');
-if ($db->getNumRows() > 0) {
-	while ($db->nextRecord()) {
-		$game_id = $db->getInt('game_id');
-		$games['Play'][$game_id]['ID'] = $game_id;
-		$games['Play'][$game_id]['Name'] = $db->getField('game_name');
-		$games['Play'][$game_id]['Type'] = SmrGame::GAME_TYPES[$db->getInt('game_type')];
-		$games['Play'][$game_id]['EndDate'] = date($account->getDateTimeFormatSplit(), $db->getInt('end_time'));
-		$games['Play'][$game_id]['Speed'] = $db->getFloat('game_speed');
+foreach ($dbResult->records() as $dbRecord) {
+	$game_id = $dbRecord->getInt('game_id');
+	$games['Play'][$game_id]['ID'] = $game_id;
+	$games['Play'][$game_id]['Name'] = $dbRecord->getField('game_name');
+	$games['Play'][$game_id]['Type'] = SmrGame::GAME_TYPES[$dbRecord->getInt('game_type')];
+	$games['Play'][$game_id]['EndDate'] = date($account->getDateTimeFormatSplit(), $dbRecord->getInt('end_time'));
+	$games['Play'][$game_id]['Speed'] = $dbRecord->getFloat('game_speed');
 
-		$container = Page::create('game_play_processing.php');
-		$container['game_id'] = $game_id;
-		$games['Play'][$game_id]['PlayGameLink'] = $container->href();
+	$container = Page::create('game_play_processing.php');
+	$container['game_id'] = $game_id;
+	$games['Play'][$game_id]['PlayGameLink'] = $container->href();
 
-		// creates a new player object
-		$curr_player = SmrPlayer::getPlayer($account->getAccountID(), $game_id);
+	// creates a new player object
+	$curr_player = SmrPlayer::getPlayer($account->getAccountID(), $game_id);
 
-		// update turns for this game
-		$curr_player->updateTurns();
+	// update turns for this game
+	$curr_player->updateTurns();
 
-		// generate list of game_id that this player is joined
-		$game_id_list[] = $game_id;
+	// generate list of game_id that this player is joined
+	$game_id_list[] = $game_id;
 
-		$db2 = Smr\Database::getInstance();
-		$db2->query('SELECT count(*) as num_playing
+	$result2 = $db->read('SELECT count(*) as num_playing
 					FROM player
 					WHERE last_cpl_action >= ' . $db->escapeNumber(Smr\Epoch::time() - 600) . '
 						AND game_id = '.$db->escapeNumber($game_id));
-		$db2->nextRecord();
-		$games['Play'][$game_id]['NumberPlaying'] = $db2->getInt('num_playing');
+	$games['Play'][$game_id]['NumberPlaying'] = $result2->record()->getInt('num_playing');
 
-		// create a container that will hold next url and additional variables.
+	// create a container that will hold next url and additional variables.
 
-		$container_game = Page::create('skeleton.php', 'game_stats.php');
-		$container_game['game_id'] = $game_id;
-		$games['Play'][$game_id]['GameStatsLink'] = $container_game->href();
-		$games['Play'][$game_id]['Turns'] = $curr_player->getTurns();
-		$games['Play'][$game_id]['LastMovement'] = format_time(Smr\Epoch::time() - $curr_player->getLastActive(), TRUE);
+	$container_game = Page::create('skeleton.php', 'game_stats.php');
+	$container_game['game_id'] = $game_id;
+	$games['Play'][$game_id]['GameStatsLink'] = $container_game->href();
+	$games['Play'][$game_id]['Turns'] = $curr_player->getTurns();
+	$games['Play'][$game_id]['LastMovement'] = format_time(Smr\Epoch::time() - $curr_player->getLastActive(), TRUE);
 
-	}
 }
 
 if (empty($games['Play'])) {
@@ -82,14 +78,14 @@ if (empty($games['Play'])) {
 // ***************************************
 
 if (count($game_id_list) > 0) {
-	$db->query('SELECT game_id
+	$dbResult = $db->read('SELECT game_id
 				FROM game
 				WHERE game_id NOT IN (' . $db->escapeArray($game_id_list) . ')
 					AND end_time >= ' . $db->escapeNumber(Smr\Epoch::time()) . '
 					AND enabled = ' . $db->escapeBoolean(true) . '
 				ORDER BY start_time DESC');
 } else {
-	$db->query('SELECT game_id
+	$dbResult = $db->read('SELECT game_id
 				FROM game
 				WHERE end_time >= ' . $db->escapeNumber(Smr\Epoch::time()) . '
 					AND enabled = ' . $db->escapeBoolean(true) . '
@@ -97,29 +93,25 @@ if (count($game_id_list) > 0) {
 }
 
 // are there any results?
-if ($db->getNumRows() > 0) {
-	$games['Join'] = array();
-	// iterate over the resultset
-	while ($db->nextRecord()) {
-		$game_id = $db->getInt('game_id');
-		$game = SmrGame::getGame($game_id);
-		$games['Join'][$game_id] = [
-			'ID' => $game_id,
-			'Name' => $game->getName(),
-			'JoinTime' => $game->getJoinTime(),
-			'StartDate' => date($account->getDateTimeFormatSplit(), $game->getStartTime()),
-			'EndDate' => date($account->getDateTimeFormatSplit(), $game->getEndTime()),
-			'Players' => $game->getTotalPlayers(),
-			'Type' => $game->getGameType(),
-			'Speed' => $game->getGameSpeed(),
-			'Credits' => $game->getCreditsNeeded(),
-		];
-		// create a container that will hold next url and additional variables.
-		$container = Page::create('skeleton.php', 'game_join.php');
-		$container['game_id'] = $game_id;
+foreach ($dbResult->records() as $dbRecord) {
+	$game_id = $dbRecord->getInt('game_id');
+	$game = SmrGame::getGame($game_id);
+	$games['Join'][$game_id] = [
+		'ID' => $game_id,
+		'Name' => $game->getName(),
+		'JoinTime' => $game->getJoinTime(),
+		'StartDate' => date($account->getDateTimeFormatSplit(), $game->getStartTime()),
+		'EndDate' => date($account->getDateTimeFormatSplit(), $game->getEndTime()),
+		'Players' => $game->getTotalPlayers(),
+		'Type' => $game->getGameType(),
+		'Speed' => $game->getGameSpeed(),
+		'Credits' => $game->getCreditsNeeded(),
+	];
+	// create a container that will hold next url and additional variables.
+	$container = Page::create('skeleton.php', 'game_join.php');
+	$container['game_id'] = $game_id;
 
-		$games['Join'][$game_id]['JoinGameLink'] = $container->href();
-	}
+	$games['Join'][$game_id]['JoinGameLink'] = $container->href();
 }
 
 // ***************************************
@@ -129,61 +121,57 @@ if ($db->getNumRows() > 0) {
 $games['Previous'] = array();
 
 //New previous games
-$db->query('SELECT start_time, end_time, game_name, game_type, game_speed, game_id ' .
+$dbResult = $db->read('SELECT start_time, end_time, game_name, game_type, game_speed, game_id ' .
 		'FROM game WHERE enabled = \'TRUE\' AND end_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY game_id DESC');
-if ($db->getNumRows()) {
-	while ($db->nextRecord()) {
-		$game_id = $db->getInt('game_id');
-		$games['Previous'][$game_id]['ID'] = $game_id;
-		$games['Previous'][$game_id]['Name'] = $db->getField('game_name');
-		$games['Previous'][$game_id]['StartDate'] = date($account->getDateFormat(), $db->getInt('start_time'));
-		$games['Previous'][$game_id]['EndDate'] = date($account->getDateFormat(), $db->getInt('end_time'));
-		$games['Previous'][$game_id]['Type'] = SmrGame::GAME_TYPES[$db->getInt('game_type')];
-		$games['Previous'][$game_id]['Speed'] = $db->getFloat('game_speed');
-		// create a container that will hold next url and additional variables.
-		$container = Page::create('skeleton.php');
-		$container['game_id'] = $container['GameID'] = $game_id;
-		$container['game_name'] = $games['Previous'][$game_id]['Name'];
+foreach ($dbResult->records() as $dbRecord) {
+	$game_id = $dbRecord->getInt('game_id');
+	$games['Previous'][$game_id]['ID'] = $game_id;
+	$games['Previous'][$game_id]['Name'] = $dbRecord->getField('game_name');
+	$games['Previous'][$game_id]['StartDate'] = date($account->getDateFormat(), $dbRecord->getInt('start_time'));
+	$games['Previous'][$game_id]['EndDate'] = date($account->getDateFormat(), $dbRecord->getInt('end_time'));
+	$games['Previous'][$game_id]['Type'] = SmrGame::GAME_TYPES[$dbRecord->getInt('game_type')];
+	$games['Previous'][$game_id]['Speed'] = $dbRecord->getFloat('game_speed');
+	// create a container that will hold next url and additional variables.
+	$container = Page::create('skeleton.php');
+	$container['game_id'] = $container['GameID'] = $game_id;
+	$container['game_name'] = $games['Previous'][$game_id]['Name'];
 
-		$container['body'] = 'hall_of_fame_new.php';
-		$games['Previous'][$game_id]['PreviousGameHOFLink'] = $container->href();
-		$container['body'] = 'news_read.php';
-		$games['Previous'][$game_id]['PreviousGameNewsLink'] = $container->href();
-		$container['body'] = 'game_stats.php';
-		$games['Previous'][$game_id]['PreviousGameStatsLink'] = $container->href();
-	}
+	$container['body'] = 'hall_of_fame_new.php';
+	$games['Previous'][$game_id]['PreviousGameHOFLink'] = $container->href();
+	$container['body'] = 'news_read.php';
+	$games['Previous'][$game_id]['PreviousGameNewsLink'] = $container->href();
+	$container['body'] = 'game_stats.php';
+	$games['Previous'][$game_id]['PreviousGameStatsLink'] = $container->href();
 }
 
 foreach (Globals::getHistoryDatabases() as $databaseName => $oldColumn) {
 	//Old previous games
 	$db->switchDatabases($databaseName);
-	$db->query('SELECT start_date, end_date, game_name, type, speed, game_id
+	$dbResult = $db->read('SELECT start_date, end_date, game_name, type, speed, game_id
 						FROM game ORDER BY game_id DESC');
-	if ($db->getNumRows()) {
-		while ($db->nextRecord()) {
-			$game_id = $db->getInt('game_id');
-			$index = $databaseName . $game_id;
-			$games['Previous'][$index]['ID'] = $game_id;
-			$games['Previous'][$index]['Name'] = $db->getField('game_name');
-			$games['Previous'][$index]['StartDate'] = date($account->getDateFormat(), $db->getInt('start_date'));
-			$games['Previous'][$index]['EndDate'] = date($account->getDateFormat(), $db->getInt('end_date'));
-			$games['Previous'][$index]['Type'] = $db->getField('type');
-			$games['Previous'][$index]['Speed'] = $db->getFloat('speed');
-			// create a container that will hold next url and additional variables.
-			$container = Page::create('skeleton.php');
-			$container['view_game_id'] = $game_id;
-			$container['HistoryDatabase'] = $databaseName;
-			$container['game_name'] = $games['Previous'][$index]['Name'];
+	foreach ($dbResult->records() as $dbRecord) {
+		$game_id = $dbRecord->getInt('game_id');
+		$index = $databaseName . $game_id;
+		$games['Previous'][$index]['ID'] = $game_id;
+		$games['Previous'][$index]['Name'] = $dbRecord->getField('game_name');
+		$games['Previous'][$index]['StartDate'] = date($account->getDateFormat(), $dbRecord->getInt('start_date'));
+		$games['Previous'][$index]['EndDate'] = date($account->getDateFormat(), $dbRecord->getInt('end_date'));
+		$games['Previous'][$index]['Type'] = $dbRecord->getField('type');
+		$games['Previous'][$index]['Speed'] = $dbRecord->getFloat('speed');
+		// create a container that will hold next url and additional variables.
+		$container = Page::create('skeleton.php');
+		$container['view_game_id'] = $game_id;
+		$container['HistoryDatabase'] = $databaseName;
+		$container['game_name'] = $games['Previous'][$index]['Name'];
 
-			$container['body'] = 'history_games.php';
-			$games['Previous'][$index]['PreviousGameLink'] = $container->href();
-			$container['body'] = 'history_games_hof.php';
-			$games['Previous'][$index]['PreviousGameHOFLink'] = $container->href();
-			$container['body'] = 'history_games_news.php';
-			$games['Previous'][$index]['PreviousGameNewsLink'] = $container->href();
-			$container['body'] = 'history_games_detail.php';
-			$games['Previous'][$index]['PreviousGameStatsLink'] = $container->href();
-		}
+		$container['body'] = 'history_games.php';
+		$games['Previous'][$index]['PreviousGameLink'] = $container->href();
+		$container['body'] = 'history_games_hof.php';
+		$games['Previous'][$index]['PreviousGameHOFLink'] = $container->href();
+		$container['body'] = 'history_games_news.php';
+		$games['Previous'][$index]['PreviousGameNewsLink'] = $container->href();
+		$container['body'] = 'history_games_detail.php';
+		$games['Previous'][$index]['PreviousGameStatsLink'] = $container->href();
 	}
 }
 $db->switchDatabaseToLive(); // restore database
@@ -196,30 +184,29 @@ $template->assign('Games', $games);
 $container = Page::create('skeleton.php', 'vote.php');
 $template->assign('VotingHref', $container->href());
 
-$db->query('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY end DESC');
-if ($db->getNumRows() > 0) {
-	$db2 = Smr\Database::getInstance();
+$dbResult = $db->read('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY end DESC');
+if ($dbResult->hasRecord()) {
 	$votedFor = array();
-	$db2->query('SELECT * FROM voting_results WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
-	while ($db2->nextRecord()) {
-		$votedFor[$db2->getInt('vote_id')] = $db2->getInt('option_id');
+	$dbResult2 = $db->read('SELECT * FROM voting_results WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+	foreach ($dbResult2->records() as $dbRecord2) {
+		$votedFor[$dbRecord2->getInt('vote_id')] = $dbRecord2->getInt('option_id');
 	}
 	$voting = array();
-	while ($db->nextRecord()) {
-		$voteID = $db->getInt('vote_id');
+	foreach ($dbResult->records() as $dbRecord) {
+		$voteID = $dbRecord->getInt('vote_id');
 		$voting[$voteID]['ID'] = $voteID;
 		$container = Page::create('vote_processing.php', 'game_play.php');
 		$container['vote_id'] = $voteID;
 		$voting[$voteID]['HREF'] = $container->href();
-		$voting[$voteID]['Question'] = $db->getField('question');
-		$voting[$voteID]['TimeRemaining'] = format_time($db->getInt('end') - Smr\Epoch::time(), true);
+		$voting[$voteID]['Question'] = $dbRecord->getField('question');
+		$voting[$voteID]['TimeRemaining'] = format_time($dbRecord->getInt('end') - Smr\Epoch::time(), true);
 		$voting[$voteID]['Options'] = array();
-		$db2->query('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = ' . $db->escapeNumber($db->getInt('vote_id')) . ' GROUP BY option_id');
-		while ($db2->nextRecord()) {
-			$voting[$voteID]['Options'][$db2->getInt('option_id')]['ID'] = $db2->getInt('option_id');
-			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Text'] = $db2->getField('text');
-			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Chosen'] = isset($votedFor[$db->getInt('vote_id')]) && $votedFor[$voteID] == $db2->getInt('option_id');
-			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Votes'] = $db2->getInt('count(account_id)');
+		$dbResult2 = $db->read('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = ' . $db->escapeNumber($dbRecord->getInt('vote_id')) . ' GROUP BY option_id');
+		foreach ($dbResult2->records() as $dbRecord2) {
+			$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['ID'] = $dbRecord2->getInt('option_id');
+			$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['Text'] = $dbRecord2->getField('text');
+			$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['Chosen'] = isset($votedFor[$dbRecord->getInt('vote_id')]) && $votedFor[$voteID] == $dbRecord2->getInt('option_id');
+			$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['Votes'] = $dbRecord2->getInt('count(account_id)');
 		}
 	}
 	$template->assign('Voting', $voting);

--- a/src/engine/Default/game_stats.php
+++ b/src/engine/Default/game_stats.php
@@ -12,44 +12,41 @@ $template->assign('StatsGame', $statsGame);
 $template->assign('PageTopic', 'Game Stats: ' . $statsGame->getName() . ' (' . $gameID . ')');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT count(*) total_players, MAX(experience) max_exp, MAX(alignment) max_align, MIN(alignment) min_alignment, MAX(kills) max_kills FROM player WHERE game_id = ' . $gameID . ' ORDER BY experience DESC');
-if ($db->nextRecord()) {
-	$template->assign('TotalPlayers', $db->getInt('total_players'));
-	$template->assign('HighestExp', $db->getInt('max_exp'));
-	$template->assign('HighestAlign', $db->getInt('max_align'));
-	$template->assign('LowestAlign', $db->getInt('min_alignment'));
-	$template->assign('HighestKills', $db->getInt('max_kills'));
+$dbResult = $db->read('SELECT count(*) total_players, MAX(experience) max_exp, MAX(alignment) max_align, MIN(alignment) min_alignment, MAX(kills) max_kills FROM player WHERE game_id = ' . $gameID . ' ORDER BY experience DESC');
+if ($dbResult->hasRecord()) {
+	$dbRecord = $dbResult->record();
+	$template->assign('TotalPlayers', $dbRecord->getInt('total_players'));
+	$template->assign('HighestExp', $dbRecord->getInt('max_exp'));
+	$template->assign('HighestAlign', $dbRecord->getInt('max_align'));
+	$template->assign('LowestAlign', $dbRecord->getInt('min_alignment'));
+	$template->assign('HighestKills', $dbRecord->getInt('max_kills'));
 }
 
-$db->query('SELECT count(*) num_alliance FROM alliance WHERE game_id = ' . $gameID);
-if ($db->nextRecord()) {
-	$template->assign('TotalAlliances', $db->getInt('num_alliance'));
-}
+$dbResult = $db->read('SELECT count(*) num_alliance FROM alliance WHERE game_id = ' . $gameID);
+$template->assign('TotalAlliances', $dbResult->record()->getInt('num_alliance'));
 
-$db->query('SELECT * FROM player WHERE game_id = ' . $gameID . ' ORDER BY experience DESC LIMIT 10');
-if ($db->getNumRows() > 0) {
-	$rank = 0;
+$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $gameID . ' ORDER BY experience DESC LIMIT 10');
+if ($dbResult->hasRecord()) {
 	$expRankings = array();
-	while ($db->nextRecord()) {
-		$expRankings[++$rank] = SmrPlayer::getPlayer($db->getInt('account_id'), $gameID, false, $db);
+	foreach ($dbResult->records() as $index => $dbRecord) {
+		$expRankings[$index + 1] = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $gameID, false, $dbRecord);
 	}
 	$template->assign('ExperienceRankings', $expRankings);
 }
 
 
-$db->query('SELECT * FROM player WHERE game_id = ' . $gameID . ' ORDER BY kills DESC LIMIT 10');
-if ($db->getNumRows() > 0) {
-	$rank = 0;
+$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $gameID . ' ORDER BY kills DESC LIMIT 10');
+if ($dbResult->hasRecord()) {
 	$killRankings = array();
-	while ($db->nextRecord()) {
-		$killRankings[++$rank] = SmrPlayer::getPlayer($db->getInt('account_id'), $gameID, false, $db);
+	foreach ($dbResult->records() as $index => $dbRecord) {
+		$killRankings[$index + 1] = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $gameID, false, $dbRecord);
 	}
 	$template->assign('KillRankings', $killRankings);
 }
 
 function allianceTopTen(int $gameID, string $field) : array {
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT alliance_id, SUM(' . $field . ') amount
+	$dbResult = $db->read('SELECT alliance_id, SUM(' . $field . ') amount
 				FROM alliance
 				LEFT JOIN player USING (game_id, alliance_id)
 				WHERE game_id = ' . $db->escapeNumber($gameID) . '
@@ -57,13 +54,9 @@ function allianceTopTen(int $gameID, string $field) : array {
 				ORDER BY amount DESC, alliance_name
 				LIMIT 10');
 	$rankings = array();
-	if ($db->getNumRows() > 0) {
-		$rank = 0;
-		while ($db->nextRecord()) {
-			++$rank;
-			$rankings[$rank]['Alliance'] = SmrAlliance::getAlliance($db->getInt('alliance_id'), $gameID);
-			$rankings[$rank]['Amount'] = $db->getInt('amount');
-		}
+	foreach ($dbResult->records() as $index => $dbRecord) {
+		$rankings[$index + 1]['Alliance'] = SmrAlliance::getAlliance($dbRecord->getInt('alliance_id'), $gameID);
+		$rankings[$index + 1]['Amount'] = $dbRecord->getInt('amount');
 	}
 	return $rankings;
 }

--- a/src/engine/Default/hall_of_fame_new.php
+++ b/src/engine/Default/hall_of_fame_new.php
@@ -31,7 +31,7 @@ const USER_SCORE_NAME = 'User Score';
 $hofTypes = array(DONATION_NAME=>true, USER_SCORE_NAME=>true);
 foreach ($dbResult->records() as $dbRecord) {
 	$hof =& $hofTypes;
-	$typeList = explode(':', $dbRecord->getField('type'));
+	$typeList = explode(':', $dbRecord->getString('type'));
 	foreach ($typeList as $type) {
 		if (!isset($hof[$type])) {
 			$hof[$type] = array();
@@ -63,7 +63,7 @@ if (!isset($var['view'])) {
 	} else {
 		$dbResult = $db->read('SELECT visibility FROM hof_visibility WHERE type = ' . $db->escapeArray($viewType, ':', false) . ' LIMIT 1');
 		if ($dbResult->hasRecord()) {
-			$vis = $dbResult->record()->getField('visibility');
+			$vis = $dbResult->record()->getString('visibility');
 		}
 		$dbResult = $db->read('SELECT account_id,SUM(amount) amount FROM player_hof WHERE type=' . $db->escapeArray($viewType, ':', false) . $gameIDSql . ' GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
 	}

--- a/src/engine/Default/hall_of_fame_new.php
+++ b/src/engine/Default/hall_of_fame_new.php
@@ -25,13 +25,13 @@ if (isset($game_id)) {
 $template->assign('PersonalHofHREF', $container->href());
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT type FROM hof_visibility WHERE visibility != ' . $db->escapeString(HOF_PRIVATE) . ' ORDER BY type');
+$dbResult = $db->read('SELECT type FROM hof_visibility WHERE visibility != ' . $db->escapeString(HOF_PRIVATE) . ' ORDER BY type');
 const DONATION_NAME = 'Money Donated To SMR';
 const USER_SCORE_NAME = 'User Score';
 $hofTypes = array(DONATION_NAME=>true, USER_SCORE_NAME=>true);
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$hof =& $hofTypes;
-	$typeList = explode(':', $db->getField('type'));
+	$typeList = explode(':', $dbRecord->getField('type'));
 	foreach ($typeList as $type) {
 		if (!isset($hof[$type])) {
 			$hof[$type] = array();
@@ -54,26 +54,26 @@ if (!isset($var['view'])) {
 	$viewType = $var['type'];
 	$viewType[] = $var['view'];
 	if ($var['view'] == DONATION_NAME) {
-		$db->query('SELECT account_id, SUM(amount) as amount FROM account_donated
+		$dbResult = $db->read('SELECT account_id, SUM(amount) as amount FROM account_donated
 					GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
 	} elseif ($var['view'] == USER_SCORE_NAME) {
 		$statements = SmrAccount::getUserScoreCaseStatement($db);
 		$query = 'SELECT account_id, ' . $statements['CASE'] . ' amount FROM (SELECT account_id, type, SUM(amount) amount FROM player_hof WHERE type IN (' . $statements['IN'] . ')' . $gameIDSql . ' GROUP BY account_id,type) x GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25';
-		$db->query($query);
+		$dbResult = $db->read($query);
 	} else {
-		$db->query('SELECT visibility FROM hof_visibility WHERE type = ' . $db->escapeArray($viewType, ':', false) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			$vis = $db->getField('visibility');
+		$dbResult = $db->read('SELECT visibility FROM hof_visibility WHERE type = ' . $db->escapeArray($viewType, ':', false) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$vis = $dbResult->record()->getField('visibility');
 		}
-		$db->query('SELECT account_id,SUM(amount) amount FROM player_hof WHERE type=' . $db->escapeArray($viewType, ':', false) . $gameIDSql . ' GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
+		$dbResult = $db->read('SELECT account_id,SUM(amount) amount FROM player_hof WHERE type=' . $db->escapeArray($viewType, ':', false) . $gameIDSql . ' GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
 	}
 	$rows = [];
-	while ($db->nextRecord()) {
-		$accountID = $db->getInt('account_id');
+	foreach ($dbResult->records() as $dbRecord) {
+		$accountID = $dbRecord->getInt('account_id');
 		if ($accountID == $account->getAccountID()) {
 			$foundMe = true;
 		}
-		$amount = applyHofVisibilityMask($db->getFloat('amount'), $vis, $game_id, $accountID);
+		$amount = applyHofVisibilityMask($dbRecord->getFloat('amount'), $vis, $game_id, $accountID);
 		$rows[] = displayHOFRow($rank++, $accountID, $amount);
 	}
 	if (!$foundMe) {

--- a/src/engine/Default/hall_of_fame_player_detail.php
+++ b/src/engine/Default/hall_of_fame_player_detail.php
@@ -31,13 +31,13 @@ if ($account->getAccountID() == $account_id) {
 }
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT type FROM hof_visibility WHERE visibility IN (' . $db->escapeArray($allowedVisibities) . ') ORDER BY type');
+$dbResult = $db->read('SELECT type FROM hof_visibility WHERE visibility IN (' . $db->escapeArray($allowedVisibities) . ') ORDER BY type');
 const DONATION_NAME = 'Money Donated To SMR';
 const USER_SCORE_NAME = 'User Score';
 $hofTypes = array(DONATION_NAME=>true, USER_SCORE_NAME=>true);
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$hof =& $hofTypes;
-	$typeList = explode(':', $db->getField('type'));
+	$typeList = explode(':', $dbRecord->getField('type'));
 	foreach ($typeList as $type) {
 		if (!isset($hof[$type])) {
 			$hof[$type] = array();

--- a/src/engine/Default/hall_of_fame_player_detail.php
+++ b/src/engine/Default/hall_of_fame_player_detail.php
@@ -37,7 +37,7 @@ const USER_SCORE_NAME = 'User Score';
 $hofTypes = array(DONATION_NAME=>true, USER_SCORE_NAME=>true);
 foreach ($dbResult->records() as $dbRecord) {
 	$hof =& $hofTypes;
-	$typeList = explode(':', $dbRecord->getField('type'));
+	$typeList = explode(':', $dbRecord->getString('type'));
 	foreach ($typeList as $type) {
 		if (!isset($hof[$type])) {
 			$hof[$type] = array();

--- a/src/engine/Default/history_alliance_detail.php
+++ b/src/engine/Default/history_alliance_detail.php
@@ -18,7 +18,7 @@ $id = $var['alliance_id'];
 $db = Smr\Database::getInstance();
 $db->switchDatabases($var['HistoryDatabase']);
 $dbResult = $db->read('SELECT alliance_name FROM alliance WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($game_id));
-$template->assign('PageTopic', 'Alliance Roster - ' . htmlentities($dbResult->record()->getField('alliance_name')));
+$template->assign('PageTopic', 'Alliance Roster - ' . htmlentities($dbResult->record()->getString('alliance_name')));
 
 //get alliance members
 $oldAccountID = $account->getOldAccountID($var['HistoryDatabase']);
@@ -27,7 +27,7 @@ $players = [];
 foreach ($dbResult->records() as $dbRecord) {
 	$players[] = [
 		'bold' => $dbRecord->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
-		'player_name' => $dbRecord->getField('player_name'),
+		'player_name' => $dbRecord->getString('player_name'),
 		'experience' => number_format($dbRecord->getInt('experience')),
 		'alignment' => number_format($dbRecord->getInt('alignment')),
 		'race' => number_format($dbRecord->getInt('race')),

--- a/src/engine/Default/history_alliance_detail.php
+++ b/src/engine/Default/history_alliance_detail.php
@@ -17,24 +17,23 @@ $id = $var['alliance_id'];
 
 $db = Smr\Database::getInstance();
 $db->switchDatabases($var['HistoryDatabase']);
-$db->query('SELECT * FROM alliance WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($game_id));
-$db->requireRecord();
-$template->assign('PageTopic', 'Alliance Roster - ' . htmlentities($db->getField('alliance_name')));
+$dbResult = $db->read('SELECT alliance_name FROM alliance WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($game_id));
+$template->assign('PageTopic', 'Alliance Roster - ' . htmlentities($dbResult->record()->getField('alliance_name')));
 
 //get alliance members
 $oldAccountID = $account->getOldAccountID($var['HistoryDatabase']);
-$db->query('SELECT * FROM player WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY experience DESC');
+$dbResult = $db->read('SELECT * FROM player WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY experience DESC');
 $players = [];
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$players[] = [
-		'bold' => $db->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
-		'player_name' => $db->getField('player_name'),
-		'experience' => number_format($db->getInt('experience')),
-		'alignment' => number_format($db->getInt('alignment')),
-		'race' => number_format($db->getInt('race')),
-		'kills' => number_format($db->getInt('kills')),
-		'deaths' => number_format($db->getInt('deaths')),
-		'bounty' => number_format($db->getInt('bounty')),
+		'bold' => $dbRecord->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
+		'player_name' => $dbRecord->getField('player_name'),
+		'experience' => number_format($dbRecord->getInt('experience')),
+		'alignment' => number_format($dbRecord->getInt('alignment')),
+		'race' => number_format($dbRecord->getInt('race')),
+		'kills' => number_format($dbRecord->getInt('kills')),
+		'deaths' => number_format($dbRecord->getInt('deaths')),
+		'bounty' => number_format($dbRecord->getInt('bounty')),
 	];
 }
 $template->assign('Players', $players);

--- a/src/engine/Default/history_games.php
+++ b/src/engine/Default/history_games.php
@@ -74,7 +74,7 @@ $dbResult = $db->read('SELECT SUM(experience) as exp, alliance_name, alliance_id
 			FROM player JOIN alliance USING (game_id, alliance_id)
 			WHERE game_id = '.$db->escapeNumber($game_id) . ' GROUP BY alliance_id ORDER BY exp DESC LIMIT 10');
 foreach ($dbResult->records() as $dbRecord) {
-	$alliance = htmlentities($dbRecord->getField('alliance_name'));
+	$alliance = htmlentities($dbRecord->getString('alliance_name'));
 	$id = $dbRecord->getInt('alliance_id');
 	$container['alliance_id'] = $id;
 	$allianceExp[] = [
@@ -88,7 +88,7 @@ $template->assign('AllianceExp', $allianceExp);
 $allianceKills = [];
 $dbResult = $db->read('SELECT kills, alliance_name, alliance_id FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY kills DESC LIMIT 10');
 foreach ($dbResult->records() as $dbRecord) {
-	$alliance = htmlentities($dbRecord->getField('alliance_name'));
+	$alliance = htmlentities($dbRecord->getString('alliance_name'));
 	$id = $dbRecord->getInt('alliance_id');
 	$container['alliance_id'] = $id;
 	$allianceKills[] = [

--- a/src/engine/Default/history_games.php
+++ b/src/engine/Default/history_games.php
@@ -16,50 +16,50 @@ Menu::history_games(0);
 
 $db = Smr\Database::getInstance();
 $db->switchDatabases($var['HistoryDatabase']);
-$db->query('SELECT start_date, type, end_date, game_name, speed, game_id ' .
+$dbResult = $db->read('SELECT start_date, type, end_date, game_name, speed, game_id ' .
            'FROM game WHERE game_id = ' . $db->escapeNumber($game_id));
-$db->requireRecord();
+$dbRecord = $dbResult->record();
 $template->assign('GameName', $game_name);
-$template->assign('Start', date($account->getDateFormat(), $db->getInt('start_date')));
-$template->assign('End', date($account->getDateFormat(), $db->getInt('end_date')));
-$template->assign('Type', $db->getField('type'));
-$template->assign('Speed', $db->getFloat('speed'));
+$template->assign('Start', date($account->getDateFormat(), $dbRecord->getInt('start_date')));
+$template->assign('End', date($account->getDateFormat(), $dbRecord->getInt('end_date')));
+$template->assign('Type', $dbRecord->getField('type'));
+$template->assign('Speed', $dbRecord->getFloat('speed'));
 
-$db->query('SELECT count(*), max(experience), max(alignment), min(alignment), max(kills) FROM player WHERE game_id = ' . $db->escapeNumber($game_id));
-if ($db->nextRecord()) {
-	$template->assign('NumPlayers', $db->getInt('count(*)'));
-	$template->assign('MaxExp', $db->getInt('max(experience)'));
-	$template->assign('MaxAlign', $db->getInt('max(alignment)'));
-	$template->assign('MinAlign', $db->getInt('min(alignment)'));
-	$template->assign('MaxKills', $db->getInt('max(kills)'));
+$dbResult = $db->read('SELECT count(*), max(experience), max(alignment), min(alignment), max(kills) FROM player WHERE game_id = ' . $db->escapeNumber($game_id));
+if ($dbResult->hasRecord()) {
+	$dbRecord = $dbResult->record();
+	$template->assign('NumPlayers', $dbRecord->getInt('count(*)'));
+	$template->assign('MaxExp', $dbRecord->getInt('max(experience)'));
+	$template->assign('MaxAlign', $dbRecord->getInt('max(alignment)'));
+	$template->assign('MinAlign', $dbRecord->getInt('min(alignment)'));
+	$template->assign('MaxKills', $dbRecord->getInt('max(kills)'));
 }
-$db->query('SELECT count(*) FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id));
-$db->requireRecord();
-$template->assign('NumAlliances', $db->getInt('count(*)'));
+$dbResult = $db->read('SELECT count(*) FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id));
+$template->assign('NumAlliances', $dbResult->record()->getInt('count(*)'));
 
 // Get linked player information, if available
 $oldAccountID = $account->getOldAccountID($var['HistoryDatabase']);
-$db->query('SELECT alliance_id FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND account_id = ' . $db->escapeNumber($oldAccountID));
-$oldAllianceID = $db->nextRecord() ? $db->getInt('alliance_id') : 0;
+$dbResult = $db->read('SELECT alliance_id FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND account_id = ' . $db->escapeNumber($oldAccountID));
+$oldAllianceID = $dbResult->hasRecord() ? $dbResult->record()->getInt('alliance_id') : 0;
 
 $playerExp = [];
-$db->query('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY experience DESC LIMIT 10');
-while ($db->nextRecord()) {
+$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY experience DESC LIMIT 10');
+foreach ($dbResult->records() as $dbRecord) {
 	$playerExp[] = [
-		'bold' => $db->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
-		'exp' => $db->getInt('experience'),
-		'name' => $db->getField('player_name'),
+		'bold' => $dbRecord->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
+		'exp' => $dbRecord->getInt('experience'),
+		'name' => $dbRecord->getField('player_name'),
 	];
 }
 $template->assign('PlayerExp', $playerExp);
 
 $playerKills = [];
-$db->query('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY kills DESC LIMIT 10');
-while ($db->nextRecord()) {
+$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY kills DESC LIMIT 10');
+foreach ($dbResult->records() as $dbRecord) {
 	$playerKills[] = [
-		'bold' => $db->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
-		'kills' => $db->getInt('kills'),
-		'name' => $db->getField('player_name'),
+		'bold' => $dbRecord->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
+		'kills' => $dbRecord->getInt('kills'),
+		'name' => $dbRecord->getField('player_name'),
 	];
 }
 $template->assign('PlayerKills', $playerKills);
@@ -70,30 +70,30 @@ $container['selected_index'] = 0;
 
 //now for the alliance stuff
 $allianceExp = [];
-$db->query('SELECT SUM(experience) as exp, alliance_name, alliance_id
+$dbResult = $db->read('SELECT SUM(experience) as exp, alliance_name, alliance_id
 			FROM player JOIN alliance USING (game_id, alliance_id)
 			WHERE game_id = '.$db->escapeNumber($game_id) . ' GROUP BY alliance_id ORDER BY exp DESC LIMIT 10');
-while ($db->nextRecord()) {
-	$alliance = htmlentities($db->getField('alliance_name'));
-	$id = $db->getInt('alliance_id');
+foreach ($dbResult->records() as $dbRecord) {
+	$alliance = htmlentities($dbRecord->getField('alliance_name'));
+	$id = $dbRecord->getInt('alliance_id');
 	$container['alliance_id'] = $id;
 	$allianceExp[] = [
-		'bold' => $db->getInt('alliance_id') == $oldAllianceID ? 'class="bold"' : '',
-		'exp' => $db->getInt('exp'),
+		'bold' => $dbRecord->getInt('alliance_id') == $oldAllianceID ? 'class="bold"' : '',
+		'exp' => $dbRecord->getInt('exp'),
 		'link' => create_link($container, $alliance),
 	];
 }
 $template->assign('AllianceExp', $allianceExp);
 
 $allianceKills = [];
-$db->query('SELECT kills, alliance_name, alliance_id FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY kills DESC LIMIT 10');
-while ($db->nextRecord()) {
-	$alliance = htmlentities($db->getField('alliance_name'));
-	$id = $db->getInt('alliance_id');
+$dbResult = $db->read('SELECT kills, alliance_name, alliance_id FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY kills DESC LIMIT 10');
+foreach ($dbResult->records() as $dbRecord) {
+	$alliance = htmlentities($dbRecord->getField('alliance_name'));
+	$id = $dbRecord->getInt('alliance_id');
 	$container['alliance_id'] = $id;
 	$allianceKills[] = [
-		'bold' => $db->getInt('alliance_id') == $oldAllianceID ? 'class="bold"' : '',
-		'kills' => $db->getInt('kills'),
+		'bold' => $dbRecord->getInt('alliance_id') == $oldAllianceID ? 'class="bold"' : '',
+		'kills' => $dbRecord->getInt('kills'),
 		'link' => create_link($container, $alliance),
 	];
 }

--- a/src/engine/Default/history_games_detail.php
+++ b/src/engine/Default/history_games_detail.php
@@ -33,25 +33,25 @@ if (!empty($action)) {
 	$db->switchDatabases($var['HistoryDatabase']);
 	if ($from != 'alliance') {
 		$template->assign('Name', 'Sector ID');
-		$db->query('SELECT ' . $sql . ' as val, sector_id FROM ' . $from . ' WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY val DESC LIMIT 25');
-		while ($db->nextRecord()) {
+		$dbResult = $db->read('SELECT ' . $sql . ' as val, sector_id FROM ' . $from . ' WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY val DESC LIMIT 25');
+		foreach ($dbResult->records() as $dbRecord) {
 			$rankings[] = [
-				'name' => $db->getInt('sector_id'),
-				'value' => $db->getField('val'),
+				'name' => $dbRecord->getInt('sector_id'),
+				'value' => $dbRecord->getField('val'),
 			];
 		}
 	} else {
 		$template->assign('Name', 'Alliance');
-		$db->query('SELECT alliance_name, alliance_id, ' . $sql . ' as val FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND alliance_id > 0 GROUP BY alliance_id ORDER BY val DESC, alliance_id LIMIT 25');
+		$dbResult = $db->read('SELECT alliance_name, alliance_id, ' . $sql . ' as val FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND alliance_id > 0 GROUP BY alliance_id ORDER BY val DESC, alliance_id LIMIT 25');
 		$container = Page::copy($var);
 		$container['body'] = 'history_alliance_detail.php';
 		$container['selected_index'] = 1;
-		while ($db->nextRecord()) {
-			$name = htmlentities($db->getField('alliance_name'));
-			$container['alliance_id'] = $db->getInt('alliance_id');
+		foreach ($dbResult->records() as $dbRecord) {
+			$name = htmlentities($dbRecord->getField('alliance_name'));
+			$container['alliance_id'] = $dbRecord->getInt('alliance_id');
 			$rankings[] = [
 				'name' => create_link($container, $name),
-				'value' => $db->getField('val'),
+				'value' => $dbRecord->getField('val'),
 			];
 		}
 	}

--- a/src/engine/Default/history_games_detail.php
+++ b/src/engine/Default/history_games_detail.php
@@ -47,7 +47,7 @@ if (!empty($action)) {
 		$container['body'] = 'history_alliance_detail.php';
 		$container['selected_index'] = 1;
 		foreach ($dbResult->records() as $dbRecord) {
-			$name = htmlentities($dbRecord->getField('alliance_name'));
+			$name = htmlentities($dbRecord->getString('alliance_name'));
 			$container['alliance_id'] = $dbRecord->getInt('alliance_id');
 			$rankings[] = [
 				'name' => create_link($container, $name),

--- a/src/engine/Default/history_games_hof.php
+++ b/src/engine/Default/history_games_hof.php
@@ -16,9 +16,9 @@ Menu::history_games(2);
 if (!isset($var['stat'])) {
 	// Display a list of stats available to view
 	$links = [];
-	$db->query('SHOW COLUMNS FROM player_has_stats');
-	while ($db->nextRecord()) {
-		$stat = $db->getField('Field');
+	$dbResult = $db->read('SHOW COLUMNS FROM player_has_stats');
+	foreach ($dbResult->records() as $dbRecord) {
+		$stat = $dbRecord->getField('Field');
 		if ($stat == 'account_id' || $stat == 'game_id') {
 			continue;
 		}
@@ -40,13 +40,13 @@ if (!isset($var['stat'])) {
 
 	// Rankings display
 	$oldAccountId = $account->getOldAccountID($var['HistoryDatabase']);
-	$db->query('SELECT * FROM player_has_stats JOIN player USING(account_id, game_id) WHERE game_id=' . $db->escapeNumber($var['view_game_id']) . ' ORDER BY player_has_stats.' . $var['stat'] . ' DESC LIMIT 25');
+	$dbResult = $db->read('SELECT * FROM player_has_stats JOIN player USING(account_id, game_id) WHERE game_id=' . $db->escapeNumber($var['view_game_id']) . ' ORDER BY player_has_stats.' . $var['stat'] . ' DESC LIMIT 25');
 	$rankings = [];
-	while ($db->nextRecord()) {
+	foreach ($dbResult->records() as $dbRecord) {
 		$rankings[] = [
-			'bold' => $db->getInt('account_id') == $oldAccountId ? 'class="bold"' : '',
-			'name' => $db->getField('player_name'),
-			'stat' => $db->getInt($var['stat']),
+			'bold' => $dbRecord->getInt('account_id') == $oldAccountId ? 'class="bold"' : '',
+			'name' => $dbRecord->getField('player_name'),
+			'stat' => $dbRecord->getInt($var['stat']),
 		];
 	}
 	$template->assign('Rankings', $rankings);

--- a/src/engine/Default/history_games_news.php
+++ b/src/engine/Default/history_games_news.php
@@ -17,12 +17,12 @@ $template->assign('ShowHREF', Page::copy($var)->href());
 
 $db = Smr\Database::getInstance();
 $db->switchDatabases($var['HistoryDatabase']);
-$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($var['view_game_id']) . ' AND news_id >= ' . $db->escapeNumber($min) . ' AND news_id <= ' . $db->escapeNumber($max));
+$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($var['view_game_id']) . ' AND news_id >= ' . $db->escapeNumber($min) . ' AND news_id <= ' . $db->escapeNumber($max));
 $rows = [];
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $dbRecord) {
 	$rows[] = [
-		'time' => date($account->getDateTimeFormat(), $db->getInt('time')),
-		'news' => $db->getField('message'),
+		'time' => date($account->getDateTimeFormat(), $dbRecord->getInt('time')),
+		'news' => $dbRecord->getField('message'),
 	];
 }
 $template->assign('Rows', $rows);

--- a/src/engine/Default/login_check_processing.php
+++ b/src/engine/Default/login_check_processing.php
@@ -17,9 +17,9 @@ $lastLogin = $account->getLastLogin();
 
 $db = Smr\Database::getInstance();
 if ($var['CheckType'] == 'Announcements') {
-	$db->query('SELECT 1 FROM announcement WHERE time >= ' . $db->escapeNumber($lastLogin) . ' LIMIT 1');
+	$dbResult = $db->read('SELECT 1 FROM announcement WHERE time >= ' . $db->escapeNumber($lastLogin) . ' LIMIT 1');
 	// do we have announcements?
-	if ($db->nextRecord()) {
+	if ($dbResult->hasRecord()) {
 		Page::create('skeleton.php', 'announcements.php')->go();
 	} else {
 		$var['CheckType'] = 'Updates';
@@ -27,9 +27,9 @@ if ($var['CheckType'] == 'Announcements') {
 }
 
 if ($var['CheckType'] == 'Updates') {
-	$db->query('SELECT 1 FROM version WHERE went_live >= ' . $db->escapeNumber($lastLogin) . ' LIMIT 1');
+	$dbResult = $db->read('SELECT 1 FROM version WHERE went_live >= ' . $db->escapeNumber($lastLogin) . ' LIMIT 1');
 	// do we have updates?
-	if ($db->nextRecord()) {
+	if ($dbResult->hasRecord()) {
 		Page::create('skeleton.php', 'changelog_view.php', array('Since' => $lastLogin))->go();
 	}
 }

--- a/src/engine/Default/message_blacklist.php
+++ b/src/engine/Default/message_blacklist.php
@@ -14,11 +14,11 @@ if (isset($var['msg'])) {
 }
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT p.player_name, p.game_id, b.entry_id FROM player p JOIN message_blacklist b ON p.account_id = b.blacklisted_id AND b.game_id = p.game_id WHERE b.account_id=' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY p.game_id, p.player_name');
+$dbResult = $db->read('SELECT p.player_name, p.game_id, b.entry_id FROM player p JOIN message_blacklist b ON p.account_id = b.blacklisted_id AND b.game_id = p.game_id WHERE b.account_id=' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY p.game_id, p.player_name');
 
 $blacklist = [];
-while ($db->nextRecord()) {
-		$blacklist[] = $db->getRow();
+foreach ($dbResult->records() as $dbRecord) {
+	$blacklist[] = $dbRecord->getRow();
 }
 $template->assign('Blacklist', $blacklist);
 

--- a/src/engine/Default/message_blacklist_add.php
+++ b/src/engine/Default/message_blacklist_add.php
@@ -18,14 +18,14 @@ if (isset($var['account_id'])) {
 }
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT account_id FROM message_blacklist WHERE ' . $player->getSQL() . ' AND blacklisted_id=' . $db->escapeNumber($blacklisted->getAccountID()) . ' LIMIT 1');
+$dbResult = $db->read('SELECT 1 FROM message_blacklist WHERE ' . $player->getSQL() . ' AND blacklisted_id=' . $db->escapeNumber($blacklisted->getAccountID()) . ' LIMIT 1');
 
-if ($db->nextRecord()) {
+if ($dbResult->hasRecord()) {
 	$container['msg'] = '<span class="red bold">ERROR: </span>Player is already blacklisted.';
 	$container->go();
 }
 
-$db->query('INSERT INTO message_blacklist (game_id,account_id,blacklisted_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($blacklisted->getAccountID()) . ')');
+$db->write('INSERT INTO message_blacklist (game_id,account_id,blacklisted_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($blacklisted->getAccountID()) . ')');
 
 $container['msg'] = $blacklisted->getDisplayName() . ' has been added to your blacklist.';
 $container->go();

--- a/src/engine/Default/message_blacklist_del.php
+++ b/src/engine/Default/message_blacklist_del.php
@@ -12,5 +12,5 @@ if (empty($entry_ids)) {
 }
 
 $db = Smr\Database::getInstance();
-$db->query('DELETE FROM message_blacklist WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND entry_id IN (' . $db->escapeArray($entry_ids) . ')');
+$db->write('DELETE FROM message_blacklist WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND entry_id IN (' . $db->escapeArray($entry_ids) . ')');
 $container->go();

--- a/src/engine/Default/message_box.php
+++ b/src/engine/Default/message_box.php
@@ -19,31 +19,30 @@ foreach (getMessageTypeNames() as $message_type_id => $message_type_name) {
 	if ($message_type_id == MSG_SENT) {
 		$messageBox['HasUnread'] = false;
 	} else {
-		$db->query('SELECT 1 FROM message
+		$dbResult = $db->read('SELECT 1 FROM message
 				WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND message_type_id = ' . $db->escapeNumber($message_type_id) . '
 					AND msg_read = ' . $db->escapeBoolean(false) . '
 					AND receiver_delete = ' . $db->escapeBoolean(false) . ' LIMIT 1');
-		$messageBox['HasUnread'] = $db->getNumRows() != 0;
+		$messageBox['HasUnread'] = $dbResult->hasRecord();
 	}
 
 	// get number of msges
 	if ($message_type_id == MSG_SENT) {
-		$db->query('SELECT count(message_id) as message_count FROM message
+		$dbResult = $db->read('SELECT count(message_id) as message_count FROM message
 				WHERE sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND message_type_id = ' . $db->escapeNumber(MSG_PLAYER) . '
 					AND sender_delete = ' . $db->escapeBoolean(false));
 	} else {
-		$db->query('SELECT count(message_id) as message_count FROM message
+		$dbResult = $db->read('SELECT count(message_id) as message_count FROM message
 				WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND message_type_id = ' . $db->escapeNumber($message_type_id) . '
 					AND receiver_delete = ' . $db->escapeBoolean(false));
 	}
-	$db->requireRecord();
-	$messageBox['MessageCount'] = $db->getInt('message_count');
+	$messageBox['MessageCount'] = $dbResult->record()->getInt('message_count');
 
 	$container = Page::create('skeleton.php', 'message_view.php');
 	$container['folder_id'] = $message_type_id;

--- a/src/engine/Default/message_box_delete_processing.php
+++ b/src/engine/Default/message_box_delete_processing.php
@@ -6,11 +6,11 @@ $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
 if ($var['folder_id'] == MSG_SENT) {
-	$db->query('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . '
+	$db->write('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . '
 				WHERE sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()));
 } else {
-	$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . '
+	$db->write('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . '
 				WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND message_type_id = ' . $db->escapeNumber($var['folder_id']) . '

--- a/src/engine/Default/message_delete_processing.php
+++ b/src/engine/Default/message_delete_processing.php
@@ -18,24 +18,24 @@ if (Request::get('action') == 'All Messages') {
 	$db = Smr\Database::getInstance();
 	foreach (Request::getArray('message_id') as $id) {
 		if ($temp = @unserialize(base64_decode($id))) {
-			$db->query('SELECT message_id FROM message
+			$dbResult = $db->read('SELECT message_id FROM message
 						WHERE sender_id = ' . $db->escapeNumber($temp[0]) . '
 						AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 						AND send_time >= ' . $db->escapeNumber($temp[1]) . '
 						AND send_time <= ' . $db->escapeNumber($temp[2]) . '
 						AND account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 						AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT) . ' AND receiver_delete = ' . $db->escapeBoolean(false));
-			while ($db->nextRecord()) {
-				$message_id_list[] = $db->getInt('message_id');
+			foreach ($dbResult->records() as $dbRecord) {
+				$message_id_list[] = $dbRecord->getInt('message_id');
 			}
 		} else {
 			$message_id_list[] = $id;
 		}
 	}
 	if ($var['folder_id'] == MSG_SENT) {
-		$db->query('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . ' WHERE message_id IN (' . $db->escapeArray($message_id_list) . ')');
+		$db->write('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . ' WHERE message_id IN (' . $db->escapeArray($message_id_list) . ')');
 	} else {
-		$db->query('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . ' WHERE message_id IN (' . $db->escapeArray($message_id_list) . ')');
+		$db->write('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . ' WHERE message_id IN (' . $db->escapeArray($message_id_list) . ')');
 	}
 }
 

--- a/src/engine/Default/message_notify_confirm.php
+++ b/src/engine/Default/message_notify_confirm.php
@@ -14,14 +14,14 @@ if (empty($var['message_id'])) {
 
 // get message form db
 $db = Smr\Database::getInstance();
-$db->query('SELECT message_text
+$dbResult = $db->read('SELECT message_text
 			FROM message
 			WHERE message_id = ' . $db->escapeNumber($var['message_id']));
-if (!$db->nextRecord()) {
+if (!$dbResult->hasRecord()) {
 	create_error('Could not find the message you selected!');
 }
 
-$template->assign('MessageText', $db->getField('message_text'));
+$template->assign('MessageText', $dbResult->record()->getField('message_text'));
 
 $container = Page::create('message_notify_processing.php', '');
 $container->addVar('folder_id');

--- a/src/engine/Default/message_notify_processing.php
+++ b/src/engine/Default/message_notify_processing.php
@@ -18,24 +18,25 @@ $player = $session->getPlayer();
 
 // get next id
 $db = Smr\Database::getInstance();
-$db->query('SELECT max(notify_id) FROM message_notify WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY notify_id DESC');
-if ($db->nextRecord()) {
-	$notify_id = $db->getInt('max(notify_id)') + 1;
+$dbResult = $db->read('SELECT max(notify_id) FROM message_notify WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY notify_id DESC');
+if ($dbResult->hasRecord()) {
+	$notify_id = $dbResult->record()->getInt('max(notify_id)') + 1;
 } else {
 	$notify_id = 1;
 }
 
 // get message form db
-$db->query('SELECT account_id, sender_id, message_text
+$dbResult = $db->read('SELECT account_id, sender_id, message_text
 			FROM message
 			WHERE message_id = ' . $var['message_id'] . ' AND receiver_delete = \'FALSE\'');
-if (!$db->nextRecord()) {
+if (!$dbResult->hasRecord()) {
 	create_error('Could not find the message you selected!');
 }
+$dbRecord = $dbResult->record();
 
 // insert
-$db->query('INSERT INTO message_notify
+$db->write('INSERT INTO message_notify
 			(notify_id, game_id, from_id, to_id, text, sent_time, notify_time)
-			VALUES ('.$notify_id . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->getInt('sender_id') . ', ' . $db->getInt('account_id') . ', ' . $db->escapeString($db->getField('message_text')) . ', ' . $var['sent_time'] . ', ' . $var['notified_time'] . ')');
+			VALUES ('.$notify_id . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $dbRecord->getInt('sender_id') . ', ' . $dbRecord->getInt('account_id') . ', ' . $db->escapeString($dbRecord->getField('message_text')) . ', ' . $var['sent_time'] . ', ' . $var['notified_time'] . ')');
 
 $container->go();

--- a/src/engine/Default/message_send_processing.php
+++ b/src/engine/Default/message_send_processing.php
@@ -25,12 +25,12 @@ if (empty($message)) {
 
 if (isset($var['alliance_id'])) {
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT account_id FROM player
+	$dbResult = $db->read('SELECT account_id FROM player
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND alliance_id = ' . $var['alliance_id'] . '
 				AND account_id != ' . $db->escapeNumber($player->getAccountID())); //No limit in case they are over limit - ie NHA
-	while ($db->nextRecord()) {
-		$player->sendMessage($db->getInt('account_id'), MSG_ALLIANCE, $message, false);
+	foreach ($dbResult->records() as $dbRecord) {
+		$player->sendMessage($dbRecord->getInt('account_id'), MSG_ALLIANCE, $message, false);
 	}
 	$player->sendMessage($player->getAccountID(), MSG_ALLIANCE, $message, true, false);
 } elseif (!empty($var['receiver'])) {

--- a/src/engine/Default/message_view.php
+++ b/src/engine/Default/message_view.php
@@ -23,15 +23,13 @@ if ($var['folder_id'] == MSG_SENT) {
 if ($var['folder_id'] == MSG_SENT) {
 	$messageBox['UnreadMessages'] = 0;
 } else {
-	$db->query('SELECT count(*) as count
+	$dbResult = $db->read('SELECT count(*) as count
 				FROM message ' . $whereClause . '
 					AND msg_read = ' . $db->escapeBoolean(false));
-	$db->requireRecord();
-	$messageBox['UnreadMessages'] = $db->getInt('count');
+	$messageBox['UnreadMessages'] = $dbResult->record()->getInt('count');
 }
-$db->query('SELECT count(*) as count FROM message ' . $whereClause);
-$db->requireRecord();
-$messageBox['TotalMessages'] = $db->getInt('count');
+$dbResult = $db->read('SELECT count(*) as count FROM message ' . $whereClause);
+$messageBox['TotalMessages'] = $dbResult->record()->getInt('count');
 $messageBox['Type'] = $var['folder_id'];
 
 $page = 0;
@@ -67,18 +65,18 @@ $container = Page::create('message_delete_processing.php');
 $container->addVar('folder_id');
 $messageBox['DeleteFormHref'] = $container->href();
 
-$db->query('SELECT * FROM message ' .
+$dbResult = $db->read('SELECT * FROM message ' .
 			$whereClause . '
 			ORDER BY send_time DESC
 			LIMIT ' . ($page * MESSAGES_PER_PAGE) . ', ' . MESSAGES_PER_PAGE);
 
-$messageBox['NumberMessages'] = $db->getNumRows();
+$messageBox['NumberMessages'] = $dbResult->getNumRecords();
 $messageBox['Messages'] = array();
 
 // Group scout messages if they wouldn't fit on a single page
 if ($var['folder_id'] == MSG_SCOUT && !isset($var['show_all']) && $messageBox['TotalMessages'] > $player->getScoutMessageGroupLimit()) {
 	// get rid of all old scout messages (>48h)
-	$db->query('DELETE FROM message WHERE expire_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT));
+	$db->write('DELETE FROM message WHERE expire_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT));
 
 	$dispContainer = Page::create('skeleton.php', 'message_view.php');
 	$dispContainer['folder_id'] = MSG_SCOUT;
@@ -88,12 +86,12 @@ if ($var['folder_id'] == MSG_SCOUT && !isset($var['show_all']) && $messageBox['T
 	displayScouts($messageBox, $player);
 	$template->unassign('NextPageHREF'); // always displaying all scout messages?
 } else {
-	while ($db->nextRecord()) {
-		displayMessage($messageBox, $db->getInt('message_id'), $db->getInt('account_id'), $db->getInt('sender_id'), $player->getGameID(), $db->getField('message_text'), $db->getInt('send_time'), $db->getBoolean('msg_read'), $var['folder_id'], $player->getAccount());
+	foreach ($dbResult->records() as $dbRecord) {
+		displayMessage($messageBox, $dbRecord->getInt('message_id'), $dbRecord->getInt('account_id'), $dbRecord->getInt('sender_id'), $player->getGameID(), $dbRecord->getField('message_text'), $dbRecord->getInt('send_time'), $dbRecord->getBoolean('msg_read'), $var['folder_id'], $player->getAccount());
 	}
 }
 if (!USING_AJAX) {
-	$db->query('UPDATE message SET msg_read = \'TRUE\'
+	$db->write('UPDATE message SET msg_read = \'TRUE\'
 				WHERE message_type_id = ' . $db->escapeNumber($var['folder_id']) . ' AND ' . $player->getSQL());
 }
 $template->assign('MessageBox', $messageBox);
@@ -102,7 +100,7 @@ $template->assign('MessageBox', $messageBox);
 function displayScouts(array &$messageBox, SmrPlayer $player) : void {
 	// Generate the group messages
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT player.*, count( message_id ) AS number, min( send_time ) as first, max( send_time) as last, sum(msg_read=\'FALSE\') as total_unread
+	$dbResult = $db->read('SELECT player.*, count( message_id ) AS number, min( send_time ) as first, max( send_time) as last, sum(msg_read=\'FALSE\') as total_unread
 					FROM message
 					JOIN player ON player.account_id = message.sender_id AND message.game_id = player.game_id
 					WHERE message.account_id = ' . $db->escapeNumber($player->getAccountID()) . '
@@ -112,33 +110,33 @@ function displayScouts(array &$messageBox, SmrPlayer $player) : void {
 					GROUP BY sender_id
 					ORDER BY last DESC');
 
-	while ($db->nextRecord()) {
-		$sender = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
-		$totalUnread = $db->getInt('total_unread');
-		$message = 'Your forces have spotted ' . $sender->getBBLink() . ' passing your forces ' . $db->getInt('number') . ' ' . pluralise('time', $db->getInt('number'));
+	foreach ($dbResult->records() as $dbRecord) {
+		$sender = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), false, $dbRecord);
+		$totalUnread = $dbRecord->getInt('total_unread');
+		$message = 'Your forces have spotted ' . $sender->getBBLink() . ' passing your forces ' . $dbRecord->getInt('number') . ' ' . pluralise('time', $dbRecord->getInt('number'));
 		$message .= ($totalUnread > 0) ? ' (' . $totalUnread . ' unread).' : '.';
-		displayGrouped($messageBox, $sender, $message, $db->getInt('first'), $db->getInt('last'), $totalUnread > 0, $player->getAccount());
+		displayGrouped($messageBox, $sender, $message, $dbRecord->getInt('first'), $dbRecord->getInt('last'), $totalUnread > 0, $player->getAccount());
 	}
 
 	// Now display individual messages in each group
 	// Perform a single query to minimize query overhead
-	$db->query('SELECT message_id, account_id, sender_id, message_text, send_time, msg_read
+	$dbResult = $db->read('SELECT message_id, account_id, sender_id, message_text, send_time, msg_read
 					FROM message
 					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND message_type_id = ' . $db->escapeNumber(MSG_SCOUT) . '
 					AND receiver_delete = ' . $db->escapeBoolean(false) . '
 					ORDER BY send_time DESC');
-	while ($db->nextRecord()) {
-		$groupBox =& $messageBox['GroupedMessages'][$db->getInt('sender_id')];
+	foreach ($dbResult->records() as $dbRecord) {
+		$groupBox =& $messageBox['GroupedMessages'][$dbRecord->getInt('sender_id')];
 		// Limit the number of messages in each group
 		if (!isset($groupBox['Messages']) || count($groupBox['Messages']) < MESSAGE_SCOUT_GROUP_LIMIT) {
-			displayMessage($groupBox, $db->getInt('message_id'), $db->getInt('account_id'), $db->getInt('sender_id'), $player->getGameID(), stripslashes($db->getField('message_text')), $db->getInt('send_time'), $db->getBoolean('msg_read'), MSG_SCOUT, $player->getAccount());
+			displayMessage($groupBox, $dbRecord->getInt('message_id'), $dbRecord->getInt('account_id'), $dbRecord->getInt('sender_id'), $player->getGameID(), stripslashes($dbRecord->getField('message_text')), $dbRecord->getInt('send_time'), $dbRecord->getBoolean('msg_read'), MSG_SCOUT, $player->getAccount());
 		}
 	}
 
 	// In the default view (groups), we're always displaying all messages
-	$messageBox['NumberMessages'] = $db->getNumRows();
+	$messageBox['NumberMessages'] = $dbResult->getNumRecords();
 }
 
 function displayGrouped(array &$messageBox, SmrPlayer $sender, string $message_text, int $first, int $last, bool $star, SmrAccount $displayAccount) : void {

--- a/src/engine/Default/message_view.php
+++ b/src/engine/Default/message_view.php
@@ -131,7 +131,7 @@ function displayScouts(array &$messageBox, SmrPlayer $player) : void {
 		$groupBox =& $messageBox['GroupedMessages'][$dbRecord->getInt('sender_id')];
 		// Limit the number of messages in each group
 		if (!isset($groupBox['Messages']) || count($groupBox['Messages']) < MESSAGE_SCOUT_GROUP_LIMIT) {
-			displayMessage($groupBox, $dbRecord->getInt('message_id'), $dbRecord->getInt('account_id'), $dbRecord->getInt('sender_id'), $player->getGameID(), stripslashes($dbRecord->getString('message_text')), $dbRecord->getInt('send_time'), $dbRecord->getBoolean('msg_read'), MSG_SCOUT, $player->getAccount());
+			displayMessage($groupBox, $dbRecord->getInt('message_id'), $dbRecord->getInt('account_id'), $dbRecord->getInt('sender_id'), $player->getGameID(), $dbRecord->getString('message_text'), $dbRecord->getInt('send_time'), $dbRecord->getBoolean('msg_read'), MSG_SCOUT, $player->getAccount());
 		}
 	}
 

--- a/src/engine/Default/message_view.php
+++ b/src/engine/Default/message_view.php
@@ -87,7 +87,7 @@ if ($var['folder_id'] == MSG_SCOUT && !isset($var['show_all']) && $messageBox['T
 	$template->unassign('NextPageHREF'); // always displaying all scout messages?
 } else {
 	foreach ($dbResult->records() as $dbRecord) {
-		displayMessage($messageBox, $dbRecord->getInt('message_id'), $dbRecord->getInt('account_id'), $dbRecord->getInt('sender_id'), $player->getGameID(), $dbRecord->getField('message_text'), $dbRecord->getInt('send_time'), $dbRecord->getBoolean('msg_read'), $var['folder_id'], $player->getAccount());
+		displayMessage($messageBox, $dbRecord->getInt('message_id'), $dbRecord->getInt('account_id'), $dbRecord->getInt('sender_id'), $player->getGameID(), $dbRecord->getString('message_text'), $dbRecord->getInt('send_time'), $dbRecord->getBoolean('msg_read'), $var['folder_id'], $player->getAccount());
 	}
 }
 if (!USING_AJAX) {
@@ -131,7 +131,7 @@ function displayScouts(array &$messageBox, SmrPlayer $player) : void {
 		$groupBox =& $messageBox['GroupedMessages'][$dbRecord->getInt('sender_id')];
 		// Limit the number of messages in each group
 		if (!isset($groupBox['Messages']) || count($groupBox['Messages']) < MESSAGE_SCOUT_GROUP_LIMIT) {
-			displayMessage($groupBox, $dbRecord->getInt('message_id'), $dbRecord->getInt('account_id'), $dbRecord->getInt('sender_id'), $player->getGameID(), stripslashes($dbRecord->getField('message_text')), $dbRecord->getInt('send_time'), $dbRecord->getBoolean('msg_read'), MSG_SCOUT, $player->getAccount());
+			displayMessage($groupBox, $dbRecord->getInt('message_id'), $dbRecord->getInt('account_id'), $dbRecord->getInt('sender_id'), $player->getGameID(), stripslashes($dbRecord->getString('message_text')), $dbRecord->getInt('send_time'), $dbRecord->getBoolean('msg_read'), MSG_SCOUT, $player->getAccount());
 		}
 	}
 

--- a/src/engine/Default/news_read.php
+++ b/src/engine/Default/news_read.php
@@ -29,5 +29,5 @@ doLottoNewsAssign($gameID);
 $template->assign('ViewNewsFormHref', Page::create('skeleton.php', 'news_read.php', array('GameID'=>$var['GameID']))->href());
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type != \'lotto\' ORDER BY news_id DESC LIMIT ' . ($min_news - 1) . ', ' . ($max_news - $min_news + 1));
-$template->assign('NewsItems', getNewsItems($db));
+$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type != \'lotto\' ORDER BY news_id DESC LIMIT ' . ($min_news - 1) . ', ' . ($max_news - $min_news + 1));
+$template->assign('NewsItems', getNewsItems($dbResult));

--- a/src/engine/Default/news_read_advanced.php
+++ b/src/engine/Default/news_read_advanced.php
@@ -12,36 +12,15 @@ $gameID = $var['GameID'];
 
 $basicContainer = array('GameID'=>$gameID);
 
-//$db->query('
-//SELECT alliance_id, alliance_name
-//FROM alliance
-//WHERE game_id = ' . $gameID . '
-//	AND
-//	(
-//		alliance_id IN
-//		(
-//			SELECT DISTINCT killer_alliance
-//			FROM news
-//			WHERE game_id = ' . $db->escapeNumber($gameID) . '
-//		)
-//		OR
-//		alliance_id IN
-//		(
-//			SELECT DISTINCT dead_alliance
-//			FROM news
-//			WHERE game_id = ' . $db->escapeNumber($gameID) . '
-//		)
-//	)');
-
 $db = Smr\Database::getInstance();
-$db->query('SELECT alliance_id, alliance_name
+$dbResult = $db->read('SELECT alliance_id, alliance_name
 			FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($gameID));
 
 $newsAlliances = array();
 $newsAlliances[0] = array('ID' => 0, 'Name' => 'None');
-while ($db->nextRecord()) {
-	$newsAlliances[$db->getInt('alliance_id')] = array('ID' => $db->getInt('alliance_id'), 'Name' => htmlentities($db->getField('alliance_name')));
+foreach ($dbResult->records() as $dbRecord) {
+	$newsAlliances[$dbRecord->getInt('alliance_id')] = array('ID' => $dbRecord->getInt('alliance_id'), 'Name' => htmlentities($dbRecord->getField('alliance_name')));
 }
 $template->assign('NewsAlliances', $newsAlliances);
 
@@ -53,42 +32,35 @@ $submit_value = $session->getRequestVar('submit', '');
 if ($submit_value == 'Search For Player') {
 	$p_name = $session->getRequestVar('playerName');
 	$template->assign('ResultsFor', $p_name);
-	$db->query('SELECT * FROM player WHERE player_name LIKE ' . $db->escapeString('%' . $p_name . '%') . ' AND game_id = ' . $db->escapeNumber($gameID));
+	$dbResult = $db->read('SELECT account_id FROM player WHERE player_name LIKE ' . $db->escapeString('%' . $p_name . '%') . ' AND game_id = ' . $db->escapeNumber($gameID));
 	$IDs = array(0);
-	while ($db->nextRecord()) {
-		$IDs[] = $db->getInt('account_id');
+	foreach ($dbResult->records() as $dbRecord) {
+		$IDs[] = $dbRecord->getInt('account_id');
 	}
-	$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND (killer_id IN (' . $db->escapeArray($IDs) . ') OR dead_id IN (' . $db->escapeArray($IDs) . ')) ORDER BY news_id DESC');
+	$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND (killer_id IN (' . $db->escapeArray($IDs) . ') OR dead_id IN (' . $db->escapeArray($IDs) . ')) ORDER BY news_id DESC');
 } elseif ($submit_value == 'Search For Alliance') {
 	$allianceID = $session->getRequestVarInt('allianceID');
 	$template->assign('ResultsFor', $newsAlliances[$allianceID]['Name']);
-	$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND ((killer_alliance = ' . $db->escapeNumber($allianceID) . ' AND killer_id != ' . $db->escapeNumber(ACCOUNT_ID_PORT) . ') OR (dead_alliance = ' . $db->escapeNumber($allianceID) . ' AND dead_id != ' . $db->escapeNumber(ACCOUNT_ID_PORT) . ')) ORDER BY news_id DESC');
+	$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND ((killer_alliance = ' . $db->escapeNumber($allianceID) . ' AND killer_id != ' . $db->escapeNumber(ACCOUNT_ID_PORT) . ') OR (dead_alliance = ' . $db->escapeNumber($allianceID) . ' AND dead_id != ' . $db->escapeNumber(ACCOUNT_ID_PORT) . ')) ORDER BY news_id DESC');
 } elseif ($submit_value == 'Search For Players') {
 	$player1 = $session->getRequestVar('player1');
 	$player2 = $session->getRequestVar('player2');
 	$template->assign('ResultsFor', $player1 . ' vs. ' . $player2);
-	$db->query('SELECT * FROM player WHERE player_name LIKE ' . $db->escapeString('%' . $player1 . '%') . ' AND game_id = ' . $db->escapeNumber($gameID));
+	$dbResult = $db->read('SELECT account_id FROM player WHERE (player_name LIKE ' . $db->escapeString('%' . $player1 . '%') . ' OR player_name LIKE ' . $db->escapeString('%' . $player2 . '%') . ') AND game_id = ' . $db->escapeNumber($gameID));
 	$IDs = array(0);
-	while ($db->nextRecord()) {
-		$IDs[] = $db->getInt('account_id');
+	foreach ($dbResult->records() as $dbRecord) {
+		$IDs[] = $dbRecord->getInt('account_id');
 	}
-	$db->query('SELECT * FROM player WHERE player_name LIKE ' . $db->escapeString('%' . $player2 . '%') . ' AND game_id = ' . $db->escapeNumber($gameID));
-	$IDs2 = array(0);
-	while ($db->nextRecord()) {
-		$IDs2[] = $db->getInt('account_id');
-	}
-	$db->query('SELECT * FROM news
+	$dbResult = $db->read('SELECT * FROM news
 				WHERE game_id = ' . $db->escapeNumber($gameID) . '
 					AND (
-						(killer_id IN (' . $db->escapeArray($IDs) . ') AND dead_id IN (' . $db->escapeArray($IDs2) . '))
-						OR
-						(killer_id IN (' . $db->escapeArray($IDs2) . ') AND dead_id IN (' . $db->escapeArray($IDs) . '))
+						killer_id IN (' . $db->escapeArray($IDs) . ') AND dead_id IN (' . $db->escapeArray($IDs) . ')
 					) ORDER BY news_id DESC');
 } elseif ($submit_value == 'Search For Alliances') {
 	$allianceID1 = $session->getRequestVar('alliance1');
 	$allianceID2 = $session->getRequestVar('alliance2');
 	$template->assign('ResultsFor', $newsAlliances[$allianceID1]['Name'] . ' vs. ' . $newsAlliances[$allianceID2]['Name']);
-	$db->query('SELECT * FROM news
+	$dbResult = $db->read('SELECT * FROM news
 				WHERE game_id = ' . $db->escapeNumber($gameID) . '
 					AND (
 						(killer_alliance = ' . $db->escapeNumber($allianceID1) . ' AND dead_alliance = ' . $db->escapeNumber($allianceID2) . ')
@@ -96,11 +68,11 @@ if ($submit_value == 'Search For Player') {
 						(killer_alliance = ' . $db->escapeNumber($allianceID2) . ' AND dead_alliance = ' . $db->escapeNumber($allianceID1) . ')
 					) ORDER BY news_id DESC');
 } else {
-	$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY news_id DESC LIMIT 50');
+	$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY news_id DESC LIMIT 50');
 }
 
 require_once(get_file_loc('news.inc.php'));
-$template->assign('NewsItems', getNewsItems($db));
+$template->assign('NewsItems', getNewsItems($dbResult));
 
 $template->assign('PageTopic', 'Advanced News');
 Menu::news();

--- a/src/engine/Default/news_read_advanced.php
+++ b/src/engine/Default/news_read_advanced.php
@@ -20,7 +20,7 @@ $dbResult = $db->read('SELECT alliance_id, alliance_name
 $newsAlliances = array();
 $newsAlliances[0] = array('ID' => 0, 'Name' => 'None');
 foreach ($dbResult->records() as $dbRecord) {
-	$newsAlliances[$dbRecord->getInt('alliance_id')] = array('ID' => $dbRecord->getInt('alliance_id'), 'Name' => htmlentities($dbRecord->getField('alliance_name')));
+	$newsAlliances[$dbRecord->getInt('alliance_id')] = array('ID' => $dbRecord->getInt('alliance_id'), 'Name' => htmlentities($dbRecord->getString('alliance_name')));
 }
 $template->assign('NewsAlliances', $newsAlliances);
 

--- a/src/engine/Default/news_read_current.php
+++ b/src/engine/Default/news_read_current.php
@@ -22,7 +22,7 @@ if (!isset($var['LastNewsUpdate'])) {
 }
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND time > ' . $db->escapeNumber($var['LastNewsUpdate']) . ' AND type != \'lotto\' ORDER BY news_id DESC');
-$template->assign('NewsItems', getNewsItems($db));
+$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND time > ' . $db->escapeNumber($var['LastNewsUpdate']) . ' AND type != \'lotto\' ORDER BY news_id DESC');
+$template->assign('NewsItems', getNewsItems($dbResult));
 
 $player->updateLastNewsUpdate();

--- a/src/engine/Default/note_add_processing.php
+++ b/src/engine/Default/note_add_processing.php
@@ -12,7 +12,7 @@ if (strlen($note) > 1000) {
 $note = htmlentities($note, ENT_QUOTES, 'utf-8');
 $note = nl2br($note);
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO player_has_notes (account_id,game_id,note) VALUES(' .
+$db->write('INSERT INTO player_has_notes (account_id,game_id,note) VALUES(' .
 		$db->escapeNumber($player->getAccountID()) . ',' .
 		$db->escapeNumber($player->getGameID()) . ',' .
 		$db->escapeBinary(gzcompress($note)) . ')');

--- a/src/engine/Default/note_delete_processing.php
+++ b/src/engine/Default/note_delete_processing.php
@@ -6,7 +6,7 @@ $player = $session->getPlayer();
 $note_ids = Request::getIntArray('note_id', []);
 if (!empty($note_ids)) {
 	$db = Smr\Database::getInstance();
-	$db->query('DELETE FROM player_has_notes WHERE game_id=' . $db->escapeNumber($player->getGameID()) . '
+	$db->write('DELETE FROM player_has_notes WHERE game_id=' . $db->escapeNumber($player->getGameID()) . '
 					AND account_id=' . $db->escapeNumber($player->getAccountID()) . '
 					AND note_id IN (' . $db->escapeArray($note_ids) . ')');
 }

--- a/src/engine/Default/planet_attack_processing.php
+++ b/src/engine/Default/planet_attack_processing.php
@@ -83,11 +83,11 @@ $account->log(LOG_TYPE_PLANET_BUSTING, 'Player attacks planet, the planet does '
 
 // Add this log to the `combat_logs` database table
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLANET\',' . $planet->getSectorID() . ',' . Smr\Epoch::time() . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $planetOwner->getAccountID() . ',' . $planetOwner->getAllianceID() . ',' . $db->escapeObject($results, true) . ')');
+$db->write('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLANET\',' . $planet->getSectorID() . ',' . Smr\Epoch::time() . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $planetOwner->getAccountID() . ',' . $planetOwner->getAllianceID() . ',' . $db->escapeObject($results, true) . ')');
 $logId = $db->getInsertID();
 
 if ($planet->isDestroyed()) {
-	$db->query('UPDATE player SET land_on_planet = \'FALSE\' WHERE sector_id = ' . $db->escapeNumber($planet->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$db->write('UPDATE player SET land_on_planet = \'FALSE\' WHERE sector_id = ' . $db->escapeNumber($planet->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	$planet->removeOwner();
 	$planet->removePassword();
 
@@ -109,7 +109,7 @@ if ($planetOwner->hasAlliance()) {
 // Update sector messages for attackers
 foreach ($attackers as $attacker) {
 	if (!$player->equals($attacker)) {
-		$db->query('REPLACE INTO sector_message VALUES(' . $attacker->getAccountID() . ',' . $attacker->getGameID() . ',' . $db->escapeString('[ATTACK_RESULTS]' . $logId) . ')');
+		$db->write('REPLACE INTO sector_message VALUES(' . $attacker->getAccountID() . ',' . $attacker->getGameID() . ',' . $db->escapeString('[ATTACK_RESULTS]' . $logId) . ')');
 	}
 }
 

--- a/src/engine/Default/planet_examine.php
+++ b/src/engine/Default/planet_examine.php
@@ -21,8 +21,8 @@ if (!$planetLand) {
 		$ownerAllianceID = $planet->getOwner()->getAllianceID();
 	}
 	$db = Smr\Database::getInstance();
-	$db->query('
-		SELECT planet_land
+	$dbResult = $db->read('
+		SELECT 1
 		FROM alliance_treaties
 		WHERE (alliance_id_1 = ' . $db->escapeNumber($ownerAllianceID) . ' OR alliance_id_1 = ' . $db->escapeNumber($player->getAllianceID()) . ')
 		AND (alliance_id_2 = ' . $db->escapeNumber($ownerAllianceID) . ' OR alliance_id_2 = ' . $db->escapeNumber($player->getAllianceID()) . ')
@@ -30,6 +30,6 @@ if (!$planetLand) {
 		AND planet_land = 1
 		AND official = ' . $db->escapeBoolean(true)
 	);
-	$planetLand = $db->nextRecord();
+	$planetLand = $dbResult->hasRecord();
 }
 $template->assign('PlanetLand', $planetLand);

--- a/src/engine/Default/planet_land_processing.php
+++ b/src/engine/Default/planet_land_processing.php
@@ -27,9 +27,8 @@ if ($planet->getMaxLanded() != 0 && $planet->getMaxLanded() <= $planet->countPla
 if ($player->hasAlliance()) {
 	$role_id = $player->getAllianceRole();
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
-	$db->requireRecord();
-	if (!$db->getBoolean('planet_access')) {
+	$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
+	if (!$dbResult->record()->getBoolean('planet_access')) {
 		if ($planet->hasOwner() && $planet->getOwnerID() != $player->getAccountID()) {
 			create_error('Your alliance doesn\'t allow you to dock at their planet.');
 		}

--- a/src/engine/Default/planet_list_financial.php
+++ b/src/engine/Default/planet_list_financial.php
@@ -13,15 +13,15 @@ $viewBonds = true;
 if ($var['alliance_id'] != 0) {
 	$role_id = $player->getAllianceRole($var['alliance_id']);
 	$db = Smr\Database::getInstance();
-	$db->query('
-		SELECT *
+	$dbResult = $db->read('
+		SELECT 1
 		FROM alliance_has_roles
 		WHERE alliance_id = ' . $db->escapeNumber($var['alliance_id']) . '
 		AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-		AND role_id = ' . $db->escapeNumber($role_id)
+		AND role_id = ' . $db->escapeNumber($role_id) . '
+		AND view_bonds = 1'
 	);
-	$db->requireRecord();
-	$viewBonds = $db->getBoolean('view_bonds');
+	$viewBonds = $dbResult->hasRecord();
 }
 $template->assign('CanViewBonds', $viewBonds);
 

--- a/src/engine/Default/planet_ownership_processing.php
+++ b/src/engine/Default/planet_ownership_processing.php
@@ -17,7 +17,7 @@ if ($action == 'Take Ownership') {
 
 	// delete all previous ownerships
 	$db = Smr\Database::getInstance();
-	$db->query('UPDATE planet SET owner_id = 0, password = NULL
+	$db->write('UPDATE planet SET owner_id = 0, password = NULL
 				WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . '
 				AND game_id = ' . $db->escapeNumber($player->getGameID()));
 

--- a/src/engine/Default/port_attack_processing.php
+++ b/src/engine/Default/port_attack_processing.php
@@ -80,11 +80,11 @@ $account->log(LOG_TYPE_PORT_RAIDING, 'Player attacks port, the port does ' . $re
 $port->update();
 
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PORT\',' . $db->escapeNumber($port->getSectorID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber(ACCOUNT_ID_PORT) . ',' . $db->escapeNumber(PORT_ALLIANCE_ID) . ',' . $db->escapeObject($results, true) . ')');
+$db->write('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PORT\',' . $db->escapeNumber($port->getSectorID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber(ACCOUNT_ID_PORT) . ',' . $db->escapeNumber(PORT_ALLIANCE_ID) . ',' . $db->escapeObject($results, true) . ')');
 $logId = $db->escapeString('[ATTACK_RESULTS]' . $db->getInsertID());
 foreach ($attackers as $attacker) {
 	if (!$player->equals($attacker)) {
-		$db->query('REPLACE INTO sector_message VALUES(' . $db->escapeNumber($attacker->getAccountID()) . ',' . $db->escapeNumber($attacker->getGameID()) . ',' . $logId . ')');
+		$db->write('REPLACE INTO sector_message VALUES(' . $db->escapeNumber($attacker->getAccountID()) . ',' . $db->escapeNumber($attacker->getGameID()) . ',' . $logId . ')');
 	}
 }
 

--- a/src/engine/Default/preferences.php
+++ b/src/engine/Default/preferences.php
@@ -18,8 +18,8 @@ $template->assign('ChatSharingHREF', Page::create('skeleton.php', 'chat_sharing.
 
 $transferAccounts = array();
 $db = Smr\Database::getInstance();
-$db->query('SELECT account_id,hof_name FROM account WHERE validated = ' . $db->escapeBoolean(true) . ' ORDER BY hof_name');
-while ($db->nextRecord()) {
-	$transferAccounts[$db->getInt('account_id')] = htmlspecialchars($db->getField('hof_name'));
+$dbResult = $db->read('SELECT account_id,hof_name FROM account WHERE validated = ' . $db->escapeBoolean(true) . ' ORDER BY hof_name');
+foreach ($dbResult->records() as $dbRecord) {
+	$transferAccounts[$dbRecord->getInt('account_id')] = htmlspecialchars($dbRecord->getField('hof_name'));
 }
 $template->assign('TransferAccounts', $transferAccounts);

--- a/src/engine/Default/preferences.php
+++ b/src/engine/Default/preferences.php
@@ -20,6 +20,6 @@ $transferAccounts = array();
 $db = Smr\Database::getInstance();
 $dbResult = $db->read('SELECT account_id,hof_name FROM account WHERE validated = ' . $db->escapeBoolean(true) . ' ORDER BY hof_name');
 foreach ($dbResult->records() as $dbRecord) {
-	$transferAccounts[$dbRecord->getInt('account_id')] = htmlspecialchars($dbRecord->getField('hof_name'));
+	$transferAccounts[$dbRecord->getInt('account_id')] = htmlspecialchars($dbRecord->getString('hof_name'));
 }
 $template->assign('TransferAccounts', $transferAccounts);

--- a/src/engine/Default/preferences_processing.php
+++ b/src/engine/Default/preferences_processing.php
@@ -74,8 +74,8 @@ if ($action == 'Save and resend validation code') {
 	}
 
 	//no duplicates
-	$db->query('SELECT * FROM account WHERE hof_name = ' . $db->escapeString($HoF_name) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
-	if ($db->nextRecord()) {
+	$dbResult = $db->read('SELECT 1 FROM account WHERE hof_name = ' . $db->escapeString($HoF_name) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
+	if ($dbResult->hasRecord()) {
 		create_error('Someone is already using that name!');
 	}
 
@@ -91,8 +91,8 @@ if ($action == 'Save and resend validation code') {
 
 	} else {
 		// no duplicates
-		$db->query('SELECT * FROM account WHERE discord_id =' . $db->escapeString($discordId) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
-		if ($db->nextRecord()) {
+		$dbResult = $db->read('SELECT 1 FROM account WHERE discord_id =' . $db->escapeString($discordId) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
 			create_error('Someone is already using that Discord User ID!');
 		}
 
@@ -116,8 +116,8 @@ if ($action == 'Save and resend validation code') {
 	} else {
 
 		// no duplicates
-		$db->query('SELECT * FROM account WHERE irc_nick = ' . $db->escapeString($ircNick) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
-		if ($db->nextRecord()) {
+		$dbResult = $db->read('SELECT 1 FROM account WHERE irc_nick = ' . $db->escapeString($ircNick) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
 			create_error('Someone is already using that nick!');
 		}
 
@@ -143,7 +143,7 @@ if ($action == 'Save and resend validation code') {
 } elseif ($action == 'Change Timezone') {
 	$timez = Request::getInt('timez');
 
-	$db->query('UPDATE account SET offset = ' . $db->escapeNumber($timez) . ' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+	$db->write('UPDATE account SET offset = ' . $db->escapeNumber($timez) . ' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your time offset.';
 } elseif ($action == 'Change Date Formats') {
 	$account->setDateFormat(Request::get('dateformat'));
@@ -221,8 +221,8 @@ if ($action == 'Save and resend validation code') {
 	// Check if name is in use.
 	// The player_name field has case-insensitive collation, so check against ID
 	// to allow player to change the case of their name.
-	$db->query('SELECT 1 FROM player WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND player_name=' . $db->escapeString($player_name) . ' AND player_id != ' . $db->escapeNumber($player->getPlayerID()) . ' LIMIT 1');
-	if ($db->getNumRows()) {
+	$dbResult = $db->read('SELECT 1 FROM player WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND player_name=' . $db->escapeString($player_name) . ' AND player_id != ' . $db->escapeNumber($player->getPlayerID()) . ' LIMIT 1');
+	if ($dbResult->hasRecord()) {
 		create_error('Name is already being used in this game!');
 	}
 
@@ -238,7 +238,7 @@ if ($action == 'Save and resend validation code') {
 	$player->setPlayerNameByPlayer($player_name);
 
 	$news = 'Please be advised that ' . $old_name . ' has changed their name to ' . $player->getBBLink();
-	$db->query('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($player->getGameID()) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
+	$db->write('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($player->getGameID()) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your player name.';
 } elseif ($action == 'change_race') {
 	if (!$player->canChangeRace()) {
@@ -265,11 +265,11 @@ if ($action == 'Save and resend validation code') {
 	$player->setRaceChanged(true);
 
 	// Reset relations
-	$db->query('DELETE FROM player_has_relation WHERE ' . $player->getSQL());
+	$db->write('DELETE FROM player_has_relation WHERE ' . $player->getSQL());
 	$player->giveStartingRelations();
 
 	$news = 'Please be advised that ' . $player->getBBLink() . ' has changed their race from [race=' . $oldRaceID . '] to [race=' . $player->getRaceID() . ']';
-	$db->query('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($player->getGameID()) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
+	$db->write('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($player->getGameID()) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your player race.';
 } elseif ($action == 'Update Colours') {
 	$friendlyColour = Request::get('friendly_color');

--- a/src/engine/Default/rankings_alliance_death.php
+++ b/src/engine/Default/rankings_alliance_death.php
@@ -8,14 +8,13 @@ $template->assign('PageTopic', 'Alliance Death Rankings');
 Menu::rankings(1, 3);
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT count(*) FROM alliance
+$dbResult = $db->read('SELECT count(*) FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
-$db->requireRecord();
-$numAlliances = $db->getInt('count(*)');
+$numAlliances = $dbResult->record()->getInt('count(*)');
 
 $ourRank = 0;
 if ($player->hasAlliance()) {
-	$db->query('SELECT ranking
+	$dbResult = $db->read('SELECT ranking
 				FROM (
 					SELECT alliance_id,
 					ROW_NUMBER() OVER (ORDER BY alliance_deaths DESC, alliance_name ASC) AS ranking
@@ -24,8 +23,7 @@ if ($player->hasAlliance()) {
 				) t
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID())
 	);
-	$db->requireRecord();
-	$ourRank = $db->getInt('ranking');
+	$ourRank = $dbResult->record()->getInt('ranking');
 	$template->assign('OurRank', $ourRank);
 }
 

--- a/src/engine/Default/rankings_alliance_experience.php
+++ b/src/engine/Default/rankings_alliance_experience.php
@@ -8,14 +8,13 @@ $template->assign('PageTopic', 'Alliance Experience Rankings');
 Menu::rankings(1, 0);
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT count(*) FROM alliance
+$dbResult = $db->read('SELECT count(*) FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
-$db->requireRecord();
-$numAlliances = $db->getInt('count(*)');
+$numAlliances = $dbResult->record()->getInt('count(*)');
 
 $ourRank = 0;
 if ($player->hasAlliance()) {
-	$db->query('SELECT ranking
+	$dbResult = $db->read('SELECT ranking
 				FROM (
 					SELECT alliance_id,
 					ROW_NUMBER() OVER (ORDER BY COALESCE(SUM(experience), 0) DESC, alliance_name ASC) AS ranking
@@ -26,22 +25,21 @@ if ($player->hasAlliance()) {
 				) t
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID())
 	);
-	$db->requireRecord();
-	$ourRank = $db->getInt('ranking');
+	$ourRank = $dbResult->record()->getInt('ranking');
 	$template->assign('OurRank', $ourRank);
 }
 
 $expRanks = function(int $minRank, int $maxRank) use ($player, $db) : array {
 	$offset = $minRank - 1;
 	$limit = $maxRank - $offset;
-	$db->query('SELECT alliance_id, COALESCE(SUM(experience), 0) amount
+	$dbResult = $db->read('SELECT alliance_id, COALESCE(SUM(experience), 0) amount
 		FROM alliance
 		LEFT JOIN player USING (game_id, alliance_id)
 		WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 		GROUP BY alliance_id
 		ORDER BY amount DESC, alliance_name ASC
 		LIMIT ' . $offset . ', ' . $limit);
-	return Rankings::collectAllianceRankings($db, $player, $offset);
+	return Rankings::collectAllianceRankings($dbResult, $player, $minRank);
 };
 
 $template->assign('Rankings', $expRanks(1, 10));

--- a/src/engine/Default/rankings_alliance_kills.php
+++ b/src/engine/Default/rankings_alliance_kills.php
@@ -8,14 +8,13 @@ $template->assign('PageTopic', 'Alliance Kill Rankings');
 Menu::rankings(1, 2);
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT count(*) FROM alliance
+$dbResult = $db->read('SELECT count(*) FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
-$db->requireRecord();
-$numAlliances = $db->getInt('count(*)');
+$numAlliances = $dbResult->record()->getInt('count(*)');
 
 $ourRank = 0;
 if ($player->hasAlliance()) {
-	$db->query('SELECT ranking
+	$dbResult = $db->read('SELECT ranking
 				FROM (
 					SELECT alliance_id,
 					ROW_NUMBER() OVER (ORDER BY alliance_kills DESC, alliance_name ASC) AS ranking
@@ -24,8 +23,7 @@ if ($player->hasAlliance()) {
 				) t
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID())
 	);
-	$db->requireRecord();
-	$ourRank = $db->getInt('ranking');
+	$ourRank = $dbResult->record()->getInt('ranking');
 	$template->assign('OurRank', $ourRank);
 }
 

--- a/src/engine/Default/rankings_alliance_profit.php
+++ b/src/engine/Default/rankings_alliance_profit.php
@@ -8,16 +8,15 @@ $template->assign('PageTopic', 'Alliance Profit Rankings');
 Menu::rankings(1, 1);
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT count(*) FROM alliance
+$dbResult = $db->read('SELECT count(*) FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
-$db->requireRecord();
-$numAlliances = $db->getInt('count(*)');
+$numAlliances = $dbResult->record()->getInt('count(*)');
 $profitType = array('Trade', 'Money', 'Profit');
 $profitTypeEscaped = $db->escapeArray($profitType, ':', false);
 
 $ourRank = 0;
 if ($player->hasAlliance()) {
-	$db->query('SELECT ranking
+	$dbResult = $db->read('SELECT ranking
 				FROM (
 					SELECT alliance_id,
 					ROW_NUMBER() OVER (ORDER BY COALESCE(SUM(amount), 0) DESC, alliance_name ASC) AS ranking
@@ -29,15 +28,14 @@ if ($player->hasAlliance()) {
 				) AS t
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID())
 	);
-	$db->requireRecord();
-	$ourRank = $db->getInt('ranking');
+	$ourRank = $dbResult->record()->getInt('ranking');
 	$template->assign('OurRank', $ourRank);
 }
 
 $profitRanks = function(int $minRank, int $maxRank) use ($player, $db, $profitTypeEscaped) : array {
 	$offset = $minRank - 1;
 	$limit = $maxRank - $offset;
-	$db->query('SELECT alliance_id, COALESCE(SUM(amount), 0) amount
+	$dbResult = $db->read('SELECT alliance_id, COALESCE(SUM(amount), 0) amount
 			FROM alliance
 			LEFT JOIN player p USING (game_id, alliance_id)
 			LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $profitTypeEscaped . '
@@ -45,7 +43,7 @@ $profitRanks = function(int $minRank, int $maxRank) use ($player, $db, $profitTy
 			GROUP BY alliance_id
 			ORDER BY amount DESC, alliance_name
 			LIMIT ' . $offset . ', ' . $limit);
-	return Rankings::collectAllianceRankings($db, $player, $offset);
+	return Rankings::collectAllianceRankings($dbResult, $player, $minRank);
 };
 
 $template->assign('Rankings', $profitRanks(1, 10));

--- a/src/engine/Default/rankings_race.php
+++ b/src/engine/Default/rankings_race.php
@@ -9,5 +9,5 @@ $template->assign('PageTopic', 'Racial Standings');
 Menu::rankings(2, 0);
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT race_id, COALESCE(SUM(experience), 0) as amount, count(*) as num_players FROM player JOIN race USING(race_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' GROUP BY race_id ORDER BY amount DESC, race_name ASC');
-$template->assign('Ranks', Rankings::collectRaceRankings($db, $player));
+$dbResult = $db->read('SELECT race_id, COALESCE(SUM(experience), 0) as amount, count(*) as num_players FROM player JOIN race USING(race_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' GROUP BY race_id ORDER BY amount DESC, race_name ASC');
+$template->assign('Ranks', Rankings::collectRaceRankings($dbResult, $player));

--- a/src/engine/Default/rankings_race_death.php
+++ b/src/engine/Default/rankings_race_death.php
@@ -9,5 +9,5 @@ $template->assign('PageTopic', 'Racial Standings');
 Menu::rankings(2, 2);
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT race_id, sum(deaths) as amount, count(*) as num_players FROM player JOIN race USING(race_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' GROUP BY race_id ORDER BY amount DESC, race_name ASC');
-$template->assign('Ranks', Rankings::collectRaceRankings($db, $player));
+$dbResult = $db->read('SELECT race_id, sum(deaths) as amount, count(*) as num_players FROM player JOIN race USING(race_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' GROUP BY race_id ORDER BY amount DESC, race_name ASC');
+$template->assign('Ranks', Rankings::collectRaceRankings($dbResult, $player));

--- a/src/engine/Default/rankings_race_kills.php
+++ b/src/engine/Default/rankings_race_kills.php
@@ -9,5 +9,5 @@ $template->assign('PageTopic', 'Racial Standings');
 Menu::rankings(2, 1);
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT race_id, sum(kills) as amount, count(*) as num_players FROM player JOIN race USING(race_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' GROUP BY race_id ORDER BY amount DESC, race_name ASC');
-$template->assign('Ranks', Rankings::collectRaceRankings($db, $player));
+$dbResult = $db->read('SELECT race_id, sum(kills) as amount, count(*) as num_players FROM player JOIN race USING(race_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' GROUP BY race_id ORDER BY amount DESC, race_name ASC');
+$template->assign('Ranks', Rankings::collectRaceRankings($dbResult, $player));

--- a/src/engine/Default/rankings_sector_kill.php
+++ b/src/engine/Default/rankings_sector_kill.php
@@ -9,14 +9,13 @@ $template->assign('PageTopic', 'Sector Death Rankings');
 Menu::rankings(3, 0);
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY battles DESC, sector_id LIMIT 10');
+$dbResult = $db->read('SELECT * FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY battles DESC, sector_id LIMIT 10');
 
-$rank = 1;
 $topTen = [];
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $index => $dbRecord) {
 	// get current player
-	$sectorID = $db->getInt('sector_id');
-	$topTen[$rank++] = SmrSector::getSector($player->getGameID(), $sectorID, false, $db);
+	$sectorID = $dbRecord->getInt('sector_id');
+	$topTen[$index + 1] = SmrSector::getSector($player->getGameID(), $sectorID, false, $dbRecord);
 }
 $template->assign('TopTen', $topTen);
 
@@ -28,12 +27,11 @@ if ($min_rank < 0) {
 	$max_rank = 10;
 }
 
-$db->query('SELECT max(sector_id) FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
-$db->requireRecord(); // we expect there to be at least 1 sector...
-$total_sector = $db->getInt('max(sector_id)');
+$dbResult = $db->read('SELECT max(sector_id) FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
+$total_sector = $dbResult->record()->getInt('max(sector_id)'); // we expect there to be at least 1 sector...
 
 // Calculate the rank of the sector the player is currently in
-$db->query('SELECT ranking
+$dbResult = $db->read('SELECT ranking
 			FROM (
 				SELECT sector_id,
 				ROW_NUMBER() OVER (ORDER BY battles DESC, sector_id ASC) AS ranking
@@ -42,8 +40,7 @@ $db->query('SELECT ranking
 			) t
 			WHERE sector_id = ' . $db->escapeNumber($player->getSectorID())
 );
-$db->requireRecord();
-$ourRank = $db->getInt('ranking');
+$ourRank = $dbResult->record()->getInt('ranking');
 
 $container = Page::create('skeleton.php', 'rankings_sector_kill.php');
 $template->assign('SubmitHREF', $container->href());
@@ -51,13 +48,12 @@ $template->assign('SubmitHREF', $container->href());
 list($minRank, $maxRank) = Rankings::calculateMinMaxRanks($ourRank, $total_sector);
 
 $lowerLimit = $minRank - 1;
-$db->query('SELECT * FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY battles DESC, sector_id LIMIT ' . $lowerLimit . ', ' . ($maxRank - $lowerLimit));
+$dbResult = $db->read('SELECT * FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY battles DESC, sector_id LIMIT ' . $lowerLimit . ', ' . ($maxRank - $lowerLimit));
 
-$rank = $minRank;
 $topCustom = [];
-while ($db->nextRecord()) {
+foreach ($dbResult->records() as $index => $dbRecord) {
 	// get current player
-	$sectorID = $db->getInt('sector_id');
-	$topCustom[$rank++] = SmrSector::getSector($player->getGameID(), $sectorID, false, $db);
+	$sectorID = $dbRecord->getInt('sector_id');
+	$topCustom[$minRank + $index] = SmrSector::getSector($player->getGameID(), $sectorID, false, $dbRecord);
 }
 $template->assign('TopCustom', $topCustom);

--- a/src/engine/Default/trader_attack_processing.php
+++ b/src/engine/Default/trader_attack_processing.php
@@ -82,7 +82,7 @@ $results = [
 $account->log(LOG_TYPE_TRADER_COMBAT, 'Player attacks player, their team does ' . $results['Attackers']['TotalDamage'] . ' and the other team does ' . $results['Defenders']['TotalDamage'], $sector->getSectorID());
 
 $db = Smr\Database::getInstance();
-$db->query('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLAYER\',' . $db->escapeNumber($sector->getSectorID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($var['target']) . ',' . $db->escapeNumber($targetPlayer->getAllianceID()) . ',' . $db->escapeObject($results, true) . ')');
+$db->write('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLAYER\',' . $db->escapeNumber($sector->getSectorID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($var['target']) . ',' . $db->escapeNumber($targetPlayer->getAllianceID()) . ',' . $db->escapeObject($results, true) . ')');
 
 $container = Page::create('skeleton.php', 'trader_attack.php');
 

--- a/src/engine/Default/trader_savings.php
+++ b/src/engine/Default/trader_savings.php
@@ -10,11 +10,11 @@ Menu::trader();
 
 $anonAccounts = [];
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM anon_bank WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-while ($db->nextRecord()) {
+$dbResult = $db->read('SELECT * FROM anon_bank WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+foreach ($dbResult->records() as $dbRecord) {
 	$anonAccounts[] = [
-		'ID' => $db->getInt('anon_id'),
-		'Password' => $db->getField('password'),
+		'ID' => $dbRecord->getInt('anon_id'),
+		'Password' => $dbRecord->getField('password'),
 	];
 }
 $template->assign('AnonAccounts', $anonAccounts);
@@ -24,15 +24,13 @@ checkForLottoWinner($player->getGameID());
 $template->assign('LottoInfo', getLottoInfo($player->getGameID()));
 
 // Number of active lotto tickets this player has
-$db->query('SELECT count(*) FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0');
-$db->requireRecord();
-$tickets = $db->getInt('count(*)');
+$dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0');
+$tickets = $dbResult->record()->getInt('count(*)');
 $template->assign('LottoTickets', $tickets);
 
 // Number of active lotto tickets all players have
-$db->query('SELECT count(*) FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND time > 0');
-$db->requireRecord();
-$tickets_tot = $db->getInt('count(*)');
+$dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND time > 0');
+$tickets_tot = $dbResult->record()->getInt('count(*)');
 if ($tickets == 0) {
 	$win_chance = 0;
 } else {
@@ -41,6 +39,5 @@ if ($tickets == 0) {
 $template->assign('LottoWinChance', $win_chance);
 
 // Number of winning lotto tickets this player has to claim
-$db->query('SELECT count(*) FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
-$db->requireRecord();
-$template->assign('WinningTickets', $db->getInt('count(*)'));
+$dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
+$template->assign('WinningTickets', $dbResult->record()->getInt('count(*)'));

--- a/src/engine/Default/trader_search_result.php
+++ b/src/engine/Default/trader_search_result.php
@@ -20,21 +20,22 @@ if (!empty($player_id)) {
 	}
 } else {
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT * FROM player
+	$dbResult = $db->read('SELECT * FROM player
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND player_name = ' . $db->escapeString($player_name) . ' LIMIT 1');
-	if ($db->nextRecord()) {
-		$resultPlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
+	if ($dbResult->hasRecord()) {
+		$dbRecord = $dbResult->record();
+		$resultPlayer = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), false, $dbRecord);
 	}
 
-	$db->query('SELECT * FROM player
+	$dbResult = $db->read('SELECT * FROM player
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND player_name LIKE ' . $db->escapeString('%' . $player_name . '%') . '
 					AND player_name != ' . $db->escapeString($player_name) . '
 				ORDER BY player_name LIMIT 5');
 	$similarPlayers = array();
-	while ($db->nextRecord()) {
-		$similarPlayers[] = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
+	foreach ($dbResult->records() as $dbRecord) {
+		$similarPlayers[] = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), false, $dbRecord);
 	}
 }
 

--- a/src/engine/Default/trader_status.php
+++ b/src/engine/Default/trader_status.php
@@ -62,9 +62,9 @@ $template->assign('NoteDeleteHREF', $container->href());
 
 $notes = [];
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM player_has_notes WHERE ' . $player->getSQL() . ' ORDER BY note_id DESC');
-while ($db->nextRecord()) {
-	$notes[$db->getInt('note_id')] = $db->getField('note');
+$dbResult = $db->read('SELECT * FROM player_has_notes WHERE ' . $player->getSQL() . ' ORDER BY note_id DESC');
+foreach ($dbResult->records() as $dbRecord) {
+	$notes[$dbRecord->getInt('note_id')] = $dbRecord->getField('note');
 }
 $template->assign('Notes', $notes);
 

--- a/src/engine/Default/validate_processing.php
+++ b/src/engine/Default/validate_processing.php
@@ -23,7 +23,7 @@ if (Request::get('action') != "skip") {
 
 	// delete the notification (when send)
 	$db = Smr\Database::getInstance();
-	$db->query('DELETE FROM notification
+	$db->write('DELETE FROM notification
 				WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . '
 				AND notification_type = \'validation_code\'');
 }

--- a/src/engine/Default/vote.php
+++ b/src/engine/Default/vote.php
@@ -7,34 +7,35 @@ $account = $session->getAccount();
 $template->assign('PageTopic', 'Voting');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT * FROM voting ORDER BY end DESC');
-if ($db->getNumRows() > 0) {
-	$db2 = Smr\Database::getInstance();
+$dbResult = $db->read('SELECT * FROM voting ORDER BY end DESC');
+if ($dbResult->hasRecord()) {
 	$votedFor = array();
-	$db2->query('SELECT * FROM voting_results WHERE account_id = ' . $db2->escapeNumber($account->getAccountID()));
-	while ($db2->nextRecord()) {
-		$votedFor[$db2->getInt('vote_id')] = $db2->getInt('option_id');
+	$dbResult2 = $db->read('SELECT * FROM voting_results WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+	foreach ($dbResult2->records() as $dbRecord2) {
+		$votedFor[$dbRecord2->getInt('vote_id')] = $dbRecord2->getInt('option_id');
 	}
+
 	$voting = array();
-	while ($db->nextRecord()) {
-		$voteID = $db->getInt('vote_id');
+	foreach ($dbResult->records() as $dbRecord) {
+		$voteID = $dbRecord->getInt('vote_id');
 		$voting[$voteID]['ID'] = $voteID;
 		$container = Page::create('vote.php', 'vote_processing.php');
 		$container['vote_id'] = $voteID;
 		$voting[$voteID]['HREF'] = $container->href();
-		$voting[$voteID]['Question'] = $db->getField('question');
-		if ($db->getInt('end') > Smr\Epoch::time()) {
-			$voting[$voteID]['TimeRemaining'] = format_time($db->getInt('end') - Smr\Epoch::time(), true);
+		$voting[$voteID]['Question'] = $dbRecord->getField('question');
+		if ($dbRecord->getInt('end') > Smr\Epoch::time()) {
+			$voting[$voteID]['TimeRemaining'] = format_time($dbRecord->getInt('end') - Smr\Epoch::time(), true);
 		} else {
-			$voting[$voteID]['EndDate'] = date($account->getDateFormat(), $db->getInt('end'));
+			$voting[$voteID]['EndDate'] = date($account->getDateFormat(), $dbRecord->getInt('end'));
 		}
+
 		$voting[$voteID]['Options'] = array();
-		$db2->query('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = ' . $db2->escapeNumber($db->getInt('vote_id')) . ' GROUP BY option_id');
-		while ($db2->nextRecord()) {
-			$voting[$voteID]['Options'][$db2->getInt('option_id')]['ID'] = $db2->getInt('option_id');
-			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Text'] = $db2->getField('text');
-			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Chosen'] = isset($votedFor[$db->getInt('vote_id')]) && $votedFor[$voteID] == $db2->getInt('option_id');
-			$voting[$voteID]['Options'][$db2->getInt('option_id')]['Votes'] = $db2->getInt('count(account_id)');
+		$dbResult2 = $db->read('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = ' . $db->escapeNumber($dbRecord->getInt('vote_id')) . ' GROUP BY option_id');
+		foreach ($dbResult2->records() as $dbRecord2) {
+			$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['ID'] = $dbRecord2->getInt('option_id');
+			$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['Text'] = $dbRecord2->getField('text');
+			$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['Chosen'] = isset($votedFor[$dbRecord->getInt('vote_id')]) && $votedFor[$voteID] == $dbRecord2->getInt('option_id');
+			$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['Votes'] = $dbRecord2->getInt('count(account_id)');
 		}
 	}
 	$template->assign('Voting', $voting);

--- a/src/engine/Default/vote_link.php
+++ b/src/engine/Default/vote_link.php
@@ -12,7 +12,7 @@ if ($var['can_get_turns'] == true) {
 		// Allow vote
 		// Don't start the timeout until the vote actually goes through.
 		$db = Smr\Database::getInstance();
-		$db->query('REPLACE INTO vote_links (account_id, link_id, timeout, turns_claimed) VALUES(' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($var['link_id']) . ',' . $db->escapeNumber(0) . ',' . $db->escapeBoolean(false) . ')');
+		$db->write('REPLACE INTO vote_links (account_id, link_id, timeout, turns_claimed) VALUES(' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($var['link_id']) . ',' . $db->escapeNumber(0) . ',' . $db->escapeBoolean(false) . ')');
 		$voting = '<b><span class="red">v</span>o<span class="blue">t</span><span class="red">i</span>n<span class="blue">g</span></b>';
 		$container['msg'] = "Thank you for $voting! You will receive bonus turns once your vote is processed.";
 	} else {

--- a/src/engine/Default/vote_processing.php
+++ b/src/engine/Default/vote_processing.php
@@ -9,6 +9,6 @@ if ($account->getAccountID() == ACCOUNT_ID_NHL) {
 }
 
 $db = Smr\Database::getInstance();
-$db->query('REPLACE INTO voting_results (account_id, vote_id, option_id) VALUES (' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber($var['vote_id']) . ',' . $db->escapeNumber(Request::getInt('vote')) . ')');
+$db->write('REPLACE INTO voting_results (account_id, vote_id, option_id) VALUES (' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber($var['vote_id']) . ',' . $db->escapeNumber(Request::getInt('vote')) . ')');
 $var['url'] = 'skeleton.php';
 Page::copy($var)->go();

--- a/src/engine/Draft/alliance_pick.php
+++ b/src/engine/Draft/alliance_pick.php
@@ -20,9 +20,9 @@ $template->assign('CanPick', $teams[$player->getAccountID()]['CanPick']);
 
 // Get a list of players still in the pick pool
 $players = array();
-$db->query('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_id=0 OR alliance_id=' . $db->escapeNumber(NHA_ID) . ') AND account_id NOT IN (SELECT account_id FROM draft_leaders WHERE draft_leaders.game_id=player.game_id) AND account_id NOT IN (SELECT picked_account_id FROM draft_history WHERE draft_history.game_id=player.game_id) AND account_id != ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ';');
-while ($db->nextRecord()) {
-	$pickPlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), false, $db);
+$dbResult = $db->read('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_id=0 OR alliance_id=' . $db->escapeNumber(NHA_ID) . ') AND account_id NOT IN (SELECT account_id FROM draft_leaders WHERE draft_leaders.game_id=player.game_id) AND account_id NOT IN (SELECT picked_account_id FROM draft_history WHERE draft_history.game_id=player.game_id) AND account_id != ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ';');
+foreach ($dbResult->records() as $dbRecord) {
+	$pickPlayer = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), false, $dbRecord);
 	$players[] = array('Player' => $pickPlayer,
 						'HREF' => Page::create('alliance_pick_processing.php', '', array('PickedAccountID'=>$pickPlayer->getAccountID()))->href());
 }
@@ -31,14 +31,14 @@ $template->assign('PickPlayers', $players);
 
 // Get the draft history
 $history = array();
-$db->query('SELECT * FROM draft_history WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' ORDER BY draft_id');
-while ($db->nextRecord()) {
-	$leader = SmrPlayer::getPlayer($db->getInt('leader_account_id'), $player->getGameID());
-	$pickedPlayer = SmrPlayer::getPlayer($db->getInt('picked_account_id'), $player->getGameID());
+$dbResult = $db->read('SELECT * FROM draft_history WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' ORDER BY draft_id');
+foreach ($dbResult->records() as $dbRecord) {
+	$leader = SmrPlayer::getPlayer($dbRecord->getInt('leader_account_id'), $player->getGameID());
+	$pickedPlayer = SmrPlayer::getPlayer($dbRecord->getInt('picked_account_id'), $player->getGameID());
 	$history[] = [
 		'Leader' => $leader,
 		'Player' => $pickedPlayer,
-		'Time'   => $db->getInt('time'),
+		'Time'   => $dbRecord->getInt('time'),
 	];
 }
 

--- a/src/engine/Draft/alliance_pick_processing.php
+++ b/src/engine/Draft/alliance_pick_processing.php
@@ -8,21 +8,16 @@ if (!is_numeric($var['PickedAccountID'])) {
 	create_error('You have to pick a player.');
 }
 
-$db = Smr\Database::getInstance();
-$db->query('SELECT 1
-			FROM draft_leaders
-			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-			AND account_id = ' . $db->escapeNumber($var['PickedAccountID']));
-if ($db->nextRecord()) {
-	create_error('You cannot pick another leader.');
-}
-
 require_once(get_file_loc('alliance_pick.inc.php'));
 $teams = get_draft_teams($player->getGameID());
 if (!$teams[$player->getAccountID()]['CanPick']) {
 	create_error('You have to wait for others to pick first.');
 }
 $pickedPlayer = SmrPlayer::getPlayer($var['PickedAccountID'], $player->getGameID());
+
+if ($pickedPlayer->isDraftLeader()) {
+	create_error('You cannot pick another leader.');
+}
 
 if ($pickedPlayer->hasAlliance()) {
 	if ($pickedPlayer->getAllianceID() == NHA_ID) {
@@ -44,6 +39,7 @@ if ($pickedPlayer->getSectorID() === 1) {
 $pickedPlayer->update();
 
 // Update the draft history
-$db->query('INSERT INTO draft_history (game_id, leader_account_id, picked_account_id, time) VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($pickedPlayer->getAccountID()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+$db = Smr\Database::getInstance();
+$db->write('INSERT INTO draft_history (game_id, leader_account_id, picked_account_id, time) VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($pickedPlayer->getAccountID()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
 
 Page::create('skeleton.php', 'alliance_pick.php')->go();

--- a/src/htdocs/album/album_comment.php
+++ b/src/htdocs/album/album_comment.php
@@ -61,14 +61,14 @@ try {
 	// check if we have comments for this album already
 	$db->lockTable('album_has_comments');
 
-	$db->query('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($album_id));
-	if ($db->nextRecord()) {
-		$comment_id = $db->getInt('MAX(comment_id)') + 1;
+	$dbResult = $db->read('SELECT MAX(comment_id) FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($album_id));
+	if ($dbResult->hasRecord()) {
+		$comment_id = $dbResult->record()->getInt('MAX(comment_id)') + 1;
 	} else {
 		$comment_id = 1;
 	}
 
-	$db->query('INSERT INTO album_has_comments
+	$db->write('INSERT INTO album_has_comments
 				(album_id, comment_id, time, post_id, msg)
 				VALUES ('.$db->escapeNumber($album_id) . ', ' . $db->escapeNumber($comment_id) . ', ' . $db->escapeNumber($curr_time) . ', ' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($comment) . ')');
 	$db->unlock();

--- a/src/htdocs/album/index.php
+++ b/src/htdocs/album/index.php
@@ -6,7 +6,6 @@ try {
 
 	// database object
 	$db = Smr\Database::getInstance();
-	$db2 = Smr\Database::getInstance();
 	?>
 	<!DOCTYPE html>
 	<html>
@@ -43,27 +42,27 @@ try {
 	if (!empty($_GET['nick'])) {
 		$query = urldecode($_GET['nick']);
 
-		$db->query('SELECT account_id as album_id
+		$dbResult = $db->read('SELECT account_id as album_id
 					FROM album JOIN account USING(account_id)
 					WHERE hof_name LIKE '.$db->escapeString($query . '%') . ' AND
 						  approved = \'YES\'
 					ORDER BY hof_name');
 
-		if ($db->getNumRows() > 1) {
-			$db2->query('SELECT account_id as album_id
+		if ($dbResult->getNumRecords() > 1) {
+			$dbResult2 = $db->read('SELECT account_id as album_id
 					FROM album JOIN account USING(account_id)
 					WHERE hof_name = '.$db->escapeString($query) . ' AND
 						  approved = \'YES\'
 					ORDER BY hof_name');
 
-			if ($db2->nextRecord()) {
-				album_entry($db2->getInt('album_id'));
+			if ($dbResult2->hasRecord()) {
+				album_entry($dbResult2->record()->getInt('album_id'));
 			} else {
 				// get all id's and build array
 				$album_ids = array();
 
-				while ($db->nextRecord()) {
-					$album_ids[] = $db->getInt('album_id');
+				foreach ($dbResult->records() as $dbRecord) {
+					$album_ids[] = $dbRecord->getInt('album_id');
 				}
 
 				// double check if we have id's
@@ -74,12 +73,8 @@ try {
 				}
 			}
 
-		} elseif ($db->getNumRows() == 1) {
-			if ($db->nextRecord()) {
-				album_entry($db->getInt('album_id'));
-			} else {
-				main_page();
-			}
+		} elseif ($dbResult->getNumRecords() == 1) {
+			album_entry($dbResult->record()->getInt('album_id'));
 		} else {
 			main_page();
 		}

--- a/src/htdocs/login.php
+++ b/src/htdocs/login.php
@@ -42,7 +42,7 @@ try {
 		$overrideGameID = $dbRecord->getInt('game_id'); //for bbifyMessage
 		$gameNews[] = [
 			'Time' => date(DEFAULT_DATE_TIME_FORMAT_SPLIT, $dbRecord->getInt('time')),
-			'Message' => bbifyMessage($dbRecord->getField('news_message')),
+			'Message' => bbifyMessage($dbRecord->getString('news_message')),
 		];
 	}
 	$template->assign('GameNews', $gameNews);

--- a/src/htdocs/login.php
+++ b/src/htdocs/login.php
@@ -37,12 +37,12 @@ try {
 	// Get recent non-admin game news
 	$gameNews = array();
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT * FROM news WHERE type != \'admin\' ORDER BY time DESC LIMIT 4');
-	while ($db->nextRecord()) {
-		$overrideGameID = $db->getInt('game_id'); //for bbifyMessage
+	$dbResult = $db->read('SELECT * FROM news WHERE type != \'admin\' ORDER BY time DESC LIMIT 4');
+	foreach ($dbResult->records() as $dbRecord) {
+		$overrideGameID = $dbRecord->getInt('game_id'); //for bbifyMessage
 		$gameNews[] = [
-			'Time' => date(DEFAULT_DATE_TIME_FORMAT_SPLIT, $db->getInt('time')),
-			'Message' => bbifyMessage($db->getField('news_message')),
+			'Time' => date(DEFAULT_DATE_TIME_FORMAT_SPLIT, $dbRecord->getInt('time')),
+			'Message' => bbifyMessage($dbRecord->getField('news_message')),
 		];
 	}
 	$template->assign('GameNews', $gameNews);

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -91,10 +91,10 @@ try {
 	// *
 	// *********************************
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT * FROM active_session ' .
+	$dbResult = $db->read('SELECT * FROM active_session ' .
 			   'WHERE last_accessed > ' . $db->escapeNumber(Smr\Epoch::time() - TIME_BEFORE_NEWBIE_TIME));
-	if ($db->getNumRows() == 0) {
-		$db->query('UPDATE player SET newbie_turns = 1
+	if (!$dbResult->hasRecord()) {
+		$db->write('UPDATE player SET newbie_turns = 1
 					WHERE newbie_turns = 0 AND
 						  land_on_planet = \'FALSE\'');
 	}
@@ -105,8 +105,8 @@ try {
 	// *
 	// ******************************************
 
-	$db->query('DELETE FROM player_has_ticker WHERE expires <= ' . $db->escapeNumber(Smr\Epoch::time()));
-	$db->query('DELETE FROM cpl_tag WHERE expires <= ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND expires > 0');
+	$db->write('DELETE FROM player_has_ticker WHERE expires <= ' . $db->escapeNumber(Smr\Epoch::time()));
+	$db->write('DELETE FROM cpl_tag WHERE expires <= ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND expires > 0');
 
 	// save ip
 	$account->updateIP();
@@ -114,10 +114,10 @@ try {
 	//now we set a cookie that we can use for mult checking
 	if (!isset($_COOKIE['Session_Info'])) {
 		//we get their info from db if they have any
-		$db->query('SELECT * FROM multi_checking_cookie WHERE account_id = ' . $account->getAccountID());
-		if ($db->nextRecord()) {
+		$dbResult = $db->read('SELECT * FROM multi_checking_cookie WHERE account_id = ' . $account->getAccountID());
+		if ($dbResult->hasRecord()) {
 			//convert to array
-			$old = explode('-', $db->getField('array'));
+			$old = explode('-', $dbResult->record()->getField('array'));
 			//get rid of old version cookie since it isn't optimal.
 			if ($old[0] != MULTI_CHECKING_COOKIE_VERSION) {
 				$old = array();
@@ -144,10 +144,10 @@ try {
 			$cookie[] = $account->getAccountID();
 		}
 
-		$db->query('SELECT * FROM multi_checking_cookie WHERE account_id = ' . $account->getAccountID());
-		if ($db->nextRecord()) {
+		$dbResult = $db->read('SELECT * FROM multi_checking_cookie WHERE account_id = ' . $account->getAccountID());
+		if ($dbResult->hasRecord()) {
 			//convert to array
-			$old = explode('-', $db->getField('array'));
+			$old = explode('-', $dbResult->record()->getField('array'));
 			if ($old[0] != MULTI_CHECKING_COOKIE_VERSION) {
 				$old = array();
 			}
@@ -170,18 +170,18 @@ try {
 			$new .= '-' . $accID;
 		}
 	}
-	$db->query('REPLACE INTO multi_checking_cookie (account_id, array, `use`) VALUES (' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($new) . ', ' . $db->escapeString($use) . ')');
+	$db->write('REPLACE INTO multi_checking_cookie (account_id, array, `use`) VALUES (' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($new) . ', ' . $db->escapeString($use) . ')');
 	//now we update their cookie with the newest info
 	setcookie('Session_Info', $new, Smr\Epoch::time() + 157680000);
 
 
 	//get rid of expired messages
-	$db->query('UPDATE message SET receiver_delete = \'TRUE\', sender_delete = \'TRUE\', expire_time = 0 WHERE expire_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND expire_time != 0');
+	$db->write('UPDATE message SET receiver_delete = \'TRUE\', sender_delete = \'TRUE\', expire_time = 0 WHERE expire_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND expire_time != 0');
 	// Mark message as read if it was sent to self as a mass mail.
-	$db->query('UPDATE message SET msg_read = \'TRUE\' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' AND account_id = sender_id AND message_type_id IN (' . $db->escapeArray(array(MSG_ALLIANCE, MSG_GLOBAL, MSG_POLITICAL)) . ');');
+	$db->write('UPDATE message SET msg_read = \'TRUE\' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' AND account_id = sender_id AND message_type_id IN (' . $db->escapeArray(array(MSG_ALLIANCE, MSG_GLOBAL, MSG_POLITICAL)) . ');');
 	//check to see if we need to remove player_has_unread
-	$db->query('DELETE FROM player_has_unread_messages WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
-	$db->query('
+	$db->write('DELETE FROM player_has_unread_messages WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+	$db->write('
 		INSERT INTO player_has_unread_messages (game_id, account_id, message_type_id)
 		SELECT game_id, account_id, message_type_id FROM message WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' AND msg_read = ' . $db->escapeBoolean(false) . ' AND receiver_delete = ' . $db->escapeBoolean(false)
 	);

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -31,10 +31,10 @@ try {
 
 	// The d3 graph links are the warp connections between galaxies
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT sector_id, warp FROM sector WHERE warp !=0 AND game_id = ' . $db->escapeNumber($gameID));
-	while ($db->nextRecord()) {
-		$warp1 = SmrSector::getSector($gameID, $db->getInt('sector_id'));
-		$warp2 = SmrSector::getSector($gameID, $db->getInt('warp'));
+	$dbResult = $db->read('SELECT sector_id, warp FROM sector WHERE warp !=0 AND game_id = ' . $db->escapeNumber($gameID));
+	foreach ($dbResult->records() as $dbRecord) {
+		$warp1 = SmrSector::getSector($gameID, $dbRecord->getInt('sector_id'));
+		$warp2 = SmrSector::getSector($gameID, $dbRecord->getInt('warp'));
 		$links[] = [
 			'source' => $warp1->getGalaxy()->getName(),
 			'target' => $warp2->getGalaxy()->getName(),

--- a/src/htdocs/weapon_list.php
+++ b/src/htdocs/weapon_list.php
@@ -7,9 +7,9 @@ try {
 	// Get a list of all the shops that sell each weapon
 	$weaponLocs = [];
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT weapon_type_id, location_type.* FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) JOIN location_type USING (location_type_id) WHERE location_type_id != ' . $db->escapeNumber(RACE_WARS_WEAPONS));
-	while ($db->nextRecord()) {
-		$weaponLocs[$db->getInt('weapon_type_id')][] = SmrLocation::getLocation($db->getInt('location_type_id'), false, $db)->getName();
+	$dbResult = $db->read('SELECT weapon_type_id, location_type.* FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) JOIN location_type USING (location_type_id) WHERE location_type_id != ' . $db->escapeNumber(RACE_WARS_WEAPONS));
+	foreach ($dbResult->records() as $dbRecord) {
+		$weaponLocs[$dbRecord->getInt('weapon_type_id')][] = SmrLocation::getLocation($dbRecord->getInt('location_type_id'), false, $dbRecord)->getName();
 	}
 
 	// Get a list of all locations that sell weapons

--- a/src/lib/Album/album_functions.php
+++ b/src/lib/Album/album_functions.php
@@ -25,32 +25,30 @@ function main_page() : void {
 
 	// most hits
 	echo('<p><u>Top 5 Pictures</u><br /><br />');
-	$db->query('SELECT *
+	$dbResult = $db->read('SELECT *
 				FROM album
 				WHERE approved = \'YES\'
 				ORDER BY page_views DESC
 				LIMIT 5');
-	if ($db->getNumRows()) {
-		while ($db->nextRecord()) {
-			$page_views = $db->getInt('page_views');
-			$nick = get_album_nick($db->getInt('account_id'));
+	foreach ($dbResult->records() as $dbRecord) {
+		$page_views = $dbRecord->getInt('page_views');
+		$nick = get_album_nick($dbRecord->getInt('account_id'));
 
-			echo('<a href="?nick=' . urlencode($nick) . '">' . $nick . '</a> (' . $page_views . ')<br />');
-		}
+		echo('<a href="?nick=' . urlencode($nick) . '">' . $nick . '</a> (' . $page_views . ')<br />');
 	}
 
 	// latest picture
 	$dateFormat = $session->hasAccount() ? $session->getAccount()->getDateTimeFormat() : DEFAULT_DATE_TIME_FORMAT;
 	echo('<p><u>Latest Picture</u><br /><br />');
-	$db->query('SELECT *
+	$dbResult = $db->read('SELECT *
 				FROM album
 				WHERE approved = \'YES\'
 				ORDER BY created DESC
 				LIMIT 5');
-	if ($db->getNumRows()) {
-		while ($db->nextRecord()) {
-			$created = $db->getInt('created');
-			$nick = get_album_nick($db->getInt('account_id'));
+	if ($dbResult->hasRecord()) {
+		foreach ($dbResult->records() as $dbRecord) {
+			$created = $dbRecord->getInt('created');
+			$nick = get_album_nick($dbRecord->getInt('account_id'));
 
 			echo('<span style="font-size:85%;"><b>[' . date($dateFormat, $created) . ']</b> Picture of <a href="?nick=' . urlencode($nick) . '">' . $nick . '</a> added</span><br />');
 		}
@@ -68,26 +66,27 @@ function album_entry(int $album_id) : void {
 	create_link_list();
 
 	if ($session->hasAccount() && $album_id != $session->getAccountID()) {
-		$db->query('UPDATE album
+		$db->write('UPDATE album
 				SET page_views = page_views + 1
 				WHERE account_id = '.$db->escapeNumber($album_id) . ' AND
 					approved = \'YES\'');
 	}
 
-	$db->query('SELECT *
+	$dbResult = $db->read('SELECT *
 				FROM album
 				WHERE account_id = '.$db->escapeNumber($album_id) . ' AND
 					approved = \'YES\'');
-	if ($db->nextRecord()) {
-		$location = stripslashes($db->getField('location'));
-		$email = stripslashes($db->getField('email'));
-		$website = stripslashes($db->getField('website'));
-		$day = $db->getField('day');
-		$month = $db->getField('month');
-		$year = $db->getField('year');
-		$other = nl2br(stripslashes($db->getField('other')));
-		$page_views = $db->getInt('page_views');
-		$disabled = $db->getBoolean('disabled');
+	if ($dbResult->hasRecord()) {
+		$dbRecord = $dbResult->record();
+		$location = stripslashes($dbRecord->getField('location'));
+		$email = stripslashes($dbRecord->getField('email'));
+		$website = stripslashes($dbRecord->getField('website'));
+		$day = $dbRecord->getField('day');
+		$month = $dbRecord->getField('month');
+		$year = $dbRecord->getField('year');
+		$other = nl2br(stripslashes($dbRecord->getField('other')));
+		$page_views = $dbRecord->getInt('page_views');
+		$disabled = $dbRecord->getBoolean('disabled');
 	} else {
 		echo('<h1>Error</h1>');
 		echo('This user doesn\'t have an entry in our album!');
@@ -104,29 +103,29 @@ function album_entry(int $album_id) : void {
 	echo('<table style="width: 100%">');
 	echo('<tr>');
 
-	$db->query('SELECT hof_name
+	$dbResult = $db->read('SELECT hof_name
 				FROM album JOIN account USING(account_id)
 				WHERE hof_name < ' . $db->escapeString($nick) . ' AND
 					approved = \'YES\'
 				ORDER BY hof_name DESC
 				LIMIT 1');
 	echo '<td class="center" style="width: 30%" valign="middle">';
-	if ($db->nextRecord()) {
-		$priv_nick = $db->getField('hof_name');
+	if ($dbResult->hasRecord()) {
+		$priv_nick = $dbResult->record()->getField('hof_name');
 		echo '<a href="?nick=' . urlencode($priv_nick) . '"><img src="/images/album/rew.jpg" alt="' . $priv_nick . '" border="0"></a>&nbsp;&nbsp;&nbsp;';
 	}
 	echo '</td>';
 	echo('<td class="center" valign="middle"><span style="font-size:150%;">' . $nick . '</span><br /><span style="font-size:75%;">Views: ' . $page_views . '</span></td>');
 
-	$db->query('SELECT hof_name
+	$dbResult = $db->read('SELECT hof_name
 				FROM album JOIN account USING(account_id)
 				WHERE hof_name > ' . $db->escapeString($nick) . ' AND
 					approved = \'YES\'
 				ORDER BY hof_name
 				LIMIT 1');
 	echo '<td class="center" style="width: 30%" valign="middle">';
-	if ($db->nextRecord()) {
-		$next_nick = $db->getField('hof_name');
+	if ($dbResult->hasRecord()) {
+		$next_nick = $dbResult->record()->getField('hof_name');
 		echo '&nbsp;&nbsp;&nbsp;<a href="?nick=' . urlencode($next_nick) . '"><img src="/images/album/fwd.jpg" alt="' . $next_nick . '" border="0"></a>';
 	}
 	echo '</td>';
@@ -196,13 +195,13 @@ function album_entry(int $album_id) : void {
 	echo('<u>Comments</u><br /><br />');
 
 	$dateFormat = $session->hasAccount() ? $session->getAccount()->getDateTimeFormat() : DEFAULT_DATE_TIME_FORMAT;
-	$db->query('SELECT *
+	$dbResult = $db->read('SELECT *
 				FROM album_has_comments
 				WHERE album_id = '.$db->escapeNumber($album_id));
-	while ($db->nextRecord()) {
-		$time = $db->getInt('time');
-		$postee = get_album_nick($db->getInt('post_id'));
-		$msg = stripslashes($db->getField('msg'));
+	foreach ($dbResult->records() as $dbRecord) {
+		$time = $dbRecord->getInt('time');
+		$postee = get_album_nick($dbRecord->getInt('post_id'));
+		$msg = stripslashes($dbRecord->getField('msg'));
 
 		echo('<span style="font-size:85%;">[' . date($dateFormat, $time) . '] &lt;' . $postee . '&gt; ' . $msg . '</span><br />');
 	}
@@ -215,11 +214,11 @@ function album_entry(int $album_id) : void {
 		echo('<td style="color:green; font-size:70%;">Nick:<br /><input type="text" size="10" name="nick" value="' . htmlspecialchars(get_album_nick($session->getAccountID())) . '" readonly></td>');
 		echo('<td style="color:green; font-size:70%;">Comment:<br /><input type="text" size="50" name="comment"></td>');
 		echo('<td style="color:green; font-size:70%;"><br /><input type="submit" value="Send"></td>');
-		$db->query('SELECT *
+		$dbResult = $db->read('SELECT 1
 					FROM account_has_permission
 					WHERE account_id = '.$db->escapeNumber($session->getAccountID()) . ' AND
 						permission_id = '.$db->escapeNumber(PERMISSION_MODERATE_PHOTO_ALBUM));
-		if ($db->nextRecord()) {
+		if ($dbResult->hasRecord()) {
 			echo('<td style="color:green; font-size:70%;"><br /><input type="submit" name="action" value="Moderate"></td>');
 		}
 

--- a/src/lib/Album/album_functions.php
+++ b/src/lib/Album/album_functions.php
@@ -78,13 +78,13 @@ function album_entry(int $album_id) : void {
 					approved = \'YES\'');
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
-		$location = stripslashes($dbRecord->getField('location'));
-		$email = stripslashes($dbRecord->getField('email'));
-		$website = stripslashes($dbRecord->getField('website'));
-		$day = $dbRecord->getField('day');
-		$month = $dbRecord->getField('month');
-		$year = $dbRecord->getField('year');
-		$other = nl2br(stripslashes($dbRecord->getField('other')));
+		$location = $dbRecord->getField('location');
+		$email = $dbRecord->getField('email');
+		$website = $dbRecord->getField('website');
+		$day = $dbRecord->getInt('day');
+		$month = $dbRecord->getInt('month');
+		$year = $dbRecord->getInt('year');
+		$other = nl2br($dbRecord->getString('other'));
 		$page_views = $dbRecord->getInt('page_views');
 		$disabled = $dbRecord->getBoolean('disabled');
 	} else {
@@ -111,7 +111,7 @@ function album_entry(int $album_id) : void {
 				LIMIT 1');
 	echo '<td class="center" style="width: 30%" valign="middle">';
 	if ($dbResult->hasRecord()) {
-		$priv_nick = $dbResult->record()->getField('hof_name');
+		$priv_nick = $dbResult->record()->getString('hof_name');
 		echo '<a href="?nick=' . urlencode($priv_nick) . '"><img src="/images/album/rew.jpg" alt="' . $priv_nick . '" border="0"></a>&nbsp;&nbsp;&nbsp;';
 	}
 	echo '</td>';
@@ -125,7 +125,7 @@ function album_entry(int $album_id) : void {
 				LIMIT 1');
 	echo '<td class="center" style="width: 30%" valign="middle">';
 	if ($dbResult->hasRecord()) {
-		$next_nick = $dbResult->record()->getField('hof_name');
+		$next_nick = $dbResult->record()->getString('hof_name');
 		echo '&nbsp;&nbsp;&nbsp;<a href="?nick=' . urlencode($next_nick) . '"><img src="/images/album/fwd.jpg" alt="' . $next_nick . '" border="0"></a>';
 	}
 	echo '</td>';
@@ -201,7 +201,7 @@ function album_entry(int $album_id) : void {
 	foreach ($dbResult->records() as $dbRecord) {
 		$time = $dbRecord->getInt('time');
 		$postee = get_album_nick($dbRecord->getInt('post_id'));
-		$msg = stripslashes($dbRecord->getField('msg'));
+		$msg = $dbRecord->getString('msg');
 
 		echo('<span style="font-size:85%;">[' . date($dateFormat, $time) . '] &lt;' . $postee . '&gt; ' . $msg . '</span><br />');
 	}

--- a/src/lib/Default/AbstractMenu.class.php
+++ b/src/lib/Default/AbstractMenu.class.php
@@ -60,22 +60,23 @@ class AbstractMenu {
 
 		// Check if player has permissions through an alliance treaty
 		if (!$in_alliance) {
-			$db->query('SELECT mb_read, mod_read, planet_land FROM alliance_treaties
+			$dbResult = $db->read('SELECT mb_read, mod_read, planet_land FROM alliance_treaties
 							WHERE (alliance_id_1 = ' . $db->escapeNumber($alliance_id) . ' OR alliance_id_1 = ' . $db->escapeNumber($player->getAllianceID()) . ')
 							AND (alliance_id_2 = ' . $db->escapeNumber($alliance_id) . ' OR alliance_id_2 = ' . $db->escapeNumber($player->getAllianceID()) . ')
 							AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 							AND (mb_read = 1 OR mod_read = 1 OR planet_land = 1) AND official = \'TRUE\'');
-			if ($db->nextRecord()) {
-				$canReadMb = $db->getBoolean('mb_read');
-				$canReadMotd = $db->getBoolean('mod_read');
-				$canSeePlanetList = $db->getBoolean('planet_land');
+			if ($dbResult->hasRecord()) {
+				$dbRecord = $dbResult->record();
+				$canReadMb = $dbRecord->getBoolean('mb_read');
+				$canReadMotd = $dbRecord->getBoolean('mod_read');
+				$canSeePlanetList = $dbRecord->getBoolean('planet_land');
 			}
 		}
 
 		$role_id = $player->getAllianceRole($alliance_id);
-		$db->query('SELECT send_alliance_msg FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
-		if ($db->nextRecord()) {
-			$send_alliance_msg = $db->getBoolean('send_alliance_msg');
+		$dbResult = $db->read('SELECT send_alliance_msg FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
+		if ($dbResult->hasRecord()) {
+			$send_alliance_msg = $dbResult->record()->getBoolean('send_alliance_msg');
 		} else {
 			$send_alliance_msg = false;
 		}

--- a/src/lib/Default/AbstractSmrAccount.class.php
+++ b/src/lib/Default/AbstractSmrAccount.class.php
@@ -101,9 +101,10 @@ abstract class AbstractSmrAccount {
 	public static function getAccountByName(string $login, bool $forceUpdate = false) : ?SmrAccount {
 		if (empty($login)) { return null; }
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT account_id FROM account WHERE login = ' . $db->escapeString($login) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getAccount($db->getInt('account_id'), $forceUpdate);
+		$dbResult = $db->read('SELECT account_id FROM account WHERE login = ' . $db->escapeString($login) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$accountID = $dbResult->record()->getInt('account_id');
+			return self::getAccount($accountID, $forceUpdate);
 		} else {
 			return null;
 		}
@@ -112,9 +113,10 @@ abstract class AbstractSmrAccount {
 	public static function getAccountByEmail(?string $email, bool $forceUpdate = false) : ?SmrAccount {
 		if (empty($email)) { return null; }
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT account_id FROM account WHERE email = ' . $db->escapeString($email) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getAccount($db->getInt('account_id'), $forceUpdate);
+		$dbResult = $db->read('SELECT account_id FROM account WHERE email = ' . $db->escapeString($email) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$accountID = $dbResult->record()->getInt('account_id');
+			return self::getAccount($accountID, $forceUpdate);
 		} else {
 			return null;
 		}
@@ -123,9 +125,10 @@ abstract class AbstractSmrAccount {
 	public static function getAccountByDiscordId(?string $id, bool $forceUpdate = false) : ?SmrAccount {
 		if (empty($id)) { return null; }
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT account_id FROM account where discord_id = ' . $db->escapeString($id) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getAccount($db->getInt('account_id'), $forceUpdate);
+		$dbResult = $db->read('SELECT account_id FROM account where discord_id = ' . $db->escapeString($id) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$accountID = $dbResult->record()->getInt('account_id');
+			return self::getAccount($accountID, $forceUpdate);
 		} else {
 			return null;
 		}
@@ -134,9 +137,10 @@ abstract class AbstractSmrAccount {
 	public static function getAccountByIrcNick(?string $nick, bool $forceUpdate = false) : ?SmrAccount {
 		if (empty($nick)) { return null; }
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT account_id FROM account WHERE irc_nick = ' . $db->escapeString($nick) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getAccount($db->getInt('account_id'), $forceUpdate);
+		$dbResult = $db->read('SELECT account_id FROM account WHERE irc_nick = ' . $db->escapeString($nick) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$accountID = $dbResult->record()->getInt('account_id');
+			return self::getAccount($accountID, $forceUpdate);
 		} else {
 			return null;
 		}
@@ -145,11 +149,12 @@ abstract class AbstractSmrAccount {
 	public static function getAccountBySocialLogin(Smr\SocialLogin\SocialLogin $social, bool $forceUpdate = false) : ?SmrAccount {
 		if (!$social->isValid()) { return null; }
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT account_id FROM account JOIN account_auth USING(account_id)
+		$dbResult = $db->read('SELECT account_id FROM account JOIN account_auth USING(account_id)
 		            WHERE login_type = '.$db->escapeString($social->getLoginType()) . '
 		              AND auth_key = '.$db->escapeString($social->getUserID()) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getAccount($db->getInt('account_id'), $forceUpdate);
+		if ($dbResult->hasRecord()) {
+			$accountID = $dbResult->record()->getInt('account_id');
+			return self::getAccount($accountID, $forceUpdate);
 		} else {
 			return null;
 		}
@@ -162,7 +167,7 @@ abstract class AbstractSmrAccount {
 		}
 		$db = Smr\Database::getInstance();
 		$passwordHash = password_hash($password, PASSWORD_DEFAULT);
-		$db->query('INSERT INTO account (login, password, email, validation_code, last_login, offset, referral_id, hof_name, hotkeys) VALUES(' .
+		$db->write('INSERT INTO account (login, password, email, validation_code, last_login, offset, referral_id, hof_name, hotkeys) VALUES(' .
 			$db->escapeString($login) . ', ' . $db->escapeString($passwordHash) . ', ' . $db->escapeString($email) . ', ' .
 			$db->escapeString(random_string(10)) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($timez) . ',' . $db->escapeNumber($referral) . ',' . $db->escapeString($login) . ',' . $db->escapeObject([]) . ')');
 		return self::getAccountByName($login);
@@ -183,38 +188,39 @@ abstract class AbstractSmrAccount {
 	protected function __construct(int $accountID) {
 		$this->db = Smr\Database::getInstance();
 		$this->SQL = 'account_id = ' . $this->db->escapeNumber($accountID);
-		$this->db->query('SELECT * FROM account WHERE ' . $this->SQL . ' LIMIT 1');
+		$dbResult = $this->db->read('SELECT * FROM account WHERE ' . $this->SQL . ' LIMIT 1');
 
-		if ($this->db->nextRecord()) {
-			$this->account_id = $this->db->getInt('account_id');
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			$this->account_id = $dbRecord->getInt('account_id');
 
-			$this->login = $this->db->getField('login');
-			$this->passwordHash = $this->db->getField('password');
-			$this->email = $this->db->getField('email');
-			$this->validated = $this->db->getBoolean('validated');
+			$this->login = $dbRecord->getField('login');
+			$this->passwordHash = $dbRecord->getField('password');
+			$this->email = $dbRecord->getField('email');
+			$this->validated = $dbRecord->getBoolean('validated');
 
-			$this->last_login = $this->db->getInt('last_login');
-			$this->validation_code = $this->db->getField('validation_code');
-			$this->veteranForced = $this->db->getBoolean('veteran');
-			$this->logging = $this->db->getBoolean('logging');
-			$this->offset = $this->db->getInt('offset');
-			$this->images = $this->db->getBoolean('images');
-			$this->fontSize = $this->db->getInt('fontsize');
+			$this->last_login = $dbRecord->getInt('last_login');
+			$this->validation_code = $dbRecord->getField('validation_code');
+			$this->veteranForced = $dbRecord->getBoolean('veteran');
+			$this->logging = $dbRecord->getBoolean('logging');
+			$this->offset = $dbRecord->getInt('offset');
+			$this->images = $dbRecord->getBoolean('images');
+			$this->fontSize = $dbRecord->getInt('fontsize');
 
-			$this->passwordReset = $this->db->getField('password_reset');
-			$this->useAJAX = $this->db->getBoolean('use_ajax');
-			$this->mailBanned = $this->db->getInt('mail_banned');
+			$this->passwordReset = $dbRecord->getField('password_reset');
+			$this->useAJAX = $dbRecord->getBoolean('use_ajax');
+			$this->mailBanned = $dbRecord->getInt('mail_banned');
 
-			$this->friendlyColour = $this->db->getField('friendly_colour');
-			$this->neutralColour = $this->db->getField('neutral_colour');
-			$this->enemyColour = $this->db->getField('enemy_colour');
+			$this->friendlyColour = $dbRecord->getField('friendly_colour');
+			$this->neutralColour = $dbRecord->getField('neutral_colour');
+			$this->enemyColour = $dbRecord->getField('enemy_colour');
 
-			$this->cssLink = $this->db->getField('css_link');
-			$this->defaultCSSEnabled = $this->db->getBoolean('default_css_enabled');
-			$this->centerGalaxyMapOnPlayer = $this->db->getBoolean('center_galaxy_map_on_player');
+			$this->cssLink = $dbRecord->getField('css_link');
+			$this->defaultCSSEnabled = $dbRecord->getBoolean('default_css_enabled');
+			$this->centerGalaxyMapOnPlayer = $dbRecord->getBoolean('center_galaxy_map_on_player');
 
-			$this->messageNotifications = $this->db->getObject('message_notifications', false, true);
-			$this->hotkeys = $this->db->getObject('hotkeys');
+			$this->messageNotifications = $dbRecord->getObject('message_notifications', false, true);
+			$this->hotkeys = $dbRecord->getObject('hotkeys');
 			foreach (self::DEFAULT_HOTKEYS as $hotkey => $binding) {
 				if (!isset($this->hotkeys[$hotkey])) {
 					$this->hotkeys[$hotkey] = $binding;
@@ -222,21 +228,21 @@ abstract class AbstractSmrAccount {
 			}
 
 			foreach (Globals::getHistoryDatabases() as $databaseName => $oldColumn) {
-				$this->oldAccountIDs[$databaseName] = $this->db->getInt($oldColumn);
+				$this->oldAccountIDs[$databaseName] = $dbRecord->getInt($oldColumn);
 			}
 
-			$this->referrerID = $this->db->getInt('referral_id');
-			$this->maxRankAchieved = $this->db->getInt('max_rank_achieved');
+			$this->referrerID = $dbRecord->getInt('referral_id');
+			$this->maxRankAchieved = $dbRecord->getInt('max_rank_achieved');
 
-			$this->hofName = $this->db->getField('hof_name');
-			$this->discordId = $this->db->getField('discord_id');
-			$this->ircNick = $this->db->getField('irc_nick');
+			$this->hofName = $dbRecord->getField('hof_name');
+			$this->discordId = $dbRecord->getField('discord_id');
+			$this->ircNick = $dbRecord->getField('irc_nick');
 
-			$this->dateFormat = $this->db->getField('date_format');
-			$this->timeFormat = $this->db->getField('time_format');
+			$this->dateFormat = $dbRecord->getField('date_format');
+			$this->timeFormat = $dbRecord->getField('time_format');
 
-			$this->template = $this->db->getField('template');
-			$this->colourScheme = $this->db->getField('colour_scheme');
+			$this->template = $dbRecord->getField('template');
+			$this->colourScheme = $dbRecord->getField('colour_scheme');
 
 			if (empty($this->hofName)) {
 				$this->hofName = $this->login;
@@ -250,11 +256,11 @@ abstract class AbstractSmrAccount {
 	 * Check if the account is disabled.
 	 */
 	public function isDisabled() : array|false {
-		$this->db->query('SELECT * FROM account_is_closed JOIN closing_reason USING(reason_id) ' .
-			'WHERE ' . $this->SQL . ' LIMIT 1');
-		if ($this->db->nextRecord()) {
+		$dbResult = $this->db->read('SELECT * FROM account_is_closed JOIN closing_reason USING(reason_id) WHERE ' . $this->SQL . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
 			// get the expire time
-			$expireTime = $this->db->getInt('expires');
+			$expireTime = $dbRecord->getInt('expires');
 
 			// are we over this time?
 			if ($expireTime > 0 && $expireTime < Smr\Epoch::time()) {
@@ -263,8 +269,8 @@ abstract class AbstractSmrAccount {
 				return false;
 			}
 			return array('Time' => $expireTime,
-				'Reason' => $this->db->getField('reason'),
-				'ReasonID' => $this->db->getInt('reason_id')
+				'Reason' => $dbRecord->getField('reason'),
+				'ReasonID' => $dbRecord->getInt('reason_id')
 			);
 		} else {
 			return false;
@@ -272,7 +278,7 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function update() : void {
-		$this->db->query('UPDATE account SET email = ' . $this->db->escapeString($this->email) .
+		$this->db->write('UPDATE account SET email = ' . $this->db->escapeString($this->email) .
 			', validation_code = ' . $this->db->escapeString($this->validation_code) .
 			', validated = ' . $this->db->escapeBoolean($this->validated) .
 			', password = ' . $this->db->escapeString($this->passwordHash) .
@@ -309,12 +315,13 @@ abstract class AbstractSmrAccount {
 
 		// more than 50 elements in it?
 
-		$this->db->query('SELECT time,ip FROM account_has_ip WHERE ' . $this->SQL . ' ORDER BY time ASC');
-		if ($this->db->getNumRows() > 50 && $this->db->nextRecord()) {
-			$delete_time = $this->db->getInt('time');
-			$delete_ip = $this->db->getField('ip');
+		$dbResult = $this->db->read('SELECT time,ip FROM account_has_ip WHERE ' . $this->SQL . ' ORDER BY time ASC');
+		if ($dbResult->getNumRecords() > 50) {
+			$dbRecord = $dbResult->records()->current();
+			$delete_time = $dbRecord->getInt('time');
+			$delete_ip = $dbRecord->getField('ip');
 
-			$this->db->query('DELETE FROM account_has_ip
+			$this->db->write('DELETE FROM account_has_ip
 				WHERE '.$this->SQL . ' AND
 				time = '.$this->db->escapeNumber($delete_time) . ' AND
 				ip = '.$this->db->escapeString($delete_ip));
@@ -328,7 +335,7 @@ abstract class AbstractSmrAccount {
 		}
 
 		// save...first make sure there isn't one for these keys (someone could double click and get error)
-		$this->db->query('REPLACE INTO account_has_ip (account_id, time, ip, host) VALUES (' . $this->db->escapeNumber($this->account_id) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ', ' . $this->db->escapeString($curr_ip) . ', ' . $this->db->escapeString($host) . ')');
+		$this->db->write('REPLACE INTO account_has_ip (account_id, time, ip, host) VALUES (' . $this->db->escapeNumber($this->account_id) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ', ' . $this->db->escapeString($curr_ip) . ', ' . $this->db->escapeString($host) . ')');
 	}
 
 	public function updateLastLogin() : void {
@@ -368,8 +375,8 @@ abstract class AbstractSmrAccount {
 
 	public function isNPC() : bool {
 		if (!isset($this->npc)) {
-			$this->db->query('SELECT login FROM npc_logins WHERE login = ' . $this->db->escapeString($this->getLogin()) . ' LIMIT 1;');
-			$this->npc = $this->db->nextRecord();
+			$dbResult = $this->db->read('SELECT 1 FROM npc_logins WHERE login = ' . $this->db->escapeString($this->getLogin()) . ' LIMIT 1;');
+			$this->npc = $dbResult->hasRecord();
 		}
 		return $this->npc;
 	}
@@ -377,18 +384,18 @@ abstract class AbstractSmrAccount {
 	protected function getHOFData() : void {
 		if (!isset($this->HOF)) {
 			//Get Player HOF
-			$this->db->query('SELECT type,sum(amount) as amount FROM player_hof WHERE ' . $this->SQL . ' AND game_id IN (SELECT game_id FROM game WHERE ignore_stats = \'FALSE\') GROUP BY type');
+			$dbResult = $this->db->read('SELECT type,sum(amount) as amount FROM player_hof WHERE ' . $this->SQL . ' AND game_id IN (SELECT game_id FROM game WHERE ignore_stats = \'FALSE\') GROUP BY type');
 			$this->HOF = array();
-			while ($this->db->nextRecord()) {
+			foreach ($dbResult->records() as $dbRecord) {
 				$hof =& $this->HOF;
-				$typeList = explode(':', $this->db->getField('type'));
+				$typeList = explode(':', $dbRecord->getField('type'));
 				foreach ($typeList as $type) {
 					if (!isset($hof[$type])) {
 						$hof[$type] = array();
 					}
 					$hof =& $hof[$type];
 				}
-				$hof = $this->db->getFloat('amount');
+				$hof = $dbRecord->getFloat('amount');
 			}
 		}
 	}
@@ -480,7 +487,7 @@ abstract class AbstractSmrAccount {
 
 	public function log(int $log_type_id, string $msg, int $sector_id = 0) : void {
 		if ($this->isLoggingEnabled()) {
-			$this->db->query('INSERT INTO account_has_logs ' .
+			$this->db->write('INSERT INTO account_has_logs ' .
 				'(account_id, microtime, log_type_id, message, sector_id) ' .
 				'VALUES(' . $this->db->escapeNumber($this->account_id) . ', ' . $this->db->escapeMicrotime(Smr\Epoch::microtime()) . ', ' . $this->db->escapeNumber($log_type_id) . ', ' . $this->db->escapeString($msg) . ', ' . $this->db->escapeNumber($sector_id) . ')');
 		}
@@ -490,10 +497,11 @@ abstract class AbstractSmrAccount {
 		if (!isset($this->credits) || !isset($this->rewardCredits)) {
 			$this->credits = 0;
 			$this->rewardCredits = 0;
-			$this->db->query('SELECT * FROM account_has_credits WHERE ' . $this->SQL . ' LIMIT 1');
-			if ($this->db->nextRecord()) {
-				$this->credits = $this->db->getInt('credits_left');
-				$this->rewardCredits = $this->db->getInt('reward_credits');
+			$dbResult = $this->db->read('SELECT * FROM account_has_credits WHERE ' . $this->SQL . ' LIMIT 1');
+			if ($dbResult->hasRecord()) {
+				$dbRecord = $dbResult->record();
+				$this->credits = $dbRecord->getInt('credits_left');
+				$this->rewardCredits = $dbRecord->getInt('reward_credits');
 			}
 		}
 	}
@@ -521,9 +529,9 @@ abstract class AbstractSmrAccount {
 			$rewardCredits = 0;
 		}
 		if ($this->credits == 0 && $this->rewardCredits == 0) {
-			$this->db->query('REPLACE INTO account_has_credits (account_id, credits_left, reward_credits) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($credits) . ',' . $this->db->escapeNumber($rewardCredits) . ')');
+			$this->db->write('REPLACE INTO account_has_credits (account_id, credits_left, reward_credits) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($credits) . ',' . $this->db->escapeNumber($rewardCredits) . ')');
 		} else {
-			$this->db->query('UPDATE account_has_credits SET credits_left=' . $this->db->escapeNumber($credits) . ', reward_credits=' . $this->db->escapeNumber($rewardCredits) . ' WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('UPDATE account_has_credits SET credits_left=' . $this->db->escapeNumber($credits) . ', reward_credits=' . $this->db->escapeNumber($rewardCredits) . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		}
 		$this->credits = $credits;
 		$this->rewardCredits = $rewardCredits;
@@ -544,9 +552,9 @@ abstract class AbstractSmrAccount {
 			return;
 		}
 		if ($this->credits == 0 && $this->rewardCredits == 0) {
-			$this->db->query('REPLACE INTO account_has_credits (account_id, credits_left) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($credits) . ')');
+			$this->db->write('REPLACE INTO account_has_credits (account_id, credits_left) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($credits) . ')');
 		} else {
-			$this->db->query('UPDATE account_has_credits SET credits_left=' . $this->db->escapeNumber($credits) . ' WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('UPDATE account_has_credits SET credits_left=' . $this->db->escapeNumber($credits) . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		}
 		$this->credits = $credits;
 	}
@@ -579,9 +587,9 @@ abstract class AbstractSmrAccount {
 			return;
 		}
 		if ($this->credits == 0 && $this->rewardCredits == 0) {
-			$this->db->query('REPLACE INTO account_has_credits (account_id, reward_credits) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($credits) . ')');
+			$this->db->write('REPLACE INTO account_has_credits (account_id, reward_credits) VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($credits) . ')');
 		} else {
-			$this->db->query('UPDATE account_has_credits SET reward_credits=' . $this->db->escapeNumber($credits) . ' WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('UPDATE account_has_credits SET reward_credits=' . $this->db->escapeNumber($credits) . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		}
 		$this->rewardCredits = $credits;
 	}
@@ -604,7 +612,7 @@ abstract class AbstractSmrAccount {
 	public static function doMessageSendingToBox(int $senderID, int $boxTypeID, string $message, int $gameID = 0) : void {
 		$db = Smr\Database::getInstance();
 		// send him the message
-		$db->query('INSERT INTO message_boxes
+		$db->write('INSERT INTO message_boxes
 			(box_type_id,game_id,message_text,
 			sender_id,send_time) VALUES (' .
 			$db->escapeNumber($boxTypeID) . ',' .
@@ -658,8 +666,8 @@ abstract class AbstractSmrAccount {
 			create_error('The email is invalid! It cannot contain any spaces.');
 		}
 
-		$this->db->query('SELECT 1 FROM account WHERE email = ' . $this->db->escapeString($email) . ' and account_id != ' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
-		if ($this->db->getNumRows() > 0) {
+		$dbResult = $this->db->read('SELECT 1 FROM account WHERE email = ' . $this->db->escapeString($email) . ' and account_id != ' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
 			create_error('This email address is already registered.');
 		}
 
@@ -678,7 +686,7 @@ abstract class AbstractSmrAccount {
 
 	public function sendValidationEmail() : void {
 		// remember when we sent validation code
-		$this->db->query('REPLACE INTO notification (notification_type, account_id, time)
+		$this->db->write('REPLACE INTO notification (notification_type, account_id, time)
 				VALUES(\'validation_code\', '.$this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ')');
 
 		$emailMessage =
@@ -881,8 +889,8 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function isLoggedIn() : bool {
-		$this->db->query('SELECT 1 FROM active_session WHERE account_id = ' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
-		return $this->db->nextRecord();
+		$dbResult = $this->db->read('SELECT 1 FROM active_session WHERE account_id = ' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
+		return $dbResult->hasRecord();
 	}
 
 	/**
@@ -923,14 +931,14 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function addAuthMethod(string $loginType, string $authKey) : void {
-		$this->db->query('SELECT account_id FROM account_auth WHERE login_type=' . $this->db->escapeString($loginType) . ' AND auth_key = ' . $this->db->escapeString($authKey) . ';');
-		if ($this->db->nextRecord()) {
-			if ($this->db->getInt('account_id') != $this->getAccountID()) {
+		$dbResult = $this->db->read('SELECT account_id FROM account_auth WHERE login_type=' . $this->db->escapeString($loginType) . ' AND auth_key = ' . $this->db->escapeString($authKey) . ';');
+		if ($dbResult->hasRecord()) {
+			if ($dbResult->record()->getInt('account_id') != $this->getAccountID()) {
 				throw new Exception('Another account already uses this form of auth.');
 			}
 			return;
 		}
-		$this->db->query('INSERT INTO account_auth values (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeString($loginType) . ',' . $this->db->escapeString($authKey) . ');');
+		$this->db->write('INSERT INTO account_auth values (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeString($loginType) . ',' . $this->db->escapeString($authKey) . ');');
 	}
 
 	public function generatePasswordReset() : void {
@@ -1076,9 +1084,9 @@ abstract class AbstractSmrAccount {
 	public function getPermissions() : array {
 		if (!isset($this->permissions)) {
 			$this->permissions = array();
-			$this->db->query('SELECT permission_id FROM account_has_permission WHERE ' . $this->SQL);
-			while ($this->db->nextRecord()) {
-				$this->permissions[$this->db->getInt('permission_id')] = true;
+			$dbResult = $this->db->read('SELECT permission_id FROM account_has_permission WHERE ' . $this->SQL);
+			foreach ($dbResult->records() as $dbRecord) {
+				$this->permissions[$dbRecord->getInt('permission_id')] = true;
 			}
 		}
 		return $this->permissions;
@@ -1096,10 +1104,11 @@ abstract class AbstractSmrAccount {
 		if (!isset($this->points)) {
 			$this->points = 0;
 			$this->db->lockTable('account_has_points');
-			$this->db->query('SELECT * FROM account_has_points WHERE ' . $this->SQL . ' LIMIT 1');
-			if ($this->db->nextRecord()) {
-				$this->points = $this->db->getInt('points');
-				$lastUpdate = $this->db->getInt('last_update');
+			$dbResult = $this->db->read('SELECT * FROM account_has_points WHERE ' . $this->SQL . ' LIMIT 1');
+			if ($dbResult->hasRecord()) {
+				$dbRecord = $dbResult->record();
+				$this->points = $dbRecord->getInt('points');
+				$lastUpdate = $dbRecord->getInt('last_update');
 				//we are gonna check for reducing points...
 				if ($this->points > 0 && $lastUpdate < Smr\Epoch::time() - (7 * 86400)) {
 					$removePoints = 0;
@@ -1121,11 +1130,11 @@ abstract class AbstractSmrAccount {
 			return;
 		}
 		if ($this->points == 0) {
-			$this->db->query('INSERT INTO account_has_points (account_id, points, last_update) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($numPoints) . ', ' . $this->db->escapeNumber($lastUpdate ?? Smr\Epoch::time()) . ')');
+			$this->db->write('INSERT INTO account_has_points (account_id, points, last_update) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($numPoints) . ', ' . $this->db->escapeNumber($lastUpdate ?? Smr\Epoch::time()) . ')');
 		} elseif ($numPoints <= 0) {
-			$this->db->query('DELETE FROM account_has_points WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('DELETE FROM account_has_points WHERE ' . $this->SQL . ' LIMIT 1');
 		} else {
-			$this->db->query('UPDATE account_has_points SET points = ' . $this->db->escapeNumber($numPoints) . (isset($lastUpdate) ? ', last_update = ' . $this->db->escapeNumber(Smr\Epoch::time()) : '') . ' WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('UPDATE account_has_points SET points = ' . $this->db->escapeNumber($numPoints) . (isset($lastUpdate) ? ', last_update = ' . $this->db->escapeNumber(Smr\Epoch::time()) : '') . ' WHERE ' . $this->SQL . ' LIMIT 1');
 		}
 		$this->points = $numPoints;
 	}
@@ -1197,32 +1206,32 @@ abstract class AbstractSmrAccount {
 	}
 
 	public function banAccount(int $expireTime, SmrAccount $admin, int $reasonID, string $suspicion, bool $removeExceptions = false) : void {
-		$this->db->query('REPLACE INTO account_is_closed
+		$this->db->write('REPLACE INTO account_is_closed
 					(account_id, reason_id, suspicion, expires)
 					VALUES('.$this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($reasonID) . ', ' . $this->db->escapeString($suspicion) . ', ' . $this->db->escapeNumber($expireTime) . ')');
 		$this->db->lockTable('active_session');
-		$this->db->query('DELETE FROM active_session WHERE ' . $this->SQL . ' LIMIT 1');
+		$this->db->write('DELETE FROM active_session WHERE ' . $this->SQL . ' LIMIT 1');
 		$this->db->unlock();
 
-		$this->db->query('INSERT INTO account_has_closing_history
+		$this->db->write('INSERT INTO account_has_closing_history
 						(account_id, time, admin_id, action)
 						VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ', ' . $this->db->escapeNumber($admin->getAccountID()) . ', ' . $this->db->escapeString('Closed') . ');');
-		$this->db->query('UPDATE player SET newbie_turns = 1
+		$this->db->write('UPDATE player SET newbie_turns = 1
 						WHERE ' . $this->SQL . '
 						AND newbie_turns = 0
 						AND land_on_planet = ' . $this->db->escapeBoolean(false));
 
-		$this->db->query('SELECT game_id FROM game JOIN player USING (game_id)
+		$dbResult = $this->db->read('SELECT game_id FROM game JOIN player USING (game_id)
 						WHERE ' . $this->SQL . '
 						AND end_time >= ' . $this->db->escapeNumber(Smr\Epoch::time()));
-		while ($this->db->nextRecord()) {
-			$player = SmrPlayer::getPlayer($this->getAccountID(), $this->db->getInt('game_id'));
+		foreach ($dbResult->records() as $dbRecord) {
+			$player = SmrPlayer::getPlayer($this->getAccountID(), $dbRecord->getInt('game_id'));
 			$player->updateTurns();
 			$player->update();
 		}
 		$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account closed by ' . $admin->getLogin() . '.');
 		if ($removeExceptions !== false) {
-			$this->db->query('DELETE FROM account_exceptions WHERE ' . $this->SQL);
+			$this->db->write('DELETE FROM account_exceptions WHERE ' . $this->SQL);
 		}
 	}
 
@@ -1231,18 +1240,18 @@ abstract class AbstractSmrAccount {
 		if ($admin !== null) {
 			$adminID = $admin->getAccountID();
 		}
-		$this->db->query('DELETE FROM account_is_closed WHERE ' . $this->SQL . ' LIMIT 1');
-		$this->db->query('INSERT INTO account_has_closing_history
+		$this->db->write('DELETE FROM account_is_closed WHERE ' . $this->SQL . ' LIMIT 1');
+		$this->db->write('INSERT INTO account_has_closing_history
 						(account_id, time, admin_id, action)
 						VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ', ' . $this->db->escapeNumber($adminID) . ', ' . $this->db->escapeString('Opened') . ')');
-		$this->db->query('UPDATE player SET last_turn_update = GREATEST(' . $this->db->escapeNumber(Smr\Epoch::time()) . ', last_turn_update) WHERE ' . $this->SQL);
+		$this->db->write('UPDATE player SET last_turn_update = GREATEST(' . $this->db->escapeNumber(Smr\Epoch::time()) . ', last_turn_update) WHERE ' . $this->SQL);
 		if ($admin !== null) {
 			$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account reopened by ' . $admin->getLogin() . '.');
 		} else {
 			$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account automatically reopened.');
 		}
 		if ($currException !== null) {
-			$this->db->query('REPLACE INTO account_exceptions (account_id, reason)
+			$this->db->write('REPLACE INTO account_exceptions (account_id, reason)
 							VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeString($currException) . ')');
 		}
 	}

--- a/src/lib/Default/AbstractSmrAccount.class.php
+++ b/src/lib/Default/AbstractSmrAccount.class.php
@@ -388,7 +388,7 @@ abstract class AbstractSmrAccount {
 			$this->HOF = array();
 			foreach ($dbResult->records() as $dbRecord) {
 				$hof =& $this->HOF;
-				$typeList = explode(':', $dbRecord->getField('type'));
+				$typeList = explode(':', $dbRecord->getString('type'));
 				foreach ($typeList as $type) {
 					if (!isset($hof[$type])) {
 						$hof[$type] = array();

--- a/src/lib/Default/AbstractSmrLocation.class.php
+++ b/src/lib/Default/AbstractSmrLocation.class.php
@@ -44,18 +44,14 @@ class AbstractSmrLocation {
 
 	public static function getGalaxyLocations(int $gameID, int $galaxyID, bool $forceUpdate = false) : array {
 		$db = Smr\Database::getInstance();
-		$dbResult = $db->read('SELECT location_type.*, sector_id FROM sector LEFT JOIN location USING(game_id, sector_id) LEFT JOIN location_type USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT location_type.*, sector_id FROM location LEFT JOIN sector USING(game_id, sector_id) LEFT JOIN location_type USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
 		$galaxyLocations = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$sectorID = $dbRecord->getInt('sector_id');
-			if (!$dbRecord->hasField('location_type_id')) {
-				self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] = [];
-			} else {
-				$locationTypeID = $dbRecord->getInt('location_type_id');
-				$location = self::getLocation($locationTypeID, $forceUpdate, $dbRecord);
-				self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID][$locationTypeID] = $location;
-				$galaxyLocations[$sectorID][$locationTypeID] = $location;
-			}
+			$locationTypeID = $dbRecord->getInt('location_type_id');
+			$location = self::getLocation($locationTypeID, $forceUpdate, $dbRecord);
+			self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID][$locationTypeID] = $location;
+			$galaxyLocations[$sectorID][$locationTypeID] = $location;
 		}
 		return $galaxyLocations;
 	}
@@ -63,7 +59,7 @@ class AbstractSmrLocation {
 	public static function getSectorLocations(int $gameID, int $sectorID, bool $forceUpdate = false) : array {
 		if ($forceUpdate || !isset(self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID])) {
 			$db = Smr\Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM location JOIN location_type USING (location_type_id) WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID));
+			$dbResult = $db->read('SELECT * FROM location LEFT JOIN location_type USING (location_type_id) WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID));
 			$locations = array();
 			foreach ($dbResult->records() as $dbRecord) {
 				$locationTypeID = $dbRecord->getInt('location_type_id');

--- a/src/lib/Default/AbstractSmrLocation.class.php
+++ b/src/lib/Default/AbstractSmrLocation.class.php
@@ -31,11 +31,11 @@ class AbstractSmrLocation {
 	public static function getAllLocations(bool $forceUpdate = false) : array {
 		if ($forceUpdate || !isset(self::$CACHE_ALL_LOCATIONS)) {
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT * FROM location_type ORDER BY location_type_id');
+			$dbResult = $db->read('SELECT * FROM location_type ORDER BY location_type_id');
 			$locations = array();
-			while ($db->nextRecord()) {
-				$locationTypeID = $db->getInt('location_type_id');
-				$locations[$locationTypeID] = SmrLocation::getLocation($locationTypeID, $forceUpdate, $db);
+			foreach ($dbResult->records() as $dbRecord) {
+				$locationTypeID = $dbRecord->getInt('location_type_id');
+				$locations[$locationTypeID] = SmrLocation::getLocation($locationTypeID, $forceUpdate, $dbRecord);
 			}
 			self::$CACHE_ALL_LOCATIONS = $locations;
 		}
@@ -44,15 +44,15 @@ class AbstractSmrLocation {
 
 	public static function getGalaxyLocations(int $gameID, int $galaxyID, bool $forceUpdate = false) : array {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT location_type.*, sector_id FROM sector LEFT JOIN location USING(game_id, sector_id) LEFT JOIN location_type USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT location_type.*, sector_id FROM sector LEFT JOIN location USING(game_id, sector_id) LEFT JOIN location_type USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
 		$galaxyLocations = [];
-		while ($db->nextRecord()) {
-			$sectorID = $db->getInt('sector_id');
-			if (!$db->hasField('location_type_id')) {
+		foreach ($dbResult->records() as $dbRecord) {
+			$sectorID = $dbRecord->getInt('sector_id');
+			if (!$dbRecord->hasField('location_type_id')) {
 				self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] = [];
 			} else {
-				$locationTypeID = $db->getInt('location_type_id');
-				$location = self::getLocation($locationTypeID, $forceUpdate, $db);
+				$locationTypeID = $dbRecord->getInt('location_type_id');
+				$location = self::getLocation($locationTypeID, $forceUpdate, $dbRecord);
 				self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID][$locationTypeID] = $location;
 				$galaxyLocations[$sectorID][$locationTypeID] = $location;
 			}
@@ -63,11 +63,11 @@ class AbstractSmrLocation {
 	public static function getSectorLocations(int $gameID, int $sectorID, bool $forceUpdate = false) : array {
 		if ($forceUpdate || !isset(self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID])) {
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT * FROM location JOIN location_type USING (location_type_id) WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID));
+			$dbResult = $db->read('SELECT * FROM location JOIN location_type USING (location_type_id) WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID));
 			$locations = array();
-			while ($db->nextRecord()) {
-				$locationTypeID = $db->getInt('location_type_id');
-				$locations[$locationTypeID] = self::getLocation($locationTypeID, $forceUpdate, $db);
+			foreach ($dbResult->records() as $dbRecord) {
+				$locationTypeID = $dbRecord->getInt('location_type_id');
+				$locations[$locationTypeID] = self::getLocation($locationTypeID, $forceUpdate, $dbRecord);
 			}
 			self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] = $locations;
 		}
@@ -77,41 +77,41 @@ class AbstractSmrLocation {
 	public static function addSectorLocation(int $gameID, int $sectorID, SmrLocation $location) : void {
 		self::getSectorLocations($gameID, $sectorID); // make sure cache is populated
 		$db = Smr\Database::getInstance();
-		$db->query('INSERT INTO location (game_id, sector_id, location_type_id)
+		$db->write('INSERT INTO location (game_id, sector_id, location_type_id)
 						values(' . $db->escapeNumber($gameID) . ',' . $db->escapeNumber($sectorID) . ',' . $db->escapeNumber($location->getTypeID()) . ')');
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID][$location->getTypeID()] = $location;
 	}
 
 	public static function removeSectorLocations(int $gameID, int $sectorID) : void {
 		$db = Smr\Database::getInstance();
-		$db->query('DELETE FROM location WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND sector_id = ' . $db->escapeNumber($sectorID));
+		$db->write('DELETE FROM location WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND sector_id = ' . $db->escapeNumber($sectorID));
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] = [];
 	}
 
-	public static function getLocation(int $locationTypeID, bool $forceUpdate = false, Smr\Database $db = null) : SmrLocation {
+	public static function getLocation(int $locationTypeID, bool $forceUpdate = false, Smr\DatabaseRecord $dbRecord = null) : SmrLocation {
 		if ($forceUpdate || !isset(self::$CACHE_LOCATIONS[$locationTypeID])) {
-			self::$CACHE_LOCATIONS[$locationTypeID] = new SmrLocation($locationTypeID, $db);
+			self::$CACHE_LOCATIONS[$locationTypeID] = new SmrLocation($locationTypeID, $dbRecord);
 		}
 		return self::$CACHE_LOCATIONS[$locationTypeID];
 	}
 
-	protected function __construct(int $locationTypeID, ?Smr\Database $db = null) {
+	protected function __construct(int $locationTypeID, Smr\DatabaseRecord $dbRecord = null) {
 		$this->db = Smr\Database::getInstance();
 		$this->SQL = 'location_type_id = ' . $this->db->escapeNumber($locationTypeID);
 
-		if (isset($db)) {
-			$locationExists = true;
-		} else {
-			$db = $this->db;
-			$db->query('SELECT * FROM location_type WHERE ' . $this->SQL . ' LIMIT 1');
-			$locationExists = $db->nextRecord();
+		if ($dbRecord === null) {
+			$dbResult = $this->db->read('SELECT * FROM location_type WHERE ' . $this->SQL . ' LIMIT 1');
+			if ($dbResult->hasRecord()) {
+				$dbRecord = $dbResult->record();
+			}
 		}
+		$locationExists = $dbRecord !== null;
 
 		if ($locationExists) {
-			$this->typeID = $db->getInt('location_type_id');
-			$this->name = $db->getField('location_name');
-			$this->processor = $db->getField('location_processor');
-			$this->image = $db->getField('location_image');
+			$this->typeID = $dbRecord->getInt('location_type_id');
+			$this->name = $dbRecord->getField('location_name');
+			$this->processor = $dbRecord->getField('location_processor');
+			$this->image = $dbRecord->getField('location_image');
 		} else {
 			throw new Exception('Cannot find location: ' . $locationTypeID);
 		}
@@ -141,7 +141,7 @@ class AbstractSmrLocation {
 			return;
 		}
 		$this->name = $name;
-		$this->db->query('UPDATE location_type SET location_name=' . $this->db->escapeString($this->name) . ' WHERE ' . $this->SQL . ' LIMIT 1');
+		$this->db->write('UPDATE location_type SET location_name=' . $this->db->escapeString($this->name) . ' WHERE ' . $this->SQL . ' LIMIT 1');
 	}
 
 	public function hasAction() : bool {
@@ -158,8 +158,8 @@ class AbstractSmrLocation {
 
 	public function isFed() : bool {
 		if (!isset($this->fed)) {
-			$this->db->query('SELECT * FROM location_is_fed WHERE ' . $this->SQL . ' LIMIT 1');
-			$this->fed = $this->db->nextRecord();
+			$dbResult = $this->db->read('SELECT 1 FROM location_is_fed WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->fed = $dbResult->hasRecord();
 		}
 		return $this->fed;
 	}
@@ -169,17 +169,17 @@ class AbstractSmrLocation {
 			return;
 		}
 		if ($bool) {
-			$this->db->query('INSERT IGNORE INTO location_is_fed (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
+			$this->db->write('INSERT IGNORE INTO location_is_fed (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 		} else {
-			$this->db->query('DELETE FROM location_is_fed WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('DELETE FROM location_is_fed WHERE ' . $this->SQL . ' LIMIT 1');
 		}
 		$this->fed = $bool;
 	}
 
 	public function isBank() : bool {
 		if (!isset($this->bank)) {
-			$this->db->query('SELECT * FROM location_is_bank WHERE ' . $this->SQL . ' LIMIT 1');
-			$this->bank = $this->db->nextRecord();
+			$dbResult = $this->db->read('SELECT 1 FROM location_is_bank WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->bank = $dbResult->hasRecord();
 		}
 		return $this->bank;
 	}
@@ -189,17 +189,17 @@ class AbstractSmrLocation {
 			return;
 		}
 		if ($bool) {
-			$this->db->query('INSERT INTO location_is_bank (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
+			$this->db->write('INSERT INTO location_is_bank (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 		} else {
-			$this->db->query('DELETE FROM location_is_bank WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('DELETE FROM location_is_bank WHERE ' . $this->SQL . ' LIMIT 1');
 		}
 		$this->bank = $bool;
 	}
 
 	public function isBar() : bool {
 		if (!isset($this->bar)) {
-			$this->db->query('SELECT * FROM location_is_bar WHERE ' . $this->SQL . ' LIMIT 1');
-			$this->bar = $this->db->nextRecord();
+			$dbResult = $this->db->read('SELECT 1 FROM location_is_bar WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->bar = $dbResult->hasRecord();
 		}
 		return $this->bar;
 	}
@@ -209,17 +209,17 @@ class AbstractSmrLocation {
 			return;
 		}
 		if ($bool) {
-			$this->db->query('INSERT IGNORE INTO location_is_bar (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
+			$this->db->write('INSERT IGNORE INTO location_is_bar (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 		} else {
-			$this->db->query('DELETE FROM location_is_bar WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('DELETE FROM location_is_bar WHERE ' . $this->SQL . ' LIMIT 1');
 		}
 		$this->bar = $bool;
 	}
 
 	public function isHQ() : bool {
 		if (!isset($this->HQ)) {
-			$this->db->query('SELECT * FROM location_is_hq WHERE ' . $this->SQL . ' LIMIT 1');
-			$this->HQ = $this->db->nextRecord();
+			$dbResult = $this->db->read('SELECT * FROM location_is_hq WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->HQ = $dbResult->hasRecord();
 		}
 		return $this->HQ;
 	}
@@ -229,17 +229,17 @@ class AbstractSmrLocation {
 			return;
 		}
 		if ($bool) {
-			$this->db->query('INSERT IGNORE INTO location_is_hq (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
+			$this->db->write('INSERT IGNORE INTO location_is_hq (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 		} else {
-			$this->db->query('DELETE FROM location_is_hq WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('DELETE FROM location_is_hq WHERE ' . $this->SQL . ' LIMIT 1');
 		}
 		$this->HQ = $bool;
 	}
 
 	public function isUG() : bool {
 		if (!isset($this->UG)) {
-			$this->db->query('SELECT * FROM location_is_ug WHERE ' . $this->SQL . ' LIMIT 1');
-			$this->UG = $this->db->nextRecord();
+			$dbResult = $this->db->read('SELECT * FROM location_is_ug WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->UG = $dbResult->hasRecord();
 		}
 		return $this->UG;
 	}
@@ -249,9 +249,9 @@ class AbstractSmrLocation {
 			return;
 		}
 		if ($bool) {
-			$this->db->query('INSERT INTO location_is_ug (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
+			$this->db->write('INSERT INTO location_is_ug (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
 		} else {
-			$this->db->query('DELETE FROM location_is_ug WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->db->write('DELETE FROM location_is_ug WHERE ' . $this->SQL . ' LIMIT 1');
 		}
 		$this->UG = $bool;
 	}
@@ -259,9 +259,9 @@ class AbstractSmrLocation {
 	public function getHardwareSold() : array {
 		if (!isset($this->hardwareSold)) {
 			$this->hardwareSold = array();
-			$this->db->query('SELECT hardware_type_id FROM location_sells_hardware WHERE ' . $this->SQL);
-			while ($this->db->nextRecord()) {
-				$this->hardwareSold[$this->db->getInt('hardware_type_id')] = Globals::getHardwareTypes($this->db->getInt('hardware_type_id'));
+			$dbResult = $this->db->read('SELECT hardware_type_id FROM location_sells_hardware WHERE ' . $this->SQL);
+			foreach ($dbResult->records() as $dbRecord) {
+				$this->hardwareSold[$dbRecord->getInt('hardware_type_id')] = Globals::getHardwareTypes($dbRecord->getInt('hardware_type_id'));
 			}
 		}
 		return $this->hardwareSold;
@@ -279,29 +279,29 @@ class AbstractSmrLocation {
 		if ($this->isHardwareSold($hardwareTypeID)) {
 			return;
 		}
-		$this->db->query('SELECT * FROM hardware_type WHERE hardware_type_id = ' . $this->db->escapeNumber($hardwareTypeID) . ' LIMIT 1');
-		if (!$this->db->nextRecord()) {
+		$dbResult = $this->db->read('SELECT 1 FROM hardware_type WHERE hardware_type_id = ' . $this->db->escapeNumber($hardwareTypeID) . ' LIMIT 1');
+		if (!$dbResult->hasRecord()) {
 			throw new Exception('Invalid hardware type id given');
 		}
-		$this->db->query('INSERT INTO location_sells_hardware (location_type_id,hardware_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($hardwareTypeID) . ')');
-		$this->hardwareSold[$hardwareTypeID] = $this->db->getField('hardware_name');
+		$this->db->write('INSERT INTO location_sells_hardware (location_type_id,hardware_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($hardwareTypeID) . ')');
+		$this->hardwareSold[$hardwareTypeID] = Globals::getHardwareTypes($hardwareTypeID);
 	}
 
 	public function removeHardwareSold(int $hardwareTypeID) : void {
 		if (!$this->isHardwareSold($hardwareTypeID)) {
 			return;
 		}
-		$this->db->query('DELETE FROM location_sells_hardware WHERE ' . $this->SQL . ' AND hardware_type_id = ' . $this->db->escapeNumber($hardwareTypeID) . ' LIMIT 1');
+		$this->db->write('DELETE FROM location_sells_hardware WHERE ' . $this->SQL . ' AND hardware_type_id = ' . $this->db->escapeNumber($hardwareTypeID) . ' LIMIT 1');
 		unset($this->hardwareSold[$hardwareTypeID]);
 	}
 
 	public function getShipsSold() : array {
 		if (!isset($this->shipsSold)) {
 			$this->shipsSold = array();
-			$this->db->query('SELECT * FROM location_sells_ships JOIN ship_type USING (ship_type_id) WHERE ' . $this->SQL);
-			while ($this->db->nextRecord()) {
-				$shipTypeID = $this->db->getInt('ship_type_id');
-				$this->shipsSold[$shipTypeID] = SmrShipType::get($shipTypeID, $this->db);
+			$dbResult = $this->db->read('SELECT * FROM location_sells_ships JOIN ship_type USING (ship_type_id) WHERE ' . $this->SQL);
+			foreach ($dbResult->records() as $dbRecord) {
+				$shipTypeID = $dbRecord->getInt('ship_type_id');
+				$this->shipsSold[$shipTypeID] = SmrShipType::get($shipTypeID, $dbRecord);
 			}
 		}
 		return $this->shipsSold;
@@ -320,7 +320,7 @@ class AbstractSmrLocation {
 			return;
 		}
 		$ship = SmrShipType::get($shipTypeID);
-		$this->db->query('INSERT INTO location_sells_ships (location_type_id,ship_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($shipTypeID) . ')');
+		$this->db->write('INSERT INTO location_sells_ships (location_type_id,ship_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($shipTypeID) . ')');
 		$this->shipsSold[$shipTypeID] = $ship;
 	}
 
@@ -328,17 +328,17 @@ class AbstractSmrLocation {
 		if (!$this->isShipSold($shipTypeID)) {
 			return;
 		}
-		$this->db->query('DELETE FROM location_sells_ships WHERE ' . $this->SQL . ' AND ship_type_id = ' . $this->db->escapeNumber($shipTypeID) . ' LIMIT 1');
+		$this->db->write('DELETE FROM location_sells_ships WHERE ' . $this->SQL . ' AND ship_type_id = ' . $this->db->escapeNumber($shipTypeID) . ' LIMIT 1');
 		unset($this->shipsSold[$shipTypeID]);
 	}
 
 	public function getWeaponsSold() : array {
 		if (!isset($this->weaponsSold)) {
 			$this->weaponsSold = array();
-			$this->db->query('SELECT * FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) WHERE ' . $this->SQL);
-			while ($this->db->nextRecord()) {
-				$weaponTypeID = $this->db->getInt('weapon_type_id');
-				$this->weaponsSold[$weaponTypeID] = SmrWeapon::getWeapon($weaponTypeID, $this->db);
+			$dbResult = $this->db->read('SELECT * FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) WHERE ' . $this->SQL);
+			foreach ($dbResult->records() as $dbRecord) {
+				$weaponTypeID = $dbRecord->getInt('weapon_type_id');
+				$this->weaponsSold[$weaponTypeID] = SmrWeapon::getWeapon($weaponTypeID, $dbRecord);
 			}
 		}
 		return $this->weaponsSold;
@@ -357,7 +357,7 @@ class AbstractSmrLocation {
 			return;
 		}
 		$weapon = SmrWeapon::getWeapon($weaponTypeID);
-		$this->db->query('INSERT INTO location_sells_weapons (location_type_id,weapon_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($weaponTypeID) . ')');
+		$this->db->write('INSERT INTO location_sells_weapons (location_type_id,weapon_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($weaponTypeID) . ')');
 		$this->weaponsSold[$weaponTypeID] = $weapon;
 	}
 
@@ -365,7 +365,7 @@ class AbstractSmrLocation {
 		if (!$this->isWeaponSold($weaponTypeID)) {
 			return;
 		}
-		$this->db->query('DELETE FROM location_sells_weapons WHERE ' . $this->SQL . ' AND weapon_type_id = ' . $this->db->escapeNumber($weaponTypeID) . ' LIMIT 1');
+		$this->db->write('DELETE FROM location_sells_weapons WHERE ' . $this->SQL . ' AND weapon_type_id = ' . $this->db->escapeNumber($weaponTypeID) . ' LIMIT 1');
 		unset($this->weaponsSold[$weaponTypeID]);
 	}
 

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -129,18 +129,14 @@ abstract class AbstractSmrPlayer {
 	 */
 	public static function getGalaxyPlayers(int $gameID, int $galaxyID, bool $forceUpdate = false) : array {
 		$db = Smr\Database::getInstance();
-		$dbResult = $db->read('SELECT player.*, sector_id FROM sector LEFT JOIN player USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(false) . ' AND (last_cpl_action > ' . $db->escapeNumber(Smr\Epoch::time() - TIME_BEFORE_INACTIVE) . ' OR newbie_turns = 0) AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT player.* FROM player LEFT JOIN sector USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(false) . ' AND (last_cpl_action > ' . $db->escapeNumber(Smr\Epoch::time() - TIME_BEFORE_INACTIVE) . ' OR newbie_turns = 0) AND galaxy_id = ' . $db->escapeNumber($galaxyID));
 		$galaxyPlayers = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$sectorID = $dbRecord->getInt('sector_id');
-			if (!$dbRecord->hasField('account_id')) {
-				self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] = [];
-			} else {
-				$accountID = $dbRecord->getInt('account_id');
-				$player = self::getPlayer($accountID, $gameID, $forceUpdate, $dbRecord);
-				self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID][$accountID] = $player;
-				$galaxyPlayers[$sectorID][$accountID] = $player;
-			}
+			$accountID = $dbRecord->getInt('account_id');
+			$player = self::getPlayer($accountID, $gameID, $forceUpdate, $dbRecord);
+			self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID][$accountID] = $player;
+			$galaxyPlayers[$sectorID][$accountID] = $player;
 		}
 		return $galaxyPlayers;
 	}

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -76,7 +76,7 @@ abstract class AbstractSmrPlayer {
 	protected array $canFed;
 	protected bool $underAttack;
 
-	protected array $visitedSectors;
+	protected array $unvisitedSectors;
 	protected array $allianceRoles = array(
 		0 => 0
 	);
@@ -129,15 +129,15 @@ abstract class AbstractSmrPlayer {
 	 */
 	public static function getGalaxyPlayers(int $gameID, int $galaxyID, bool $forceUpdate = false) : array {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT player.*, sector_id FROM sector LEFT JOIN player USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(false) . ' AND (last_cpl_action > ' . $db->escapeNumber(Smr\Epoch::time() - TIME_BEFORE_INACTIVE) . ' OR newbie_turns = 0) AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT player.*, sector_id FROM sector LEFT JOIN player USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(false) . ' AND (last_cpl_action > ' . $db->escapeNumber(Smr\Epoch::time() - TIME_BEFORE_INACTIVE) . ' OR newbie_turns = 0) AND galaxy_id = ' . $db->escapeNumber($galaxyID));
 		$galaxyPlayers = [];
-		while ($db->nextRecord()) {
-			$sectorID = $db->getInt('sector_id');
-			if (!$db->hasField('account_id')) {
+		foreach ($dbResult->records() as $dbRecord) {
+			$sectorID = $dbRecord->getInt('sector_id');
+			if (!$dbRecord->hasField('account_id')) {
 				self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] = [];
 			} else {
-				$accountID = $db->getInt('account_id');
-				$player = self::getPlayer($accountID, $gameID, $forceUpdate, $db);
+				$accountID = $dbRecord->getInt('account_id');
+				$player = self::getPlayer($accountID, $gameID, $forceUpdate, $dbRecord);
 				self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID][$accountID] = $player;
 				$galaxyPlayers[$sectorID][$accountID] = $player;
 			}
@@ -148,11 +148,11 @@ abstract class AbstractSmrPlayer {
 	public static function getSectorPlayers(int $gameID, int $sectorID, bool $forceUpdate = false) : array {
 		if ($forceUpdate || !isset(self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID])) {
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT * FROM player WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(false) . ' AND (last_cpl_action > ' . $db->escapeNumber(Smr\Epoch::time() - TIME_BEFORE_INACTIVE) . ' OR newbie_turns = 0) AND account_id NOT IN (' . $db->escapeArray(Globals::getHiddenPlayers()) . ') ORDER BY last_cpl_action DESC');
+			$dbResult = $db->read('SELECT * FROM player WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(false) . ' AND (last_cpl_action > ' . $db->escapeNumber(Smr\Epoch::time() - TIME_BEFORE_INACTIVE) . ' OR newbie_turns = 0) AND account_id NOT IN (' . $db->escapeArray(Globals::getHiddenPlayers()) . ') ORDER BY last_cpl_action DESC');
 			$players = array();
-			while ($db->nextRecord()) {
-				$accountID = $db->getInt('account_id');
-				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $db);
+			foreach ($dbResult->records() as $dbRecord) {
+				$accountID = $dbRecord->getInt('account_id');
+				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $dbRecord);
 			}
 			self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] = $players;
 		}
@@ -162,11 +162,11 @@ abstract class AbstractSmrPlayer {
 	public static function getPlanetPlayers(int $gameID, int $sectorID, bool $forceUpdate = false) : array {
 		if ($forceUpdate || !isset(self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID])) {
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT * FROM player WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(true) . ' AND account_id NOT IN (' . $db->escapeArray(Globals::getHiddenPlayers()) . ') ORDER BY last_cpl_action DESC');
+			$dbResult = $db->read('SELECT * FROM player WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(true) . ' AND account_id NOT IN (' . $db->escapeArray(Globals::getHiddenPlayers()) . ') ORDER BY last_cpl_action DESC');
 			$players = array();
-			while ($db->nextRecord()) {
-				$accountID = $db->getInt('account_id');
-				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $db);
+			foreach ($dbResult->records() as $dbRecord) {
+				$accountID = $dbRecord->getInt('account_id');
+				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $dbRecord);
 			}
 			self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID] = $players;
 		}
@@ -176,99 +176,99 @@ abstract class AbstractSmrPlayer {
 	public static function getAlliancePlayers(int $gameID, int $allianceID, bool $forceUpdate = false) : array {
 		if ($forceUpdate || !isset(self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID])) {
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT * FROM player WHERE alliance_id = ' . $db->escapeNumber($allianceID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' ORDER BY experience DESC');
+			$dbResult = $db->read('SELECT * FROM player WHERE alliance_id = ' . $db->escapeNumber($allianceID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' ORDER BY experience DESC');
 			$players = array();
-			while ($db->nextRecord()) {
-				$accountID = $db->getInt('account_id');
-				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $db);
+			foreach ($dbResult->records() as $dbRecord) {
+				$accountID = $dbRecord->getInt('account_id');
+				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $dbRecord);
 			}
 			self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID] = $players;
 		}
 		return self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID];
 	}
 
-	public static function getPlayer(int $accountID, int $gameID, bool $forceUpdate = false, Smr\Database $db = null) : self {
+	public static function getPlayer(int $accountID, int $gameID, bool $forceUpdate = false, Smr\DatabaseRecord $dbRecord = null) : self {
 		if ($forceUpdate || !isset(self::$CACHE_PLAYERS[$gameID][$accountID])) {
-			self::$CACHE_PLAYERS[$gameID][$accountID] = new SmrPlayer($gameID, $accountID, $db);
+			self::$CACHE_PLAYERS[$gameID][$accountID] = new SmrPlayer($gameID, $accountID, $dbRecord);
 		}
 		return self::$CACHE_PLAYERS[$gameID][$accountID];
 	}
 
 	public static function getPlayerByPlayerID(int $playerID, int $gameID, bool $forceUpdate = false) : self {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND player_id = ' . $db->escapeNumber($playerID) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getPlayer($db->getInt('account_id'), $gameID, $forceUpdate, $db);
+		$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND player_id = ' . $db->escapeNumber($playerID) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			return self::getPlayer($dbRecord->getInt('account_id'), $gameID, $forceUpdate, $dbRecord);
 		}
 		throw new PlayerNotFoundException('Player ID not found.');
 	}
 
 	public static function getPlayerByPlayerName(string $playerName, int $gameID, bool $forceUpdate = false) : self {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND player_name = ' . $db->escapeString($playerName) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getPlayer($db->getInt('account_id'), $gameID, $forceUpdate, $db);
+		$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND player_name = ' . $db->escapeString($playerName) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			return self::getPlayer($dbRecord->getInt('account_id'), $gameID, $forceUpdate, $dbRecord);
 		}
 		throw new PlayerNotFoundException('Player Name not found.');
 	}
 
-	protected function __construct(int $gameID, int $accountID, Smr\Database $db = null) {
+	protected function __construct(int $gameID, int $accountID, Smr\DatabaseRecord $dbRecord = null) {
 		$this->db = Smr\Database::getInstance();
 		$this->SQL = 'account_id = ' . $this->db->escapeNumber($accountID) . ' AND game_id = ' . $this->db->escapeNumber($gameID);
 
-		if (isset($db)) {
-			$playerExists = true;
-		} else {
-			$db = $this->db;
-			$this->db->query('SELECT * FROM player WHERE ' . $this->SQL . ' LIMIT 1');
-			$playerExists = $db->nextRecord();
+		if ($dbRecord === null) {
+			$dbResult = $this->db->read('SELECT * FROM player WHERE ' . $this->SQL . ' LIMIT 1');
+			if ($dbResult->hasRecord()) {
+				$dbRecord = $dbResult->record();
+			}
 		}
-
-		if ($playerExists) {
-			$this->accountID = (int)$accountID;
-			$this->gameID = (int)$gameID;
-			$this->playerName = $db->getField('player_name');
-			$this->playerID = $db->getInt('player_id');
-			$this->sectorID = $db->getInt('sector_id');
-			$this->lastSectorID = $db->getInt('last_sector_id');
-			$this->turns = $db->getInt('turns');
-			$this->lastTurnUpdate = $db->getInt('last_turn_update');
-			$this->newbieTurns = $db->getInt('newbie_turns');
-			$this->lastNewsUpdate = $db->getInt('last_news_update');
-			$this->attackColour = $db->getField('attack_warning');
-			$this->dead = $db->getBoolean('dead');
-			$this->npc = $db->getBoolean('npc');
-			$this->newbieStatus = $db->getBoolean('newbie_status');
-			$this->landedOnPlanet = $db->getBoolean('land_on_planet');
-			$this->lastActive = $db->getInt('last_active');
-			$this->lastCPLAction = $db->getInt('last_cpl_action');
-			$this->raceID = $db->getInt('race_id');
-			$this->credits = $db->getInt('credits');
-			$this->experience = $db->getInt('experience');
-			$this->alignment = $db->getInt('alignment');
-			$this->militaryPayment = $db->getInt('military_payment');
-			$this->allianceID = $db->getInt('alliance_id');
-			$this->allianceJoinable = $db->getInt('alliance_join');
-			$this->shipID = $db->getInt('ship_type_id');
-			$this->kills = $db->getInt('kills');
-			$this->deaths = $db->getInt('deaths');
-			$this->assists = $db->getInt('assists');
-			$this->lastPort = $db->getInt('last_port');
-			$this->bank = $db->getInt('bank');
-			$this->zoom = $db->getInt('zoom');
-			$this->displayMissions = $db->getBoolean('display_missions');
-			$this->displayWeapons = $db->getBoolean('display_weapons');
-			$this->forceDropMessages = $db->getBoolean('force_drop_messages');
-			$this->groupScoutMessages = $db->getField('group_scout_messages');
-			$this->ignoreGlobals = $db->getBoolean('ignore_globals');
-			$this->newbieWarning = $db->getBoolean('newbie_warning');
-			$this->nameChanged = $db->getBoolean('name_changed');
-			$this->raceChanged = $db->getBoolean('race_changed');
-			$this->combatDronesKamikazeOnMines = $db->getBoolean('combat_drones_kamikaze_on_mines');
-			$this->underAttack = $db->getBoolean('under_attack');
-		} else {
+		if ($dbRecord === null) {
 			throw new PlayerNotFoundException('Invalid accountID: ' . $accountID . ' OR gameID:' . $gameID);
 		}
+
+		$this->accountID = $accountID;
+		$this->gameID = $gameID;
+		$this->playerName = $dbRecord->getField('player_name');
+		$this->playerID = $dbRecord->getInt('player_id');
+		$this->sectorID = $dbRecord->getInt('sector_id');
+		$this->lastSectorID = $dbRecord->getInt('last_sector_id');
+		$this->turns = $dbRecord->getInt('turns');
+		$this->lastTurnUpdate = $dbRecord->getInt('last_turn_update');
+		$this->newbieTurns = $dbRecord->getInt('newbie_turns');
+		$this->lastNewsUpdate = $dbRecord->getInt('last_news_update');
+		$this->attackColour = $dbRecord->getField('attack_warning');
+		$this->dead = $dbRecord->getBoolean('dead');
+		$this->npc = $dbRecord->getBoolean('npc');
+		$this->newbieStatus = $dbRecord->getBoolean('newbie_status');
+		$this->landedOnPlanet = $dbRecord->getBoolean('land_on_planet');
+		$this->lastActive = $dbRecord->getInt('last_active');
+		$this->lastCPLAction = $dbRecord->getInt('last_cpl_action');
+		$this->raceID = $dbRecord->getInt('race_id');
+		$this->credits = $dbRecord->getInt('credits');
+		$this->experience = $dbRecord->getInt('experience');
+		$this->alignment = $dbRecord->getInt('alignment');
+		$this->militaryPayment = $dbRecord->getInt('military_payment');
+		$this->allianceID = $dbRecord->getInt('alliance_id');
+		$this->allianceJoinable = $dbRecord->getInt('alliance_join');
+		$this->shipID = $dbRecord->getInt('ship_type_id');
+		$this->kills = $dbRecord->getInt('kills');
+		$this->deaths = $dbRecord->getInt('deaths');
+		$this->assists = $dbRecord->getInt('assists');
+		$this->lastPort = $dbRecord->getInt('last_port');
+		$this->bank = $dbRecord->getInt('bank');
+		$this->zoom = $dbRecord->getInt('zoom');
+		$this->displayMissions = $dbRecord->getBoolean('display_missions');
+		$this->displayWeapons = $dbRecord->getBoolean('display_weapons');
+		$this->forceDropMessages = $dbRecord->getBoolean('force_drop_messages');
+		$this->groupScoutMessages = $dbRecord->getField('group_scout_messages');
+		$this->ignoreGlobals = $dbRecord->getBoolean('ignore_globals');
+		$this->newbieWarning = $dbRecord->getBoolean('newbie_warning');
+		$this->nameChanged = $dbRecord->getBoolean('name_changed');
+		$this->raceChanged = $dbRecord->getBoolean('race_changed');
+		$this->combatDronesKamikazeOnMines = $dbRecord->getBoolean('combat_drones_kamikaze_on_mines');
+		$this->underAttack = $dbRecord->getBoolean('under_attack');
 	}
 
 	/**
@@ -289,15 +289,15 @@ abstract class AbstractSmrPlayer {
 		}
 
 		// get last registered player id in that game and increase by one.
-		$db->query('SELECT MAX(player_id) FROM player WHERE game_id = ' . $db->escapeNumber($gameID));
-		if ($db->nextRecord()) {
-			$playerID = $db->getInt('MAX(player_id)') + 1;
+		$dbResult = $db->read('SELECT MAX(player_id) FROM player WHERE game_id = ' . $db->escapeNumber($gameID));
+		if ($dbResult->hasRecord()) {
+			$playerID = $dbResult->record()->getInt('MAX(player_id)') + 1;
 		} else {
 			$playerID = 1;
 		}
 
 		$startSectorID = 0; // Temporarily put player into non-existent sector
-		$db->query('INSERT INTO player (account_id, game_id, player_id, player_name, race_id, sector_id, last_cpl_action, last_active, npc, newbie_status)
+		$db->write('INSERT INTO player (account_id, game_id, player_id, player_name, race_id, sector_id, last_cpl_action, last_active, npc, newbie_status)
 					VALUES(' . $db->escapeNumber($accountID) . ', ' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber($playerID) . ', ' . $db->escapeString($playerName) . ', ' . $db->escapeNumber($raceID) . ', ' . $db->escapeNumber($startSectorID) . ', ' . $db->escapeNumber($time) . ', ' . $db->escapeNumber($time) . ',' . $db->escapeBoolean($npc) . ',' . $db->escapeBoolean($isNewbie) . ')');
 
 		$db->unlock();
@@ -321,10 +321,10 @@ abstract class AbstractSmrPlayer {
 
 		// Get other players who are sharing info for this game.
 		// NOTE: game_id=0 means that player shares info for all games.
-		$this->db->query('SELECT from_account_id FROM account_shares_info WHERE to_account_id=' . $this->db->escapeNumber($this->getAccountID()) . ' AND (game_id=0 OR game_id=' . $this->db->escapeNumber($this->getGameID()) . ')');
-		while ($this->db->nextRecord()) {
+		$dbResult = $this->db->read('SELECT from_account_id FROM account_shares_info WHERE to_account_id=' . $this->db->escapeNumber($this->getAccountID()) . ' AND (game_id=0 OR game_id=' . $this->db->escapeNumber($this->getGameID()) . ')');
+		foreach ($dbResult->records() as $dbRecord) {
 			try {
-				$otherPlayer = SmrPlayer::getPlayer($this->db->getInt('from_account_id'),
+				$otherPlayer = SmrPlayer::getPlayer($dbRecord->getInt('from_account_id'),
 				                                    $this->getGameID(), $forceUpdate);
 			} catch (PlayerNotFoundException $e) {
 				// Skip players that have not joined this game
@@ -452,9 +452,9 @@ abstract class AbstractSmrPlayer {
 
 	public function getCustomShipName() : string|false {
 		if (!isset($this->customShipName)) {
-			$this->db->query('SELECT * FROM ship_has_name WHERE ' . $this->SQL . ' LIMIT 1');
-			if ($this->db->nextRecord()) {
-				$this->customShipName = $this->db->getField('ship_name');
+			$dbResult = $this->db->read('SELECT * FROM ship_has_name WHERE ' . $this->SQL . ' LIMIT 1');
+			if ($dbResult->hasRecord()) {
+				$this->customShipName = $dbResult->record()->getField('ship_name');
 			} else {
 				$this->customShipName = false;
 			}
@@ -463,7 +463,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setCustomShipName(string $name) : void {
-		$this->db->query('REPLACE INTO ship_has_name (game_id, account_id, ship_name)
+		$this->db->write('REPLACE INTO ship_has_name (game_id, account_id, ship_name)
 			VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeString($name) . ')');
 	}
 
@@ -472,9 +472,10 @@ abstract class AbstractSmrPlayer {
 	 * Returns false if this player does not own a planet.
 	 */
 	public function getPlanet() : SmrPlanet|false {
-		$this->db->query('SELECT * FROM planet WHERE game_id=' . $this->db->escapeNumber($this->getGameID()) . ' AND owner_id=' . $this->db->escapeNumber($this->getAccountID()));
-		if ($this->db->nextRecord()) {
-			return SmrPlanet::getPlanet($this->getGameID(), $this->db->getInt('sector_id'), false, $this->db);
+		$dbResult = $this->db->read('SELECT * FROM planet WHERE game_id=' . $this->db->escapeNumber($this->getGameID()) . ' AND owner_id=' . $this->db->escapeNumber($this->getAccountID()));
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			return SmrPlanet::getPlanet($this->getGameID(), $dbRecord->getInt('sector_id'), false, $dbRecord);
 		} else {
 			return false;
 		}
@@ -582,11 +583,8 @@ abstract class AbstractSmrPlayer {
 
 	public function isDraftLeader() : bool {
 		if (!isset($this->draftLeader)) {
-			$this->draftLeader = false;
-			$this->db->query('SELECT 1 FROM draft_leaders WHERE ' . $this->SQL . ' LIMIT 1');
-			if ($this->db->nextRecord()) {
-				$this->draftLeader = true;
-			}
+			$dbResult = $this->db->read('SELECT 1 FROM draft_leaders WHERE ' . $this->SQL . ' LIMIT 1');
+			$this->draftLeader = $dbResult->hasRecord();
 		}
 		return $this->draftLeader;
 	}
@@ -594,9 +592,9 @@ abstract class AbstractSmrPlayer {
 	public function getGPWriter() : string|false {
 		if (!isset($this->gpWriter)) {
 			$this->gpWriter = false;
-			$this->db->query('SELECT position FROM galactic_post_writer WHERE ' . $this->SQL);
-			if ($this->db->nextRecord()) {
-				$this->gpWriter = $this->db->getField('position');
+			$dbResult = $this->db->read('SELECT position FROM galactic_post_writer WHERE ' . $this->SQL);
+			if ($dbResult->hasRecord()) {
+				$this->gpWriter = $dbResult->record()->getField('position');
 			}
 		}
 		return $this->gpWriter;
@@ -645,7 +643,7 @@ abstract class AbstractSmrPlayer {
 		$message = trim($message);
 		$db = Smr\Database::getInstance();
 		// send him the message
-		$db->query('INSERT INTO message
+		$db->write('INSERT INTO message
 			(account_id,game_id,message_type_id,message_text,
 			sender_id,send_time,expire_time,sender_delete) VALUES(' .
 			$db->escapeNumber($receiverID) . ',' .
@@ -662,7 +660,7 @@ abstract class AbstractSmrPlayer {
 
 		if ($unread === true) {
 			// give him the message icon
-			$db->query('REPLACE INTO player_has_unread_messages (game_id, account_id, message_type_id) VALUES
+			$db->write('REPLACE INTO player_has_unread_messages (game_id, account_id, message_type_id) VALUES
 						(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber($receiverID) . ', ' . $db->escapeNumber($messageTypeID) . ')');
 		}
 
@@ -707,7 +705,7 @@ abstract class AbstractSmrPlayer {
 
 		// send to all online player
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT account_id
+		$dbResult = $db->read('SELECT account_id
 					FROM active_session
 					JOIN player USING (game_id, account_id)
 					WHERE active_session.last_accessed >= ' . $db->escapeNumber(Smr\Epoch::time() - Smr\Session::TIME_BEFORE_EXPIRY) . '
@@ -715,8 +713,8 @@ abstract class AbstractSmrPlayer {
 						AND ignore_globals = \'FALSE\'
 						AND account_id != ' . $db->escapeNumber($this->getAccountID()));
 
-		while ($db->nextRecord()) {
-			$this->sendMessage($db->getInt('account_id'), MSG_GLOBAL, $message, $canBeIgnored);
+		foreach ($dbResult->records() as $dbRecord) {
+			$this->sendMessage($dbRecord->getInt('account_id'), MSG_GLOBAL, $message, $canBeIgnored);
 		}
 		$this->sendMessage($this->getAccountID(), MSG_GLOBAL, $message, $canBeIgnored, false);
 	}
@@ -731,8 +729,8 @@ abstract class AbstractSmrPlayer {
 				create_error('You are currently banned from sending messages');
 			}
 			// Don't send messages to players ignoring us
-			$this->db->query('SELECT account_id FROM message_blacklist WHERE account_id=' . $this->db->escapeNumber($receiverID) . ' AND blacklisted_id=' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
-			if ($this->db->nextRecord()) {
+			$dbResult = $this->db->read('SELECT 1 FROM message_blacklist WHERE account_id=' . $this->db->escapeNumber($receiverID) . ' AND blacklisted_id=' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
+			if ($dbResult->hasRecord()) {
 				return false;
 			}
 		}
@@ -833,7 +831,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function setMessagesRead(int $messageTypeID) : void {
-		$this->db->query('DELETE FROM player_has_unread_messages
+		$this->db->write('DELETE FROM player_has_unread_messages
 							WHERE '.$this->SQL . ' AND message_type_id = ' . $this->db->escapeNumber($messageTypeID));
 	}
 
@@ -870,10 +868,10 @@ abstract class AbstractSmrPlayer {
 			foreach ($RACES as $raceID2 => $raceName) {
 				$this->canFed[$raceID2] = $this->getRelation($raceID2) >= ALIGN_FED_PROTECTION;
 			}
-			$this->db->query('SELECT race_id, allowed FROM player_can_fed
+			$dbResult = $this->db->read('SELECT race_id, allowed FROM player_can_fed
 								WHERE ' . $this->SQL . ' AND expiry > ' . $this->db->escapeNumber(Smr\Epoch::time()));
-			while ($this->db->nextRecord()) {
-				$this->canFed[$this->db->getInt('race_id')] = $this->db->getBoolean('allowed');
+			foreach ($dbResult->records() as $dbRecord) {
+				$this->canFed[$dbRecord->getInt('race_id')] = $dbRecord->getBoolean('allowed');
 			}
 		}
 		return $this->canFed[$raceID];
@@ -1313,7 +1311,7 @@ abstract class AbstractSmrPlayer {
 		$this->allianceID = $ID;
 		if ($this->allianceID != 0) {
 			$status = $this->hasNewbieStatus() ? 'NEWBIE' : 'VETERAN';
-			$this->db->query('INSERT IGNORE INTO player_joined_alliance (account_id,game_id,alliance_id,status) ' .
+			$this->db->write('INSERT IGNORE INTO player_joined_alliance (account_id,game_id,alliance_id,status) ' .
 				'VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ',' . $this->db->escapeString($status) . ')');
 		}
 		$this->hasChanged = true;
@@ -1337,13 +1335,13 @@ abstract class AbstractSmrPlayer {
 		}
 		if (!isset($this->allianceRoles[$allianceID])) {
 			$this->allianceRoles[$allianceID] = 0;
-			$this->db->query('SELECT role_id
+			$dbResult = $this->db->read('SELECT role_id
 						FROM player_has_alliance_role
 						WHERE ' . $this->SQL . '
 						AND alliance_id=' . $this->db->escapeNumber($allianceID) . '
 						LIMIT 1');
-			if ($this->db->nextRecord()) {
-				$this->allianceRoles[$allianceID] = $this->db->getInt('role_id');
+			if ($dbResult->hasRecord()) {
+				$this->allianceRoles[$allianceID] = $dbResult->record()->getInt('role_id');
 			}
 		}
 		return $this->allianceRoles[$allianceID];
@@ -1371,7 +1369,7 @@ abstract class AbstractSmrPlayer {
 		}
 
 		$this->setAllianceID(0);
-		$this->db->query('DELETE FROM player_has_alliance_role WHERE ' . $this->SQL);
+		$this->db->write('DELETE FROM player_has_alliance_role WHERE ' . $this->SQL);
 	}
 
 	/**
@@ -1395,7 +1393,7 @@ abstract class AbstractSmrPlayer {
 		} else {
 			$roleID = ALLIANCE_ROLE_LEADER;
 		}
-		$this->db->query('INSERT INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($roleID) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
+		$this->db->write('INSERT INTO player_has_alliance_role (game_id, account_id, role_id, alliance_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($roleID) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
 		$this->actionTaken('JoinAlliance', array('Alliance' => $alliance));
 	}
@@ -1444,9 +1442,9 @@ abstract class AbstractSmrPlayer {
 			foreach ($RACES as $raceID => $raceName) {
 				$this->personalRelations[$raceID] = 0;
 			}
-			$this->db->query('SELECT race_id,relation FROM player_has_relation WHERE ' . $this->SQL . ' LIMIT ' . count($RACES));
-			while ($this->db->nextRecord()) {
-				$this->personalRelations[$this->db->getInt('race_id')] = $this->db->getInt('relation');
+			$dbResult = $this->db->read('SELECT race_id,relation FROM player_has_relation WHERE ' . $this->SQL . ' LIMIT ' . count($RACES));
+			foreach ($dbResult->records() as $dbRecord) {
+				$this->personalRelations[$dbRecord->getInt('race_id')] = $dbRecord->getInt('relation');
 			}
 		}
 	}
@@ -1553,7 +1551,7 @@ abstract class AbstractSmrPlayer {
 		$relationsDiff = IRound($relations - $this->personalRelations[$raceID]);
 		$this->personalRelations[$raceID] = $relations;
 		$this->relations[$raceID] += $relationsDiff;
-		$this->db->query('REPLACE INTO player_has_relation (account_id,game_id,race_id,relation) values (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber($raceID) . ',' . $this->db->escapeNumber($this->personalRelations[$raceID]) . ')');
+		$this->db->write('REPLACE INTO player_has_relation (account_id,game_id,race_id,relation) values (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber($raceID) . ',' . $this->db->escapeNumber($this->personalRelations[$raceID]) . ')');
 	}
 
 	/**
@@ -1599,11 +1597,11 @@ abstract class AbstractSmrPlayer {
 	public function getPlottedCourse() : Distance|false {
 		if (!isset($this->plottedCourse)) {
 			// check if we have a course plotted
-			$this->db->query('SELECT course FROM player_plotted_course WHERE ' . $this->SQL . ' LIMIT 1');
+			$dbResult = $this->db->read('SELECT course FROM player_plotted_course WHERE ' . $this->SQL . ' LIMIT 1');
 
-			if ($this->db->nextRecord()) {
+			if ($dbResult->hasRecord()) {
 				// get the course back
-				$this->plottedCourse = $this->db->getObject('course');
+				$this->plottedCourse = $dbResult->record()->getObject('course');
 			} else {
 				$this->plottedCourse = false;
 			}
@@ -1630,7 +1628,7 @@ abstract class AbstractSmrPlayer {
 		$hadPlottedCourse = $this->hasPlottedCourse();
 		$this->plottedCourse = $plottedCourse;
 		if ($this->plottedCourse->getTotalSectors() > 0) {
-			$this->db->query('REPLACE INTO player_plotted_course
+			$this->db->write('REPLACE INTO player_plotted_course
 				(account_id, game_id, course)
 				VALUES(' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeObject($this->plottedCourse) . ')');
 		} elseif ($hadPlottedCourse) {
@@ -1656,7 +1654,7 @@ abstract class AbstractSmrPlayer {
 
 	public function deletePlottedCourse() : void {
 		$this->plottedCourse = false;
-		$this->db->query('DELETE FROM player_plotted_course WHERE ' . $this->SQL . ' LIMIT 1');
+		$this->db->write('DELETE FROM player_plotted_course WHERE ' . $this->SQL . ' LIMIT 1');
 	}
 
 	// Computes the turn cost and max misjump between current and target sector
@@ -1679,13 +1677,13 @@ abstract class AbstractSmrPlayer {
 	public function &getStoredDestinations() : array {
 		if (!isset($this->storedDestinations)) {
 			$this->storedDestinations = array();
-			$this->db->query('SELECT * FROM player_stored_sector WHERE ' . $this->SQL);
-			while ($this->db->nextRecord()) {
+			$dbResult = $this->db->read('SELECT * FROM player_stored_sector WHERE ' . $this->SQL);
+			foreach ($dbResult->records() as $dbRecord) {
 				$this->storedDestinations[] = array(
-					'Label' => $this->db->getField('label'),
-					'SectorID' => $this->db->getInt('sector_id'),
-					'OffsetTop' => $this->db->getInt('offset_top'),
-					'OffsetLeft' => $this->db->getInt('offset_left')
+					'Label' => $dbRecord->getField('label'),
+					'SectorID' => $dbRecord->getInt('sector_id'),
+					'OffsetTop' => $dbRecord->getInt('offset_top'),
+					'OffsetLeft' => $dbRecord->getInt('offset_left')
 				);
 			}
 		}
@@ -1703,7 +1701,7 @@ abstract class AbstractSmrPlayer {
 			if ($sd['SectorID'] == $sectorID) {
 				$sd['OffsetTop'] = $offsetTop;
 				$sd['OffsetLeft'] = $offsetLeft;
-				$this->db->query('
+				$this->db->write('
 					UPDATE player_stored_sector
 						SET offset_left = ' . $this->db->escapeNumber($offsetLeft) . ', offset_top=' . $this->db->escapeNumber($offsetTop) . '
 					WHERE ' . $this->SQL . ' AND sector_id = ' . $this->db->escapeNumber($sectorID)
@@ -1735,7 +1733,7 @@ abstract class AbstractSmrPlayer {
 			'OffsetLeft' => 1
 		);
 
-		$this->db->query('
+		$this->db->write('
 			INSERT INTO player_stored_sector (account_id, game_id, sector_id, label, offset_top, offset_left)
 			VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ', ' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($sectorID) . ',' . $this->db->escapeString($label) . ',1,1)'
 		);
@@ -1745,7 +1743,7 @@ abstract class AbstractSmrPlayer {
 
 		foreach ($this->getStoredDestinations() as $key => $sd) {
 			if ($sd['SectorID'] == $sectorID) {
-				$this->db->query('
+				$this->db->write('
 					DELETE FROM player_stored_sector
 					WHERE ' . $this->SQL . '
 					AND sector_id = ' . $this->db->escapeNumber($sectorID)
@@ -1761,13 +1759,13 @@ abstract class AbstractSmrPlayer {
 		if (!isset($this->tickers)) {
 			$this->tickers = array();
 			//get ticker info
-			$this->db->query('SELECT type,time,expires,recent FROM player_has_ticker WHERE ' . $this->SQL . ' AND expires > ' . $this->db->escapeNumber(Smr\Epoch::time()));
-			while ($this->db->nextRecord()) {
-				$this->tickers[$this->db->getField('type')] = [
-					'Type' => $this->db->getField('type'),
-					'Time' => $this->db->getInt('time'),
-					'Expires' => $this->db->getInt('expires'),
-					'Recent' => $this->db->getField('recent'),
+			$dbResult = $this->db->read('SELECT type,time,expires,recent FROM player_has_ticker WHERE ' . $this->SQL . ' AND expires > ' . $this->db->escapeNumber(Smr\Epoch::time()));
+			foreach ($dbResult->records() as $dbRecord) {
+				$this->tickers[$dbRecord->getField('type')] = [
+					'Type' => $dbRecord->getField('type'),
+					'Time' => $dbRecord->getInt('time'),
+					'Expires' => $dbRecord->getInt('expires'),
+					'Recent' => $dbRecord->getField('recent'),
 				];
 			}
 		}
@@ -1839,15 +1837,15 @@ abstract class AbstractSmrPlayer {
 	protected function getBountiesData() : void {
 		if (!isset($this->bounties)) {
 			$this->bounties = array();
-			$this->db->query('SELECT * FROM bounty WHERE ' . $this->SQL);
-			while ($this->db->nextRecord()) {
-				$this->bounties[$this->db->getInt('bounty_id')] = array(
-							'Amount' => $this->db->getInt('amount'),
-							'SmrCredits' => $this->db->getInt('smr_credits'),
-							'Type' => $this->db->getField('type'),
-							'Claimer' => $this->db->getInt('claimer_id'),
-							'Time' => $this->db->getInt('time'),
-							'ID' => $this->db->getInt('bounty_id'),
+			$dbResult = $this->db->read('SELECT * FROM bounty WHERE ' . $this->SQL);
+			foreach ($dbResult->records() as $dbRecord) {
+				$this->bounties[$dbRecord->getInt('bounty_id')] = array(
+							'Amount' => $dbRecord->getInt('amount'),
+							'SmrCredits' => $dbRecord->getInt('smr_credits'),
+							'Type' => $dbRecord->getField('type'),
+							'Claimer' => $dbRecord->getInt('claimer_id'),
+							'Time' => $dbRecord->getInt('time'),
+							'ID' => $dbRecord->getInt('bounty_id'),
 							'New' => false);
 			}
 		}
@@ -1864,13 +1862,13 @@ abstract class AbstractSmrPlayer {
 			'HQ', 'UG' => ' AND type=' . $this->db->escapeString($type),
 			null => '',
 		};
-		$this->db->query($query);
-		while ($this->db->nextRecord()) {
+		$dbResult = $this->db->read($query);
+		foreach ($dbResult->records() as $dbRecord) {
 			$bounties[] = array(
-				'player' => SmrPlayer::getPlayer($this->db->getInt('account_id'), $this->getGameID()),
-				'bounty_id' => $this->db->getInt('bounty_id'),
-				'credits' => $this->db->getInt('amount'),
-				'smr_credits' => $this->db->getInt('smr_credits'),
+				'player' => SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $this->getGameID()),
+				'bounty_id' => $dbRecord->getInt('bounty_id'),
+				'credits' => $dbRecord->getInt('amount'),
+				'smr_credits' => $dbRecord->getInt('smr_credits'),
 			);
 		}
 		return $bounties;
@@ -2022,18 +2020,18 @@ abstract class AbstractSmrPlayer {
 	protected function getHOFData() : void {
 		if (!isset($this->HOF)) {
 			//Get Player HOF
-			$this->db->query('SELECT type,amount FROM player_hof WHERE ' . $this->SQL);
+			$dbResult = $this->db->read('SELECT type,amount FROM player_hof WHERE ' . $this->SQL);
 			$this->HOF = array();
-			while ($this->db->nextRecord()) {
+			foreach ($dbResult->records() as $dbRecord) {
 				$hof =& $this->HOF;
-				$typeList = explode(':', $this->db->getField('type'));
+				$typeList = explode(':', $dbRecord->getField('type'));
 				foreach ($typeList as $type) {
 					if (!isset($hof[$type])) {
 						$hof[$type] = array();
 					}
 					$hof =& $hof[$type];
 				}
-				$hof = $this->db->getFloat('amount');
+				$hof = $dbRecord->getFloat('amount');
 			}
 			self::getHOFVis();
 		}
@@ -2043,10 +2041,10 @@ abstract class AbstractSmrPlayer {
 		if (!isset(self::$HOFVis)) {
 			//Get Player HOF Vis
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT type,visibility FROM hof_visibility');
+			$dbResult = $db->read('SELECT type,visibility FROM hof_visibility');
 			self::$HOFVis = array();
-			while ($db->nextRecord()) {
-				self::$HOFVis[$db->getField('type')] = $db->getField('visibility');
+			foreach ($dbResult->records() as $dbRecord) {
+				self::$HOFVis[$dbRecord->getField('type')] = $dbRecord->getField('visibility');
 			}
 		}
 	}
@@ -2150,7 +2148,7 @@ abstract class AbstractSmrPlayer {
 	}
 
 	private function computeRanking(string $dbField) : int {
-		$this->db->query('SELECT ranking
+		$dbResult = $this->db->read('SELECT ranking
 			FROM (
 				SELECT player_id,
 				ROW_NUMBER() OVER (ORDER BY ' . $dbField . ' DESC, player_name ASC) AS ranking
@@ -2159,8 +2157,7 @@ abstract class AbstractSmrPlayer {
 			) t
 			WHERE player_id = ' . $this->db->escapeNumber($this->getPlayerID())
 		);
-		$this->db->requireRecord();
-		return $this->db->getInt('ranking');
+		return $dbResult->record()->getInt('ranking');
 	}
 
 	public function isUnderAttack() : bool {
@@ -2199,7 +2196,7 @@ abstract class AbstractSmrPlayer {
 
 		// if we are in an alliance we increase their deaths
 		if ($this->hasAlliance()) {
-			$this->db->query('UPDATE alliance SET alliance_deaths = alliance_deaths + 1
+			$this->db->write('UPDATE alliance SET alliance_deaths = alliance_deaths + 1
 							WHERE game_id = ' . $this->db->escapeNumber($this->getGameID()) . ' AND alliance_id = ' . $this->db->escapeNumber($this->getAllianceID()) . ' LIMIT 1');
 		}
 
@@ -2240,7 +2237,7 @@ abstract class AbstractSmrPlayer {
 		}
 		$msg .= ' in Sector&nbsp;' . Globals::getSectorBBLink($this->getSectorID());
 		$this->getSector()->increaseBattles(1);
-		$this->db->query('INSERT INTO news (game_id,time,news_message,type,killer_id,killer_alliance,dead_id,dead_alliance) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber(Smr\Epoch::time()) . ',' . $this->db->escapeString($msg) . ',\'regular\',' . $this->db->escapeNumber($killer->getAccountID()) . ',' . $this->db->escapeNumber($killer->getAllianceID()) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
+		$this->db->write('INSERT INTO news (game_id,time,news_message,type,killer_id,killer_alliance,dead_id,dead_alliance) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber(Smr\Epoch::time()) . ',' . $this->db->escapeString($msg) . ',\'regular\',' . $this->db->escapeNumber($killer->getAccountID()) . ',' . $this->db->escapeNumber($killer->getAllianceID()) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
 		self::sendMessageFromFedClerk($this->getGameID(), $this->getAccountID(), 'You were <span class="red">DESTROYED</span> by ' . $killer->getBBLink() . ' in sector ' . Globals::getSectorBBLink($this->getSectorID()));
 		self::sendMessageFromFedClerk($this->getGameID(), $killer->getAccountID(), 'You <span class="red">DESTROYED</span>&nbsp;' . $this->getBBLink() . ' in sector ' . Globals::getSectorBBLink($this->getSectorID()));
@@ -2278,14 +2275,14 @@ abstract class AbstractSmrPlayer {
 		}
 
 		//check for federal bounty being offered for current port raiders;
-		$this->db->query('DELETE FROM player_attacks_port WHERE time < ' . $this->db->escapeNumber(Smr\Epoch::time() - self::TIME_FOR_FEDERAL_BOUNTY_ON_PR));
+		$this->db->write('DELETE FROM player_attacks_port WHERE time < ' . $this->db->escapeNumber(Smr\Epoch::time() - self::TIME_FOR_FEDERAL_BOUNTY_ON_PR));
 		$query = 'SELECT 1
 					FROM player_attacks_port
 					JOIN port USING(game_id, sector_id)
 					JOIN player USING(game_id, account_id)
 					WHERE armour > 0 AND ' . $this->SQL . ' LIMIT 1';
-		$this->db->query($query);
-		if ($this->db->nextRecord()) {
+		$dbResult = $this->db->read($query);
+		if ($dbResult->hasRecord()) {
 			$bounty = IFloor(DEFEND_PORT_BOUNTY_PER_LEVEL * $this->getLevelID());
 			$this->increaseCurrentBountyAmount('HQ', $bounty);
 		}
@@ -2357,7 +2354,7 @@ abstract class AbstractSmrPlayer {
 				$killer->increaseHOF(1, array('Killing', 'Kills'), HOF_PUBLIC);
 
 				if ($killer->hasAlliance()) {
-					$this->db->query('UPDATE alliance SET alliance_kills=alliance_kills+1 WHERE alliance_id=' . $this->db->escapeNumber($killer->getAllianceID()) . ' AND game_id=' . $this->db->escapeNumber($killer->getGameID()) . ' LIMIT 1');
+					$this->db->write('UPDATE alliance SET alliance_kills=alliance_kills+1 WHERE alliance_id=' . $this->db->escapeNumber($killer->getAllianceID()) . ' AND game_id=' . $this->db->escapeNumber($killer->getGameID()) . ' LIMIT 1');
 				}
 
 				// alliance vs. alliance stats
@@ -2391,7 +2388,7 @@ abstract class AbstractSmrPlayer {
 		}
 		$news_message .= ' was destroyed by ' . $owner->getBBLink() . '\'s forces in sector ' . Globals::getSectorBBLink($forces->getSectorID());
 		// insert the news entry
-		$this->db->query('INSERT INTO news (game_id, time, news_message,killer_id,killer_alliance,dead_id,dead_alliance)
+		$this->db->write('INSERT INTO news (game_id, time, news_message,killer_id,killer_alliance,dead_id,dead_alliance)
 						VALUES(' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ', ' . $this->db->escapeString($news_message) . ',' . $this->db->escapeNumber($owner->getAccountID()) . ',' . $this->db->escapeNumber($owner->getAllianceID()) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
 		// Player loses 15% experience
@@ -2427,7 +2424,7 @@ abstract class AbstractSmrPlayer {
 		}
 		$news_message .= ' was destroyed while invading ' . $port->getDisplayName() . '.';
 		// insert the news entry
-		$this->db->query('INSERT INTO news (game_id, time, news_message,killer_id,dead_id,dead_alliance)
+		$this->db->write('INSERT INTO news (game_id, time, news_message,killer_id,dead_id,dead_alliance)
 						VALUES(' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ', ' . $this->db->escapeString($news_message) . ',' . $this->db->escapeNumber(ACCOUNT_ID_PORT) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
 		// Player loses between 15% and 20% experience
@@ -2464,7 +2461,7 @@ abstract class AbstractSmrPlayer {
 		}
 		$news_message .= ' was destroyed by ' . $planet->getCombatName() . '\'s planetary defenses in sector ' . Globals::getSectorBBLink($planet->getSectorID()) . '.';
 		// insert the news entry
-		$this->db->query('INSERT INTO news (game_id, time, news_message,killer_id,killer_alliance,dead_id,dead_alliance)
+		$this->db->write('INSERT INTO news (game_id, time, news_message,killer_id,killer_alliance,dead_id,dead_alliance)
 						VALUES(' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ', ' . $this->db->escapeString($news_message) . ',' . $this->db->escapeNumber($planetOwner->getAccountID()) . ',' . $this->db->escapeNumber($planetOwner->getAllianceID()) . ',' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ')');
 
 		// Player loses between 15% and 20% experience
@@ -2490,12 +2487,12 @@ abstract class AbstractSmrPlayer {
 
 	public function incrementAllianceVsKills(int $otherID) : void {
 		$values = [$this->getGameID(), $this->getAllianceID(), $otherID, 1];
-		$this->db->query('INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) VALUES (' . $this->db->escapeArray($values) . ') ON DUPLICATE KEY UPDATE kills = kills + 1');
+		$this->db->write('INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) VALUES (' . $this->db->escapeArray($values) . ') ON DUPLICATE KEY UPDATE kills = kills + 1');
 	}
 
 	public function incrementAllianceVsDeaths(int $otherID) : void {
 		$values = [$this->getGameID(), $otherID, $this->getAllianceID(), 1];
-		$this->db->query('INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) VALUES (' . $this->db->escapeArray($values) . ') ON DUPLICATE KEY UPDATE kills = kills + 1');
+		$this->db->write('INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) VALUES (' . $this->db->escapeArray($values) . ') ON DUPLICATE KEY UPDATE kills = kills + 1');
 	}
 
 	public function getTurnsLevel() : string {
@@ -2685,17 +2682,17 @@ abstract class AbstractSmrPlayer {
 
 	public function getMissions() : array {
 		if (!isset($this->missions)) {
-			$this->db->query('SELECT * FROM player_has_mission WHERE ' . $this->SQL);
+			$dbResult = $this->db->read('SELECT * FROM player_has_mission WHERE ' . $this->SQL);
 			$this->missions = array();
-			while ($this->db->nextRecord()) {
-				$missionID = $this->db->getInt('mission_id');
+			foreach ($dbResult->records() as $dbRecord) {
+				$missionID = $dbRecord->getInt('mission_id');
 				$this->missions[$missionID] = array(
-					'On Step' => $this->db->getInt('on_step'),
-					'Progress' => $this->db->getInt('progress'),
-					'Unread' => $this->db->getBoolean('unread'),
-					'Expires' => $this->db->getInt('step_fails'),
-					'Sector' => $this->db->getInt('mission_sector'),
-					'Starting Sector' => $this->db->getInt('starting_sector')
+					'On Step' => $dbRecord->getInt('on_step'),
+					'Progress' => $dbRecord->getInt('progress'),
+					'Unread' => $dbRecord->getBoolean('unread'),
+					'Expires' => $dbRecord->getInt('step_fails'),
+					'Sector' => $dbRecord->getInt('mission_sector'),
+					'Starting Sector' => $dbRecord->getInt('starting_sector')
 				);
 				$this->rebuildMission($missionID);
 			}
@@ -2729,7 +2726,7 @@ abstract class AbstractSmrPlayer {
 		$this->getMissions();
 		if (isset($this->missions[$missionID])) {
 			$mission = $this->missions[$missionID];
-			$this->db->query('
+			$this->db->write('
 				UPDATE player_has_mission
 				SET on_step = ' . $this->db->escapeNumber($mission['On Step']) . ',
 					progress = ' . $this->db->escapeNumber($mission['Progress']) . ',
@@ -2795,7 +2792,7 @@ abstract class AbstractSmrPlayer {
 		$this->setupMissionStep($missionID);
 		$this->rebuildMission($missionID);
 
-		$this->db->query('
+		$this->db->write('
 			REPLACE INTO player_has_mission (game_id,account_id,mission_id,on_step,progress,unread,starting_sector,mission_sector,step_fails)
 			VALUES ('.$this->db->escapeNumber($this->gameID) . ',' . $this->db->escapeNumber($this->accountID) . ',' . $this->db->escapeNumber($missionID) . ',' . $this->db->escapeNumber($mission['On Step']) . ',' . $this->db->escapeNumber($mission['Progress']) . ',' . $this->db->escapeBoolean($mission['Unread']) . ',' . $this->db->escapeNumber($mission['Starting Sector']) . ',' . $this->db->escapeNumber($mission['Sector']) . ',' . $this->db->escapeNumber($mission['Expires']) . ')'
 		);
@@ -2820,7 +2817,7 @@ abstract class AbstractSmrPlayer {
 		$this->getMissions();
 		if (isset($this->missions[$missionID])) {
 			unset($this->missions[$missionID]);
-			$this->db->query('DELETE FROM player_has_mission WHERE ' . $this->SQL . ' AND mission_id = ' . $this->db->escapeNumber($missionID) . ' LIMIT 1');
+			$this->db->write('DELETE FROM player_has_mission WHERE ' . $this->SQL . ' AND mission_id = ' . $this->db->escapeNumber($missionID) . ' LIMIT 1');
 			return;
 		}
 		throw new Exception('Mission with ID not found: ' . $missionID);
@@ -3025,17 +3022,26 @@ abstract class AbstractSmrPlayer {
 	}
 
 	/**
-	 * Will retrieve all visited sectors, use only when you are likely to check a large number of these
+	 * Returns an array of all unvisited sectors.
 	 */
-	public function hasVisitedSector(int $sectorID) : bool {
-		if (!isset($this->visitedSectors)) {
-			$this->visitedSectors = array();
-			$this->db->query('SELECT sector_id FROM player_visited_sector WHERE ' . $this->SQL);
-			while ($this->db->nextRecord()) {
-				$this->visitedSectors[$this->db->getInt('sector_id')] = false;
+	public function getUnvisitedSectors() : array {
+		if (!isset($this->unvisitedSectors)) {
+			$this->unvisitedSectors = array();
+			// Note that this table actually has entries for the *unvisited* sectors!
+			$dbResult = $this->db->read('SELECT sector_id FROM player_visited_sector WHERE ' . $this->SQL);
+			foreach ($dbResult->records() as $dbRecord) {
+				$this->unvisitedSectors[] = $dbRecord->getInt('sector_id');
 			}
 		}
-		return !isset($this->visitedSectors[$sectorID]);
+		return $this->unvisitedSectors;
+	}
+
+	/**
+	 * Check if player has visited the input sector.
+	 * Note that this populates the list of *all* unvisited sectors!
+	 */
+	public function hasVisitedSector(int $sectorID) : bool {
+		return !in_array($sectorID, $this->getUnvisitedSectors());
 	}
 
 	public function getLeaveNewbieProtectionHREF() : string {
@@ -3089,7 +3095,7 @@ abstract class AbstractSmrPlayer {
 			return;
 		}
 		$this->displayWeapons = $bool;
-		$this->db->query('UPDATE player SET display_weapons=' . $this->db->escapeBoolean($this->displayWeapons) . ' WHERE ' . $this->SQL);
+		$this->db->write('UPDATE player SET display_weapons=' . $this->db->escapeBoolean($this->displayWeapons) . ' WHERE ' . $this->SQL);
 	}
 
 	public function update() : void {
@@ -3098,7 +3104,7 @@ abstract class AbstractSmrPlayer {
 
 	public function save() : void {
 		if ($this->hasChanged === true) {
-			$this->db->query('UPDATE player SET player_name=' . $this->db->escapeString($this->playerName) .
+			$this->db->write('UPDATE player SET player_name=' . $this->db->escapeString($this->playerName) .
 				', player_id=' . $this->db->escapeNumber($this->playerID) .
 				', sector_id=' . $this->db->escapeNumber($this->sectorID) .
 				', last_sector_id=' . $this->db->escapeNumber($this->lastSectorID) .
@@ -3144,11 +3150,11 @@ abstract class AbstractSmrPlayer {
 				$bounty = $this->getBounty($key);
 				if ($bounty['New'] === true) {
 					if ($bounty['Amount'] > 0 || $bounty['SmrCredits'] > 0) {
-						$this->db->query('INSERT INTO bounty (account_id,game_id,type,amount,smr_credits,claimer_id,time) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeString($bounty['Type']) . ',' . $this->db->escapeNumber($bounty['Amount']) . ',' . $this->db->escapeNumber($bounty['SmrCredits']) . ',' . $this->db->escapeNumber($bounty['Claimer']) . ',' . $this->db->escapeNumber($bounty['Time']) . ')');
+						$this->db->write('INSERT INTO bounty (account_id,game_id,type,amount,smr_credits,claimer_id,time) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeString($bounty['Type']) . ',' . $this->db->escapeNumber($bounty['Amount']) . ',' . $this->db->escapeNumber($bounty['SmrCredits']) . ',' . $this->db->escapeNumber($bounty['Claimer']) . ',' . $this->db->escapeNumber($bounty['Time']) . ')');
 					}
 				} else {
 					if ($bounty['Amount'] > 0 || $bounty['SmrCredits'] > 0) {
-						$this->db->query('UPDATE bounty
+						$this->db->write('UPDATE bounty
 							SET amount=' . $this->db->escapeNumber($bounty['Amount']) . ',
 							smr_credits=' . $this->db->escapeNumber($bounty['SmrCredits']) . ',
 							type=' . $this->db->escapeString($bounty['Type']) . ',
@@ -3156,7 +3162,7 @@ abstract class AbstractSmrPlayer {
 							time=' . $this->db->escapeNumber($bounty['Time']) . '
 							WHERE bounty_id=' . $this->db->escapeNumber($bounty['ID']) . ' AND ' . $this->SQL . ' LIMIT 1');
 					} else {
-						$this->db->query('DELETE FROM bounty WHERE bounty_id=' . $this->db->escapeNumber($bounty['ID']) . ' AND ' . $this->SQL . ' LIMIT 1');
+						$this->db->write('DELETE FROM bounty WHERE bounty_id=' . $this->db->escapeNumber($bounty['ID']) . ' AND ' . $this->SQL . ' LIMIT 1');
 					}
 				}
 			}
@@ -3172,9 +3178,9 @@ abstract class AbstractSmrPlayer {
 		if (!empty(self::$hasHOFVisChanged)) {
 			foreach (self::$hasHOFVisChanged as $hofType => $changeType) {
 				if ($changeType == self::HOF_NEW) {
-					$this->db->query('INSERT INTO hof_visibility (type, visibility) VALUES (' . $this->db->escapeString($hofType) . ',' . $this->db->escapeString(self::$HOFVis[$hofType]) . ')');
+					$this->db->write('INSERT INTO hof_visibility (type, visibility) VALUES (' . $this->db->escapeString($hofType) . ',' . $this->db->escapeString(self::$HOFVis[$hofType]) . ')');
 				} else {
-					$this->db->query('UPDATE hof_visibility SET visibility = ' . $this->db->escapeString(self::$HOFVis[$hofType]) . ' WHERE type = ' . $this->db->escapeString($hofType) . ' LIMIT 1');
+					$this->db->write('UPDATE hof_visibility SET visibility = ' . $this->db->escapeString(self::$HOFVis[$hofType]) . ' WHERE type = ' . $this->db->escapeString($hofType) . ' LIMIT 1');
 				}
 				unset(self::$hasHOFVisChanged[$hofType]);
 			}
@@ -3195,10 +3201,10 @@ abstract class AbstractSmrPlayer {
 				$amount = $this->getHOF($tempTypeList);
 				if ($hofChanged == self::HOF_NEW) {
 					if ($amount > 0) {
-						$this->db->query('INSERT INTO player_hof (account_id,game_id,type,amount) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeArray($tempTypeList, ':', false) . ',' . $this->db->escapeNumber($amount) . ')');
+						$this->db->write('INSERT INTO player_hof (account_id,game_id,type,amount) VALUES (' . $this->db->escapeNumber($this->getAccountID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeArray($tempTypeList, ':', false) . ',' . $this->db->escapeNumber($amount) . ')');
 					}
 				} elseif ($hofChanged == self::HOF_CHANGED) {
-					$this->db->query('UPDATE player_hof
+					$this->db->write('UPDATE player_hof
 						SET amount=' . $this->db->escapeNumber($amount) . '
 						WHERE ' . $this->SQL . ' AND type = ' . $this->db->escapeArray($tempTypeList, ':', false) . ' LIMIT 1');
 				}

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -2020,7 +2020,7 @@ abstract class AbstractSmrPlayer {
 			$this->HOF = array();
 			foreach ($dbResult->records() as $dbRecord) {
 				$hof =& $this->HOF;
-				$typeList = explode(':', $dbRecord->getField('type'));
+				$typeList = explode(':', $dbRecord->getString('type'));
 				foreach ($typeList as $type) {
 					if (!isset($hof[$type])) {
 						$hof[$type] = array();

--- a/src/lib/Default/AbstractSmrPort.class.php
+++ b/src/lib/Default/AbstractSmrPort.class.php
@@ -72,7 +72,7 @@ class AbstractSmrPort {
 	public static function getGalaxyPorts(int $gameID, int $galaxyID, bool $forceUpdate = false) : array {
 		$db = Smr\Database::getInstance();
 		// Use a left join so that we populate the cache for every sector
-		$dbResult = $db->read('SELECT port.*, sector_id FROM sector LEFT JOIN port USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT port.* FROM port LEFT JOIN sector USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
 		$galaxyPorts = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$sectorID = $dbRecord->getInt('sector_id');

--- a/src/lib/Default/DummyPlayer.class.php
+++ b/src/lib/Default/DummyPlayer.class.php
@@ -45,18 +45,18 @@ class DummyPlayer extends AbstractSmrPlayer {
 	public function cacheDummyPlayer() : void {
 		$this->getShip()->cacheDummyShip();
 		$db = Smr\Database::getInstance();
-		$db->query('REPLACE INTO cached_dummys ' .
+		$db->write('REPLACE INTO cached_dummys ' .
 					'(type, id, info) ' .
 					'VALUES (\'DummyPlayer\', ' . $db->escapeString($this->getPlayerName()) . ', ' . $db->escapeObject($this) . ')');
 	}
 
 	public static function getCachedDummyPlayer(string $name) : self {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT info FROM cached_dummys
+		$dbResult = $db->read('SELECT info FROM cached_dummys
 					WHERE type = \'DummyPlayer\'
 						AND id = ' . $db->escapeString($name) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return $db->getObject('info');
+		if ($dbResult->hasRecord()) {
+			return $dbResult->record()->getObject('info');
 		} else {
 			return new DummyPlayer($name);
 		}
@@ -64,11 +64,11 @@ class DummyPlayer extends AbstractSmrPlayer {
 
 	public static function getDummyPlayerNames() : array {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT id FROM cached_dummys
+		$dbResult = $db->read('SELECT id FROM cached_dummys
 					WHERE type = \'DummyPlayer\'');
 		$dummyNames = array();
-		while ($db->nextRecord()) {
-			$dummyNames[] = $db->getField('id');
+		foreach ($dbResult->records() as $dbRecord) {
+			$dummyNames[] = $dbRecord->getField('id');
 		}
 		return $dummyNames;
 	}

--- a/src/lib/Default/DummyShip.class.php
+++ b/src/lib/Default/DummyShip.class.php
@@ -10,7 +10,7 @@ class DummyShip extends AbstractSmrShip {
 
 	public function cacheDummyShip() : void {
 		$db = Smr\Database::getInstance();
-		$db->query('REPLACE INTO cached_dummys (type, id, info)
+		$db->write('REPLACE INTO cached_dummys (type, id, info)
 					VALUES (\'DummyShip\', ' . $db->escapeString($this->getPlayer()->getPlayerName()) . ', ' . $db->escapeObject($this) . ')');
 	}
 
@@ -20,10 +20,10 @@ class DummyShip extends AbstractSmrShip {
 
 			// Load weapons from the dummy database cache, if available
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT info FROM cached_dummys WHERE type = \'DummyShip\'
+			$dbResult = $db->read('SELECT info FROM cached_dummys WHERE type = \'DummyShip\'
 						AND id = ' . $db->escapeString($player->getPlayerName()) . ' LIMIT 1');
-			if ($db->nextRecord()) {
-				$cachedShip = $db->getObject('info');
+			if ($dbResult->hasRecord()) {
+				$cachedShip = $dbResult->record()->getObject('info');
 				foreach ($cachedShip->getWeapons() as $weapon) {
 					$ship->addWeapon($weapon);
 				}
@@ -36,10 +36,10 @@ class DummyShip extends AbstractSmrShip {
 
 	public static function getDummyShipNames() : array {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT id FROM cached_dummys WHERE type = \'DummyShip\'');
+		$dbResult = $db->read('SELECT id FROM cached_dummys WHERE type = \'DummyShip\'');
 		$dummyNames = array();
-		while ($db->nextRecord()) {
-			$dummyNames[] = $db->getField('id');
+		foreach ($dbResult->records() as $dbRecord) {
+			$dummyNames[] = $dbRecord->getField('id');
 		}
 		return $dummyNames;
 	}

--- a/src/lib/Default/Globals.class.php
+++ b/src/lib/Default/Globals.class.php
@@ -35,10 +35,10 @@ class Globals {
 	public static function getHiddenPlayers() : array {
 		if (!isset(self::$HIDDEN_PLAYERS)) {
 			self::initialiseDatabase();
-			self::$db->query('SELECT account_id FROM hidden_players');
+			$dbResult = self::$db->read('SELECT account_id FROM hidden_players');
 			self::$HIDDEN_PLAYERS = array(0); //stop errors
-			while (self::$db->nextRecord()) {
-				self::$HIDDEN_PLAYERS[] = self::$db->getInt('account_id');
+			foreach ($dbResult->records() as $dbRecord) {
+				self::$HIDDEN_PLAYERS[] = $dbRecord->getInt('account_id');
 			}
 		}
 		return self::$HIDDEN_PLAYERS;
@@ -47,9 +47,9 @@ class Globals {
 	public static function getGalacticPostEditorIDs(int $gameID) : array {
 		self::initialiseDatabase();
 		$editorIDs = [];
-		self::$db->query('SELECT account_id FROM galactic_post_writer WHERE position=\'editor\' AND game_id=' . self::$db->escapeNumber($gameID));
-		while (self::$db->nextRecord()) {
-			$editorIDs[] = self::$db->getInt('account_id');
+		$dbResult = self::$db->read('SELECT account_id FROM galactic_post_writer WHERE position=\'editor\' AND game_id=' . self::$db->escapeNumber($gameID));
+		foreach ($dbResult->records() as $dbRecord) {
+			$editorIDs[] = $dbRecord->getInt('account_id');
 		}
 		return $editorIDs;
 	}
@@ -60,12 +60,12 @@ class Globals {
 			self::$LEVEL_REQUIREMENTS = array();
 
 			// determine user level
-			self::$db->query('SELECT * FROM level ORDER BY level_id ASC');
-			while (self::$db->nextRecord()) {
-				self::$LEVEL_REQUIREMENTS[self::$db->getInt('level_id')] = array(
-																				'Name' => self::$db->getField('level_name'),
-																				'Requirement' => self::$db->getInt('requirement')
-																				);
+			$dbResult = self::$db->read('SELECT * FROM level ORDER BY level_id ASC');
+			foreach ($dbResult->records() as $dbRecord) {
+				self::$LEVEL_REQUIREMENTS[$dbRecord->getInt('level_id')] = array(
+					'Name' => $dbRecord->getField('level_name'),
+					'Requirement' => $dbRecord->getInt('requirement'),
+				);
 			}
 		}
 		return self::$LEVEL_REQUIREMENTS;
@@ -77,15 +77,15 @@ class Globals {
 			self::$RACES = array();
 
 			// determine user level
-			self::$db->query('SELECT race_id,race_name,race_description FROM race ORDER BY race_id');
-			while (self::$db->nextRecord()) {
-				self::$RACES[self::$db->getInt('race_id')] = array(
-																'Race ID' => self::$db->getInt('race_id'),
-																'Race Name' => self::$db->getField('race_name'),
-																'Description' => self::$db->getField('race_description'),
-																'ImageLink' => 'images/race/race' . self::$db->getInt('race_id') . '.jpg',
-																'ImageHeadLink' => 'images/race/head/race' . self::$db->getInt('race_id') . '.jpg',
-																);
+			$dbResult = self::$db->read('SELECT race_id,race_name,race_description FROM race ORDER BY race_id');
+			foreach ($dbResult->records() as $dbRecord) {
+				self::$RACES[$dbRecord->getInt('race_id')] = array(
+					'Race ID' => $dbRecord->getInt('race_id'),
+					'Race Name' => $dbRecord->getField('race_name'),
+					'Description' => $dbRecord->getField('race_description'),
+					'ImageLink' => 'images/race/race' . $dbRecord->getInt('race_id') . '.jpg',
+					'ImageHeadLink' => 'images/race/head/race' . $dbRecord->getInt('race_id') . '.jpg',
+				);
 			}
 		}
 		return self::$RACES;
@@ -123,18 +123,18 @@ class Globals {
 			self::$GOODS = array();
 
 			// determine user level
-			self::$db->query('SELECT * FROM good ORDER BY good_id');
-			while (self::$db->nextRecord()) {
-				self::$GOODS[self::$db->getInt('good_id')] = array(
-																'Type' => 'Good',
-																'ID' => self::$db->getInt('good_id'),
-																'Name' => self::$db->getField('good_name'),
-																'Max' => self::$db->getInt('max_amount'),
-																'BasePrice' => self::$db->getInt('base_price'),
-																'Class' => self::$db->getInt('good_class'),
-																'ImageLink' => 'images/port/' . self::$db->getInt('good_id') . '.png',
-																'AlignRestriction' => self::$db->getInt('align_restriction')
-															);
+			$dbResult = self::$db->read('SELECT * FROM good ORDER BY good_id');
+			foreach ($dbResult->records() as $dbRecord) {
+				self::$GOODS[$dbRecord->getInt('good_id')] = array(
+					'Type' => 'Good',
+					'ID' => $dbRecord->getInt('good_id'),
+					'Name' => $dbRecord->getField('good_name'),
+					'Max' => $dbRecord->getInt('max_amount'),
+					'BasePrice' => $dbRecord->getInt('base_price'),
+					'Class' => $dbRecord->getInt('good_class'),
+					'ImageLink' => 'images/port/' . $dbRecord->getInt('good_id') . '.png',
+					'AlignRestriction' => $dbRecord->getInt('align_restriction'),
+				);
 			}
 		}
 		return self::$GOODS;
@@ -157,14 +157,14 @@ class Globals {
 			self::$HARDWARE_TYPES = array();
 
 			// determine user level
-			self::$db->query('SELECT * FROM hardware_type ORDER BY hardware_type_id');
-			while (self::$db->nextRecord()) {
-				self::$HARDWARE_TYPES[self::$db->getInt('hardware_type_id')] = array(
-																			'Type' => 'Hardware',
-																			'ID' => self::$db->getInt('hardware_type_id'),
-																			'Name' => self::$db->getField('hardware_name'),
-																			'Cost' => self::$db->getInt('cost')
-																			);
+			$dbResult = self::$db->read('SELECT * FROM hardware_type ORDER BY hardware_type_id');
+			foreach ($dbResult->records() as $dbRecord) {
+				self::$HARDWARE_TYPES[$dbRecord->getInt('hardware_type_id')] = array(
+					'Type' => 'Hardware',
+					'ID' => $dbRecord->getInt('hardware_type_id'),
+					'Name' => $dbRecord->getField('hardware_name'),
+					'Cost' => $dbRecord->getInt('cost'),
+				);
 			}
 		}
 		if ($hardwareTypeID === null) {
@@ -197,10 +197,9 @@ class Globals {
 	public static function isFeatureRequestOpen() : bool {
 		if (!isset(self::$FEATURE_REQUEST_OPEN)) {
 			self::initialiseDatabase();
-			self::$db->query('SELECT open FROM open_forms WHERE type=\'FEATURE\'');
-			self::$db->nextRecord();
+			$dbResult = self::$db->read('SELECT open FROM open_forms WHERE type=\'FEATURE\'');
 
-			self::$FEATURE_REQUEST_OPEN = self::$db->getBoolean('open');
+			self::$FEATURE_REQUEST_OPEN = $dbResult->record()->getBoolean('open');
 		}
 		return self::$FEATURE_REQUEST_OPEN;
 	}
@@ -214,9 +213,9 @@ class Globals {
 			foreach ($RACES as $otherRaceID => $raceArray) {
 				self::$RACE_RELATIONS[$gameID][$raceID][$otherRaceID] = 0;
 			}
-			self::$db->query('SELECT race_id_2,relation FROM race_has_relation WHERE race_id_1=' . self::$db->escapeNumber($raceID) . ' AND game_id=' . self::$db->escapeNumber($gameID) . ' LIMIT ' . count($RACES));
-			while (self::$db->nextRecord()) {
-				self::$RACE_RELATIONS[$gameID][$raceID][self::$db->getInt('race_id_2')] = self::$db->getInt('relation');
+			$dbResult = self::$db->read('SELECT race_id_2,relation FROM race_has_relation WHERE race_id_1=' . self::$db->escapeNumber($raceID) . ' AND game_id=' . self::$db->escapeNumber($gameID) . ' LIMIT ' . count($RACES));
+			foreach ($dbResult->records() as $dbRecord) {
+				self::$RACE_RELATIONS[$gameID][$raceID][$dbRecord->getInt('race_id_2')] = $dbRecord->getInt('relation');
 			}
 		}
 		return self::$RACE_RELATIONS[$gameID][$raceID];

--- a/src/lib/Default/SmrAlliance.class.php
+++ b/src/lib/Default/SmrAlliance.class.php
@@ -40,9 +40,10 @@ class SmrAlliance {
 
 	public static function getAllianceByDiscordChannel(string $channel, bool $forceUpdate = false) : ?SmrAlliance {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT alliance_id, game_id FROM alliance JOIN game USING(game_id) WHERE discord_channel = ' . $db->escapeString($channel) . ' AND game.end_time > ' . $db->escapeNumber(time()) . ' ORDER BY game_id DESC LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getAlliance($db->getInt('alliance_id'), $db->getInt('game_id'), $forceUpdate);
+		$dbResult = $db->read('SELECT alliance_id, game_id FROM alliance JOIN game USING(game_id) WHERE discord_channel = ' . $db->escapeString($channel) . ' AND game.end_time > ' . $db->escapeNumber(time()) . ' ORDER BY game_id DESC LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			return self::getAlliance($dbRecord->getInt('alliance_id'), $dbRecord->getInt('game_id'), $forceUpdate);
 		} else {
 			return null;
 		}
@@ -50,9 +51,10 @@ class SmrAlliance {
 
 	public static function getAllianceByIrcChannel(string $channel, bool $forceUpdate = false) : ?SmrAlliance {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT alliance_id, game_id FROM irc_alliance_has_channel WHERE channel = ' . $db->escapeString($channel) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getAlliance($db->getInt('alliance_id'), $db->getInt('game_id'), $forceUpdate);
+		$dbResult = $db->read('SELECT alliance_id, game_id FROM irc_alliance_has_channel WHERE channel = ' . $db->escapeString($channel) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			return self::getAlliance($dbRecord->getInt('alliance_id'), $dbRecord->getInt('game_id'), $forceUpdate);
 		} else {
 			return null;
 		}
@@ -60,9 +62,10 @@ class SmrAlliance {
 
 	public static function getAllianceByName(string $name, int $gameID, bool $forceUpdate = false) : ?SmrAlliance {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT alliance_id FROM alliance WHERE alliance_name = ' . $db->escapeString($name) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' LIMIT 1');
-		if ($db->nextRecord()) {
-			return self::getAlliance($db->getInt('alliance_id'), $gameID, $forceUpdate);
+		$dbResult = $db->read('SELECT alliance_id FROM alliance WHERE alliance_name = ' . $db->escapeString($name) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			return self::getAlliance($dbRecord->getInt('alliance_id'), $gameID, $forceUpdate);
 		} else {
 			return null;
 		}
@@ -76,21 +79,21 @@ class SmrAlliance {
 		$this->SQL = 'alliance_id=' . $this->db->escapeNumber($allianceID) . ' AND game_id=' . $this->db->escapeNumber($gameID);
 
 		if ($allianceID != 0) {
-			$this->db->query('SELECT * FROM alliance WHERE ' . $this->SQL);
-			$this->db->nextRecord();
-			$this->allianceName = $this->db->getField('alliance_name');
-			$this->password = stripslashes($this->db->getField('alliance_password'));
-			$this->recruiting = $this->db->getBoolean('recruiting');
-			$this->description = $this->db->getField('alliance_description');
-			$this->leaderID = $this->db->getInt('leader_id');
-			$this->bank = $this->db->getInt('alliance_account');
-			$this->kills = $this->db->getInt('alliance_kills');
-			$this->deaths = $this->db->getInt('alliance_deaths');
-			$this->motd = $this->db->getField('mod');
-			$this->imgSrc = $this->db->getField('img_src');
-			$this->discordServer = $this->db->getField('discord_server');
-			$this->discordChannel = $this->db->getField('discord_channel');
-			$this->flagshipID = $this->db->getInt('flagship_id');
+			$dbResult = $this->db->read('SELECT * FROM alliance WHERE ' . $this->SQL);
+			$dbRecord = $dbResult->record();
+			$this->allianceName = $dbRecord->getField('alliance_name');
+			$this->password = stripslashes($dbRecord->getField('alliance_password'));
+			$this->recruiting = $dbRecord->getBoolean('recruiting');
+			$this->description = $dbRecord->getField('alliance_description');
+			$this->leaderID = $dbRecord->getInt('leader_id');
+			$this->bank = $dbRecord->getInt('alliance_account');
+			$this->kills = $dbRecord->getInt('alliance_kills');
+			$this->deaths = $dbRecord->getInt('alliance_deaths');
+			$this->motd = $dbRecord->getField('mod');
+			$this->imgSrc = $dbRecord->getField('img_src');
+			$this->discordServer = $dbRecord->getField('discord_server');
+			$this->discordChannel = $dbRecord->getField('discord_channel');
+			$this->flagshipID = $dbRecord->getInt('flagship_id');
 
 			if (empty($this->kills)) {
 				$this->kills = 0;
@@ -109,21 +112,20 @@ class SmrAlliance {
 		$db = Smr\Database::getInstance();
 
 		// check if the alliance name already exists
-		$db->query('SELECT 1 FROM alliance WHERE alliance_name = ' . $db->escapeString($name) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' LIMIT 1');
-		if ($db->getNumRows() > 0) {
+		$dbResult = $db->read('SELECT 1 FROM alliance WHERE alliance_name = ' . $db->escapeString($name) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
 			create_error('That alliance name already exists!');
 		}
 
 		// get the next alliance id (ignoring reserved ID's)
-		$db->query('SELECT max(alliance_id) FROM alliance WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND (alliance_id < ' . $db->escapeNumber(NHA_ID) . ' OR alliance_id > ' . $db->escapeNumber(NHA_ID + 7) . ') LIMIT 1');
-		$db->requireRecord();
-		$allianceID = $db->getInt('max(alliance_id)') + 1;
+		$dbResult = $db->read('SELECT max(alliance_id) FROM alliance WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND (alliance_id < ' . $db->escapeNumber(NHA_ID) . ' OR alliance_id > ' . $db->escapeNumber(NHA_ID + 7) . ') LIMIT 1');
+		$allianceID = $dbResult->record()->getInt('max(alliance_id)') + 1;
 		if ($allianceID >= NHA_ID && $allianceID <= NHA_ID + 7) {
 			$allianceID = NHA_ID + 8;
 		}
 
 		// actually create the alliance here
-		$db->query('INSERT INTO alliance (alliance_id, game_id, alliance_name, alliance_password, recruiting) VALUES(' . $db->escapeNumber($allianceID) . ', ' . $db->escapeNumber($gameID) . ', ' . $db->escapeString($name) . ', \'\', \'FALSE\')');
+		$db->write('INSERT INTO alliance (alliance_id, game_id, alliance_name, alliance_password, recruiting) VALUES(' . $db->escapeNumber($allianceID) . ', ' . $db->escapeNumber($gameID) . ', ' . $db->escapeString($name) . ', \'\', \'FALSE\')');
 
 		return self::getAlliance($allianceID, $gameID);
 	}
@@ -208,9 +210,9 @@ class SmrAlliance {
 
 	public function getIrcChannel() : string {
 		if (!isset($this->ircChannel)) {
-			$this->db->query('SELECT channel FROM irc_alliance_has_channel WHERE ' . $this->SQL);
-			if ($this->db->nextRecord()) {
-				$this->ircChannel = $this->db->getField('channel');
+			$dbResult = $this->db->read('SELECT channel FROM irc_alliance_has_channel WHERE ' . $this->SQL);
+			if ($dbResult->hasRecord()) {
+				$this->ircChannel = $dbResult->record()->getField('channel');
 			} else {
 				$this->ircChannel = '';
 			}
@@ -231,9 +233,9 @@ class SmrAlliance {
 				create_error('Please enter a valid irc channel for your alliance.');
 			}
 
-			$this->db->query('REPLACE INTO irc_alliance_has_channel (channel,alliance_id,game_id) values (' . $this->db->escapeString($ircChannel) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ');');
+			$this->db->write('REPLACE INTO irc_alliance_has_channel (channel,alliance_id,game_id) values (' . $this->db->escapeString($ircChannel) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ');');
 		} else {
-			$this->db->query('DELETE FROM irc_alliance_has_channel WHERE ' . $this->SQL);
+			$this->db->write('DELETE FROM irc_alliance_has_channel WHERE ' . $this->SQL);
 		}
 		$this->ircChannel = $ircChannel;
 	}
@@ -419,17 +421,17 @@ class SmrAlliance {
 			if ($this->getNumMembers() < $maxVets) {
 				return false;
 			}
-			$this->db->query('SELECT status FROM player_joined_alliance WHERE account_id=' . $this->db->escapeNumber($player->getAccountID()) . ' AND ' . $this->SQL);
-			if ($this->db->nextRecord()) {
-				if ($this->db->getField('status') == 'NEWBIE') {
+			$dbResult = $this->db->read('SELECT status FROM player_joined_alliance WHERE account_id=' . $this->db->escapeNumber($player->getAccountID()) . ' AND ' . $this->SQL);
+			if ($dbResult->hasRecord()) {
+				if ($dbResult->record()->getField('status') == 'NEWBIE') {
 					return false;
 				}
 			}
-			$this->db->query('SELECT COUNT(*) AS num_orig_vets
+			$dbResult = $this->db->read('SELECT COUNT(*) AS num_orig_vets
 							FROM player_joined_alliance
 							JOIN player USING (account_id, alliance_id, game_id)
 							WHERE ' . $this->SQL . ' AND status=\'VETERAN\'');
-			if (!$this->db->nextRecord() || $this->db->getInt('num_orig_vets') < $maxVets) {
+			if (!$dbResult->hasRecord() || $dbResult->record()->getInt('num_orig_vets') < $maxVets) {
 				return false;
 			}
 		}
@@ -451,7 +453,7 @@ class SmrAlliance {
 	}
 
 	public function update() : void {
-		$this->db->query('UPDATE alliance SET
+		$this->db->write('UPDATE alliance SET
 								alliance_password = ' . $this->db->escapeString($this->password) . ',
 								recruiting = ' . $this->db->escapeBoolean($this->recruiting) . ',
 								alliance_account = ' . $this->db->escapeNumber($this->bank) . ',
@@ -476,12 +478,12 @@ class SmrAlliance {
 
 	public function getMemberIDs() : array {
 		if (!isset($this->memberList)) {
-			$this->db->query('SELECT account_id FROM player WHERE ' . $this->SQL);
+			$dbResult = $this->db->read('SELECT account_id FROM player WHERE ' . $this->SQL);
 
 			//we have the list of players put them in an array now
 			$this->memberList = array();
-			while ($this->db->nextRecord()) {
-				$this->memberList[] = $this->db->getInt('account_id');
+			foreach ($dbResult->records() as $dbRecord) {
+				$this->memberList[] = $dbRecord->getInt('account_id');
 			}
 		}
 		return $this->memberList;
@@ -490,13 +492,13 @@ class SmrAlliance {
 	public function getActiveIDs() : array {
 		$activeIDs = array();
 
-		$this->db->query('SELECT account_id
+		$dbResult = $this->db->read('SELECT account_id
 						FROM active_session
 						JOIN player USING(account_id, game_id)
 						WHERE '.$this->SQL . ' AND last_accessed >= ' . $this->db->escapeNumber(Smr\Epoch::time() - 600));
 
-		while ($this->db->nextRecord()) {
-			$activeIDs[] = $this->db->getInt('account_id');
+		foreach ($dbResult->records() as $dbRecord) {
+			$activeIDs[] = $dbRecord->getInt('account_id');
 		}
 
 		return $activeIDs;
@@ -506,7 +508,7 @@ class SmrAlliance {
 	 * Return all planets owned by members of this alliance.
 	 */
 	public function getPlanets() : array {
-		$this->db->query('SELECT planet.*
+		$dbResult = $this->db->read('SELECT planet.*
 			FROM player
 			JOIN planet ON player.game_id = planet.game_id AND player.account_id = planet.owner_id
 			WHERE player.game_id=' . $this->db->escapeNumber($this->gameID) . '
@@ -514,8 +516,8 @@ class SmrAlliance {
 			ORDER BY planet.sector_id
 		');
 		$planets = array();
-		while ($this->db->nextRecord()) {
-			$planets[] = SmrPlanet::getPlanet($this->gameID, $this->db->getInt('sector_id'), false, $this->db);
+		foreach ($dbResult->records() as $dbRecord) {
+			$planets[] = SmrPlanet::getPlanet($this->gameID, $dbRecord->getInt('sector_id'), false, $dbRecord);
 		}
 		return $planets;
 	}
@@ -525,10 +527,10 @@ class SmrAlliance {
 	 */
 	public function getSeedlist() : array {
 		if (!isset($this->seedlist)) {
-			$this->db->query('SELECT sector_id FROM alliance_has_seedlist WHERE ' . $this->SQL);
+			$dbResult = $this->db->read('SELECT sector_id FROM alliance_has_seedlist WHERE ' . $this->SQL);
 			$this->seedlist = array();
-			while ($this->db->nextRecord()) {
-				$this->seedlist[] = $this->db->getInt('sector_id');
+			foreach ($dbResult->records() as $dbRecord) {
+				$this->seedlist[] = $dbRecord->getInt('sector_id');
 			}
 		}
 		return $this->seedlist;
@@ -559,7 +561,7 @@ class SmrAlliance {
 		$sendAllMsg = TRUE;
 		$opLeader = TRUE;
 		$viewBonds = TRUE;
-		$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
+		$db->write('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
 			'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ', \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 
 		switch ($newMemberPermission) {
@@ -593,7 +595,7 @@ class SmrAlliance {
 				$viewBonds = FALSE;
 			break;
 		}
-		$db->query('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
+		$db->write('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
 					'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ', \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
 
 	}

--- a/src/lib/Default/SmrAlliance.class.php
+++ b/src/lib/Default/SmrAlliance.class.php
@@ -81,8 +81,8 @@ class SmrAlliance {
 		if ($allianceID != 0) {
 			$dbResult = $this->db->read('SELECT * FROM alliance WHERE ' . $this->SQL);
 			$dbRecord = $dbResult->record();
-			$this->allianceName = $dbRecord->getField('alliance_name');
-			$this->password = stripslashes($dbRecord->getField('alliance_password'));
+			$this->allianceName = $dbRecord->getString('alliance_name');
+			$this->password = $dbRecord->getField('alliance_password');
 			$this->recruiting = $dbRecord->getBoolean('recruiting');
 			$this->description = $dbRecord->getField('alliance_description');
 			$this->leaderID = $dbRecord->getInt('leader_id');

--- a/src/lib/Default/SmrForce.class.php
+++ b/src/lib/Default/SmrForce.class.php
@@ -63,18 +63,14 @@ class SmrForce {
 
 	public static function getGalaxyForces(int $gameID, int $galaxyID, bool $forceUpdate = false) : array {
 		$db = Smr\Database::getInstance();
-		$dbResult = $db->read('SELECT sector_has_forces.*, sector_id FROM sector LEFT JOIN sector_has_forces USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT sector_has_forces.* FROM sector_has_forces LEFT JOIN sector USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
 		$galaxyForces = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$sectorID = $dbRecord->getInt('sector_id');
-			if (!$dbRecord->hasField('owner_id')) {
-				self::$CACHE_SECTOR_FORCES[$gameID][$sectorID] = [];
-			} else {
-				$ownerID = $dbRecord->getInt('owner_id');
-				$force = self::getForce($gameID, $sectorID, $ownerID, $forceUpdate, $dbRecord);
-				self::$CACHE_SECTOR_FORCES[$gameID][$sectorID][$ownerID] = $force;
-				$galaxyForces[$sectorID][$ownerID] = $force;
-			}
+			$ownerID = $dbRecord->getInt('owner_id');
+			$force = self::getForce($gameID, $sectorID, $ownerID, $forceUpdate, $dbRecord);
+			self::$CACHE_SECTOR_FORCES[$gameID][$sectorID][$ownerID] = $force;
+			$galaxyForces[$sectorID][$ownerID] = $force;
 		}
 		return $galaxyForces;
 	}

--- a/src/lib/Default/SmrPlanet.class.php
+++ b/src/lib/Default/SmrPlanet.class.php
@@ -137,7 +137,7 @@ class SmrPlanet {
 		if ($this->exists) {
 			$this->gameID = $gameID;
 			$this->sectorID = $sectorID;
-			$this->planetName = stripslashes($dbRecord->getField('planet_name'));
+			$this->planetName = $dbRecord->getString('planet_name');
 			$this->ownerID = $dbRecord->getInt('owner_id');
 			$this->password = $dbRecord->getField('password');
 			$this->shields = $dbRecord->getInt('shields');

--- a/src/lib/Default/SmrPlanet.class.php
+++ b/src/lib/Default/SmrPlanet.class.php
@@ -74,14 +74,11 @@ class SmrPlanet {
 
 	public static function getGalaxyPlanets(int $gameID, int $galaxyID, bool $forceUpdate = false) : array {
 		$db = Smr\Database::getInstance();
-		$dbResult = $db->read('SELECT planet.*, sector_id FROM sector LEFT JOIN planet USING (game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT planet.* FROM planet LEFT JOIN sector USING (game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
 		$galaxyPlanets = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$sectorID = $dbRecord->getInt('sector_id');
-			$planet = self::getPlanet($gameID, $sectorID, $forceUpdate, $dbRecord);
-			if ($planet->exists()) {
-				$galaxyPlanets[$sectorID] = $planet;
-			}
+			$galaxyPlanets[$sectorID] = self::getPlanet($gameID, $sectorID, $forceUpdate, $dbRecord);
 		}
 		return $galaxyPlanets;
 	}

--- a/src/lib/Default/SmrWeapon.class.php
+++ b/src/lib/Default/SmrWeapon.class.php
@@ -17,12 +17,12 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	protected bool $bonusDamage = false; // default
 	protected bool $damageRollover = false; // fixed for all SmrWeapons
 
-	public static function getWeapon(int $weaponTypeID, Smr\Database $db = null) : SmrWeapon {
-		return new SmrWeapon($weaponTypeID, $db);
+	public static function getWeapon(int $weaponTypeID, Smr\DatabaseRecord $dbRecord = null) : SmrWeapon {
+		return new SmrWeapon($weaponTypeID, $dbRecord);
 	}
 
-	protected function __construct(int $weaponTypeID, Smr\Database $db = null) {
-		$this->weaponType = SmrWeaponType::getWeaponType($weaponTypeID, $db);
+	protected function __construct(int $weaponTypeID, Smr\DatabaseRecord $dbRecord = null) {
+		$this->weaponType = SmrWeaponType::getWeaponType($weaponTypeID, $dbRecord);
 		$this->weaponTypeID = $weaponTypeID;
 		$this->raceID = $this->weaponType->getRaceID();
 	}

--- a/src/lib/Default/SmrWeaponType.class.php
+++ b/src/lib/Default/SmrWeaponType.class.php
@@ -17,14 +17,14 @@ class SmrWeaponType {
 	protected int $powerLevel;
 	protected int $buyerRestriction;
 
-	public static function getWeaponType(int $weaponTypeID, Smr\Database $db = null) : SmrWeaponType {
+	public static function getWeaponType(int $weaponTypeID, Smr\DatabaseRecord $dbRecord = null) : SmrWeaponType {
 		if (!isset(self::$CACHE_WEAPON_TYPES[$weaponTypeID])) {
-			if (is_null($db)) {
+			if ($dbRecord === null) {
 				$db = Smr\Database::getInstance();
-				$db->query('SELECT * FROM weapon_type WHERE weapon_type_id = ' . $db->escapeNumber($weaponTypeID));
-				$db->requireRecord();
+				$dbResult = $db->read('SELECT * FROM weapon_type WHERE weapon_type_id = ' . $db->escapeNumber($weaponTypeID));
+				$dbRecord = $dbResult->record();
 			}
-			$weapon = new SmrWeaponType($weaponTypeID, $db);
+			$weapon = new SmrWeaponType($weaponTypeID, $dbRecord);
 			self::$CACHE_WEAPON_TYPES[$weaponTypeID] = $weapon;
 		}
 		return self::$CACHE_WEAPON_TYPES[$weaponTypeID];
@@ -32,11 +32,11 @@ class SmrWeaponType {
 
 	public static function getAllWeaponTypes() : array {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT * FROM weapon_type');
+		$dbResult = $db->read('SELECT * FROM weapon_type');
 		$weapons = array();
-		while ($db->nextRecord()) {
-			$weaponTypeID = $db->getInt('weapon_type_id');
-			$weapons[$weaponTypeID] = self::getWeaponType($weaponTypeID, $db);
+		foreach ($dbResult->records() as $dbRecord) {
+			$weaponTypeID = $dbRecord->getInt('weapon_type_id');
+			$weapons[$weaponTypeID] = self::getWeaponType($weaponTypeID, $dbRecord);
 		}
 		return $weapons;
 	}
@@ -46,25 +46,25 @@ class SmrWeaponType {
 	 */
 	public static function getAllSoldWeaponTypes(int $gameID) : array {
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT DISTINCT weapon_type.* FROM weapon_type JOIN location_sells_weapons USING (weapon_type_id) JOIN location USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID));
+		$dbResult = $db->read('SELECT DISTINCT weapon_type.* FROM weapon_type JOIN location_sells_weapons USING (weapon_type_id) JOIN location USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID));
 		$weapons = [];
-		while ($db->nextRecord()) {
-			$weaponTypeID = $db->getInt('weapon_type_id');
-			$weapons[$weaponTypeID] = self::getWeaponType($weaponTypeID, $db);
+		foreach ($dbResult->records() as $dbRecord) {
+			$weaponTypeID = $dbRecord->getInt('weapon_type_id');
+			$weapons[$weaponTypeID] = self::getWeaponType($weaponTypeID, $dbRecord);
 		}
 		return $weapons;
 	}
 
-	protected function __construct(int $weaponTypeID, Smr\Database $db) {
+	protected function __construct(int $weaponTypeID, Smr\DatabaseRecord $dbRecord) {
 		$this->weaponTypeID = $weaponTypeID;
-		$this->name = $db->getField('weapon_name');
-		$this->raceID = $db->getInt('race_id');
-		$this->cost = $db->getInt('cost');
-		$this->shieldDamage = $db->getInt('shield_damage');
-		$this->armourDamage = $db->getInt('armour_damage');
-		$this->accuracy = $db->getInt('accuracy');
-		$this->powerLevel = $db->getInt('power_level');
-		$this->buyerRestriction = $db->getInt('buyer_restriction');
+		$this->name = $dbRecord->getField('weapon_name');
+		$this->raceID = $dbRecord->getInt('race_id');
+		$this->cost = $dbRecord->getInt('cost');
+		$this->shieldDamage = $dbRecord->getInt('shield_damage');
+		$this->armourDamage = $dbRecord->getInt('armour_damage');
+		$this->accuracy = $dbRecord->getInt('accuracy');
+		$this->powerLevel = $dbRecord->getInt('power_level');
+		$this->buyerRestriction = $dbRecord->getInt('buyer_restriction');
 	}
 
 	public function getWeaponTypeID() : int {

--- a/src/lib/Default/VoteSite.class.php
+++ b/src/lib/Default/VoteSite.class.php
@@ -89,10 +89,10 @@ class VoteSite {
 			$WAIT_TIMES = array(); // ensure this is set
 			$activeLinkIDs = array_keys(self::getAllSites());
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT link_id, timeout FROM vote_links WHERE account_id=' . $db->escapeNumber($accountID) . ' AND link_id IN (' . join(',', $activeLinkIDs) . ') LIMIT ' . $db->escapeNumber(count($activeLinkIDs)));
-			while ($db->nextRecord()) {
+			$dbResult = $db->read('SELECT link_id, timeout FROM vote_links WHERE account_id=' . $db->escapeNumber($accountID) . ' AND link_id IN (' . join(',', $activeLinkIDs) . ') LIMIT ' . $db->escapeNumber(count($activeLinkIDs)));
+			foreach ($dbResult->records() as $dbRecord) {
 				// 'timeout' is the last time the player claimed free turns (or 0, if unclaimed)
-				$WAIT_TIMES[$db->getInt('link_id')] = ($db->getInt('timeout') + TIME_BETWEEN_VOTING) - Smr\Epoch::time();
+				$WAIT_TIMES[$dbRecord->getInt('link_id')] = ($dbRecord->getInt('timeout') + TIME_BETWEEN_VOTING) - Smr\Epoch::time();
 			}
 			// If not in the vote_link database, this site is eligible now.
 			foreach ($activeLinkIDs as $linkID) {

--- a/src/lib/Default/WeightedRandom.class.php
+++ b/src/lib/Default/WeightedRandom.class.php
@@ -55,9 +55,9 @@ class WeightedRandom {
 		$this->typeID = $typeID;
 
 		$this->db = Smr\Database::getInstance();
-		$this->db->query('SELECT weighting FROM weighted_random WHERE game_id = ' . $this->db->escapeNumber($gameID) . ' AND account_id = ' . $this->db->escapeNumber($accountID) . ' AND type = ' . $this->db->escapeString($type) . ' AND type_id = ' . $this->db->escapeNumber($typeID) . ' LIMIT 1');
-		if ($this->db->nextRecord()) {
-			$this->weighting = $this->db->getInt('weighting');
+		$dbResult = $this->db->read('SELECT weighting FROM weighted_random WHERE game_id = ' . $this->db->escapeNumber($gameID) . ' AND account_id = ' . $this->db->escapeNumber($accountID) . ' AND type = ' . $this->db->escapeString($type) . ' AND type_id = ' . $this->db->escapeNumber($typeID) . ' LIMIT 1');
+		if ($dbResult->hasRecord()) {
+			$this->weighting = $dbResult->record()->getInt('weighting');
 		} else {
 			$this->weighting = 0;
 		}
@@ -108,7 +108,7 @@ class WeightedRandom {
 
 	public function update() : void {
 		if ($this->hasChanged === true) {
-			$this->db->query('REPLACE INTO weighted_random (game_id,account_id,type,type_id,weighting)
+			$this->db->write('REPLACE INTO weighted_random (game_id,account_id,type,type_id,weighting)
 							values
 							(' . $this->db->escapeNumber($this->getGameID()) .
 							',' . $this->db->escapeNumber($this->getAccountID()) .

--- a/src/lib/Default/bar.inc.php
+++ b/src/lib/Default/bar.inc.php
@@ -19,19 +19,18 @@ function checkForLottoWinner(int $gameID) : void {
 	}
 
 	//we need to pick a winner
-	$db->query('SELECT * FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND time > 0 ORDER BY rand() LIMIT 1');
-	$db->requireRecord();
-	$winner_id = $db->getInt('account_id');
+	$dbResult = $db->read('SELECT * FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND time > 0 ORDER BY rand() LIMIT 1');
+	$winner_id = $dbResult->record()->getInt('account_id');
 
 	// Any unclaimed prizes get merged into this prize
-	$db->query('SELECT SUM(prize) FROM player_has_ticket WHERE time = 0 AND game_id = ' . $db->escapeNumber($gameID));
-	if ($db->nextRecord()) {
-		$lottoInfo['Prize'] += $db->getInt('SUM(prize)');
+	$dbResult = $db->read('SELECT SUM(prize) FROM player_has_ticket WHERE time = 0 AND game_id = ' . $db->escapeNumber($gameID));
+	if ($dbResult->hasRecord()) {
+		$lottoInfo['Prize'] += $dbResult->record()->getInt('SUM(prize)');
 	}
 
 	// Delete all tickets and re-insert the winning ticket
-	$db->query('DELETE FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($gameID));
-	$db->query('INSERT INTO player_has_ticket (game_id, account_id, time, prize) '
+	$db->write('DELETE FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($gameID));
+	$db->write('INSERT INTO player_has_ticket (game_id, account_id, time, prize) '
 	           .'VALUES (' . $db->escapeNumber($gameID) . ',' . $db->escapeNumber($winner_id) . ',\'0\',' . $db->escapeNumber($lottoInfo['Prize']) . ')');
 
 	$db->unlock();
@@ -42,8 +41,8 @@ function checkForLottoWinner(int $gameID) : void {
 	$winner->increaseHOF(1, array('Bar', 'Lotto', 'Results', 'Wins'), HOF_PUBLIC);
 	$news_message = $winner->getBBLink() . ' has won the lotto! The jackpot was ' . number_format($lottoInfo['Prize']) . '. ' . $winner->getBBLink() . ' can report to any bar to claim their prize before the next drawing!';
 	// insert the news entry
-	$db->query('DELETE FROM news WHERE type = \'lotto\' AND game_id = ' . $db->escapeNumber($gameID));
-	$db->query('INSERT INTO news
+	$db->write('DELETE FROM news WHERE type = \'lotto\' AND game_id = ' . $db->escapeNumber($gameID));
+	$db->write('INSERT INTO news
 				(game_id, time, news_message, type, dead_id, dead_alliance)
 				VALUES ('.$db->escapeNumber($gameID) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeString($news_message) . ',\'lotto\',' . $db->escapeNumber($winner->getAccountID()) . ',' . $db->escapeNumber($winner->getAllianceID()) . ')');
 }
@@ -53,12 +52,12 @@ function getLottoInfo(int $gameID) : array {
 	$firstBuy = Smr\Epoch::time();
 
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT count(*) as num, min(time) as time FROM player_has_ticket
+	$dbResult = $db->read('SELECT count(*) as num, min(time) as time FROM player_has_ticket
 				WHERE game_id = '.$db->escapeNumber($gameID) . ' AND time > 0');
-	$db->requireRecord();
-	if ($db->getInt('num') > 0) {
-		$amount += $db->getInt('num') * 1000000 * .9;
-		$firstBuy = $db->getInt('time');
+	$dbRecord = $dbResult->record();
+	if ($dbRecord->getInt('num') > 0) {
+		$amount += $dbRecord->getInt('num') * 1000000 * .9;
+		$firstBuy = $dbRecord->getInt('time');
 	}
 	//find the time remaining in this jackpot. (which is 2 days from the first purchased ticket)
 	return array('Prize' => $amount, 'TimeRemaining' => $firstBuy + TIME_LOTTO - Smr\Epoch::time());

--- a/src/lib/Default/gov.inc.php
+++ b/src/lib/Default/gov.inc.php
@@ -6,13 +6,13 @@
 function getBounties(string $type) : array {
 	$db = Smr\Database::getInstance();
 	$session = Smr\Session::getInstance();
-	$db->query('SELECT * FROM bounty WHERE game_id = ' . $db->escapeNumber($session->getGameID()) . ' AND type =' . $db->escapeString($type) . ' AND claimer_id = 0 ORDER BY amount DESC');
+	$dbResult = $db->read('SELECT * FROM bounty WHERE game_id = ' . $db->escapeNumber($session->getGameID()) . ' AND type =' . $db->escapeString($type) . ' AND claimer_id = 0 ORDER BY amount DESC');
 	$bounties = [];
-	while ($db->nextRecord()) {
+	foreach ($dbResult->records() as $dbRecord) {
 		$bounties[] = [
-			'player' => SmrPlayer::getPlayer($db->getInt('account_id'), $session->getGameID()),
-			'credits' => $db->getInt('amount'),
-			'smr_credits' => $db->getInt('smr_credits')
+			'player' => SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $session->getGameID()),
+			'credits' => $dbRecord->getInt('amount'),
+			'smr_credits' => $dbRecord->getInt('smr_credits')
 		];
 	}
 	return $bounties;

--- a/src/lib/Default/help.inc.php
+++ b/src/lib/Default/help.inc.php
@@ -10,7 +10,7 @@ function echo_nav($topic_id) {
 		$dbRecord = $dbResult->record();
 		$parent_topic_id = $dbRecord->getInt('parent_topic_id');
 		$order_id = $dbRecord->getInt('order_id');
-		$topic = stripslashes($dbRecord->getField('topic'));
+		$topic = stripslashes($dbRecord->getString('topic'));
 
 		echo ('<table>');
 		echo ('<tr>');
@@ -29,7 +29,7 @@ function echo_nav($topic_id) {
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			$previous_topic_id = $dbRecord->getInt('topic_id');
-			$previous_topic = stripslashes($dbRecord->getField('topic'));
+			$previous_topic = stripslashes($dbRecord->getString('topic'));
 			echo ('<a href="/manual.php?' . $previous_topic_id . '"><img src="/images/help/previous.jpg" width="32" height="32" border="0"></a>');
 		} else {
 			echo ('<img src="/images/help/empty.jpg" width="32" height="32">');
@@ -44,7 +44,7 @@ function echo_nav($topic_id) {
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			$up_topic_id = $dbRecord->getInt('topic_id');
-			$up_topic = stripslashes($dbRecord->getField('topic'));
+			$up_topic = stripslashes($dbRecord->getString('topic'));
 			echo ('<a href="/manual.php?' . $up_topic_id . '"><img src="/images/help/up.jpg" width="32" height="32" border="0"></a>');
 		} else {
 			echo ('<img src="/images/help/empty.jpg" width="32" height="32">');
@@ -76,7 +76,7 @@ function echo_nav($topic_id) {
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			$next_topic_id = $dbRecord->getInt('topic_id');
-			$next_topic = stripslashes($dbRecord->getField('topic'));
+			$next_topic = stripslashes($dbRecord->getString('topic'));
 			echo ('<a href="/manual.php?' . $next_topic_id . '"><img src="/images/help/next.jpg" width="32" height="32" border="0"></a>');
 		} else {
 			echo ('<img src="/images/help/empty.jpg" width="32" height="32">');
@@ -113,8 +113,8 @@ function echo_content($topic_id) {
 		$dbRecord = $dbResult->record();
 		$parent_topic_id = $dbRecord->getInt('parent_topic_id');
 		$order_id = $dbRecord->getInt('order_id');
-		$topic = stripslashes($dbRecord->getField('topic'));
-		$text = stripslashes($dbRecord->getField('text'));
+		$topic = stripslashes($dbRecord->getString('topic'));
+		$text = stripslashes($dbRecord->getString('text'));
 
 		echo ('<div id="help_content">');
 		echo ('<h1>' . get_numbering($topic_id) . $topic . '</h1>');
@@ -154,7 +154,7 @@ function echo_menu($topic_id) {
 		foreach ($dbResult->records() as $dbRecord) {
 			$sub_topic_id = $dbRecord->getInt('topic_id');
 			$order_id = $dbRecord->getInt('order_id');
-			$sub_topic = stripslashes($dbRecord->getField('topic'));
+			$sub_topic = stripslashes($dbRecord->getString('topic'));
 
 			echo ('<li><a href="/manual.php?' . $sub_topic_id . '">' . get_numbering($sub_topic_id) . $sub_topic . '</a></li>');
 			echo_menu($sub_topic_id);

--- a/src/lib/Default/help.inc.php
+++ b/src/lib/Default/help.inc.php
@@ -3,15 +3,14 @@
 function echo_nav($topic_id) {
 	// database object
 	$db = Smr\Database::getInstance();
-	$db2 = Smr\Database::getInstance();
-	$db3 = Smr\Database::getInstance();
 
 	// get current entry
-	$db->query('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($topic_id));
-	if ($db->nextRecord()) {
-		$parent_topic_id = $db->getInt('parent_topic_id');
-		$order_id = $db->getInt('order_id');
-		$topic = stripslashes($db->getField('topic'));
+	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($topic_id));
+	if ($dbResult->hasRecord()) {
+		$dbRecord = $dbResult->record();
+		$parent_topic_id = $dbRecord->getInt('parent_topic_id');
+		$order_id = $dbRecord->getInt('order_id');
+		$topic = stripslashes($dbRecord->getField('topic'));
 
 		echo ('<table>');
 		echo ('<tr>');
@@ -19,61 +18,67 @@ function echo_nav($topic_id) {
 		// **************************
 		// **  PREVIOUS
 		// **************************
-		$db2->query('SELECT * FROM manual WHERE parent_topic_id = ' . $db2->escapeNumber($parent_topic_id) . ' AND order_id = ' . $db2->escapeNumber($order_id - 1));
+		$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($parent_topic_id) . ' AND order_id = ' . $db->escapeNumber($order_id - 1));
 
 		// no result?
-		if (!$db2->getNumRows())
-			$db2->query('SELECT * FROM manual WHERE topic_id = ' . $db2->escapeNumber($parent_topic_id));
+		if (!$dbResult->hasRecord()) {
+			$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($parent_topic_id));
+		}
 
 		echo ('<th width="32">');
-		if ($db2->nextRecord()) {
-			$previous_topic_id = $db2->getInt('topic_id');
-			$previous_topic = stripslashes($db2->getField('topic'));
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			$previous_topic_id = $dbRecord->getInt('topic_id');
+			$previous_topic = stripslashes($dbRecord->getField('topic'));
 			echo ('<a href="/manual.php?' . $previous_topic_id . '"><img src="/images/help/previous.jpg" width="32" height="32" border="0"></a>');
-		} else
+		} else {
 			echo ('<img src="/images/help/empty.jpg" width="32" height="32">');
+		}
 		echo ('</th>');
 
 		// **************************
 		// **  UP
 		// **************************
-		$db2->query('SELECT * FROM manual WHERE topic_id = ' . $db2->escapeNumber($parent_topic_id));
+		$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($parent_topic_id));
 		echo ('<th width="32">');
-		if ($db2->nextRecord()) {
-			$up_topic_id = $db2->getInt('topic_id');
-			$up_topic = stripslashes($db2->getField('topic'));
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			$up_topic_id = $dbRecord->getInt('topic_id');
+			$up_topic = stripslashes($dbRecord->getField('topic'));
 			echo ('<a href="/manual.php?' . $up_topic_id . '"><img src="/images/help/up.jpg" width="32" height="32" border="0"></a>');
-		} else
+		} else {
 			echo ('<img src="/images/help/empty.jpg" width="32" height="32">');
+		}
 		echo ('</th>');
 
 		// **************************
 		// **  NEXT
 		// **************************
-		$db2->query('SELECT * FROM manual WHERE parent_topic_id = ' . $db2->escapeNumber($topic_id) . ' AND order_id = 1');
+		$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' AND order_id = 1');
 
-		if (!$db2->getNumRows())
-			$db2->query('SELECT * FROM manual WHERE parent_topic_id = ' . $db2->escapeNumber($parent_topic_id) . ' AND order_id = ' . $db2->escapeNumber($order_id + 1));
+		if (!$dbResult->hasRecord()) {
+			$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($parent_topic_id) . ' AND order_id = ' . $db->escapeNumber($order_id + 1));
+		}
 
 		$seenParentIDs = array(0);
 		$curr_parent_topic_id = $parent_topic_id;
-		while (!$db2->getNumRows() && !in_array($curr_parent_topic_id, $seenParentIDs)) {
+		while (!$dbResult->hasRecord() && !in_array($curr_parent_topic_id, $seenParentIDs)) {
 			$seenParentIDs[] = $curr_parent_topic_id;
-			$db3->query('SELECT * FROM manual WHERE topic_id = ' . $db3->escapeNumber($parent_topic_id));
-			$db3->nextRecord();
-			$curr_order_id = $db3->getInt('order_id');
-			$curr_parent_topic_id = $db3->getInt('parent_topic_id');
+			$dbResult2 = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($parent_topic_id));
+			$dbRecord2 = $dbResult2->record();
+			$curr_order_id = $dbRecord2->getInt('order_id');
+			$curr_parent_topic_id = $dbRecord2->getInt('parent_topic_id');
 
-			$db2->query('SELECT * FROM manual WHERE parent_topic_id = ' . $db2->escapeNumber($parent_topic_id) . ' AND order_id = ' . $db2->escapeNumber($curr_order_id + 1));
+			$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($parent_topic_id) . ' AND order_id = ' . $db->escapeNumber($curr_order_id + 1));
 		}
 
 		echo ('<th width="32">');
-		if ($db2->nextRecord()) {
-			$next_topic_id = $db2->getInt('topic_id');
-			$next_topic = stripslashes($db2->getField('topic'));
+		if ($dbResult->hasRecord()) {
+			$dbRecord = $dbResult->record();
+			$next_topic_id = $dbRecord->getInt('topic_id');
+			$next_topic = stripslashes($dbRecord->getField('topic'));
 			echo ('<a href="/manual.php?' . $next_topic_id . '"><img src="/images/help/next.jpg" width="32" height="32" border="0"></a>');
-		}
-		else {
+		} else {
 			echo ('<img src="/images/help/empty.jpg" width="32" height="32">');
 		}
 		echo ('</th>');
@@ -103,19 +108,21 @@ function echo_content($topic_id) {
 	$db = Smr\Database::getInstance();
 
 	// get current entry
-	$db->query('SELECT * FROM manual WHERE topic_id = ' . $topic_id);
-	if ($db->nextRecord()) {
-		$parent_topic_id = $db->getInt('parent_topic_id');
-		$order_id = $db->getInt('order_id');
-		$topic = stripslashes($db->getField('topic'));
-		$text = stripslashes($db->getField('text'));
+	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $topic_id);
+	if ($dbResult->hasRecord()) {
+		$dbRecord = $dbResult->record();
+		$parent_topic_id = $dbRecord->getInt('parent_topic_id');
+		$order_id = $dbRecord->getInt('order_id');
+		$topic = stripslashes($dbRecord->getField('topic'));
+		$text = stripslashes($dbRecord->getField('text'));
 
 		echo ('<div id="help_content">');
 		echo ('<h1>' . get_numbering($topic_id) . $topic . '</h1>');
 		echo ('<p>' . $text . '<p>');
 		echo ('</div>');
-	} else
+	} else {
 		echo ('Invalid Topic!');
+	}
 }
 
 function echo_subsection($topic_id) {
@@ -123,8 +130,8 @@ function echo_subsection($topic_id) {
 	$db = Smr\Database::getInstance();
 	$return = '';
 	// check if there are subsections
-	$db->query('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' ORDER BY order_id');
-	if ($db->getNumRows()) {
+	$dbResult = $db->read('SELECT 1 FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' ORDER BY order_id');
+	if ($dbResult->hasRecord()) {
 		echo ('<hr noshade width="75%" size="1" class="center"/>');
 		echo ('<div id="help_menu">');
 		echo ('<h2>Subsections:</h2>');
@@ -141,13 +148,13 @@ function echo_menu($topic_id) {
 	// database object
 	$db = Smr\Database::getInstance();
 
-	$db->query('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' ORDER BY order_id');
-	if ($db->getNumRows()) {
+	$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' ORDER BY order_id');
+	if ($dbResult->hasRecord()) {
 		echo ('<ul type="disc">');
-		while ($db->nextRecord()) {
-			$sub_topic_id = $db->getInt('topic_id');
-			$order_id = $db->getInt('order_id');
-			$sub_topic = stripslashes($db->getField('topic'));
+		foreach ($dbResult->records() as $dbRecord) {
+			$sub_topic_id = $dbRecord->getInt('topic_id');
+			$order_id = $dbRecord->getInt('order_id');
+			$sub_topic = stripslashes($dbRecord->getField('topic'));
 
 			echo ('<li><a href="/manual.php?' . $sub_topic_id . '">' . get_numbering($sub_topic_id) . $sub_topic . '</a></li>');
 			echo_menu($sub_topic_id);
@@ -160,10 +167,11 @@ function echo_menu($topic_id) {
 function get_numbering($topic_id) {
 	$db = Smr\Database::getInstance();
 
-	$db->query('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($topic_id));
-	if ($db->nextRecord()) {
-		$up_topic_id = $db->getInt('parent_topic_id');
-		$order_id = $db->getInt('order_id');
+	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($topic_id));
+	if ($dbResult->hasRecord()) {
+		$dbRecord = $dbResult->record();
+		$up_topic_id = $dbRecord->getInt('parent_topic_id');
+		$order_id = $dbRecord->getInt('order_id');
 
 		return get_numbering($up_topic_id) . $order_id . '. ';
 	}

--- a/src/lib/Default/hof.inc.php
+++ b/src/lib/Default/hof.inc.php
@@ -82,7 +82,7 @@ function getHofRank(string $view, array $viewType, int $accountID, ?int $gameID)
 		if (!$dbResult->hasRecord()) {
 			return $rank;
 		}
-		$vis = $dbResult->record()->getField('visibility');
+		$vis = $dbResult->record()->getString('visibility');
 		$dbResult = $db->read('SELECT SUM(amount) amount FROM player_hof WHERE type=' . $db->escapeArray($viewType, ':', false) . ' AND account_id=' . $db->escapeNumber($accountID) . $gameIDSql . ' GROUP BY account_id LIMIT 1');
 	}
 

--- a/src/lib/Default/login_processing.inc.php
+++ b/src/lib/Default/login_processing.inc.php
@@ -38,8 +38,8 @@ function redirectIfDisabled(SmrAccount $account) : array|false {
 function redirectIfOffline(SmrAccount $account) : void {
 	// Check if the game is offline
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT * FROM game_disable');
-	$offline = $db->nextRecord();
+	$dbResult = $db->read('SELECT reason FROM game_disable');
+	$offline = $dbResult->hasRecord();
 
 	// Skip redirect if we're not offline or if account has admin permission
 	if ($offline === false || $account->hasPermission(PERMISSION_GAME_OPEN_CLOSE)) {
@@ -54,7 +54,7 @@ function redirectIfOffline(SmrAccount $account) : void {
 	if (session_status() === PHP_SESSION_NONE) {
 		session_start();
 	}
-	$_SESSION['login_msg'] = '<span class="red">Space Merchant Realms is temporarily offline.<br />' . $db->getField('reason') . '</span>';
+	$_SESSION['login_msg'] = '<span class="red">Space Merchant Realms is temporarily offline.<br />' . $dbResult->record()->getField('reason') . '</span>';
 
 	header('location: /login.php?status=offline');
 	exit;

--- a/src/lib/Default/news.inc.php
+++ b/src/lib/Default/news.inc.php
@@ -9,7 +9,7 @@ function getNewsItems(Smr\DatabaseResult $dbResult) : array {
 
 	$newsItems = [];
 	foreach ($dbResult->records() as $dbRecord) {
-		$message = bbifyMessage($dbRecord->getField('news_message'));
+		$message = bbifyMessage($dbRecord->getString('news_message'));
 		if ($dbRecord->getField('type') == 'admin') {
 			$message = '<span class="admin">ADMIN </span>' . $message;
 		}
@@ -27,7 +27,7 @@ function doBreakingNewsAssign(int $gameID) : void {
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
 		$template = Smr\Template::getInstance();
-		$template->assign('BreakingNews', array('Time' => $dbRecord->getInt('time'), 'Message' => bbifyMessage($dbRecord->getField('news_message'))));
+		$template->assign('BreakingNews', array('Time' => $dbRecord->getInt('time'), 'Message' => bbifyMessage($dbRecord->getString('news_message'))));
 	}
 }
 
@@ -39,6 +39,6 @@ function doLottoNewsAssign(int $gameID) : void {
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
 		$template = Smr\Template::getInstance();
-		$template->assign('LottoNews', array('Time' => $dbRecord->getInt('time'), 'Message' => bbifyMessage($dbRecord->getField('news_message'))));
+		$template->assign('LottoNews', array('Time' => $dbRecord->getInt('time'), 'Message' => bbifyMessage($dbRecord->getString('news_message'))));
 	}
 }

--- a/src/lib/Draft/SmrPlayer.class.php
+++ b/src/lib/Draft/SmrPlayer.class.php
@@ -5,9 +5,9 @@ class SmrPlayer extends AbstractSmrPlayer {
 	public function getHome() : int {
 		if ($this->hasAlliance()) {
 			$leaderID = $this->getAlliance()->getLeaderID();
-			$this->db->query('SELECT home_sector_id FROM draft_leaders WHERE account_id = ' . $this->db->escapeNumber($leaderID) . ' AND game_id = ' . $this->db->escapeNumber($this->getGameID()));
-			if ($this->db->nextRecord()) {
-				return $this->db->getInt('home_sector_id');
+			$dbResult = $this->db->read('SELECT home_sector_id FROM draft_leaders WHERE account_id = ' . $this->db->escapeNumber($leaderID) . ' AND game_id = ' . $this->db->escapeNumber($this->getGameID()));
+			if ($dbResult->hasRecord()) {
+				return $dbResult->record()->getInt('home_sector_id');
 			}
 		}
 		// Fallback to the standard home sector

--- a/src/lib/Draft/alliance_pick.inc.php
+++ b/src/lib/Draft/alliance_pick.inc.php
@@ -4,12 +4,12 @@
 // including their current size and if the leader can pick teammates.
 function get_draft_teams(int $gameId) : array {
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT account_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($gameId));
+	$dbResult = $db->read('SELECT account_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($gameId));
 
 	// Get team leader, alliance, and alliance size
 	$teams = array();
-	while ($db->nextRecord()) {
-		$leader = SmrPlayer::getPlayer($db->getInt('account_id'), $gameId);
+	foreach ($dbResult->records() as $dbRecord) {
+		$leader = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $gameId);
 		$alliance = $leader->getAlliance();
 		if (!$leader->hasAlliance() || $alliance->getAllianceID() == NHA_ID) {
 			// Special case for leaders who haven't made their own alliance yet,

--- a/src/lib/Smr/DatabaseRecord.php
+++ b/src/lib/Smr/DatabaseRecord.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Smr;
+
+class DatabaseRecord {
+
+	/**
+	 * @param array $dbRecord A record from a DatabaseResult.
+	 */
+	public function __construct(
+		private array $dbRecord
+	) {}
+
+	public function hasField(string $name) : bool {
+		return isset($this->dbRecord[$name]);
+	}
+
+	public function getField(string $name) : ?string {
+		return $this->dbRecord[$name];
+	}
+
+	public function getBoolean(string $name) : bool {
+		return match($this->dbRecord[$name]) {
+			'TRUE' => true,
+			'FALSE' => false,
+		};
+	}
+
+	public function getInt(string $name) : int {
+		return (int)$this->dbRecord[$name];
+	}
+
+	public function getFloat(string $name) : float {
+		return (float)$this->dbRecord[$name];
+	}
+
+	public function getMicrotime(string $name) : string {
+		// All digits of precision are stored in a MySQL bigint
+		$data = $this->dbRecord[$name];
+		return sprintf('%f', $data / 1E6);
+	}
+
+	public function getObject(string $name, bool $compressed = false, bool $nullable = false) : mixed {
+		$object = $this->getField($name);
+		if ($nullable === true && $object === null) {
+			return null;
+		}
+		if ($compressed === true) {
+			$object = gzuncompress($object);
+		}
+		return unserialize($object);
+	}
+
+	public function getRow() : array {
+		return $this->dbRecord;
+	}
+
+}

--- a/src/lib/Smr/DatabaseRecord.php
+++ b/src/lib/Smr/DatabaseRecord.php
@@ -19,6 +19,14 @@ class DatabaseRecord {
 		return $this->dbRecord[$name];
 	}
 
+	/**
+	 * Get a string-only field from the database record.
+	 * If the field can be null, use `getField` instead.
+	 */
+	public function getString(string $name) : string {
+		return $this->dbRecord[$name];
+	}
+
 	public function getBoolean(string $name) : bool {
 		return match($this->dbRecord[$name]) {
 			'TRUE' => true,

--- a/src/lib/Smr/DatabaseResult.php
+++ b/src/lib/Smr/DatabaseResult.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Smr;
+
+/**
+ * Holds the result of a Database query (e.g. read or write).
+ */
+class DatabaseResult {
+
+	public function __construct(
+		private \mysqli_result $dbResult
+	) {}
+
+	/**
+	 * Use to iterate over the records from the result set.
+	 * @return \Generator<DatabaseRecord>
+	 */
+	public function records() : \Generator {
+		foreach ($this->dbResult as $dbRecord) {
+			yield new DatabaseRecord($dbRecord);
+		}
+	}
+
+	/**
+	 * Use when exactly one record is expected from the result set.
+	 */
+	public function record() : DatabaseRecord {
+		if ($this->getNumRecords() != 1) {
+			throw new \RuntimeException('One record required, but found ' . $this->getNumRecords());
+		}
+		return new DatabaseRecord($this->dbResult->fetch_assoc());
+	}
+
+	public function getNumRecords() : int {
+		return $this->dbResult->num_rows;
+	}
+
+	public function hasRecord() : bool {
+		return $this->getNumRecords() > 0;
+	}
+
+}

--- a/src/templates/Default/engine/Default/includes/AllianceRankingsList.inc.php
+++ b/src/templates/Default/engine/Default/includes/AllianceRankingsList.inc.php
@@ -6,9 +6,9 @@
 		<th>Average <?php echo $RankingStat; ?></th>
 		<th>Total Members</th>
 	</tr><?php
-	foreach ($Rankings as $Ranking) { ?>
+	foreach ($Rankings as $Rank => $Ranking) { ?>
 		<tr<?php echo $Ranking['Class']; ?>>
-			<td class="top"><?php echo $Ranking['Rank']; ?></td>
+			<td class="top"><?php echo $Rank; ?></td>
 			<td class="top left"><?php echo $Ranking['Alliance']->getAllianceDisplayName(true); ?></td>
 			<td class="top"><?php echo number_format($Ranking['Value']); ?></td>
 			<td class="top"><?php echo number_format($Ranking['Value'] / max(1, $Ranking['Alliance']->getNumMembers())); ?></td>

--- a/src/templates/Default/engine/Default/includes/PlayerRankingsList.inc.php
+++ b/src/templates/Default/engine/Default/includes/PlayerRankingsList.inc.php
@@ -6,9 +6,9 @@
 		<th>Alliance</th>
 		<th><?php echo $RankingStat; ?></th>
 	</tr><?php
-	foreach ($Rankings as $Ranking) { ?>
+	foreach ($Rankings as $Rank => $Ranking) { ?>
 		<tr<?php echo $Ranking['Class']; ?>>
-			<td class="top"><?php echo $Ranking['Rank']; ?></td>
+			<td class="top"><?php echo $Rank; ?></td>
 			<td class="top left"><?php echo $Ranking['Player']->getLevelName(); ?> <?php echo $Ranking['Player']->getLinkedDisplayName(false); ?></td>
 			<td class="top"><?php echo $ThisPlayer->getColouredRaceName($Ranking['Player']->getRaceID(), true); ?></td>
 			<td class="top"><?php echo $Ranking['Player']->getAllianceDisplayName(true); ?></td>

--- a/src/tools/chat_helpers/channel_msg_money.php
+++ b/src/tools/chat_helpers/channel_msg_money.php
@@ -14,18 +14,20 @@ function shared_channel_msg_money(SmrPlayer $player) : array {
 
 	// get money on ships and personal bank accounts
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT sum(credits) as total_onship, sum(bank) as total_onbank FROM player WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID());
+	$dbResult = $db->read('SELECT sum(credits) as total_onship, sum(bank) as total_onbank FROM player WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID());
 
-	if ($db->nextRecord()) {
-		$result[] = 'Alliance members carry a total of ' . number_format($db->getInt('total_onship')) . ' credits with them';
-		$result[] = 'and keep a total of ' . number_format($db->getInt('total_onbank')) . ' credits in their personal bank accounts.';
+	if ($dbResult->hasRecord()) {
+		$dbRecord = $dbResult->record();
+		$result[] = 'Alliance members carry a total of ' . number_format($dbRecord->getInt('total_onship')) . ' credits with them';
+		$result[] = 'and keep a total of ' . number_format($dbRecord->getInt('total_onbank')) . ' credits in their personal bank accounts.';
 	}
 
 	// get money on planets
-	$db->query('SELECT SUM(credits) AS total_credits, SUM(bonds) AS total_bonds FROM planet WHERE game_id = ' . $player->getGameID() . ' AND owner_id IN (SELECT account_id FROM player WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID() . ')');
-	if ($db->nextRecord()) {
-		$result[] = 'There is a total of ' . number_format($db->getInt('total_credits')) . ' credits on the planets';
-		$result[] = 'and ' . number_format($db->getInt('total_bonds')) . ' credits in bonds.';
+	$dbResult = $db->read('SELECT SUM(credits) AS total_credits, SUM(bonds) AS total_bonds FROM planet WHERE game_id = ' . $player->getGameID() . ' AND owner_id IN (SELECT account_id FROM player WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID() . ')');
+	if ($dbResult->hasRecord()) {
+		$dbRecord = $dbResult->record();
+		$result[] = 'There is a total of ' . number_format($dbRecord->getInt('total_credits')) . ' credits on the planets';
+		$result[] = 'and ' . number_format($dbRecord->getInt('total_bonds')) . ' credits in bonds.';
 	}
 
 	return $result;

--- a/src/tools/chat_helpers/channel_msg_op_info.php
+++ b/src/tools/chat_helpers/channel_msg_op_info.php
@@ -3,13 +3,13 @@
 function shared_channel_msg_op_info(SmrPlayer $player) : array {
 	// get the op from db
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT time FROM alliance_has_op WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	if (!$db->nextRecord()) {
+	$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	if (!$dbResult->hasRecord()) {
 		return array('Your leader has not scheduled an operation.');
 	}
 
 	// check if the op has already started
-	$opTime = $db->getInt('time');
+	$opTime = $dbResult->record()->getInt('time');
 	if ($opTime < time()) {
 		return array('The op started ' . format_time(time() - $opTime, true) . ' ago!');
 	}
@@ -18,9 +18,9 @@ function shared_channel_msg_op_info(SmrPlayer $player) : array {
 	$getOpInfoMessage = function($player) use ($opTime) {
 		// have we signed up?
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT response FROM alliance_has_op_response WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND ' . $player->getSQL());
-		if ($db->nextRecord()) {
-			$msg = $player->getPlayerName() . ' is on the ' . $db->getField('response') . ' list.';
+		$dbResult = $db->read('SELECT response FROM alliance_has_op_response WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND ' . $player->getSQL());
+		if ($dbResult->hasRecord()) {
+			$msg = $player->getPlayerName() . ' is on the ' . $dbResult->record()->getField('response') . ' list.';
 		} else {
 			$msg = $player->getPlayerName() . ' has not signed up for this one.';
 		}

--- a/src/tools/chat_helpers/channel_msg_op_list.php
+++ b/src/tools/chat_helpers/channel_msg_op_list.php
@@ -3,28 +3,28 @@
 function shared_channel_msg_op_list(SmrPlayer $player) : array {
 	// get the op info from db
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT 1
+	$dbResult = $db->read('SELECT 1
 				FROM alliance_has_op
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	if (!$db->nextRecord()) {
+	if (!$dbResult->hasRecord()) {
 		return array('Your leader has not scheduled an op.');
 	}
 
 	$yes = array();
 	$no = array();
 	$maybe = array();
-	$db->query('SELECT account_id, response
+	$dbResult = $db->read('SELECT account_id, response
 				FROM alliance_has_op_response
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	while ($db->nextRecord()) {
-		$respondingPlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), true);
+	foreach ($dbResult->records() as $dbRecord) {
+		$respondingPlayer = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), true);
 		// check that the player is still in this alliance
 		if (!$player->sameAlliance($respondingPlayer)) {
 			continue;
 		}
-		switch ($db->getField('response')) {
+		switch ($dbRecord->getField('response')) {
 			case 'YES':
 				$yes[] = $respondingPlayer;
 			break;

--- a/src/tools/chat_helpers/channel_msg_op_turns.php
+++ b/src/tools/chat_helpers/channel_msg_op_turns.php
@@ -3,22 +3,22 @@
 function shared_channel_msg_op_turns(SmrPlayer $player) : array {
 	// get the op from db
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT 1
+	$dbResult = $db->read('SELECT 1
 				FROM alliance_has_op
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	if (!$db->nextRecord()) {
+	if (!$dbResult->hasRecord()) {
 		return array('There is no op scheduled.');
 	}
 
 	$oppers = array();
-	$db->query('SELECT account_id
+	$dbResult = $db->read('SELECT account_id
 				FROM alliance_has_op_response
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND response = \'YES\'');
-	while ($db->nextRecord()) {
-		$attendeePlayer = SmrPlayer::getPlayer($db->getInt('account_id'), $player->getGameID(), true);
+	foreach ($dbResult->records() as $dbRecord) {
+		$attendeePlayer = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), true);
 		// check that the player is still in this alliance
 		if (!$player->sameAlliance($attendeePlayer)) {
 			continue;

--- a/src/tools/chat_helpers/channel_msg_seed.php
+++ b/src/tools/chat_helpers/channel_msg_seed.php
@@ -3,7 +3,7 @@
 function get_seed_message(SmrPlayer $player) : string {
 	// get a list of seedlist sectors that the player hasn't seeded
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT sector_id
+	$dbResult = $db->read('SELECT sector_id
 		FROM alliance_has_seedlist
 		WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 			AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
@@ -15,8 +15,8 @@ function get_seed_message(SmrPlayer $player) : string {
 			)');
 
 	$missingSeeds = array();
-	while ($db->nextRecord()) {
-		$missingSeeds[] = $db->getInt('sector_id');
+	foreach ($dbResult->records() as $dbRecord) {
+		$missingSeeds[] = $dbRecord->getInt('sector_id');
 	}
 
 	if (count($missingSeeds) == 0) {
@@ -29,12 +29,11 @@ function get_seed_message(SmrPlayer $player) : string {
 function shared_channel_msg_seed(SmrPlayer $player) : array {
 	// Check to see how many sectors are in the seedlist
 	$db = Smr\Database::getInstance();
-	$db->query('SELECT count(*)
+	$dbResult = $db->read('SELECT count(*)
 		FROM alliance_has_seedlist
 		WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 			AND game_id = ' . $db->escapeNumber($player->getGameID()));
-	$db->requireRecord();
-	$numSectors = $db->getInt('count(*)');
+	$numSectors = $dbResult->record()->getInt('count(*)');
 
 	if ($numSectors == 0) {
 		return array('Your alliance has not set up a seedlist yet.');

--- a/src/tools/discord/GameLink.class.php
+++ b/src/tools/discord/GameLink.class.php
@@ -23,14 +23,13 @@ class GameLink
 		if ($message->channel->is_private) {
 			// Get the most recent enabled game, since there is no other way to determine the game ID
 			$db = Smr\Database::getInstance();
-			$db->query('SELECT MAX(game_id) FROM game WHERE enabled=' . $db->escapeBoolean(true) . ' AND end_time > ' . $db->escapeNumber(time()));
-			if ($db->nextRecord()) {
-				$game_id = $db->getInt('MAX(game_id)');
-			} else {
+			$dbResult = $db->read('SELECT MAX(game_id) FROM game WHERE enabled=' . $db->escapeBoolean(true) . ' AND end_time > ' . $db->escapeNumber(time()));
+			if (!$dbResult->hasRecord()) {
 				$message->reply('Could not find any games!')
 					->done(null, 'logException');
 				return;
 			}
+			$game_id = $dbResult->record()->getInt('MAX(game_id)');
 
 			$this->player = SmrPlayer::getPlayer($account->getAccountID(), $game_id, true);
 		} else {

--- a/src/tools/discord/mysql_cleanup.php
+++ b/src/tools/discord/mysql_cleanup.php
@@ -6,6 +6,12 @@ function mysql_cleanup(callable $func) : callable {
 
 	// Create a new closure that wraps the original closure
 	$func_wrapper = function($message, $params) use ($func) {
+		$db = Smr\Database::getInstance();
+
+		// Since we close the database connection after each call, we may
+		// need to reconnect here.
+		$db->reconnect();
+
 		// First, call the original closure
 		try {
 			$func($message, $params);
@@ -16,7 +22,6 @@ function mysql_cleanup(callable $func) : callable {
 		}
 
 		// Then, close the mysql connection to prevent timeouts
-		$db = Smr\Database::getInstance();
 		$db->close();
 	};
 

--- a/src/tools/irc/channel_msg.php
+++ b/src/tools/irc/channel_msg.php
@@ -19,7 +19,7 @@ function check_for_registration(&$account, &$player, $fp, $nick, $channel, $call
 		return true;
 	}
 
-	$registeredNick = $dbResult->record()->getField('registered_nick');
+	$registeredNick = $dbResult->record()->getString('registered_nick');
 
 	// get alliance_id and game_id for this channel
 	$alliance = SmrAlliance::getAllianceByIrcChannel($channel, true);

--- a/src/tools/irc/channel_msg_op.php
+++ b/src/tools/irc/channel_msg_op.php
@@ -71,20 +71,20 @@ function channel_msg_op_cancel($fp, $rdata, $account, $player)
 
 		// get the op from db
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT 1
+		$dbResult = $db->read('SELECT 1
 					FROM alliance_has_op
 					WHERE alliance_id = ' . $player->getAllianceID() . '
 						AND game_id = ' . $player->getGameID());
-		if (!$db->nextRecord()) {
+		if (!$dbResult->hasRecord()) {
 			fputs($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', your leader has not scheduled an OP.' . EOL);
 			return true;
 		}
 
 		// just get rid of op
-		$db->query('DELETE FROM alliance_has_op
+		$db->write('DELETE FROM alliance_has_op
 					WHERE alliance_id = ' . $player->getAllianceID() . '
 						AND game_id = ' . $player->getGameID());
-		$db->query('DELETE FROM alliance_has_op_response
+		$db->write('DELETE FROM alliance_has_op_response
 					WHERE alliance_id = ' . $player->getAllianceID() . '
 						AND game_id = ' . $player->getGameID());
 
@@ -118,11 +118,11 @@ function channel_msg_op_set($fp, $rdata, $account, $player)
 
 		// get the op from db
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT time
+		$dbResult = $db->read('SELECT 1
 					FROM alliance_has_op
 					WHERE alliance_id = ' . $player->getAllianceID() . '
 						AND  game_id = ' . $player->getGameID());
-		if ($db->nextRecord()) {
+		if ($dbResult->hasRecord()) {
 			fputs($fp, 'PRIVMSG ' . $channel . ' :There is already an OP scheduled. Cancel it first!' . EOL);
 			return true;
 		}
@@ -133,7 +133,7 @@ function channel_msg_op_set($fp, $rdata, $account, $player)
 		}
 
 		// add op to db
-		$db->query('INSERT INTO alliance_has_op (alliance_id, game_id, time)
+		$db->write('INSERT INTO alliance_has_op (alliance_id, game_id, time)
 					VALUES (' . $player->getAllianceID() . ', ' . $player->getGameID() . ', ' . $db->escapeNumber($op_time) . ')');
 
 		fputs($fp, 'PRIVMSG ' . $channel . ' :The OP has been scheduled.' . EOL);
@@ -186,16 +186,16 @@ function channel_msg_op_response($fp, $rdata, $account, $player) {
 
 		// get the op info from db
 		$db = Smr\Database::getInstance();
-		$db->query('SELECT 1
+		$dbResult = $db->read('SELECT 1
 					FROM alliance_has_op
 					WHERE alliance_id = ' . $player->getAllianceID() . '
 						AND game_id = ' . $player->getGameID());
-		if (!$db->nextRecord()) {
+		if (!$dbResult->hasRecord()) {
 			fputs($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', your leader has not scheduled an OP.' . EOL);
 			return true;
 		}
 
-		$db->query('REPLACE INTO alliance_has_op_response (alliance_id, game_id, account_id, response)
+		$db->write('REPLACE INTO alliance_has_op_response (alliance_id, game_id, account_id, response)
 					VALUES (' . $player->getAllianceID() . ', ' . $player->getGameID() . ', ' . $player->getAccountID() . ', ' . $db->escapeString($response) . ')');
 
 		fputs($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', you have been added to the ' . $response . ' list.' . EOL);
@@ -238,21 +238,21 @@ function channel_op_notification($fp, $rdata, $nick, $channel) {
 
 	$db = Smr\Database::getInstance();
 	// check if there is an upcoming op
-	$db->query('SELECT 1
+	$dbResult = $db->read('SELECT 1
 				FROM alliance_has_op
 				WHERE alliance_id = ' . $player->getAllianceID() . '
 					AND game_id = ' . $player->getGameID() . '
 					AND time > ' . time());
-	if (!$db->nextRecord()) {
+	if (!$dbResult->hasRecord()) {
 		return true;
 	}
 
-	$db->query('SELECT 1
+	$dbResult = $db->read('SELECT 1
 				FROM alliance_has_op_response
 				WHERE alliance_id = ' . $player->getAllianceID() . '
 					AND game_id = ' . $player->getGameID() . '
 					AND account_id = ' . $player->getAccountID());
-	if (!$db->nextRecord()) {
+	if (!$dbResult->hasRecord()) {
 		fputs($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', your alliance leader has scheduled an OP, which you have not signed up yet. Please use the !op yes/no/maybe command to do so.' . EOL);
 	}
 

--- a/src/tools/irc/notice.php
+++ b/src/tools/irc/notice.php
@@ -12,13 +12,12 @@ function notice_nickserv_registered_user($fp, $rdata)
 		echo_r('[NOTICE_NICKSERV_REGISTERED_NICK] ' . $nick . ' is ' . $registeredNick);
 
 		$db = Smr\Database::getInstance();
-		$db2 = Smr\Database::getInstance();
 
-		$db->query('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick));
-		while ($db->nextRecord()) {
-			$seen_id = $db->getInt('seen_id');
+		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick));
+		foreach ($dbResult->records() as $dbRecord) {
+			$seen_id = $dbRecord->getInt('seen_id');
 
-			$db2->query('UPDATE irc_seen SET
+			$db->write('UPDATE irc_seen SET
 						registered_nick = ' . $db->escapeString($registeredNick) . '
 						WHERE seen_id = ' . $seen_id);
 		}

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -10,7 +10,7 @@ try {
 
 	debug('Script started');
 	define('SCRIPT_ID', $db->getInsertID());
-	$db->query('UPDATE npc_logs SET script_id=' . SCRIPT_ID . ' WHERE log_id=' . SCRIPT_ID);
+	$db->write('UPDATE npc_logs SET script_id=' . SCRIPT_ID . ' WHERE log_id=' . SCRIPT_ID);
 
 	define('NPC_SCRIPT', true);
 
@@ -84,5 +84,5 @@ try {
 function debug($message, $debugObject = null) {
 	echo date('Y-m-d H:i:s - ') . $message . ($debugObject !== null ? EOL . var_export($debugObject, true) : '') . EOL;
 	$db = Smr\Database::getInstance();
-	$db->query('INSERT INTO npc_logs (script_id, npc_id, time, message, debug_info, var) VALUES (' . (defined('SCRIPT_ID') ? SCRIPT_ID : 0) . ', 0, NOW(),' . $db->escapeString($message) . ',' . $db->escapeString(var_export($debugObject,true)) . ',' . $db->escapeString('') . ')');
+	$db->write('INSERT INTO npc_logs (script_id, npc_id, time, message, debug_info, var) VALUES (' . (defined('SCRIPT_ID') ? SCRIPT_ID : 0) . ', 0, NOW(),' . $db->escapeString($message) . ',' . $db->escapeString(var_export($debugObject,true)) . ',' . $db->escapeString('') . ')');
 }

--- a/src/tools/rerunChessGames.php
+++ b/src/tools/rerunChessGames.php
@@ -4,10 +4,10 @@ require_once('../bootstrap.php');
 Smr\Session::getInstance()->updateGame(44);
 
 $db = Smr\Database::getInstance();
-$db->query('DELETE FROM player_hof WHERE type LIKE \'Chess%\'');
-$db->query('SELECT chess_game_id FROM chess_game');
-while ($db->nextRecord()) {
-	$chessGameID = $db->getInt('chess_game_id');
+$db->write('DELETE FROM player_hof WHERE type LIKE \'Chess%\'');
+$dbResult = $db->read('SELECT chess_game_id FROM chess_game');
+foreach ($dbResult->records() as $dbRecord) {
+	$chessGameID = $dbRecord->getInt('chess_game_id');
 	$game = ChessGame::getChessGame($chessGameID);
 	echo 'Running game ' . $chessGameID . ' for white id "' . $game->getWhiteID() . '", black id "' . $game->getBlackID() . '", winner "' . $game->getWinner() . '"' . EOL;
 	echoChessMoves($game);

--- a/src/tools/reserializeCombatLogs.php
+++ b/src/tools/reserializeCombatLogs.php
@@ -3,12 +3,11 @@
 require_once('../bootstrap.php');
 
 $db = Smr\Database::getInstance();
-$db2 = Smr\Database::getInstance();
 
-//$db->query('SELECT * FROM combat_logs WHERE type=\'PLAYER\' ORDER BY OCTET_LENGTH(result) DESC LIMIT 1');
-//if($db->nextRecord())
+//$dbResult = $db->read('SELECT * FROM combat_logs WHERE type=\'PLAYER\' ORDER BY OCTET_LENGTH(result) DESC LIMIT 1');
+//if ($dbResult->hasRecord())
 //{
-//	$x = $db->getField('result');
+//	$x = $dbResult->record()->getField('result');
 //	$y = gzuncompress($x);
 //	var_dump($y);
 //
@@ -20,7 +19,7 @@ $db2 = Smr\Database::getInstance();
 //	var_dump(strlen(bzcompress($z)));
 //}
 
-$db->query('SELECT result,log_id FROM combat_logs');
-while ($db->nextRecord()) {
-	$db2->query('UPDATE combat_logs SET result=' . $db2->escapeObject($db->getObject('result', true), true) . ' WHERE log_id=' . $db->getField('log_id'));
+$dbResult = $db->read('SELECT result,log_id FROM combat_logs');
+foreach ($dbResult->records() as $dbRecord) {
+	$db->write('UPDATE combat_logs SET result=' . $db->escapeObject($dbRecord->getObject('result', true), true) . ' WHERE log_id=' . $dbRecord->getField('log_id'));
 }

--- a/src/tools/updatePortCache.php
+++ b/src/tools/updatePortCache.php
@@ -2,8 +2,8 @@
 require_once('../bootstrap.php');
 
 $db = Smr\Database::getInstance();
-$db->query('SELECT account_id,sector_id,game_id FROM player_visited_port');
-while ($db->nextRecord()) {
-	SmrPort::getCachedPort($db->getInt('game_id'), $db->getInt('sector_id'), $db->getInt('account_id'))->addCachePort($db->getInt('account_id'));
+$dbResult = $db->read('SELECT account_id,sector_id,game_id FROM player_visited_port');
+foreach ($dbResult->records() as $dbRecord) {
+	SmrPort::getCachedPort($dbRecord->getInt('game_id'), $dbRecord->getInt('sector_id'), $dbRecord->getInt('account_id'))->addCachePort($dbRecord->getInt('account_id'));
 	SmrPort::clearCache();
 }

--- a/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
@@ -205,8 +205,10 @@ class DatabaseIntegrationTest extends TestCase {
 			[false, 'escapeBoolean', 'getBoolean', 'assertSame', []],
 			[3, 'escapeNumber', 'getInt', 'assertSame', []],
 			[3.14, 'escapeNumber', 'getFloat', 'assertSame', []],
+			['hello', 'escapeString', 'getString', 'assertSame', []],
 			['hello', 'escapeString', 'getField', 'assertSame', []],
 			// Test nullable objects
+			[null, 'escapeString', 'getField', 'assertSame', [true]],
 			[null, 'escapeObject', 'getObject', 'assertSame', [false, true]],
 			// Test object with compression
 			[[1, 2, 3], 'escapeObject', 'getObject', 'assertSame', [true]],

--- a/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
@@ -34,12 +34,12 @@ class DatabaseIntegrationTest extends TestCase {
 		$this->assertNotNull($db);
 	}
 
-	public function test_getInstance_always_returns_new_instance() {
+	public function test_getInstance_always_returns_same_instance() {
 		// Given a Database object
 		$original = Database::getInstance();
 		// When calling getInstance again
 		$second = Database::getInstance();
-		self::assertNotSame($original, $second);
+		self::assertSame($original, $second);
 	}
 
 	public function test_performing_operations_on_closed_database_throws_error() {
@@ -50,7 +50,7 @@ class DatabaseIntegrationTest extends TestCase {
 		// When calling database methods
 		$this->expectException(\Error::class);
 		$this->expectExceptionMessage('Typed property Smr\Database::$dbConn must not be accessed before initialization');
-		$db->query("foo query");
+		$db->read("foo query");
 	}
 
 	public function test_closing_database_returns_boolean() {
@@ -61,28 +61,27 @@ class DatabaseIntegrationTest extends TestCase {
 		self::assertFalse($db->close());
 	}
 
-	public function test_getInstance_will_perform_reconnect_after_connection_closed() {
+	public function test_reconnect_after_connection_closed() {
 		// Given an original mysql connection
 		$originalMysql = DiContainer::get(mysqli::class);
 		// And a Database instance
 		$db = Database::getInstance();
 		// And disconnect is called
 		$db->close();
-		// And Database is retrieved from the container
-		$db = Database::getInstance();
-		// When performing a query
-		$db ->query("select 1");
+		// And Database is usable again after reconnecting
+		$db->reconnect();
+		$db->read("SELECT 1");
 		// Then new mysqli instance is not the same as the initial mock
 		self::assertNotSame($originalMysql, DiContainer::get(mysqli::class));
 	}
 
-	public function test_getInstance_will_not_perform_reconnect_if_connection_not_closed() {
+	public function test_reconnect_when_connection_not_closed() {
 		// Given an original mysql connection
 		$originalMysql = DiContainer::get(mysqli::class);
 		// And a Database instance
-		Database::getInstance();
-		// And get instance is called again
-		Database::getInstance();
+		$db = Database::getInstance();
+		// And reconnect is called before closing the connection
+		$db->reconnect();
 		// Then the two mysqli instances are the same
 		self::assertSame($originalMysql, DiContainer::get(mysqli::class));
 	}
@@ -177,7 +176,7 @@ class DatabaseIntegrationTest extends TestCase {
 		$this->expectException(\RuntimeException::class);
 		$this->expectExceptionMessage("Table 'account' was not locked with LOCK TABLES");
 		try {
-			$db->query('SELECT 1 FROM account LIMIT 1');
+			$db->read('SELECT 1 FROM account LIMIT 1');
 		} catch (\RuntimeException $err) {
 			// Avoid leaving database in a locked state
 			$db->unlock();
@@ -190,54 +189,12 @@ class DatabaseIntegrationTest extends TestCase {
 		$db->lockTable('good');
 
 		// Perform a query on the locked table
-		$db->query('SELECT good_name FROM good WHERE good_id = 1');
-		$db->requireRecord();
-		self::assertSame(['good_name' => 'Wood'], $db->getRow());
+		$result = $db->read('SELECT good_name FROM good WHERE good_id = 1');
+		self::assertSame(['good_name' => 'Wood'], $result->record()->getRow());
 
 		// After unlock we can access other tables again
 		$db->unlock();
-		$db->query('SELECT 1 FROM account LIMIT 1');
-	}
-
-	public function test_requireRecord() {
-		$db = Database::getInstance();
-		// Create a query that returns one record
-		$db->query('SELECT 1');
-		$db->requireRecord();
-		self::assertSame([1 => '1'], $db->getRow());
-	}
-
-	public function test_requireRecord_too_many_rows() {
-		$db = Database::getInstance();
-		// Create a query that returns two rows
-		$db->query('SELECT 1 UNION SELECT 2');
-		$this->expectException(\RuntimeException::class);
-		$this->expectExceptionMessage('One record required, but found 2');
-		$db->requireRecord();
-	}
-
-	public function test_nextRecord_no_resource() {
-		$db = Database::getInstance();
-		$this->expectException(\RuntimeException::class);
-		$this->expectExceptionMessage('No resource to get record from.');
-		// Call nextRecord before any query is made
-		$db->nextRecord();
-	}
-
-	public function test_nextRecord_no_result() {
-		$db = Database::getInstance();
-		// Construct a query that has an empty result set
-		$db->query('SELECT 1 FROM good WHERE good_id = 0');
-		self::assertFalse($db->nextRecord());
-	}
-
-	public function test_hasField() {
-		$db = Database::getInstance();
-		// Construct a query that has the field 'val', but not 'bla'
-		$db->query('SELECT 1 AS val');
-		$db->requireRecord();
-		self::assertTrue($db->hasField('val'));
-		self::assertFalse($db->hasField('bla'));
+		$db->read('SELECT 1 FROM account LIMIT 1');
 	}
 
 	public function test_inversion_of_escape_and_get() {
@@ -259,19 +216,9 @@ class DatabaseIntegrationTest extends TestCase {
 			[microtime(true), 'escapeMicrotime', 'getMicrotime', 'assertEquals', []],
 		];
 		foreach ($params as list($value, $escaper, $getter, $cmp, $args)) {
-			$db->query('SELECT ' . $db->$escaper($value, ...$args) . ' AS val');
-			$db->requireRecord();
-			self::$cmp($value, $db->$getter('val', ...$args));
+			$result = $db->read('SELECT ' . $db->$escaper($value, ...$args) . ' AS val');
+			self::$cmp($value, $result->record()->$getter('val', ...$args));
 		}
-	}
-
-	public function test_getBoolean_with_non_boolean_field() {
-		$db = Database::getInstance();
-		$db->query('SELECT \'bla\'');
-		$db->requireRecord();
-		$this->expectException(\RuntimeException::class);
-		$this->expectExceptionMessage('Field is not a boolean: bla');
-		$db->getBoolean('bla');
 	}
 
 }

--- a/test/SmrTest/lib/DefaultGame/DatabaseRecordTest.php
+++ b/test/SmrTest/lib/DefaultGame/DatabaseRecordTest.php
@@ -28,6 +28,19 @@ class DatabaseRecordTest extends \PHPUnit\Framework\TestCase {
 		self::assertSame(null, $record->getField('name'));
 	}
 
+	public function test_getString() {
+		// Construct a record with a string value
+		$record = new DatabaseRecord(['name' => 'value_string']);
+		self::assertSame('value_string', $record->getString('name'));
+	}
+
+	public function test_getString_with_null_value() {
+		// Construct a record with a null value
+		$record = new DatabaseRecord(['name' => null]);
+		$this->expectException(\TypeError::class);
+		$record->getString('name');
+	}
+
 	public function test_getBoolean() {
 		$record = new DatabaseRecord([
 			'name_true' => 'TRUE',

--- a/test/SmrTest/lib/DefaultGame/DatabaseRecordTest.php
+++ b/test/SmrTest/lib/DefaultGame/DatabaseRecordTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use Smr\DatabaseRecord;
+
+/**
+ * @covers \Smr\DatabaseRecord
+ */
+class DatabaseRecordTest extends \PHPUnit\Framework\TestCase {
+
+	public function test_hasField() {
+		// Construct a record that has the field 'foo', but not 'bla'
+		$record = new DatabaseRecord(['name' => 'value']);
+		self::assertTrue($record->hasField('name'));
+		self::assertFalse($record->hasField('does_not_exist'));
+	}
+
+	public function test_getField() {
+		// Construct a record with a string value
+		$record = new DatabaseRecord(['name' => 'value_string']);
+		self::assertSame('value_string', $record->getField('name'));
+	}
+
+	public function test_getField_with_null_value() {
+		// Construct a record with a null value
+		$record = new DatabaseRecord(['name' => null]);
+		self::assertSame(null, $record->getField('name'));
+	}
+
+	public function test_getBoolean() {
+		$record = new DatabaseRecord([
+			'name_true' => 'TRUE',
+			'name_false' => 'FALSE',
+		]);
+		self::assertSame(true, $record->getBoolean('name_true'));
+		self::assertSame(false, $record->getBoolean('name_false'));
+	}
+
+	public function test_getBoolean_with_non_boolean_field() {
+		$record = new DatabaseRecord(['name' => 'NONBOOLEAN']);
+		$this->expectException(\UnhandledMatchError::class);
+		$record->getBoolean('name');
+	}
+
+	public function test_getInt() {
+		$record = new DatabaseRecord(['name' => '3']);
+		self::assertSame(3, $record->getInt('name'));
+	}
+
+	public function test_getFloat() {
+		$record = new DatabaseRecord(['name' => '3.14']);
+		self::assertSame(3.14, $record->getFloat('name'));
+	}
+
+	public function test_getMicrotime() {
+		// Construct a record with a numeric string
+		$record = new DatabaseRecord(['name' => '123456789']);
+		self::assertSame('123.456789', $record->getMicrotime('name'));
+	}
+
+	public function test_getObject() {
+		// Construct a record with various types of objects
+		$record = new DatabaseRecord([
+			'name' => serialize(new \ArrayObject(['a' => 1, 'b' => 2])),
+			'name_null' => null,
+			'name_compressed' => gzcompress(serialize(['c', 'd'])),
+		]);
+		// Class objects must be compared here with Equals instead of Same
+		// since the two objects will not be the same instance.
+		self::assertEquals(new \ArrayObject(['a' => 1, 'b' => 2]), $record->getObject('name'));
+		self::assertSame(null, $record->getObject('name_null', nullable: true));
+		self::assertSame(['c', 'd'], $record->getObject('name_compressed', compressed: true));
+	}
+
+	public function test_getRow() {
+		// getRow returns the entire record
+		$record = new DatabaseRecord(['name1' => '1', 'name2' => '2']);
+		self::assertSame(['name1' => '1', 'name2' => '2'], $record->getRow());
+	}
+
+}

--- a/test/SmrTest/lib/DefaultGame/DatabaseResultTest.php
+++ b/test/SmrTest/lib/DefaultGame/DatabaseResultTest.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use Smr\Database;
+use Smr\DatabaseResult;
+
+/**
+ * @covers \Smr\DatabaseResult
+ */
+class DatabaseResultTest extends \PHPUnit\Framework\TestCase {
+
+	/**
+	 * Create and run a trivial query that returns $num rows
+	 */
+	private function runQuery(int $num) : DatabaseResult {
+		$db = Database::getInstance();
+		// This query will look like (for increasing $num):
+		//    SELECT 1 LIMIT 0
+		//    SELECT 1 LIMIT 1
+		//    SELECT 1 UNION SELECT 2 LIMIT 2
+		//    SELECT 1 UNION SELECT 2 UNION SELECT 3 LIMIT 3
+		// We always include at least "SELECT 1" so that we have a valid
+		// query in the $num=0 case, and then add "LIMIT $num" to ensure
+		// that we get the requested number of rows.
+		$query = 'SELECT 1';
+		for ($i = 2; $i <= $num; $i++) {
+			$query .= ' UNION SELECT ' . $i;
+		}
+		$query .= ' LIMIT ' . $num;
+		return $db->read($query);
+	}
+
+	public function test_record_one_row() {
+		self::assertSame([1 => '1'], $this->runQuery(1)->record()->getRow());
+	}
+
+	public function test_record_too_many_rows() {
+		$result = $this->runQuery(2);
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('One record required, but found 2');
+		$result->record();
+	}
+
+	public function test_record_too_few_rows() {
+		$result = $this->runQuery(0);
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('One record required, but found 0');
+		$result->record();
+	}
+
+	public function test_hasRecord_no_rows() {
+		$result = $this->runQuery(0);
+		self::assertFalse($result->hasRecord());
+	}
+
+	public function test_hasRecord_with_rows() {
+		$result = $this->runQuery(1);
+		self::assertTrue($result->hasRecord());
+	}
+
+	public function test_getNumRecords() {
+		foreach ([0, 1, 2] as $numRecords) {
+			$result = $this->runQuery($numRecords);
+			self::assertSame($numRecords, $result->getNumRecords());
+		}
+	}
+
+	public function test_records() {
+		$numRecords = 0;
+		$result = $this->runQuery(3);
+		foreach ($result->records() as $index => $record) {
+			$row = $index + 1;
+			self::assertSame([1 => (string)$row], $record->getRow());
+			$numRecords++;
+		}
+		self::assertSame(3, $numRecords);
+	}
+
+	public function test_records_no_rows() {
+		$result = $this->runQuery(0);
+		self::assertSame([], iterator_to_array($result->records()));
+	}
+
+}


### PR DESCRIPTION
Create separate classes for storing the database result and each
record of the result (DatabaseResult and DatabaseRecord respectively).
This simplifies the Database class, which now only holds the `dbConn`
property.

* Split Database::query into `write` and `read` methods, to clearly
  delineate between the different return types of mysqli::query.
  The `write` method is for queries that return "true" on success.
  The `read` method is for queries that return a `mysqli_result`
  object, from which we get our records.

* Interface changes:
    - Database::nextRecord -> DatabaseResult::records
    - Database::requireRecord -> DatabaseResult::record
    - Database::getNumRows -> DatabaseResult::getNumRecords
    - Added DatabaseResult::hasRecord

* When looping over SELECT records, we return them with a generator
  (`DatabaseResult::records`), which allows us to use a foreach loop,
  instead of a while loop.

* In queries where we only check if a record exists, use `SELECT 1` to
  optimize the query (instead of selecting columns that we won't use).

* Note that because we use `getInstance` properly now (i.e. there
  really only is one `Database` that is ever retrieved from the DI
  Container), once we store the result from a query in a DatabaseResult,
  we can immediately reuse the Database for additional queries.
  (That is, we can remove `$db2`, `$db3`, etc.)