### PR TITLE
Session: remove updateVar

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $link = $container->href();
 ```
 
 ## Request variables
-For any page which takes input through POST or GET (or other forms?) they should store these values in $var using Smr\Session::updateVar() and only access via $var, this is required as when auto-refresh updates the page it will *not* resend these inputs but still requires them to render the page correctly.
+For any page which takes input through POST or GET, these values must be accessed using `Smr\Session::getRequestVar()` and relatives, which will store the value in `$var`. This is required because auto-refresh updates of the page will *not* resend these inputs, but they are still required to render the page correctly.
 
 ## Abstract vs normal classes
 This initially started out to be used in the "standard" way for NPCs but that idea has since been discarded.

--- a/src/admin/Default/1.6/universe_create_save_processing.php
+++ b/src/admin/Default/1.6/universe_create_save_processing.php
@@ -4,7 +4,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
 $submit = Request::getVar('submit');
-$session->updateVar('submit', null);
+$var['submit'] = null; // clear if set
 
 if ($submit == 'Create Galaxies') {
 	for ($i = 1; $i <= $var['num_gals']; $i++) {

--- a/src/admin/Default/1.6/universe_create_sectors.php
+++ b/src/admin/Default/1.6/universe_create_sectors.php
@@ -45,7 +45,7 @@ $template->assign('LastSector', $lastSector);
 
 if (isset($var['message'])) {
 	$template->assign('Message', $var['message']);
-	$session->updateVar('message', null); // Only show message once
+	unset($var['message']); // Only show message once
 }
 
 $container = Page::create('skeleton.php', '1.6/universe_create_sectors.php');

--- a/src/admin/Default/1.6/universe_create_warps.php
+++ b/src/admin/Default/1.6/universe_create_warps.php
@@ -7,7 +7,7 @@ $var = $session->getCurrentVar();
 
 if (isset($var['message'])) {
 	$template->assign('Message', $var['message']);
-	$session->updateVar('message', null); // Only show message once
+	unset($var['message']); // Only show message once
 }
 
 $galaxies = SmrGalaxy::getGameGalaxies($var['game_id']);

--- a/src/admin/Default/manage_draft_leaders.php
+++ b/src/admin/Default/manage_draft_leaders.php
@@ -40,13 +40,14 @@ if ($activeGames) {
 	$template->assign('CurrentLeaders', $currentLeaders);
 }
 
-// If we are selecting a different game, clear the processing message.
-if (Request::has('selected_game_id')) {
-	$session->updateVar('processing_msg', null);
-}
-// If we have just forwarded from the processing file, pass its message.
 if (isset($var['processing_msg'])) {
-	$template->assign('ProcessingMsg', $var['processing_msg']);
+	if (Request::has('selected_game_id')) {
+		// If we are selecting a different game, clear the processing message.
+		unset($var['processing_msg']);
+	} else {
+		// If we have just forwarded from the processing file, pass its message.
+		$template->assign('ProcessingMsg', $var['processing_msg']);
+	}
 }
 
 // Create the link to the processing file

--- a/src/admin/Default/manage_draft_leaders_processing.php
+++ b/src/admin/Default/manage_draft_leaders_processing.php
@@ -7,26 +7,27 @@ $var = $session->getCurrentVar();
 // Get the selected game
 $gameId = $var['selected_game_id'];
 
-// Clear any messages from prior processing
-$session->updateVar('processing_msg', null);
-
 // Get the POST variables
 $playerId = Request::getInt('player_id');
 $homeSectorID = Request::getInt('home_sector_id');
 $action = Request::get('submit');
 
+// Pass entire $var so that the selected game remains selected
+$container = Page::create('skeleton.php', 'manage_draft_leaders.php', $var);
+
 try {
 	$selectedPlayer = SmrPlayer::getPlayerByPlayerID($playerId, $gameId);
 } catch (PlayerNotFoundException $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
-	$session->updateVar('processing_msg', $msg);
-	Page::create('skeleton.php', 'manage_draft_leaders.php', $var)->go();
+	$container['processing_msg'] = $msg;
+	$container->go();
 }
 
 $name = $selectedPlayer->getDisplayName();
 $accountId = $selectedPlayer->getAccountID();
 $game = $selectedPlayer->getGame()->getDisplayName();
 
+$msg = null; // by default, clear any messages from prior processing
 if ($action == "Assign") {
 	if ($selectedPlayer->isDraftLeader()) {
 		$msg = "<span class='red'>ERROR: </span>$name is already a draft leader in game $game!";
@@ -43,9 +44,5 @@ if ($action == "Assign") {
 	$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";
 }
 
-if (!empty($msg)) {
-	$session->updateVar('processing_msg', $msg);
-}
-
-// Pass entire $var so that the selected game remains selected
-Page::create('skeleton.php', 'manage_draft_leaders.php', $var)->go();
+$container['processing_msg'] = $msg;
+$container->go();

--- a/src/admin/Default/manage_post_editors.php
+++ b/src/admin/Default/manage_post_editors.php
@@ -35,13 +35,14 @@ if ($activeGames) {
 	$template->assign('CurrentEditors', $currentEditors);
 }
 
-// If we are selecting a different game, clear the processing message.
-if (Request::has('game_id')) {
-	$session->updateVar('processing_msg', null);
-}
-// If we have just forwarded from the processing file, pass its message.
 if (isset($var['processing_msg'])) {
-	$template->assign('ProcessingMsg', $var['processing_msg']);
+	if (Request::has('game_id')) {
+		// If we are selecting a different game, clear the processing message.
+		unset($var['processing_msg']);
+	} else {
+		// If we have just forwarded from the processing file, pass its message.
+		$template->assign('ProcessingMsg', $var['processing_msg']);
+	}
 }
 
 // Create the link to the processing file

--- a/src/admin/Default/manage_post_editors_processing.php
+++ b/src/admin/Default/manage_post_editors_processing.php
@@ -7,25 +7,26 @@ $var = $session->getCurrentVar();
 // Get the selected game
 $game_id = $var['selected_game_id'];
 
-// Clear any messages from prior processing
-$session->updateVar('processing_msg', null);
-
 // Get the POST variables
 $player_id = Request::getInt('player_id');
 $action = Request::get('submit');
+
+// Pass entire $var so that the selected game remains selected
+$container = Page::create('skeleton.php', 'manage_post_editors.php', $var);
 
 try {
 	$selected_player = SmrPlayer::getPlayerByPlayerID($player_id, $game_id);
 } catch (PlayerNotFoundException $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
-	$session->updateVar('processing_msg', $msg);
-	Page::create('skeleton.php', 'manage_post_editors.php', $var)->go();
+	$container['processing_msg'] = $msg;
+	$container->go();
 }
 
 $name = $selected_player->getDisplayName();
 $account_id = $selected_player->getAccountID();
 $game = $selected_player->getGame()->getDisplayName();
 
+$msg = null; // by default, clear any messages from prior processing
 if ($action == "Assign") {
 	if ($selected_player->isGPEditor()) {
 		$msg = "<span class='red'>ERROR: </span>$name is already an editor in game $game!";
@@ -42,9 +43,5 @@ if ($action == "Assign") {
 	$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";
 }
 
-if (!empty($msg)) {
-	$session->updateVar('processing_msg', $msg);
-}
-
-// Pass entire $var so that the selected game remains selected
-Page::create('skeleton.php', 'manage_post_editors.php', $var)->go();
+$container['processing_msg'] = $msg;
+$container->go();

--- a/src/engine/Default/alliance_forces.php
+++ b/src/engine/Default/alliance_forces.php
@@ -5,11 +5,9 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
+$allianceID = $var['alliance_id'] ?? $player->getAllianceID();
 
-$alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
+$alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 

--- a/src/engine/Default/alliance_invite_player_processing.php
+++ b/src/engine/Default/alliance_invite_player_processing.php
@@ -21,10 +21,10 @@ if ($dbResult->hasRecord() || $account->isMailBanned()) {
 
 // Construct the mail to send to the receiver
 $msg = 'You have been invited to join an alliance!
-This invitation will remain open for '.$expireDays . ' ' . pluralise('day', $expireDays) . ' or until you join another alliance.
+This invitation will remain open for ' . $expireDays . ' ' . pluralise('day', $expireDays) . ' or until you join another alliance.
 If you are currently in an alliance, you will leave it if you accept this invitation.
 
-[join_alliance='.$player->getAllianceID() . ']
+[join_alliance=' . $player->getAllianceID() . ']
 ';
 if (!empty($addMessage)) {
 	$msg .= '<br />' . $addMessage;

--- a/src/engine/Default/alliance_message.php
+++ b/src/engine/Default/alliance_message.php
@@ -6,11 +6,9 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
+$allianceID = $var['alliance_id'] ?? $player->getAllianceID();
 
-$alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
+$alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 

--- a/src/engine/Default/alliance_message_add_processing.php
+++ b/src/engine/Default/alliance_message_add_processing.php
@@ -23,10 +23,7 @@ if ($action == 'Preview Thread' || $action == 'Preview Reply') {
 	$container->go();
 }
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
-$alliance_id = $var['alliance_id'];
+$alliance_id = $var['alliance_id'] ?? $player->getAllianceID();
 
 // it could be we got kicked during writing the msg
 if (!$player->hasAlliance()) {

--- a/src/engine/Default/alliance_message_delete_processing.php
+++ b/src/engine/Default/alliance_message_delete_processing.php
@@ -5,10 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
-$alliance_id = $var['alliance_id'];
+$alliance_id = $var['alliance_id'] ?? $player->getAllianceID();
 
 if (isset($var['reply_id'])) {
 	$db->write('DELETE FROM alliance_thread
@@ -26,5 +23,5 @@ if (isset($var['reply_id'])) {
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
 				AND thread_id = ' . $db->escapeNumber($var['thread_id']));
-	Page::create('skeleton.php', 'alliance_message.php')->go();
+	Page::create('skeleton.php', 'alliance_message.php', ['alliance_id' => $alliance_id])->go();
 }

--- a/src/engine/Default/alliance_message_view.php
+++ b/src/engine/Default/alliance_message_view.php
@@ -6,7 +6,7 @@ $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
 if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
+	$var['alliance_id'] = $player->getAllianceID();
 }
 
 $alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());

--- a/src/engine/Default/alliance_mod.php
+++ b/src/engine/Default/alliance_mod.php
@@ -5,11 +5,9 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
+$allianceID = $var['alliance_id'] ?? $player->getAllianceID();
 
-$alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
+$alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
 $template->assign('Alliance', $alliance);
 
 Globals::canAccessPage('AllianceMOTD', $player, array('AllianceID' => $alliance->getAllianceID()));

--- a/src/engine/Default/alliance_option.php
+++ b/src/engine/Default/alliance_option.php
@@ -5,11 +5,9 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
+$allianceID = $var['alliance_id'] ?? $player->getAllianceID();
 
-$alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
+$alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 

--- a/src/engine/Default/alliance_roles.php
+++ b/src/engine/Default/alliance_roles.php
@@ -5,11 +5,9 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
+$allianceID = $var['alliance_id'] ?? $player->getAllianceID();
 
-$alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
+$alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 

--- a/src/engine/Default/alliance_roster.php
+++ b/src/engine/Default/alliance_roster.php
@@ -7,11 +7,9 @@ $var = $session->getCurrentVar();
 $account = $session->getAccount();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
+$allianceID = $var['alliance_id'] ?? $player->getAllianceID();
 
-$alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
+$alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
 $template->assign('Alliance', $alliance);
 
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));

--- a/src/engine/Default/alliance_stat.php
+++ b/src/engine/Default/alliance_stat.php
@@ -6,10 +6,7 @@ $account = $session->getAccount();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
-$alliance_id = $var['alliance_id'];
+$alliance_id = $var['alliance_id'] ?? $player->getAllianceID();
 
 $alliance = SmrAlliance::getAlliance($alliance_id, $player->getGameID());
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));

--- a/src/engine/Default/alliance_stat_processing.php
+++ b/src/engine/Default/alliance_stat_processing.php
@@ -4,10 +4,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
-$alliance_id = $var['alliance_id'];
+$alliance_id = $var['alliance_id'] ?? $player->getAllianceID();
 if (Request::has('description')) {
 	$description = trim(Request::get('description'));
 }

--- a/src/engine/Default/bank_alliance.php
+++ b/src/engine/Default/bank_alliance.php
@@ -17,11 +17,9 @@ if (!$account->isValidated()) {
 	create_error('You are not validated so you cannot use banks.');
 }
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
+$allianceID = $var['alliance_id'] ?? $player->getAllianceID();
 
-$alliance = SmrAlliance::getAlliance($var['alliance_id'], $player->getGameID());
+$alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
 $template->assign('PageTopic', 'Bank');
 
 Menu::bank();

--- a/src/engine/Default/bank_alliance_processing.php
+++ b/src/engine/Default/bank_alliance_processing.php
@@ -5,10 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
-$alliance_id = $var['alliance_id'];
+$alliance_id = $var['alliance_id'] ?? $player->getAllianceID();
 
 $amount = Request::getInt('amount');
 

--- a/src/engine/Default/bank_report.php
+++ b/src/engine/Default/bank_report.php
@@ -5,10 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['alliance_id'])) {
-	$session->updateVar('alliance_id', $player->getAllianceID());
-}
-$alliance_id = $var['alliance_id'];
+$alliance_id = $var['alliance_id'] ?? $player->getAllianceID();
 const WITHDRAW = 0;
 const DEPOSIT = 1;
 

--- a/src/engine/Default/bar_talk_bartender.php
+++ b/src/engine/Default/bar_talk_bartender.php
@@ -17,7 +17,7 @@ if (!isset($var['Message'])) {
 	} else {
 		$message = 'I havent heard anything recently... got anything to tell me?';
 	}
-	$session->updateVar('Message', $message);
+	$var['Message'] = $message;
 }
 $template->assign('Message', bbifyMessage($var['Message']));
 

--- a/src/engine/Default/bounty_claim.php
+++ b/src/engine/Default/bounty_claim.php
@@ -53,6 +53,6 @@ if (!isset($var['ClaimText'])) {
 		$claimText .= ('You have no claimable bounties<br /><br />');
 	}
 
-	$session->updateVar('ClaimText', $claimText);
+	$var['ClaimText'] = $claimText;
 }
 $template->assign('ClaimText', $var['ClaimText']);

--- a/src/engine/Default/combat_log_list.php
+++ b/src/engine/Default/combat_log_list.php
@@ -16,7 +16,7 @@ if (isset($var['message'])) {
 
 // $var['action'] is the page log type
 if (!isset($var['action'])) {
-	$session->updateVar('action', COMBAT_LOG_PERSONAL);
+	$var['action'] = COMBAT_LOG_PERSONAL;
 }
 $action = $var['action'];
 

--- a/src/engine/Default/council_list.php
+++ b/src/engine/Default/council_list.php
@@ -5,10 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['race_id'])) {
-	$session->updateVar('race_id', $player->getRaceID());
-}
-$raceID = $var['race_id'];
+$raceID = $var['race_id'] ?? $player->getRaceID();
 
 $template->assign('PageTopic', 'Ruling Council Of ' . Smr\Race::getName($raceID));
 $template->assign('RaceID', $raceID);

--- a/src/engine/Default/council_politics.php
+++ b/src/engine/Default/council_politics.php
@@ -5,10 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['race_id'])) {
-	$session->updateVar('race_id', $player->getRaceID());
-}
-$raceID = $var['race_id'];
+$raceID = $var['race_id'] ?? $player->getRaceID();
 
 $template->assign('PageTopic', 'Ruling Council Of ' . Smr\Race::getName($raceID));
 

--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -58,8 +58,7 @@ $template->assign('Sectors', $links);
 doTickerAssigns($template, $player, $db);
 
 if (!isset($var['UnreadMissions'])) {
-	$unreadMissions = $player->markMissionsRead();
-	$session->updateVar('UnreadMissions', $unreadMissions);
+	$var['UnreadMissions'] = $player->markMissionsRead();
 }
 $template->assign('UnreadMissions', $var['UnreadMissions']);
 
@@ -179,7 +178,8 @@ function checkForAttackMessage(string &$msg) : void {
 		$logID = (int)$msg;
 
 		$session = Smr\Session::getInstance();
-		$session->updateVar('AttackMessage', '[ATTACK_RESULTS]' . $msg);
+		$var = $session->getCurrentVar();
+		$var['AttackMessage'] = '[ATTACK_RESULTS]' . $msg;
 
 		$template = Smr\Template::getInstance();
 		if (!$template->hasTemplateVar('AttackResults')) {

--- a/src/engine/Default/feature_request.php
+++ b/src/engine/Default/feature_request.php
@@ -11,7 +11,7 @@ if (!Globals::isFeatureRequestOpen()) {
 }
 
 if (!isset($var['category'])) {
-	$session->updateVar('category', 'New');
+	$var['category'] = 'New';
 }
 $thisStatus = statusFromCategory($var['category']);
 

--- a/src/engine/Default/galactic_post_view_article.php
+++ b/src/engine/Default/galactic_post_view_article.php
@@ -13,8 +13,8 @@ if (isset($var['news'])) {
 	$db->write('INSERT INTO news (game_id, time, news_message, type) ' .
 		'VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeString($var['news']) . ', \'BREAKING\')');
 	// avoid multiple insertion on ajax updates
-	$session->updateVar('news', null);
-	$session->updateVar('added_to_breaking_news', true);
+	unset($var['news']);
+	$var['added_to_breaking_news'] = true;
 }
 
 // Get the articles that are not already in a paper

--- a/src/engine/Default/galactic_post_write_article.php
+++ b/src/engine/Default/galactic_post_write_article.php
@@ -16,8 +16,8 @@ if (isset($var['id'])) {
 		$dbResult = $db->read('SELECT title, text FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']) . ' LIMIT 1');
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
-			$session->updateVar('PreviewTitle', $dbRecord->getField('title'));
-			$session->updateVar('Preview', $dbRecord->getField('text'));
+			$var['PreviewTitle'] = $dbRecord->getField('title');
+			$var['Preview'] = $dbRecord->getField('text');
 		}
 	}
 } else {

--- a/src/engine/Default/map_local.php
+++ b/src/engine/Default/map_local.php
@@ -37,7 +37,7 @@ if (isset($var['ZoomDir'])) {
 		$player->increaseZoom(1);
 	}
 	// Unset so that refreshing doesn't zoom again
-	$session->updateVar('ZoomDir', null);
+	unset($var['ZoomDir']);
 }
 
 $container = Page::create('skeleton.php', 'map_local.php');

--- a/src/engine/Default/message_notify_confirm.php
+++ b/src/engine/Default/message_notify_confirm.php
@@ -5,7 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
 if (!isset($var['notified_time'])) {
-	$session->updateVar('notified_time', Smr\Epoch::time());
+	$var['notified_time'] = Smr\Epoch::time();
 }
 
 if (empty($var['message_id'])) {

--- a/src/engine/Default/military_payment_claim.php
+++ b/src/engine/Default/military_payment_claim.php
@@ -25,7 +25,7 @@ if (!isset($var['ClaimText'])) {
 		$claimText = ('You have done nothing worthy of military payment.');
 	}
 
-	$session->updateVar('ClaimText', $claimText);
+	$var['ClaimText'] = $claimText;
 }
 
 $template->assign('ClaimText', $var['ClaimText']);

--- a/src/engine/Default/news_read.php
+++ b/src/engine/Default/news_read.php
@@ -4,11 +4,7 @@ $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
-if (!isset($var['GameID'])) {
-	$player = $session->getPlayer();
-	$session->updateVar('GameID', $player->getGameID());
-}
-$gameID = $var['GameID'];
+$gameID = $var['GameID'] ?? $session->getPlayer()->getGameID();
 
 $min_news = Request::getInt('min_news', 1);
 $max_news = Request::getInt('max_news', 50);
@@ -26,7 +22,7 @@ require_once(get_file_loc('news.inc.php'));
 doBreakingNewsAssign($gameID);
 doLottoNewsAssign($gameID);
 
-$template->assign('ViewNewsFormHref', Page::create('skeleton.php', 'news_read.php', array('GameID'=>$var['GameID']))->href());
+$template->assign('ViewNewsFormHref', Page::create('skeleton.php', 'news_read.php', ['GameID' => $gameID])->href());
 
 $db = Smr\Database::getInstance();
 $dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type != \'lotto\' ORDER BY news_id DESC LIMIT ' . ($min_news - 1) . ', ' . ($max_news - $min_news + 1));

--- a/src/engine/Default/news_read_advanced.php
+++ b/src/engine/Default/news_read_advanced.php
@@ -4,13 +4,7 @@ $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
-if (!isset($var['GameID'])) {
-	$player = $session->getPlayer();
-	$session->updateVar('GameID', $player->getGameID());
-}
-$gameID = $var['GameID'];
-
-$basicContainer = array('GameID'=>$gameID);
+$gameID = $var['GameID'] ?? $session->getPlayer()->getGameID();
 
 $db = Smr\Database::getInstance();
 $dbResult = $db->read('SELECT alliance_id, alliance_name
@@ -24,7 +18,7 @@ foreach ($dbResult->records() as $dbRecord) {
 }
 $template->assign('NewsAlliances', $newsAlliances);
 
-$template->assign('AdvancedNewsFormHref', Page::create('skeleton.php', 'news_read_advanced.php', $basicContainer)->href());
+$template->assign('AdvancedNewsFormHref', Page::create('skeleton.php', 'news_read_advanced.php', ['GameID' => $gameID])->href());
 
 // No submit value when first navigating to the page
 $submit_value = $session->getRequestVar('submit', '');

--- a/src/engine/Default/news_read_current.php
+++ b/src/engine/Default/news_read_current.php
@@ -5,10 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-if (!isset($var['GameID'])) {
-	$session->updateVar('GameID', $player->getGameID());
-}
-$gameID = $var['GameID'];
+$gameID = $var['GameID'] ?? $player->getGameID();
 
 $template->assign('PageTopic', 'Current News');
 Menu::news();
@@ -18,7 +15,7 @@ doBreakingNewsAssign($gameID);
 doLottoNewsAssign($gameID);
 
 if (!isset($var['LastNewsUpdate'])) {
-	$session->updateVar('LastNewsUpdate', $player->getLastNewsUpdate());
+	$var['LastNewsUpdate'] = $player->getLastNewsUpdate();
 }
 
 $db = Smr\Database::getInstance();

--- a/src/engine/Default/shop_goods_processing.php
+++ b/src/engine/Default/shop_goods_processing.php
@@ -70,12 +70,12 @@ if ($transaction === TRADER_BUYS && $player->getCredits() < $bargain_price) {
 $relations = $player->getRelation($port->getRaceID());
 
 if (!isset($var['ideal_price'])) {
-	$session->updateVar('ideal_price', $port->getIdealPrice($good_id, $transaction, $amount, $relations));
+	$var['ideal_price'] = $port->getIdealPrice($good_id, $transaction, $amount, $relations);
 }
 $ideal_price = $var['ideal_price'];
 
 if (!isset($var['offered_price'])) {
-	$session->updateVar('offered_price', $port->getOfferPrice($ideal_price, $relations, $transaction));
+	$var['offered_price'] = $port->getOfferPrice($ideal_price, $relations, $transaction);
 }
 $offered_price = $var['offered_price'];
 

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -2173,7 +2173,7 @@ abstract class AbstractSmrPlayer {
 		}
 		$underAttack = $this->isUnderAttack();
 		if ($underAttack && !USING_AJAX) {
-			$session->updateVar('UnderAttack', $underAttack); //Remember we are under attack for AJAX
+			$var['UnderAttack'] = $underAttack; //Remember we are under attack for AJAX
 		}
 		$this->setUnderAttack(false);
 		return $underAttack;

--- a/src/lib/Smr/Session.php
+++ b/src/lib/Smr/Session.php
@@ -268,19 +268,22 @@ class Session {
 	 */
 	public function getRequestVar(string $varName, string $default = null) : string {
 		$result = Request::getVar($varName, $default);
-		$this->updateVar($varName, $result);
+		$var = $this->getCurrentVar();
+		$var[$varName] = $result;
 		return $result;
 	}
 
 	public function getRequestVarInt(string $varName, int $default = null) : int {
 		$result = Request::getVarInt($varName, $default);
-		$this->updateVar($varName, $result);
+		$var = $this->getCurrentVar();
+		$var[$varName] = $result;
 		return $result;
 	}
 
 	public function getRequestVarIntArray(string $varName, array $default = null) : array {
 		$result = Request::getVarIntArray($varName, $default);
-		$this->updateVar($varName, $result);
+		$var = $this->getCurrentVar();
+		$var[$varName] = $result;
 		return $result;
 	}
 
@@ -304,17 +307,6 @@ class Session {
 		}
 
 		$this->var[$this->SN] = $container;
-	}
-
-	public function updateVar(string $key, mixed $value) : void {
-		$var = $this->getCurrentVar();
-		if ($value === null) {
-			if (isset($var[$key])) {
-				unset($var[$key]);
-			}
-		} else {
-			$var[$key] = $value;
-		}
 	}
 
 	public function clearLinks() : void {

--- a/test/SmrTest/lib/DefaultGame/SessionIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SessionIntegrationTest.php
@@ -132,4 +132,33 @@ class SessionIntegrationTest extends BaseIntegrationSpec {
 		self::assertFalse($session->hasCurrentVar());
 	}
 
+	public function test_getRequestVar() : void {
+		// Initialize the current var so that we can update it
+		$page = Page::create('some_page');
+		$this->session->setCurrentVar($page);
+
+		// Prepare request values
+		$_REQUEST = [
+			'str' => 'foo',
+			'int' => 4,
+			'arr' => [5, 6],
+		];
+
+		// Check the following conditions:
+		// 1. The index is not set in the current var beforehand
+		// 2. We return the expected value from getRequestVar
+		// 3. The value is stored in the current var afterwards
+		self::assertArrayNotHasKey('str', $this->session->getCurrentVar());
+		self::assertSame('foo', $this->session->getRequestVar('str'));
+		self::assertSame('foo', $this->session->getCurrentVar()['str']);
+
+		self::assertArrayNotHasKey('int', $this->session->getCurrentVar());
+		self::assertSame(4, $this->session->getRequestVarInt('int'));
+		self::assertSame(4, $this->session->getCurrentVar()['int']);
+
+		self::assertArrayNotHasKey('arr', $this->session->getCurrentVar());
+		self::assertSame([5, 6], $this->session->getRequestVarIntArray('arr'));
+		self::assertSame([5, 6], $this->session->getCurrentVar()['arr']);
+	}
+
 }


### PR DESCRIPTION
With the change in `$var` from an array to a `Page` (i.e. a wrapper
around `ArrayObject`), modifying `$var` directly persists in the
Session. Since it is more straightforward to modify `$var` directly,
we can remove the `SmrSession::updateVar` method.

Note that while removing `updateVar`, some instances where we didn't
need to be updating the `$var` were modified accordingly.