### PR TITLE
Chess refactor

### DIFF
--- a/db/patches/V1_6_67_02__chess_piece_colour.sql
+++ b/db/patches/V1_6_67_02__chess_piece_colour.sql
@@ -1,0 +1,23 @@
+-- Replace column `account_id` with `colour` in `chess_game_pieces` table
+
+-- Add the new column
+ALTER TABLE `chess_game_pieces` ADD COLUMN `colour` enum('White','Black') NOT NULL;
+
+-- Set the new column values based on which colour the account is
+UPDATE `chess_game_pieces`
+	INNER JOIN `chess_game` ON
+		`chess_game_pieces`.`chess_game_id` = `chess_game`.`chess_game_id` AND
+		`chess_game_pieces`.`account_id` = `chess_game`.`white_id`
+	SET `chess_game_pieces`.`colour` = 'White';
+UPDATE `chess_game_pieces`
+	INNER JOIN `chess_game` ON
+		`chess_game_pieces`.`chess_game_id` = `chess_game`.`chess_game_id` AND
+		`chess_game_pieces`.`account_id` = `chess_game`.`black_id`
+	SET `chess_game_pieces`.`colour` = 'Black';
+
+-- Make the new column a primary key
+ALTER TABLE `chess_game_pieces` DROP PRIMARY KEY,
+  ADD PRIMARY KEY (`chess_game_id`,`colour`,`piece_id`,`piece_no`);
+
+-- Remove the old column
+ALTER TABLE `chess_game_pieces` DROP COLUMN `account_id`;

--- a/src/engine/Default/chess.php
+++ b/src/engine/Default/chess.php
@@ -4,7 +4,7 @@ $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$chessGames = ChessGame::getOngoingPlayerGames($player);
+$chessGames = Smr\Chess\ChessGame::getOngoingPlayerGames($player);
 $template->assign('ChessGames', $chessGames);
 $template->assign('PageTopic', 'Casino');
 

--- a/src/engine/Default/chess_create_processing.php
+++ b/src/engine/Default/chess_create_processing.php
@@ -4,6 +4,6 @@ $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 $challengePlayer = SmrPlayer::getPlayerByPlayerID(Smr\Request::getInt('player_id'), $player->getGameID());
-ChessGame::insertNewGame(Smr\Epoch::time(), null, $player, $challengePlayer);
+Smr\Chess\ChessGame::insertNewGame(Smr\Epoch::time(), null, $player, $challengePlayer);
 
 Page::create('skeleton.php', 'chess.php')->go();

--- a/src/engine/Default/chess_move_processing.php
+++ b/src/engine/Default/chess_move_processing.php
@@ -7,7 +7,7 @@ $player = $session->getPlayer();
 $container = Page::create('skeleton.php', 'chess_play.php');
 $container->addVar('ChessGameID');
 
-$chessGame = ChessGame::getChessGame($var['ChessGameID']);
+$chessGame = Smr\Chess\ChessGame::getChessGame($var['ChessGameID']);
 $x = Smr\Request::getInt('x');
 $y = Smr\Request::getInt('y');
 $toX = Smr\Request::getInt('toX');
