### PR TITLE
Refactor SmrAccount constructors

### DIFF
--- a/src/engine/Default/preferences_processing.php
+++ b/src/engine/Default/preferences_processing.php
@@ -64,12 +64,15 @@ if ($action == 'Save and resend validation code') {
 	if (empty($discordId)) {
 		$account->setDiscordId(null);
 		$container['msg'] = '<span class="green">SUCCESS: </span>You have deleted your Discord User ID.';
-
 	} else {
 		// no duplicates
-		$dbResult = $db->read('SELECT 1 FROM account WHERE discord_id =' . $db->escapeString($discordId) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
-		if ($dbResult->hasRecord()) {
-			create_error('Someone is already using that Discord User ID!');
+		try {
+			$other = SmrAccount::getAccountByDiscordId($discordId);
+			if ($account->getAccountID() != $other->getAccountID()) {
+				create_error('Someone is already using that Discord User ID!');
+			}
+		} catch (Smr\Exceptions\AccountNotFound) {
+			// Proceed, this Discord ID is not in use
 		}
 
 		$account->setDiscordId($discordId);
@@ -89,9 +92,13 @@ if ($action == 'Save and resend validation code') {
 		}
 
 		// no duplicates
-		$dbResult = $db->read('SELECT 1 FROM account WHERE irc_nick = ' . $db->escapeString($ircNick) . ' AND account_id != ' . $db->escapeNumber($account->getAccountID()) . ' LIMIT 1');
-		if ($dbResult->hasRecord()) {
-			create_error('Someone is already using that nick!');
+		try {
+			$other = SmrAccount::getAccountByIrcNick($ircNick);
+			if ($account->getAccountID() != $other->getAccountID()) {
+				create_error('Someone is already using that IRC nick!');
+			}
+		} catch (Smr\Exceptions\AccountNotFound) {
+			// Proceed, this IRC nick is not in use
 		}
 
 		// save irc nick in db and set message

--- a/src/htdocs/login_create_processing.php
+++ b/src/htdocs/login_create_processing.php
@@ -119,16 +119,22 @@ try {
 		exit;
 	}
 
-	if (SmrAccount::getAccountByName($login) != null) {
+	try {
+		SmrAccount::getAccountByName($login);
 		$msg = 'This user name is already registered.';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
+	} catch (Smr\Exceptions\AccountNotFound) {
+		// Proceed, login is not yet registered
 	}
 
-	if (SmrAccount::getAccountByEmail($email) != null) {
+	try {
+		SmrAccount::getAccountByEmail($email);
 		$msg = 'This email address is already registered.';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
+	} catch (Smr\Exceptions\AccountNotFound) {
+		// Proceed, email is not yet registered
 	}
 
 	$referral = Smr\Request::getInt('referral_id');

--- a/src/htdocs/login_social_create.php
+++ b/src/htdocs/login_social_create.php
@@ -19,9 +19,11 @@ try {
 	// Pre-populate the login field if an account with this email exists.
 	// (Also disable creating a new account because they would just get
 	// an "Email already registered" error anyway.)
-	$account = SmrAccount::getAccountByEmail($socialLogin->getEmail());
-	if (!is_null($account)) {
+	try {
+		$account = SmrAccount::getAccountByEmail($socialLogin->getEmail());
 		$template->assign('MatchingLogin', $account->getLogin());
+	} catch (Smr\Exceptions\AccountNotFound) {
+		// Proceed without matching account
 	}
 
 	$template->assign('Body', 'login/login_social_create.php');

--- a/src/htdocs/resend_password_processing.php
+++ b/src/htdocs/resend_password_processing.php
@@ -8,8 +8,9 @@ try {
 	}
 
 	// get this user from db
-	$account = SmrAccount::getAccountByEmail(Smr\Request::get('email'));
-	if ($account == null) {
+	try {
+		$account = SmrAccount::getAccountByEmail(Smr\Request::get('email'));
+	} catch (Smr\Exceptions\AccountNotFound) {
 		// unknown user
 		header('Location: /error.php?msg=' . rawurlencode('The specified e-mail address is not registered!'));
 		exit;

--- a/src/htdocs/reset_password_processing.php
+++ b/src/htdocs/reset_password_processing.php
@@ -23,11 +23,13 @@ try {
 		exit;
 	}
 
-	// creates a new user account object
-	$account = SmrAccount::getAccountByName($login);
 	$passwordReset = Smr\Request::get('password_reset');
-	if ($account == null || empty($passwordReset) || $account->getPasswordReset() != $passwordReset) {
-		// unknown user
+	try {
+		$account = SmrAccount::getAccountByName($login);
+		if (empty($passwordReset) || $account->getPasswordReset() != $passwordReset) {
+			throw new Smr\Exceptions\AccountNotFound('Wrong password reset code');
+		}
+	} catch (Smr\Exceptions\AccountNotFound) {
 		header('Location: /error.php?msg=' . rawurlencode('User does not exist or reset password code is incorrect.'));
 		exit;
 	}

--- a/src/tools/discord/GameLink.class.php
+++ b/src/tools/discord/GameLink.class.php
@@ -15,9 +15,10 @@ class GameLink
 
 		// force update in case the ID has been changed in-game
 		$user_id = $message->author->id;
-		$account = SmrAccount::getAccountByDiscordId($user_id, true);
 
-		if (is_null($account)) {
+		try {
+			$account = SmrAccount::getAccountByDiscordId($user_id, true);
+		} catch (Smr\Exceptions\AccountNotFound) {
 			$message->reply("There is no SMR account associated with your Discord User ID. To set this up, go to `Preferences` in-game and set `$user_id` as your `Discord User ID`.")
 				->done(null, 'logException');
 			return;

--- a/src/tools/irc/channel_msg.php
+++ b/src/tools/irc/channel_msg.php
@@ -35,12 +35,12 @@ function check_for_registration($fp, string $nick, string $channel, callable $ca
 	}
 
 	// get smr account
-	$account = SmrAccount::getAccountByIrcNick($nick, true);
-	if ($account == null) {
-		if ($registeredNick != '') {
+	try {
+		$account = SmrAccount::getAccountByIrcNick($nick, true);
+	} catch (Smr\Exceptions\AccountNotFound) {
+		try {
 			$account = SmrAccount::getAccountByIrcNick($registeredNick, true);
-		}
-		if ($account == null) {
+		} catch (Smr\Exceptions\AccountNotFound) {
 			if ($validationMessages === true) {
 				fputs($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', please set your \'irc nick\' in SMR preferences to your registered nick so i can recognize you.' . EOL);
 			}

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
@@ -68,19 +68,18 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 		$this->assertSame($original, $account);
 	}
 
-	public function test_get_account_by_name_returns_null_when_no_account_name_provided() : void {
-		// When retrieving account by empty string name
-		$account = AbstractSmrAccount::getAccountByName('');
-		// Then the record is null
-		$this->assertNull($account);
+	public function test_get_account_by_name_throws_when_no_account_name_provided() : void {
+		// When retrieving account by empty string name, exception is thrown
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account login not found');
+		AbstractSmrAccount::getAccountByName('');
 	}
 
-	public function test_get_account_by_name_returns_null_when_no_record_found() : void {
-		// Given no record exists
-		// When retrieving account by name
-		$account = AbstractSmrAccount::getAccountByName('any');
-		// Then the record is null
-		$this->assertNull($account);
+	public function test_get_account_by_name_throws_when_no_record_found() : void {
+		// When retrieving account by name, exception is thrown if no record exists
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account login not found');
+		AbstractSmrAccount::getAccountByName('does_not_exist');
 	}
 
 	public function test_get_account_by_email_happy_path() : void {
@@ -92,19 +91,18 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 		$this->assertSame($original, $account);
 	}
 
-	public function test_get_account_by_email_returns_null_when_no_email_provided() : void {
-		// When retrieving account by null email
-		$account = AbstractSmrAccount::getAccountByEmail(null);
-		// Then the record is null
-		$this->assertNull($account);
+	public function test_get_account_by_email_throws_when_no_email_provided() : void {
+		// When retrieving account by empty string email, exception is thrown
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account email not found');
+		AbstractSmrAccount::getAccountByEmail('');
 	}
 
-	public function test_get_account_by_email_returns_null_when_no_record_found() : void {
-		// Given no record exists
-		// When retrieving account by email
-		$account = AbstractSmrAccount::getAccountByEmail('any');
-		// Then the record is null
-		$this->assertNull($account);
+	public function test_get_account_by_email_throws_when_no_record_found() : void {
+		// When retrieving account by email, exception is thrown if no record exists
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account email not found');
+		AbstractSmrAccount::getAccountByEmail('does_not_exist');
 	}
 
 	public function test_get_account_by_discord_happy_path() : void {
@@ -119,19 +117,18 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 		$this->assertSame($original->getAccountID(), $account->getAccountID());
 	}
 
-	public function test_get_account_by_discord_returns_null_when_no_discord_provided() : void {
-		// When retrieving account by null discord
-		$account = AbstractSmrAccount::getAccountByDiscordId(null);
-		// Then the record is null
-		$this->assertNull($account);
+	public function test_get_account_by_discord_throws_when_no_discord_provided() : void {
+		// When retrieving account by empty string discord ID, exception is thrown
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account discord ID not found');
+		AbstractSmrAccount::getAccountByDiscordId('');
 	}
 
-	public function test_get_account_by_discord_returns_null_when_no_record_found() : void {
-		// Given no record exists
-		// When retrieving account by discord
-		$account = AbstractSmrAccount::getAccountByDiscordId('any');
-		// Then the record is null
-		$this->assertNull($account);
+	public function test_get_account_by_discord_throws_when_no_record_found() : void {
+		// When retrieving account by discord, exception is thrown if no record exists.
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account discord ID not found');
+		AbstractSmrAccount::getAccountByDiscordId('does_not_exist');
 	}
 
 	public function test_get_account_by_irc_happy_path() : void {
@@ -146,19 +143,18 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 		$this->assertSame($original->getAccountID(), $account->getAccountID());
 	}
 
-	public function test_get_account_by_irc_returns_null_when_no_irc_provided() : void {
-		// When retrieving account by null irc
-		$account = AbstractSmrAccount::getAccountByIrcNick(null);
-		// Then the record is null
-		$this->assertNull($account);
+	public function test_get_account_by_irc_throws_when_no_irc_provided() : void {
+		// When retrieving account by empty string irc, exception is thrown
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account IRC nick not found');
+		AbstractSmrAccount::getAccountByIrcNick('');
 	}
 
 	public function test_get_account_by_irc_returns_null_when_no_record_found() : void {
-		// Given no record exists
-		// When retrieving account by irc
-		$account = AbstractSmrAccount::getAccountByIrcNick('any');
-		// Then the record is null
-		$this->assertNull($account);
+		// When retrieving account by irc, exception is thrown if no record exists.
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account IRC nick not found');
+		AbstractSmrAccount::getAccountByIrcNick('does_not_exist');
 	}
 
 	public function test_get_account_by_social_happy_path() : void {
@@ -191,20 +187,20 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 		$this->assertSame($original->getAccountID(), $account->getAccountID());
 	}
 
-	public function test_get_account_by_social_returns_null_when_social_invalid() : void {
+	public function test_get_account_by_social_throws_when_social_invalid() : void {
 		// Given an invalid social login
 		$socialLogin = $this->createMock(Facebook::class);
 		$socialLogin
 			->expects(self::once())
 			->method('isValid')
 			->willReturn(false);
-		// When retrieving account by null social
-		$account = AbstractSmrAccount::getAccountBySocialLogin($socialLogin);
-		// Then the record is null
-		$this->assertNull($account);
+		// When retrieving account by invalid social, exception is thrown
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account social login not found');
+		AbstractSmrAccount::getAccountBySocialLogin($socialLogin);
 	}
 
-	public function test_get_account_by_social_returns_null_when_no_record_found() : void {
+	public function test_get_account_by_social_throws_when_no_record_found() : void {
 		// Given no record exists
 		// And a valid social login
 		/*
@@ -224,10 +220,10 @@ class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 			->expects(self::once())
 			->method($getUserId)
 			->willReturn('123');
-		// When retrieving account by social
-		$account = AbstractSmrAccount::getAccountBySocialLogin($socialLogin);
-		// Then the record is null
-		$this->assertNull($account);
+		// When retrieving account by social, exception is thrown if no record exists
+		$this->expectException(AccountNotFound::class);
+		$this->expectExceptionMessage('Account social login not found');
+		AbstractSmrAccount::getAccountBySocialLogin($socialLogin);
 	}
 
 	public function test_date_format_methods() : void {


### PR DESCRIPTION
If an account cannot be found, it now throws an exception instead of
returning null. This is important for ensuring that the `getAccount*`
functions all return a single type. It also makes it consistent with
the other fundamental object classes (SmrPlayer, SmrAlliance, etc.).

As a result of this change, all places that check for null returns
needed to be modified to do a try-catch instead.