### PR TITLE
Minor combat interface cleanup

### DIFF
--- a/src/engine/Default/planet_attack_processing.php
+++ b/src/engine/Default/planet_attack_processing.php
@@ -63,7 +63,7 @@ foreach ($attackers as $attacker) {
 
 $totalShieldDamage = 0;
 foreach ($attackers as $attacker) {
-	$playerResults = $attacker->shootPlanet($planet, false);
+	$playerResults = $attacker->shootPlanet($planet);
 	$results['Attackers']['Traders'][$attacker->getAccountID()] = $playerResults;
 	$results['Attackers']['TotalDamage'] += $playerResults['TotalDamage'];
 	foreach ($playerResults['Weapons'] as $weapon) {

--- a/src/lib/Default/AbstractSmrCombatWeapon.class.php
+++ b/src/lib/Default/AbstractSmrCombatWeapon.class.php
@@ -54,7 +54,7 @@ abstract class AbstractSmrCombatWeapon {
 
 	protected function doPlayerDamageToForce(array $return, AbstractSmrPlayer $weaponPlayer, SmrForce $forces) : array {
 		$return['WeaponDamage'] = $this->getModifiedDamageAgainstForces($weaponPlayer, $forces);
-		$return['ActualDamage'] = $forces->doWeaponDamage($return['WeaponDamage']);
+		$return['ActualDamage'] = $forces->takeDamage($return['WeaponDamage']);
 		if ($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] = $forces->killForcesByPlayer($weaponPlayer);
 		}
@@ -63,7 +63,7 @@ abstract class AbstractSmrCombatWeapon {
 
 	protected function doPlayerDamageToPlayer(array $return, AbstractSmrPlayer $weaponPlayer, AbstractSmrPlayer $targetPlayer) : array {
 		$return['WeaponDamage'] = $this->getModifiedDamageAgainstPlayer($weaponPlayer, $targetPlayer);
-		$return['ActualDamage'] = $targetPlayer->getShip()->doWeaponDamage($return['WeaponDamage']);
+		$return['ActualDamage'] = $targetPlayer->getShip()->takeDamage($return['WeaponDamage']);
 
 		if ($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] = $targetPlayer->killPlayerByPlayer($weaponPlayer);
@@ -73,7 +73,7 @@ abstract class AbstractSmrCombatWeapon {
 
 	protected function doPlayerDamageToPort(array $return, AbstractSmrPlayer $weaponPlayer, SmrPort $port) : array {
 		$return['WeaponDamage'] = $this->getModifiedDamageAgainstPort($weaponPlayer, $port);
-		$return['ActualDamage'] = $port->doWeaponDamage($return['WeaponDamage']);
+		$return['ActualDamage'] = $port->takeDamage($return['WeaponDamage']);
 		if ($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] = $port->killPortByPlayer($weaponPlayer);
 		}
@@ -82,7 +82,7 @@ abstract class AbstractSmrCombatWeapon {
 
 	protected function doPlayerDamageToPlanet(array $return, AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet, bool $delayed) : array {
 		$return['WeaponDamage'] = $this->getModifiedDamageAgainstPlanet($weaponPlayer, $planet);
-		$return['ActualDamage'] = $planet->doWeaponDamage($return['WeaponDamage'], $delayed);
+		$return['ActualDamage'] = $planet->takeDamage($return['WeaponDamage'], $delayed);
 		if ($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] = $planet->killPlanetByPlayer($weaponPlayer);
 		}
@@ -91,7 +91,7 @@ abstract class AbstractSmrCombatWeapon {
 
 	protected function doPortDamageToPlayer(array $return, SmrPort $port, AbstractSmrPlayer $targetPlayer) : array {
 		$return['WeaponDamage'] = $this->getModifiedPortDamageAgainstPlayer($port, $targetPlayer);
-		$return['ActualDamage'] = $targetPlayer->getShip()->doWeaponDamage($return['WeaponDamage']);
+		$return['ActualDamage'] = $targetPlayer->getShip()->takeDamage($return['WeaponDamage']);
 
 		if ($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] = $targetPlayer->killPlayerByPort($port);
@@ -101,7 +101,7 @@ abstract class AbstractSmrCombatWeapon {
 
 	protected function doPlanetDamageToPlayer(array $return, SmrPlanet $planet, AbstractSmrPlayer $targetPlayer) : array {
 		$return['WeaponDamage'] = $this->getModifiedPlanetDamageAgainstPlayer($planet, $targetPlayer);
-		$return['ActualDamage'] = $targetPlayer->getShip()->doWeaponDamage($return['WeaponDamage']);
+		$return['ActualDamage'] = $targetPlayer->getShip()->takeDamage($return['WeaponDamage']);
 
 		if ($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] = $targetPlayer->killPlayerByPlanet($planet);
@@ -111,7 +111,7 @@ abstract class AbstractSmrCombatWeapon {
 
 	protected function doForceDamageToPlayer(array $return, SmrForce $forces, AbstractSmrPlayer $targetPlayer) : array {
 		$return['WeaponDamage'] = $this->getModifiedForceDamageAgainstPlayer($forces, $targetPlayer);
-		$return['ActualDamage'] = $targetPlayer->getShip()->doWeaponDamage($return['WeaponDamage']);
+		$return['ActualDamage'] = $targetPlayer->getShip()->takeDamage($return['WeaponDamage']);
 
 		if ($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] = $targetPlayer->killPlayerByForces($forces);

--- a/src/lib/Default/AbstractSmrCombatWeapon.class.php
+++ b/src/lib/Default/AbstractSmrCombatWeapon.class.php
@@ -80,9 +80,9 @@ abstract class AbstractSmrCombatWeapon {
 		return $return;
 	}
 
-	protected function doPlayerDamageToPlanet(array $return, AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet, bool $delayed) : array {
+	protected function doPlayerDamageToPlanet(array $return, AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet) : array {
 		$return['WeaponDamage'] = $this->getModifiedDamageAgainstPlanet($weaponPlayer, $planet);
-		$return['ActualDamage'] = $planet->takeDamage($return['WeaponDamage'], $delayed);
+		$return['ActualDamage'] = $planet->takeDamage($return['WeaponDamage']);
 		if ($return['ActualDamage']['KillingShot']) {
 			$return['KillResults'] = $planet->killPlanetByPlayer($weaponPlayer);
 		}

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -1781,8 +1781,8 @@ abstract class AbstractSmrPlayer {
 		return $this->getShip()->shootPort($port);
 	}
 
-	public function shootPlanet(SmrPlanet $planet, bool $delayed) : array {
-		return $this->getShip()->shootPlanet($planet, $delayed);
+	public function shootPlanet(SmrPlanet $planet) : array {
+		return $this->getShip()->shootPlanet($planet);
 	}
 
 	public function shootPlayers(array $targetPlayers) : array {

--- a/src/lib/Default/AbstractSmrPort.class.php
+++ b/src/lib/Default/AbstractSmrPort.class.php
@@ -1239,25 +1239,25 @@ class AbstractSmrPort {
 		return $results;
 	}
 
-	public function doWeaponDamage(array $damage) : array {
+	public function takeDamage(array $damage) : array {
 		$alreadyDead = $this->isDestroyed();
 		$shieldDamage = 0;
 		$cdDamage = 0;
 		$armourDamage = 0;
 		if (!$alreadyDead) {
 			if ($damage['Shield'] || !$this->hasShields()) {
-				$shieldDamage = $this->doShieldDamage(min($damage['MaxDamage'], $damage['Shield']));
+				$shieldDamage = $this->takeDamageToShields(min($damage['MaxDamage'], $damage['Shield']));
 				$damage['MaxDamage'] -= $shieldDamage;
 				if (!$this->hasShields() && ($shieldDamage == 0 || $damage['Rollover'])) {
-					$cdDamage = $this->doCDDamage(min($damage['MaxDamage'], $damage['Armour']));
+					$cdDamage = $this->takeDamageToCDs(min($damage['MaxDamage'], $damage['Armour']));
 					$damage['Armour'] -= $cdDamage;
 					$damage['MaxDamage'] -= $cdDamage;
 					if (!$this->hasCDs() && ($cdDamage == 0 || $damage['Rollover'])) {
-						$armourDamage = $this->doArmourDamage(min($damage['MaxDamage'], $damage['Armour']));
+						$armourDamage = $this->takeDamageToArmour(min($damage['MaxDamage'], $damage['Armour']));
 					}
 				}
 			} else { //hit drones behind shields
-				$cdDamage = $this->doCDDamage(IFloor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT));
+				$cdDamage = $this->takeDamageToCDs(IFloor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT));
 			}
 		}
 
@@ -1275,19 +1275,19 @@ class AbstractSmrPort {
 		return $return;
 	}
 
-	protected function doShieldDamage(int $damage) : int {
+	protected function takeDamageToShields(int $damage) : int {
 		$actualDamage = min($this->getShields(), $damage);
 		$this->decreaseShields($actualDamage);
 		return $actualDamage;
 	}
 
-	protected function doCDDamage(int $damage) : int {
+	protected function takeDamageToCDs(int $damage) : int {
 		$actualDamage = min($this->getCDs(), IFloor($damage / CD_ARMOUR));
 		$this->decreaseCDs($actualDamage);
 		return $actualDamage * CD_ARMOUR;
 	}
 
-	protected function doArmourDamage(int $damage) : int {
+	protected function takeDamageToArmour(int $damage) : int {
 		$actualDamage = min($this->getArmour(), IFloor($damage));
 		$this->decreaseArmour($actualDamage);
 		return $actualDamage;

--- a/src/lib/Default/AbstractSmrShip.class.php
+++ b/src/lib/Default/AbstractSmrShip.class.php
@@ -872,7 +872,7 @@ class AbstractSmrShip {
 		return $results;
 	}
 
-	public function doWeaponDamage(array $damage) : array {
+	public function takeDamage(array $damage) : array {
 		$alreadyDead = $this->getPlayer()->isDead();
 		$armourDamage = 0;
 		$cdDamage = 0;
@@ -882,14 +882,14 @@ class AbstractSmrShip {
 			// player, so alert them that they're under attack.
 			$this->getPlayer()->setUnderAttack(true);
 
-			$shieldDamage = $this->doShieldDamage(min($damage['MaxDamage'], $damage['Shield']));
+			$shieldDamage = $this->takeDamageToShields(min($damage['MaxDamage'], $damage['Shield']));
 			$damage['MaxDamage'] -= $shieldDamage;
 			if (!$this->hasShields() && ($shieldDamage == 0 || $damage['Rollover'])) {
-				$cdDamage = $this->doCDDamage(min($damage['MaxDamage'], $damage['Armour']));
+				$cdDamage = $this->takeDamageToCDs(min($damage['MaxDamage'], $damage['Armour']));
 				$damage['Armour'] -= $cdDamage;
 				$damage['MaxDamage'] -= $cdDamage;
 				if (!$this->hasCDs() && ($cdDamage == 0 || $damage['Rollover'])) {
-					$armourDamage = $this->doArmourDamage(min($damage['MaxDamage'], $damage['Armour']));
+					$armourDamage = $this->takeDamageToArmour(min($damage['MaxDamage'], $damage['Armour']));
 				}
 			}
 		}
@@ -905,16 +905,16 @@ class AbstractSmrShip {
 		);
 	}
 
-	public function doMinesDamage(array $damage) : array {
+	public function takeDamageFromMines(array $damage) : array {
 		$alreadyDead = $this->getPlayer()->isDead();
 		$armourDamage = 0;
 		$cdDamage = 0;
 		$shieldDamage = 0;
 		if (!$alreadyDead) {
-			$shieldDamage = $this->doShieldDamage(min($damage['MaxDamage'], $damage['Shield']));
+			$shieldDamage = $this->takeDamageToShields(min($damage['MaxDamage'], $damage['Shield']));
 			$damage['MaxDamage'] -= $shieldDamage;
 			if (!$this->hasShields() && ($shieldDamage == 0 || $damage['Rollover'])) { //skip CDs if it's mines
-				$armourDamage = $this->doArmourDamage(min($damage['MaxDamage'], $damage['Armour']));
+				$armourDamage = $this->takeDamageToArmour(min($damage['MaxDamage'], $damage['Armour']));
 			}
 		}
 		return array(
@@ -929,19 +929,19 @@ class AbstractSmrShip {
 		);
 	}
 
-	protected function doShieldDamage(int $damage) : int {
+	protected function takeDamageToShields(int $damage) : int {
 		$actualDamage = min($this->getShields(), $damage);
 		$this->decreaseShields($actualDamage);
 		return $actualDamage;
 	}
 
-	protected function doCDDamage(int $damage) : int {
+	protected function takeDamageToCDs(int $damage) : int {
 		$actualDamage = min($this->getCDs(), IFloor($damage / CD_ARMOUR));
 		$this->decreaseCDs($actualDamage);
 		return $actualDamage * CD_ARMOUR;
 	}
 
-	protected function doArmourDamage(int $damage) : int {
+	protected function takeDamageToArmour(int $damage) : int {
 		$actualDamage = min($this->getArmour(), $damage);
 		$this->decreaseArmour($actualDamage);
 		return $actualDamage;

--- a/src/lib/Default/AbstractSmrShip.class.php
+++ b/src/lib/Default/AbstractSmrShip.class.php
@@ -847,7 +847,7 @@ class AbstractSmrShip {
 		return $results;
 	}
 
-	public function shootPlanet(SmrPlanet $planet, bool $delayed) : array {
+	public function shootPlanet(SmrPlanet $planet) : array {
 		$thisPlayer = $this->getPlayer();
 		$results = array('Player' => $thisPlayer, 'TotalDamage' => 0, 'Weapons' => []);
 		if ($thisPlayer->isDead()) {
@@ -856,14 +856,14 @@ class AbstractSmrShip {
 		}
 		$results['DeadBeforeShot'] = false;
 		foreach ($this->weapons as $orderID => $weapon) {
-			$results['Weapons'][$orderID] = $weapon->shootPlanet($thisPlayer, $planet, $delayed);
+			$results['Weapons'][$orderID] = $weapon->shootPlanet($thisPlayer, $planet);
 			if ($results['Weapons'][$orderID]['Hit']) {
 				$results['TotalDamage'] += $results['Weapons'][$orderID]['ActualDamage']['TotalDamage'];
 			}
 		}
 		if ($this->hasCDs()) {
 			$thisCDs = new SmrCombatDrones($this->getCDs());
-			$results['Drones'] = $thisCDs->shootPlanet($thisPlayer, $planet, $delayed);
+			$results['Drones'] = $thisCDs->shootPlanet($thisPlayer, $planet);
 			$results['TotalDamage'] += $results['Drones']['ActualDamage']['TotalDamage'];
 		}
 		$thisPlayer->increaseExperience(IRound($results['TotalDamage'] * self::EXP_PER_DAMAGE_PLANET));

--- a/src/lib/Default/SmrCombatDrones.class.php
+++ b/src/lib/Default/SmrCombatDrones.class.php
@@ -238,9 +238,9 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 		return $this->doPlayerDamageToPort($return, $weaponPlayer, $port);
 	}
 
-	public function shootPlanet(AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet, bool $delayed) : array {
+	public function shootPlanet(AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet) : array {
 		$return = array('Weapon' => $this, 'TargetPlanet' => $planet, 'Hit' => true);
-		return $this->doPlayerDamageToPlanet($return, $weaponPlayer, $planet, $delayed);
+		return $this->doPlayerDamageToPlanet($return, $weaponPlayer, $planet);
 	}
 
 	public function shootPlayer(AbstractSmrPlayer $weaponPlayer, AbstractSmrPlayer $targetPlayer) : array {

--- a/src/lib/Default/SmrForce.class.php
+++ b/src/lib/Default/SmrForce.class.php
@@ -472,21 +472,21 @@ class SmrForce {
 		return $results;
 	}
 
-	public function doWeaponDamage(array $damage) : array {
+	public function takeDamage(array $damage) : array {
 		$alreadyDead = !$this->exists();
 		$minesDamage = 0;
 		$cdDamage = 0;
 		$sdDamage = 0;
 		if (!$alreadyDead) {
-			$minesDamage = $this->doMinesDamage(min($damage['MaxDamage'], $damage['Armour']));
+			$minesDamage = $this->takeDamageToMines(min($damage['MaxDamage'], $damage['Armour']));
 			$damage['Armour'] -= $minesDamage;
 			$damage['MaxDamage'] -= $minesDamage;
 			if (!$this->hasMines() && ($minesDamage == 0 || $damage['Rollover'])) {
-				$cdDamage = $this->doCDDamage(min($damage['MaxDamage'], $damage['Armour']));
+				$cdDamage = $this->takeDamageToCDs(min($damage['MaxDamage'], $damage['Armour']));
 				$damage['Armour'] -= $cdDamage;
 				$damage['MaxDamage'] -= $cdDamage;
 				if (!$this->hasCDs() && ($cdDamage == 0 || $damage['Rollover'])) {
-					$sdDamage = $this->doSDDamage(min($damage['MaxDamage'], $damage['Armour']));
+					$sdDamage = $this->takeDamageToSDs(min($damage['MaxDamage'], $damage['Armour']));
 				}
 			}
 		}
@@ -507,19 +507,19 @@ class SmrForce {
 		return $return;
 	}
 
-	protected function doMinesDamage(int $damage) : int {
+	protected function takeDamageToMines(int $damage) : int {
 		$actualDamage = min($this->getMines(), IFloor($damage / MINE_ARMOUR));
 		$this->takeMines($actualDamage);
 		return $actualDamage * MINE_ARMOUR;
 	}
 
-	protected function doCDDamage(int $damage) : int {
+	protected function takeDamageToCDs(int $damage) : int {
 		$actualDamage = min($this->getCDs(), IFloor($damage / CD_ARMOUR));
 		$this->takeCDs($actualDamage);
 		return $actualDamage * CD_ARMOUR;
 	}
 
-	protected function doSDDamage(int $damage) : int {
+	protected function takeDamageToSDs(int $damage) : int {
 		$actualDamage = min($this->getSDs(), IFloor($damage / SD_ARMOUR));
 		$this->takeSDs($actualDamage);
 		return $actualDamage * SD_ARMOUR;

--- a/src/lib/Default/SmrMines.class.php
+++ b/src/lib/Default/SmrMines.class.php
@@ -116,7 +116,7 @@ class SmrMines extends AbstractSmrCombatWeapon {
 
 	protected function doForceDamageToPlayer(array $return, SmrForce $forces, AbstractSmrPlayer $targetPlayer, bool $minesAreAttacker = false) : array {
 		$return['WeaponDamage'] = $this->getModifiedForceDamageAgainstPlayer($forces, $targetPlayer, $minesAreAttacker);
-		$return['ActualDamage'] = $targetPlayer->getShip()->doMinesDamage($return['WeaponDamage']);
+		$return['ActualDamage'] = $targetPlayer->getShip()->takeDamageFromMines($return['WeaponDamage']);
 		$return['ActualDamage']['Launched'] = ICeil($return['WeaponDamage']['Launched'] * $return['ActualDamage']['TotalDamage'] / $return['WeaponDamage']['MaxDamage']);
 
 		if ($return['ActualDamage']['KillingShot']) {

--- a/src/lib/Default/SmrPlanet.class.php
+++ b/src/lib/Default/SmrPlanet.class.php
@@ -1220,32 +1220,32 @@ class SmrPlanet {
 		return $results;
 	}
 
-	public function doWeaponDamage(array $damage, bool $delayed) : array {
+	public function takeDamage(array $damage, bool $delayed) : array {
 		$alreadyDead = $this->isDestroyed(true);
 		$shieldDamage = 0;
 		$cdDamage = 0;
 		$armourDamage = 0;
 		if (!$alreadyDead) {
 			if ($damage['Shield'] || !$this->hasShields(true)) {
-				$shieldDamage = $this->doShieldDamage(min($damage['MaxDamage'], $damage['Shield']), $delayed);
+				$shieldDamage = $this->takeDamageToShields(min($damage['MaxDamage'], $damage['Shield']), $delayed);
 				$damage['Shield'] -= $shieldDamage;
 				$damage['MaxDamage'] -= $shieldDamage;
 
 				if (!$this->hasShields(true) && ($shieldDamage == 0 || $damage['Rollover'])) {
 					if ($this->hasCDs(true)) {
-						$cdDamage = $this->doCDDamage(min($damage['MaxDamage'], $damage['Armour']), $delayed);
+						$cdDamage = $this->takeDamageToCDs(min($damage['MaxDamage'], $damage['Armour']), $delayed);
 						$damage['Armour'] -= $cdDamage;
 						$damage['MaxDamage'] -= $cdDamage;
 					}
 					if ($this->hasArmour(true) && ($cdDamage == 0 || $damage['Rollover'])) {
-						$armourDamage = $this->doArmourDamage(min($damage['MaxDamage'], $damage['Armour']), $delayed);
+						$armourDamage = $this->takeDamageToArmour(min($damage['MaxDamage'], $damage['Armour']), $delayed);
 						$damage['Armour'] -= $armourDamage;
 						$damage['MaxDamage'] -= $armourDamage;
 					}
 				}
 
 			} else { // hit drones behind shields - we should only use this reduced damage branch if we cannot hit shields.
-				$cdDamage = $this->doCDDamage(IFloor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT), $delayed);
+				$cdDamage = $this->takeDamageToCDs(IFloor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT), $delayed);
 			}
 		}
 
@@ -1264,19 +1264,19 @@ class SmrPlanet {
 		return $return;
 	}
 
-	protected function doShieldDamage(int $damage, bool $delayed) : int {
+	protected function takeDamageToShields(int $damage, bool $delayed) : int {
 		$actualDamage = min($this->getShields(true), $damage);
 		$this->decreaseShields($actualDamage, $delayed);
 		return $actualDamage;
 	}
 
-	protected function doCDDamage(int $damage, bool $delayed) : int {
+	protected function takeDamageToCDs(int $damage, bool $delayed) : int {
 		$actualDamage = min($this->getCDs(true), IFloor($damage / CD_ARMOUR));
 		$this->decreaseCDs($actualDamage, $delayed);
 		return $actualDamage * CD_ARMOUR;
 	}
 
-	protected function doArmourDamage(int $damage, bool $delayed) : int {
+	protected function takeDamageToArmour(int $damage, bool $delayed) : int {
 		$actualDamage = min($this->getArmour(true), $damage);
 		$this->decreaseArmour($actualDamage, $delayed);
 		return $actualDamage;

--- a/src/lib/Default/SmrPlanet.class.php
+++ b/src/lib/Default/SmrPlanet.class.php
@@ -44,10 +44,6 @@ class SmrPlanet {
 	protected array $hasStoppedBuilding = array();
 	protected bool $isNew = false;
 
-	protected int $delayedShieldsDelta = 0;
-	protected int $delayedCDsDelta = 0;
-	protected int $delayedArmourDelta = 0;
-
 	public function __sleep() {
 		return ['sectorID', 'gameID', 'planetName', 'ownerID', 'typeID'];
 	}
@@ -367,12 +363,12 @@ class SmrPlanet {
 		}
 	}
 
-	public function getShields(bool $delayed = false) : int {
-		return $this->shields + ($delayed ? $this->delayedShieldsDelta : 0);
+	public function getShields() : int {
+		return $this->shields;
 	}
 
-	public function hasShields(bool $delayed = false) : bool {
-		return $this->getShields($delayed) > 0;
+	public function hasShields() : bool {
+		return $this->getShields() > 0;
 	}
 
 	public function setShields(int $shields) : void {
@@ -384,38 +380,30 @@ class SmrPlanet {
 		$this->hasChanged = true;
 	}
 
-	public function decreaseShields(int $number, bool $delayed = false) : void {
+	public function decreaseShields(int $number) : void {
 		if ($number === 0) {
 			return;
 		}
-		if ($delayed === false) {
-			$this->setShields($this->getShields() - $number);
-		} else {
-			$this->delayedShieldsDelta -= $number;
-		}
+		$this->setShields($this->getShields() - $number);
 	}
 
-	public function increaseShields(int $number, bool $delayed = false) : void {
+	public function increaseShields(int $number) : void {
 		if ($number === 0) {
 			return;
 		}
-		if ($delayed === false) {
-			$this->setShields($this->getShields() + $number);
-		} else {
-			$this->delayedShieldsDelta += $number;
-		}
+		$this->setShields($this->getShields() + $number);
 	}
 
 	public function getMaxShields() : int {
 		return $this->getBuilding(PLANET_GENERATOR) * PLANET_GENERATOR_SHIELDS;
 	}
 
-	public function getArmour(bool $delayed = false) : int {
-		return $this->armour + ($delayed ? $this->delayedArmourDelta : 0);
+	public function getArmour() : int {
+		return $this->armour;
 	}
 
-	public function hasArmour(bool $delayed = false) : bool {
-		return $this->getArmour($delayed) > 0;
+	public function hasArmour() : bool {
+		return $this->getArmour() > 0;
 	}
 
 	public function setArmour(int $armour) : void {
@@ -427,38 +415,30 @@ class SmrPlanet {
 		$this->hasChanged = true;
 	}
 
-	public function decreaseArmour(int $number, bool $delayed = false) : void {
+	public function decreaseArmour(int $number) : void {
 		if ($number === 0) {
 			return;
 		}
-		if ($delayed === false) {
-			$this->setArmour($this->getArmour() - $number);
-		} else {
-			$this->delayedArmourDelta -= $number;
-		}
+		$this->setArmour($this->getArmour() - $number);
 	}
 
-	public function increaseArmour(int $number, bool $delayed = false) : void {
+	public function increaseArmour(int $number) : void {
 		if ($number === 0) {
 			return;
 		}
-		if ($delayed === false) {
-			$this->setArmour($this->getArmour() + $number);
-		} else {
-			$this->delayedArmourDelta += $number;
-		}
+		$this->setArmour($this->getArmour() + $number);
 	}
 
 	public function getMaxArmour() : int {
 		return $this->getBuilding(PLANET_BUNKER) * PLANET_BUNKER_ARMOUR;
 	}
 
-	public function getCDs(bool $delayed = false) : int {
-		return $this->drones + ($delayed ? $this->delayedCDsDelta : 0);
+	public function getCDs() : int {
+		return $this->drones;
 	}
 
-	public function hasCDs(bool $delayed = false) : bool {
-		return $this->getCDs($delayed) > 0;
+	public function hasCDs() : bool {
+		return $this->getCDs() > 0;
 	}
 
 	public function setCDs(int $combatDrones) : void {
@@ -470,26 +450,18 @@ class SmrPlanet {
 		$this->hasChanged = true;
 	}
 
-	public function decreaseCDs(int $number, bool $delayed = false) : void {
+	public function decreaseCDs(int $number) : void {
 		if ($number === 0) {
 			return;
 		}
-		if ($delayed === false) {
-			$this->setCDs($this->getCDs() - $number);
-		} else {
-			$this->delayedCDsDelta -= $number;
-		}
+		$this->setCDs($this->getCDs() - $number);
 	}
 
-	public function increaseCDs(int $number, bool $delayed = false) : void {
+	public function increaseCDs(int $number) : void {
 		if ($number === 0) {
 			return;
 		}
-		if ($delayed === false) {
-			$this->setCDs($this->getCDs() + $number);
-		} else {
-			$this->delayedCDsDelta += $number;
-		}
+		$this->setCDs($this->getCDs() + $number);
 	}
 
 	public function getMaxCDs() : int {
@@ -569,8 +541,8 @@ class SmrPlanet {
 	}
 
 
-	public function isDestroyed(bool $delayed = false) : bool {
-		return !$this->hasCDs($delayed) && !$this->hasShields($delayed) && !$this->hasArmour($delayed);
+	public function isDestroyed() : bool {
+		return !$this->hasCDs() && !$this->hasShields() && !$this->hasArmour();
 	}
 
 	public function exists() : bool {
@@ -791,20 +763,10 @@ class SmrPlanet {
 		return in_array($option, $this->typeInfo->menuOptions());
 	}
 
-	public function doDelayedUpdates() : void {
-		$this->setShields($this->getShields(true));
-		$this->delayedShieldsDelta = 0;
-		$this->setCDs($this->getCDs(true));
-		$this->delayedCDsDelta = 0;
-		$this->setArmour($this->getArmour(true));
-		$this->delayedArmourDelta = 0;
-	}
-
 	public function update() : void {
 		if (!$this->exists()) {
 			return;
 		}
-		$this->doDelayedUpdates();
 		if ($this->hasChanged) {
 			$this->db->write('UPDATE planet SET
 									owner_id = ' . $this->db->escapeNumber($this->ownerID) . ',
@@ -1220,65 +1182,65 @@ class SmrPlanet {
 		return $results;
 	}
 
-	public function takeDamage(array $damage, bool $delayed) : array {
-		$alreadyDead = $this->isDestroyed(true);
+	public function takeDamage(array $damage) : array {
+		$alreadyDead = $this->isDestroyed();
 		$shieldDamage = 0;
 		$cdDamage = 0;
 		$armourDamage = 0;
 		if (!$alreadyDead) {
-			if ($damage['Shield'] || !$this->hasShields(true)) {
-				$shieldDamage = $this->takeDamageToShields(min($damage['MaxDamage'], $damage['Shield']), $delayed);
+			if ($damage['Shield'] || !$this->hasShields()) {
+				$shieldDamage = $this->takeDamageToShields(min($damage['MaxDamage'], $damage['Shield']));
 				$damage['Shield'] -= $shieldDamage;
 				$damage['MaxDamage'] -= $shieldDamage;
 
-				if (!$this->hasShields(true) && ($shieldDamage == 0 || $damage['Rollover'])) {
-					if ($this->hasCDs(true)) {
-						$cdDamage = $this->takeDamageToCDs(min($damage['MaxDamage'], $damage['Armour']), $delayed);
+				if (!$this->hasShields() && ($shieldDamage == 0 || $damage['Rollover'])) {
+					if ($this->hasCDs()) {
+						$cdDamage = $this->takeDamageToCDs(min($damage['MaxDamage'], $damage['Armour']));
 						$damage['Armour'] -= $cdDamage;
 						$damage['MaxDamage'] -= $cdDamage;
 					}
-					if ($this->hasArmour(true) && ($cdDamage == 0 || $damage['Rollover'])) {
-						$armourDamage = $this->takeDamageToArmour(min($damage['MaxDamage'], $damage['Armour']), $delayed);
+					if ($this->hasArmour() && ($cdDamage == 0 || $damage['Rollover'])) {
+						$armourDamage = $this->takeDamageToArmour(min($damage['MaxDamage'], $damage['Armour']));
 						$damage['Armour'] -= $armourDamage;
 						$damage['MaxDamage'] -= $armourDamage;
 					}
 				}
 
 			} else { // hit drones behind shields - we should only use this reduced damage branch if we cannot hit shields.
-				$cdDamage = $this->takeDamageToCDs(IFloor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT), $delayed);
+				$cdDamage = $this->takeDamageToCDs(IFloor(min($damage['MaxDamage'], $damage['Armour']) * DRONES_BEHIND_SHIELDS_DAMAGE_PERCENT));
 			}
 		}
 
 		$return = array(
-			'KillingShot' => !$alreadyDead && $this->isDestroyed(true),
+			'KillingShot' => !$alreadyDead && $this->isDestroyed(),
 			'TargetAlreadyDead' => $alreadyDead,
 			'Shield' => $shieldDamage,
 			'Armour' => $armourDamage,
-			'HasShields' => $this->hasShields(true),
-			'HasArmour' => $this->hasArmour(true),
+			'HasShields' => $this->hasShields(),
+			'HasArmour' => $this->hasArmour(),
 			'CDs' => $cdDamage,
 			'NumCDs' => $cdDamage / CD_ARMOUR,
-			'HasCDs' => $this->hasCDs(true),
+			'HasCDs' => $this->hasCDs(),
 			'TotalDamage' => $shieldDamage + $cdDamage + $armourDamage
 		);
 		return $return;
 	}
 
-	protected function takeDamageToShields(int $damage, bool $delayed) : int {
-		$actualDamage = min($this->getShields(true), $damage);
-		$this->decreaseShields($actualDamage, $delayed);
+	protected function takeDamageToShields(int $damage) : int {
+		$actualDamage = min($this->getShields(), $damage);
+		$this->decreaseShields($actualDamage);
 		return $actualDamage;
 	}
 
-	protected function takeDamageToCDs(int $damage, bool $delayed) : int {
-		$actualDamage = min($this->getCDs(true), IFloor($damage / CD_ARMOUR));
-		$this->decreaseCDs($actualDamage, $delayed);
+	protected function takeDamageToCDs(int $damage) : int {
+		$actualDamage = min($this->getCDs(), IFloor($damage / CD_ARMOUR));
+		$this->decreaseCDs($actualDamage);
 		return $actualDamage * CD_ARMOUR;
 	}
 
-	protected function takeDamageToArmour(int $damage, bool $delayed) : int {
-		$actualDamage = min($this->getArmour(true), $damage);
-		$this->decreaseArmour($actualDamage, $delayed);
+	protected function takeDamageToArmour(int $damage) : int {
+		$actualDamage = min($this->getArmour(), $damage);
+		$this->decreaseArmour($actualDamage);
 		return $actualDamage;
 	}
 

--- a/src/lib/Default/SmrWeapon.class.php
+++ b/src/lib/Default/SmrWeapon.class.php
@@ -307,12 +307,12 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 		return $return;
 	}
 
-	public function shootPlanet(AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet, bool $delayed) : array {
+	public function shootPlanet(AbstractSmrPlayer $weaponPlayer, SmrPlanet $planet) : array {
 		$return = array('Weapon' => $this, 'TargetPlanet' => $planet, 'Hit' => false);
 		$modifiedAccuracy = $this->getModifiedAccuracyAgainstPlanet($weaponPlayer, $planet);
 		if ($this->checkHit($weaponPlayer, $modifiedAccuracy)) {
 			$return['Hit'] = true;
-			return $this->doPlayerDamageToPlanet($return, $weaponPlayer, $planet, $delayed);
+			return $this->doPlayerDamageToPlanet($return, $weaponPlayer, $planet);
 		}
 		return $return;
 	}

--- a/test/SmrTest/lib/DefaultGame/SmrPlanetIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrPlanetIntegrationTest.php
@@ -238,4 +238,85 @@ class SmrPlanetIntegrationTest extends BaseIntegrationSpec {
 		$this->assertSame(2/3, $planet->getLevel());
 	}
 
+	public function test_defenses() : void {
+		// Make a Defense World planet
+		$planet = SmrPlanet::createPlanet(1, 1, 4, 1);
+
+		// Add buildings so that we can add defenses
+		$planet->increaseBuilding(PLANET_GENERATOR, 1);
+		$planet->increaseBuilding(PLANET_HANGAR, 1);
+		$planet->increaseBuilding(PLANET_BUNKER, 1);
+
+		// Make sure there are no defenses to start
+		self::assertSame(0, $planet->getShields());
+		self::assertFalse($planet->hasShields());
+		self::assertSame(0, $planet->getCDs());
+		self::assertFalse($planet->hasCDs());
+		self::assertSame(0, $planet->getArmour());
+		self::assertFalse($planet->hasArmour());
+
+		// Increase shields
+		$planet->increaseShields(10);
+		self::assertSame(10, $planet->getShields());
+		self::assertTrue($planet->hasShields());
+
+		// Don't increase shields
+		$planet->increaseShields(0);
+		self::assertSame(10, $planet->getShields());
+
+		// Decrease shields
+		$planet->decreaseShields(2);
+		self::assertSame(8, $planet->getShields());
+
+		// Make sure we can't go above the Generator limit
+		$planet->setShields(PLANET_GENERATOR_SHIELDS + 1);
+		self::assertSame(PLANET_GENERATOR_SHIELDS, $planet->getShields());
+
+		// Make sure we can't go below 0 shields
+		$planet->setShields(-1);
+		self::assertSame(0, $planet->getShields());
+
+		// Increase CDs
+		$planet->increaseCDs(5);
+		self::assertSame(5, $planet->getCDs());
+		self::assertTrue($planet->hasCDs());
+
+		// Don't increase CDs
+		$planet->increaseCDs(0);
+		self::assertSame(5, $planet->getCDs());
+
+		// Decrease CDs
+		$planet->decreaseCDs(3);
+		self::assertSame(2, $planet->getCDs());
+
+		// Make sure we can't go above the Hangar limit
+		$planet->setCDs(PLANET_HANGAR_DRONES + 1);
+		self::assertSame(PLANET_HANGAR_DRONES, $planet->getCDs());
+
+		// Make sure we can't go below 0 CDs
+		$planet->setCDs(-1);
+		self::assertSame(0, $planet->getCDs());
+
+		// Increase armour
+		$planet->increaseArmour(15);
+		self::assertSame(15, $planet->getArmour());
+		self::assertTrue($planet->hasArmour());
+
+		// Don't increase armour
+		$planet->increaseArmour(0);
+		self::assertSame(15, $planet->getArmour());
+
+		// Decrease armour
+		$planet->decreaseArmour(4);
+		self::assertSame(11, $planet->getArmour());
+
+		// Make sure we can't go above the Bunker limit
+		$planet->setArmour(PLANET_BUNKER_ARMOUR + 1);
+		self::assertSame(PLANET_BUNKER_ARMOUR, $planet->getArmour());
+
+		// Make sure we can't go below 0 armour
+		$planet->setArmour(-1);
+		self::assertSame(0, $planet->getArmour());
+	}
+
 }


### PR DESCRIPTION
* Rename combat damage methods for clarity (e.g. `doMinesDamage` -> `takeDamageFromMines`).
* Remove delayed planet defense updating, because it is unused.