### PR TITLE
Omit codecov PR comments when coverage unchanged

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+    require_changes: true


### PR DESCRIPTION
We have a lot of PRs that don't change coverage (i.e. dependabot PRs),
and the huge codecov PR comments just get in the way when there are no
coverage changes to report.