### PR TITLE
Refactor pluralise function

### DIFF
--- a/src/engine/Default/alliance_invite_player_processing.php
+++ b/src/engine/Default/alliance_invite_player_processing.php
@@ -21,7 +21,7 @@ if ($dbResult->hasRecord() || $account->isMailBanned()) {
 
 // Construct the mail to send to the receiver
 $msg = 'You have been invited to join an alliance!
-This invitation will remain open for ' . $expireDays . ' ' . pluralise('day', $expireDays) . ' or until you join another alliance.
+This invitation will remain open for ' . pluralise($expireDays, 'day') . ' or until you join another alliance.
 If you are currently in an alliance, you will leave it if you accept this invitation.
 
 [join_alliance=' . $player->getAllianceID() . ']

--- a/src/engine/Default/bar_lotto_buy_processing.php
+++ b/src/engine/Default/bar_lotto_buy_processing.php
@@ -30,7 +30,7 @@ $player->increaseHOF(1, ['Bar', 'Lotto', 'Tickets Bought'], HOF_PUBLIC);
 $dbResult = $db->read('SELECT count(*) as num FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0 GROUP BY account_id');
 $num = $dbResult->record()->getInt('num');
 $message = ('<div class="center">Thanks for your purchase and good luck!  You currently');
-$message .= (' own ' . $num . ' ' . pluralise('ticket', $num) . '!</div><br />');
+$message .= (' own ' . pluralise($num, 'ticket') . '!</div><br />');
 
 $container = Page::create('skeleton.php', 'bar_main.php');
 $container->addVar('LocationID');

--- a/src/engine/Default/cargo_dump_processing.php
+++ b/src/engine/Default/cargo_dump_processing.php
@@ -33,6 +33,8 @@ if ($sector->offersFederalProtection()) {
 
 $container = Page::create('skeleton.php', 'current_sector.php');
 
+$container['msg'] = 'You have jettisoned <span class="yellow">' . $amount . '</span> ' . pluralise($amount, 'unit', false) . ' of ' . $good_name;
+
 if ($player->getExperience() > 0) {
 	// If they have any experience left, lose exp
 
@@ -53,7 +55,8 @@ if ($player->getExperience() > 0) {
 	$player->decreaseExperience($lost_xp);
 	$player->increaseHOF($lost_xp, ['Trade', 'Experience', 'Jettisoned'], HOF_PUBLIC);
 
-	$container['msg'] = 'You have jettisoned <span class="yellow">' . $amount . '</span> ' . pluralise('unit', $amount) . ' of ' . $good_name . ' and have lost <span class="exp">' . $lost_xp . '</span> experience.';
+
+	$container['msg'] .= ' and have lost <span class="exp">' . $lost_xp . '</span> experience.';
 	// log action
 	$player->log(LOG_TYPE_TRADING, 'Dumps ' . $amount . ' of ' . $good_name . ' and loses ' . $lost_xp . ' experience');
 } else {
@@ -67,7 +70,7 @@ if ($player->getExperience() > 0) {
 
 	$ship->decreaseArmour($damage);
 
-	$container['msg'] = 'You have jettisoned <span class="yellow">' . $amount . '</span> ' . pluralise('unit', $amount) . ' of ' . $good_name . '. Due to your lack of piloting experience, the cargo pierces the hull of your ship as you clumsily try to jettison the goods through the bay doors, destroying <span class="red">' . $damage . '</span> ' . pluralise('plate', $damage) . ' of armour!';
+	$container['msg'] .= '. Due to your lack of piloting experience, the cargo pierces the hull of your ship as you clumsily try to jettison the goods through the bay doors, destroying <span class="red">' . $damage . '</span> ' . pluralise($damage, 'plate', false) . ' of armour!';
 	// log action
 	$player->log(LOG_TYPE_TRADING, 'Dumps ' . $amount . ' of ' . $good_name . ' and takes ' . $damage . ' armour damage');
 }

--- a/src/engine/Default/current_players.php
+++ b/src/engine/Default/current_players.php
@@ -47,7 +47,7 @@ if ($count_last_active == 0) {
 	} else {
 		$summary .= 'A few ';
 	}
-	$summary .= 'of them were moving so your ship computer was able to intercept ' . $count_last_active . ' ' . pluralise('transmission', $count_last_active) . '.';
+	$summary .= 'of them were moving so your ship computer was able to intercept ' . pluralise($count_last_active, 'transmission') . '.';
 }
 
 $summary .= '<br />The traders listed in <span class="italic">italics</span> are still ranked as Newbie or Beginner.';

--- a/src/engine/Default/message_view.php
+++ b/src/engine/Default/message_view.php
@@ -110,7 +110,7 @@ function displayScouts(array &$messageBox, SmrPlayer $player): void {
 	foreach ($dbResult->records() as $dbRecord) {
 		$sender = SmrPlayer::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), false, $dbRecord);
 		$totalUnread = $dbRecord->getInt('total_unread');
-		$message = 'Your forces have spotted ' . $sender->getBBLink() . ' passing your forces ' . $dbRecord->getInt('number') . ' ' . pluralise('time', $dbRecord->getInt('number'));
+		$message = 'Your forces have spotted ' . $sender->getBBLink() . ' passing your forces ' . pluralise($dbRecord->getInt('number'), 'time');
 		$message .= ($totalUnread > 0) ? ' (' . $totalUnread . ' unread).' : '.';
 		$messageBox['Messages'][] = displayGrouped($sender, $message, $dbRecord->getInt('first'), $dbRecord->getInt('last'), $totalUnread > 0, $player->getAccount());
 	}

--- a/src/engine/Default/sector_mines.inc.php
+++ b/src/engine/Default/sector_mines.inc.php
@@ -21,7 +21,7 @@ if ($mine_owner_id) {
 		} else {
 			$flavor = 'Your ship was sufficiently agile to evade them';
 		}
-		$container['msg'] = 'You have just flown past a sprinkle of mines.<br />' . $flavor . ',<br />but it has cost you <span class="red">' . $turns . ' ' . pluralise('turn', $turns) . '</span> to navigate the minefield safely.';
+		$container['msg'] = 'You have just flown past a sprinkle of mines.<br />' . $flavor . ',<br />but it has cost you <span class="red">' . pluralise($turns, 'turn') . '</span> to navigate the minefield safely.';
 		$container->go();
 	} else {
 		$container = Page::create('forces_attack_processing.php');

--- a/src/engine/Default/shop_goods_processing.php
+++ b/src/engine/Default/shop_goods_processing.php
@@ -165,9 +165,9 @@ if ($transaction === TRADER_STEALS ||
 	$player->increaseExperience($gained_exp);
 
 	//will use these variables in current sector and port after successful trade
-	$tradeMessage = 'You have just ' . $msg_transaction . ' <span class="yellow">' . $amount . '</span> ' . pluralise('unit', $amount) . ' of <span class="yellow">' . $good_name . '</span>';
+	$tradeMessage = 'You have just ' . $msg_transaction . ' <span class="yellow">' . $amount . '</span> ' . pluralise($amount, 'unit', false) . ' of <span class="yellow">' . $good_name . '</span>';
 	if ($bargain_price > 0) {
-		$tradeMessage .= ' for <span class="creds">' . $bargain_price . '</span> ' . pluralise('credit', $bargain_price) . '.';
+		$tradeMessage .= ' for <span class="creds">' . $bargain_price . '</span> ' . pluralise($bargain_price, 'credit', false) . '.';
 	}
 
 	if ($gained_exp > 0) {
@@ -185,7 +185,7 @@ if ($transaction === TRADER_STEALS ||
 			$qualifier = 'peerless';
 		}
 		$skill = $transaction === TRADER_STEALS ? 'thievery' : 'trading';
-		$tradeMessage .= '<br />Your ' . $qualifier . ' ' . $skill . ' skills have earned you <span class="exp">' . $gained_exp . ' </span> experience ' . pluralise('point', $gained_exp) . '!';
+		$tradeMessage .= '<br />Your ' . $qualifier . ' ' . $skill . ' skills have earned you <span class="exp">' . $gained_exp . ' </span> ' . pluralise($gained_exp, 'experience point', false) . '!';
 	}
 
 	$container['trade_msg'] = $tradeMessage;

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -270,14 +270,15 @@ function word_filter(string $string): string {
 }
 
 // choose correct pluralization based on amount
-function pluralise(string $word, float $count = 0): string {
-	if ($count == 1) {
-		return $word;
+function pluralise(int|float $amount, string $word, bool $includeAmount = true): string {
+	$result = $word;
+	if ($amount != 1) {
+		$result .= 's';
 	}
-	if (strtolower($word) == 'is') {
-		return 'are';
+	if ($includeAmount) {
+		$result = $amount . ' ' . $result;
 	}
-	return $word . 's';
+	return $result;
 }
 
 /**
@@ -779,7 +780,7 @@ function format_time(int $seconds, bool $short = false): string {
 			if ($short) {
 				$parts[] = $amount . $unit[0];
 			} else {
-				$parts[] = $amount . ' ' . pluralise($unit, $amount);
+				$parts[] = pluralise($amount, $unit);
 			}
 		}
 	}

--- a/src/templates/Default/engine/Default/combat_log_list.php
+++ b/src/templates/Default/engine/Default/combat_log_list.php
@@ -6,7 +6,7 @@ if (isset($Message)) {?>
 <div class="center"><?php
 	$NumLogs = count($Logs);
 	if ($NumLogs > 0) { ?>
-		There <span id="total-logs"><?php echo pluralise('is', $TotalLogs), ' ', $TotalLogs, ' ', $LogType, pluralise(' log', $NumLogs); ?></span> available for viewing of which <?php echo $NumLogs, ' ', pluralise('is', $NumLogs); ?> being shown.<br /><br />
+		You have <span id="total-logs"><?php echo pluralise($TotalLogs, $LogType . ' log'); ?></span> available for viewing (<?php echo $NumLogs; ?> shown).<br /><br />
 		<form class="standard" method="POST" action="<?php echo $LogFormHREF; ?>">
 			<table class="fullwidth center">
 				<tr>

--- a/src/templates/Default/engine/Default/course_plot_result.php
+++ b/src/templates/Default/engine/Default/course_plot_result.php
@@ -1,4 +1,4 @@
-<p>The plotted course is <?php echo $Path->getLength() . ' ' . pluralise('sector', $Path->getLength()); ?> long and costs <?php echo $Path->getTurns() . ' ' . pluralise('turn', $Path->getTurns()); ?> to traverse.</p>
+<p>The plotted course is <?php echo pluralise($Path->getLength(), 'sector'); ?> long and costs <?php echo pluralise($Path->getTurns(), 'turn'); ?> to traverse.</p>
 
 <br />
 <h2>Plotted Course</h2>

--- a/src/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc.php
@@ -135,5 +135,5 @@ foreach ($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
 $TotalDamage = $TraderTeamCombatResults['TotalDamage']; ?>
 This fleet <?php if ($TotalDamage > 0) { ?>hits for a total of <span class="red"><?php echo $TotalDamage ?></span> damage in this round of combat<?php } else { ?>does no damage this round. You call that a fleet? They need a better recruiter<?php } ?>.<br /><?php
 foreach ($TraderTeamCombatResults['Downgrades'] as $structureID => $numDestroyed) { ?>
-	This team destroys <span class="red"><?php echo $numDestroyed; ?> </span><?php echo pluralise((new SmrPlanetStructureType($structureID, []))->name(), $numDestroyed); ?>.<br /><?php
+	This team destroys <span class="red"><?php echo pluralise($numDestroyed, (new SmrPlanetStructureType($structureID, []))->name()); ?></span>.<br /><?php
 } ?>

--- a/src/templates/Default/engine/Default/includes/PlottedCourse.inc.php
+++ b/src/templates/Default/engine/Default/includes/PlottedCourse.inc.php
@@ -9,8 +9,8 @@ if ($ThisPlayer->hasPlottedCourse()) {
 			<td class="top left">
 				<h2>Plotted Course</h2><br />
 				<?php echo implode(' - ', $PlottedCourse->getPath()); ?><br />
-				(<?php $s = $PlottedCourse->getLength(); echo $s . ' ' . pluralise('sector', $s); ?>,
-				<?php $t = $PlottedCourse->getTurns(); echo $t . ' ' . pluralise('turn', $t); ?>)
+				(<?php echo pluralise($PlottedCourse->getLength(), 'sector'); ?>,
+				<?php echo pluralise($PlottedCourse->getTurns(), 'turn'); ?>)
 			</td>
 			<td class="top right"><?php
 				if ($ThisSector->isLinked($NextSector->getSectorID())) { ?>

--- a/src/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc.php
@@ -140,5 +140,5 @@ This fleet <?php if ($TotalDamage > 0) { ?>hits for a total of <span class="red"
 <?php
 $Downgrades = $TraderTeamCombatResults['Downgrades'];
 if ($Downgrades != 0) {
-	?>The port has lost <?php echo $Downgrades . ' ' . pluralise('level', $Downgrades); ?>.<?php
+	?>The port has lost <?php echo pluralise($Downgrades, 'level'); ?>.<?php
 } ?>

--- a/src/templates/Default/engine/Default/message_view.php
+++ b/src/templates/Default/engine/Default/message_view.php
@@ -29,7 +29,7 @@ if ($MessageBox['Type'] == MSG_GLOBAL) { ?>
 					<option>Marked Messages</option>
 					<option>All Messages</option>
 				</select>
-				<p>You have <span class="yellow"><?php echo $MessageBox['TotalMessages']; ?></span> <?php echo pluralise('message', $MessageBox['TotalMessages']); if ($MessageBox['TotalMessages'] != $MessageBox['NumberMessages']) { ?> of which <span class="yellow"><?php echo $MessageBox['NumberMessages']; ?></span> <?php echo pluralise('is', $MessageBox['NumberMessages']); ?> being displayed<?php } ?>.</p>
+				<p>You have <span class="yellow"><?php echo $MessageBox['TotalMessages']; ?></span> <?php echo pluralise($MessageBox['TotalMessages'], 'message', false); if ($MessageBox['TotalMessages'] != $MessageBox['NumberMessages']) { ?> (<?php echo $MessageBox['NumberMessages']; ?> displayed)<?php } ?>.</p>
 			</td>
 			<td style="width: 30%" valign="middle"><?php
 				if (isset($NextPageHREF)) {

--- a/src/templates/Default/engine/Default/planet_list.inc.php
+++ b/src/templates/Default/engine/Default/planet_list.inc.php
@@ -16,7 +16,7 @@
 		}
 	} else {
 		if (!$PlayerOnly) { ?>
-			<?php echo $Alliance->getAllianceDisplayName(true); ?> currently has <span id="numplanets"><?php echo count($AllPlanets); ?></span> <?php echo pluralise('planet', count($AllPlanets)); ?> in the universe!<br /><br /><?php
+			<?php echo $Alliance->getAllianceDisplayName(true); ?> currently has <span id="numplanets"><?php echo pluralise(count($AllPlanets), 'planet'); ?></span> in the universe!<br /><br /><?php
 		}
 		$this->includeTemplate($ExtraInclude, ['Planets' => $AllPlanets]);
 	} ?>

--- a/src/templates/Default/engine/Default/sector_jump_calculate.php
+++ b/src/templates/Default/engine/Default/sector_jump_calculate.php
@@ -5,7 +5,7 @@ Within moments, the onboard computer dictates the report in a reassuringly confi
 It will cost <span class="red"><?php echo $TurnCost; ?></span> turns to jump to Sector #<?php echo $Target; ?>.
 <?php
 if ($MaxMisjump > 0) { ?>
-	There is a possibility to misjump up to <?php echo $MaxMisjump . ' ' . pluralise('sector', $MaxMisjump); ?>.<?php
+	There is a possibility to misjump up to <?php echo pluralise($MaxMisjump, 'sector'); ?>.<?php
 } else { ?>
 	There is no possibility to misjump.<?php
 } ?>

--- a/test/SmrTest/lib/DefaultGame/PluraliseTest.php
+++ b/test/SmrTest/lib/DefaultGame/PluraliseTest.php
@@ -12,20 +12,19 @@ class PluraliseTest extends TestCase {
 	/**
 	 * @dataProvider pluralise_provider
 	 */
-	public function test_pluralise(string $in, mixed $count, string $expect): void {
-		$result = pluralise($in, $count);
+	public function test_pluralise(float|int $amount, bool $includeAmount, string $expect): void {
+		$result = pluralise($amount, 'test', $includeAmount);
 		$this->assertSame($expect, $result);
 	}
 
 	public function pluralise_provider(): array {
 		return [
-			['test', 3, 'tests'],
-			['test', 1, 'test'],
-			['is', 3, 'are'],
-			['Is', 3, 'are'],
-			['is', 1, 'is'],
-			['test', 0, 'tests'],
-			['test', 0.5, 'tests'],
+			[3, true, '3 tests'],
+			[1, true, '1 test'],
+			[0, true, '0 tests'],
+			[0.5, true, '0.5 tests'],
+			[3, false, 'tests'],
+			[1, false, 'test'],
 		];
 	}
 


### PR DESCRIPTION
Include the amount in the returned value to simplify the way it is
used in a majority of cases.

The only times when we don't want to include the value, it is because
we are using some special HTML formatting of the amount. This is why
the function now has a `$includeAmount` boolean argument.

We remove the "is -> are" functionality, since places where this was
used could be reworded in a sensible way.