### PR TITLE
Change NPC_SCRIPT from a const to a DI variable

### DIFF
--- a/src/lib/Smr/Container/DiContainer.php
+++ b/src/lib/Smr/Container/DiContainer.php
@@ -47,6 +47,7 @@ class DiContainer {
 			'DatabaseName' => function(DatabaseProperties $dbProperties): string {
 				return $dbProperties->getDatabaseName();
 			},
+			'NPC_SCRIPT' => false,
 			// Explicitly name all classes that are autowired, so we can take advantage of
 			// the compiled container feature for a performance boost
 			Epoch::class => autowire(),

--- a/src/lib/Smr/Epoch.php
+++ b/src/lib/Smr/Epoch.php
@@ -66,7 +66,7 @@ class Epoch {
 	 * only be used by the CLI programs that run continuously.
 	 */
 	public static function update(): void {
-		if (!defined('NPC_SCRIPT')) {
+		if (DiContainer::get('NPC_SCRIPT') === false) {
 			throw new Exception('Only call this function from CLI programs!');
 		}
 		DiContainer::getContainer()->set(self::class, new self());

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -7,7 +7,9 @@ try {
 	require_once(CONFIG . 'npc/config.specific.php');
 
 	debug('Script started');
-	define('NPC_SCRIPT', true);
+
+	// Enable NPC-specific conditions
+	Smr\Container\DiContainer::getContainer()->set('NPC_SCRIPT', true);
 
 	$descriptorSpec = [
 		0 => ['pipe', 'r'], // stdin is a pipe that the child will read from

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -15,13 +15,13 @@ function overrideForward(Page $container): never {
 }
 const OVERRIDE_FORWARD = true;
 
-// Must be defined before anything that might throw an exception
-const NPC_SCRIPT = true;
-
 // global config
 require_once(realpath(dirname(__FILE__)) . '/../../bootstrap.php');
 // bot config
 require_once(CONFIG . 'npc/config.specific.php');
+
+// Enable NPC-specific conditions
+Smr\Container\DiContainer::getContainer()->set('NPC_SCRIPT', true);
 
 // Raise exceptions for all types of errors for improved error reporting
 // and to attempt to shut down the NPCs cleanly on errors.

--- a/test/SmrTest/lib/DefaultGame/EpochTest.php
+++ b/test/SmrTest/lib/DefaultGame/EpochTest.php
@@ -4,6 +4,7 @@ namespace SmrTest\lib\DefaultGame;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Smr\Container\DiContainer;
 use Smr\Epoch;
 
 /**
@@ -11,15 +12,17 @@ use Smr\Epoch;
  */
 class EpochTest extends TestCase {
 
+	protected function tearDown(): void {
+		// Reset the DI container to avoid contaminating other tests
+		DiContainer::initialize(false);
+	}
+
 	/**
 	 * Test that the `update` function works properly when NPC_SCRIPT is set.
-	 * We run in a separate process so that the constant doesn't propagate into
-	 * other tests.
-	 * @runInSeparateProcess
 	 */
 	public function test_update_cli(): void {
 		// Set the NPC_SCRIPT variable as if this were a CLI program
-		define('NPC_SCRIPT', true);
+		DiContainer::getContainer()->set('NPC_SCRIPT', true);
 
 		$time = Epoch::time();
 		$microtime = Epoch::microtime();
@@ -34,7 +37,7 @@ class EpochTest extends TestCase {
 	}
 
 	/**
-	 * update should throw if called without NPC_SCRIPT defined.
+	 * update should throw if NPC_SCRIPT is false (its default value).
 	 */
 	public function test_update(): void {
 		$this->expectException(Exception::class);


### PR DESCRIPTION
Setting NPC_SCRIPT as a PHP constant made it difficult to test classes
that depended on it. This is because PHPUnit has no mechanism to change
the value of a PHP constant, apart from `@runInSeparateProcess`, and
then setting the constant to a different value in that process.

Unfortunately, `@runInSeparateProcess` interacted poorly with PHP-DI
in a way that I don't completely understand. When running tests using
this decorator, the following error would be triggered:

```
PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught Error: Using $this when not in object context in /smr/vendor/php-di/php-di/src/Compiler/Template.php:4
Stack trace:
#0 Standard input code(1154): require_once()
#1 {main}
  thrown in /smr/vendor/php-di/php-di/src/Compiler/Template.php on line 4
Fatal error: Uncaught Error: Using $this when not in object context in /smr/vendor/php-di/php-di/src/Compiler/Template.php:4
Stack trace:
#0 Standard input code(1154): require_once()
#1 {main}
  thrown in /smr/vendor/php-di/php-di/src/Compiler/Template.php on line 4
```

This error always occurred when running the associated test files
directly, but in an upcoming class `SectorLock`, it also occurred when
running the entire test suite, which is obviously a blocking issue.

To fix this, we convert the PHP constant `NPC_SCRIPT` into a PHP-DI
variable with the same name. This allows us to change its value more
easily, and particularly at runtime instead of compile time. In some
sense this is an abuse of the DI container, since we're not actually
using it for DI -- rather just for global variable storage. Oh well.