### PR TITLE
Drop unused tables

### DIFF
--- a/db/patches/V1_6_66_22__drop_unused.sql
+++ b/db/patches/V1_6_66_22__drop_unused.sql
@@ -1,0 +1,6 @@
+-- Drop unused tables
+DROP TABLE
+	`npc_long_term_goal`,
+	`npc_short_term_goal`,
+	`player_repaired`,
+	`plot_cache`;

--- a/src/admin/Default/game_delete_processing.php
+++ b/src/admin/Default/game_delete_processing.php
@@ -230,7 +230,6 @@ if ($action == 'Yes') {
 	$smr_db_sql[] = 'DELETE FROM player_visited_sector WHERE game_id = ' . $db->escapeNumber($game_id);
 	$smr_db_sql[] = 'DELETE FROM player_votes_pact WHERE game_id = ' . $db->escapeNumber($game_id);
 	$smr_db_sql[] = 'DELETE FROM player_votes_relation WHERE game_id = ' . $db->escapeNumber($game_id);
-	$smr_db_sql[] = 'DELETE FROM plot_cache WHERE game_id = ' . $db->escapeNumber($game_id);
 	$smr_db_sql[] = 'DELETE FROM port WHERE game_id = ' . $db->escapeNumber($game_id);
 	$smr_db_sql[] = 'DELETE FROM port_has_goods WHERE game_id = ' . $db->escapeNumber($game_id);
 	$smr_db_sql[] = 'DELETE FROM race_has_relation WHERE game_id = ' . $db->escapeNumber($game_id);


### PR DESCRIPTION
* npc_long_term_goal
* npc_short_term_goal
* player_repaired
* plot_cache

Verified that these tables are empty in the live database.