### PR TITLE
Remove resetCache methods

### DIFF
--- a/src/htdocs/vote_link_callback.php
+++ b/src/htdocs/vote_link_callback.php
@@ -34,7 +34,7 @@ try {
 		// Lock the sector to ensure the player gets the turns
 		// Refresh player after lock is acquired in case any values are stale
 		acquire_lock($player->getSectorID());
-		SmrPlayer::refreshCache();
+		$player = SmrPlayer::getPlayer($accountId, $gameId, true);
 
 		// Now that we are locked, check the database again to make sure turns
 		// weren't claimed while we were waiting for the lock.

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -91,14 +91,6 @@ abstract class AbstractSmrPlayer {
 	protected static array $hasHOFVisChanged = [];
 	protected array $hasBountyChanged = [];
 
-	public static function refreshCache() : void {
-		foreach (self::$CACHE_PLAYERS as $gameID => &$gamePlayers) {
-			foreach ($gamePlayers as $accountID => &$player) {
-				$player = self::getPlayer($accountID, $gameID, true);
-			}
-		}
-	}
-
 	public static function clearCache() : void {
 		self::$CACHE_PLAYERS = array();
 		self::$CACHE_SECTOR_PLAYERS = array();

--- a/src/lib/Default/AbstractSmrPort.class.php
+++ b/src/lib/Default/AbstractSmrPort.class.php
@@ -56,14 +56,6 @@ class AbstractSmrPort {
 	protected bool $hasChanged = false;
 	protected bool $isNew = false;
 
-	public static function refreshCache() : void {
-		foreach (self::$CACHE_PORTS as $gameID => &$gamePorts) {
-			foreach ($gamePorts as $sectorID => &$port) {
-				$port = self::getPort($gameID, $sectorID, true);
-			}
-		}
-	}
-
 	public static function clearCache() : void {
 		self::$CACHE_PORTS = array();
 		self::$CACHE_CACHED_PORTS = array();

--- a/src/lib/Default/SmrForce.class.php
+++ b/src/lib/Default/SmrForce.class.php
@@ -34,16 +34,6 @@ class SmrForce {
 		return ['ownerID', 'sectorID', 'gameID'];
 	}
 
-	public static function refreshCache() : void {
-		foreach (self::$CACHE_FORCES as $gameID => &$gameForces) {
-			foreach ($gameForces as $sectorID => &$gameSectorForces) {
-				foreach ($gameSectorForces as $ownerID => &$forces) {
-					$forces = self::getForce($gameID, $sectorID, $ownerID, true);
-				}
-			}
-		}
-	}
-
 	public static function clearCache() : void {
 		self::$CACHE_FORCES = [];
 		self::$CACHE_SECTOR_FORCES = [];

--- a/src/lib/Default/SmrPlanet.class.php
+++ b/src/lib/Default/SmrPlanet.class.php
@@ -52,14 +52,6 @@ class SmrPlanet {
 		return ['sectorID', 'gameID', 'planetName', 'ownerID', 'typeID'];
 	}
 
-	public static function refreshCache() : void {
-		foreach (self::$CACHE_PLANETS as $gameID => &$gamePlanets) {
-			foreach ($gamePlanets as $sectorID => &$planet) {
-				$planet = self::getPlanet($gameID, $sectorID, true);
-			}
-		}
-	}
-
 	public static function clearCache() : void {
 		self::$CACHE_PLANETS = array();
 	}

--- a/src/lib/Default/SmrShip.class.php
+++ b/src/lib/Default/SmrShip.class.php
@@ -9,14 +9,6 @@ class SmrShip extends AbstractSmrShip {
 
 	protected string $SQL;
 
-	public static function refreshCache() : void {
-		foreach (self::$CACHE_SHIPS as &$gameShips) {
-			foreach ($gameShips as &$ship) {
-				$ship = self::getShip($ship->getPlayer(), true);
-			}
-		}
-	}
-
 	public static function clearCache() : void {
 		self::$CACHE_SHIPS = array();
 	}


### PR DESCRIPTION
These methods had two major flaws:

1. They do not actually update existing instances of classes. So any
   place where an instance was stored outside the cache could be out
   of sync with the version in the cache.

2. They do more work than simply using `clearCache` since it forces
   all existing instances to be reloaded immediately, rather than
   letting them be reloaded on demand.

The only place any of these were used was in vote_link_callback.php,
and it was being used incorrectly there. Specifically, `$player` was a
reference to the _original_ instance, prior to getting a sector lock,
and we were not updating it after calling `resetCache`. Therefore, we
were potentially overwriting data if the database was updated between
the initial `getPlayer` call and acquiring the lock. (Note that this
was not a _practical_ issue, due to requiring precise race conditions,
but a problematic design nonetheless.)