### PR TITLE
Backend Fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
             - ./vol_xdebug:/tmp/xdebug
         environment:
             - XDEBUG_MODE
-            - DISABLE_PHPDI_COMPILATION="true"
+            - DISABLE_PHPDI_COMPILATION=true
 
     smtp:
         image: mwader/postfix-relay

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,9 @@
 			<directory suffix="Test.php">test</directory>
 		</testsuite>
 	</testsuites>
+	<php>
+		<env name="DISABLE_PHPDI_COMPILATION" value="true" force="true" />
+	</php>
 	<coverage
 		cacheDirectory=".phpunit.cache/code-coverage"
 		includeUncoveredFiles="true">

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -206,4 +206,4 @@ require_once(LIB . 'autoload.inc.php');
 spl_autoload_register('get_class_loc');
 
 // Set up dependency injection container
-DiContainer::initializeContainer();
+DiContainer::initialize(getenv('DISABLE_PHPDI_COMPILATION') !== "true");

--- a/src/lib/Smr/Container/DiContainer.php
+++ b/src/lib/Smr/Container/DiContainer.php
@@ -43,11 +43,15 @@ class DiContainer {
 			Dotenv::class => function(): Dotenv {
 				return Dotenv::createArrayBacked(CONFIG, 'env');
 			},
+			'DatabaseName' => function(DatabaseProperties $dbProperties): string {
+				return $dbProperties->getDatabaseName();
+			},
 			// Explicitly name all classes that are autowired, so we can take advantage of
 			// the compiled container feature for a performance boost
 			Epoch::class => autowire(),
 			DatabaseProperties::class => autowire(),
-			Database::class => autowire(),
+			Database::class => autowire()
+				->constructorParameter('dbName', \DI\get('DatabaseName')),
 			Session::class => autowire(),
 			Template::class => autowire(),
 		];

