### PR TITLE
Speed up tests that modify the database

### DIFF
--- a/test/SmrTest/BaseIntegrationSpec.php
+++ b/test/SmrTest/BaseIntegrationSpec.php
@@ -3,44 +3,89 @@
 namespace SmrTest;
 
 use mysqli;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
-use Throwable;
 
+/**
+ * Any test that modifies the database should inherit from this class.
+ */
 class BaseIntegrationSpec extends TestCase {
 
-	protected static mysqli $conn;
-	private static array $defaultPopulatedTables = [];
+	protected array $tablesToTruncate;
 
-	public static function setUpBeforeClass(): void {
+	private static mysqli $conn;
+	private static array $checksums;
+
+	/**
+	 * Get checksums for the initial state of the database tables.
+	 *
+	 * @beforeClass
+	 */
+	final public static function initializeTableRowCounts(): void {
 		if (!isset(self::$conn)) {
 			self::$conn = DiContainer::make(mysqli::class);
-			$query = "SELECT table_name FROM information_schema.tables WHERE table_rows > 0 AND TABLE_SCHEMA='smr_live_test'";
-			$rs = self::$conn->query($query);
-			$all = $rs->fetch_all();
-			array_walk_recursive($all, function($a) {
-				self::$defaultPopulatedTables[] = "'" . $a . "'";
-			});
+			self::$checksums = self::getChecksums();
 		}
 	}
 
-	protected function onNotSuccessfulTest(Throwable $t): void {
-		$this->cleanUp();
-		throw $t;
-	}
-
-	protected function tearDown(): void {
-		$this->cleanUp();
-	}
-
-	protected function cleanUp(): void {
-		$implode = implode(',', self::$defaultPopulatedTables);
-		$query = "SELECT Concat('TRUNCATE TABLE ', TABLE_NAME, ';') FROM INFORMATION_SCHEMA.TABLES where TABLE_SCHEMA = 'smr_live_test' and TABLE_NAME not in (${implode})";
-		$rs = self::$conn->query($query);
-		$all = $rs->fetch_all();
-		foreach ($all as $truncate) {
-			self::$conn->query($truncate[0]);
+	/**
+	 * Any table that is modified during a test class should be declared in the
+	 * `tablesToTruncate` attribute, and those tables will be reset after each
+	 * test method.
+	 *
+	 * @after
+	 */
+	final protected function truncateTables(): void {
+		foreach ($this->tablesToTruncate as $name) {
+			// Include hard-coded test database name as a safety precaution
+			self::$conn->query('TRUNCATE TABLE smr_live_test.`' . $name . '`');
 		}
+	}
+
+	/**
+	 * All modified tables should be reset after each test, but here we perform
+	 * a final sanity check to make sure that no tables have changed checksums.
+	 * This is only done once per class because it is expensive!
+	 *
+	 * @afterClass
+	 */
+	final public static function checkTables(): void {
+		$checksums = self::getChecksums();
+		$errors = [];
+		foreach (self::$checksums as $table => $expected) {
+			try {
+				self::assertSame($expected, $checksums[$table], 'Unexpected checksum for table: ' . $table);
+			} catch (AssertionFailedError $err) {
+				$errors[] = $err;
+				if ($expected === 0) {
+					// For convenience, we truncate this table now to avoid
+					// issues with rerunning tests.
+					self::$conn->query('TRUNCATE TABLE ' . $table);
+				}
+			}
+		}
+		self::assertEquals(self::$checksums, $checksums, implode("\n", $errors));
+	}
+
+	private static function getTableNames(): array {
+		$query = 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=\'smr_live_test\'';
+		$result = self::$conn->query($query);
+		$tables = [];
+		foreach ($result as $record) {
+			$tables[] = $record['TABLE_NAME'];
+		}
+		return $tables;
+	}
+
+	private static function getChecksums(): array {
+		$tableNames = self::getTableNames();
+		$result = self::$conn->query('CHECKSUM TABLE ' . implode(', ', $tableNames));
+		$checksums = [];
+		foreach ($result as $record) {
+			$checksums[$record['Table']] = (int)$record['Checksum'];
+		}
+		return $checksums;
 	}
 
 }

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrAccountIntegrationTest.php
@@ -12,6 +12,8 @@ use SmrTest\BaseIntegrationSpec;
  */
 class AbstractSmrAccountIntegrationTest extends BaseIntegrationSpec {
 
+	protected array $tablesToTruncate = ['account', 'account_auth'];
+
 	protected function setUp(): void {
 		AbstractSmrAccount::clearCache();
 	}

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrPlayerIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrPlayerIntegrationTest.php
@@ -11,6 +11,8 @@ use SmrTest\BaseIntegrationSpec;
  */
 class AbstractSmrPlayerIntegrationTest extends BaseIntegrationSpec {
 
+	protected array $tablesToTruncate = ['player'];
+
 	public function test_createPlayer(): void {
 		// Test arbitrary input
 		$accountID = 2;

--- a/test/SmrTest/lib/DefaultGame/CreateNHATest.php
+++ b/test/SmrTest/lib/DefaultGame/CreateNHATest.php
@@ -12,6 +12,13 @@ require_once(LIB . 'Default/nha.inc.php');
  */
 class CreateNHATest extends BaseIntegrationSpec {
 
+	protected array $tablesToTruncate = [
+		'alliance',
+		'alliance_has_roles',
+		'alliance_thread',
+		'alliance_thread_topic',
+	];
+
 	public function test_createNHA(): void {
 		// Create the NHA
 		$gameID = 1;

--- a/test/SmrTest/lib/DefaultGame/SectorLockTest.php
+++ b/test/SmrTest/lib/DefaultGame/SectorLockTest.php
@@ -3,23 +3,19 @@
 namespace SmrTest\lib\DefaultGame;
 
 use Exception;
-use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
-use Smr\Database;
 use Smr\Exceptions\UserError;
 use Smr\SectorLock;
+use SmrTest\BaseIntegrationSpec;
 
 /**
  * @covers Smr\SectorLock
  */
-class SectorLockTest extends TestCase {
+class SectorLockTest extends BaseIntegrationSpec {
+
+	protected array $tablesToTruncate = ['locks_queue'];
 
 	protected function tearDown(): void {
-		// We only write to one table, so clear it after each test instead of
-		// using the more heavy-handed BaseIntegrationSpec.
-		$db = Database::getInstance();
-		$db->write('TRUNCATE TABLE locks_queue');
-
 		// Reset the DI container to avoid contaminating other tests
 		DiContainer::initialize(false);
 	}

--- a/test/SmrTest/lib/DefaultGame/SessionIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SessionIntegrationTest.php
@@ -13,6 +13,8 @@ use SmrTest\BaseIntegrationSpec;
  */
 class SessionIntegrationTest extends BaseIntegrationSpec {
 
+	protected array $tablesToTruncate = ['debug'];
+
 	private Session $session;
 
 	protected function setUp(): void {
@@ -23,7 +25,6 @@ class SessionIntegrationTest extends BaseIntegrationSpec {
 	}
 
 	protected function tearDown(): void {
-		parent::tearDown();
 		// Clear superglobals to avoid impacting other tests
 		$_REQUEST = [];
 		$_COOKIE = [];

--- a/test/SmrTest/lib/DefaultGame/SmrAllianceIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrAllianceIntegrationTest.php
@@ -12,6 +12,8 @@ use SmrTest\BaseIntegrationSpec;
  */
 class SmrAllianceIntegrationTest extends BaseIntegrationSpec {
 
+	protected array $tablesToTruncate = ['alliance', 'irc_alliance_has_channel'];
+
 	protected function setUp(): void {
 		// Start each test with an empty alliance cache
 		SmrAlliance::clearCache();

--- a/test/SmrTest/lib/DefaultGame/SmrGameIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrGameIntegrationTest.php
@@ -12,9 +12,10 @@ use SmrTest\BaseIntegrationSpec;
  */
 class SmrGameIntegrationTest extends BaseIntegrationSpec {
 
+	protected array $tablesToTruncate = ['game', 'race_has_relation'];
+
 	protected function tearDown(): void {
 		SmrGame::clearCache();
-		parent::tearDown();
 	}
 
 	public function test_gameExists(): void {

--- a/test/SmrTest/lib/DefaultGame/SmrPlanetIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrPlanetIntegrationTest.php
@@ -12,9 +12,10 @@ use SmrTest\BaseIntegrationSpec;
  */
 class SmrPlanetIntegrationTest extends BaseIntegrationSpec {
 
+	protected array $tablesToTruncate = ['planet'];
+
 	protected function tearDown(): void {
 		SmrPlanet::clearCache();
-		parent::tearDown();
 	}
 
 	public function test_createPlanet(): void {

--- a/test/SmrTest/lib/DefaultGame/SmrShipIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrShipIntegrationTest.php
@@ -12,6 +12,8 @@ use SmrWeapon;
  */
 class SmrShipIntegrationTest extends BaseIntegrationSpec {
 
+	protected array $tablesToTruncate = ['ship_has_hardware'];
+
 	private \PHPUnit\Framework\MockObject\MockObject $player;
 
 	protected function setUp(): void {

--- a/test/SmrTest/lib/DefaultGame/VoteSiteIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/VoteSiteIntegrationTest.php
@@ -11,9 +11,10 @@ use SmrTest\BaseIntegrationSpec;
  */
 class VoteSiteIntegrationTest extends BaseIntegrationSpec {
 
+	protected array $tablesToTruncate = ['vote_links'];
+
 	protected function tearDown(): void {
 		VoteSite::clearCache();
-		parent::tearDown();
 	}
 
 	public function test_getTimeUntilFreeTurns_invalid(): void {


### PR DESCRIPTION
The goal is to have the database return to its initial state after
every test, so that tests are independent of each other.

The way we were previously achieving this was by storing a list of
tables that start empty and truncating all those tables after every
test, since we (happen to) only modify tables that start empty.
This is the slowest method (apart from re-initializing the database
after every test) because we currently have ~120 empty tables, but
most test only modify a handful of them. This incurs a lot of overhead
cost, even with empty tables. With this method, the tests take ~23
seconds.

A faster way to do this is to count the number of rows of each table,
and then only truncate tables that change from zero to non-zero rows.
I suspect this is faster because counting rows is done in a single
query, whereas each `TRUNCATE` must be done in a separate query (for
whatever reason). This still involves a fairly expensive query after
each test, but brings the total time to ~17 seconds.

The fastest method is to explicitly specify the tables that need to be
reset after every test for each class, and only truncate those tables.
This is the method that we now use, and takes ~12 seconds. We add a
sanity check after each test class to make sure that all tables are
properly truncated, and we fail if any have changed size. (This helps
us identify which, if any, tables need to be added to the list of
tables to truncate for any given class.) This still requires us to
initialize a list of table sizes once for the entire test suite.

Counting table rows is actually pretty complicated, since the values
that are queried from the `information_schema` are not accurate until
we run an `ANALYZE TABLE` query on every table. This turns out to be
a major expense (though less than blindly truncating every table), so
as an alternative to counting table rows, we can use `CHECKSUM TABLE`
queries, which is always accurate (and can even be optimized for our
MyISAM tables, which can be configured to properly cache their
checksums; though this is a complicated optimization that we probably
do not need, and we may want to be using InnoDB ultimately anyway).
Since we only care about empty vs. non-empty, we just look for tables
whose checksum is not zero. This significantly reduces test overhead,
and the whole test suite only takes ~8 seconds.

A few special notes:

* Initial table names are not stored for faster `CHECKSUM` queries
  since we want to be aware if any tables are created or dropped.

* We use the special `@before(Class)` and `@after(Class)` annotations
  on the `BaseIntegrationSpec` methods so that we don't need to worry
  about accidentally overriding the setup/teardown methods in child
  classes (without calling `parent::*`, which is no longer needed).

* The `smr_live_test` database name is used explicitly in the base
  class to avoid accidentally using the live database (e.g. if we
  forget to pass the `test/env` file to docker-compose.

* The `SectorLockTest` can now inherit from `BaseIntegrationSpec` and
  its special table truncating logic can be removed.