### PR TITLE
SmrPort: isolate database changes

### DIFF
--- a/src/lib/Default/AbstractSmrPort.php
+++ b/src/lib/Default/AbstractSmrPort.php
@@ -154,7 +154,7 @@ class AbstractSmrPort {
 			$this->armour = 0;
 			$this->reinforceTime = 0;
 			$this->attackStarted = 0;
-			$this->raceID = 1;
+			$this->raceID = RACE_NEUTRAL;
 			$this->level = 0;
 			$this->credits = 0;
 			$this->upgrade = 0;

--- a/src/lib/Default/AbstractSmrPort.php
+++ b/src/lib/Default/AbstractSmrPort.php
@@ -533,7 +533,6 @@ class AbstractSmrPort {
 			'amount' => $this->db->escapeNumber($this->getGoodAmount($goodID)),
 			'last_update' => $this->db->escapeNumber(Smr\Epoch::time()),
 		]);
-		$this->db->write('DELETE FROM route_cache WHERE game_id=' . $this->db->escapeNumber($this->getGameID()));
 	}
 
 	/**
@@ -561,7 +560,6 @@ class AbstractSmrPort {
 
 		$this->cacheIsValid = false;
 		$this->db->write('DELETE FROM port_has_goods WHERE ' . $this->SQL . ' AND good_id=' . $this->db->escapeNumber($goodID) . ';');
-		$this->db->write('DELETE FROM route_cache WHERE game_id=' . $this->db->escapeNumber($this->getGameID()));
 	}
 
 	/**
@@ -837,8 +835,6 @@ class AbstractSmrPort {
 		$this->raceID = $raceID;
 		$this->hasChanged = true;
 		$this->cacheIsValid = false;
-		// route_cache tells NPC's where they can trade
-		$this->db->write('DELETE FROM route_cache WHERE game_id=' . $this->db->escapeNumber($this->getGameID()));
 	}
 
 	public function getLevel(): int {
@@ -1175,6 +1171,8 @@ class AbstractSmrPort {
 		// If any cached members (see `__sleep`) changed, update the cached port
 		if (!$this->cacheIsValid) {
 			$this->updateSectorPlayersCache();
+			// route_cache tells NPC's where they can trade
+			$this->db->write('DELETE FROM route_cache WHERE game_id=' . $this->db->escapeNumber($this->getGameID()));
 		}
 
 		// If any fields in the `port` table have changed, update table

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrPortTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrPortTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\DefaultGame;
+
+use AbstractSmrPort;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers AbstractSmrPort
+ */
+class AbstractSmrPortTest extends TestCase {
+
+	protected function tearDown(): void {
+		AbstractSmrPort::clearCache();
+	}
+
+	public function test_new_port_does_not_exist_yet(): void {
+		$port = AbstractSmrPort::createPort(1, 1);
+		self::assertFalse($port->exists());
+	}
+
+	public function test_port_primary_keys(): void {
+		// Ports are keyed on game ID and sector ID
+		$gameID = 2;
+		$sectorID = 3;
+		$port = AbstractSmrPort::createPort($gameID, $sectorID);
+		self::assertSame($gameID, $port->getGameID());
+		self::assertSame($sectorID, $port->getSectorID());
+	}
+
+	public function test_setRaceID(): void {
+		$port = AbstractSmrPort::createPort(1, 1);
+		// New ports start as Neutral
+		self::assertSame(RACE_NEUTRAL, $port->getRaceID());
+		// Then check changing the race
+		$port->setRaceID(RACE_HUMAN);
+		self::assertSame(RACE_HUMAN, $port->getRaceID());
+	}
+
+	public function test_addPortGood(): void {
+		// When we add the good
+		$port = AbstractSmrPort::createPort(1, 1);
+		$port->addPortGood(GOODS_WOOD, TRADER_SELLS);
+		$port->addPortGood(GOODS_ORE, TRADER_BUYS);
+		self::assertSame([GOODS_WOOD, GOODS_ORE], $port->getAllGoodIDs());
+		self::assertSame([GOODS_WOOD], $port->getSoldGoodIDs());
+		self::assertSame([GOODS_ORE], $port->getBoughtGoodIDs());
+	}
+
+	/**
+	 * @dataProvider provider_getGoodTransaction
+	 */
+	public function test_getGoodTransaction($transaction): void {
+		$port = AbstractSmrPort::createPort(1, 1);
+		$port->addPortGood(GOODS_ORE, $transaction);
+		self::assertSame($transaction, $port->getGoodTransaction(GOODS_ORE));
+	}
+
+	/**
+	 * @return array<string>
+	 */
+	public function provider_getGoodTransaction(): array {
+		return [[TRADER_BUYS], [TRADER_SELLS]];
+	}
+
+	public function test_getGoodTransaction_throws_if_port_does_not_have_good(): void {
+		// New ports don't have any goods yet, so this will throw on any good
+		$port = AbstractSmrPort::createPort(1, 1);
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Port does not trade goodID 3');
+		$port->getGoodTransaction(GOODS_ORE);
+	}
+
+}


### PR DESCRIPTION
The `port_has_goods` and `route_cache` tables will now only be updated when `SmrPort::update` is called.