### PR TITLE
Add .scrutinizer.yml

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,17 @@
+build_failure_conditions:
+  # Fail on any new issues (note that 'issues.new.exists' does not work)
+  - 'issues.severity(>= INFO).new.exists'
+
+build:
+  image: default-bionic
+  environment:
+    php: 8.1.3
+  nodes:
+    analysis:
+      project_setup:
+        override:
+          - cp config/config.specific.sample.php config/config.specific.php
+
+filter:
+  excluded_paths:
+    - 'tests/*'


### PR DESCRIPTION
This configuration used to be stored online at Scrutinizer-CI, but it
was difficult to track when something needed to change (such as PHP
version or directory structure). The configuration included here is
merged with the online configuration.

See https://scrutinizer-ci.com/docs/configuration/cascade.