### PR TITLE
Minor refactor of SmrGame

### DIFF
--- a/src/admin/Default/box_view.php
+++ b/src/admin/Default/box_view.php
@@ -41,7 +41,7 @@ if (!isset($var['box_type_id'])) {
 		$template->assign('DeleteHREF', $container->href());
 		foreach ($dbResult->records() as $dbRecord) {
 			$gameID = $dbRecord->getInt('game_id');
-			$validGame = $gameID > 0 && Globals::isValidGame($gameID);
+			$validGame = $gameID > 0 && SmrGame::gameExists($gameID);
 			$messageID = $dbRecord->getInt('message_id');
 			$messages[$messageID] = array(
 				'ID' => $messageID

--- a/src/admin/Default/notify_view.php
+++ b/src/admin/Default/notify_view.php
@@ -38,7 +38,7 @@ foreach ($dbResult->records() as $dbRecord) {
 		return $name;
 	};
 
-	if (!Globals::isValidGame($gameID)) {
+	if (!SmrGame::gameExists($gameID)) {
 		$gameName = 'Game ' . $gameID . ' no longer exists';
 	} else {
 		$gameName = SmrGame::getGame($gameID)->getDisplayName();

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -5,7 +5,7 @@ try {
 	$session = Smr\Session::getInstance();
 
 	$gameID = Smr\Request::getInt('game');
-	if (!$session->hasAccount() || !Globals::isValidGame($gameID)) {
+	if (!$session->hasAccount() || !SmrGame::gameExists($gameID)) {
 		header('Location: /login.php');
 		exit;
 	}

--- a/src/lib/Default/Globals.class.php
+++ b/src/lib/Default/Globals.class.php
@@ -149,15 +149,6 @@ class Globals {
 		return Globals::getHardwareTypes()[$hardwareTypeID]['Cost'];
 	}
 
-	public static function isValidGame(int $gameID) : bool {
-		try {
-			SmrGame::getGame($gameID);
-			return true;
-		} catch (Smr\Exceptions\GameNotFound) {
-			return false;
-		}
-	}
-
 	public static function isFeatureRequestOpen() : bool {
 		if (!isset(self::$FEATURE_REQUEST_OPEN)) {
 			self::initialiseDatabase();

--- a/src/lib/Default/Globals.class.php
+++ b/src/lib/Default/Globals.class.php
@@ -158,10 +158,6 @@ class Globals {
 		}
 	}
 
-	public static function getGameType(int $gameID) : string {
-		return SmrGame::getGame($gameID)->getGameType();
-	}
-
 	public static function isFeatureRequestOpen() : bool {
 		if (!isset(self::$FEATURE_REQUEST_OPEN)) {
 			self::initialiseDatabase();

--- a/src/lib/Default/SmrGame.class.php
+++ b/src/lib/Default/SmrGame.class.php
@@ -63,6 +63,10 @@ class SmrGame {
 		return self::$CACHE_GAMES[$gameID];
 	}
 
+	public static function clearCache() : void {
+		self::$CACHE_GAMES = [];
+	}
+
 	public static function saveGames() : void {
 		foreach (self::$CACHE_GAMES as $game) {
 			$game->save();

--- a/src/lib/Default/SmrGame.class.php
+++ b/src/lib/Default/SmrGame.class.php
@@ -56,10 +56,9 @@ class SmrGame {
 		}
 	}
 
-	public static function getGame(int $gameID, bool $forceUpdate = false) : SmrGame {
+	public static function getGame(int $gameID, bool $forceUpdate = false) : self {
 		if ($forceUpdate || !isset(self::$CACHE_GAMES[$gameID])) {
-			$g = new SmrGame($gameID);
-			self::$CACHE_GAMES[$gameID] = $g;
+			self::$CACHE_GAMES[$gameID] = new self($gameID);
 		}
 		return self::$CACHE_GAMES[$gameID];
 	}
@@ -70,10 +69,9 @@ class SmrGame {
 		}
 	}
 
-	public static function createGame(int $gameID) : SmrGame {
+	public static function createGame(int $gameID) : self {
 		if (!isset(self::$CACHE_GAMES[$gameID])) {
-			$g = new SmrGame($gameID, true);
-			self::$CACHE_GAMES[$gameID] = $g;
+			self::$CACHE_GAMES[$gameID] = new self($gameID, true);
 		}
 		return self::$CACHE_GAMES[$gameID];
 	}
@@ -380,7 +378,7 @@ class SmrGame {
 		return count(SmrGalaxy::getGameGalaxies($this->getGameID()));
 	}
 
-	public function equals(SmrGame $otherGame) : bool {
+	public function equals(self $otherGame) : bool {
 		return $otherGame->getGameID() == $this->getGameID();
 	}
 

--- a/src/lib/Default/SmrGame.class.php
+++ b/src/lib/Default/SmrGame.class.php
@@ -44,6 +44,18 @@ class SmrGame {
 		self::GAME_TYPE_NEWBIE => 'Newbie',
 	];
 
+	/**
+	 * Attempts to construct the game to determine if it exists.
+	 */
+	public static function gameExists(int $gameID) : bool {
+		try {
+			self::getGame($gameID);
+			return true;
+		} catch (Smr\Exceptions\GameNotFound) {
+			return false;
+		}
+	}
+
 	public static function getGame(int $gameID, bool $forceUpdate = false) : SmrGame {
 		if ($forceUpdate || !isset(self::$CACHE_GAMES[$gameID])) {
 			$g = new SmrGame($gameID);

--- a/src/lib/Default/hof.inc.php
+++ b/src/lib/Default/hof.inc.php
@@ -109,7 +109,7 @@ function displayHOFRow(int $rank, int $accountID, float|string $amount) : string
 	$var = Smr\Session::getInstance()->getCurrentVar();
 
 	$account = Smr\Session::getInstance()->getAccount();
-	if (isset($var['game_id']) && Globals::isValidGame($var['game_id'])) {
+	if (isset($var['game_id']) && SmrGame::gameExists($var['game_id'])) {
 		try {
 			$hofPlayer = SmrPlayer::getPlayer($accountID, $var['game_id']);
 		} catch (Smr\Exceptions\PlayerNotFound) {

--- a/test/SmrTest/lib/DefaultGame/SmrGameIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrGameIntegrationTest.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use Globals;
+use SmrGame;
+use Smr\Race;
+use SmrTest\BaseIntegrationSpec;
+
+/**
+ * @covers SmrGame
+ */
+class SmrGameIntegrationTest extends BaseIntegrationSpec {
+
+	protected function tearDown() : void {
+		SmrGame::clearCache();
+		parent::tearDown();
+	}
+
+	public function test_gameExists() : void {
+		// Test that the game does not exist beforehand
+		$gameID = 42;
+		self::assertFalse(SmrGame::gameExists($gameID));
+
+		// Now create the game and confirm that the game now exists
+		SmrGame::createGame($gameID);
+		self::assertTrue(SmrGame::gameExists($gameID));
+	}
+
+	public function test_save_and_reload_required_properties() : void {
+		// First create a new game
+		$gameID = 3;
+		$game1 = SmrGame::createGame($gameID);
+
+		// Then set all of its properties
+		$game1->setName('Test Game');
+		$game1->setDescription('A test game.');
+		$game1->setStartTime(123);
+		$game1->setJoinTime(234);
+		$game1->setEndTime(345);
+		$game1->setMaxPlayers(5);
+		$game1->setMaxTurns(1000);
+		$game1->setStartTurnHours(24);
+		$game1->setGameTypeID(SmrGame::GAME_TYPE_DRAFT);
+		$game1->setCreditsNeeded(10);
+		$game1->setGameSpeed(1.5);
+		$game1->setEnabled(true);
+		$game1->setIgnoreStats(true);
+		$game1->setAllianceMaxPlayers(15);
+		$game1->setAllianceMaxVets(10);
+		$game1->setStartingCredits(3000);
+
+		// Now save the game and reload it
+		$game1->save();
+		$game2 = SmrGame::getGame($gameID, true);
+
+		// Test that the properties have all propagated correctly
+		self::assertSame('Test Game', $game2->getName());
+		self::assertSame('A test game.', $game2->getDescription());
+		self::assertSame(123, $game2->getStartTime());
+		self::assertSame(234, $game2->getJoinTime());
+		self::assertSame(345, $game2->getEndTime());
+		self::assertSame(5, $game2->getMaxPlayers());
+		self::assertSame(1000, $game2->getMaxTurns());
+		self::assertSame(24, $game2->getStartTurnHours());
+		self::assertSame('Draft', $game2->getGameType());
+		self::assertSame(10, $game2->getCreditsNeeded());
+		self::assertSame(1.5, $game2->getGameSpeed());
+		self::assertTrue($game2->isEnabled());
+		self::assertTrue($game2->isIgnoreStats());
+		self::assertSame(15, $game2->getAllianceMaxPlayers());
+		self::assertSame(10, $game2->getAllianceMaxVets());
+		self::assertSame(3000, $game2->getStartingCredits());
+	}
+
+	public function test_setStartingRelations() : void {
+		// Set the starting relations
+		$game = SmrGame::createGame(1);
+		$game->setStartingRelations(-123);
+
+		// Verify that relations have been set properly
+		foreach (Race::getAllIDs() as $raceID1) {
+			$relations = Globals::getRaceRelations(1, $raceID1);
+			foreach (Race::getAllIDs() as $raceID2) {
+				$expected = -123;
+				if ($raceID1 == $raceID2) {
+					$expected = MAX_GLOBAL_RELATIONS;
+				} elseif ($raceID1 == RACE_NEUTRAL || $raceID2 == RACE_NEUTRAL) {
+					$expected = 0;
+				}
+				self::assertSame($expected, $relations[$raceID2]);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
* Remove unused method `Globals::getGameType` (we use `$game->getGameType()` instead).
* Rename `Globals::isValidGame` to `SmrGame::gameExists`.
* Use `self` typehint in SmrGame.
* Add SmrGame unit test.