@@ -16,7 +16,7 @@ if (!$chessGame->hasEnded()) {
 	if ($chessGame->isCurrentTurn($player->getAccountID())) {
 		$board = $chessGame->getBoard();
 		if ($board[$y][$x] != null) {
-			$result = $chessGame->tryMove($x, $y, $toX, $toY, $player->getAccountID(), ChessPiece::QUEEN);
+			$result = $chessGame->tryMove($x, $y, $toX, $toY, $player->getAccountID(), Smr\Chess\ChessPiece::QUEEN);
 			$container['MoveMessage'] = match($result) {
 				0 => '', // valid move, no message
 				1 => 'You have just checkmated your opponent, congratulations!',

--- a/src/engine/Default/chess_move_processing.php
+++ b/src/engine/Default/chess_move_processing.php
@@ -16,7 +16,8 @@ if (!$chessGame->hasEnded()) {
 	if ($chessGame->isCurrentTurn($player->getAccountID())) {
 		$board = $chessGame->getBoard();
 		if ($board[$y][$x] != null) {
-			$result = $chessGame->tryMove($x, $y, $toX, $toY, $player->getAccountID(), Smr\Chess\ChessPiece::QUEEN);
+			$colour = $chessGame->getColourForAccountID($player->getAccountID());
+			$result = $chessGame->tryMove($x, $y, $toX, $toY, $colour, Smr\Chess\ChessPiece::QUEEN);
 			$container['MoveMessage'] = match($result) {
 				0 => '', // valid move, no message
 				1 => 'You have just checkmated your opponent, congratulations!',

--- a/src/engine/Default/chess_play.php
+++ b/src/engine/Default/chess_play.php
@@ -5,7 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$chessGame = ChessGame::getChessGame($var['ChessGameID']);
+$chessGame = Smr\Chess\ChessGame::getChessGame($var['ChessGameID']);
 $template->assign('ChessGame', $chessGame);
 
 // Board orientation depends on the player's color.

--- a/src/engine/Default/chess_resign_processing.php
+++ b/src/engine/Default/chess_resign_processing.php
@@ -5,7 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$chessGame = ChessGame::getChessGame($var['ChessGameID']);
+$chessGame = Smr\Chess\ChessGame::getChessGame($var['ChessGameID']);
 $result = $chessGame->resign($player->getAccountID());
 
 $container = Page::create('skeleton.php', 'current_sector.php');

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -97,7 +97,7 @@ function smrBBCode($bbParser, $action, $tagName, $default, $tagParams, $tagConte
 					return is_numeric($default);
 				}
 				$chessGameID = (int)$default;
-				$chessGame = ChessGame::getChessGame($chessGameID);
+				$chessGame = Smr\Chess\ChessGame::getChessGame($chessGameID);
 				return '<a href="' . $chessGame->getPlayGameHREF() . '">chess game (' . $chessGame->getChessGameID() . ')</a>';
 			break;
 

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -457,22 +457,11 @@ class ChessGame {
 
 	public static function isCastling(int $x, int $toX) : array|false {
 		$movement = $toX - $x;
-		if (abs($movement) == 2) {
-			//To the left.
-			if ($movement == -2) {
-				return array('Type' => 'Queen',
-						'X' => 0,
-						'ToX' => 3
-					);
-			} //To the right
-			elseif ($movement == 2) {
-				return array('Type' => 'King',
-						'X' => 7,
-						'ToX' => 5
-					);
-			}
-		}
-		return false;
+		return match($movement) {
+			-2 => ['Type' => 'Queen', 'X' => 0, 'ToX' => 3],
+			2 => ['Type' => 'King', 'X' => 7, 'ToX' => 5],
+			default => false,
+		};
 	}
 
 	public static function movePiece(array &$board, array &$hasMoved, int $x, int $y, int $toX, int $toY, int $pawnPromotionPiece = ChessPiece::QUEEN) : array {
@@ -506,7 +495,7 @@ class ChessGame {
 				$hasMoved[$p->colour][ChessPiece::KING] = true;
 				$hasMoved[$p->colour][ChessPiece::ROOK][$castling['Type']] = true;
 				if ($board[$y][$castling['X']] === null) {
-					throw new Exception('Cannot castle with non-existent castle.');
+					throw new Exception('Cannot castle with non-existent rook.');
 				}
 				$board[$toY][$castling['ToX']] = $board[$y][$castling['X']];
 				$board[$toY][$castling['ToX']]->x = $castling['ToX'];

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -152,12 +152,12 @@ class ChessGame {
 				$start_y = $dbRecord->getInt('start_y');
 				$end_x = $dbRecord->getInt('end_x');
 				$end_y = $dbRecord->getInt('end_y');
-				$moveAccountID = $dbRecord->getInt('move_id') % 2 == 1 ? $this->getWhiteID() : $this->getBlackID();
+				$colour = $dbRecord->getInt('move_id') % 2 == 1 ? self::PLAYER_WHITE : self::PLAYER_BLACK;
 				$promotePieceID = $dbRecord->getInt('promote_piece_id');
 				if ($debugInfo === true) {
-					echo 'x=', $start_x, ', y=', $start_y, ', endX=', $end_x, ', endY=', $end_y, ', forAccountID=', $moveAccountID, EOL;
+					echo 'x=', $start_x, ', y=', $start_y, ', endX=', $end_x, ', endY=', $end_y, ', colour=', $colour, EOL;
 				}
-				if (0 != $this->tryMove($start_x, $start_y, $end_x, $end_y, $moveAccountID, $promotePieceID)) {
+				if (0 != $this->tryMove($start_x, $start_y, $end_x, $end_y, $colour, $promotePieceID)) {
 					break;
 				}
 			}
@@ -175,7 +175,7 @@ class ChessGame {
 			$pieces = array();
 			foreach ($dbResult->records() as $dbRecord) {
 				$accountID = $dbRecord->getInt('account_id');
-				$pieces[] = new ChessPiece($this->chessGameID, $accountID, $this->getColourForAccountID($accountID), $dbRecord->getInt('piece_id'), $dbRecord->getInt('x'), $dbRecord->getInt('y'), $dbRecord->getInt('piece_no'));
+				$pieces[] = new ChessPiece($this->getColourForAccountID($accountID), $dbRecord->getInt('piece_id'), $dbRecord->getInt('x'), $dbRecord->getInt('y'), $dbRecord->getInt('piece_no'));
 			}
 			$this->board = $this->parsePieces($pieces);
 		}
@@ -325,45 +325,43 @@ class ChessGame {
 		return $board;
 	}
 
-	public static function getStandardGame(int $chessGameID, AbstractSmrPlayer $whitePlayer, AbstractSmrPlayer $blackPlayer) : array {
-		$white = $whitePlayer->getAccountID();
-		$black = $blackPlayer->getAccountID();
+	public static function getStandardGame() : array {
 		return array(
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::ROOK, 0, 0),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::KNIGHT, 1, 0),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::BISHOP, 2, 0),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::QUEEN, 3, 0),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::KING, 4, 0),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::BISHOP, 5, 0),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::KNIGHT, 6, 0),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::ROOK, 7, 0),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::ROOK, 0, 0),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::KNIGHT, 1, 0),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::BISHOP, 2, 0),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::QUEEN, 3, 0),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::KING, 4, 0),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::BISHOP, 5, 0),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::KNIGHT, 6, 0),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::ROOK, 7, 0),
 
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 0, 1),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 1, 1),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 2, 1),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 3, 1),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 4, 1),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 5, 1),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 6, 1),
-				new ChessPiece($chessGameID, $black, self::PLAYER_BLACK, ChessPiece::PAWN, 7, 1),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::PAWN, 0, 1),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::PAWN, 1, 1),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::PAWN, 2, 1),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::PAWN, 3, 1),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::PAWN, 4, 1),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::PAWN, 5, 1),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::PAWN, 6, 1),
+				new ChessPiece(self::PLAYER_BLACK, ChessPiece::PAWN, 7, 1),
 
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 0, 6),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 1, 6),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 2, 6),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 3, 6),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 4, 6),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 5, 6),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 6, 6),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::PAWN, 7, 6),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::PAWN, 0, 6),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::PAWN, 1, 6),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::PAWN, 2, 6),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::PAWN, 3, 6),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::PAWN, 4, 6),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::PAWN, 5, 6),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::PAWN, 6, 6),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::PAWN, 7, 6),
 
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::ROOK, 0, 7),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::KNIGHT, 1, 7),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::BISHOP, 2, 7),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::QUEEN, 3, 7),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::KING, 4, 7),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::BISHOP, 5, 7),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::KNIGHT, 6, 7),
-				new ChessPiece($chessGameID, $white, self::PLAYER_WHITE, ChessPiece::ROOK, 7, 7),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::ROOK, 0, 7),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::KNIGHT, 1, 7),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::BISHOP, 2, 7),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::QUEEN, 3, 7),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::KING, 4, 7),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::BISHOP, 5, 7),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::KNIGHT, 6, 7),
+				new ChessPiece(self::PLAYER_WHITE, ChessPiece::ROOK, 7, 7),
 			);
 	}
 
