### PR TITLE
npc.php: reship the NPC immediately after death

### DIFF
--- a/src/engine/Default/death_processing.php
+++ b/src/engine/Default/death_processing.php
@@ -4,7 +4,6 @@ $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 $player->setDead(false);
-$player->deletePlottedCourse();
 
 $player->log(LOG_TYPE_TRADER_COMBAT, 'Player sees death screen');
 Page::create('skeleton.php', 'death.php')->go();

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -154,7 +154,7 @@ function NPCStuff() : void {
 
 				// Ensure the NPC doesn't think it's under attack at startup,
 				// since this could cause it to get stuck in a loop in Fed.
-				$player->removeUnderAttack();
+				$player->setUnderAttack(false);
 
 				// Initialize the trade route for this NPC
 				$allTradeRoutes = findRoutes($player);


### PR DESCRIPTION
The NPCs were continuing to trade in an Escape Pod if they were killed
in the middle of their session.

Now they will reship in the same way that they would at the start of
the session.

And some other small misc improvements.