### PR TITLE
SmrAlliance: make createAlliance threadsafe

### DIFF
--- a/src/engine/Default/alliance_create_processing.php
+++ b/src/engine/Default/alliance_create_processing.php
@@ -35,7 +35,11 @@ if ($name != $filteredName) {
 }
 
 // create the alliance
-$alliance = SmrAlliance::createAlliance($player->getGameID(), $name);
+try {
+	$alliance = SmrAlliance::createAlliance($player->getGameID(), $name);
+} catch (Smr\UserException $err) {
+	create_error($err->getMessage());
+}
 $alliance->setRecruitType($recruitType, $password);
 $alliance->setAllianceDescription($description, $player);
 $alliance->setLeaderID($player->getAccountID());

--- a/src/engine/Default/game_join_processing.php
+++ b/src/engine/Default/game_join_processing.php
@@ -62,7 +62,7 @@ if ($isNewbie) {
 // insert into player table.
 try {
 	$player = SmrPlayer::createPlayer($account->getAccountID(), $gameID, $player_name, $race_id, $isNewbie);
-} catch (\Smr\UserException $err) {
+} catch (Smr\UserException $err) {
 	create_error($err->getMessage());
 }
 

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -279,7 +279,7 @@ abstract class AbstractSmrPlayer {
 		try {
 			self::getPlayerByPlayerName($playerName, $gameID);
 			$db->unlock();
-			throw new \Smr\UserException('That player name already exists.');
+			throw new Smr\UserException('That player name already exists.');
 		} catch (PlayerNotFoundException $e) {
 			// Player name does not yet exist, we may proceed
 		}

--- a/src/lib/Default/SmrAlliance.class.php
+++ b/src/lib/Default/SmrAlliance.class.php
@@ -110,11 +110,12 @@ class SmrAlliance {
 	 */
 	public static function createAlliance(int $gameID, string $name) : SmrAlliance {
 		$db = Smr\Database::getInstance();
+		$db->lockTable('alliance');
 
 		// check if the alliance name already exists
-		$dbResult = $db->read('SELECT 1 FROM alliance WHERE alliance_name = ' . $db->escapeString($name) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' LIMIT 1');
-		if ($dbResult->hasRecord()) {
-			create_error('That alliance name already exists!');
+		if (self::getAllianceByName($name, $gameID) !== null) {
+			$db->unlock();
+			throw new Smr\UserException('That alliance name already exists.');
 		}
 
 		// get the next alliance id (ignoring reserved ID's)
@@ -126,6 +127,7 @@ class SmrAlliance {
 
 		// actually create the alliance here
 		$db->write('INSERT INTO alliance (alliance_id, game_id, alliance_name, alliance_password, recruiting) VALUES(' . $db->escapeNumber($allianceID) . ', ' . $db->escapeNumber($gameID) . ', ' . $db->escapeString($name) . ', \'\', \'FALSE\')');
+		$db->unlock();
 
 		return self::getAlliance($allianceID, $gameID);
 	}

--- a/test/SmrTest/lib/DefaultGame/SmrAllianceIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrAllianceIntegrationTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use SmrAlliance;
+use SmrTest\BaseIntegrationSpec;
+use Smr\UserException;
+
+/**
+ * @covers SmrAlliance
+ */
+class SmrAllianceIntegrationTest extends BaseIntegrationSpec {
+
+	public function test_createAlliance() : void {
+		// Test arbitrary input
+		$gameID = 42;
+		$name = 'test';
+
+		$alliance = SmrAlliance::createAlliance($gameID, $name);
+
+		$this->assertSame($gameID, $alliance->getGameID());
+		$this->assertSame($name, $alliance->getAllianceName());
+		$this->assertSame(1, $alliance->getAllianceID());
+	}
+
+	public function test_createAlliance_duplicate_name() : void {
+		$name = 'test';
+		SmrAlliance::createAlliance(1, $name);
+		$this->expectException(UserException::class);
+		$this->expectExceptionMessage('That alliance name already exists.');
+		SmrAlliance::createAlliance(1, $name);
+	}
+
+	public function test_createAlliance_increment_allianceID() : void {
+		SmrAlliance::createAlliance(1, 'test1');
+		$alliance = SmrAlliance::createAlliance(1, 'test2');
+		$this->assertSame(2, $alliance->getAllianceID());
+	}
+
+}


### PR DESCRIPTION
Use table locking on the `alliance` table to ensure that when we get
the `alliance_id` for a new alliance, it is unique.

Two things prevent us from using AUTO_INCREMENT for the `alliance_id`:

1. We have a range of IDs that are reserved for the NHA and similar.

2. When we switch to an InnoDB engine, AUTO_INCREMENT on a column that
   is part of a multi-column primary key will no longer reset the
   increment when the other primary key changes (as it does with the
   current MyISAM engine). Therefore, we cannot rely on this behavior.