@@ -381,12 +379,13 @@ class ChessGame {
 
 	private static function insertPieces(int $chessGameID, AbstractSmrPlayer $whitePlayer, AbstractSmrPlayer $blackPlayer) : void {
 		$db = Smr\Database::getInstance();
-		$pieces = self::getStandardGame($chessGameID, $whitePlayer, $blackPlayer);
+		$pieces = self::getStandardGame();
 		foreach ($pieces as $p) {
+			$pieceOwner = $p->colour === self::PLAYER_WHITE ? $whitePlayer : $blackPlayer;
 			$db->write('INSERT INTO chess_game_pieces' .
 			'(chess_game_id,account_id,piece_id,x,y)' .
 			'values' .
-			'(' . $db->escapeNumber($chessGameID) . ',' . $db->escapeNumber($p->accountID) . ',' . $db->escapeNumber($p->pieceID) . ',' . $db->escapeNumber($p->x) . ',' . $db->escapeNumber($p->y) . ');');
+			'(' . $db->escapeNumber($chessGameID) . ',' . $db->escapeNumber($pieceOwner->getAccountID()) . ',' . $db->escapeNumber($p->pieceID) . ',' . $db->escapeNumber($p->x) . ',' . $db->escapeNumber($p->y) . ');');
 		}
 	}
 
