### PR TITLE
composer.json: update PHP-DI from 6.3.5 to 6.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"league/oauth2-facebook": "2.2.0",
 		"league/oauth2-google": "4.0.0",
 		"php": "^8.0",
-		"php-di/php-di": "6.3.5",
+		"php-di/php-di": "6.4.0",
 		"phpmailer/phpmailer": "6.6.0",
 		"team-reflex/discord-php": "7.0.9",
 		"vanilla/nbbc": "2.3.1",

--- a/src/lib/Smr/Container/DiContainer.php
+++ b/src/lib/Smr/Container/DiContainer.php
@@ -69,9 +69,7 @@ class DiContainer {
 			// during its lifecycle (first request)
 			$builder->enableCompilation('/tmp');
 		}
-		// TODO: deprecation warnings suppressed until PHP 8.1 supported!
-		// See https://github.com/PHP-DI/PHP-DI/pull/794.
-		return @$builder->build();
+		return $builder->build();
 	}
 
 	/**


### PR DESCRIPTION
Fixes deprecation warning from one of its dependencies.

https://github.com/PHP-DI/PHP-DI/releases/tag/6.4.0