### PR TITLE
Globally trim strings input by the user

### DIFF
--- a/src/engine/Default/admin/admin_message_send_processing.php
+++ b/src/engine/Default/admin/admin_message_send_processing.php
@@ -3,7 +3,7 @@
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 const ALL_GAMES_ID = 20000;
-$message = trim(Smr\Request::get('message'));
+$message = Smr\Request::get('message');
 $expire = Smr\Request::getFloat('expire');
 $game_id = $var['SendGameID'];
 if ($game_id != ALL_GAMES_ID) {

--- a/src/engine/Default/admin/announcement_create_processing.php
+++ b/src/engine/Default/admin/announcement_create_processing.php
@@ -3,7 +3,7 @@
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
-$message = trim(Smr\Request::get('message'));
+$message = Smr\Request::get('message');
 if (Smr\Request::get('action') == 'Preview announcement') {
 	$container = Page::create('skeleton.php', 'admin/announcement_create.php');
 	$container['preview'] = $message;

--- a/src/engine/Default/admin/box_reply_processing.php
+++ b/src/engine/Default/admin/box_reply_processing.php
@@ -4,7 +4,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
 
-$message = trim(Smr\Request::get('message'));
+$message = Smr\Request::get('message');
 $banPoints = Smr\Request::getInt('BanPoints');
 $rewardCredits = Smr\Request::getInt('RewardCredits');
 if (Smr\Request::get('action') == 'Preview message') {

--- a/src/engine/Default/admin/newsletter_send_processing.php
+++ b/src/engine/Default/admin/newsletter_send_processing.php
@@ -72,7 +72,7 @@ if (Smr\Request::get('to_email') == '*') {
 		$to_name = $dbRecord->getField('login');
 
 		// Reset the message body with personalized salutation, if requested
-		$salutation = trim(Smr\Request::get('salutation'));
+		$salutation = Smr\Request::get('salutation');
 		if (!empty($salutation)) {
 			$salutation .= ' ' . $to_name . ',';
 			set_mail_body($mail, $var['newsletter_html'], $var['newsletter_text'], $salutation);

--- a/src/engine/Default/admin/notify_reply_processing.php
+++ b/src/engine/Default/admin/notify_reply_processing.php
@@ -4,9 +4,9 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
 
-$offenderReply = trim(Smr\Request::get('offenderReply'));
+$offenderReply = Smr\Request::get('offenderReply');
 $offenderBanPoints = Smr\Request::getInt('offenderBanPoints');
-$offendedReply = trim(Smr\Request::get('offendedReply'));
+$offendedReply = Smr\Request::get('offendedReply');
 $offendedBanPoints = Smr\Request::getInt('offendedBanPoints');
 if (Smr\Request::get('action') == 'Preview messages') {
 	$container = Page::create('skeleton.php', 'admin/notify_reply.php');

--- a/src/engine/Default/admin/vote_create_processing.php
+++ b/src/engine/Default/admin/vote_create_processing.php
@@ -16,14 +16,14 @@ if ($action == 'Preview Option') {
 
 $db = Smr\Database::getInstance();
 if ($action == 'Create Vote') {
-	$question = trim(Smr\Request::get('question'));
+	$question = Smr\Request::get('question');
 	$end = Smr\Epoch::time() + 86400 * Smr\Request::getInt('days');
 	$db->insert('voting', [
 		'question' => $db->escapeString($question),
 		'end' => $db->escapeNumber($end),
 	]);
 } elseif ($action == 'Add Option') {
-	$option = trim(Smr\Request::get('option'));
+	$option = Smr\Request::get('option');
 	$voteID = Smr\Request::getInt('vote');
 	$db->insert('voting_options', [
 		'vote_id' => $db->escapeNumber($voteID),

--- a/src/engine/Default/admin/word_filter_add.php
+++ b/src/engine/Default/admin/word_filter_add.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
-$word = strtoupper(trim(Smr\Request::get('Word')));
-$word_replacement = strtoupper(trim(Smr\Request::get('WordReplacement')));
+$word = strtoupper(Smr\Request::get('Word'));
+$word_replacement = strtoupper(Smr\Request::get('WordReplacement'));
 
 $container = Page::create('skeleton.php', 'admin/word_filter.php');
 

--- a/src/engine/Default/alliance_create_processing.php
+++ b/src/engine/Default/alliance_create_processing.php
@@ -7,8 +7,7 @@ if ($player->getAllianceJoinable() > Smr\Epoch::time()) {
 	create_error('You cannot create an alliance for another ' . format_time($player->getAllianceJoinable() - Smr\Epoch::time()) . '.');
 }
 
-// trim input first
-$name = trim(Smr\Request::get('name'));
+$name = Smr\Request::get('name');
 if (empty($name)) {
 	throw new Exception('No alliance name entered');
 }
@@ -18,7 +17,7 @@ if (!ctype_print($name)) {
 	create_error('The alliance name contains invalid characters!');
 }
 
-$password = trim(Smr\Request::get('password', ''));
+$password = Smr\Request::get('password', '');
 $description = Smr\Request::get('description');
 $recruitType = Smr\Request::get('recruit_type');
 $perms = Smr\Request::get('Perms');

--- a/src/engine/Default/alliance_message_add_processing.php
+++ b/src/engine/Default/alliance_message_add_processing.php
@@ -5,7 +5,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$body = htmlentities(trim(Smr\Request::get('body')), ENT_COMPAT, 'utf-8');
+$body = htmlentities(Smr\Request::get('body'), ENT_COMPAT, 'utf-8');
 $topic = Smr\Request::get('topic', ''); // only present for Create Thread
 $allEyesOnly = Smr\Request::has('allEyesOnly'); // only present for Create Thread
 

--- a/src/engine/Default/alliance_stat_processing.php
+++ b/src/engine/Default/alliance_stat_processing.php
@@ -6,22 +6,22 @@ $player = $session->getPlayer();
 
 $alliance_id = $var['alliance_id'] ?? $player->getAllianceID();
 if (Smr\Request::has('description')) {
-	$description = trim(Smr\Request::get('description'));
+	$description = Smr\Request::get('description');
 }
 if (Smr\Request::has('discord_server')) {
-	$discordServer = trim(Smr\Request::get('discord_server'));
+	$discordServer = Smr\Request::get('discord_server');
 }
 if (Smr\Request::has('discord_channel')) {
-	$discordChannel = trim(Smr\Request::get('discord_channel'));
+	$discordChannel = Smr\Request::get('discord_channel');
 }
 if (Smr\Request::has('irc')) {
-	$irc = trim(Smr\Request::get('irc'));
+	$irc = Smr\Request::get('irc');
 }
 if (Smr\Request::has('mod')) {
-	$mod = trim(Smr\Request::get('mod'));
+	$mod = Smr\Request::get('mod');
 }
 if (Smr\Request::has('url')) {
-	$url = trim(Smr\Request::get('url'));
+	$url = Smr\Request::get('url');
 }
 
 // Prevent XSS attacks

--- a/src/engine/Default/bank_anon_create_processing.php
+++ b/src/engine/Default/bank_anon_create_processing.php
@@ -3,7 +3,7 @@
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$password = trim(Smr\Request::get('password'));
+$password = Smr\Request::get('password');
 
 if (empty($password)) {
 	create_error('You cannot use a blank password!');

--- a/src/engine/Default/council_send_message_processing.php
+++ b/src/engine/Default/council_send_message_processing.php
@@ -4,7 +4,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$message = htmlentities(trim(Smr\Request::get('message')), ENT_COMPAT, 'utf-8');
+$message = htmlentities(Smr\Request::get('message'), ENT_COMPAT, 'utf-8');
 
 if (empty($message)) {
 	create_error('You have to enter text to send a message!');

--- a/src/engine/Default/course_destination_button_processing.php
+++ b/src/engine/Default/course_destination_button_processing.php
@@ -8,7 +8,7 @@ $sectorId = Smr\Request::getInt('sectorId');
 
 switch ($type) {
 	case 'add':
-		$label = trim(Smr\Request::get('label'));
+		$label = Smr\Request::get('label');
 		$player->addDestinationButton($sectorId, $label);
 		break;
 

--- a/src/engine/Default/galactic_post_write_article_processing.php
+++ b/src/engine/Default/galactic_post_write_article_processing.php
@@ -4,8 +4,8 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$title = trim(Smr\Request::get('title'));
-$message = trim(Smr\Request::get('message'));
+$title = Smr\Request::get('title');
+$message = Smr\Request::get('message');
 if (!$player->isGPEditor()) {
 	$title = htmlentities($title, ENT_COMPAT, 'utf-8');
 	$message = htmlentities($message, ENT_COMPAT, 'utf-8');

--- a/src/engine/Default/game_join_processing.php
+++ b/src/engine/Default/game_join_processing.php
@@ -4,8 +4,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
 
-// trim input now
-$player_name = trim(Smr\Request::get('player_name'));
+$player_name = Smr\Request::get('player_name');
 
 Smr\DisplayNameValidator::validate($player_name);
 

--- a/src/engine/Default/message_send_processing.php
+++ b/src/engine/Default/message_send_processing.php
@@ -4,7 +4,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$message = htmlentities(trim(Smr\Request::get('message')), ENT_COMPAT, 'utf-8');
+$message = htmlentities(Smr\Request::get('message'), ENT_COMPAT, 'utf-8');
 
 if (Smr\Request::get('action') == 'Preview message') {
 	$container = Page::create('skeleton.php');

--- a/src/engine/Default/planet_ownership_processing.php
+++ b/src/engine/Default/planet_ownership_processing.php
@@ -26,7 +26,7 @@ if ($action == 'Take Ownership') {
 	$planet->removePassword();
 	$player->log(LOG_TYPE_PLANETS, 'Player takes ownership of planet.');
 } elseif ($action == 'Rename') {
-	$name = trim(Smr\Request::get('name'));
+	$name = Smr\Request::get('name');
 	if (empty($name)) {
 		create_error('You cannot leave your planet nameless!');
 	}

--- a/src/engine/Default/preferences_processing.php
+++ b/src/engine/Default/preferences_processing.php
@@ -45,7 +45,7 @@ if ($action == 'Save and resend validation code') {
 	$account->setPassword($new_password);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your password.';
 } elseif ($action == 'Change Name') {
-	$HoF_name = trim(Smr\Request::get('HoF_name'));
+	$HoF_name = Smr\Request::get('HoF_name');
 
 	Smr\DisplayNameValidator::validate($HoF_name);
 
@@ -59,7 +59,7 @@ if ($action == 'Save and resend validation code') {
 	$account->setHofName($HoF_name);
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your hall of fame name.';
 } elseif ($action == 'Change Discord ID') {
-	$discordId = trim(Smr\Request::get('discord_id'));
+	$discordId = Smr\Request::get('discord_id');
 
 	if (empty($discordId)) {
 		$account->setDiscordId(null);
@@ -79,7 +79,7 @@ if ($action == 'Save and resend validation code') {
 		$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your Discord User ID.';
 	}
 } elseif ($action == 'Change IRC Nick') {
-	$ircNick = trim(Smr\Request::get('irc_nick'));
+	$ircNick = Smr\Request::get('irc_nick');
 
 	// here you can delete your registered irc nick
 	if (empty($ircNick)) {
@@ -166,8 +166,7 @@ if ($action == 'Save and resend validation code') {
 	}
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have saved your hotkeys.';
 } elseif ($action == 'change_name') {
-	// trim input now
-	$player_name = trim(Smr\Request::get('PlayerName'));
+	$player_name = Smr\Request::get('PlayerName');
 
 	if ($player->getPlayerName() == $player_name) {
 		create_error('Your player already has that name!');

--- a/src/htdocs/login.php
+++ b/src/htdocs/login.php
@@ -24,7 +24,7 @@ try {
 
 	$template = Smr\Template::getInstance();
 	if (Smr\Request::has('msg')) {
-		$template->assign('Message', htmlentities(trim(Smr\Request::get('msg')), ENT_COMPAT, 'utf-8'));
+		$template->assign('Message', htmlentities(Smr\Request::get('msg'), ENT_COMPAT, 'utf-8'));
 	} elseif (Smr\Request::has('status')) {
 		session_start();
 		if (isset($_SESSION['login_msg'])) {

--- a/src/htdocs/login_create_processing.php
+++ b/src/htdocs/login_create_processing.php
@@ -42,8 +42,8 @@ try {
 		}
 	}
 
-	$login = trim(Smr\Request::get('login'));
-	$password = trim(Smr\Request::get('password'));
+	$login = Smr\Request::get('login');
+	$password = Smr\Request::get('password');
 	if (strstr($login, '\'')) {
 		$msg = 'Illegal character in login detected! Don\'t use the apostrophe.';
 		header('Location: /error.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
@@ -84,7 +84,7 @@ try {
 	// 2. social account creation without an associated e-mail
 	// In these two cases, we still need to validate the input address.
 	if (!$socialLogin || empty($_SESSION['socialLogin']->getEmail())) {
-		$email = trim(Smr\Request::get('email'));
+		$email = Smr\Request::get('email');
 		$validatedBySocial = false;
 	} else {
 		$email = $_SESSION['socialLogin']->getEmail();

--- a/src/lib/Smr/Request.php
+++ b/src/lib/Smr/Request.php
@@ -72,11 +72,11 @@ class Request {
 	}
 
 	/**
-	 * Returns index value as a string.
+	 * Returns index value as a (trimmed) string.
 	 */
 	public static function get(string $index, string $default = null): string {
 		if (self::has($index)) {
-			return $_REQUEST[$index];
+			return trim($_REQUEST[$index]);
 		} elseif ($default !== null) {
 			return $default;
 		}

--- a/test/SmrTest/lib/DefaultGame/RequestTest.php
+++ b/test/SmrTest/lib/DefaultGame/RequestTest.php
@@ -15,13 +15,15 @@ use Smr\Session;
 class RequestTest extends TestCase {
 
 	public static function setUpBeforeClass(): void {
+		// All request variables are stored by PHP as strings
 		$_REQUEST = [
-			'int' => 2,
-			'float' => 3.14,
+			'int' => '2',
+			'float' => '3.14',
 			'str' => 'ing',
+			'str_padded' => '   ing ',
 			'array_empty' => [],
 			'array_str' => ['a', 'b', 'c'],
-			'array_int' => [1, 2, 3],
+			'array_int' => ['1', '2', '3'],
 		];
 	}
 
@@ -131,6 +133,8 @@ class RequestTest extends TestCase {
 		$this->assertSame('ing', Request::get('str', 'foo'));
 		// An index that exists, no default
 		$this->assertSame('ing', Request::get('str'));
+		// An index that exists, with whitespace padding that gets trimmed
+		$this->assertSame('ing', Request::get('str_padded'));
 		// An index that doesn't exist, with default
 		$this->assertSame('foo', Request::get('noexist', 'foo'));
 	}


### PR DESCRIPTION
In many cases where we use `Request::get`, we trim the returned value
manually. This is because leading and trailing whitespace from a form
input is almost always accidental and/or meaningless.

For example, I was copy-pasting the alliance name when creating NPCs,
and because we were _not_ trimming that form input, I ended up creating
a second alliance due to a trailing whitespace artifact from the copy.

Now we will _always_ trim form inputs in `Request::get`, and so we no
longer need to call `trim` explicitly on its returned value.