@@ -624,24 +623,24 @@ class ChessGame {
 		if (isset($move[4])) {
 			$pawnPromotionPiece = ChessPiece::getPieceForLetter($move[4]);
 		}
-		return $this->tryMove($x, $y, $toX, $toY, $this->getCurrentTurnAccountID(), $pawnPromotionPiece);
+		return $this->tryMove($x, $y, $toX, $toY, $this->getCurrentTurnColour(), $pawnPromotionPiece);
 	}
 
-	public function tryMove(int $x, int $y, int $toX, int $toY, int $forAccountID, int $pawnPromotionPiece) : int {
+	public function tryMove(int $x, int $y, int $toX, int $toY, string $forColour, int $pawnPromotionPiece) : int {
 		if ($this->hasEnded()) {
 			return 5;
 		}
-		if ($this->getCurrentTurnAccountID() != $forAccountID) {
+		if ($this->getCurrentTurnColour() != $forColour) {
 			return 4;
 		}
 		$lastTurnPlayer = $this->getCurrentTurnPlayer();
 		$this->getBoard();
 		$p = $this->board[$y][$x];
-		if ($p === null || $p->colour != $this->getColourForAccountID($forAccountID)) {
+		if ($p === null || $p->colour != $forColour) {
 			return 2;
 		}
 
-		$moves = $p->getPossibleMoves($this->board, $this->getHasMoved(), $forAccountID);
+		$moves = $p->getPossibleMoves($this->board, $this->getHasMoved(), $forColour);
 		foreach ($moves as $move) {
 			if ($move[0] == $toX && $move[1] == $toY) {
 				$chessType = $this->isNPCGame() ? 'Chess (NPC)' : 'Chess';
@@ -697,13 +696,15 @@ class ChessGame {
 				$this->db->write('INSERT INTO chess_game_moves
 								(chess_game_id,piece_id,start_x,start_y,end_x,end_y,checked,piece_taken,castling,en_passant,promote_piece_id)
 								VALUES
-								(' . $this->db->escapeNumber($p->chessGameID) . ',' . $this->db->escapeNumber($pieceID) . ',' . $this->db->escapeNumber($x) . ',' . $this->db->escapeNumber($y) . ',' . $this->db->escapeNumber($toX) . ',' . $this->db->escapeNumber($toY) . ',' . $this->db->escapeString($checking, true) . ',' . ($moveInfo['PieceTaken'] === null ? 'NULL' : $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID)) . ',' . $this->db->escapeString($castlingType, true) . ',' . $this->db->escapeBoolean($moveInfo['EnPassant']) . ',' . ($moveInfo['PawnPromotion'] == false ? 'NULL' : $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceID'])) . ');');
+								(' . $this->db->escapeNumber($this->chessGameID) . ',' . $this->db->escapeNumber($pieceID) . ',' . $this->db->escapeNumber($x) . ',' . $this->db->escapeNumber($y) . ',' . $this->db->escapeNumber($toX) . ',' . $this->db->escapeNumber($toY) . ',' . $this->db->escapeString($checking, true) . ',' . ($moveInfo['PieceTaken'] === null ? 'NULL' : $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID)) . ',' . $this->db->escapeString($castlingType, true) . ',' . $this->db->escapeBoolean($moveInfo['EnPassant']) . ',' . ($moveInfo['PawnPromotion'] == false ? 'NULL' : $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceID'])) . ');');
 
 
 				$currentPlayer->increaseHOF(1, array($chessType, 'Moves', 'Total Taken'), HOF_PUBLIC);
 				if ($moveInfo['PieceTaken'] != null) {
+					// Get the owner of the taken piece
+					$takenOwnerID = self::getColourID($moveInfo['PieceTaken']->colour);
 					$this->db->write('DELETE FROM chess_game_pieces
-									WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ' AND account_id=' . $this->db->escapeNumber($moveInfo['PieceTaken']->accountID) . ' AND piece_id=' . $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID) . ' AND piece_no=' . $this->db->escapeNumber($moveInfo['PieceTaken']->pieceNo) . ';');
+									WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ' AND account_id=' . $this->db->escapeNumber($takenOwnerID) . ' AND piece_id=' . $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID) . ' AND piece_no=' . $this->db->escapeNumber($moveInfo['PieceTaken']->pieceNo) . ';');
 
 					$pieceTakenSymbol = $moveInfo['PieceTaken']->getPieceSymbol();
 					$currentPlayer->increaseHOF(1, array($chessType, 'Moves', 'Opponent Pieces Taken', 'Total'), HOF_PUBLIC);
