### PR TITLE
bar_gambling_processing.php: major simplification

### DIFF
--- a/src/lib/Smr/Blackjack/Hand.php
+++ b/src/lib/Smr/Blackjack/Hand.php
@@ -36,6 +36,13 @@ class Hand {
 	}
 
 	/**
+	 * Has this hand busted?
+	 */
+	public function hasBusted(): bool {
+		return $this->getValue() > 21;
+	}
+
+	/**
 	 * Add a card to this hand.
 	 */
 	public function addCard(Card $card): void {

--- a/test/SmrTest/lib/DefaultGame/Blackjack/HandTest.php
+++ b/test/SmrTest/lib/DefaultGame/Blackjack/HandTest.php
@@ -80,4 +80,19 @@ class HandTest extends TestCase {
 		self::assertFalse($hand->hasBlackjack());
 	}
 
+	public function test_hasBusted(): void {
+		// add 3 cards that add to 22 (busted)
+		$hand = new Hand();
+		$hand->addCard(new Card(1)); // 2 of hearts
+		$hand->addCard(new Card(11)); // queen of hearts
+		$hand->addCard(new Card(12)); // king of hearts
+		self::assertTrue($hand->hasBusted());
+
+		// add 2 cards that add to 21 (not busted)
+		$hand = new Hand();
+		$hand->addCard(new Card(0)); // ace of hearts
+		$hand->addCard(new Card(12)); // king of hearts
+		self::assertFalse($hand->hasBusted());
+	}
+
 }


### PR DESCRIPTION
This page has been one of the last holdouts of intermixed processing
and display logic. While it's not fully disentangled, it is much less
egregious now.

The two most impactful simplifications made here are:

1. The logic for displaying a hand of cards has been refactored into
   a `display_hand` function.

2. There is a single condition for tracking if the game has ended.
   Previously this was scattered all over, and resulted in a bunch of
   code that turned out to be unreachable.

Additional changes:

* Converted the `check_for_win` function to use a match function
  instead of a complex if-statement.

* Added the Hand::hasBusted method.