### PR TITLE
Fix middle panel ajax updates

### DIFF
--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -237,7 +237,11 @@ class Template {
 		$dom = new DOMDocument();
 		$dom->loadHTML($str);
 		$xpath = new DOMXPath($dom);
-		$ajaxSelectors = array('//span[@id]', '//*[contains(@class,"ajax")]');
+
+		// Use relative xpath selectors so that they can be reused when we
+		// pass the middle panel as the xpath query's context node.
+		$ajaxSelectors = array('.//span[@id]', './/*[contains(@class,"ajax")]');
+
 		foreach ($ajaxSelectors as $selector) {
 			$matchNodes = $xpath->query($selector);
 			foreach ($matchNodes as $node) {

--- a/test/SmrTest/lib/DefaultGame/TemplateTest.php
+++ b/test/SmrTest/lib/DefaultGame/TemplateTest.php
@@ -94,6 +94,8 @@ class TemplateTest extends \PHPUnit\Framework\TestCase {
 			['<div id="middle_panel">Foo</div>', '', true],
 			// Empty string
 			['', ''],
+			// Ajax-enabled elements both outside and inside middle panel
+			['<span id="foo">Test</span><div id="middle_panel">Foo</div>', '<foo>Test</foo><middle_panel>Foo</middle_panel>']
 		];
 	}
 


### PR DESCRIPTION
The middle panel was not ajax updating due to a Template bug that was
introduced in 2b4257472. Basically, we were using the `contextNode`
argument of `DOMXPath::query` to check for ajax-enabled content in the
middle panel, but even though the `contextNode` was the middle panel
element, we were using an XPath expression starting with "//", which:

> Selects nodes in the document from the current node that match the
> selection no matter where they are

As a result, the query was escaping the context node and finding ajax-
enabled elements _outside_ of the middle panel. The context node is
_only_ relevant for _relative_ XPath queries (i.e. it is not the same
as creating a new DOMDocument out of the context node).

The fix is simple: we convert the queries to be relative by prepending
a ".". This works in both the case where we do not pass a context node
(when we search for ajax-enabled elements in the entire document) and
the case where we do (when we only want ajax-enabled elements in the
middle panel).

Added a test case for the failing example where an element outside the
middle panel ajax-updates, to make sure it does not disable the middle
panel from also ajax-updating.