### PR TITLE
docker-compose.yml: add smr-builder YAML anchor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,17 @@ networks:
         name: backend
         external: false
 
-# Base configuration for `smr` (production) and `smr-dev` (testing).
-x-smr-common: &smr-common
+# Builds a local smr image for use in other services
+x-smr-builder: &smr-builder
     build:
         context: .
         args:
             - NO_DEV
+    image: local/smr
+
+# Base configuration for `smr` (production) and `smr-dev` (testing).
+x-smr-common: &smr-common
+    <<: *smr-builder
     container_name: ${SMR_HOST}
     networks:
         - frontend
@@ -30,10 +35,7 @@ x-smr-common: &smr-common
 
 # Base configuration for the SMR command line tools
 x-smr-cli: &smr-cli
-    build:
-        context: .
-        args:
-            - NO_DEV
+    <<: *smr-builder
     networks:
         - backend
     depends_on:


### PR DESCRIPTION
Many of our services were building their own image, but were able to
avoid doing any extra work thanks to the Docker layer cache. Basically,
this was the same image but with many different names.

In some sense this was nice because it decoupled the services. Building
for one service would not modify the container for other services.
This was a double-edged sword, however, because often we wanted to keep
the images in sync, but it was easy to forget the build step for some
of the services.

By specifying an `image` field in addition to `build`, we are telling
Docker to build the image with the name indicated by `image` (rather
than giving it an automatic name based on the directory/service name).
Now all the services that specify `image` will use the updated image,
regardless of which service it was originally built for.

The common `build` and `image` fields are refactored into a YAML anchor
called `smr-builder` for easy reuse in the services that need it.

The choice of docker-compose to overload `image` for local and remote
images is a poor design, because now `docker-compose pull` will warn
about all the services that use a local image. For this usage, `build`
should have had its own `image` sub-field.