### PR TITLE
Add Database::insert method

### DIFF
--- a/src/engine/Default/admin/account_edit_processing.php
+++ b/src/engine/Default/admin/account_edit_processing.php
@@ -26,7 +26,11 @@ $actions = [];
 
 if (!empty($donation)) {
 	// add entry to account donated table
-	$db->write('INSERT INTO account_donated (account_id, time, amount) VALUES (' . $db->escapeNumber($account_id) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ' , ' . $db->escapeNumber($donation) . ')');
+	$db->insert('account_donated', [
+		'account_id' => $db->escapeNumber($account_id),
+		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'amount' => $db->escapeNumber($donation),
+	]);
 
 	// add the credits to the players account - if requested
 	if (!empty($smr_credit)) {
@@ -48,8 +52,9 @@ if (Smr\Request::has('special_close')) {
 	if ($dbResult->hasRecord()) {
 		$reasonID = $dbResult->record()->getInt('reason_id');
 	} else {
-		$db->write('INSERT INTO closing_reason (reason) VALUES(' . $db->escapeString($specialClose) . ')');
-		$reasonID = $db->getInsertID();
+		$reasonID = $db->insert('closing_reason', [
+			'reason' => $db->escapeString($specialClose),
+		]);
 	}
 
 	$closeByRequestNote = Smr\Request::get('close_by_request_note');
@@ -68,8 +73,9 @@ if ($choise == 'reopen') {
 	$actions[] = 'reopened account and removed ' . $points . ' points';
 } elseif ($points > 0) {
 	if ($choise == 'individual') {
-		$db->write('INSERT INTO closing_reason (reason) VALUES(' . $db->escapeString($reason_msg) . ')');
-		$reason_id = $db->getInsertID();
+		$reason_id = $db->insert('closing_reason', [
+			'reason' => $db->escapeString($reason_msg),
+		]);
 	} else {
 		$reason_id = $reason_pre_select;
 	}
@@ -111,7 +117,10 @@ if ($logging_status != $curr_account->isLoggingEnabled()) {
 }
 
 if ($except != 'Add An Exception' && $except != '') {
-	$db->write('INSERT INTO account_exceptions (account_id, reason) VALUES (' . $db->escapeNumber($account_id) . ', ' . $db->escapeString($except) . ')');
+	$db->insert('account_exceptions', [
+		'account_id' => $db->escapeNumber($account_id),
+		'reason' => $db->escapeString($except),
+	]);
 	$actions[] = 'added the exception ' . $except;
 }
 
@@ -129,7 +138,13 @@ if (!empty($names)) {
 				//insert news message
 				$news = 'Please be advised that player ' . $editPlayer->getPlayerID() . ' has had their name changed to ' . $editPlayer->getBBLink();
 
-				$db->write('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($game_id) . ', \'admin\', ' . $db->escapeNumber($account_id) . ')');
+				$db->insert('news', [
+					'time' => $db->escapeNumber(Smr\Epoch::time()),
+					'news_message' => $db->escapeString($news),
+					'game_id' => $db->escapeNumber($game_id),
+					'type' => $db->escapeString('admin'),
+					'killer_id' => $db->escapeNumber($account_id),
+				]);
 			} elseif ($dbResult->record()->getInt('account_id') != $account_id) {
 				$actions[] = 'have NOT changed player name to ' . htmlentities($new_name) . ' (already taken)';
 			}

--- a/src/engine/Default/admin/album_moderate_processing.php
+++ b/src/engine/Default/admin/album_moderate_processing.php
@@ -19,9 +19,13 @@ if ($var['task'] == 'reset_image') {
 		$comment_id = 1;
 	}
 
-	$db->write('INSERT INTO album_has_comments
-				(album_id, comment_id, time, post_id, msg)
-				VALUES ('.$db->escapeNumber($account_id) . ', ' . $db->escapeNumber($comment_id) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', 0, ' . $db->escapeString('<span class="green">*** Picture disabled by an admin</span>') . ')');
+	$db->insert('album_has_comments', [
+		'album_id' => $db->escapeNumber($account_id),
+		'comment_id' => $db->escapeNumber($comment_id),
+		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'post_id' => 0,
+		'msg' => $db->escapeString('<span class="green">*** Picture disabled by an admin</span>'),
+	]);
 	$db->unlock();
 
 	// get his email address and send the mail

--- a/src/engine/Default/admin/announcement_create_processing.php
+++ b/src/engine/Default/admin/announcement_create_processing.php
@@ -12,6 +12,10 @@ if (Smr\Request::get('action') == 'Preview announcement') {
 
 // put the msg into the database
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO announcement (time, admin_id, msg) VALUES(' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($message) . ')');
+$db->insert('announcement', [
+	'time' => $db->escapeNumber(Smr\Epoch::time()),
+	'admin_id' => $db->escapeNumber($account->getAccountID()),
+	'msg' => $db->escapeString($message),
+]);
 
 Page::create('skeleton.php', 'admin/admin_tools.php')->go();

--- a/src/engine/Default/admin/changelog_add_processing.php
+++ b/src/engine/Default/admin/changelog_add_processing.php
@@ -28,10 +28,13 @@ if ($dbResult->hasRecord()) {
 	$changelog_id = 1;
 }
 
-$db->write('INSERT INTO changelog
-			(version_id, changelog_id, change_title, change_message, affected_db)
-			VALUES (' . $db->escapeNumber($var['version_id']) . ', ' . $db->escapeNumber($changelog_id) . ', ' . $db->escapeString($change_title) . ', ' . $db->escapeString($change_message) . ', ' . $db->escapeString($affected_db) . ')');
-
+$db->insert('changelog', [
+	'version_id' => $db->escapeNumber($var['version_id']),
+	'changelog_id' => $db->escapeNumber($changelog_id),
+	'change_title' => $db->escapeString($change_title),
+	'change_message' => $db->escapeString($change_message),
+	'affected_db' => $db->escapeString($affected_db),
+]);
 $db->unlock();
 
 $container->go();

--- a/src/engine/Default/admin/manage_draft_leaders_processing.php
+++ b/src/engine/Default/admin/manage_draft_leaders_processing.php
@@ -32,7 +32,11 @@ if ($action == "Assign") {
 	if ($selectedPlayer->isDraftLeader()) {
 		$msg = "<span class='red'>ERROR: </span>$name is already a draft leader in game $game!";
 	} else {
-		$db->write('INSERT INTO draft_leaders (account_id, game_id, home_sector_id) VALUES (' . $db->escapeNumber($accountId) . ', ' . $db->escapeNumber($gameId) . ', ' . $db->escapeNumber($homeSectorID) . ')');
+		$db->insert('draft_leaders', [
+			'account_id' => $db->escapeNumber($accountId),
+			'game_id' => $db->escapeNumber($gameId),
+			'home_sector_id' => $db->escapeNumber($homeSectorID),
+		]);
 	}
 } elseif ($action == "Remove") {
 	if (!$selectedPlayer->isDraftLeader()) {

--- a/src/engine/Default/admin/manage_post_editors_processing.php
+++ b/src/engine/Default/admin/manage_post_editors_processing.php
@@ -31,7 +31,10 @@ if ($action == "Assign") {
 	if ($selected_player->isGPEditor()) {
 		$msg = "<span class='red'>ERROR: </span>$name is already an editor in game $game!";
 	} else {
-		$db->write('INSERT INTO galactic_post_writer (account_id, game_id) VALUES (' . $db->escapeNumber($account_id) . ', ' . $db->escapeNumber($game_id) . ')');
+		$db->insert('galactic_post_writer', [
+			'account_id' => $db->escapeNumber($account_id),
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 	}
 } elseif ($action == "Remove") {
 	if (!$selected_player->isGPEditor()) {

--- a/src/engine/Default/admin/npc_manage_processing.php
+++ b/src/engine/Default/admin/npc_manage_processing.php
@@ -50,7 +50,11 @@ if (Smr\Request::has('add_npc_account')) {
 	$npcAccount = SmrAccount::createAccount($login, '', 'NPC@smrealms.de', 0, 0);
 	$npcAccount->setValidated(true);
 	$npcAccount->update();
-	$db->write('INSERT INTO npc_logins (login, player_name, alliance_name) VALUES(' . $db->escapeString($login) . ',' . $db->escapeString(Smr\Request::get('default_player_name')) . ',' . $db->escapeString(Smr\Request::get('default_alliance')) . ')');
+	$db->insert('npc_logins', [
+		'login' => $db->escapeString($login),
+		'player_name' => $db->escapeString(Smr\Request::get('default_player_name')),
+		'alliance_name' => $db->escapeString(Smr\Request::get('default_alliance')),
+	]);
 }
 
 $container = Page::create('skeleton.php', 'admin/npc_manage.php');

--- a/src/engine/Default/admin/vote_create_processing.php
+++ b/src/engine/Default/admin/vote_create_processing.php
@@ -18,10 +18,16 @@ $db = Smr\Database::getInstance();
 if ($action == 'Create Vote') {
 	$question = trim(Smr\Request::get('question'));
 	$end = Smr\Epoch::time() + 86400 * Smr\Request::getInt('days');
-	$db->write('INSERT INTO voting (question, end) VALUES(' . $db->escapeString($question) . ',' . $db->escapeNumber($end) . ')');
+	$db->insert('voting', [
+		'question' => $db->escapeString($question),
+		'end' => $db->escapeNumber($end),
+	]);
 } elseif ($action == 'Add Option') {
 	$option = trim(Smr\Request::get('option'));
 	$voteID = Smr\Request::getInt('vote');
-	$db->write('INSERT INTO voting_options (vote_id, text) VALUES(' . $db->escapeNumber($voteID) . ',' . $db->escapeString($option) . ')');
+	$db->insert('voting_options', [
+		'vote_id' => $db->escapeNumber($voteID),
+		'text' => $db->escapeString($option),
+	]);
 }
 Page::create('skeleton.php', 'admin/vote_create.php')->go();

--- a/src/engine/Default/admin/word_filter_add.php
+++ b/src/engine/Default/admin/word_filter_add.php
@@ -12,7 +12,10 @@ if ($dbResult->hasRecord()) {
 	$container->go();
 }
 
-$db->write('INSERT INTO word_filter(word_value,word_replacement) VALUES (' . $db->escapeString($word) . ',' . $db->escapeString($word_replacement) . ')');
+$db->insert('word_filter', [
+	'word_value' => $db->escapeString($word),
+	'word_replacement' => $db->escapeString($word_replacement),
+]);
 
 $container['msg'] = '<span class="yellow">' . $word . '</span> will now be replaced with <span class="yellow">' . $word_replacement . '</span>.';
 $container->go();

--- a/src/engine/Default/album_edit_processing.php
+++ b/src/engine/Default/album_edit_processing.php
@@ -90,8 +90,19 @@ if ($dbResult->hasRecord()) {
 	$comment = '<span class="green">*** Picture added</span>';
 
 	// add album entry
-	$db->write('INSERT INTO album (account_id, location, email, website, day, month, year, other, created, last_changed, approved)
-				VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($location) . ', ' . $db->escapeString($email) . ', ' . $db->escapeString($website) . ', ' . $db->escapeNumber($day) . ', ' . $db->escapeNumber($month) . ', ' . $db->escapeNumber($year) . ', ' . $db->escapeString($other) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', \'TBC\')');
+	$db->insert('album', [
+		'account_id' => $db->escapeNumber($account->getAccountID()),
+		'location' => $db->escapeString($location),
+		'email' => $db->escapeString($email),
+		'website' => $db->escapeString($website),
+		'day' => $db->escapeNumber($day),
+		'month' => $db->escapeNumber($month),
+		'year' => $db->escapeNumber($year),
+		'other' => $db->escapeString($other),
+		'created' => $db->escapeNumber(Smr\Epoch::time()),
+		'last_changed' => $db->escapeNumber(Smr\Epoch::time()),
+		'approved' => $db->escapeString('TBC'),
+	]);
 }
 
 if (!empty($comment)) {
@@ -105,9 +116,13 @@ if (!empty($comment)) {
 		$comment_id = 1;
 	}
 
-	$db->write('INSERT INTO album_has_comments
-				(album_id, comment_id, time, post_id, msg)
-				VALUES (' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($comment_id) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', 0, ' . $db->escapeString($comment) . ')');
+	$db->insert('album_has_comments', [
+		'album_id' => $db->escapeNumber($account->getAccountID()),
+		'comment_id' => $db->escapeNumber($comment_id),
+		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'post_id' => 0,
+		'msg' => $db->escapeString($comment),
+	]);
 	$db->unlock();
 }
 

--- a/src/engine/Default/alliance_message_add_processing.php
+++ b/src/engine/Default/alliance_message_add_processing.php
@@ -76,13 +76,25 @@ if ($reply_id == 1) {
 		create_error('This topic exist already!');
 	}
 
-	$db->write('INSERT INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic, alliance_only)
-				VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', ' . $db->escapeString($topic) . ', ' . $db->escapeBoolean($allEyesOnly) . ')');
+	$db->insert('alliance_thread_topic', [
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'alliance_id' => $db->escapeNumber($alliance_id),
+		'thread_id' => $db->escapeNumber($thread_id),
+		'topic' => $db->escapeString($topic),
+		'alliance_only' => $db->escapeBoolean($allEyesOnly),
+	]);
 }
 
 // and the body
-$db->write('INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time)
-			VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', ' . $db->escapeNumber($reply_id) . ', ' . $db->escapeString($body) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+$db->insert('alliance_thread', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'alliance_id' => $db->escapeNumber($alliance_id),
+	'thread_id' => $db->escapeNumber($thread_id),
+	'reply_id' => $db->escapeNumber($reply_id),
+	'text' => $db->escapeString($body),
+	'sender_id' => $db->escapeNumber($player->getAccountID()),
+	'time' => $db->escapeNumber(Smr\Epoch::time()),
+]);
 $db->write('REPLACE INTO player_read_thread
 			(account_id, game_id, alliance_id, thread_id, time)
 			VALUES(' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', ' . $db->escapeNumber(Smr\Epoch::time() + 2) . ')');

--- a/src/engine/Default/alliance_roles_processing.php
+++ b/src/engine/Default/alliance_roles_processing.php
@@ -51,10 +51,24 @@ if (!isset($var['role_id'])) {
 		$role_id = $dbResult->record()->getInt('MAX(role_id)') + 1;
 	}
 
-	$db->write('INSERT INTO alliance_has_roles
-				(alliance_id, game_id, role_id, role, with_per_day, positive_balance, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds)
-				VALUES (' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($role_id) . ', ' . $db->escapeString(Smr\Request::get('role')) . ', ' . $db->escapeNumber($withPerDay) . ',' . $db->escapeBoolean($positiveBalance) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
-
+	$db->insert('alliance_has_roles', [
+		'alliance_id' => $db->escapeNumber($alliance_id),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'role_id' => $db->escapeNumber($role_id),
+		'role' => $db->escapeString(Smr\Request::get('role')),
+		'with_per_day' => $db->escapeNumber($withPerDay),
+		'positive_balance' => $db->escapeBoolean($positiveBalance),
+		'remove_member' => $db->escapeBoolean($removeMember),
+		'change_pass' => $db->escapeBoolean($changePass),
+		'change_mod' => $db->escapeBoolean($changeMOD),
+		'change_roles' => $db->escapeBoolean($changeRoles),
+		'planet_access' => $db->escapeBoolean($planetAccess),
+		'exempt_with' => $db->escapeBoolean($exemptWith),
+		'mb_messages' => $db->escapeBoolean($mbMessages),
+		'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
+		'op_leader' => $db->escapeBoolean($opLeader),
+		'view_bonds' => $db->escapeBoolean($viewBonds),
+	]);
 	$db->unlock();
 } else {
 	// if no role is given we delete that entry

--- a/src/engine/Default/alliance_set_op_processing.php
+++ b/src/engine/Default/alliance_set_op_processing.php
@@ -34,7 +34,11 @@ if (!empty($var['cancel'])) {
 	}
 
 	// add op to db
-	$db->write('INSERT INTO alliance_has_op (alliance_id, game_id, time) VALUES (' . $db->escapeNumber($player->getAllianceID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($time) . ')');
+	$db->insert('alliance_has_op', [
+		'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'time' => $db->escapeNumber($time),
+	]);
 
 	// Send an alliance message that expires at the time of the op.
 	// Since the message is procedural, don't exclude this player.

--- a/src/engine/Default/alliance_treaties_confirm_processing.php
+++ b/src/engine/Default/alliance_treaties_confirm_processing.php
@@ -11,10 +11,23 @@ $alliance_id_1 = $alliance1->getAllianceID();
 $alliance_id_2 = $alliance2->getAllianceID();
 
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO alliance_treaties (alliance_id_1,alliance_id_2,game_id,trader_assist,trader_defend,trader_nap,raid_assist,planet_land,planet_nap,forces_nap,aa_access,mb_read,mb_write,mod_read,official)
-			VALUES (' . $db->escapeNumber($alliance_id_1) . ', ' . $db->escapeNumber($alliance_id_2) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeBoolean($var['trader_assist']) . ', ' .
-			$db->escapeBoolean($var['trader_defend']) . ', ' . $db->escapeBoolean($var['trader_nap']) . ', ' . $db->escapeBoolean($var['raid_assist']) . ', ' . $db->escapeBoolean($var['planet_land']) . ', ' . $db->escapeBoolean($var['planet_nap']) . ', ' .
-			$db->escapeBoolean($var['forces_nap']) . ', ' . $db->escapeBoolean($var['aa_access']) . ', ' . $db->escapeBoolean($var['mb_read']) . ', ' . $db->escapeBoolean($var['mb_write']) . ', ' . $db->escapeBoolean($var['mod_read']) . ', \'FALSE\')');
+$db->insert('alliance_treaties', [
+	'alliance_id_1' => $db->escapeNumber($alliance_id_1),
+	'alliance_id_2' => $db->escapeNumber($alliance_id_2),
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'trader_assist' => $db->escapeBoolean($var['trader_assist']),
+	'trader_defend' => $db->escapeBoolean($var['trader_defend']),
+	'trader_nap' => $db->escapeBoolean($var['trader_nap']),
+	'raid_assist' => $db->escapeBoolean($var['raid_assist']),
+	'planet_land' => $db->escapeBoolean($var['planet_land']),
+	'planet_nap' => $db->escapeBoolean($var['planet_nap']),
+	'forces_nap' => $db->escapeBoolean($var['forces_nap']),
+	'aa_access' => $db->escapeBoolean($var['aa_access']),
+	'mb_read' => $db->escapeBoolean($var['mb_read']),
+	'mb_write' => $db->escapeBoolean($var['mb_write']),
+	'mod_read' => $db->escapeBoolean($var['mod_read']),
+	'official' => $db->escapeBoolean(false),
+]);
 
 //send a message to the leader letting them know the offer is waiting.
 $leader2 = $alliance2->getLeaderID();

--- a/src/engine/Default/alliance_treaties_processing.php
+++ b/src/engine/Default/alliance_treaties_processing.php
@@ -31,9 +31,13 @@ if ($var['accept']) {
 				$role_id = $dbResult->record()->getInt('MAX(role_id)') + 1;
 			}
 			$allianceName = SmrAlliance::getAlliance($alliance_id_B, $player->getGameID())->getAllianceName();
-			$db->write('INSERT INTO alliance_has_roles
-				(alliance_id, game_id, role_id, role, treaty_created)
-				VALUES (' . $db->escapeNumber($alliance_id_A) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($role_id) . ', ' . $db->escapeString($allianceName) . ',1)');
+			$db->insert('alliance_has_roles', [
+				'alliance_id' => $db->escapeNumber($alliance_id_A),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'role_id' => $db->escapeNumber($role_id),
+				'role' => $db->escapeString($allianceName),
+				'treaty_created' => 1,
+			]);
 		}
 	}
 } else {

--- a/src/engine/Default/bank_alliance_processing.php
+++ b/src/engine/Default/bank_alliance_processing.php
@@ -93,9 +93,17 @@ if ($dbResult->hasRecord()) {
 
 // save log
 $requestExempt = Smr\Request::has('requestExempt') ? 1 : 0;
-$db->write('INSERT INTO alliance_bank_transactions
-			(alliance_id, game_id, transaction_id, time, payee_id, reason, transaction, amount, request_exempt)
-			VALUES(' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($next_id) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($message) . ', ' . $db->escapeString($action) . ', ' . $db->escapeNumber($amount) . ', ' . $db->escapeNumber($requestExempt) . ')');
+$db->insert('alliance_bank_transactions', [
+	'alliance_id' => $db->escapeNumber($alliance_id),
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'transaction_id' => $db->escapeNumber($next_id),
+	'time' => $db->escapeNumber(Smr\Epoch::time()),
+	'payee_id' => $db->escapeNumber($player->getAccountID()),
+	'reason' => $db->escapeString($message),
+	'transaction' => $db->escapeString($action),
+	'amount' => $db->escapeNumber($amount),
+	'request_exempt' => $db->escapeNumber($requestExempt),
+]);
 
 // update player credits
 $player->update();

--- a/src/engine/Default/bank_anon_create_processing.php
+++ b/src/engine/Default/bank_anon_create_processing.php
@@ -14,7 +14,13 @@ $dbResult = $db->read('SELECT MAX(anon_id) FROM anon_bank WHERE game_id = ' . $d
 if ($dbResult->hasRecord()) {
 	$new_acc = $dbResult->record()->getInt('MAX(anon_id)') + 1;
 }
-$db->write('INSERT INTO anon_bank (game_id, anon_id, owner_id, password, amount) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($new_acc) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($password) . ', 0)');
+$db->insert('anon_bank', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'anon_id' => $db->escapeNumber($new_acc),
+	'owner_id' => $db->escapeNumber($player->getAccountID()),
+	'password' => $db->escapeString($password),
+	'amount' => 0,
+]);
 
 $container = Page::create('skeleton.php', 'bank_anon.php');
 $container['message'] = '<p>Account #' . $new_acc . ' has been opened for you.</p>';

--- a/src/engine/Default/bank_anon_detail_processing.php
+++ b/src/engine/Default/bank_anon_detail_processing.php
@@ -47,8 +47,15 @@ if ($action == 'Deposit') {
 $player->update();
 
 // Log the bank transaction
-$db->write('INSERT INTO anon_bank_transactions (account_id, game_id, anon_id, transaction_id, transaction, amount, time)
-			VALUES (' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($account_num) . ', ' . $db->escapeNumber($trans_id) . ', ' . $db->escapeString($action) . ', ' . $db->escapeNumber($amount) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+$db->insert('anon_bank_transactions', [
+	'account_id' => $db->escapeNumber($player->getAccountID()),
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'anon_id' => $db->escapeNumber($account_num),
+	'transaction_id' => $db->escapeNumber($trans_id),
+	'transaction' => $db->escapeString($action),
+	'amount' => $db->escapeNumber($amount),
+	'time' => $db->escapeNumber(Smr\Epoch::time()),
+]);
 
 // Log the player action
 $player->log(LOG_TYPE_BANK, $action . ' of ' . $amount . ' credits in anonymous account #' . $account_num);

--- a/src/engine/Default/bank_report_processing.php
+++ b/src/engine/Default/bank_report_processing.php
@@ -25,8 +25,21 @@ if ($dbResult->hasRecord()) {
 	} else {
 		$thread_id = 1;
 	}
-	$db->write('INSERT INTO alliance_thread_topic (game_id, alliance_id, thread_id, topic) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', \'Bank Statement\')');
-	$db->write('INSERT INTO alliance_thread (game_id, alliance_id, thread_id, reply_id, text, sender_id, time) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($alliance_id) . ', ' . $db->escapeNumber($thread_id) . ', 1, ' . $db->escapeString($text) . ', ' . $db->escapeNumber(ACCOUNT_ID_BANK_REPORTER) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->insert('alliance_thread_topic', [
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'alliance_id' => $db->escapeNumber($alliance_id),
+		'thread_id' => $db->escapeNumber($thread_id),
+		'topic' => $db->escapeString('Bank Statement'),
+	]);
+	$db->insert('alliance_thread', [
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'alliance_id' => $db->escapeNumber($alliance_id),
+		'thread_id' => $db->escapeNumber($thread_id),
+		'reply_id' => 1,
+		'text' => $db->escapeString($text),
+		'sender_id' => $db->escapeNumber(ACCOUNT_ID_BANK_REPORTER),
+		'time' => $db->escapeNumber(Smr\Epoch::time()),
+	]);
 }
 
 $container = Page::create('skeleton.php', 'bank_report.php');

--- a/src/engine/Default/bar_buy_drink_processing.php
+++ b/src/engine/Default/bar_buy_drink_processing.php
@@ -39,7 +39,12 @@ if (isset($var['action']) && $var['action'] != 'drink') {
 	$drinkName = $drinkList[array_rand($drinkList)];
 
 	$curr_drink_id++;
-	$db->write('INSERT INTO player_has_drinks (account_id, game_id, drink_id, time) VALUES (' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($curr_drink_id) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->insert('player_has_drinks', [
+		'account_id' => $db->escapeNumber($player->getAccountID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'drink_id' => $db->escapeNumber($curr_drink_id),
+		'time' => $db->escapeNumber(Smr\Epoch::time()),
+	]);
 
 	if (!Smr\BarDrink::isSpecial($drinkName)) {
 		$message .= ('You have bought a ' . $drinkName . ' for $10');

--- a/src/engine/Default/bar_lotto_buy_processing.php
+++ b/src/engine/Default/bar_lotto_buy_processing.php
@@ -19,7 +19,11 @@ while (true) {
 	$time++;
 }
 
-$db->write('INSERT INTO player_has_ticket (game_id, account_id, time) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($time) . ')');
+$db->insert('player_has_ticket', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'account_id' => $db->escapeNumber($player->getAccountID()),
+	'time' => $db->escapeNumber($time),
+]);
 $player->decreaseCredits(1000000);
 $player->increaseHOF(1000000, array('Bar', 'Lotto', 'Money', 'Spent'), HOF_PUBLIC);
 $player->increaseHOF(1, array('Bar', 'Lotto', 'Tickets Bought'), HOF_PUBLIC);

--- a/src/engine/Default/bar_talk_bartender_processing.php
+++ b/src/engine/Default/bar_talk_bartender_processing.php
@@ -14,12 +14,16 @@ if ($action == 'tell') {
 		$db = Smr\Database::getInstance();
 		$dbResult = $db->read('SELECT message_id FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY message_id DESC LIMIT 1');
 		if ($dbResult->hasRecord()) {
-			$amount = $dbResult->record()->getInt('message_id') + 1;
+			$messageID = $dbResult->record()->getInt('message_id') + 1;
 		} else {
-			$amount = 1;
+			$messageID = 1;
 		}
 
-		$db->write('INSERT INTO bar_tender (game_id, message_id, message) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($amount) . ',  ' . $db->escapeString($gossip) . ' )');
+		$db->insert('bar_tender', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'message_id' => $db->escapeNumber($messageID),
+			'message' => $db->escapeString($gossip),
+		]);
 		SmrAccount::doMessageSendingToBox($player->getAccountID(), BOX_BARTENDER, $gossip, $player->getGameID());
 
 		$container['Message'] = 'Huh, that\'s news to me...<br /><br />Got anything else to tell me?';

--- a/src/engine/Default/chat_sharing_processing.php
+++ b/src/engine/Default/chat_sharing_processing.php
@@ -32,7 +32,11 @@ if (Smr\Request::has('add')) {
 	}
 
 	$gameId = Smr\Request::has('all_games') ? '0' : $player->getGameID();
-	$db->write('INSERT INTO account_shares_info (to_account_id, from_account_id, game_id) VALUES (' . $db->escapeNumber($accountId) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($gameId) . ')');
+	$db->insert('account_shares_info', [
+		'to_account_id' => $db->escapeNumber($accountId),
+		'from_account_id' => $db->escapeNumber($player->getAccountID()),
+		'game_id' => $db->escapeNumber($gameId),
+	]);
 }
 
 // Process removing a "share to" account

--- a/src/engine/Default/feature_request_comment_processing.php
+++ b/src/engine/Default/feature_request_comment_processing.php
@@ -11,8 +11,13 @@ if (empty($comment)) {
 
 // add this feature comment
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
-			VALUES(' . $db->escapeNumber($var['RequestID']) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeBoolean(Smr\Request::has('anon')) . ',' . $db->escapeString(word_filter($comment)) . ')');
+$db->insert('feature_request_comments', [
+	'feature_request_id' => $db->escapeNumber($var['RequestID']),
+	'poster_id' => $db->escapeNumber($account->getAccountID()),
+	'posting_time' => $db->escapeNumber(Smr\Epoch::time()),
+	'anonymous' => $db->escapeBoolean(Smr\Request::has('anon')),
+	'text' => $db->escapeString(word_filter($comment)),
+]);
 
 $container = Page::copy($var);
 $container['url'] = 'skeleton.php';

--- a/src/engine/Default/feature_request_processing.php
+++ b/src/engine/Default/feature_request_processing.php
@@ -13,12 +13,20 @@ if (strlen($feature) > 500) {
 
 // add this feature to db
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO feature_request (feature_request_id) VALUES (NULL)');
-$featureRequestID = $db->getInsertID();
-$db->write('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text) ' .
-								'VALUES(' . $db->escapeNumber($featureRequestID) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeBoolean(Smr\Request::has('anon')) . ',' . $db->escapeString(word_filter($feature)) . ')');
+$featureRequestID = $db->insert('feature_request', []);
+$db->insert('feature_request_comments', [
+	'feature_request_id' => $db->escapeNumber($featureRequestID),
+	'poster_id' => $db->escapeNumber($account->getAccountID()),
+	'posting_time' => $db->escapeNumber(Smr\Epoch::time()),
+	'anonymous' => $db->escapeBoolean(Smr\Request::has('anon')),
+	'text' => $db->escapeString(word_filter($feature)),
+]);
 
 // vote for this feature
-$db->write('INSERT INTO account_votes_for_feature VALUES(' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeNumber($featureRequestID) . ',\'YES\')');
+$db->insert('account_votes_for_feature', [
+	'account_id' => $db->escapeNumber($account->getAccountID()),
+	'feature_request_id' => $db->escapeNumber($featureRequestID),
+	'vote_type' => $db->escapeString('YES'),
+]);
 
 Page::create('skeleton.php', 'feature_request.php')->go();

--- a/src/engine/Default/feature_request_vote_processing.php
+++ b/src/engine/Default/feature_request_vote_processing.php
@@ -55,8 +55,13 @@ if ($action == 'Vote') {
 			)
 			WHERE feature_request_id IN (' . $db->escapeArray($setStatusIDs) . ')');
 	foreach ($setStatusIDs as $featureID) {
-		$db->write('INSERT INTO feature_request_comments (feature_request_id, poster_id, posting_time, anonymous, text)
-					VALUES(' . $db->escapeNumber($featureID) . ', ' . $db->escapeNumber($account->getAccountID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeBoolean(false) . ',' . $db->escapeString($status) . ')');
+		$db->insert('feature_request_comments', [
+			'feature_request_id' => $db->escapeNumber($featureID),
+			'poster_id' => $db->escapeNumber($account->getAccountID()),
+			'posting_time' => $db->escapeNumber(Smr\Epoch::time()),
+			'anonymous' => $db->escapeBoolean(false),
+			'text' => $db->escapeString($status),
+		]);
 	}
 
 	Page::create('skeleton.php', 'feature_request.php')->go();

--- a/src/engine/Default/forces_attack_processing.php
+++ b/src/engine/Default/forces_attack_processing.php
@@ -100,8 +100,17 @@ if (!$bump) {
 
 // Add this log to the `combat_logs` database table
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'FORCE\',' . $db->escapeNumber($forces->getSectorID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($forceOwner->getAccountID()) . ',' . $db->escapeNumber($forceOwner->getAllianceID()) . ',' . $db->escapeObject($results, true) . ')');
-$logId = $db->getInsertID();
+$logId = $db->insert('combat_logs', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'type' => $db->escapeString('FORCE'),
+	'sector_id' => $db->escapeNumber($forces->getSectorID()),
+	'timestamp' => $db->escapeNumber(Smr\Epoch::time()),
+	'attacker_id' => $db->escapeNumber($player->getAccountID()),
+	'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
+	'defender_id' => $db->escapeNumber($forceOwner->getAccountID()),
+	'defender_alliance_id' => $db->escapeNumber($forceOwner->getAllianceID()),
+	'result' => $db->escapeObject($results, true),
+]);
 
 if ($sendMessage) {
 	$message = 'Your forces in sector ' . Globals::getSectorBBLink($forces->getSectorID()) . ' are under <span class="red">attack</span> by ' . $player->getBBLink() . '! [combatlog=' . $logId . ']';

--- a/src/engine/Default/galactic_post_add_article_to_paper.php
+++ b/src/engine/Default/galactic_post_add_article_to_paper.php
@@ -10,7 +10,11 @@ $dbResult = $db->read('SELECT 1 FROM galactic_post_paper_content WHERE game_id =
 if ($dbResult->getNumRecords() >= 8) {
 	create_error('You can only have 8 articles per paper.');
 }
-$db->write('INSERT INTO galactic_post_paper_content (game_id, paper_id, article_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($var['paper_id']) . ', ' . $db->escapeNumber($var['id']) . ')');
+$db->insert('galactic_post_paper_content', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'paper_id' => $db->escapeNumber($var['paper_id']),
+	'article_id' => $db->escapeNumber($var['id']),
+]);
 //we now have that article in the paper
 $container = Page::create('skeleton.php', 'galactic_post_view_article.php');
 $container->go();

--- a/src/engine/Default/galactic_post_make_paper_processing.php
+++ b/src/engine/Default/galactic_post_make_paper_processing.php
@@ -11,7 +11,11 @@ if ($dbResult->hasRecord()) {
 	$num = 1;
 }
 $title = Smr\Request::get('title');
-$db->write('INSERT INTO galactic_post_paper (game_id, paper_id, title) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($num) . ', ' . $db->escapeString($title) . ')');
+$db->insert('galactic_post_paper', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'paper_id' => $db->escapeNumber($num),
+	'title' => $db->escapeString($title),
+]);
 //send em back
 $container = Page::create('skeleton.php', 'galactic_post_view_article.php');
 $container->go();

--- a/src/engine/Default/galactic_post_view_article.php
+++ b/src/engine/Default/galactic_post_view_article.php
@@ -10,8 +10,12 @@ $template->assign('PageTopic', 'Viewing Articles');
 Menu::galactic_post();
 
 if (isset($var['news'])) {
-	$db->write('INSERT INTO news (game_id, time, news_message, type) ' .
-		'VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ', ' . $db->escapeString($var['news']) . ', \'BREAKING\')');
+	$db->insert('news', [
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'news_message' => $db->escapeString($var['news']),
+		'type' => $db->escapeString('breaking'),
+	]);
 	// avoid multiple insertion on ajax updates
 	unset($var['news']);
 	$var['added_to_breaking_news'] = true;

--- a/src/engine/Default/galactic_post_write_article_processing.php
+++ b/src/engine/Default/galactic_post_write_article_processing.php
@@ -38,7 +38,14 @@ if (isset($var['id'])) {
 	$dbResult = $db->read('SELECT MAX(article_id) article_id FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' LIMIT 1');
 	$num = $dbResult->record()->getInt('article_id') + 1;
 
-	$db->write('INSERT INTO galactic_post_article (game_id, article_id, writer_id, title, text, last_modified) VALUES (' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($num) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeString($title) . ' , ' . $db->escapeString($message) . ' , ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+	$db->insert('galactic_post_article', [
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'article_id' => $db->escapeNumber($num),
+		'writer_id' => $db->escapeNumber($player->getAccountID()),
+		'title' => $db->escapeString($title),
+		'text' => $db->escapeString($message),
+		'last_modified' => $db->escapeNumber(Smr\Epoch::time()),
+	]);
 	$db->write('UPDATE galactic_post_writer SET last_wrote = ' . $db->escapeNumber(Smr\Epoch::time()) . ' WHERE account_id = ' . $db->escapeNumber($player->getAccountID()));
 	Page::create('skeleton.php', 'galactic_post_read.php')->go();
 }

--- a/src/engine/Default/game_join_processing.php
+++ b/src/engine/Default/game_join_processing.php
@@ -72,7 +72,13 @@ $player->getShip()->update();
 
 // Announce the player joining in the news
 $news = '[player=' . $player->getPlayerID() . '] has joined the game!';
-$db->write('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($gameID) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
+$db->insert('news', [
+	'time' => $db->escapeNumber(Smr\Epoch::time()),
+	'news_message' => $db->escapeString($news),
+	'game_id' => $db->escapeNumber($gameID),
+	'type' => $db->escapeString('admin'),
+	'killer_id' => $db->escapeNumber($player->getAccountID()),
+]);
 
 // Send the player directly into the game
 $container = Page::create('game_play_processing.php');

--- a/src/engine/Default/message_blacklist_add.php
+++ b/src/engine/Default/message_blacklist_add.php
@@ -25,7 +25,11 @@ if ($dbResult->hasRecord()) {
 	$container->go();
 }
 
-$db->write('INSERT INTO message_blacklist (game_id,account_id,blacklisted_id) VALUES (' . $db->escapeNumber($player->getGameID()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($blacklisted->getAccountID()) . ')');
+$db->insert('message_blacklist', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'account_id' => $db->escapeNumber($player->getAccountID()),
+	'blacklisted_id' => $db->escapeNumber($blacklisted->getAccountID()),
+]);
 
 $container['msg'] = $blacklisted->getDisplayName() . ' has been added to your blacklist.';
 $container->go();

--- a/src/engine/Default/message_notify_processing.php
+++ b/src/engine/Default/message_notify_processing.php
@@ -35,8 +35,14 @@ if (!$dbResult->hasRecord()) {
 $dbRecord = $dbResult->record();
 
 // insert
-$db->write('INSERT INTO message_notify
-			(notify_id, game_id, from_id, to_id, text, sent_time, notify_time)
-			VALUES ('.$notify_id . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $dbRecord->getInt('sender_id') . ', ' . $dbRecord->getInt('account_id') . ', ' . $db->escapeString($dbRecord->getField('message_text')) . ', ' . $var['sent_time'] . ', ' . $var['notified_time'] . ')');
+$db->insert('message_notify', [
+	'notify_id' => $db->escapeNumber($notify_id),
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'from_id' => $dbRecord->getInt('sender_id'),
+	'to_id' => $dbRecord->getInt('account_id'),
+	'text' => $db->escapeString($dbRecord->getField('message_text')),
+	'sent_time' => $db->escapeNumber($var['sent_time']),
+	'notify_time' => $db->escapeNumber($var['notified_time']),
+]);
 
 $container->go();

--- a/src/engine/Default/note_add_processing.php
+++ b/src/engine/Default/note_add_processing.php
@@ -12,9 +12,10 @@ if (strlen($note) > 1000) {
 $note = htmlentities($note, ENT_QUOTES, 'utf-8');
 $note = nl2br($note);
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO player_has_notes (account_id,game_id,note) VALUES(' .
-		$db->escapeNumber($player->getAccountID()) . ',' .
-		$db->escapeNumber($player->getGameID()) . ',' .
-		$db->escapeBinary(gzcompress($note)) . ')');
+$db->insert('player_has_notes', [
+	'account_id' => $db->escapeNumber($player->getAccountID()),
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'note' => $db->escapeBinary(gzcompress($note)),
+]);
 
 Page::create('skeleton.php', 'trader_status.php')->go();

--- a/src/engine/Default/planet_attack_processing.php
+++ b/src/engine/Default/planet_attack_processing.php
@@ -83,8 +83,17 @@ $account->log(LOG_TYPE_PLANET_BUSTING, 'Player attacks planet, the planet does '
 
 // Add this log to the `combat_logs` database table
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLANET\',' . $planet->getSectorID() . ',' . Smr\Epoch::time() . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $planetOwner->getAccountID() . ',' . $planetOwner->getAllianceID() . ',' . $db->escapeObject($results, true) . ')');
-$logId = $db->getInsertID();
+$logId = $db->insert('combat_logs', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'type' => $db->escapeString('PLANET'),
+	'sector_id' => $db->escapeNumber($planet->getSectorID()),
+	'timestamp' => $db->escapeNumber(Smr\Epoch::time()),
+	'attacker_id' => $db->escapeNumber($player->getAccountID()),
+	'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
+	'defender_id' => $db->escapeNumber($planetOwner->getAccountID()),
+	'defender_alliance_id' => $db->escapeNumber($planetOwner->getAllianceID()),
+	'result' => $db->escapeObject($results, true),
+]);
 
 if ($planet->isDestroyed()) {
 	$db->write('UPDATE player SET land_on_planet = \'FALSE\' WHERE sector_id = ' . $db->escapeNumber($planet->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));

--- a/src/engine/Default/port_attack_processing.php
+++ b/src/engine/Default/port_attack_processing.php
@@ -80,11 +80,22 @@ $account->log(LOG_TYPE_PORT_RAIDING, 'Player attacks port, the port does ' . $re
 $port->update();
 
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PORT\',' . $db->escapeNumber($port->getSectorID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber(ACCOUNT_ID_PORT) . ',' . $db->escapeNumber(PORT_ALLIANCE_ID) . ',' . $db->escapeObject($results, true) . ')');
-$logId = $db->escapeString('[ATTACK_RESULTS]' . $db->getInsertID());
+$logId = $db->insert('combat_logs', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'type' => $db->escapeString('PORT'),
+	'sector_id' => $db->escapeNumber($port->getSectorID()),
+	'timestamp' => $db->escapeNumber(Smr\Epoch::time()),
+	'attacker_id' => $db->escapeNumber($player->getAccountID()),
+	'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
+	'defender_id' => $db->escapeNumber(ACCOUNT_ID_PORT),
+	'defender_alliance_id' => $db->escapeNumber(PORT_ALLIANCE_ID),
+	'result' => $db->escapeObject($results, true),
+]);
+
+$sectorMessage = '[ATTACK_RESULTS]' . $logId;
 foreach ($attackers as $attacker) {
 	if (!$player->equals($attacker)) {
-		$db->write('REPLACE INTO sector_message VALUES(' . $db->escapeNumber($attacker->getAccountID()) . ',' . $db->escapeNumber($attacker->getGameID()) . ',' . $logId . ')');
+		$db->write('REPLACE INTO sector_message VALUES(' . $db->escapeNumber($attacker->getAccountID()) . ',' . $db->escapeNumber($attacker->getGameID()) . ',' . $db->escapeString($sectorMessage) . ')');
 	}
 }
 

--- a/src/engine/Default/preferences_processing.php
+++ b/src/engine/Default/preferences_processing.php
@@ -188,7 +188,13 @@ if ($action == 'Save and resend validation code') {
 	$player->setPlayerNameByPlayer($player_name);
 
 	$news = 'Please be advised that ' . $old_name . ' has changed their name to ' . $player->getBBLink();
-	$db->write('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($player->getGameID()) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
+	$db->insert('news', [
+		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'news_message' => $db->escapeString($news),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'type' => $db->escapeString('admin'),
+		'killer_id' => $db->escapeNumber($player->getAccountID()),
+	]);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your player name.';
 } elseif ($action == 'change_race') {
 	if (!$player->canChangeRace()) {
@@ -219,7 +225,13 @@ if ($action == 'Save and resend validation code') {
 	$player->giveStartingRelations();
 
 	$news = 'Please be advised that ' . $player->getBBLink() . ' has changed their race from [race=' . $oldRaceID . '] to [race=' . $player->getRaceID() . ']';
-	$db->write('INSERT INTO news (time, news_message, game_id, type, killer_id) VALUES (' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeString($news) . ',' . $db->escapeNumber($player->getGameID()) . ', \'admin\', ' . $db->escapeNumber($player->getAccountID()) . ')');
+	$db->insert('news', [
+		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'news_message' => $db->escapeString($news),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'type' => $db->escapeString('admin'),
+		'killer_id' => $db->escapeNumber($player->getAccountID()),
+	]);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your player race.';
 } elseif ($action == 'Update Colours') {
 	$friendlyColour = Smr\Request::get('friendly_color');

--- a/src/engine/Default/trader_attack_processing.php
+++ b/src/engine/Default/trader_attack_processing.php
@@ -82,7 +82,17 @@ $results = [
 $account->log(LOG_TYPE_TRADER_COMBAT, 'Player attacks player, their team does ' . $results['Attackers']['TotalDamage'] . ' and the other team does ' . $results['Defenders']['TotalDamage'], $sector->getSectorID());
 
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO combat_logs VALUES(\'\',' . $db->escapeNumber($player->getGameID()) . ',\'PLAYER\',' . $db->escapeNumber($sector->getSectorID()) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ',' . $db->escapeNumber($player->getAccountID()) . ',' . $db->escapeNumber($player->getAllianceID()) . ',' . $db->escapeNumber($var['target']) . ',' . $db->escapeNumber($targetPlayer->getAllianceID()) . ',' . $db->escapeObject($results, true) . ')');
+$db->insert('combat_logs', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'type' => $db->escapeString('PLAYER'),
+	'sector_id' => $db->escapeNumber($sector->getSectorID()),
+	'timestamp' => $db->escapeNumber(Smr\Epoch::time()),
+	'attacker_id' => $db->escapeNumber($player->getAccountID()),
+	'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
+	'defender_id' => $db->escapeNumber($var['target']),
+	'defender_alliance_id' => $db->escapeNumber($targetPlayer->getAllianceID()),
+	'result' => $db->escapeObject($results, true),
+]);
 
 $container = Page::create('skeleton.php', 'trader_attack.php');
 

--- a/src/engine/Draft/alliance_pick_processing.php
+++ b/src/engine/Draft/alliance_pick_processing.php
@@ -40,6 +40,11 @@ $pickedPlayer->update();
 
 // Update the draft history
 $db = Smr\Database::getInstance();
-$db->write('INSERT INTO draft_history (game_id, leader_account_id, picked_account_id, time) VALUES(' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($player->getAccountID()) . ', ' . $db->escapeNumber($pickedPlayer->getAccountID()) . ', ' . $db->escapeNumber(Smr\Epoch::time()) . ')');
+$db->insert('draft_history', [
+	'game_id' => $db->escapeNumber($player->getGameID()),
+	'leader_account_id' => $db->escapeNumber($player->getAccountID()),
+	'picked_account_id' => $db->escapeNumber($pickedPlayer->getAccountID()),
+	'time' => $db->escapeNumber(Smr\Epoch::time()),
+]);
 
 Page::create('skeleton.php', 'alliance_pick.php')->go();

--- a/src/htdocs/album/album_comment.php
+++ b/src/htdocs/album/album_comment.php
@@ -67,9 +67,13 @@ try {
 		$comment_id = 1;
 	}
 
-	$db->write('INSERT INTO album_has_comments
-				(album_id, comment_id, time, post_id, msg)
-				VALUES ('.$db->escapeNumber($album_id) . ', ' . $db->escapeNumber($comment_id) . ', ' . $db->escapeNumber($curr_time) . ', ' . $db->escapeNumber($account->getAccountID()) . ', ' . $db->escapeString($comment) . ')');
+	$db->insert('album_has_comments', [
+		'album_id' => $db->escapeNumber($album_id),
+		'comment_id' => $db->escapeNumber($comment_id),
+		'time' => $db->escapeNumber($curr_time),
+		'post_id' => $db->escapeNumber($account->getAccountID()),
+		'msg' => $db->escapeString($comment),
+	]);
 	$db->unlock();
 
 	header('Location: /album/?nick=' . urlencode(get_album_nick($album_id)));

--- a/src/lib/Default/AbstractSmrLocation.class.php
+++ b/src/lib/Default/AbstractSmrLocation.class.php
@@ -74,8 +74,11 @@ class AbstractSmrLocation {
 	public static function addSectorLocation(int $gameID, int $sectorID, SmrLocation $location) : void {
 		self::getSectorLocations($gameID, $sectorID); // make sure cache is populated
 		$db = Smr\Database::getInstance();
-		$db->write('INSERT INTO location (game_id, sector_id, location_type_id)
-						values(' . $db->escapeNumber($gameID) . ',' . $db->escapeNumber($sectorID) . ',' . $db->escapeNumber($location->getTypeID()) . ')');
+		$db->insert('location', [
+			'game_id' => $db->escapeNumber($gameID),
+			'sector_id' => $db->escapeNumber($sectorID),
+			'location_type_id' => $db->escapeNumber($location->getTypeID()),
+		]);
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID][$location->getTypeID()] = $location;
 	}
 
@@ -204,7 +207,9 @@ class AbstractSmrLocation {
 			return;
 		}
 		if ($bool) {
-			$this->db->write('INSERT INTO location_is_bank (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
+			$this->db->insert('location_is_bank', [
+				'location_type_id' => $this->db->escapeNumber($this->getTypeID()),
+			]);
 		} else {
 			$this->db->write('DELETE FROM location_is_bank WHERE ' . $this->SQL . ' LIMIT 1');
 		}
@@ -264,7 +269,9 @@ class AbstractSmrLocation {
 			return;
 		}
 		if ($bool) {
-			$this->db->write('INSERT INTO location_is_ug (location_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ')');
+			$this->db->insert('location_is_ug', [
+				'location_type_id' => $this->db->escapeNumber($this->getTypeID()),
+			]);
 		} else {
 			$this->db->write('DELETE FROM location_is_ug WHERE ' . $this->SQL . ' LIMIT 1');
 		}
@@ -298,7 +305,10 @@ class AbstractSmrLocation {
 		if (!$dbResult->hasRecord()) {
 			throw new Exception('Invalid hardware type id given');
 		}
-		$this->db->write('INSERT INTO location_sells_hardware (location_type_id,hardware_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($hardwareTypeID) . ')');
+		$this->db->insert('location_sells_hardware', [
+			'location_type_id' => $this->db->escapeNumber($this->getTypeID()),
+			'hardware_type_id' => $this->db->escapeNumber($hardwareTypeID),
+		]);
 		$this->hardwareSold[$hardwareTypeID] = Globals::getHardwareTypes($hardwareTypeID);
 	}
 
@@ -335,7 +345,10 @@ class AbstractSmrLocation {
 			return;
 		}
 		$ship = SmrShipType::get($shipTypeID);
-		$this->db->write('INSERT INTO location_sells_ships (location_type_id,ship_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($shipTypeID) . ')');
+		$this->db->insert('location_sells_ships', [
+			'location_type_id' => $this->db->escapeNumber($this->getTypeID()),
+			'ship_type_id' => $this->db->escapeNumber($shipTypeID),
+		]);
 		$this->shipsSold[$shipTypeID] = $ship;
 	}
 
@@ -372,7 +385,10 @@ class AbstractSmrLocation {
 			return;
 		}
 		$weapon = SmrWeapon::getWeapon($weaponTypeID);
-		$this->db->write('INSERT INTO location_sells_weapons (location_type_id,weapon_type_id) values (' . $this->db->escapeNumber($this->getTypeID()) . ',' . $this->db->escapeNumber($weaponTypeID) . ')');
+		$this->db->insert('location_sells_weapons', [
+			'location_type_id' => $this->db->escapeNumber($this->getTypeID()),
+			'weapon_type_id' => $this->db->escapeNumber($weaponTypeID),
+		]);
 		$this->weaponsSold[$weaponTypeID] = $weapon;
 	}
 

--- a/src/lib/Default/AbstractSmrPort.class.php
+++ b/src/lib/Default/AbstractSmrPort.class.php
@@ -645,8 +645,15 @@ class AbstractSmrPort {
 				$newsMessage .= 'a bounty of <span class="creds">' . $bounty . '</span> credits for the death of ' . $trigger->getBBLink();
 			}
 			$newsMessage .= ' prior to the destruction of the port, or until federal forces arrive to defend the port.';
-//			$irc_message = '[k00,01]The port in sector [k11]'.$this->sectorID.'[k00] is under attack![/k]';
-			$this->db->write('INSERT INTO news (game_id, time, news_message, type,killer_id,killer_alliance,dead_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ',' . $this->db->escapeNumber(Smr\Epoch::time()) . ',' . $this->db->escapeString($newsMessage) . ',\'REGULAR\',' . $this->db->escapeNumber($trigger->getAccountID()) . ',' . $this->db->escapeNumber($trigger->getAllianceID()) . ',' . $this->db->escapeNumber(ACCOUNT_ID_PORT) . ')');
+
+			$this->db->insert('news', [
+				'game_id' => $this->db->escapeNumber($this->getGameID()),
+				'time' => $this->db->escapeNumber(Smr\Epoch::time()),
+				'news_message' => $this->db->escapeString($newsMessage),
+				'killer_id' => $this->db->escapeNumber($trigger->getAccountID()),
+				'killer_alliance' => $this->db->escapeNumber($trigger->getAllianceID()),
+				'dead_id' => $this->db->escapeNumber(ACCOUNT_ID_PORT),
+			]);
 		}
 	}
 
@@ -1179,20 +1186,20 @@ class AbstractSmrPort {
 								', race_id = ' . $this->db->escapeNumber($this->getRaceID()) . '
 								WHERE ' . $this->SQL . ' LIMIT 1');
 			} else {
-				$this->db->write('INSERT INTO port (game_id,sector_id,experience,shields,armour,combat_drones,level,credits,upgrade,reinforce_time,attack_started,race_id)
-								values
-								(' . $this->db->escapeNumber($this->getGameID()) .
-								',' . $this->db->escapeNumber($this->getSectorID()) .
-								',' . $this->db->escapeNumber($this->getExperience()) .
-								',' . $this->db->escapeNumber($this->getShields()) .
-								',' . $this->db->escapeNumber($this->getArmour()) .
-								',' . $this->db->escapeNumber($this->getCDs()) .
-								',' . $this->db->escapeNumber($this->getLevel()) .
-								',' . $this->db->escapeNumber($this->getCredits()) .
-								',' . $this->db->escapeNumber($this->getUpgrade()) .
-								',' . $this->db->escapeNumber($this->getReinforceTime()) .
-								',' . $this->db->escapeNumber($this->getAttackStarted()) .
-								',' . $this->db->escapeNumber($this->getRaceID()) . ')');
+				$this->db->insert('port', [
+					'game_id' => $this->db->escapeNumber($this->getGameID()),
+					'sector_id' => $this->db->escapeNumber($this->getSectorID()),
+					'experience' => $this->db->escapeNumber($this->getExperience()),
+					'shields' => $this->db->escapeNumber($this->getShields()),
+					'armour' => $this->db->escapeNumber($this->getArmour()),
+					'combat_drones' => $this->db->escapeNumber($this->getCDs()),
+					'level' => $this->db->escapeNumber($this->getLevel()),
+					'credits' => $this->db->escapeNumber($this->getCredits()),
+					'upgrade' => $this->db->escapeNumber($this->getUpgrade()),
+					'reinforce_time' => $this->db->escapeNumber($this->getReinforceTime()),
+					'attack_started' => $this->db->escapeNumber($this->getAttackStarted()),
+					'race_id' => $this->db->escapeNumber($this->getRaceID()),
+				]);
 				$this->isNew = false;
 			}
 			$this->hasChanged = false;
@@ -1365,7 +1372,15 @@ class AbstractSmrPort {
 		} else {
 			$news .= $killer->getBBLink();
 		}
-		$this->db->write('INSERT INTO news (game_id, time, news_message, type,killer_id,killer_alliance,dead_id) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ', ' . $this->db->escapeString($news) . ', \'REGULAR\',' . $this->db->escapeNumber($killer->getAccountID()) . ',' . $this->db->escapeNumber($killer->getAllianceID()) . ',' . $this->db->escapeNumber(ACCOUNT_ID_PORT) . ')');
+		$this->db->insert('news', [
+			'game_id' => $this->db->escapeNumber($this->getGameID()),
+			'time' => $this->db->escapeNumber(Smr\Epoch::time()),
+			'news_message' => $this->db->escapeString($news),
+			'killer_id' => $this->db->escapeNumber($killer->getAccountID()),
+			'killer_alliance' => $this->db->escapeNumber($killer->getAllianceID()),
+			'dead_id' => $this->db->escapeNumber(ACCOUNT_ID_PORT),
+		]);
+
 		// Killer gets a relations change and a bounty if port is taken
 		$return['KillerBounty'] = $killer->getExperience() * $this->getLevel();
 		$killer->increaseCurrentBountyAmount('HQ', $return['KillerBounty']);

--- a/src/lib/Default/SmrAlliance.class.php
+++ b/src/lib/Default/SmrAlliance.class.php
@@ -125,7 +125,13 @@ class SmrAlliance {
 		$allianceID = $dbResult->record()->getInt('max(alliance_id)') + 1;
 
 		// actually create the alliance here
-		$db->write('INSERT INTO alliance (alliance_id, game_id, alliance_name, alliance_password, recruiting) VALUES(' . $db->escapeNumber($allianceID) . ', ' . $db->escapeNumber($gameID) . ', ' . $db->escapeString($name) . ', \'\', \'FALSE\')');
+		$db->insert('alliance', [
+			'alliance_id' => $db->escapeNumber($allianceID),
+			'game_id' => $db->escapeNumber($gameID),
+			'alliance_name' => $db->escapeString($name),
+			'alliance_password' => $db->escapeString(''),
+			'recruiting' => $db->escapeBoolean(false),
+		]);
 		$db->unlock();
 
 		return self::getAlliance($allianceID, $gameID);
@@ -560,6 +566,7 @@ class SmrAlliance {
 	public function createDefaultRoles(string $newMemberPermission = 'basic') : void {
 		$db = $this->db; //for convenience
 
+		// Create leader role
 		$withPerDay = ALLIANCE_BANK_UNLIMITED;
 		$removeMember = TRUE;
 		$changePass = TRUE;
@@ -571,9 +578,25 @@ class SmrAlliance {
 		$sendAllMsg = TRUE;
 		$opLeader = TRUE;
 		$viewBonds = TRUE;
-		$db->write('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
-			'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ', \'Leader\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
+		$db->insert('alliance_has_roles', [
+			'alliance_id' => $db->escapeNumber($this->getAllianceID()),
+			'game_id' => $db->escapeNumber($this->getGameID()),
+			'role_id' => $db->escapeNumber(ALLIANCE_ROLE_LEADER),
+			'role' => $db->escapeString('Leader'),
+			'with_per_day' => $db->escapeNumber($withPerDay),
+			'remove_member' => $db->escapeBoolean($removeMember),
+			'change_pass' => $db->escapeBoolean($changePass),
+			'change_mod' => $db->escapeBoolean($changeMOD),
+			'change_roles' => $db->escapeBoolean($changeRoles),
+			'planet_access' => $db->escapeBoolean($planetAccess),
+			'exempt_with' => $db->escapeBoolean($exemptWith),
+			'mb_messages' => $db->escapeBoolean($mbMessages),
+			'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
+			'op_leader' => $db->escapeBoolean($opLeader),
+			'view_bonds' => $db->escapeBoolean($viewBonds),
+		]);
 
+		// Create new member role
 		switch ($newMemberPermission) {
 			case 'full':
 				//do nothing, perms already set above.
@@ -605,9 +628,23 @@ class SmrAlliance {
 				$viewBonds = FALSE;
 			break;
 		}
-		$db->write('INSERT INTO alliance_has_roles (alliance_id, game_id, role_id, role, with_per_day, remove_member, change_pass, change_mod, change_roles, planet_access, exempt_with, mb_messages, send_alliance_msg, op_leader, view_bonds) ' .
-					'VALUES (' . $db->escapeNumber($this->getAllianceID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ', \'New Member\', ' . $db->escapeNumber($withPerDay) . ', ' . $db->escapeBoolean($removeMember) . ', ' . $db->escapeBoolean($changePass) . ', ' . $db->escapeBoolean($changeMOD) . ', ' . $db->escapeBoolean($changeRoles) . ', ' . $db->escapeBoolean($planetAccess) . ', ' . $db->escapeBoolean($exemptWith) . ', ' . $db->escapeBoolean($mbMessages) . ', ' . $db->escapeBoolean($sendAllMsg) . ', ' . $db->escapeBoolean($opLeader) . ', ' . $db->escapeBoolean($viewBonds) . ')');
-
+		$db->insert('alliance_has_roles', [
+			'alliance_id' => $db->escapeNumber($this->getAllianceID()),
+			'game_id' => $db->escapeNumber($this->getGameID()),
+			'role_id' => $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER),
+			'role' => $db->escapeString('New Member'),
+			'with_per_day' => $db->escapeNumber($withPerDay),
+			'remove_member' => $db->escapeBoolean($removeMember),
+			'change_pass' => $db->escapeBoolean($changePass),
+			'change_mod' => $db->escapeBoolean($changeMOD),
+			'change_roles' => $db->escapeBoolean($changeRoles),
+			'planet_access' => $db->escapeBoolean($planetAccess),
+			'exempt_with' => $db->escapeBoolean($exemptWith),
+			'mb_messages' => $db->escapeBoolean($mbMessages),
+			'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
+			'op_leader' => $db->escapeBoolean($opLeader),
+			'view_bonds' => $db->escapeBoolean($viewBonds),
+		]);
 	}
 
 }

--- a/src/lib/Default/SmrEnhancedWeaponEvent.class.php
+++ b/src/lib/Default/SmrEnhancedWeaponEvent.class.php
@@ -84,7 +84,15 @@ class SmrEnhancedWeaponEvent {
 			$bonusDamage = true;
 		}
 
-		$db->write('INSERT INTO location_sells_special (game_id, sector_id, location_type_id, weapon_type_id, expires, bonus_accuracy, bonus_damage) VALUES (' . $db->escapeNumber($gameID) . ',' . $db->escapeNumber($sectorID) . ',' . $db->escapeNumber($locationTypeID) . ',' . $db->escapeNumber($weaponTypeID) . ',' . $db->escapeNumber($expires) . ',' . $db->escapeBoolean($bonusAccuracy) . ',' . $db->escapeBoolean($bonusDamage) . ')');
+		$db->insert('location_sells_special', [
+			'game_id' => $db->escapeNumber($gameID),
+			'sector_id' => $db->escapeNumber($sectorID),
+			'location_type_id' => $db->escapeNumber($locationTypeID),
+			'weapon_type_id' => $db->escapeNumber($weaponTypeID),
+			'expires' => $db->escapeNumber($expires),
+			'bonus_accuracy' => $db->escapeBoolean($bonusAccuracy),
+			'bonus_damage' => $db->escapeBoolean($bonusDamage),
+		]);
 
 		return new SmrEnhancedWeaponEvent($gameID, $weaponTypeID, $locationTypeID, $sectorID, $expires, $bonusAccuracy, $bonusDamage);
 	}

--- a/src/lib/Default/SmrForce.class.php
+++ b/src/lib/Default/SmrForce.class.php
@@ -359,8 +359,15 @@ class SmrForce {
 				$this->db->write('UPDATE sector_has_forces SET combat_drones = ' . $this->db->escapeNumber($this->combatDrones) . ', scout_drones = ' . $this->db->escapeNumber($this->scoutDrones) . ', mines = ' . $this->db->escapeNumber($this->mines) . ', expire_time = ' . $this->db->escapeNumber($this->expire) . ' WHERE ' . $this->SQL);
 			}
 		} elseif ($this->exists()) {
-			$this->db->write('INSERT INTO sector_has_forces (game_id, sector_id, owner_id, combat_drones, scout_drones, mines, expire_time)
-								VALUES('.$this->db->escapeNumber($this->gameID) . ', ' . $this->db->escapeNumber($this->sectorID) . ', ' . $this->db->escapeNumber($this->ownerID) . ', ' . $this->db->escapeNumber($this->combatDrones) . ', ' . $this->db->escapeNumber($this->scoutDrones) . ', ' . $this->db->escapeNumber($this->mines) . ', ' . $this->db->escapeNumber($this->expire) . ')');
+			$this->db->insert('sector_has_forces', [
+				'game_id' => $this->db->escapeNumber($this->gameID),
+				'sector_id' => $this->db->escapeNumber($this->sectorID),
+				'owner_id' => $this->db->escapeNumber($this->ownerID),
+				'combat_drones' => $this->db->escapeNumber($this->combatDrones),
+				'scout_drones' => $this->db->escapeNumber($this->scoutDrones),
+				'mines' => $this->db->escapeNumber($this->mines),
+				'expire_time' => $this->db->escapeNumber($this->expire),
+			]);
 			$this->isNew = false;
 		}
 		// This instance is now in sync with the database

--- a/src/lib/Default/SmrGalaxy.class.php
+++ b/src/lib/Default/SmrGalaxy.class.php
@@ -87,17 +87,17 @@ class SmrGalaxy {
 
 	public function save() : void {
 		if ($this->isNew) {
-				$this->db->write('INSERT INTO game_galaxy (game_id,galaxy_id,galaxy_name,width,height,galaxy_type,max_force_time)
-									values
-									(' . $this->db->escapeNumber($this->getGameID()) .
-									',' . $this->db->escapeNumber($this->getGalaxyID()) .
-									',' . $this->db->escapeString($this->getName()) .
-									',' . $this->db->escapeNumber($this->getWidth()) .
-									',' . $this->db->escapeNumber($this->getHeight()) .
-									',' . $this->db->escapeString($this->getGalaxyType()) .
-									',' . $this->db->escapeNumber($this->getMaxForceTime()) . ')');
+			$this->db->insert('game_galaxy', [
+				'game_id' => $this->db->escapeNumber($this->getGameID()),
+				'galaxy_id' => $this->db->escapeNumber($this->getGalaxyID()),
+				'galaxy_name' => $this->db->escapeString($this->getName()),
+				'width' => $this->db->escapeNumber($this->getWidth()),
+				'height' => $this->db->escapeNumber($this->getHeight()),
+				'galaxy_type' => $this->db->escapeString($this->getGalaxyType()),
+				'max_force_time' => $this->db->escapeNumber($this->getMaxForceTime()),
+			]);
 		} elseif ($this->hasChanged) {
-				$this->db->write('UPDATE game_galaxy SET galaxy_name = ' . $this->db->escapeString($this->getName()) .
+			$this->db->write('UPDATE game_galaxy SET galaxy_name = ' . $this->db->escapeString($this->getName()) .
 										', width = ' . $this->db->escapeNumber($this->getWidth()) .
 										', height = ' . $this->db->escapeNumber($this->getHeight()) .
 										', galaxy_type = ' . $this->db->escapeString($this->getGalaxyType()) .

--- a/src/lib/Default/SmrGame.class.php
+++ b/src/lib/Default/SmrGame.class.php
@@ -114,25 +114,25 @@ class SmrGame {
 
 	public function save() : void {
 		if ($this->isNew) {
-			$this->db->write('INSERT INTO game (game_id,game_name,game_description,join_time,start_time,end_time,max_players,max_turns,start_turns,game_type,credits_needed,game_speed,enabled,ignore_stats,alliance_max_players,alliance_max_vets,starting_credits)
-									VALUES
-									(' . $this->db->escapeNumber($this->getGameID()) .
-										',' . $this->db->escapeString($this->getName()) .
-										',' . $this->db->escapeString($this->getDescription()) .
-										',' . $this->db->escapeNumber($this->getJoinTime()) .
-										',' . $this->db->escapeNumber($this->getStartTime()) .
-										',' . $this->db->escapeNumber($this->getEndTime()) .
-										',' . $this->db->escapeNumber($this->getMaxPlayers()) .
-										',' . $this->db->escapeNumber($this->getMaxTurns()) .
-										',' . $this->db->escapeNumber($this->getStartTurnHours()) .
-										',' . $this->db->escapeNumber($this->gameTypeID) .
-										',' . $this->db->escapeNumber($this->getCreditsNeeded()) .
-										',' . $this->db->escapeNumber($this->getGameSpeed()) .
-										',' . $this->db->escapeBoolean($this->isEnabled()) .
-										',' . $this->db->escapeBoolean($this->isIgnoreStats()) .
-										',' . $this->db->escapeNumber($this->getAllianceMaxPlayers()) .
-										',' . $this->db->escapeNumber($this->getAllianceMaxVets()) .
-										',' . $this->db->escapeNumber($this->getStartingCredits()) . ')');
+			$this->db->insert('game', [
+				'game_id' => $this->db->escapeNumber($this->getGameID()),
+				'game_name' => $this->db->escapeString($this->getName()),
+				'game_description' => $this->db->escapeString($this->getDescription()),
+				'join_time' => $this->db->escapeNumber($this->getJoinTime()),
+				'start_time' => $this->db->escapeNumber($this->getStartTime()),
+				'end_time' => $this->db->escapeNumber($this->getEndTime()),
+				'max_players' => $this->db->escapeNumber($this->getMaxPlayers()),
+				'max_turns' => $this->db->escapeNumber($this->getMaxTurns()),
+				'start_turns' => $this->db->escapeNumber($this->getStartTurnHours()),
+				'game_type' => $this->db->escapeNumber($this->gameTypeID),
+				'credits_needed' => $this->db->escapeNumber($this->getCreditsNeeded()),
+				'game_speed' => $this->db->escapeNumber($this->getGameSpeed()),
+				'enabled' => $this->db->escapeBoolean($this->isEnabled()),
+				'ignore_stats' => $this->db->escapeBoolean($this->isIgnoreStats()),
+				'alliance_max_players' => $this->db->escapeNumber($this->getAllianceMaxPlayers()),
+				'alliance_max_vets' => $this->db->escapeNumber($this->getAllianceMaxVets()),
+				'starting_credits' => $this->db->escapeNumber($this->getStartingCredits()),
+			]);
 		} elseif ($this->hasChanged) {
 			$this->db->write('UPDATE game SET game_name = ' . $this->db->escapeString($this->getName()) .
 										', game_description = ' . $this->db->escapeString($this->getDescription()) .

--- a/src/lib/Default/SmrInvitation.class.php
+++ b/src/lib/Default/SmrInvitation.class.php
@@ -14,7 +14,14 @@ class SmrInvitation {
 
 	static public function send(int $allianceID, int $gameID, int $receiverAccountID, int $senderAccountID, int $messageID, int $expires) : void {
 		$db = Smr\Database::getInstance();
-		$db->write('INSERT INTO alliance_invites_player (game_id, account_id, alliance_id, invited_by_id, expires, message_id) VALUES(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber($receiverAccountID) . ', ' . $db->escapeNumber($allianceID) . ', ' . $db->escapeNumber($senderAccountID) . ', ' . $db->escapeNumber($expires) . ', ' . $db->escapeNumber($messageID) . ')');
+		$db->insert('alliance_invites_player', [
+			'game_id' => $db->escapeNumber($gameID),
+			'account_id' => $db->escapeNumber($receiverAccountID),
+			'alliance_id' => $db->escapeNumber($allianceID),
+			'invited_by_id' => $db->escapeNumber($senderAccountID),
+			'expires' => $db->escapeNumber($expires),
+			'message_id' => $db->escapeNumber($messageID),
+		]);
 	}
 
 	/**

--- a/src/lib/Default/SmrPlanet.class.php
+++ b/src/lib/Default/SmrPlanet.class.php
@@ -90,8 +90,12 @@ class SmrPlanet {
 
 		// insert planet into db
 		$db = Smr\Database::getInstance();
-		$db->write('INSERT INTO planet (game_id, sector_id, inhabitable_time, planet_type_id)
-				VALUES (' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber($sectorID) . ', ' . $db->escapeNumber($inhabitableTime) . ', ' . $db->escapeNumber($typeID) . ')');
+		$db->insert('planet', [
+			'game_id' => $db->escapeNumber($gameID),
+			'sector_id' => $db->escapeNumber($sectorID),
+			'inhabitable_time' => $db->escapeNumber($inhabitableTime),
+			'planet_type_id' => $db->escapeNumber($typeID),
+		]);
 		return self::getPlanet($gameID, $sectorID, true);
 	}
 
@@ -933,11 +937,16 @@ class SmrPlanet {
 
 		// gets the time for the buildings
 		$timeComplete = Smr\Epoch::time() + $this->getConstructionTime($constructionID);
-		$this->db->write('INSERT INTO planet_is_building (game_id, sector_id, construction_id, constructor_id, time_complete) ' .
-						'VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber($this->getSectorID()) . ', ' . $this->db->escapeNumber($constructionID) . ', ' . $this->db->escapeNumber($constructor->getAccountID()) . ',' . $this->db->escapeNumber($timeComplete) . ')');
+		$insertID = $this->db->insert('planet_is_building', [
+			'game_id' => $this->db->escapeNumber($this->getGameID()),
+			'sector_id' => $this->db->escapeNumber($this->getSectorID()),
+			'construction_id' => $this->db->escapeNumber($constructionID),
+			'constructor_id' => $this->db->escapeNumber($constructor->getAccountID()),
+			'time_complete' => $this->db->escapeNumber($timeComplete),
+		]);
 
-		$this->currentlyBuilding[$this->db->getInsertID()] = array(
-			'BuildingSlotID' => $this->db->getInsertID(),
+		$this->currentlyBuilding[$insertID] = array(
+			'BuildingSlotID' => $insertID,
 			'ConstructionID' => $constructionID,
 			'ConstructorID' => $constructor->getAccountID(),
 			'Finishes' => $timeComplete,
@@ -1056,7 +1065,16 @@ class SmrPlanet {
 					$text .= ', a member of ' . $owner->getAllianceBBLink();
 				}
 				$text .= '.';
-				$this->db->write('INSERT INTO news (game_id, time, news_message, type,killer_id,killer_alliance,dead_id,dead_alliance) VALUES (' . $this->db->escapeNumber($this->getGameID()) . ', ' . $this->db->escapeNumber(Smr\Epoch::time()) . ', ' . $this->db->escapeString($text) . ', \'BREAKING\',' . $this->db->escapeNumber($trigger->getAccountID()) . ',' . $this->db->escapeNumber($trigger->getAllianceID()) . ',' . $this->db->escapeNumber($owner->getAccountID()) . ',' . $this->db->escapeNumber($owner->getAllianceID()) . ')');
+				$this->db->insert('news', [
+					'game_id' => $this->db->escapeNumber($this->getGameID()),
+					'time' => $this->db->escapeNumber(Smr\Epoch::time()),
+					'news_message' => $this->db->escapeString($text),
+					'type' => $this->db->escapeString('breaking'),
+					'killer_id' => $this->db->escapeNumber($trigger->getAccountID()),
+					'killer_alliance' => $this->db->escapeNumber($trigger->getAllianceID()),
+					'dead_id' => $this->db->escapeNumber($owner->getAccountID()),
+					'dead_alliance' => $this->db->escapeNumber($owner->getAllianceID()),
+				]);
 			}
 		}
 	}

--- a/src/lib/Default/SmrSector.class.php
+++ b/src/lib/Default/SmrSector.class.php
@@ -137,17 +137,16 @@ class SmrSector {
 
 	public function update() : void {
 		if ($this->isNew) {
-			$this->db->write('INSERT INTO sector(sector_id,game_id,galaxy_id,link_up,link_down,link_left,link_right,warp)
-								values
-								(' . $this->db->escapeNumber($this->getSectorID()) .
-								',' . $this->db->escapeNumber($this->getGameID()) .
-								',' . $this->db->escapeNumber($this->getGalaxyID()) .
-								',' . $this->db->escapeNumber($this->getLinkUp()) .
-								',' . $this->db->escapeNumber($this->getLinkDown()) .
-								',' . $this->db->escapeNumber($this->getLinkLeft()) .
-								',' . $this->db->escapeNumber($this->getLinkRight()) .
-								',' . $this->db->escapeNumber($this->getWarp()) .
-								')');
+			$this->db->insert('sector', [
+				'sector_id' => $this->db->escapeNumber($this->getSectorID()),
+				'game_id' => $this->db->escapeNumber($this->getGameID()),
+				'galaxy_id' => $this->db->escapeNumber($this->getGalaxyID()),
+				'link_up' => $this->db->escapeNumber($this->getLinkUp()),
+				'link_down' => $this->db->escapeNumber($this->getLinkDown()),
+				'link_left' => $this->db->escapeNumber($this->getLinkLeft()),
+				'link_right' => $this->db->escapeNumber($this->getLinkRight()),
+				'warp' => $this->db->escapeNumber($this->getWarp()),
+			]);
 		} elseif ($this->hasChanged) {
 			$this->db->write('UPDATE sector SET battles = ' . $this->db->escapeNumber($this->getBattles()) .
 									', galaxy_id=' . $this->db->escapeNumber($this->getGalaxyID()) .

--- a/src/lib/Default/SmrShip.class.php
+++ b/src/lib/Default/SmrShip.class.php
@@ -151,8 +151,14 @@ class SmrShip extends AbstractSmrShip {
 		$db = Smr\Database::getInstance();
 		$db->write('DELETE FROM ship_has_weapon WHERE ' . $this->SQL);
 		foreach ($this->weapons as $orderID => $weapon) {
-			$db->write('INSERT INTO ship_has_weapon (account_id, game_id, order_id, weapon_type_id, bonus_accuracy, bonus_damage)
-							VALUES(' . $db->escapeNumber($this->getAccountID()) . ', ' . $db->escapeNumber($this->getGameID()) . ', ' . $db->escapeNumber($orderID) . ', ' . $db->escapeNumber($weapon->getWeaponTypeID()) . ', ' . $db->escapeBoolean($weapon->hasBonusAccuracy()) . ', ' . $db->escapeBoolean($weapon->hasBonusDamage()) . ')');
+			$db->insert('ship_has_weapon', [
+				'account_id' => $db->escapeNumber($this->getAccountID()),
+				'game_id' => $db->escapeNumber($this->getGameID()),
+				'order_id' => $db->escapeNumber($orderID),
+				'weapon_type_id' => $db->escapeNumber($weapon->getWeaponTypeID()),
+				'bonus_accuracy' => $db->escapeBoolean($weapon->hasBonusAccuracy()),
+				'bonus_damage' => $db->escapeBoolean($weapon->hasBonusDamage()),
+			]);
 		}
 		$this->hasChangedWeapons = false;
 	}
@@ -175,7 +181,10 @@ class SmrShip extends AbstractSmrShip {
 		if ($this->isCloaked === false) {
 			$db->write('DELETE FROM ship_is_cloaked WHERE ' . $this->SQL . ' LIMIT 1');
 		} else {
-			$db->write('INSERT INTO ship_is_cloaked VALUES(' . $db->escapeNumber($this->getAccountID()) . ', ' . $db->escapeNumber($this->getGameID()) . ')');
+			$db->insert('ship_is_cloaked', [
+				'account_id' => $db->escapeNumber($this->getAccountID()),
+				'game_id' => $db->escapeNumber($this->getGameID()),
+			]);
 		}
 		$this->hasChangedCloak = false;
 	}

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -327,7 +327,12 @@ function do_voodoo() : never {
 				$session->fetchVarInfo();
 				if ($session->hasCurrentVar() === false) {
 					if (ENABLE_DEBUG) {
-						$db->write('INSERT INTO debug VALUES (\'SPAM\',' . $db->escapeNumber($account->getAccountID()) . ',0,0)');
+						$db->insert('debug', [
+							'debug_type' => $db->escapeString('SPAM'),
+							'account_id' => $db->escapeNumber($account->getAccountID()),
+							'value' => 0,
+							'value_2' => 0,
+						]);
 					}
 					throw new Smr\Exceptions\UserError('Please do not spam click!');
 				}
@@ -426,8 +431,12 @@ function acquire_lock(int $sector) : bool {
 	// Insert ourselves into the queue.
 	$session = Smr\Session::getInstance();
 	$db = Smr\Database::getInstance();
-	$db->write('INSERT INTO locks_queue (game_id,account_id,sector_id,timestamp) VALUES(' . $db->escapeNumber($session->getGameID()) . ',' . $db->escapeNumber($session->getAccountID()) . ',' . $db->escapeNumber($sector) . ',' . $db->escapeNumber(Smr\Epoch::time()) . ')');
-	$lock = $db->getInsertID();
+	$lock = $db->insert('locks_queue', [
+		'game_id' => $db->escapeNumber($session->getGameID()),
+		'account_id' => $db->escapeNumber($session->getAccountID()),
+		'sector_id' => $db->escapeNumber($sector),
+		'timestamp' => $db->escapeNumber(Smr\Epoch::time()),
+	]);
 
 	for ($i = 0; $i < 250; ++$i) {
 		if (time() - Smr\Epoch::time() >= LOCK_DURATION - LOCK_BUFFER) {

--- a/src/lib/Smr/CouncilVoting.php
+++ b/src/lib/Smr/CouncilVoting.php
@@ -142,8 +142,11 @@ class CouncilVoting {
 
 					// get news message
 					$news = 'The [race=' . $race_id_1 . '] have declared <span class="red">WAR</span> on the [race=' . $race_id_2 . ']';
-					$db->write('INSERT INTO news (game_id, time, news_message) VALUES ' .
-							'(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(Epoch::time()) . ', ' . $db->escapeString($news) . ')');
+					$db->insert('news', [
+						'game_id' => $db->escapeNumber($gameID),
+						'time' => $db->escapeNumber(Epoch::time()),
+						'news_message' => $db->escapeString($news),
+					]);
 				} elseif ($type == 'PEACE') {
 					// get 'yes' votes
 					$dbResult2 = $db->read('SELECT 1 FROM player_votes_pact
@@ -176,8 +179,11 @@ class CouncilVoting {
 
 						//get news message
 						$news = 'The [race=' . $race_id_1 . '] have signed a <span class="dgreen">PEACE</span> treaty with the [race=' . $race_id_2 . ']';
-						$db->write('INSERT INTO news (game_id, time, news_message) VALUES
-								(' . $db->escapeNumber($gameID) . ', ' . $db->escapeNumber(Epoch::time()) . ', ' . $db->escapeString($news) . ')');
+						$db->insert('news', [
+							'game_id' => $db->escapeNumber($gameID),
+							'time' => $db->escapeNumber(Epoch::time()),
+							'news_message' => $db->escapeString($news),
+						]);
 					}
 				}
 			}

--- a/src/lib/Smr/Database.php
+++ b/src/lib/Smr/Database.php
@@ -139,6 +139,19 @@ class Database {
 		return new DatabaseResult($this->dbConn->query($query));
 	}
 
+	/**
+	 * INSERT a row into $table.
+	 *
+	 * @param array<string, mixed> $fields
+	 * @return int Insert ID of auto-incrementing column, if applicable
+	 */
+	public function insert(string $table, array $fields) : int {
+		$query = 'INSERT INTO ' . $table . ' (' . join(', ', array_keys($fields))
+			. ') VALUES (' . join(', ', array_values($fields)) . ')';
+		$this->write($query);
+		return $this->getInsertID();
+	}
+
 	public function lockTable(string $table) : void {
 		$this->write('LOCK TABLES ' . $table . ' WRITE');
 	}

--- a/src/lib/Smr/Lotto.php
+++ b/src/lib/Smr/Lotto.php
@@ -40,9 +40,12 @@ class Lotto {
 
 		// Delete all tickets and re-insert the winning ticket
 		$db->write('DELETE FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($gameID));
-		$db->write('INSERT INTO player_has_ticket (game_id, account_id, time, prize) '
-		           .'VALUES (' . $db->escapeNumber($gameID) . ',' . $db->escapeNumber($winner_id) . ',\'0\',' . $db->escapeNumber($lottoInfo['Prize']) . ')');
-
+		$db->insert('player_has_ticket', [
+			'game_id' => $db->escapeNumber($gameID),
+			'account_id' => $db->escapeNumber($winner_id),
+			'time' => 0,
+			'prize' => $db->escapeNumber($lottoInfo['Prize']),
+		]);
 		$db->unlock();
 
 		// create news msg
@@ -52,9 +55,14 @@ class Lotto {
 		$news_message = $winner->getBBLink() . ' has won the lotto! The jackpot was ' . number_format($lottoInfo['Prize']) . '. ' . $winner->getBBLink() . ' can report to any bar to claim their prize before the next drawing!';
 		// insert the news entry
 		$db->write('DELETE FROM news WHERE type = \'lotto\' AND game_id = ' . $db->escapeNumber($gameID));
-		$db->write('INSERT INTO news
-				(game_id, time, news_message, type, dead_id, dead_alliance)
-				VALUES ('.$db->escapeNumber($gameID) . ', ' . $db->escapeNumber(Epoch::time()) . ', ' . $db->escapeString($news_message) . ',\'lotto\',' . $db->escapeNumber($winner->getAccountID()) . ',' . $db->escapeNumber($winner->getAllianceID()) . ')');
+		$db->insert('news', [
+			'game_id' => $db->escapeNumber($gameID),
+			'time' => $db->escapeNumber(Epoch::time()),
+			'news_message' => $db->escapeString($news_message),
+			'type' => $db->escapeString('lotto'),
+			'dead_id' => $db->escapeNumber($winner->getAccountID()),
+			'dead_alliance' => $db->escapeNumber($winner->getAllianceID()),
+		]);
 	}
 
 	public static function getLottoInfo(int $gameID) : array {

--- a/src/lib/Smr/Session.php
+++ b/src/lib/Smr/Session.php
@@ -97,7 +97,12 @@ class Session {
 				usleep($sleepTime);
 			}
 			if (ENABLE_DEBUG) {
-				$this->db->write('INSERT INTO debug VALUES (' . $this->db->escapeString('Delay: ' . $currentPage) . ',' . $this->db->escapeNumber($this->accountID) . ',' . $this->db->escapeNumber($initialTimeBetweenLoads) . ',' . $this->db->escapeNumber($timeBetweenLoads) . ')');
+				$this->db->insert('debug', [
+					'debug_type' => $this->db->escapeString('Delay: ' . $currentPage),
+					'account_id' => $this->db->escapeNumber($this->accountID),
+					'value' => $this->db->escapeNumber($initialTimeBetweenLoads),
+					'value_2' => $this->db->escapeNumber($timeBetweenLoads),
+				]);
 			}
 		}
 	}
@@ -159,7 +164,13 @@ class Session {
 					' WHERE session_id=' . $this->db->escapeString($this->sessionID) . (USING_AJAX ? ' AND last_sn=' . $this->db->escapeString($this->lastSN) : '') . ' LIMIT 1');
 		} else {
 			$this->db->write('DELETE FROM active_session WHERE account_id = ' . $this->db->escapeNumber($this->accountID) . ' AND game_id = ' . $this->db->escapeNumber($this->gameID));
-			$this->db->write('INSERT INTO active_session (session_id, account_id, game_id, last_accessed, session_var) VALUES(' . $this->db->escapeString($this->sessionID) . ',' . $this->db->escapeNumber($this->accountID) . ',' . $this->db->escapeNumber($this->gameID) . ',' . $this->db->escapeNumber(Epoch::time()) . ',' . $this->db->escapeObject($this->var, true) . ')');
+			$this->db->insert('active_session', [
+				'session_id' => $this->db->escapeString($this->sessionID),
+				'account_id' => $this->db->escapeNumber($this->accountID),
+				'game_id' => $this->db->escapeNumber($this->gameID),
+				'last_accessed' => $this->db->escapeNumber(Epoch::time()),
+				'session_var' => $this->db->escapeObject($this->var, true),
+			]);
 			$this->generate = false;
 		}
 	}

--- a/src/tools/chat_helpers/channel_msg_seedlist.php
+++ b/src/tools/chat_helpers/channel_msg_seedlist.php
@@ -70,9 +70,11 @@ function shared_channel_msg_seedlist_add(SmrPlayer $player, ?array $sectors) : a
 		}
 
 		// add sector to db (and the current seedlist)
-		$db->write('INSERT INTO alliance_has_seedlist
-					(alliance_id, game_id, sector_id)
-					VALUES (' . $db->escapeNumber($player->getAllianceID()) . ', ' . $db->escapeNumber($player->getGameID()) . ', ' . $db->escapeNumber($sector) . ')');
+		$db->insert('alliance_has_seedlist', [
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'sector_id' => $db->escapeNumber($sector),
+		]);
 		$currentSeedlist[] = $sector;
 	}
 

--- a/src/tools/irc/channel.php
+++ b/src/tools/irc/channel.php
@@ -46,7 +46,13 @@ function channel_join($fp, string $rdata) : bool
 
 		} else {
 			// new nick?
-			$db->write('INSERT INTO irc_seen (nick, user, host, channel, signed_on) VALUES(' . $db->escapeString($nick) . ', ' . $db->escapeString($user) . ', ' . $db->escapeString($host) . ', ' . $db->escapeString($channel) . ', ' . time() . ')');
+			$db->insert('irc_seen', [
+				'nick' => $db->escapeString($nick),
+				'user' => $db->escapeString($user),
+				'host' => $db->escapeString($host),
+				'channel' => $db->escapeString($channel),
+				'signed_on' => $db->escapeNumber(time()),
+			]);
 
 			if ($nick != IRC_BOT_NICK) {
 				fputs($fp, 'PRIVMSG ' . $channel . ' :Welcome, ' . $nick . '! Most players are using Discord (' . DISCORD_URL . ') instead of IRC, but the two platforms are linked by discordbot. Anything you say here will be relayed to the Discord channel and vice versa.' . EOL);

--- a/src/tools/irc/channel_msg_op.php
+++ b/src/tools/irc/channel_msg_op.php
@@ -141,8 +141,11 @@ function channel_msg_op_set($fp, string $rdata, AbstractSmrPlayer $player) : boo
 		}
 
 		// add op to db
-		$db->write('INSERT INTO alliance_has_op (alliance_id, game_id, time)
-					VALUES (' . $player->getAllianceID() . ', ' . $player->getGameID() . ', ' . $db->escapeNumber($op_time) . ')');
+		$db->insert('alliance_has_op', [
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'time' => $db->escapeNumber($op_time),
+		]);
 
 		fputs($fp, 'PRIVMSG ' . $channel . ' :The OP has been scheduled.' . EOL);
 		return true;

--- a/src/tools/irc/server.php
+++ b/src/tools/irc/server.php
@@ -157,8 +157,13 @@ function server_msg_352($fp, string $rdata) : bool
 
 		} else {
 			// new nick?
-			$db->write('INSERT INTO irc_seen (nick, user, host, channel, signed_on) ' .
-					   'VALUES(' . $db->escapeString($nick) . ', ' . $db->escapeString($user) . ', ' . $db->escapeString($host) . ', ' . $db->escapeString($channel) . ', ' . time() . ')');
+			$db->insert('irc_seen', [
+				'nick' => $db->escapeString($nick),
+				'user' => $db->escapeString($user),
+				'host' => $db->escapeString($host),
+				'channel' => $db->escapeString($channel),
+				'signed_on' => $db->escapeNumber(time()),
+			]);
 		}
 
 		return true;

--- a/src/tools/irc/user.php
+++ b/src/tools/irc/user.php
@@ -88,7 +88,13 @@ function user_nick(string $rdata) : bool
 
 			} else {
 				// new nick?
-				$db->write('INSERT INTO irc_seen (nick, user, host, channel, signed_on) VALUES(' . $db->escapeString($new_nick) . ', ' . $db->escapeString($user) . ', ' . $db->escapeString($host) . ', ' . $db->escapeString($channel) . ', ' . time() . ')');
+				$db->insert('irc_seen', [
+					'nick' => $db->escapeString($new_nick),
+					'user' => $db->escapeString($user),
+					'host' => $db->escapeString($host),
+					'channel' => $db->escapeString($channel),
+					'signed_on' => $db->escapeNumber(time()),
+				]);
 			}
 
 		}

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -6,12 +6,7 @@ try {
 	// bot config
 	require_once(CONFIG . 'npc/config.specific.php');
 
-	$db = Smr\Database::getInstance();
-
 	debug('Script started');
-	define('SCRIPT_ID', $db->getInsertID());
-	$db->write('UPDATE npc_logs SET script_id=' . SCRIPT_ID . ' WHERE log_id=' . SCRIPT_ID);
-
 	define('NPC_SCRIPT', true);
 
 	$descriptorSpec = array(
@@ -84,5 +79,18 @@ try {
 function debug($message, $debugObject = null) {
 	echo date('Y-m-d H:i:s - ') . $message . ($debugObject !== null ? EOL . var_export($debugObject, true) : '') . EOL;
 	$db = Smr\Database::getInstance();
-	$db->write('INSERT INTO npc_logs (script_id, npc_id, time, message, debug_info, var) VALUES (' . (defined('SCRIPT_ID') ? SCRIPT_ID : 0) . ', 0, NOW(),' . $db->escapeString($message) . ',' . $db->escapeString(var_export($debugObject, true)) . ',' . $db->escapeString('') . ')');
+	$logID = $db->insert('npc_logs', [
+		'script_id' => defined('SCRIPT_ID') ? SCRIPT_ID : 0,
+		'npc_id' => 0,
+		'time' => 'NOW()',
+		'message' => $db->escapeString($message),
+		'debug_info' => $db->escapeString(var_export($debugObject, true)),
+		'var' => $db->escapeString(''),
+	]);
+
+	// On the first call to debug, we need to update the script_id retroactively
+	if (!defined('SCRIPT_ID')) {
+		define('SCRIPT_ID', $logID);
+		$db->write('UPDATE npc_logs SET script_id=' . SCRIPT_ID . ' WHERE log_id=' . SCRIPT_ID);
+	}
 }

--- a/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
@@ -248,7 +248,7 @@ class DatabaseIntegrationTest extends TestCase {
 		self::assertSame(0, $db->insert('debug', []));
 
 		// Non-zero insert ID when table has an auto-increment column
-		for ($i = 1; $i <=3; $i++) {
+		for ($i = 1; $i <= 3; $i++) {
 			self::assertSame($i, $db->insert('newsletter', []));
 		}
 

--- a/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/DatabaseIntegrationTest.php
@@ -241,4 +241,26 @@ class DatabaseIntegrationTest extends TestCase {
 		}
 	}
 
+	public function test_insert() : void {
+		$db = Database::getInstance();
+
+		// Zero insert ID when table does not have an auto-increment column
+		self::assertSame(0, $db->insert('debug', []));
+
+		// Non-zero insert ID when table has an auto-increment column
+		for ($i = 1; $i <=3; $i++) {
+			self::assertSame($i, $db->insert('newsletter', []));
+		}
+
+		// Non-empty fields are successfully recovered
+		$logID = $db->insert('newsletter', [
+			'newsletter_text' => $db->escapeString('foo'),
+			'newsletter_html' => $db->escapeString('bar'),
+		]);
+		$result = $db->read('SELECT * FROM newsletter WHERE newsletter_id = ' . $logID);
+		$record = $result->record();
+		self::assertSame('foo', $record->getString('newsletter_text'));
+		self::assertSame('bar', $record->getString('newsletter_html'));
+	}
+
 }


### PR DESCRIPTION
Manual construction of SQL statements is fragile and dangerous, since
there is no way to validate the resulting string apart from executing
the query.

We replace all basic INSERT statements with calls to Database::insert,
with structured data passed as an argument. (In the future, we should
apply this strategy to other statement types, but UPDATE statements,
as an example, are often more complex.)

This design has some very important benefits:

1. The key-value pairs are directly (and visually) associated, so it
   is much harder to pass the wrong value to a column.

2. It is impossible to create a string with a SQL syntax error, since
   all of the formatting (commas, parentheses, etc.) is automatic.

3. If we can unify the way that we escape content in the future, then
   we can construct the `$fields` array with raw values, and perform
   the escaping irrespective of the value types. (Though this could
   possibly degrade specificity, if we're not validating the types
   against a schema for the given table, for example.)

4. Just generally it is _much_ easier to read.