@@ -711,18 +712,20 @@ class ChessGame {
 					$currentPlayer->increaseHOF(1, array($chessType, 'Moves', 'Opponent Pieces Taken', $pieceTakenSymbol), HOF_PUBLIC);
 					$otherPlayer->increaseHOF(1, array($chessType, 'Moves', 'Own Pieces Taken', $pieceTakenSymbol), HOF_PUBLIC);
 				}
+
+				$pieceOwnerID = self::getColourID($p->colour);
 				$this->db->write('UPDATE chess_game_pieces
 							SET x=' . $this->db->escapeNumber($toX) . ', y=' . $this->db->escapeNumber($toY) .
 								($moveInfo['PawnPromotion'] !== false ? ', piece_id=' . $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceID']) . ', piece_no=' . $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceNo']) : '') . '
-							WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ' AND account_id=' . $this->db->escapeNumber($p->accountID) . ' AND piece_id=' . $this->db->escapeNumber($pieceID) . ' AND piece_no=' . $this->db->escapeNumber($pieceNo) . ';');
+							WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ' AND account_id=' . $this->db->escapeNumber($pieceOwnerID) . ' AND piece_id=' . $this->db->escapeNumber($pieceID) . ' AND piece_no=' . $this->db->escapeNumber($pieceNo) . ';');
 				if ($moveInfo['Castling'] !== false) {
 					$this->db->write('UPDATE chess_game_pieces
 								SET x=' . $this->db->escapeNumber($moveInfo['Castling']['ToX']) . '
-								WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ' AND account_id=' . $this->db->escapeNumber($p->accountID) . ' AND x = ' . $this->db->escapeNumber($moveInfo['Castling']['X']) . ' AND y = ' . $this->db->escapeNumber($y) . ';');
+								WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ' AND account_id=' . $this->db->escapeNumber($pieceOwnerID) . ' AND x = ' . $this->db->escapeNumber($moveInfo['Castling']['X']) . ' AND y = ' . $this->db->escapeNumber($y) . ';');
 				}
 				$return = 0;
 				if ($checking == 'MATE') {
-					$this->setWinner($forAccountID);
+					$this->setWinner($this->getColourID($forColour));
 					$return = 1;
 					SmrPlayer::sendMessageFromCasino($lastTurnPlayer->getGameID(), $this->getCurrentTurnAccountID(), 'You have just lost [chess=' . $this->getChessGameID() . '] against [player=' . $lastTurnPlayer->getPlayerID() . '].');
 				} else {

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -606,7 +606,7 @@ class ChessGame {
 		$y = 8 - $move[1];
 		$toX = ord($move[2]) - $aVal;
 		$toY = 8 - $move[3];
-		$pawnPromotionPiece = null;
+		$pawnPromotionPiece = ChessPiece::QUEEN;
 		if (isset($move[4])) {
 			$pawnPromotionPiece = ChessPiece::getPieceForLetter($move[4]);
 		}

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -1,8 +1,14 @@
 <?php declare(strict_types=1);
-/**
- * @author Page
- *
- */
+
+namespace Smr\Chess;
+
+use AbstractSmrPlayer;
+use Exception;
+use Page;
+use SmrAccount;
+use SmrPlayer;
+use Smr;
+
 class ChessGame {
 	const GAMETYPE_STANDARD = 'Standard';
 	const PLAYER_BLACK = 'Black';
@@ -64,7 +70,7 @@ class ChessGame {
 
 	public static function getChessGame(int $chessGameID, bool $forceUpdate = false) : self {
 		if ($forceUpdate || !isset(self::$CACHE_CHESS_GAMES[$chessGameID])) {
-			self::$CACHE_CHESS_GAMES[$chessGameID] = new ChessGame($chessGameID);
+			self::$CACHE_CHESS_GAMES[$chessGameID] = new self($chessGameID);
 		}
 		return self::$CACHE_CHESS_GAMES[$chessGameID];
 	}
@@ -641,7 +647,7 @@ class ChessGame {
 				$chessType = $this->isNPCGame() ? 'Chess (NPC)' : 'Chess';
 				$currentPlayer = $this->getCurrentTurnPlayer();
 
-				$moveInfo = ChessGame::movePiece($this->board, $this->getHasMoved(), $x, $y, $toX, $toY, $pawnPromotionPiece);
+				$moveInfo = self::movePiece($this->board, $this->getHasMoved(), $x, $y, $toX, $toY, $pawnPromotionPiece);
 
 				//We have taken the move, we should refresh $p
 				$p = $this->board[$toY][$toX];

--- a/src/lib/Smr/Chess/ChessPiece.php
+++ b/src/lib/Smr/Chess/ChessPiece.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+namespace Smr\Chess;
+
 class ChessPiece {
 	const KING = 1;
 	const QUEEN = 2;
@@ -60,7 +62,7 @@ class ChessPiece {
 					$moveX = $this->x + $i;
 					if (ChessGame::isValidCoord($moveX, $moveY, $board)) {
 						if ($attackingCheck ||
-							((($hasMoved[ChessPiece::PAWN][0] == $moveX && $hasMoved[ChessPiece::PAWN][1] == $this->y) ||
+							((($hasMoved[self::PAWN][0] == $moveX && $hasMoved[self::PAWN][1] == $this->y) ||
 							($board[$moveY][$moveX] != null && $board[$moveY][$moveX]->colour != $this->colour))
 							&& $this->isSafeMove($board, $hasMoved, $moveX, $moveY))) {
 							$moves[] = array($moveX, $moveY);
@@ -76,14 +78,14 @@ class ChessPiece {
 					}
 				}
 				//Castling is not attacking - so don't check it if doing an attacking check.
-				if (!$attackingCheck && !$hasMoved[$this->colour][ChessPiece::KING] && !ChessGame::isPlayerChecked($board, $hasMoved, $this->colour)) {
-					if (!$hasMoved[$this->colour][ChessPiece::ROOK]['Queen'] &&
+				if (!$attackingCheck && !$hasMoved[$this->colour][self::KING] && !ChessGame::isPlayerChecked($board, $hasMoved, $this->colour)) {
+					if (!$hasMoved[$this->colour][self::ROOK]['Queen'] &&
 							ChessGame::isValidCoord($this->x - 1, $this->y, $board) && $board[$this->y][$this->x - 1] === null &&
 							ChessGame::isValidCoord($this->x - 3, $this->y, $board) && $board[$this->y][$this->x - 3] === null &&
 							$this->isSafeMove($board, $hasMoved, $this->x - 1, $this->y)) {
 						$this->addMove($this->x - 2, $this->y, $board, $moves, $hasMoved, $attackingCheck);
 					}
-					if (!$hasMoved[$this->colour][ChessPiece::ROOK]['King'] &&
+					if (!$hasMoved[$this->colour][self::ROOK]['King'] &&
 							ChessGame::isValidCoord($this->x + 1, $this->y, $board) && $board[$this->y][$this->x + 1] === null &&
 							$this->isSafeMove($board, $hasMoved, $this->x + 1, $this->y)) {
 						$this->addMove($this->x + 2, $this->y, $board, $moves, $hasMoved, $attackingCheck);

--- a/src/lib/Smr/Chess/ChessPiece.php
+++ b/src/lib/Smr/Chess/ChessPiece.php
@@ -11,8 +11,6 @@ class ChessPiece {
 	const PAWN = 6;
 
 	public function __construct(
-		public int $chessGameID,
-		public int $accountID,
 		public string $colour,
 		public int $pieceID,
 		public int $x,
@@ -40,9 +38,9 @@ class ChessPiece {
 		return false;
 	}
 
-	public function getPossibleMoves(array &$board, array &$hasMoved, int $forAccountID = null, bool $attackingCheck = false) : array {
+	public function getPossibleMoves(array &$board, array &$hasMoved, string $forColour = null, bool $attackingCheck = false) : array {
 		$moves = array();
-		if ($forAccountID === null || $this->accountID == $forAccountID) {
+		if ($forColour === null || $this->colour === $forColour) {
 			if ($this->pieceID == self::PAWN) {
 				$dirY = $this->colour == ChessGame::PLAYER_BLACK ? 1 : -1;
 				$moveY = $this->y + $dirY;

--- a/src/templates/Default/engine/Default/chess_play.php
+++ b/src/templates/Default/engine/Default/chess_play.php
@@ -47,12 +47,13 @@
 
 <script><?php
 	$AvailableMoves = array_pad(array(), count($Board), array());
-	foreach ($Board as $Y => $Row) {
-		foreach ($Row as $X => $Cell) {
-			$AvailableMoves[$Y][$X] = array();
-			if ($Cell != null) {
-				if ($ChessGame->isCurrentTurn($ThisAccount->getAccountID())) {
-					$Moves = $Cell->getPossibleMoves($Board, $ChessGame->getHasMoved(), $ThisAccount->getAccountID());
+	if ($ChessGame->isCurrentTurn($ThisAccount->getAccountID())) {
+		$Colour = $ChessGame->getColourForAccountID($ThisAccount->getAccountID());
+		foreach ($Board as $Y => $Row) {
+			foreach ($Row as $X => $Cell) {
+				$AvailableMoves[$Y][$X] = array();
+				if ($Cell != null) {
+					$Moves = $Cell->getPossibleMoves($Board, $ChessGame->getHasMoved(), $Colour);
 					foreach ($Moves as $Move) {
 						$AvailableMoves[$Y][$X][] = '#c' . $Move[0] . $Move[1];
 					}

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -49,10 +49,10 @@ try {
 		// The next "page request" must occur at an updated time.
 		Smr\Epoch::update();
 
-		foreach (ChessGame::getNPCMoveGames(true) as $chessGame) {
+		foreach (Smr\Chess\ChessGame::getNPCMoveGames(true) as $chessGame) {
 			debug('Looking at game: ' . $chessGame->getChessGameID());
 			writeToEngine('position fen ' . $chessGame->getFENString(), false);
-			writeToEngine('go ' . ($chessGame->getCurrentTurnColour() == ChessGame::PLAYER_WHITE ? 'w' : 'b') . 'time ' . UCI_TIME_PER_MOVE_MS, true, false);
+			writeToEngine('go ' . ($chessGame->getCurrentTurnColour() == Smr\Chess\ChessGame::PLAYER_WHITE ? 'w' : 'b') . 'time ' . UCI_TIME_PER_MOVE_MS, true, false);
 			stream_set_blocking($fromEngine, 1);
 			while (stripos($move = trim(fgets($fromEngine)), 'bestmove') !== 0) {
 				debug('<-- ' . $move);

--- a/src/tools/rerunChessGames.php
+++ b/src/tools/rerunChessGames.php
@@ -8,7 +8,7 @@ $db->write('DELETE FROM player_hof WHERE type LIKE \'Chess%\'');
 $dbResult = $db->read('SELECT chess_game_id FROM chess_game');
 foreach ($dbResult->records() as $dbRecord) {
 	$chessGameID = $dbRecord->getInt('chess_game_id');
-	$game = ChessGame::getChessGame($chessGameID);
+	$game = Smr\Chess\ChessGame::getChessGame($chessGameID);
 	echo 'Running game ' . $chessGameID . ' for white id "' . $game->getWhiteID() . '", black id "' . $game->getBlackID() . '", winner "' . $game->getWinner() . '"' . EOL;
 	echoChessMoves($game);
 
@@ -17,7 +17,7 @@ foreach ($dbResult->records() as $dbRecord) {
 	echoChessMoves($game);
 }
 
-function echoChessMoves(ChessGame $game) : void {
+function echoChessMoves(Smr\Chess\ChessGame $game) : void {
 	echo 'Moves: ' . EOL;
 	$moves = $game->getMoves();
 	foreach ($moves as $move) {


### PR DESCRIPTION
* Move chess-related classes into the PSR-4 autoloader.
* Simplify some chess class methods.
* Remove unneeded properties from `ChessPiece` class.

See commit messages for details.