### PR TITLE
Highlight last chess move server-side

### DIFF
--- a/src/htdocs/css/shared.css
+++ b/src/htdocs/css/shared.css
@@ -475,38 +475,40 @@ a.lmUp:hover div, a.lmLeft:hover div, a.lmRight:hover div, a.lmDown:hover div {
 }
 
 table.chess {
-	border-collapse: separate;
-	border-spacing: 0px;
-    white-space: nowrap;
+	border-collapse: collapse;
+	white-space: nowrap;
 }
 
 .chess td {
-	font-size: 37px;
-	text-align: center;
-	border: 4px solid;
+	padding: 0px;
 }
 
-.chess td.whiteSquare {
-	width: 44px;
-	height: 44px;
+.chess td div {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	font-size: 37px;
+	border: 4px solid;
+	width: 50px;
+	height: 50px;
 	color: black;
+}
+
+.chess td.whiteSquare div {
 	background-color: white;
 	border-color: white;
 }
 
-.chess td.blackSquare {
-	width: 44px;
-	height: 44px;
-	color: black;
+.chess td.blackSquare div {
 	background-color: #999;
 	border-color: #999;
 }
 
-.chess td.lastMove {
+.chess td div.lastMove {
 	border: 4px green ridge;
 }
 
-.chess td.chessHighlight {
+.chess td.chessHighlight > div {
 	border: 4px orange ridge;
 }
 
@@ -514,7 +516,8 @@ td.chessOutline {
 	border: none;
 	font-size: 18px;
 	width: 10px;
-	padding: 0px 3px;
+	padding: 3px;
+	text-align: center;
 }
 
 div.chat, table#moveTable td {

--- a/src/lib/Default/ChessGame.class.php
+++ b/src/lib/Default/ChessGame.class.php
@@ -188,9 +188,21 @@ class ChessGame {
 		return $board;
 	}
 
-	public function getLastMove() {
+	public function getLastMove() : ?array {
 		$this->getMoves();
 		return $this->lastMove;
+	}
+
+	/**
+	 * Determines if a board square is part of the last move
+	 * (returns true for both the 'To' and 'From' squares).
+	 */
+	public function isLastMoveSquare(int $x, int $y) : bool {
+		$lastMove = $this->getLastMove();
+		if ($lastMove === null) {
+			return false;
+		}
+		return ($x == $lastMove['From']['X'] && $y == $lastMove['From']['Y']) || ($x == $lastMove['To']['X'] && $y == $lastMove['To']['Y']);
 	}
 
 	public function getMoves() : array {

--- a/src/templates/Default/engine/Default/chess_play.php
+++ b/src/templates/Default/engine/Default/chess_play.php
@@ -10,8 +10,10 @@
 						<tr>
 							<td class="chessOutline"><?php echo 8 - $Y; ?></td><?php
 							foreach ($Row as $X => $Cell) { ?>
-								<td id="c<?php echo $X . $Y; ?>" data-x="<?php echo $X; ?>" data-y="<?php echo $Y; ?>" class="ajax<?php if (($X + $Y) % 2 == 0) { ?> whiteSquare<?php } else { ?> blackSquare<?php } ?>" onClick="highlightMoves.call(this)"><?php
-									if ($Cell == null) { ?>&nbsp;<?php } else { ?><span class="pointer"><?php echo $Cell->getPieceSymbol(); ?></span><?php } ?>
+								<td id="c<?php echo $X . $Y; ?>" data-x="<?php echo $X; ?>" data-y="<?php echo $Y; ?>" class="ajax<?php if (($X + $Y) % 2 == 0) { ?> whiteSquare<?php } else { ?> blackSquare<?php } ?>" onClick="highlightMoves.call(this)">
+									<div<?php if ($ChessGame->isLastMoveSquare($X, $Y)) { ?> class="lastMove"<?php } ?>><?php
+										if ($Cell !== null) { ?><span class="pointer lastMove"><?php echo $Cell->getPieceSymbol(); ?></span><?php } ?>
+									</div>
 								</td><?php
 							} ?>
 						</tr><?php
@@ -59,16 +61,8 @@
 			}
 		}
 	} ?>
-	var submitMoveHREF = <?php echo $this->addJavascriptForAjax('submitMoveHREF', $ChessMoveHREF); ?>,
-		availableMoves = <?php echo $this->addJavascriptForAjax('availableMoves', $AvailableMoves); ?>;<?php
-	$LastMove = $ChessGame->getLastMove();
-	if ($LastMove != null) {
-		echo $this->addJavascriptForAjax('EVAL', '
-			$("table.chess td").removeClass("lastMove").filter(function() {
-				var x = $(this).data("x"), y = $(this).data("y");
-				return (x == ' . $LastMove['From']['X'] . ' && y == ' . $LastMove['From']['Y'] . ') || (x == ' . $LastMove['To']['X'] . ' && y == ' . $LastMove['To']['Y'] . ')
-			}).addClass("lastMove");');
-	} ?>
+	var submitMoveHREF = <?php echo $this->addJavascriptForAjax('submitMoveHREF', $ChessMoveHREF); ?>;
+	var availableMoves = <?php echo $this->addJavascriptForAjax('availableMoves', $AvailableMoves); ?>;
 </script>
 
 <?php


### PR DESCRIPTION
We had a complicated scheme for highlighting the last move of a chess
game, where the JavaScript code would be transmitted to the browser
via ajax, and then a special "EVAL" hook would run that code.

A simpler scheme would be to put the highlighting code in the JS file,
and then only transmit the "lastMove" data via ajax.

However, the simplest scheme seems to be to just add the `lastMove`
HTML class attribute when processing the page server-side. Otherwise,
the browser needs to run the highlighting code on every ajax update,
even though most of the time the page won't be changing. This way we
don't even need to transmit the "lastMove" data to the browser at all.

Additional details:

* To pass the `lastMove` HTML class attribute via ajax, we had to move
  it to a new child `<div>` of the `<td>` element (which is the ajax
  element). This required adjusting the CSS a bit, as we now style the
  div instead of the td.

* We no longer put a `&nbsp;` in empty squares, as it does not seem to
  be necessary.