--- a/src/lib/Smr/Container/DiContainer.php
+++ b/src/lib/Smr/Container/DiContainer.php
@@ -21,8 +21,8 @@ class DiContainer {
 	private static DiContainer $instance;
 	private Container $container;
 
-	private function __construct() {
-		$this->container = $this->buildContainer();
+	private function __construct(bool $enableCompilation) {
+		$this->container = $this->buildContainer($enableCompilation);
 	}
 
 	private function getDefinitions() : array {
@@ -57,13 +57,13 @@ class DiContainer {
 		];
 	}
 
-	private function buildContainer() : Container {
+	private function buildContainer(bool $enableCompilation) : Container {
 		$builder = new ContainerBuilder();
 		$builder
 			->addDefinitions($this->getDefinitions())
 			->useAnnotations(false)
 			->useAutowiring(true);
-		if (!isset($_ENV["DISABLE_PHPDI_COMPILATION"])) {
+		if ($enableCompilation) {
 			// The CompiledContainer.php will be saved to the /tmp directory on the Docker container once
 			// during its lifecycle (first request)
 			$builder->enableCompilation("/tmp");
@@ -75,8 +75,8 @@ class DiContainer {
 	 * Create a new DI\Container instance.
 	 * This needs to be done once during a bootstrapping script, like bootstrap.php
 	 */
-	public static function initializeContainer() : void {
-		self::$instance = new DiContainer();
+	public static function initialize($enableCompilation) : void {
+		self::$instance = new DiContainer($enableCompilation);
 	}
 
 	/**

--- a/src/lib/Smr/Database.php
+++ b/src/lib/Smr/Database.php
@@ -48,11 +48,11 @@ class Database {
 	 * Not intended to be constructed by hand. If you need an instance of Database,
 	 * use Database::getInstance();
 	 * @param mysqli $dbConn The mysqli instance
-	 * @param DatabaseProperties $dbProperties The properties object that was used to construct the mysqli instance
+	 * @param DatabaseProperties $dbName The name of the database that was used to construct the mysqli instance
 	 */
 	public function __construct(
 		private mysqli $dbConn,
-		private DatabaseProperties $dbProperties,
+		private string $dbName,
 	) {}
 
 	/**
@@ -69,14 +69,14 @@ class Database {
 	 * Switch back to the configured live database
 	 */
 	public function switchDatabaseToLive() : void {
-		$this->switchDatabases($this->dbProperties->getDatabaseName());
+		$this->switchDatabases($this->dbName);
 	}
 
 	/**
-	 * Returns the size of the live database in bytes.
+	 * Returns the size of the current database in bytes.
 	 */
 	public function getDbBytes() : int {
-		$query = 'SELECT SUM(data_length + index_length) as db_bytes FROM information_schema.tables WHERE table_schema=' . $this->escapeString($this->dbProperties->getDatabaseName());
+		$query = 'SELECT SUM(data_length + index_length) as db_bytes FROM information_schema.tables WHERE table_schema=(SELECT database())';
 		return $this->read($query)->record()->getInt('db_bytes');
 	}
 

--- a/test/SmrTest/Container/DiContainerTest.php
+++ b/test/SmrTest/Container/DiContainerTest.php
@@ -12,33 +12,29 @@ use Smr\DatabaseProperties;
 class DiContainerTest extends TestCase {
 	private const PHPDI_COMPILED_CONTAINER_FILE = "/tmp/CompiledContainer.php";
 
-	protected function setUp() : void {
+	protected function tearDown() : void {
 		if (file_exists(self::PHPDI_COMPILED_CONTAINER_FILE)) {
 			unlink(self::PHPDI_COMPILED_CONTAINER_FILE);
 		}
 	}
 
 	public function test_compilation_enabled_true() : void {
-		// Given environment variable is turned off
-		unset($_ENV["DISABLE_PHPDI_COMPILATION"]);
-		// And the container is built
-		DiContainer::initializeContainer();
+		// Given the container is built with compilation enabled
+		DiContainer::initialize(true);
 		// Then
 		self::assertFileExists(self::PHPDI_COMPILED_CONTAINER_FILE);
 	}
 
 	public function test_compilation_enabled_false() : void {
-		// Given environment variable is turned on
-		$_ENV["DISABLE_PHPDI_COMPILATION"] = "true";
-		// And the container is built
-		DiContainer::initializeContainer();
+		// Given the container is built with compilation disabled
+		DiContainer::initialize(false);
 		// Then
 		self::assertFileDoesNotExist(self::PHPDI_COMPILED_CONTAINER_FILE);
 	}
 
 	public function test_container_get_and_make() : void {
 		// Start with a fresh container
-		DiContainer::initializeContainer();
+		DiContainer::initialize(false);
 
 		// The first get should construct a new object
 		$class = DatabaseProperties::class;

--- a/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
@@ -17,7 +17,7 @@ class DatabaseIntegrationTest extends TestCase {
 	protected function setUp() : void {
 		// Start each test with a fresh container (and mysqli connection).
 		// This ensures the independence of each test.
-		DiContainer::initializeContainer();
+		DiContainer::initialize(false);
 	}
 
 	public function test_mysqli_factory() : void {

--- a/test/SmrTest/lib/DefaultGame/PageIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/PageIntegrationTest.php
@@ -15,7 +15,7 @@ class PageIntegrationTest extends \PHPUnit\Framework\TestCase {
 
 	protected function setUp() : void {
 		// Reset the DI container for each test to ensure independence.
-		DiContainer::initializeContainer();
+		DiContainer::initialize(false);
 	}
 
 	/**

--- a/test/SmrTest/lib/DefaultGame/RequestTest.php
+++ b/test/SmrTest/lib/DefaultGame/RequestTest.php
@@ -25,7 +25,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase {
 
 	protected function setUp() : void {
 		// Reset the DI container for each test to ensure independence.
-		DiContainer::initializeContainer();
+		DiContainer::initialize(false);
 	}
 
 	/**

--- a/test/SmrTest/lib/DefaultGame/SessionIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SessionIntegrationTest.php
@@ -17,7 +17,7 @@ class SessionIntegrationTest extends BaseIntegrationSpec {
 	protected function setUp() : void {
 		// Start each test with a fresh container (and Smr\Session).
 		// This ensures the independence of each test.
-		DiContainer::initializeContainer();
+		DiContainer::initialize(false);
 		$this->session = Session::getInstance();
 	}
 

--- a/test/SmrTest/lib/DefaultGame/TemplateTest.php
+++ b/test/SmrTest/lib/DefaultGame/TemplateTest.php
@@ -14,7 +14,7 @@ class TemplateTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp() : void {
 		// Start each test with a fresh container (and Template instance).
 		// This ensures the independence of each test.
-		DiContainer::initializeContainer();
+		DiContainer::initialize(false);
 	}
 
 	public function test_assign_unassign() : void {


### PR DESCRIPTION
* Improve security of the database password by not storing it in the `Database` instance.
* Fix DI compilation not being properly disabled in development builds/tests.