### PR TITLE
Allow NPCs to trade in any Racial/Neutral galaxy

### DIFF
--- a/src/engine/Default/admin/unigen/check_map.php
+++ b/src/engine/Default/admin/unigen/check_map.php
@@ -11,7 +11,7 @@ $container->addVar('game_id');
 $container->addVar('gal_on');
 $template->assign('BackHREF', $container->href());
 
-$galaxies = SmrGalaxy::getGameGalaxies($var['game_id']);
+$galaxies = $game->getGalaxies();
 
 // Check if any locations are missing
 $existingLocs = [];
@@ -48,7 +48,7 @@ $numberOfRoutes = 1;
 $maxDistance = 999;
 
 $allGalaxyRoutes = [];
-foreach (SmrGalaxy::getGameGalaxies($var['game_id']) as $galaxy) {
+foreach ($galaxies as $galaxy) {
 	$galaxy->getSectors(); // Efficiently construct the sector cache
 	$ports = $galaxy->getPorts();
 	$distances = Plotter::calculatePortToPortDistances($ports, $tradeRaces, $maxDistance, $galaxy->getStartSector(), $galaxy->getEndSector());
@@ -64,7 +64,7 @@ $template->assign('RouteTypes', $routeTypes);
 
 // Largest port sell multipliers per galaxy
 $maxSellMultipliers = [];
-foreach (SmrGalaxy::getGameGalaxies($var['game_id']) as $galaxy) {
+foreach ($galaxies as $galaxy) {
 	$max = [];
 	foreach ($galaxy->getPorts() as $port) {
 		foreach ($port->getSoldGoodIDs() as $goodID) {

--- a/src/engine/Default/admin/unigen/galaxies_edit.php
+++ b/src/engine/Default/admin/unigen/galaxies_edit.php
@@ -17,7 +17,7 @@ $submit = [
 $template->assign('Submit', $submit);
 
 $galaxies = [];
-foreach (SmrGalaxy::getGameGalaxies($var['game_id']) as $galaxy) {
+foreach ($game->getGalaxies() as $galaxy) {
 	$galaxies[$galaxy->getGalaxyID()] = [
 		'Name' => $galaxy->getDisplayName(),
 		'Width' => $galaxy->getWidth(),

--- a/src/engine/Default/admin/unigen/galaxies_edit_processing.php
+++ b/src/engine/Default/admin/unigen/galaxies_edit_processing.php
@@ -4,7 +4,8 @@ $db = Smr\Database::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 $gameID = $var['game_id'];
-$galaxies = SmrGalaxy::getGameGalaxies($gameID);
+$game = SmrGame::getGame($gameID);
+$galaxies = $game->getGalaxies();
 
 // Prepare our forwarding container
 $container = Page::create('skeleton.php', 'admin/unigen/universe_create_sectors.php');
@@ -25,7 +26,7 @@ foreach ($galaxies as $i => $galaxy) {
 	$galaxy->setName(Smr\Request::get('gal' . $i));
 	$galaxy->setGalaxyType(Smr\Request::get('type' . $i));
 	$galaxy->setMaxForceTime(IFloor(Smr\Request::getFloat('forces' . $i) * 3600));
-	if (!SmrGame::getGame($gameID)->isEnabled()) {
+	if (!$game->isEnabled()) {
 		$galaxy->setWidth(Smr\Request::getInt('width' . $i));
 		$galaxy->setHeight(Smr\Request::getInt('height' . $i));
 	}

--- a/src/engine/Default/admin/unigen/universe_create_galaxies.php
+++ b/src/engine/Default/admin/unigen/universe_create_galaxies.php
@@ -40,7 +40,7 @@ for ($i = 1; $i <= $numGals; ++$i) {
 		'Name' => $defaultNames[$i] ?? 'Unknown',
 		'Width' => 10,
 		'Height' => 10,
-		'Type' => $isRacial ? 'Racial' : 'Neutral',
+		'Type' => $isRacial ? SmrGalaxy::TYPE_RACIAL : SmrGalaxy::TYPE_NEUTRAL,
 		'ForceMaxHours' => $isRacial ? 12 : 60,
 	];
 }

--- a/src/engine/Default/admin/unigen/universe_create_locations.php
+++ b/src/engine/Default/admin/unigen/universe_create_locations.php
@@ -19,17 +19,16 @@ foreach ($locations as $location) {
 	$totalLocs[$location->getTypeID()] = 0;
 }
 
+$galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
+$template->assign('Galaxy', $galaxy);
+
 // Determine the current amount of each location
-$galSectors = SmrSector::getGalaxySectors($var['game_id'], $var['gal_on']);
-foreach ($galSectors as $galSector) {
+foreach ($galaxy->getSectors() as $galSector) {
 	foreach ($galSector->getLocations() as $sectorLocation) {
 		$totalLocs[$sectorLocation->getTypeID()]++;
 	}
 }
 $template->assign('TotalLocs', $totalLocs);
-
-$galaxy = SmrGalaxy::getGalaxy($var['game_id'], $var['gal_on']);
-$template->assign('Galaxy', $galaxy);
 
 // Though we expect a location to be only in one category, it is possible to
 // edit a location in the Admin Tools so that it is in two or more categories.

--- a/src/engine/Default/admin/unigen/universe_create_save_processing.php
+++ b/src/engine/Default/admin/unigen/universe_create_save_processing.php
@@ -15,6 +15,7 @@ if ($submit == 'Create Galaxies') {
 		$galaxy->setGalaxyType(Smr\Request::get('type' . $i));
 		$galaxy->setMaxForceTime(IFloor(Smr\Request::getFloat('forces' . $i) * 3600));
 	}
+	// Workaround for SmrGalaxy::getStartSector depending on all other galaxies
 	SmrGalaxy::saveGalaxies();
 	$galaxies = SmrGalaxy::getGameGalaxies($var['game_id'], true);
 	foreach ($galaxies as $galaxy) {

--- a/src/engine/Default/smr_file_create.php
+++ b/src/engine/Default/smr_file_create.php
@@ -106,13 +106,14 @@ foreach (SmrLocation::getAllLocations() as $location) {
 }
 
 // Everything below here must be valid INI syntax (safe to parse)
+$game = SmrGame::getGame($gameID);
 $file .= '[Metadata]
 FileVersion=' . SMR_FILE_VERSION . '
 [Game]
-Name=' . inify(SmrGame::getGame($gameID)->getName()) . '
+Name=' . inify($game->getName()) . '
 [Galaxies]
 ';
-$galaxies = SmrGalaxy::getGameGalaxies($gameID);
+$galaxies = $game->getGalaxies();
 foreach ($galaxies as $galaxy) {
 	$file .= $galaxy->getGalaxyID() . '=' . $galaxy->getWidth() . ',' . $galaxy->getHeight() . ',' . $galaxy->getGalaxyType() . ',' . inify($galaxy->getName()) . ',' . $galaxy->getMaxForceTime() . EOL;
 }
@@ -185,7 +186,7 @@ header('Expires: 0');
 header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 header('Cache-Control: private', false);
 header('Content-Type: application/force-download');
-header('Content-Disposition: attachment; filename="' . SmrGame::getGame($gameID)->getName() . '.smr"');
+header('Content-Disposition: attachment; filename="' . $game->getName() . '.smr"');
 header('Content-Transfer-Encoding: binary');
 header('Content-Length: ' . $size);
 

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -9,9 +9,10 @@ try {
 		header('Location: /login.php');
 		exit;
 	}
-
+	$game = SmrGame::getGame($gameID);
 	$account = $session->getAccount();
-	if (!SmrGame::getGame($gameID)->isEnabled() && !$account->hasPermission(PERMISSION_UNI_GEN)) {
+
+	if (!$game->isEnabled() && !$account->hasPermission(PERMISSION_UNI_GEN)) {
 		create_error('You do not have permission to view this map!');
 	}
 
@@ -19,7 +20,7 @@ try {
 	$links = [];
 
 	// The d3 graph nodes are the galaxies
-	foreach (SmrGalaxy::getGameGalaxies($gameID) as $galaxy) {
+	foreach ($game->getGalaxies() as $galaxy) {
 		$nodes[] = [
 			'name' => $galaxy->getName(),
 			'id' => $galaxy->getGalaxyID(),
@@ -54,7 +55,7 @@ try {
 <!DOCTYPE html>
 <html>
 	<head>
-		<title><?php echo PAGE_TITLE . ': ' . SmrGame::getGame($gameID)->getName(); ?></title>
+		<title><?php echo PAGE_TITLE . ': ' . $game->getName(); ?></title>
 		<meta charset="utf-8">
 		<style>
 		body { background-image: url("images/stars2.png"); }

--- a/src/lib/Default/SmrGalaxy.php
+++ b/src/lib/Default/SmrGalaxy.php
@@ -4,7 +4,10 @@ class SmrGalaxy {
 	protected static array $CACHE_GALAXIES = [];
 	protected static array $CACHE_GAME_GALAXIES = [];
 
-	public const TYPES = ['Racial', 'Neutral', 'Planet'];
+	public const TYPE_RACIAL = 'Racial';
+	public const TYPE_NEUTRAL = 'Neutral';
+	public const TYPE_PLANET = 'Planet';
+	public const TYPES = [self::TYPE_RACIAL, self::TYPE_NEUTRAL, self::TYPE_PLANET];
 
 	protected Smr\Database $db;
 	protected string $SQL;

--- a/src/lib/Default/SmrGame.php
+++ b/src/lib/Default/SmrGame.php
@@ -379,8 +379,15 @@ class SmrGame {
 		return $this->totalPlayers;
 	}
 
+	/**
+	 * @return array<int, \SmrGalaxy>
+	 */
+	public function getGalaxies(): array {
+		return SmrGalaxy::getGameGalaxies($this->gameID);
+	}
+
 	public function getNumberOfGalaxies(): int {
-		return count(SmrGalaxy::getGameGalaxies($this->getGameID()));
+		return count($this->getGalaxies());
 	}
 
 	public function equals(self $otherGame): bool {

--- a/src/templates/Default/engine/Default/bar_galmap_buy.php
+++ b/src/templates/Default/engine/Default/bar_galmap_buy.php
@@ -3,8 +3,7 @@
 	<form method="POST" action="<?php echo $BuyHREF; ?>">
 		<select type="select" name="gal_id" required>
 			<option value="" disabled selected>[Select a galaxy]</option><?php
-			$GameGalaxies = SmrGalaxy::getGameGalaxies($ThisPlayer->getGameID());
-			foreach ($GameGalaxies as $Galaxy) { ?>
+			foreach ($ThisPlayer->getGame()->getGalaxies() as $Galaxy) { ?>
 				<option value="<?php echo $Galaxy->getGalaxyID(); ?>"><?php echo $Galaxy->getDisplayName(); ?></option><?php
 			} ?>
 		</select>

--- a/src/templates/Default/engine/Default/course_plot.php
+++ b/src/templates/Default/engine/Default/course_plot.php
@@ -74,8 +74,7 @@ if (isset($XType)) { ?>
 					}
 					break;
 				case 'Galaxies':
-					$Galaxies = SmrGalaxy::getGameGalaxies($ThisPlayer->getGameID());
-					foreach ($Galaxies as $Galaxy) {
+					foreach ($ThisPlayer->getGame()->getGalaxies() as $Galaxy) {
 						?><option value="<?php echo $Galaxy->getGalaxyID(); ?>"><?php echo $Galaxy->getDisplayName(); ?></option><?php
 					}
 					break;


### PR DESCRIPTION
Because the Plotter and RouteGenerator require a contiguous sector
range, we can only select the galaxies until the first Planet galaxy
is encountered. If no galaxies are selected with this method (i.e. if
the first galaxy is a Planet galaxy), then we will just use the NPC's
current galaxy only.

If this causes memory exhaustion, then we may need to rethink this
feature (or optimize the route generator).

* Add `SmrGame::getGalaxies`
* Add galaxy type constants to `SmrGalaxy`