### PR TITLE
Enhancements for player lists

### DIFF
--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -144,6 +144,26 @@ if ($sector->hasPort()) {
 	$template->assign('PortIsAtWar', $player->getRelation($port->getRaceID()) < RELATIONS_WAR);
 }
 
+// *******************************************
+// *
+// * Ships
+// *
+// *******************************************
+$otherPlayers = $sector->getOtherTraders($player);
+$visiblePlayers = [];
+$cloakedPlayers = [];
+foreach ($otherPlayers as $accountID => $otherPlayer) {
+	if ($player->canSee($otherPlayer)) {
+		$visiblePlayers[$accountID] = $otherPlayer;
+	} else {
+		$cloakedPlayers[$accountID] = $otherPlayer;
+	}
+}
+$template->assign('VisiblePlayers', $visiblePlayers);
+$template->assign('CloakedPlayers', $cloakedPlayers);
+$template->assign('SectorPlayersLabel', 'Ships');
+
+
 function checkForForceRefreshMessage(string &$msg): void {
 	$contains = 0;
 	$msg = str_replace('[Force Check]', '', $msg, $contains);

--- a/src/engine/Default/planet_examine.php
+++ b/src/engine/Default/planet_examine.php
@@ -32,3 +32,11 @@ if (!$planetLand) {
 	$planetLand = $dbResult->hasRecord();
 }
 $template->assign('PlanetLand', $planetLand);
+
+if ($planetLand) {
+	$eligibleAttackers = []; // no option to attack if we can land
+} else {
+	$eligibleAttackers = $player->getSector()->getFightingTradersAgainstPlanet($player, $planet, allEligible: true);
+}
+$template->assign('VisiblePlayers', $eligibleAttackers);
+$template->assign('SectorPlayersLabel', 'Attackers');

--- a/src/engine/Default/planet_main.php
+++ b/src/engine/Default/planet_main.php
@@ -4,6 +4,7 @@ $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
+$planet = $player->getSectorPlanet();
 
 require('planet.inc.php');
 
@@ -19,3 +20,7 @@ $db = Smr\Database::getInstance();
 doTickerAssigns($template, $player, $db);
 
 $template->assign('LaunchLink', Page::create('planet_launch_processing.php', '')->href());
+
+// Cloaked ships are visible on planets
+$template->assign('VisiblePlayers', $planet->getOtherTraders($player));
+$template->assign('SectorPlayersLabel', 'Ships');

--- a/src/engine/Default/port_attack_warning.php
+++ b/src/engine/Default/port_attack_warning.php
@@ -1,13 +1,15 @@
 <?php declare(strict_types=1);
 
 $session = Smr\Session::getInstance();
-$sector = $session->getPlayer()->getSector();
+$player = $session->getPlayer();
+$sector = $player->getSector();
 
 if (!$sector->hasPort()) {
 	create_error('This sector does not have a port.');
 }
+$port = $sector->getPort();
 
-if ($sector->getPort()->isDestroyed()) {
+if ($port->isDestroyed()) {
 	Page::create('skeleton.php', 'port_attack.php')->go();
 }
 
@@ -16,4 +18,8 @@ $template = Smr\Template::getInstance();
 $template->assign('PageTopic', 'Port Raid');
 
 $template->assign('PortAttackHREF', Page::create('port_attack_processing.php')->href());
-$template->assign('Port', $sector->getPort());
+$template->assign('Port', $port);
+
+$eligibleAttackers = $sector->getFightingTradersAgainstPort($player, $port, allEligible: true);
+$template->assign('VisiblePlayers', $eligibleAttackers);
+$template->assign('SectorPlayersLabel', 'Attackers');

--- a/src/engine/Default/trader_attack_processing.php
+++ b/src/engine/Default/trader_attack_processing.php
@@ -40,6 +40,10 @@ if ($player->traderNAPAlliance($targetPlayer)) {
 
 $fightingPlayers = $sector->getFightingTraders($player, $targetPlayer);
 
+// Randomize players so that the attack order is always different
+shuffle($fightingPlayers['Attackers']);
+shuffle($fightingPlayers['Defenders']);
+
 //decloak all fighters
 foreach ($fightingPlayers as $teamPlayers) {
 	foreach ($teamPlayers as $teamPlayer) {

--- a/src/lib/Default/SmrSector.php
+++ b/src/lib/Default/SmrSector.php
@@ -930,7 +930,7 @@ class SmrSector {
 	}
 
 	public function getPotentialFightingTraders(AbstractSmrPlayer $attackingPlayer): array {
-		$fightingPlayers = [];
+		$fightingPlayers = ['Attackers' => [], 'Defenders' => []];
 		$alliancePlayers = SmrPlayer::getSectorPlayersByAlliances($this->getGameID(), $this->getSectorID(), [$attackingPlayer->getAllianceID()]);
 		foreach ($alliancePlayers as $accountID => $player) {
 			if ($player->canFight()) {

--- a/src/lib/Default/SmrSector.php
+++ b/src/lib/Default/SmrSector.php
@@ -851,7 +851,7 @@ class SmrSector {
 		return [$attackingPlayer];
 	}
 
-	public function getFightingTradersAgainstPort(AbstractSmrPlayer $attackingPlayer, SmrPort $defendingPort): array {
+	public function getFightingTradersAgainstPort(AbstractSmrPlayer $attackingPlayer, SmrPort $defendingPort, bool $allEligible = false): array {
 		$fightingPlayers = [];
 		$alliancePlayers = SmrPlayer::getSectorPlayersByAlliances($this->getGameID(), $this->getSectorID(), [$attackingPlayer->getAllianceID()]);
 		foreach ($alliancePlayers as $accountID => $player) {
@@ -861,10 +861,13 @@ class SmrSector {
 				}
 			}
 		}
+		if ($allEligible) {
+			return $fightingPlayers;
+		}
 		return self::limitFightingTraders($fightingPlayers, $attackingPlayer, MAXIMUM_PORT_FLEET_SIZE);
 	}
 
-	public function getFightingTradersAgainstPlanet(AbstractSmrPlayer $attackingPlayer, SmrPlanet $defendingPlanet): array {
+	public function getFightingTradersAgainstPlanet(AbstractSmrPlayer $attackingPlayer, SmrPlanet $defendingPlanet, bool $allEligible = false): array {
 		$fightingPlayers = [];
 		$alliancePlayers = SmrPlayer::getSectorPlayersByAlliances($this->getGameID(), $this->getSectorID(), [$attackingPlayer->getAllianceID()]);
 		if (count($alliancePlayers) > 0) {
@@ -876,6 +879,9 @@ class SmrSector {
 					}
 				}
 			}
+		}
+		if ($allEligible) {
+			return $fightingPlayers;
 		}
 		return self::limitFightingTraders($fightingPlayers, $attackingPlayer, min($defendingPlanet->getMaxAttackers(), MAXIMUM_PLANET_FLEET_SIZE));
 	}

--- a/src/lib/Default/SmrSector.php
+++ b/src/lib/Default/SmrSector.php
@@ -904,12 +904,10 @@ class SmrSector {
 			}
 		}
 		$attackers = self::limitFightingTraders($attackers, $attackingPlayer, MAXIMUM_PVP_FLEET_SIZE);
-		shuffle($attackers);
 		foreach ($attackers as $attacker) {
 			$fightingPlayers['Attackers'][$attacker->getAccountID()] = $attacker;
 		}
 		$defenders = self::limitFightingTraders($defenders, $defendingPlayer, MAXIMUM_PVP_FLEET_SIZE);
-		shuffle($defenders);
 		foreach ($defenders as $defender) {
 			$fightingPlayers['Defenders'][$defender->getAccountID()] = $defender;
 		}

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -11,7 +11,6 @@ use Smr\Container\DiContainer;
 class Template {
 
 	private array $data = [];
-	private bool $ignoreMiddle = false;
 	private int $nestedIncludes = 0;
 	private array $ajaxJS = [];
 	protected array $jsAlerts = [];
@@ -238,30 +237,28 @@ class Template {
 			}
 		}
 
-		if (!$this->ignoreMiddle) {
-			$mid = $dom->getElementById('middle_panel');
-
-			$doAjaxMiddle = true;
-			if ($mid === null) {
-				// Skip if there is no middle_panel.
-				$doAjaxMiddle = false;
-			} else {
-				// Skip if middle_panel has ajax-enabled children.
-				foreach ($ajaxSelectors as $selector) {
-					if (count($xpath->query($selector, $mid)) > 0) {
-						$doAjaxMiddle = false;
-						break;
-					}
+		// Determine if we should do ajax updates on the middle panel div
+		$mid = $dom->getElementById('middle_panel');
+		$doAjaxMiddle = true;
+		if ($mid === null) {
+			// Skip if there is no middle_panel.
+			$doAjaxMiddle = false;
+		} else {
+			// Skip if middle_panel has ajax-enabled children.
+			foreach ($ajaxSelectors as $selector) {
+				if (count($xpath->query($selector, $mid)) > 0) {
+					$doAjaxMiddle = false;
+					break;
 				}
 			}
+		}
 
-			if ($doAjaxMiddle) {
-				$inner = $getInnerHTML($mid);
-				if (!$this->checkDisableAJAX($inner)) {
-					$id = $mid->getAttribute('id');
-					if (!$session->addAjaxReturns($id, $inner) && $returnXml) {
-						$xml .= $xmlify($id, $inner);
-					}
+		if ($doAjaxMiddle) {
+			$inner = $getInnerHTML($mid);
+			if (!$this->checkDisableAJAX($inner)) {
+				$id = $mid->getAttribute('id');
+				if (!$session->addAjaxReturns($id, $inner) && $returnXml) {
+					$xml .= $xmlify($id, $inner);
 				}
 			}
 		}
@@ -279,10 +276,6 @@ class Template {
 			$xml .= '<JS>' . $js . '</JS>';
 		}
 		return $xml;
-	}
-
-	public function ignoreMiddle(): void {
-		$this->ignoreMiddle = true;
 	}
 
 }

--- a/src/templates/Default/engine/Default/current_sector.php
+++ b/src/templates/Default/engine/Default/current_sector.php
@@ -44,6 +44,6 @@
 $this->includeTemplate('includes/SectorPlanet.inc.php');
 $this->includeTemplate('includes/SectorPort.inc.php');
 $this->includeTemplate('includes/SectorLocations.inc.php');
-$this->includeTemplate('includes/SectorPlayers.inc.php', ['PlayersContainer' => $ThisSector]);
+$this->includeTemplate('includes/SectorPlayers.inc.php');
 $this->includeTemplate('includes/SectorForces.inc.php'); ?>
 <br />

--- a/src/templates/Default/engine/Default/includes/SectorPlayers.inc.php
+++ b/src/templates/Default/engine/Default/includes/SectorPlayers.inc.php
@@ -10,81 +10,77 @@ function getPlayerOptionClass($player, $other) {
 ?>
 
 <div id="players_cs" class="ajax"><?php
-	if ($PlayersContainer->hasOtherTraders($ThisPlayer)) {
-		$Players = $PlayersContainer->getOtherTraders($ThisPlayer);
-		if (!($PlayersContainer instanceof SmrSector) || $ThisPlayer->canSeeAny($Players)) { ?>
-			<table class="standard fullwidth csShips">
-				<tr>
-					<th class="header" colspan="5">Ships (<?php echo count($Players) ?>)</th>
-				</tr>
-				<tr>
-					<th>Trader</th>
-					<th>Ship</th>
-					<th>Rating</th>
-					<th>Level</th>
-					<th>Option</th>
-				</tr>
-				<?php
-				foreach ($Players as $Player) {
-					if (!($PlayersContainer instanceof SmrSector) || $ThisPlayer->canSee($Player)) {
-						$Ship = $Player->getShip(); ?>
-						<tr<?php if ($Player->hasNewbieStatus()) { ?> class="newbie"<?php } ?>>
-							<td>
-								<?php echo $Player->getLinkedDisplayName(); ?>
-							</td>
-							<td><?php
-								if ($ThisPlayer->traderMAPAlliance($Player)) {
-									if ($Player->isFlagship() && $ThisPlayer->sameAlliance($Player)) { ?>
-										<img title="Alliance Flagship" alt="Alliance Flagship" src="images/flagship.png" width="16" height="12" />&nbsp;<?php
-									}
-									echo $Ship->getName();
-									if ($Ship->hasActiveIllusion()) {
-										if ($Ship->getName() != $Ship->getIllusionShipName()) {
-											?> <span class="npcColour">(<?php echo $Ship->getIllusionShipName(); ?>)</span><?php
-										}
-									}
-								} else {
-									echo $Ship->getDisplayName();
+	if (count($VisiblePlayers) > 0) { ?>
+		<table class="standard fullwidth csShips">
+			<tr>
+				<th class="header" colspan="5"><?php echo $SectorPlayersLabel; ?> (<?php echo count($VisiblePlayers) ?>)</th>
+			</tr>
+			<tr>
+				<th>Trader</th>
+				<th>Ship</th>
+				<th>Rating</th>
+				<th>Level</th>
+				<th>Option</th>
+			</tr>
+			<?php
+			foreach ($VisiblePlayers as $Player) {
+				$Ship = $Player->getShip(); ?>
+				<tr<?php if ($Player->hasNewbieStatus()) { ?> class="newbie"<?php } ?>>
+					<td>
+						<?php echo $Player->getLinkedDisplayName(); ?>
+					</td>
+					<td><?php
+						if ($ThisPlayer->traderMAPAlliance($Player)) {
+							if ($Player->isFlagship() && $ThisPlayer->sameAlliance($Player)) { ?>
+								<img title="Alliance Flagship" alt="Alliance Flagship" src="images/flagship.png" width="16" height="12" />&nbsp;<?php
+							}
+							echo $Ship->getName();
+							if ($Ship->hasActiveIllusion()) {
+								if ($Ship->getName() != $Ship->getIllusionShipName()) {
+									?> <span class="npcColour">(<?php echo $Ship->getIllusionShipName(); ?>)</span><?php
 								}
-								if ($Ship->isCloaked()) {
-									?> <span class="red">[Cloaked]</span><?php
+							}
+						} else {
+							echo $Ship->getDisplayName();
+						}
+						if ($Ship->isCloaked()) {
+							?> <span class="red">[Cloaked]</span><?php
+						}
+						if ($Player->hasCustomShipName() && ($ThisAccount->isDisplayShipImages() || stripos($Player->getCustomShipName(), '<img') === false)) {
+							?><br /><?php echo $Player->getCustomShipName();
+						} ?>
+					</td>
+					<td class="shrink center noWrap"><?php
+						if ($ThisPlayer->traderMAPAlliance($Player)) {
+							echo $Ship->getAttackRating(); ?> / <?php echo $Ship->getDefenseRating();
+							if ($Ship->hasActiveIllusion()) {
+								?> <span class="npcColour">(<?php echo $Ship->getIllusionAttack(); ?> / <?php echo $Ship->getIllusionDefense(); ?>)</span><?php
+							}
+						} else {
+							echo $Ship->getDisplayAttackRating(); ?> / <?php echo $Ship->getDisplayDefenseRating();
+						} ?>
+					</td>
+					<td class="shrink center noWrap"><?php echo $Player->getLevelID() ?></td>
+					<td class="shrink center noWrap">
+						<div class="buttonA"><?php
+							if ($ThisPlayer->isLandedOnPlanet()) {
+								if ($ThisPlanet->getOwnerID() == $ThisPlayer->getAccountID()) {
+									?><a href="<?php echo $Player->getPlanetKickHREF() ?>" class="<?php
+										echo getPlayerOptionClass($ThisPlayer, $Player);
+										?>"> Kick </a><?php
 								}
-								if ($Player->hasCustomShipName() && ($ThisAccount->isDisplayShipImages() || stripos($Player->getCustomShipName(), '<img') === false)) {
-									?><br /><?php echo $Player->getCustomShipName();
-								} ?>
-							</td>
-							<td class="shrink center noWrap"><?php
-								if ($ThisPlayer->traderMAPAlliance($Player)) {
-									echo $Ship->getAttackRating(); ?> / <?php echo $Ship->getDefenseRating();
-									if ($Ship->hasActiveIllusion()) {
-										?> <span class="npcColour">(<?php echo $Ship->getIllusionAttack(); ?> / <?php echo $Ship->getIllusionDefense(); ?>)</span><?php
-									}
-								} else {
-									echo $Ship->getDisplayAttackRating(); ?> / <?php echo $Ship->getDisplayDefenseRating();
-								} ?>
-							</td>
-							<td class="shrink center noWrap"><?php echo $Player->getLevelID() ?></td>
-							<td class="shrink center noWrap">
-								<div class="buttonA"><?php
-									if ($PlayersContainer instanceof SmrPlanet) {
-										if ($ThisPlanet->getOwnerID() == $ThisPlayer->getAccountID()) {
-											?><a href="<?php echo $Player->getPlanetKickHREF() ?>" class="<?php
-												echo getPlayerOptionClass($ThisPlayer, $Player);
-												?>"> Kick </a><?php
-										}
-									} else {
-										?><a href="<?php echo $Player->getExamineTraderHREF() ?>" class="<?php
-											echo getPlayerOptionClass($ThisPlayer, $Player);
-										?>"> Examine </a><?php
-									} ?>
-								</div>
-							</td>
-						</tr><?php
-					}
-				} ?>
-			</table><?php
-		} else {
-			?><span class="red bold">WARNING:</span> Sensors have detected the presence of cloaked vessels in this sector<?php
-		}
+							} else {
+								?><a href="<?php echo $Player->getExamineTraderHREF() ?>" class="<?php
+									echo getPlayerOptionClass($ThisPlayer, $Player);
+								?>"> Examine </a><?php
+							} ?>
+						</div>
+					</td>
+				</tr><?php
+			} ?>
+		</table><?php
+	}
+	if (isset($CloakedPlayers) && count($CloakedPlayers) > 0) {
+		?><span class="red bold">WARNING:</span> Sensors have detected the presence of cloaked vessels in this sector<?php
 	} ?>
 </div><br />

--- a/src/templates/Default/engine/Default/planet_examine.php
+++ b/src/templates/Default/engine/Default/planet_examine.php
@@ -1,7 +1,7 @@
 <table>
 	<tr>
 		<td class="bold">Planet Name:</td>
-		<td><?php echo $ThisPlanet->getDisplayName(); ?></td>
+		<td><span id="planet_name"><?php echo $ThisPlanet->getDisplayName(); ?></span></td>
 	</tr>
 	<tr>
 		<td class="bold">Planet Type:</td>
@@ -17,22 +17,26 @@
 	</tr>
 	<tr>
 		<td class="bold">Owner:</td>
-		<td><?php
-			if ($ThisPlanet->hasOwner()) {
-				echo $ThisPlanet->getOwner()->getLinkedDisplayName(false);
-			} else { ?>
-				Unclaimed<?php
-			} ?>
+		<td>
+			<span id="planet_owner"><?php
+				if ($ThisPlanet->hasOwner()) {
+					echo $ThisPlanet->getOwner()->getLinkedDisplayName(false);
+				} else { ?>
+					Unclaimed<?php
+				} ?>
+			</span>
 		</td>
 	</tr>
 	<tr>
 		<td class="bold">Alliance:</td>
-		<td><?php
-			if ($ThisPlanet->hasOwner()) {
-				echo $ThisPlanet->getOwner()->getAllianceDisplayName(true);
-			} else { ?>
-				none<?php
-			} ?>
+		<td>
+			<span id="planet_alliance"><?php
+				if ($ThisPlanet->hasOwner()) {
+					echo $ThisPlanet->getOwner()->getAllianceDisplayName(true);
+				} else { ?>
+					none<?php
+				} ?>
+			</span>
 		</td>
 	</tr>
 	<tr>
@@ -52,7 +56,12 @@
 </table>
 
 <br />
-<div class="center"><?php
+
+<?php
+$this->includeTemplate('includes/SectorPlayers.inc.php');
+?>
+
+<div class="center ajax"><?php
 	if (!$PlanetLand) { ?>
 		<div class="buttonA"><a class="buttonA" href="<?php echo $ThisPlanet->getAttackHREF(); ?>">Attack Planet (<?php echo TURNS_TO_SHOOT_PLANET; ?>)</a></div><?php
 	} elseif ($ThisPlanet->isInhabitable()) { ?>

--- a/src/templates/Default/engine/Default/planet_main.php
+++ b/src/templates/Default/engine/Default/planet_main.php
@@ -99,5 +99,5 @@ if (isset($Msg)) {
 </table>
 <p><a href="<?php echo $LaunchLink; ?>" class="submitStyle">Launch</a></p>
 <?php
-$this->includeTemplate('includes/SectorPlayers.inc.php', ['PlayersContainer' => $ThisPlanet]);
+$this->includeTemplate('includes/SectorPlayers.inc.php');
 ?>

--- a/src/templates/Default/engine/Default/port_attack_warning.php
+++ b/src/templates/Default/engine/Default/port_attack_warning.php
@@ -34,6 +34,11 @@ if ($ThisShip->hasScanner()) { ?>
 	<br /><?php
 } ?>
 
+<br />
+<?php
+$this->includeTemplate('includes/SectorPlayers.inc.php');
+?>
+
 Are you sure you want to attack this port?<br /><br />
 
 <div class="buttonA">

--- a/src/templates/Default/engine/Default/trader_examine.php
+++ b/src/templates/Default/engine/Default/trader_examine.php
@@ -29,11 +29,14 @@ if ($ThisPlayer->hasNewbieTurns()) {
 if (!$canAttack) {
 	$fightingPlayers = $ThisSector->getPotentialFightingTraders($ThisPlayer);
 }
-$fightingPlayers['Attackers'][$ThisPlayer->getAccountID()] = $ThisPlayer;
 ?>
 
 <table class="standard centered inset">
-	<tr><th width="50%">Attacker</th><th width="50%">Defender</th></tr>
+	<tr><?php
+		foreach ($fightingPlayers as $label => $fleet) { ?>
+			<th width="50%"><?php echo $label; ?> (<?php echo count($fleet); ?>)</th><?php
+		} ?>
+	</tr>
 	<tr><?php
 		foreach ($fightingPlayers as $fleet) {
 			?><td class="top"><?php
@@ -60,9 +63,6 @@ $fightingPlayers['Attackers'][$ThisPlayer->getAccountID()] = $ThisPlayer;
 				?>&nbsp;<?php
 			} ?>
 			</td><?php
-		}
-		if (!$canAttack) {
-			?><td>&nbsp;</td><?php
 		} ?>
 	</tr>
 </table>

--- a/src/templates/Default/engine/Default/trader_examine.php
+++ b/src/templates/Default/engine/Default/trader_examine.php
@@ -19,7 +19,7 @@ if ($ThisPlayer->hasNewbieTurns()) {
 	?><p class="big red">Your target has cloaked!</p><?php
 } else {
 	$canAttack = true;
-	$fightingPlayers = $ThisSector->getFightingTraders($ThisPlayer, $TargetPlayer, true);
+	$fightingPlayers = $ThisSector->getFightingTraders($ThisPlayer, $TargetPlayer, true, allEligible: true);
 	if (count($fightingPlayers['Defenders']) > 0) {
 		?><p><a class="submitStyle" href="<?php echo $TargetPlayer->getAttackTraderHREF(); ?>">Attack Trader (<?php echo TURNS_TO_SHOOT_SHIP; ?>)</a></p><?php
 	} else {

--- a/test/SmrTest/lib/DefaultGame/TemplateTest.php
+++ b/test/SmrTest/lib/DefaultGame/TemplateTest.php
@@ -77,11 +77,8 @@ class TemplateTest extends TestCase {
 	/**
 	 * @dataProvider convertHtmlToAjaxXml_provider
 	 */
-	public function test_convertHtmlToAjaxXml(string $html, string $expected, bool $ignoreMiddle = false): void {
+	public function test_convertHtmlToAjaxXml(string $html, string $expected): void {
 		$template = Template::getInstance();
-		if ($ignoreMiddle) {
-			$template->ignoreMiddle();
-		}
 		$method = TestUtils::getPrivateMethod($template, 'convertHtmlToAjaxXml');
 		$this->assertSame($expected, $method->invoke($template, $html, true));
 	}
@@ -103,8 +100,6 @@ class TemplateTest extends TestCase {
 			['<div id="middle_panel"><span id="foo">Test</span></div>', '<foo>Test</foo>'],
 			// Middle panel with ajax disabled by the ajax class
 			['<div id="middle_panel"><div id="bar" class="ajax">Hello</div></div>', '<bar>Hello</bar>'],
-			// Middle panel disabled by ignoreMiddle
-			['<div id="middle_panel">Foo</div>', '', true],
 			// Empty string
 			['', ''],
 			// Ajax-enabled elements both outside and inside middle panel


### PR DESCRIPTION
* Add eligible attacker lists to the "Port Raid" and (hostile) "Examine Planet" pages. This will help triggers to make sure everyone is ready for the shot (e.g. who is in sector, if anyone still has newbie turns, etc.). It should also help to prevent people from accidentally clicking on the "Attack Planet" button when they intend to land, because the page will look significantly different (i.e. it will have a list of attackers).
* On the "Current Sector" page, ship sensors will now _always_ detect cloaked ships, even if there are other ships in sector. This improves parity between the information provided by the "Current Sector" and "Local Map" pages.
* Changes to the "Examine Ship" page:
  * Player lists will no longer get randomly sorted on each auto-refresh.
  * All players eligible to participate in the fight will be displayed, instead of a random subset of 10 players (since the 10 selected players would be different between the display and the actual battle).
  * Total number of eligible attackers/defenders will be displayed at the top of the player lists.

![image](https://user-images.githubusercontent.com/846186/166179592-ee77bb06-6633-429f-9d3b-433874931f6b.png)

![image](https://user-images.githubusercontent.com/846186/166179641-a52829f9-0bf9-4aee-945c-86ea56742574.png)

![image](https://user-images.githubusercontent.com/846186/166179695-cb0655d8-146f-47ea-a09f-d6b2b17a8889.png)

![image](https://user-images.githubusercontent.com/846186/166179982-3e41318f-bfaf-4cb2-8d16-03186e544b63.png)
