### PR TITLE
composer.json: pin the php-code-coverage dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
 	"require-dev": {
 		"overtrue/phplint": "4.1.0",
 		"phpunit/phpunit": "9.5.14",
+		"phpunit/php-code-coverage": "9.2.13",
 		"phpstan/phpstan": "1.4.6"
 	}
 }


### PR DESCRIPTION
Previously, we were not pinning the version of php-code-coverage, which
made it hard to disentangle real coverage changes from changes in the
behavior of the code coverage library. Historically, this has not been
a problem, because php-code-coverage was very stable. However, between
versions 9.2.10 and 9.2.13, there were several changes/regressions that
caused coverage changes.

Pinning avoids any ambiguity, and ensures that coverage changes in a
PR come _only_ from the PR code changes (unless we're explicitly
updating the php-code-coverage pinned version).