### PR TITLE
irc: fix check_for_registration interface

### DIFF
--- a/src/tools/irc/channel_msg_op.php
+++ b/src/tools/irc/channel_msg_op.php
@@ -248,7 +248,11 @@ function channel_msg_op_list($fp, string $rdata, AbstractSmrPlayer $player) : bo
  */
 function channel_op_notification($fp, string $rdata, string $nick, string $channel) : bool {
 	echo_r('[OP_ATTENDANCE_CHECK] ' . $nick);
-	if (check_for_registration($player, $fp, $nick, $channel, 'channel_op_notification($fp, \'' . $rdata . '\', \'' . $nick . '\', \'' . $channel . '\');', false)) {
+
+	$callback = function() use($fp, $rdata, $nick, $channel) : bool {
+		return channel_op_notification($fp, $rdata, $nick, $channel);
+	};
+	if (($player = check_for_registration($fp, $nick, $channel, $callback, false)) === false) {
 		return true;
 	}
 

--- a/src/tools/irc/notice.php
+++ b/src/tools/irc/notice.php
@@ -27,24 +27,18 @@ function notice_nickserv_registered_user($fp, string $rdata) : bool
 
 			// is that a callback for our nick?
 			if ($action[0] == 'NICKSERV_INFO' && $nick == $action[2]) {
-
-				echo_r('Callback found: ' . $action[3]);
-
 				unset($actions[$key]);
 
-				eval($action[3]);
-
+				echo_r('Callback found: ' . $action[3]);
+				$action[3]();
 			}
 
 		}
 
-
 		return true;
-
 	}
 
 	return false;
-
 }
 
 function notice_nickserv_unknown_user($fp, string $rdata) : bool
@@ -74,11 +68,9 @@ function notice_nickserv_unknown_user($fp, string $rdata) : bool
 			}
 
 		}
-
 		return true;
 
 	}
 
 	return false;
-
 }


### PR DESCRIPTION
* Return `$player` instead of returning it by reference. This change
  is needed because the value is `null` when it is passed in, which
  breaks the type requirement `AbstractSmrPlayer`. Fixes the error:

    > Unncaught TypeError: check_for_registration(): Argument `#1`
    > ($player) must be of type AbstractSmrPlayer, null given

* If the registration check fails, we return `false` instead of `true`
  so that we can use the union return type `AbstractSmrPlayer|false`.

* Use a `callable` for the `$callback` argument instead of a string
  representation that must be run with `eval`.