### PR TITLE
Uni Gen: fix linked location handling

### DIFF
--- a/src/engine/Default/admin/unigen/universe_create_locations.php
+++ b/src/engine/Default/admin/unigen/universe_create_locations.php
@@ -53,6 +53,14 @@ class Categories {
 	}
 }
 
+// Remove any linked locations, as they will be added automatically
+// with any corresponding HQs.
+foreach ($locations as $location) {
+	foreach ($location->getLinkedLocations() as $linkedLoc) {
+		unset($locations[$linkedLoc->getTypeID()]);
+	}
+}
+
 // Set any extra information to be displayed with each location
 $locText = array();
 $categories = new Categories();
@@ -84,6 +92,9 @@ foreach ($locations as $location) {
 	}
 	if ($location->isHQ() || $location->isUG() || $location->isFed()) {
 		$extra .= $categories->addLoc($location->getTypeID(), 'Headquarters');
+		foreach ($location->getLinkedLocations() as $linkedLoc) {
+			$extra .= $linkedLoc->getName() . '<br />';
+		}
 	}
 	if (!$categories->added($location->getTypeID())) {
 		// Anything that doesn't fit the other categories

--- a/src/templates/Default/engine/Default/admin/unigen/universe_create_sector_details.php
+++ b/src/templates/Default/engine/Default/admin/unigen/universe_create_sector_details.php
@@ -61,6 +61,8 @@
 	<br />
 
 	<h2>Locations</h2>
+	<input type="checkbox" name="add_linked_locs" />
+	Automatically add linked locations for Headquarters
 	<table class="shrink">
 		<tr>
 			<td class="center noWrap">


### PR DESCRIPTION
* In the "Headquarters" section of page for adding Locations, only the
  primary HQ locations are specified, and the linked locations will be
  added automatically. Previously, if this page was used after the HQ
  locations were already populated, the linked locations would be
  scattered across the galaxy (in addition to new ones being added
  alongside the HQ). Now, the only caveat is that any _intentionally_
  unlinked locations will be clobbered if this page is used.

![image](https://user-images.githubusercontent.com/846186/156959747-a1023293-52dc-43fe-85df-e47066d314d0.png)


* You can now manually edit the location/placement of linked locations
  in the "Edit Sector" page by using the new checkbox to toggle whether
  or not linked locations should be added with the HQ.

![image](https://user-images.githubusercontent.com/846186/156959698-67bd3d67-5ff5-43c2-ad89-0f2a64ed8705.png)
