### PR TITLE
Natural Exception Handling

### DIFF
--- a/src/admin/Default/manage_draft_leaders_processing.php
+++ b/src/admin/Default/manage_draft_leaders_processing.php
@@ -17,7 +17,7 @@ $container = Page::create('skeleton.php', 'manage_draft_leaders.php', $var);
 
 try {
 	$selectedPlayer = SmrPlayer::getPlayerByPlayerID($playerId, $gameId);
-} catch (PlayerNotFoundException $e) {
+} catch (Smr\Exceptions\PlayerNotFound $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
 	$container['processing_msg'] = $msg;
 	$container->go();

--- a/src/admin/Default/manage_post_editors_processing.php
+++ b/src/admin/Default/manage_post_editors_processing.php
@@ -16,7 +16,7 @@ $container = Page::create('skeleton.php', 'manage_post_editors.php', $var);
 
 try {
 	$selected_player = SmrPlayer::getPlayerByPlayerID($player_id, $game_id);
-} catch (PlayerNotFoundException $e) {
+} catch (Smr\Exceptions\PlayerNotFound $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
 	$container['processing_msg'] = $msg;
 	$container->go();

--- a/src/admin/Default/npc_manage_processing.php
+++ b/src/admin/Default/npc_manage_processing.php
@@ -16,11 +16,7 @@ if (Smr\Request::has('create_npc_player')) {
 	$gameID = $var['selected_game_id'];
 	$playerName = Smr\Request::get('player_name');
 	$raceID = Smr\Request::getInt('race_id');
-	try {
-		$npcPlayer = SmrPlayer::createPlayer($accountID, $gameID, $playerName, $raceID, false, true);
-	} catch (\Smr\UserException $err) {
-		create_error($err->getMessage());
-	}
+	$npcPlayer = SmrPlayer::createPlayer($accountID, $gameID, $playerName, $raceID, false, true);
 
 	$npcPlayer->getShip()->setHardwareToMax();
 	$npcPlayer->giveStartingTurns();

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -97,7 +97,7 @@ function handleException(Throwable $e) : void {
 	// The real error message may display sensitive information, so we
 	// need to catch any exceptions that are thrown while logging the error.
 	try {
-		if ($e instanceof Smr\UserException) {
+		if ($e instanceof Smr\Exceptions\UserError) {
 			create_error($e->getMessage());
 		}
 		logException($e);

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -84,10 +84,22 @@ function logException(Throwable $e) : void {
 	}
 }
 
+/**
+ * Handles all user-facing exceptions.
+ *
+ * If the error is fatal, the exception is logged and the player is redirected
+ * to an appropriate error page.
+ *
+ * If the error is just informational (e.g. the user input an invalid value),
+ * then the message is displayed on the page without being logged.
+ */
 function handleException(Throwable $e) : void {
 	// The real error message may display sensitive information, so we
 	// need to catch any exceptions that are thrown while logging the error.
 	try {
+		if ($e instanceof Smr\UserException) {
+			create_error($e->getMessage());
+		}
 		logException($e);
 		$errorType = 'Unexpected Error!';
 	} catch (Throwable $e2) {

--- a/src/engine/Default/alliance_create_processing.php
+++ b/src/engine/Default/alliance_create_processing.php
@@ -35,11 +35,7 @@ if ($name != $filteredName) {
 }
 
 // create the alliance
-try {
-	$alliance = SmrAlliance::createAlliance($player->getGameID(), $name);
-} catch (Smr\UserException $err) {
-	create_error($err->getMessage());
-}
+$alliance = SmrAlliance::createAlliance($player->getGameID(), $name);
 $alliance->setRecruitType($recruitType, $password);
 $alliance->setAllianceDescription($description, $player);
 $alliance->setLeaderID($player->getAccountID());

--- a/src/engine/Default/alliance_invite_accept_processing.php
+++ b/src/engine/Default/alliance_invite_accept_processing.php
@@ -7,7 +7,7 @@ $player = $session->getPlayer();
 // Check that the invitation is registered in the database
 try {
 	$invite = SmrInvitation::get($var['alliance_id'], $player->getGameID(), $player->getAccountID());
-} catch (InvitationNotFoundException $e) {
+} catch (Smr\Exceptions\AllianceInvitationNotFound $e) {
 	create_error('Your invitation to join this alliance has expired or been canceled!');
 }
 

--- a/src/engine/Default/alliance_message.php
+++ b/src/engine/Default/alliance_message.php
@@ -81,7 +81,7 @@ if ($dbResult->hasRecord()) {
 			try {
 				$author = SmrPlayer::getPlayer($sender_id, $player->getGameID());
 				$playerName = $author->getLinkedDisplayName(false);
-			} catch (PlayerNotFoundException $e) {
+			} catch (Smr\Exceptions\PlayerNotFound $e) {
 				$playerName = 'Unknown'; // default
 			}
 		}

--- a/src/engine/Default/chat_sharing.php
+++ b/src/engine/Default/chat_sharing.php
@@ -19,7 +19,7 @@ foreach ($dbResult->records() as $dbRecord) {
 	$gameId = $dbRecord->getInt('game_id');
 	try {
 		$otherPlayer = SmrPlayer::getPlayer($fromAccountId, $player->getGameID());
-	} catch (PlayerNotFoundException $e) {
+	} catch (Smr\Exceptions\PlayerNotFound $e) {
 		// Player has not joined this game yet
 		$otherPlayer = null;
 	}
@@ -40,7 +40,7 @@ foreach ($dbResult->records() as $dbRecord) {
 	$toAccountId = $dbRecord->getInt('to_account_id');
 	try {
 		$otherPlayer = SmrPlayer::getPlayer($toAccountId, $player->getGameID());
-	} catch (PlayerNotFoundException $e) {
+	} catch (Smr\Exceptions\PlayerNotFound $e) {
 		// Player has not joined this game yet
 		$otherPlayer = null;
 	}

--- a/src/engine/Default/chat_sharing_processing.php
+++ b/src/engine/Default/chat_sharing_processing.php
@@ -22,7 +22,7 @@ if (Smr\Request::has('add')) {
 
 	try {
 		$accountId = SmrPlayer::getPlayerByPlayerID($addPlayerID, $player->getGameID())->getAccountID();
-	} catch (PlayerNotFoundException $e) {
+	} catch (Smr\Exceptions\PlayerNotFound $e) {
 		error_on_page($e->getMessage());
 	}
 

--- a/src/engine/Default/course_plot_processing.php
+++ b/src/engine/Default/course_plot_processing.php
@@ -18,7 +18,7 @@ if ($start == $target) {
 try {
 	$startSector = SmrSector::getSector($player->getGameID(), $start);
 	$targetSector = SmrSector::getSector($player->getGameID(), $target);
-} catch (SectorNotFoundException $e) {
+} catch (Smr\Exceptions\SectorNotFound $e) {
 	create_error('The sectors have to exist!');
 }
 

--- a/src/engine/Default/game_join_processing.php
+++ b/src/engine/Default/game_join_processing.php
@@ -60,11 +60,7 @@ if ($isNewbie) {
 }
 
 // insert into player table.
-try {
-	$player = SmrPlayer::createPlayer($account->getAccountID(), $gameID, $player_name, $race_id, $isNewbie);
-} catch (Smr\UserException $err) {
-	create_error($err->getMessage());
-}
+$player = SmrPlayer::createPlayer($account->getAccountID(), $gameID, $player_name, $race_id, $isNewbie);
 
 // Equip the ship
 $player->getShip()->giveStarterShip();

--- a/src/engine/Default/hall_of_fame_player_detail.php
+++ b/src/engine/Default/hall_of_fame_player_detail.php
@@ -13,7 +13,7 @@ $game_id = $var['game_id'] ?? null;
 if (isset($game_id)) {
 	try {
 		$hofPlayer = SmrPlayer::getPlayer($account_id, $game_id);
-	} catch (PlayerNotFoundException $e) {
+	} catch (Smr\Exceptions\PlayerNotFound $e) {
 		create_error('That player has not yet joined this game.');
 	}
 	$template->assign('PageTopic', htmlentities($hofPlayer->getPlayerName()) . '\'s Personal Hall of Fame: ' . SmrGame::getGame($game_id)->getDisplayName());

--- a/src/engine/Default/message_blacklist_add.php
+++ b/src/engine/Default/message_blacklist_add.php
@@ -11,7 +11,7 @@ if (isset($var['account_id'])) {
 } else {
 	try {
 		$blacklisted = SmrPlayer::getPlayerByPlayerName(Smr\Request::get('PlayerName'), $player->getGameID());
-	} catch (PlayerNotFoundException $e) {
+	} catch (Smr\Exceptions\PlayerNotFound $e) {
 		$container['msg'] = '<span class="red bold">ERROR: </span>Player does not exist.';
 		$container->go();
 	}

--- a/src/engine/Default/planet_construction_processing.php
+++ b/src/engine/Default/planet_construction_processing.php
@@ -11,11 +11,7 @@ $planet = $player->getSectorPlanet();
 $action = $var['action'];
 if ($action == 'Build') {
 	// now start the construction
-	try {
-		$planet->startBuilding($player, $var['construction_id']);
-	} catch (\Smr\UserException $err) {
-		create_error($err->getMessage());
-	}
+	$planet->startBuilding($player, $var['construction_id']);
 	$player->increaseHOF(1, array('Planet', 'Buildings', 'Started'), HOF_ALLIANCE);
 
 	$player->log(LOG_TYPE_PLANETS, 'Player starts a ' . $planet->getStructureTypes($var['construction_id'])->name() . ' on planet.');

--- a/src/engine/Default/trader_search_result.php
+++ b/src/engine/Default/trader_search_result.php
@@ -15,7 +15,7 @@ if (empty($player_name) && empty($player_id)) {
 if (!empty($player_id)) {
 	try {
 		$resultPlayer = SmrPlayer::getPlayerByPlayerID($player_id, $player->getGameID());
-	} catch (PlayerNotFoundException $e) {
+	} catch (Smr\Exceptions\PlayerNotFound $e) {
 		// No player found, we'll return an empty result
 	}
 } else {

--- a/src/htdocs/login_create_processing.php
+++ b/src/htdocs/login_create_processing.php
@@ -140,7 +140,7 @@ try {
 	// creates a new user account object
 	try {
 		$account = SmrAccount::createAccount($login, $password, $email, $timez, $referral);
-	} catch (AccountNotFoundException $e) {
+	} catch (Smr\Exceptions\AccountNotFound $e) {
 		$msg = 'Invalid referral account ID!';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;

--- a/src/htdocs/login_social_processing.php
+++ b/src/htdocs/login_social_processing.php
@@ -14,7 +14,7 @@ try {
 		require_once('../bootstrap.php');
 		try {
 			header('Location: ' . Smr\SocialLogin\SocialLogin::get($type)->getLoginUrl());
-		} catch (Smr\SocialLogin\SocialLoginNotFound $e) {
+		} catch (Smr\Exceptions\SocialLoginInvalidType $e) {
 			header('location: /error.php?msg=' . urlencode('Unknown social login type'));
 		}
 	}

--- a/src/htdocs/map_galaxy.php
+++ b/src/htdocs/map_galaxy.php
@@ -27,7 +27,7 @@ try {
 		$sectorID = Smr\Request::getInt('sector_id');
 		try {
 			$galaxy = SmrGalaxy::getGalaxyContaining($session->getGameID(), $sectorID);
-		} catch (SectorNotFoundException $e) {
+		} catch (Smr\Exceptions\SectorNotFound $e) {
 			header('location: /error.php?msg=Invalid sector ID');
 			exit;
 		}

--- a/src/lib/Default/AbstractSmrAccount.class.php
+++ b/src/lib/Default/AbstractSmrAccount.class.php
@@ -1,8 +1,5 @@
 <?php declare(strict_types=1);
 
-// Exception thrown when an account cannot be found in the database
-class AccountNotFoundException extends Exception {}
-
 abstract class AbstractSmrAccount {
 
 	const USER_RANKINGS_EACH_STAT_POW = .9;
@@ -248,7 +245,7 @@ abstract class AbstractSmrAccount {
 				$this->hofName = $this->login;
 			}
 		} else {
-			throw new AccountNotFoundException('Account ID ' . $accountID . ' does not exist!');
+			throw new Smr\Exceptions\AccountNotFound('Account ID ' . $accountID . ' does not exist!');
 		}
 	}
 

--- a/src/lib/Default/AbstractSmrAccount.class.php
+++ b/src/lib/Default/AbstractSmrAccount.class.php
@@ -656,16 +656,16 @@ abstract class AbstractSmrAccount {
 
 		// check if the host got a MX or at least an A entry
 		if (!checkdnsrr($host, 'MX') && !checkdnsrr($host, 'A')) {
-			create_error('This is not a valid email address! The domain ' . $host . ' does not exist.');
+			throw new Smr\Exceptions\UserError('This is not a valid email address! The domain ' . $host . ' does not exist.');
 		}
 
 		if (strstr($email, ' ')) {
-			create_error('The email is invalid! It cannot contain any spaces.');
+			throw new Smr\Exceptions\UserError('The email is invalid! It cannot contain any spaces.');
 		}
 
 		$dbResult = $this->db->read('SELECT 1 FROM account WHERE email = ' . $this->db->escapeString($email) . ' and account_id != ' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
 		if ($dbResult->hasRecord()) {
-			create_error('This email address is already registered.');
+			throw new Smr\Exceptions\UserError('This email address is already registered.');
 		}
 
 		$this->setEmail($email);

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -1,9 +1,6 @@
 <?php declare(strict_types=1);
 require_once('missions.inc.php');
 
-// Exception thrown when a player cannot be found in the database
-class PlayerNotFoundException extends Exception {}
-
 abstract class AbstractSmrPlayer {
 	use Traits\RaceID;
 
@@ -189,7 +186,7 @@ abstract class AbstractSmrPlayer {
 			$dbRecord = $dbResult->record();
 			return self::getPlayer($dbRecord->getInt('account_id'), $gameID, $forceUpdate, $dbRecord);
 		}
-		throw new PlayerNotFoundException('Player ID not found.');
+		throw new Smr\Exceptions\PlayerNotFound('Player ID not found.');
 	}
 
 	public static function getPlayerByPlayerName(string $playerName, int $gameID, bool $forceUpdate = false) : self {
@@ -199,7 +196,7 @@ abstract class AbstractSmrPlayer {
 			$dbRecord = $dbResult->record();
 			return self::getPlayer($dbRecord->getInt('account_id'), $gameID, $forceUpdate, $dbRecord);
 		}
-		throw new PlayerNotFoundException('Player Name not found.');
+		throw new Smr\Exceptions\PlayerNotFound('Player Name not found.');
 	}
 
 	protected function __construct(int $gameID, int $accountID, Smr\DatabaseRecord $dbRecord = null) {
@@ -213,7 +210,7 @@ abstract class AbstractSmrPlayer {
 			}
 		}
 		if ($dbRecord === null) {
-			throw new PlayerNotFoundException('Invalid accountID: ' . $accountID . ' OR gameID:' . $gameID);
+			throw new Smr\Exceptions\PlayerNotFound('Invalid accountID: ' . $accountID . ' OR gameID:' . $gameID);
 		}
 
 		$this->accountID = $accountID;
@@ -271,8 +268,8 @@ abstract class AbstractSmrPlayer {
 		try {
 			self::getPlayerByPlayerName($playerName, $gameID);
 			$db->unlock();
-			throw new Smr\UserException('That player name already exists.');
-		} catch (PlayerNotFoundException $e) {
+			throw new Smr\Exceptions\UserError('That player name already exists.');
+		} catch (Smr\Exceptions\PlayerNotFound $e) {
 			// Player name does not yet exist, we may proceed
 		}
 
@@ -314,7 +311,7 @@ abstract class AbstractSmrPlayer {
 			try {
 				$otherPlayer = SmrPlayer::getPlayer($dbRecord->getInt('from_account_id'),
 				                                    $this->getGameID(), $forceUpdate);
-			} catch (PlayerNotFoundException $e) {
+			} catch (Smr\Exceptions\PlayerNotFound $e) {
 				// Skip players that have not joined this game
 				continue;
 			}
@@ -1370,7 +1367,7 @@ abstract class AbstractSmrPlayer {
 			// Do not throw an exception if the NHL account doesn't exist.
 			try {
 				$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I joined your alliance!', false);
-			} catch (AccountNotFoundException $e) {
+			} catch (Smr\Exceptions\AccountNotFound $e) {
 				if ($alliance->getLeaderID() != ACCOUNT_ID_NHL) {
 					throw $e;
 				}

--- a/src/lib/Default/AbstractSmrPlayer.class.php
+++ b/src/lib/Default/AbstractSmrPlayer.class.php
@@ -683,7 +683,7 @@ abstract class AbstractSmrPlayer {
 	public function sendGlobalMessage(string $message, bool $canBeIgnored = true) : void {
 		if ($canBeIgnored) {
 			if ($this->getAccount()->isMailBanned()) {
-				create_error('You are currently banned from sending messages');
+				throw new Smr\Exceptions\UserError('You are currently banned from sending messages');
 			}
 		}
 		$this->sendMessageToBox(BOX_GLOBALS, $message);
@@ -711,7 +711,7 @@ abstract class AbstractSmrPlayer {
 		//get expire time
 		if ($canBeIgnored) {
 			if ($this->getAccount()->isMailBanned()) {
-				create_error('You are currently banned from sending messages');
+				throw new Smr\Exceptions\UserError('You are currently banned from sending messages');
 			}
 			// Don't send messages to players ignoring us
 			$dbResult = $this->db->read('SELECT 1 FROM message_blacklist WHERE account_id=' . $this->db->escapeNumber($receiverID) . ' AND blacklisted_id=' . $this->db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
@@ -1643,7 +1643,7 @@ abstract class AbstractSmrPlayer {
 	public function getJumpInfo(SmrSector $targetSector) : array {
 		$path = Plotter::findDistanceToX($targetSector, $this->getSector(), true);
 		if ($path === false) {
-			create_error('Unable to plot from ' . $this->getSectorID() . ' to ' . $targetSector->getSectorID() . '.');
+			throw new Smr\Exceptions\UserError('Unable to plot from ' . $this->getSectorID() . ' to ' . $targetSector->getSectorID() . '.');
 		}
 		$distance = $path->getRelativeDistance();
 
@@ -1675,7 +1675,7 @@ abstract class AbstractSmrPlayer {
 	public function moveDestinationButton(int $sectorID, int $offsetTop, int $offsetLeft) : void {
 
 		if ($offsetLeft < 0 || $offsetLeft > 500 || $offsetTop < 0 || $offsetTop > 300) {
-			create_error('The saved sector must be in the box!');
+			throw new Smr\Exceptions\UserError('The saved sector must be in the box!');
 		}
 
 		$storedDestinations =& $this->getStoredDestinations();
@@ -1692,19 +1692,19 @@ abstract class AbstractSmrPlayer {
 			}
 		}
 
-		create_error('You do not have a saved sector for #' . $sectorID);
+		throw new Smr\Exceptions\UserError('You do not have a saved sector for #' . $sectorID);
 	}
 
 	public function addDestinationButton(int $sectorID, string $label) : void {
 
 		if (!SmrSector::sectorExists($this->getGameID(), $sectorID)) {
-			create_error('You want to add a non-existent sector?');
+			throw new Smr\Exceptions\UserError('You want to add a non-existent sector?');
 		}
 
 		// sector already stored ?
 		foreach ($this->getStoredDestinations() as $sd) {
 			if ($sd['SectorID'] == $sectorID) {
-				create_error('Sector already stored!');
+				throw new Smr\Exceptions\UserError('Sector already stored!');
 			}
 		}
 
@@ -2709,7 +2709,7 @@ abstract class AbstractSmrPlayer {
 				// sector that does not exist or cannot be reached.
 				// (Probably shouldn't bestow this mission in the first place)
 				$this->deleteMission($missionID);
-				create_error('Cannot find a path to the destination!');
+				throw new Smr\Exceptions\UserError('Cannot find a path to the destination!');
 			}
 			$this->missions[$missionID]['Sector'] = $path->getEndSectorID();
 		}

--- a/src/lib/Default/Globals.class.php
+++ b/src/lib/Default/Globals.class.php
@@ -26,7 +26,7 @@ class Globals {
 			case 'AllianceMOTD':
 				if ($player->getAllianceID() != $extraInfo['AllianceID']) {
 					logException(new Exception('Tried to access page without permission.'));
-					create_error('You cannot access this page.');
+					throw new Smr\Exceptions\UserError('You cannot access this page.');
 				}
 			break;
 		}

--- a/src/lib/Default/Globals.class.php
+++ b/src/lib/Default/Globals.class.php
@@ -153,7 +153,7 @@ class Globals {
 		try {
 			SmrGame::getGame($gameID);
 			return true;
-		} catch (GameNotFoundException $e) {
+		} catch (Smr\Exceptions\GameNotFound $e) {
 			return false;
 		}
 	}

--- a/src/lib/Default/Plotter.class.php
+++ b/src/lib/Default/Plotter.class.php
@@ -18,7 +18,7 @@ class Plotter {
 		$getGoodWithTransaction = function(int $goodID) use ($xType, $player) {
 			$good = Globals::getGood($goodID);
 			if (isset($player) && !$player->meetsAlignmentRestriction($good['AlignRestriction'])) {
-				create_error('You do not have the correct alignment to see this good!');
+				throw new Smr\Exceptions\UserError('You do not have the correct alignment to see this good!');
 			}
 			$good['TransactionType'] = explode(' ', $xType)[0]; // use 'Buy' or 'Sell'
 			return $good;
@@ -54,7 +54,7 @@ class Plotter {
 			}
 			$path = Plotter::findDistanceToX($end, $start, $useFirst, $needsToHaveBeenExploredBy, $player);
 			if ($path === false) {
-				create_error('Unable to plot from ' . $sector->getSectorID() . ' to ' . $x->getSectorID() . '.');
+				throw new Smr\Exceptions\UserError('Unable to plot from ' . $sector->getSectorID() . ' to ' . $x->getSectorID() . '.');
 			}
 			// Reverse if we plotted $x -> $sector (since we want $sector -> $x)
 			if ($reverse) {
@@ -66,7 +66,7 @@ class Plotter {
 			// At this point we don't know what sector $x will be at
 			$path = Plotter::findDistanceToX($x, $sector, $useFirst, $needsToHaveBeenExploredBy, $player);
 			if ($path === false) {
-				create_error('Unable to find what you\'re looking for, it either hasn\'t been added to this game or you haven\'t explored it yet.');
+				throw new Smr\Exceptions\UserError('Unable to find what you\'re looking for, it either hasn\'t been added to this game or you haven\'t explored it yet.');
 			}
 			// Now that we know where $x is, make sure path is reversible
 			// (i.e. start sector < end sector)

--- a/src/lib/Default/Plotter.class.php
+++ b/src/lib/Default/Plotter.class.php
@@ -18,7 +18,7 @@ class Plotter {
 		$getGoodWithTransaction = function(int $goodID) use ($xType, $player) {
 			$good = Globals::getGood($goodID);
 			if (isset($player) && !$player->meetsAlignmentRestriction($good['AlignRestriction'])) {
-				throw new Smr\Exceptions\UserError('You do not have the correct alignment to see this good!');
+				throw new Exception('Player trying to access alignment-restricted good!');
 			}
 			$good['TransactionType'] = explode(' ', $xType)[0]; // use 'Buy' or 'Sell'
 			return $good;

--- a/src/lib/Default/SmrAlliance.class.php
+++ b/src/lib/Default/SmrAlliance.class.php
@@ -108,7 +108,7 @@ class SmrAlliance {
 		// check if the alliance name already exists
 		if (self::getAllianceByName($name, $gameID) !== null) {
 			$db->unlock();
-			throw new Smr\UserException('That alliance name already exists.');
+			throw new Smr\Exceptions\UserError('That alliance name already exists.');
 		}
 
 		// get the next alliance id (ignoring reserved ID's)

--- a/src/lib/Default/SmrAlliance.class.php
+++ b/src/lib/Default/SmrAlliance.class.php
@@ -225,7 +225,7 @@ class SmrAlliance {
 				$ircChannel = '#' . $ircChannel;
 			}
 			if ($ircChannel == '#smr' || $ircChannel == '#smr-bar') {
-				create_error('Please enter a valid irc channel for your alliance.');
+				throw new Smr\Exceptions\UserError('Please enter a valid irc channel for your alliance.');
 			}
 
 			$this->db->write('REPLACE INTO irc_alliance_has_channel (channel,alliance_id,game_id) values (' . $this->db->escapeString($ircChannel) . ',' . $this->db->escapeNumber($this->getAllianceID()) . ',' . $this->db->escapeNumber($this->getGameID()) . ');');

--- a/src/lib/Default/SmrGame.class.php
+++ b/src/lib/Default/SmrGame.class.php
@@ -1,8 +1,5 @@
 <?php declare(strict_types=1);
 
-// Exception thrown when a game cannot be found in the database
-class GameNotFoundException extends Exception {}
-
 class SmrGame {
 	protected static array $CACHE_GAMES = [];
 
@@ -97,7 +94,7 @@ class SmrGame {
 			$this->isNew = true;
 			return;
 		} else {
-			throw new GameNotFoundException('No such game: ' . $gameID);
+			throw new Smr\Exceptions\GameNotFound('No such game: ' . $gameID);
 		}
 	}
 

--- a/src/lib/Default/SmrInvitation.class.php
+++ b/src/lib/Default/SmrInvitation.class.php
@@ -1,8 +1,5 @@
 <?php declare(strict_types=1);
 
-// Exception thrown when an alliance invitation cannot be found in the database
-class InvitationNotFoundException extends Exception {}
-
 /**
  * Object interfacing with the alliance_invites_player table.
  */
@@ -48,7 +45,7 @@ class SmrInvitation {
 		if ($dbResult->hasRecord()) {
 			return new SmrInvitation($dbResult->record());
 		}
-		throw new InvitationNotFoundException();
+		throw new Smr\Exceptions\AllianceInvitationNotFound;
 	}
 
 	public function __construct(Smr\DatabaseRecord $dbRecord) {

--- a/src/lib/Default/SmrPlanet.class.php
+++ b/src/lib/Default/SmrPlanet.class.php
@@ -923,12 +923,12 @@ class SmrPlanet {
 	}
 
 	/**
-	 * @throws \Smr\UserException If the player cannot build the structure.
+	 * @throws \Smr\Exceptions\UserError If the player cannot build the structure.
 	 */
 	public function startBuilding(AbstractSmrPlayer $constructor, int $constructionID) : void {
 		$restriction = $this->getBuildRestriction($constructor, $constructionID);
 		if ($restriction !== false) {
-			throw new \Smr\UserException('Unable to start building: ' . $restriction);
+			throw new \Smr\Exceptions\UserError('Unable to start building: ' . $restriction);
 		}
 
 		// gets the time for the buildings

--- a/src/lib/Default/SmrSector.class.php
+++ b/src/lib/Default/SmrSector.class.php
@@ -1,8 +1,5 @@
 <?php declare(strict_types=1);
 
-// Exception thrown when a sector cannot be found in the database
-class SectorNotFoundException extends Exception {}
-
 class SmrSector {
 	protected static array $CACHE_SECTORS = [];
 	protected static array $CACHE_GALAXY_SECTORS = [];
@@ -40,7 +37,7 @@ class SmrSector {
 		try {
 			self::getSector($gameID, $sectorID);
 			return true;
-		} catch (SectorNotFoundException $e) {
+		} catch (Smr\Exceptions\SectorNotFound $e) {
 			return false;
 		}
 	}
@@ -134,7 +131,7 @@ class SmrSector {
 			$this->warp = 0;
 			$this->isNew = true;
 		} else {
-			throw new SectorNotFoundException('No sector ' . $sectorID . ' in game ' . $gameID);
+			throw new Smr\Exceptions\SectorNotFound('No sector ' . $sectorID . ' in game ' . $gameID);
 		}
 	}
 

--- a/src/lib/Default/hof.inc.php
+++ b/src/lib/Default/hof.inc.php
@@ -112,7 +112,7 @@ function displayHOFRow(int $rank, int $accountID, float|string $amount) : string
 	if (isset($var['game_id']) && Globals::isValidGame($var['game_id'])) {
 		try {
 			$hofPlayer = SmrPlayer::getPlayer($accountID, $var['game_id']);
-		} catch (PlayerNotFoundException $e) {
+		} catch (Smr\Exceptions\PlayerNotFound $e) {
 			$hofAccount = SmrAccount::getAccount($accountID);
 		}
 	} else {

--- a/src/lib/Default/planet_list.inc.php
+++ b/src/lib/Default/planet_list.inc.php
@@ -9,7 +9,7 @@ function planet_list_common(int $allianceId, bool $getPlanets) : void {
 	$playerOnly = $allianceId == 0;
 	if ($playerOnly && $player->hasAlliance()) {
 		// This page doesn't support this combination
-		throw new Smr\Exceptions\UserError('Internal error. Please report this to an admin!');
+		throw new Exception('Sanity check failed!');
 	}
 	$template->assign('PlayerOnly', $playerOnly);
 

--- a/src/lib/Default/planet_list.inc.php
+++ b/src/lib/Default/planet_list.inc.php
@@ -9,7 +9,7 @@ function planet_list_common(int $allianceId, bool $getPlanets) : void {
 	$playerOnly = $allianceId == 0;
 	if ($playerOnly && $player->hasAlliance()) {
 		// This page doesn't support this combination
-		create_error('Internal error. Please report this to an admin!');
+		throw new Smr\Exceptions\UserError('Internal error. Please report this to an admin!');
 	}
 	$template->assign('PlayerOnly', $playerOnly);
 

--- a/src/lib/Default/shop_goods.inc.php
+++ b/src/lib/Default/shop_goods.inc.php
@@ -19,7 +19,7 @@ function check_bargain_number(int $amount, int $ideal_price, int $offered_price,
 		if ($container['number_of_bargains'] > $container['overall_number_of_bargains']) {
 			$player->decreaseRelationsByTrade($amount, $port->getRaceID());
 			$player->increaseHOF(1, array('Trade', 'Results', 'Epic Fail'), HOF_PUBLIC);
-			create_error('You don\'t want to accept my offer? I\'m sick of you! Get out of here!');
+			throw new Smr\Exceptions\UserError('You don\'t want to accept my offer? I\'m sick of you! Get out of here!');
 		}
 
 		$port_off = IRound($offered_price * 100 / $ideal_price);

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -330,7 +330,7 @@ function do_voodoo() : never {
 			) {
 			if (!$lock && !isset($locksFailed[$sector_id])) {
 				if (!acquire_lock($sector_id)) {
-					create_error('Failed to acquire sector lock');
+					throw new Smr\Exceptions\UserError('Failed to acquire sector lock');
 				}
 				//Refetch var info in case it changed between grabbing lock.
 				$session->fetchVarInfo();
@@ -338,7 +338,7 @@ function do_voodoo() : never {
 					if (ENABLE_DEBUG) {
 						$db->write('INSERT INTO debug VALUES (\'SPAM\',' . $db->escapeNumber($account->getAccountID()) . ',0,0)');
 					}
-					create_error('Please do not spam click!');
+					throw new Smr\Exceptions\UserError('Please do not spam click!');
 				}
 				$var = $session->getCurrentVar();
 			}
@@ -453,7 +453,7 @@ function acquire_lock(int $sector) : bool {
 			if ($dbResult->record()->getInt('COUNT(*)') > 1) {
 				release_lock();
 				$locksFailed[$sector] = true;
-				create_error('Multiple actions cannot be performed at the same time!');
+				throw new Smr\Exceptions\UserError('Multiple actions cannot be performed at the same time!');
 			}
 
 			usleep(25000 * $locksInQueue);

--- a/src/lib/Smr/Exceptions/AccountNotFound.php
+++ b/src/lib/Smr/Exceptions/AccountNotFound.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Exceptions;
+
+/**
+ * Exception thrown when an account cannot be found in the database
+ */
+class AccountNotFound extends \Exception {}

--- a/src/lib/Smr/Exceptions/AllianceInvitationNotFound.php
+++ b/src/lib/Smr/Exceptions/AllianceInvitationNotFound.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Exceptions;
+
+/**
+ *  Exception thrown when an alliance invitation cannot be found in the database
+ */
+class AllianceInvitationNotFound extends \Exception {}

--- a/src/lib/Smr/Exceptions/GameNotFound.php
+++ b/src/lib/Smr/Exceptions/GameNotFound.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Exceptions;
+
+/**
+ * Exception thrown when a game cannot be found in the database
+ */
+class GameNotFound extends \Exception {}

--- a/src/lib/Smr/Exceptions/PlayerNotFound.php
+++ b/src/lib/Smr/Exceptions/PlayerNotFound.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Exceptions;
+
+/**
+ * Exception thrown when a player cannot be found in the database
+ */
+class PlayerNotFound extends \Exception {}

--- a/src/lib/Smr/Exceptions/SectorNotFound.php
+++ b/src/lib/Smr/Exceptions/SectorNotFound.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Exceptions;
+
+/**
+ * Exception thrown when a sector cannot be found in the database
+ */
+class SectorNotFound extends \Exception {}

--- a/src/lib/Smr/Exceptions/SocialLoginInvalidType.php
+++ b/src/lib/Smr/Exceptions/SocialLoginInvalidType.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Exceptions;
+
+/**
+ * Exception thrown when a SocialLogin type is not valid
+ */
+class SocialLoginInvalidType extends \Exception {}
+

--- a/src/lib/Smr/Exceptions/UserError.php
+++ b/src/lib/Smr/Exceptions/UserError.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace Smr;
+namespace Smr\Exceptions;
 
 /**
  * This exception should be used to pass an error message to the user.
  * It should only encompass errors that can be triggered by otherwise
  * valid user input (i.e. NOT internal errors, request forgery, etc.).
  */
-class UserException extends \RuntimeException {}
+class UserError extends \RuntimeException {}

--- a/src/lib/Smr/SocialLogin/SocialLogin.php
+++ b/src/lib/Smr/SocialLogin/SocialLogin.php
@@ -3,11 +3,6 @@
 namespace Smr\SocialLogin;
 
 /**
- * Exception thrown when a SocialLogin type cannot be found
- */
-class SocialLoginNotFound extends \Exception {}
-
-/**
  * Defines the methods to be implemented by each social login platform.
  */
 abstract class SocialLogin {
@@ -32,7 +27,7 @@ abstract class SocialLogin {
 		} elseif ($loginType === Google::getLoginType()) {
 			return new Google();
 		} else {
-			throw new SocialLoginNotFound('Unknown social login type: ' . $loginType);
+			throw new \Smr\Exceptions\SocialLoginInvalidType('Unknown social login type: ' . $loginType);
 		}
 	}
 

--- a/src/tools/irc/channel_msg.php
+++ b/src/tools/irc/channel_msg.php
@@ -50,7 +50,7 @@ function check_for_registration($fp, string $nick, string $channel, callable $ca
 	// get smr player
 	try {
 		$player = SmrPlayer::getPlayer($account->getAccountID(), $alliance->getGameID(), true);
-	} catch (PlayerNotFoundException $e) {
+	} catch (Smr\Exceptions\PlayerNotFound $e) {
 		if ($validationMessages === true) {
 			fputs($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', you have not joined the game that this channel belongs to.' . EOL);
 		}

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
@@ -3,9 +3,9 @@
 namespace SmrTest\lib\DefaultGame;
 
 use AbstractSmrAccount;
-use AccountNotFoundException;
-use SmrTest\BaseIntegrationSpec;
+use Smr\Exceptions\AccountNotFound;
 use Smr\SocialLogin\Facebook;
+use SmrTest\BaseIntegrationSpec;
 
 /**
  * @covers AbstractSmrAccount
@@ -30,7 +30,7 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 	}
 
 	public function test_createAccount_throws_if_referrer_does_not_exist() : void {
-		$this->expectException(AccountNotFoundException::class);
+		$this->expectException(AccountNotFound::class);
 		$this->expectExceptionMessage('Account ID 123 does not exist');
 		AbstractSmrAccount::createAccount('test', 'test', 'test@test.com', 9, 123);
 	}
@@ -53,7 +53,7 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 	}
 
 	public function test_get_account_by_account_id_no_account_found_throws_exception() : void {
-		$this->expectException(AccountNotFoundException::class);
+		$this->expectException(AccountNotFound::class);
 		// Given there is no account record
 		// When performing an account lookup by id
 		AbstractSmrAccount::getAccount(123);

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrPlayerIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrPlayerIntegrationTest.php
@@ -34,7 +34,7 @@ class AbstractSmrPlayerIntegrationTest extends BaseIntegrationSpec {
 	public function test_createPlayer_duplicate_name() : void {
 		$name = 'test';
 		AbstractSmrPlayer::createPlayer(1, 1, $name, RACE_HUMAN, false);
-		$this->expectException(\Smr\UserException::class);
+		$this->expectException(\Smr\Exceptions\UserError::class);
 		$this->expectExceptionMessage('That player name already exists.');
 		AbstractSmrPlayer::createPlayer(2, 1, $name, RACE_HUMAN, false);
 	}

--- a/test/SmrTest/lib/DefaultGame/SmrAllianceIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrAllianceIntegrationTest.php
@@ -4,7 +4,7 @@ namespace SmrTest\lib\DefaultGame;
 
 use SmrAlliance;
 use SmrTest\BaseIntegrationSpec;
-use Smr\UserException;
+use Smr\Exceptions\UserError;
 
 /**
  * @covers SmrAlliance
@@ -26,7 +26,7 @@ class SmrAllianceIntegrationTest extends BaseIntegrationSpec {
 	public function test_createAlliance_duplicate_name() : void {
 		$name = 'test';
 		SmrAlliance::createAlliance(1, $name);
-		$this->expectException(UserException::class);
+		$this->expectException(UserError::class);
 		$this->expectExceptionMessage('That alliance name already exists.');
 		SmrAlliance::createAlliance(1, $name);
 	}


### PR DESCRIPTION
* Refactor Exceptions into their own files.
* Change `create_error` to `UserError` exceptions and catch these exceptions at the `handleException` level.
* Convert some `UserError` exceptions to regular `Exception` in cases where normal input should not encounter the error.

See commit messages for details.