### PR TITLE
Fix port raid loopholes

### DIFF
--- a/src/engine/Default/port_attack.php
+++ b/src/engine/Default/port_attack.php
@@ -3,13 +3,16 @@
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
-$sector = $session->getPlayer()->getSector();
+$player = $session->getPlayer();
+$port = $player->getSector()->getPort();
 
 if (isset($var['results'])) {
 	$template->assign('FullPortCombatResults', $var['results']);
 	$template->assign('AlreadyDestroyed', false);
+	$template->assign('CreditedAttacker', true);
 } else {
 	$template->assign('AlreadyDestroyed', true);
+	$template->assign('CreditedAttacker', in_array($player, $port->getAttackersToCredit()));
 }
 $template->assign('MinimalDisplay', false);
 
@@ -18,4 +21,4 @@ if (isset($var['override_death'])) {
 } else {
 	$template->assign('OverrideDeath', false);
 }
-$template->assign('Port', $sector->getPort());
+$template->assign('Port', $port);

--- a/src/engine/Default/port_payout_processing.php
+++ b/src/engine/Default/port_payout_processing.php
@@ -5,6 +5,10 @@ $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
 $port = $player->getSectorPort();
+if (!$port->isDestroyed()) {
+	create_error('The port is no longer defenceless!');
+}
+
 $credits = match($var['PayoutType']) {
 	'Raze' => $port->razePort($player),
 	'Loot' => $port->lootPort($player),

--- a/src/lib/Default/AbstractSmrPort.class.php
+++ b/src/lib/Default/AbstractSmrPort.class.php
@@ -1301,12 +1301,12 @@ class AbstractSmrPort {
 		return $actualDamage;
 	}
 
-	protected function getAttackersToCredit() : array {
+	public function getAttackersToCredit() : array {
 		//get all players involved for HoF
 		$attackers = array();
-		$dbResult = $this->db->read('SELECT account_id FROM player_attacks_port WHERE ' . $this->SQL . ' AND time > ' . $this->db->escapeNumber(Smr\Epoch::time() - self::TIME_TO_CREDIT_RAID));
+		$dbResult = $this->db->read('SELECT player.* FROM player_attacks_port JOIN player USING (game_id, account_id) WHERE game_id = ' . $this->db->escapeNumber($this->gameID) . ' AND player_attacks_port.sector_id = ' . $this->db->escapeNumber($this->sectorID) . ' AND time > ' . $this->db->escapeNumber(Smr\Epoch::time() - self::TIME_TO_CREDIT_RAID));
 		foreach ($dbResult->records() as $dbRecord) {
-			$attackers[] = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $this->getGameID());
+			$attackers[] = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $this->getGameID(), false, $dbRecord);
 		}
 		return $attackers;
 	}

--- a/src/templates/Default/engine/Default/port_attack.php
+++ b/src/templates/Default/engine/Default/port_attack.php
@@ -5,22 +5,20 @@
 		<div class="buttonA">
 			<a href="<?php echo $Port->getAttackHREF() ?>" class="buttonA">Continue Attack</a>
 		</div><?php
-	} else {
-		if ($OverrideDeath) {
-			?><span class="red">You have been destroyed.</span><?php
-		} else { ?>
-			<span class="yellow">You have breached the port defenses.</span><?php
-		} ?>
+	} elseif ($OverrideDeath) { ?>
+		<span class="red">You have been destroyed.</span>
 		<br /><br />
-		<div class="buttonA"><?php
-			if ($OverrideDeath) { ?>
-				<a href="<?php echo Globals::getPodScreenHREF() ?>" class="buttonA">Let there be pod</a><?php
-			} else { ?>
-				<a href="<?php echo $Port->getClaimHREF(); ?>" class="buttonA">Claim this port for your race</a><?php
-				if ($Port->getCredits() > 0) { ?>&nbsp;
-					<a href="<?php echo $Port->getLootHREF(); ?>" class="buttonA">Loot the port<?php if ($Port->getCredits() > 0) { ?> (100% money)<?php } ?></a>&nbsp;
-					<a href="<?php echo $Port->getRazeHREF(); ?>" class="buttonA">Raze the port (<?php echo IRound(SmrPort::RAZE_PAYOUT * 100); ?>% money, 1 downgrade)</a><?php
-				}
+		<div class="buttonA">
+			<a href="<?php echo Globals::getPodScreenHREF() ?>" class="buttonA">Let there be pod</a>
+		</div><?php
+	} elseif ($CreditedAttacker) { ?>
+		<span class="yellow">You have breached the port defenses.</span>
+		<br /><br />
+		<div class="buttonA">
+			<a href="<?php echo $Port->getClaimHREF(); ?>" class="buttonA">Claim this port for your race</a><?php
+			if ($Port->getCredits() > 0) { ?>&nbsp;
+				<a href="<?php echo $Port->getLootHREF(); ?>" class="buttonA">Loot the port (100% money)</a>&nbsp;
+				<a href="<?php echo $Port->getRazeHREF(); ?>" class="buttonA">Raze the port (<?php echo IRound(SmrPort::RAZE_PAYOUT * 100); ?>% money, 1 downgrade)</a><?php
 			} ?>
 		</div><?php
 	} ?>


### PR DESCRIPTION
* Ports can no longer be looted after the defenses have reset.
* Only players who participated in the port raid can loot/claim the port.