### PR TITLE
RouteGenerator special case fixes

### DIFF
--- a/src/lib/Default/Routes/MultiplePortRoute.class.php
+++ b/src/lib/Default/Routes/MultiplePortRoute.class.php
@@ -5,11 +5,11 @@ namespace Routes;
 class MultiplePortRoute extends Route {
 
 	public function __construct(
-		private OneWayRoute $forwardRoute,
+		private Route $forwardRoute,
 		private OneWayRoute $returnRoute,
 	) {}
 
-	public function getForwardRoute() : ?OneWayRoute {
+	public function getForwardRoute() : ?Route {
 		return $this->forwardRoute;
 	}
 

--- a/src/lib/Default/Routes/OneWayRoute.class.php
+++ b/src/lib/Default/Routes/OneWayRoute.class.php
@@ -85,7 +85,7 @@ class OneWayRoute extends Route {
 		return $this->sellSectorId == $sectorID || $this->buySectorId == $sectorID;
 	}
 
-	public function getForwardRoute() : ?OneWayRoute {
+	public function getForwardRoute() : ?Route {
 		return null;
 	}
 

--- a/src/lib/Default/Routes/Route.class.php
+++ b/src/lib/Default/Routes/Route.class.php
@@ -28,7 +28,7 @@ abstract class Route {
 		return ($route != null && $route->containsPort($sectorID)) || (($route = $this->getForwardRoute()) != null && $route->containsPort($sectorID));
 	}
 
-	public abstract function getForwardRoute() : ?OneWayRoute;
+	public abstract function getForwardRoute() : ?Route;
 
 	public abstract function getReturnRoute() : ?OneWayRoute;
 

--- a/src/lib/Default/Routes/RouteGenerator.class.php
+++ b/src/lib/Default/Routes/RouteGenerator.class.php
@@ -63,6 +63,9 @@ class RouteGenerator {
 		}
 	}
 
+	/**
+	 * @return array<int, array<OneWayRoute>>
+	 */
 	private static function findOneWayRoutes(array $sectors, array $distances, int $routesForPort, array $goods, array $races) : array {
 		$routes = array();
 		foreach ($distances as $currentSectorId => $d) {

--- a/src/lib/Default/Routes/RouteGenerator.class.php
+++ b/src/lib/Default/Routes/RouteGenerator.class.php
@@ -38,8 +38,9 @@ class RouteGenerator {
 	private static function startRoutesToContinue(int $maxNumPorts, int $startSectorId, array $forwardRoutes, array $routeLists) : void {
 		foreach ($forwardRoutes as $currentStepRoute) {
 			$currentStepBuySector = $currentStepRoute->getBuySectorId();
+			$currentGoodIsNothing = $currentStepRoute->getGoodID() === GOODS_NOTHING;
 			if ($currentStepBuySector > $startSectorId) { // Not already checked
-				self::getContinueRoutes($maxNumPorts - 1, $startSectorId, $currentStepRoute, $routeLists[$currentStepBuySector], $routeLists, $currentStepRoute->getGoodID() === GOODS_NOTHING);
+				self::getContinueRoutes($maxNumPorts - 1, $startSectorId, $currentStepRoute, $routeLists[$currentStepBuySector], $routeLists, $currentGoodIsNothing);
 			}
 		}
 	}
@@ -47,7 +48,8 @@ class RouteGenerator {
 	private static function getContinueRoutes(int $maxNumPorts, int $startSectorId, Route $routeToContinue, array $forwardRoutes, array $routeLists, bool $lastGoodIsNothing) : void {
 		foreach ($forwardRoutes as $currentStepRoute) {
 			$currentStepBuySector = $currentStepRoute->getBuySectorId();
-			if ($lastGoodIsNothing && ($lastGoodIsNothing = GOODS_NOTHING === $currentStepRoute->getGoodID())) {
+			$currentGoodIsNothing = $currentStepRoute->getGoodID() === GOODS_NOTHING;
+			if ($lastGoodIsNothing && $currentGoodIsNothing) {
 				continue; // Don't do two nothings in a row
 			}
 			if ($currentStepBuySector >= $startSectorId) { // Not already checked or back to start
@@ -57,7 +59,7 @@ class RouteGenerator {
 					self::addMoneyRoute($mpr);
 				} elseif ($maxNumPorts > 1 && !$routeToContinue->containsPort($currentStepBuySector)) {
 					$mpr = new MultiplePortRoute($routeToContinue, $currentStepRoute);
-					self::getContinueRoutes($maxNumPorts - 1, $startSectorId, $mpr, $routeLists[$currentStepBuySector], $routeLists, $lastGoodIsNothing);
+					self::getContinueRoutes($maxNumPorts - 1, $startSectorId, $mpr, $routeLists[$currentStepBuySector], $routeLists, $currentGoodIsNothing);
 				}
 			}
 		}


### PR DESCRIPTION
* Fix typed properties and typehints to recover 3+ port route functionality.
* Fix corner case where routes with multiple empty legs would be incorrectly included in search results.