### PR TITLE
Fix code smell UnneededElse

### DIFF
--- a/src/engine/Default/admin/ip_view_results.php
+++ b/src/engine/Default/admin/ip_view_results.php
@@ -21,8 +21,9 @@ if ($type == 'comp_share') {
 	//another script for comp share
 	require('comp_share.php');
 	return;
+}
 
-} elseif ($type == 'list') {
+if ($type == 'list') {
 	//=========================================================
 	// List all IPs
 	//=========================================================

--- a/src/engine/Default/admin/unigen/universe_create_locations.php
+++ b/src/engine/Default/admin/unigen/universe_create_locations.php
@@ -41,13 +41,12 @@ class Categories {
 	public array $locTypes = [];
 	private array $locAdded = []; // list of locs added to a category
 	public function addLoc(int $locID, string $category): string {
-		if (!$this->added($locID)) {
-			$this->locTypes[$category][] = $locID;
-			$this->locAdded[] = $locID;
-			return '';
-		} else {
+		if ($this->added($locID)) {
 			return "<b>Also in $category</b><br />";
 		}
+		$this->locTypes[$category][] = $locID;
+		$this->locAdded[] = $locID;
+		return '';
 	}
 	public function added(int $locID): bool {
 		return in_array($locID, $this->locAdded);

--- a/src/engine/Default/album_edit_processing.php
+++ b/src/engine/Default/album_edit_processing.php
@@ -164,28 +164,27 @@ function php_link_check(string $url): string|false {
 	}
 
 	$fp = fsockopen($url['host'], $url['port'], $errno, $errstr, 30);
-
 	if ($fp === false) {
 		return false;
-	} else {
-		$head = '';
-		$httpRequest = 'HEAD ' . $url['path'] . ' HTTP/1.1' . EOL
-								. 'Host: ' . $url['host'] . EOL
-								. 'Connection: close' . EOL . EOL;
-		fwrite($fp, $httpRequest);
-		while (!feof($fp)) {
-			$head .= fgets($fp, 1024);
-		}
-		fclose($fp);
-
-		preg_match('=^(HTTP/\d+\.\d+) (\d{3}) ([^\r\n]*)=', $head, $matches);
-		$http = [
-			'Status-Line' => $matches[0],
-			'HTTP-Version' => $matches[1],
-			'Status-Code' => $matches[2],
-			'Reason-Phrase' => $matches[3],
-		];
-
-		return $http['Status-Code'];
 	}
+
+	$head = '';
+	$httpRequest = 'HEAD ' . $url['path'] . ' HTTP/1.1' . EOL
+							. 'Host: ' . $url['host'] . EOL
+							. 'Connection: close' . EOL . EOL;
+	fwrite($fp, $httpRequest);
+	while (!feof($fp)) {
+		$head .= fgets($fp, 1024);
+	}
+	fclose($fp);
+
+	preg_match('=^(HTTP/\d+\.\d+) (\d{3}) ([^\r\n]*)=', $head, $matches);
+	$http = [
+		'Status-Line' => $matches[0],
+		'HTTP-Version' => $matches[1],
+		'Status-Code' => $matches[2],
+		'Reason-Phrase' => $matches[3],
+	];
+
+	return $http['Status-Code'];
 }

--- a/src/lib/Default/AbstractSmrAccount.php
+++ b/src/lib/Default/AbstractSmrAccount.php
@@ -262,25 +262,24 @@ abstract class AbstractSmrAccount {
 	 */
 	public function isDisabled(): array|false {
 		$dbResult = $this->db->read('SELECT * FROM account_is_closed JOIN closing_reason USING(reason_id) WHERE ' . $this->SQL . ' LIMIT 1');
-		if ($dbResult->hasRecord()) {
-			$dbRecord = $dbResult->record();
-			// get the expire time
-			$expireTime = $dbRecord->getInt('expires');
-
-			// are we over this time?
-			if ($expireTime > 0 && $expireTime < Smr\Epoch::time()) {
-				// get rid of the expire entry
-				$this->unbanAccount();
-				return false;
-			}
-			return [
-				'Time' => $expireTime,
-				'Reason' => $dbRecord->getField('reason'),
-				'ReasonID' => $dbRecord->getInt('reason_id'),
-			];
-		} else {
+		if (!$dbResult->hasRecord()) {
 			return false;
 		}
+		$dbRecord = $dbResult->record();
+		// get the expire time
+		$expireTime = $dbRecord->getInt('expires');
+
+		// are we over this time?
+		if ($expireTime > 0 && $expireTime < Smr\Epoch::time()) {
+			// get rid of the expire entry
+			$this->unbanAccount();
+			return false;
+		}
+		return [
+			'Time' => $expireTime,
+			'Reason' => $dbRecord->getField('reason'),
+			'ReasonID' => $dbRecord->getInt('reason_id'),
+		];
 	}
 
 	public function update(): void {
@@ -791,9 +790,8 @@ abstract class AbstractSmrAccount {
 		$hofDisplayName = htmlspecialchars($this->getHofName());
 		if ($linked) {
 			return '<a href="' . $this->getPersonalHofHREF() . '">' . $hofDisplayName . '</a>';
-		} else {
-			return $hofDisplayName;
 		}
+		return $hofDisplayName;
 	}
 
 	public function getHofName(): string {
@@ -1011,11 +1009,7 @@ abstract class AbstractSmrAccount {
 
 	public function getHotkeys(string $hotkeyType = null): array {
 		if ($hotkeyType !== null) {
-			if (isset($this->hotkeys[$hotkeyType])) {
-				return $this->hotkeys[$hotkeyType];
-			} else {
-				return [];
-			}
+			return $this->hotkeys[$hotkeyType] ?? [];
 		}
 		return $this->hotkeys;
 	}

--- a/src/lib/Default/AbstractSmrPlayer.php
+++ b/src/lib/Default/AbstractSmrPlayer.php
@@ -469,9 +469,8 @@ abstract class AbstractSmrPlayer {
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			return SmrPlanet::getPlanet($this->getGameID(), $dbRecord->getInt('sector_id'), false, $dbRecord);
-		} else {
-			return false;
 		}
+		return false;
 	}
 
 	public function getSectorPlanet(): SmrPlanet {
@@ -524,12 +523,12 @@ abstract class AbstractSmrPlayer {
 		// get his home sector
 		$hq_id = GOVERNMENT + $this->getRaceID();
 		$raceHqSectors = SmrSector::getLocationSectors($this->getGameID(), $hq_id);
-		if (!empty($raceHqSectors)) {
-			// If race has multiple HQ's for some reason, use the first one
-			return key($raceHqSectors);
-		} else {
+		if (empty($raceHqSectors)) {
+			// No HQ, default to sector 1
 			return 1;
 		}
+		// If race has multiple HQ's for some reason, use the first one
+		return key($raceHqSectors);
 	}
 
 	public function isDead(): bool {
@@ -1309,11 +1308,10 @@ abstract class AbstractSmrPlayer {
 	}
 
 	public function getAllianceDisplayName(bool $linked = false, bool $includeAllianceID = false): string {
-		if ($this->hasAlliance()) {
-			return $this->getAlliance()->getAllianceDisplayName($linked, $includeAllianceID);
-		} else {
+		if (!$this->hasAlliance()) {
 			return 'No Alliance';
 		}
+		return $this->getAlliance()->getAllianceDisplayName($linked, $includeAllianceID);
 	}
 
 	public function getAllianceRole(int $allianceID = null): int {
@@ -1898,12 +1896,10 @@ abstract class AbstractSmrPlayer {
 	}
 
 	protected function getNextBountyID(): int {
-		$keys = array_keys($this->getBounties());
-		if (count($keys) > 0) {
-			return max($keys) + 1;
-		} else {
+		if (!$this->hasBounties()) {
 			return 0;
 		}
+		return max(array_keys($this->getBounties())) + 1;
 	}
 
 	protected function setBounty(array $bounty): void {

--- a/src/lib/Default/AbstractSmrPort.php
+++ b/src/lib/Default/AbstractSmrPort.php
@@ -235,12 +235,11 @@ class AbstractSmrPort {
 		$goodIDs = $this->goodIDs[$transaction];
 		if ($player == null) {
 			return $goodIDs;
-		} else {
-			return array_filter($goodIDs, function($goodID) use ($player) {
-				$good = Globals::getGood($goodID);
-				return $player->meetsAlignmentRestriction($good['AlignRestriction']);
-			});
 		}
+		return array_filter($goodIDs, function($goodID) use ($player) {
+			$good = Globals::getGood($goodID);
+			return $player->meetsAlignmentRestriction($good['AlignRestriction']);
+		});
 	}
 
 	/**
@@ -427,13 +426,11 @@ class AbstractSmrPort {
 		if ($level === null) {
 			$level = $this->getLevel();
 		}
-		if ($level <= 2) {
-			return 1;
-		} elseif ($level <= 6) {
-			return 2;
-		} else {
-			return 3;
-		}
+		return match (true) {
+			$level <= 2 => 1,
+			$level <= 6 => 2,
+			$level >= 7 => 3,
+		};
 	}
 
 	protected function selectAndAddGood(int $goodClass): array {

--- a/src/lib/Default/AbstractSmrShip.php
+++ b/src/lib/Default/AbstractSmrShip.php
@@ -123,25 +123,22 @@ class AbstractSmrShip {
 	public function getDisplayAttackRating(): int {
 		if ($this->hasActiveIllusion()) {
 			return $this->getIllusionAttack();
-		} else {
-			return $this->getAttackRating();
 		}
+		return $this->getAttackRating();
 	}
 
 	public function getDisplayDefenseRating(): int {
 		if ($this->hasActiveIllusion()) {
 			return $this->getIllusionDefense();
-		} else {
-			return $this->getDefenseRating();
 		}
+		return $this->getDefenseRating();
 	}
 
 	public function getDisplayName(): string {
 		if ($this->hasActiveIllusion()) {
 			return $this->getIllusionShipName();
-		} else {
-			return $this->getName();
 		}
+		return $this->getName();
 	}
 
 	public function getAttackRating(): int {

--- a/src/lib/Default/Globals.php
+++ b/src/lib/Default/Globals.php
@@ -246,9 +246,8 @@ class Globals {
 	public static function getPlotCourseHREF(int $fromSector = null, int $toSector = null): string {
 		if ($fromSector === null && $toSector === null) {
 			return self::$AVAILABLE_LINKS['PlotCourse'] = Page::create('skeleton.php', 'course_plot.php')->href();
-		} else {
-			return Page::create('course_plot_processing.php', '', ['from' => $fromSector, 'to' => $toSector])->href();
 		}
+		return Page::create('course_plot_processing.php', '', ['from' => $fromSector, 'to' => $toSector])->href();
 	}
 
 	public static function getPlanetMainHREF(): string {
@@ -278,9 +277,8 @@ class Globals {
 	public static function getAllianceHREF(int $allianceID = null): string {
 		if ($allianceID > 0) {
 			return self::getAllianceMotdHREF($allianceID);
-		} else {
-			return self::getAllianceListHREF();
 		}
+		return self::getAllianceListHREF();
 	}
 
 	public static function getAllianceBankHREF(int $allianceID = null): string {
@@ -436,11 +434,10 @@ class Globals {
 	 * the `account` table with the linked historical account ID's.
 	 */
 	public static function getHistoryDatabases(): array {
-		if (defined('HISTORY_DATABASES')) {
-			return HISTORY_DATABASES;
-		} else {
+		if (!defined('HISTORY_DATABASES')) {
 			return [];
 		}
+		return HISTORY_DATABASES;
 	}
 
 }

--- a/src/lib/Default/SmrAlliance.php
+++ b/src/lib/Default/SmrAlliance.php
@@ -339,13 +339,11 @@ class SmrAlliance {
 	}
 
 	public function getRecruitType(): string {
-		if (!$this->isRecruiting()) {
-			return self::RECRUIT_CLOSED;
-		} elseif (empty($this->getPassword())) {
-			return self::RECRUIT_OPEN;
-		} else {
-			return self::RECRUIT_PASSWORD;
-		}
+		return match (true) {
+			!$this->isRecruiting() => self::RECRUIT_CLOSED,
+			empty($this->getPassword()) => self::RECRUIT_OPEN,
+			default => self::RECRUIT_PASSWORD,
+		};
 	}
 
 	/**
@@ -375,9 +373,8 @@ class SmrAlliance {
 	public function getDescription(): string {
 		if (empty($this->description)) {
 			return '';
-		} else {
-			return htmlentities($this->description);
 		}
+		return htmlentities($this->description);
 	}
 
 	public function setAllianceDescription(string $description, AbstractSmrPlayer $player = null): void {

--- a/src/lib/Default/SmrPlanet.php
+++ b/src/lib/Default/SmrPlanet.php
@@ -149,23 +149,16 @@ class SmrPlanet {
 
 	public function getInterestRate(): float {
 		$level = $this->getLevel();
-		if ($level < 9) {
-			return .0404;
-		} elseif ($level < 19) {
-			return .0609;
-		} elseif ($level < 29) {
-			return .1236;
-		} elseif ($level < 39) {
-			return .050625;
-		} elseif ($level < 49) {
-			return .0404;
-		} elseif ($level < 59) {
-			return .030225;
-		} elseif ($level < 69) {
-			return .0201;
-		} else {
-			return .018081;
-		}
+		return match (true) {
+			$level < 9 => .0404,
+			$level < 19 => .0609,
+			$level < 29 => .1236,
+			$level < 39 => .050625,
+			$level < 49 => .0404,
+			$level < 59 => .030225,
+			$level < 69 => .0201,
+			default => .018081,
+		};
 	}
 
 	public function checkBondMaturity(bool $partial = false): void {
@@ -578,9 +571,8 @@ class SmrPlanet {
 		if ($goodID === null) {
 			$stockpile = $this->getStockpile();
 			return count($stockpile) > 0 && max($stockpile) > 0;
-		} else {
-			return $this->getStockpile($goodID) > 0;
 		}
+		return $this->getStockpile($goodID) > 0;
 	}
 
 	public function setStockpile(int $goodID, int $amount): void {

--- a/src/lib/Default/SmrPlanetType.php
+++ b/src/lib/Default/SmrPlanetType.php
@@ -61,11 +61,11 @@ abstract class SmrPlanetType {
 		}
 		if ($structureID === null) {
 			return $this->structures;
-		} elseif (isset($this->structures[$structureID])) {
-			return $this->structures[$structureID];
-		} else {
-			throw new Exception("Structure not supported on this planet type: $structureID");
 		}
+		if (isset($this->structures[$structureID])) {
+			return $this->structures[$structureID];
+		}
+		throw new Exception("Structure not supported on this planet type: $structureID");
 	}
 
 }

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -870,6 +870,7 @@ class ChessGame {
 		if ($this->hasEnded() || !$this->isPlayer($accountID)) {
 			throw new Exception('Invalid resign conditions');
 		}
+
 		// If only 1 person has moved then just end the game.
 		if (count($this->getMoves()) < 2) {
 			$this->endDate = Epoch::time();
@@ -877,15 +878,15 @@ class ChessGame {
 							SET end_time=' . $this->db->escapeNumber(Epoch::time()) . '
 							WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ';');
 			return 1;
-		} else {
-			$loserColour = $this->getColourForAccountID($accountID);
-			$winnerAccountID = $this->getColourID(self::getOtherColour($loserColour));
-			$results = $this->setWinner($winnerAccountID);
-			$chessType = $this->isNPCGame() ? 'Chess (NPC)' : 'Chess';
-			$results['Loser']->increaseHOF(1, [$chessType, 'Games', 'Resigned'], HOF_PUBLIC);
-			SmrPlayer::sendMessageFromCasino($results['Winner']->getGameID(), $results['Winner']->getPlayerID(), '[player=' . $results['Loser']->getPlayerID() . '] just resigned against you in [chess=' . $this->getChessGameID() . '].');
-			return 0;
 		}
+
+		$loserColour = $this->getColourForAccountID($accountID);
+		$winnerAccountID = $this->getColourID(self::getOtherColour($loserColour));
+		$results = $this->setWinner($winnerAccountID);
+		$chessType = $this->isNPCGame() ? 'Chess (NPC)' : 'Chess';
+		$results['Loser']->increaseHOF(1, [$chessType, 'Games', 'Resigned'], HOF_PUBLIC);
+		SmrPlayer::sendMessageFromCasino($results['Winner']->getGameID(), $results['Winner']->getPlayerID(), '[player=' . $results['Loser']->getPlayerID() . '] just resigned against you in [chess=' . $this->getChessGameID() . '].');
+		return 0;
 	}
 
 	public function getPlayGameHREF(): string {

--- a/src/lib/Smr/Database.php
+++ b/src/lib/Smr/Database.php
@@ -217,11 +217,7 @@ class Database {
 
 	public function escapeBoolean(bool $bool): string {
 		// We store booleans as an enum
-		if ($bool) {
-			return '\'TRUE\'';
-		} else {
-			return '\'FALSE\'';
-		}
+		return $bool ? '\'TRUE\'' : '\'FALSE\'';
 	}
 
 	public function escapeObject(mixed $object, bool $compress = false, bool $nullable = false): string {

--- a/src/lib/Smr/HallOfFame.php
+++ b/src/lib/Smr/HallOfFame.php
@@ -71,9 +71,8 @@ class HallOfFame {
 		     !SmrGame::getGame($gameID)->hasEnded() &&
 		     !SmrPlayer::getPlayer($accountID, $gameID)->sameAlliance($session->getPlayer()))) {
 			return '-';
-		} else {
-			return $amount;
 		}
+		return $amount;
 	}
 
 	public static function getHofRank(string $view, array $viewType, int $accountID, ?int $gameID): array {
@@ -171,9 +170,8 @@ class HallOfFame {
 					$var['type'] = $typeList;
 					$var['view'] = $type;
 					break;
-				} else {
-					$typeList[] = $type;
 				}
+				$typeList[] = $type;
 				$viewing .= ' &rarr; ';
 				$container = Page::copy($var);
 				$container['type'] = $typeList;

--- a/src/lib/Smr/SocialLogin/SocialLogin.php
+++ b/src/lib/Smr/SocialLogin/SocialLogin.php
@@ -23,15 +23,12 @@ abstract class SocialLogin {
 	 * Returns a SocialLogin class of the given derived type.
 	 */
 	public static function get(string $loginType): self {
-		if ($loginType === Facebook::getLoginType()) {
-			return new Facebook();
-		} elseif ($loginType === Twitter::getLoginType()) {
-			return new Twitter();
-		} elseif ($loginType === Google::getLoginType()) {
-			return new Google();
-		} else {
-			throw new SocialLoginInvalidType('Unknown social login type: ' . $loginType);
-		}
+		return match ($loginType) {
+			Facebook::getLoginType() => new Facebook(),
+			Twitter::getLoginType() => new Twitter(),
+			Google::getLoginType() => new Google(),
+			default => throw new SocialLoginInvalidType('Unknown social login type: ' . $loginType),
+		};
 	}
 
 	public function __construct() {

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -156,11 +156,7 @@ class Template {
 
 	protected function doAn(string $wordAfter): string {
 		$char = strtoupper($wordAfter[0]);
-		if (str_contains('AEIOU', $char)) {
-			return 'an';
-		} else {
-			return 'a';
-		}
+		return str_contains('AEIOU', $char) ? 'an' : 'a';
 	}
 
 	/**

--- a/src/lib/Smr/VoteSite.php
+++ b/src/lib/Smr/VoteSite.php
@@ -165,11 +165,10 @@ class VoteSite {
 	 * Returns the image to display for this voting site.
 	 */
 	public function getLinkImg(int $gameID): string {
-		if ($this->freeTurnsReady($gameID)) {
-			return $this->data['img_star'];
-		} else {
+		if (!$this->freeTurnsReady($gameID)) {
 			return $this->data['img_default'];
 		}
+		return $this->data['img_star'];
 	}
 
 	/**
@@ -177,11 +176,10 @@ class VoteSite {
 	 */
 	public function getLinkUrl(int $gameID): string {
 		$baseUrl = $this->data['url_base'];
-		if ($this->freeTurnsReady($gameID)) {
-			return $this->data['url_func']($baseUrl, $this->accountID, $gameID, $this->linkID);
-		} else {
+		if (!$this->freeTurnsReady($gameID)) {
 			return $baseUrl;
 		}
+		return $this->data['url_func']($baseUrl, $this->accountID, $gameID, $this->linkID);
 	}
 
 	/**

--- a/src/templates/Default/engine/Default/includes/SectorPlayers.inc.php
+++ b/src/templates/Default/engine/Default/includes/SectorPlayers.inc.php
@@ -1,15 +1,11 @@
 <?php
 function getPlayerOptionClass($player, $other) {
 	// Returns the CSS relational class of player "other" relative to "player".
-	if (!$player->traderNAPAlliance($other)) {
-		if ($other->canFight()) {
-			return 'enemy';
-		} else {
-			return 'neutral';
-		}
-	} else {
-		return 'friendly';
-	}
+	return match (true) {
+		$player->traderNAPAlliance($other) => 'friendly',
+		$other->canFight() => 'enemy',
+		default => 'neutral',
+	};
 }
 ?>
 

--- a/src/tools/chat_helpers/channel_msg_forces.php
+++ b/src/tools/chat_helpers/channel_msg_forces.php
@@ -50,13 +50,12 @@ function shared_channel_msg_forces(SmrPlayer $player, ?string $option): array {
 					ORDER BY expire_time ASC LIMIT 1');
 	}
 
-	if ($dbResult->hasRecord()) {
-		$dbRecord = $dbResult->record();
-		$sectorId = $dbRecord->getInt('sector');
-		$expire = $dbRecord->getInt('expire_time');
-
-		return ['Forces in sector ' . $sectorId . ' will expire in ' . format_time($expire - time())];
-	} else {
+	if (!$dbResult->hasRecord()) {
 		return ['Your alliance does not own any forces in these sectors.'];
 	}
+	$dbRecord = $dbResult->record();
+	$sectorId = $dbRecord->getInt('sector');
+	$expire = $dbRecord->getInt('expire_time');
+
+	return ['Forces in sector ' . $sectorId . ' will expire in ' . format_time($expire - time())];
 }

--- a/src/tools/chat_helpers/channel_msg_seed.php
+++ b/src/tools/chat_helpers/channel_msg_seed.php
@@ -21,9 +21,8 @@ function get_seed_message(SmrPlayer $player): string {
 
 	if (count($missingSeeds) == 0) {
 		return $player->getPlayerName() . ' has seeded all sectors.';
-	} else {
-		return $player->getPlayerName() . ' (' . count($missingSeeds) . ' missing) : ' . implode(' ', $missingSeeds);
 	}
+	return $player->getPlayerName() . ' (' . count($missingSeeds) . ' missing) : ' . implode(' ', $missingSeeds);
 }
 
 function shared_channel_msg_seed(SmrPlayer $player): array {

--- a/src/tools/chat_helpers/channel_msg_seedlist.php
+++ b/src/tools/chat_helpers/channel_msg_seedlist.php
@@ -20,11 +20,10 @@ function shared_channel_msg_seedlist(SmrPlayer $player): array {
 
 	if (count($seedlist) == 0) {
 		return ['Your alliance has not set up a seedlist yet.'];
-	} else {
-		$result = ['Your alliance has a ' . count($seedlist) . ' sector seedlist:'];
-		$result[] = implode(' ', $seedlist);
-		return $result;
 	}
+	$result = ['Your alliance has a ' . count($seedlist) . ' sector seedlist:'];
+	$result[] = implode(' ', $seedlist);
+	return $result;
 }
 
 function shared_channel_msg_seedlist_add(SmrPlayer $player, ?array $sectors): array {

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -653,49 +653,49 @@ function findRoutes(SmrPlayer $player): array {
 		$routes = $dbResult->record()->getObject('routes', true);
 		debug('Using Cached Routes: #' . count($routes));
 		return $routes;
-	} else {
-		debug('Generating Routes');
-		$allSectors = [];
-		foreach (SmrGalaxy::getGameGalaxies($player->getGameID()) as $galaxy) {
-			$allSectors += $galaxy->getSectors(); //Merge arrays
-		}
-
-		$distances = Plotter::calculatePortToPortDistances($allSectors, $maxDistance, $startSectorID, $endSectorID);
-
-		if ($maxNumberOfPorts == 1) {
-			$allRoutes = \Routes\RouteGenerator::generateOneWayRoutes($allSectors, $distances, $tradeGoods, $tradeRaces, $routesForPort);
-		} else {
-			$allRoutes = \Routes\RouteGenerator::generateMultiPortRoutes($maxNumberOfPorts, $allSectors, $tradeGoods, $tradeRaces, $distances, $routesForPort, $numberOfRoutes);
-		}
-
-		unset($distances);
-
-		$routesMerged = [];
-		foreach ($allRoutes[\Routes\RouteGenerator::MONEY_ROUTE] as $multi => $routesByMulti) {
-			$routesMerged += $routesByMulti; //Merge arrays
-		}
-
-		unset($allSectors);
-		SmrPort::clearCache();
-		SmrSector::clearCache();
-
-		if (count($routesMerged) == 0) {
-			debug('Could not find any routes! Try another NPC.');
-			throw new FinalActionException();
-		}
-
-		$db->insert('route_cache', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'max_ports' => $db->escapeNumber($maxNumberOfPorts),
-			'goods_allowed' => $db->escapeObject($tradeGoods),
-			'races_allowed' => $db->escapeObject($tradeRaces),
-			'start_sector_id' => $db->escapeNumber($startSectorID),
-			'end_sector_id' => $db->escapeNumber($endSectorID),
-			'routes_for_port' => $db->escapeNumber($routesForPort),
-			'max_distance' => $db->escapeNumber($maxDistance),
-			'routes' => $db->escapeObject($routesMerged, true),
-		]);
-		debug('Found Routes: #' . count($routesMerged));
-		return $routesMerged;
 	}
+
+	debug('Generating Routes');
+	$allSectors = [];
+	foreach (SmrGalaxy::getGameGalaxies($player->getGameID()) as $galaxy) {
+		$allSectors += $galaxy->getSectors(); //Merge arrays
+	}
+
+	$distances = Plotter::calculatePortToPortDistances($allSectors, $maxDistance, $startSectorID, $endSectorID);
+
+	if ($maxNumberOfPorts == 1) {
+		$allRoutes = \Routes\RouteGenerator::generateOneWayRoutes($allSectors, $distances, $tradeGoods, $tradeRaces, $routesForPort);
+	} else {
+		$allRoutes = \Routes\RouteGenerator::generateMultiPortRoutes($maxNumberOfPorts, $allSectors, $tradeGoods, $tradeRaces, $distances, $routesForPort, $numberOfRoutes);
+	}
+
+	unset($distances);
+
+	$routesMerged = [];
+	foreach ($allRoutes[\Routes\RouteGenerator::MONEY_ROUTE] as $multi => $routesByMulti) {
+		$routesMerged += $routesByMulti; //Merge arrays
+	}
+
+	unset($allSectors);
+	SmrPort::clearCache();
+	SmrSector::clearCache();
+
+	if (count($routesMerged) == 0) {
+		debug('Could not find any routes! Try another NPC.');
+		throw new FinalActionException();
+	}
+
+	$db->insert('route_cache', [
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'max_ports' => $db->escapeNumber($maxNumberOfPorts),
+		'goods_allowed' => $db->escapeObject($tradeGoods),
+		'races_allowed' => $db->escapeObject($tradeRaces),
+		'start_sector_id' => $db->escapeNumber($startSectorID),
+		'end_sector_id' => $db->escapeNumber($endSectorID),
+		'routes_for_port' => $db->escapeNumber($routesForPort),
+		'max_distance' => $db->escapeNumber($maxDistance),
+		'routes' => $db->escapeObject($routesMerged, true),
+	]);
+	debug('Found Routes: #' . count($routesMerged));
+	return $routesMerged;
 }


### PR DESCRIPTION
PSR2R.ControlStructures.UnneededElse

In general, if/else clauses that create exit points (continue, break,
return, etc.) are unneeded because the code that follows will not be
reachable. The extra indentation caused by this code smell can also
be harmful to code readability (since deep nesting is hard to read).

When a condition clearly indicates a departure from the "normal"
execution path, then:

```php
  if (condition) {
    return foo
  }
  return bar
```

matches the asymmetry of the logic better than:

```php
  if (condition) {
    return foo
  } else {
    return bar
  }
```

The former also has the benefit of reducing indentation levels, and
thus (usually) making the code easier to read.

At first, I was skeptical that this was a good code sniff, but after
reassessing each case carefully, I realized that it was more often the
case that fixing this code smell improved its readability. Of course,
there will be exceptions, especially when there is more symmetry in
the various exit points.

In some cases, we replace the if/else clauses with a match expression
or a ternary operator, both of which have the added benefit of being
a single expression (and thus a single exit point).