### PR TITLE
Session: simplify session ID creation

### DIFF
--- a/src/lib/Smr/Session.php
+++ b/src/lib/Smr/Session.php
@@ -63,12 +63,13 @@ class Session {
 		$this->db = Database::getInstance();
 
 		// now try the cookie
-		if (isset($_COOKIE['session_id']) && strlen($_COOKIE['session_id']) === 32) {
+		$idLength = 32;
+		if (isset($_COOKIE['session_id']) && strlen($_COOKIE['session_id']) === $idLength) {
 			$this->sessionID = $_COOKIE['session_id'];
 		} else {
 			// create a new session id
 			do {
-				$this->sessionID = md5(uniqid(strval(rand())));
+				$this->sessionID = random_string($idLength);
 				$dbResult = $this->db->read('SELECT 1 FROM active_session WHERE session_id = ' . $this->db->escapeString($this->sessionID) . ' LIMIT 1');
 			} while ($dbResult->hasRecord()); //Make sure we haven't somehow clashed with someone else's session.
 

--- a/test/SmrTest/lib/DefaultGame/VoteSiteIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/VoteSiteIntegrationTest.php
@@ -58,12 +58,12 @@ class VoteSiteIntegrationTest extends BaseIntegrationSpec {
 			VoteSite::LINK_ID_TWG => [
 				'img' => 'twg_vote.png',
 				'url' => 'http://topwebgames.com/in.aspx?ID=136&account=7&game=42&link=3&alwaysreward=1',
-				'sn' => '?sn=buyayw',
+				'sn' => '?sn=gbuyay',
 			],
 			VoteSite::LINK_ID_DOG => [
 				'img' => 'dog_vote.png',
 				'url' => 'http://www.directoryofgames.com/main.php?view=topgames&action=vote&v_tgame=2315&votedef=7,42,4',
-				'sn' => '?sn=npclry',
+				'sn' => '?sn=wnpclr',
 			],
 			VoteSite::LINK_ID_PBBG => [
 				'img' => 'pbbg.png',


### PR DESCRIPTION
We do not need to use a cryptographically strong ID for the session,
but it doesn't hurt. Our `random_string` function is perfect for this
job, and even allows us to explicitly specify the length.

This change is motivated by the poor properties of `uniqid` (it is
based on the system time, which is why we were generating a prefix
string from a random int), which were further degraded by taking the
md5 hash of the result.

In the tests that compute an SN, we see a different random string
because we're no longer calling `rand()` inside the Session ctor.