### PR TITLE
Gameplay: add recruitment column to alliance list

### DIFF
--- a/src/engine/Default/alliance_list.php
+++ b/src/engine/Default/alliance_list.php
@@ -35,6 +35,7 @@ foreach ($dbResult->records() as $dbRecord) {
 		'TotalExperience' => $dbRecord->getInt('alliance_xp'),
 		'AverageExperience' => $dbRecord->getInt('alliance_avg'),
 		'Members' => $dbRecord->getInt('alliance_member_count'),
+		'OpenRecruitment' => $alliance->getRecruitType() === SmrAlliance::RECRUIT_OPEN,
 	];
 }
 $template->assign('Alliances', $alliances);

--- a/src/engine/Default/alliance_list.php
+++ b/src/engine/Default/alliance_list.php
@@ -17,8 +17,7 @@ $dbResult = $db->read('SELECT
 count(account_id) as alliance_member_count,
 sum(experience) as alliance_xp,
 floor(avg(experience)) as alliance_avg,
-alliance_name,
-alliance_id
+alliance.*
 FROM player
 JOIN alliance USING (game_id, alliance_id)
 WHERE leader_id > 0
@@ -28,17 +27,11 @@ ORDER BY alliance_name ASC');
 
 $alliances = [];
 foreach ($dbResult->records() as $dbRecord) {
-	if ($dbRecord->getInt('alliance_id') != $player->getAllianceID()) {
-		$container = Page::create('alliance_roster.php');
-	} else {
-		$container = Page::create('alliance_mod.php');
-	}
 	$allianceID = $dbRecord->getInt('alliance_id');
-	$container['alliance_id'] = $allianceID;
+	$alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID(), false, $dbRecord);
 
 	$alliances[$allianceID] = [
-		'ViewHREF' => $container->href(),
-		'Name' => htmlentities($dbRecord->getString('alliance_name')),
+		'Name' => $alliance->getAllianceDisplayName(true),
 		'TotalExperience' => $dbRecord->getInt('alliance_xp'),
 		'AverageExperience' => $dbRecord->getInt('alliance_avg'),
 		'Members' => $dbRecord->getInt('alliance_member_count'),

--- a/src/engine/Default/alliance_treaties.php
+++ b/src/engine/Default/alliance_treaties.php
@@ -13,7 +13,9 @@ $alliances = [];
 $db = Smr\Database::getInstance();
 $dbResult = $db->read('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($player->getAllianceID()) . ' ORDER BY alliance_name');
 foreach ($dbResult->records() as $dbRecord) {
-	$alliances[$dbRecord->getInt('alliance_id')] = htmlentities($dbRecord->getString('alliance_name'));
+	$allianceID = $dbRecord->getInt('alliance_id');
+	$alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID(), false, $dbRecord);
+	$alliances[$allianceID] = $alliance->getAllianceDisplayName();
 }
 $template->assign('Alliances', $alliances);
 

--- a/src/engine/Default/game_stats.php
+++ b/src/engine/Default/game_stats.php
@@ -50,7 +50,7 @@ if ($dbResult->hasRecord()) {
 function allianceTopTen(SmrGame $game, string $field): array {
 	$gameID = $game->getGameID();
 	$db = Smr\Database::getInstance();
-	$dbResult = $db->read('SELECT alliance_id, SUM(' . $field . ') amount
+	$dbResult = $db->read('SELECT alliance.*, SUM(' . $field . ') amount
 				FROM alliance
 				LEFT JOIN player USING (game_id, alliance_id)
 				WHERE game_id = ' . $db->escapeNumber($gameID) . '
@@ -59,7 +59,7 @@ function allianceTopTen(SmrGame $game, string $field): array {
 				LIMIT 10');
 	$rankings = [];
 	foreach ($dbResult->records() as $index => $dbRecord) {
-		$alliance = SmrAlliance::getAlliance($dbRecord->getInt('alliance_id'), $gameID);
+		$alliance = SmrAlliance::getAlliance($dbRecord->getInt('alliance_id'), $gameID, false, $dbRecord);
 		$rankings[$index + 1]['Amount'] = $dbRecord->getInt('amount');
 		if ($game->hasEnded()) {
 			// If game has ended, offer a link to alliance roster details

--- a/src/engine/Default/rankings_alliance_experience.php
+++ b/src/engine/Default/rankings_alliance_experience.php
@@ -9,7 +9,7 @@ Menu::rankings(1, 0);
 
 $db = Smr\Database::getInstance();
 $rankedStats = [];
-$dbResult = $db->read('SELECT alliance_id, COALESCE(SUM(experience), 0) amount
+$dbResult = $db->read('SELECT alliance.*, COALESCE(SUM(experience), 0) amount
 		FROM alliance
 		LEFT JOIN player USING (game_id, alliance_id)
 		WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '

--- a/src/engine/Default/rankings_alliance_profit.php
+++ b/src/engine/Default/rankings_alliance_profit.php
@@ -11,7 +11,7 @@ $profitType = implode(':', ['Trade', 'Money', 'Profit']);
 
 $db = Smr\Database::getInstance();
 $rankedStats = [];
-$dbResult = $db->read('SELECT alliance_id, COALESCE(SUM(amount), 0) amount
+$dbResult = $db->read('SELECT alliance.*, COALESCE(SUM(amount), 0) amount
 	FROM alliance
 	LEFT JOIN player p USING (game_id, alliance_id)
 	LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $db->escapeString($profitType) . '

--- a/src/engine/Default/rankings_alliance_vs_alliance.php
+++ b/src/engine/Default/rankings_alliance_vs_alliance.php
@@ -17,16 +17,17 @@ $detailsAllianceID = $session->getRequestVarInt('alliance_id', $player->getAllia
 
 // Get list of alliances that have kills or deaths
 $activeAlliances = [];
-$dbResult = $db->read('SELECT alliance_id FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_deaths > 0 OR alliance_kills > 0) ORDER BY alliance_kills DESC, alliance_name');
+$dbResult = $db->read('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_deaths > 0 OR alliance_kills > 0) ORDER BY alliance_kills DESC, alliance_name');
 foreach ($dbResult->records() as $dbRecord) {
-	$activeAlliances[] = $dbRecord->getInt('alliance_id');
+	$allianceID = $dbRecord->getInt('alliance_id');
+	$activeAlliances[$allianceID] = SmrAlliance::getAlliance($allianceID, $player->getGameID(), false, $dbRecord);
 }
 $template->assign('ActiveAlliances', $activeAlliances);
 
 // Get list of alliances to display (max of 5)
 // These must be a subset of the active alliances
 if (empty($alliancer)) {
-	$alliance_vs_ids = array_slice($activeAlliances, 0, 4);
+	$alliance_vs_ids = array_slice(array_keys($activeAlliances), 0, 4);
 	$alliance_vs_ids[] = 0;
 } else {
 	$alliance_vs_ids = $alliancer;

--- a/src/htdocs/js/listjs_include.js
+++ b/src/htdocs/js/listjs_include.js
@@ -27,7 +27,7 @@ var listjs = (function() {
 	};
 
 	listjs.alliance_list = function() {
-		defaultList('alliance-list', ['sort_name', 'sort_totExp', 'sort_avgExp', 'sort_members']);
+		defaultList('alliance-list', ['sort_recruit', 'sort_name', 'sort_totExp', 'sort_avgExp', 'sort_members']);
 	};
 
 	listjs.alliance_message = function() {

--- a/src/lib/Default/Rankings.php
+++ b/src/lib/Default/Rankings.php
@@ -62,7 +62,7 @@ class Rankings {
 
 		$rankings = [];
 		foreach ($rankedStats as $allianceID => $dbRecord) {
-			$currentAlliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
+			$currentAlliance = SmrAlliance::getAlliance($allianceID, $player->getGameID(), false, $dbRecord);
 
 			$class = '';
 			if ($player->getAllianceID() == $currentAlliance->getAllianceID()) {
@@ -176,7 +176,7 @@ class Rankings {
 	public static function allianceStats(string $stat, int $gameID): array {
 		$db = Smr\Database::getInstance();
 		$allianceStats = [];
-		$dbResult = $db->read('SELECT alliance_id, alliance_' . $stat . ' AS amount FROM alliance WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY amount DESC, alliance_name');
+		$dbResult = $db->read('SELECT alliance.*, alliance_' . $stat . ' AS amount FROM alliance WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY amount DESC, alliance_name');
 		foreach ($dbResult->records() as $dbRecord) {
 			$allianceStats[$dbRecord->getInt('alliance_id')] = $dbRecord;
 		}

--- a/src/templates/Default/engine/Default/alliance_list.php
+++ b/src/templates/Default/engine/Default/alliance_list.php
@@ -22,9 +22,7 @@ if (count($Alliances) > 0) { ?>
 		<tbody class="list"><?php
 			foreach ($Alliances as $AllianceID => $Alliance) { ?>
 				<tr id="alliance-<?php echo $AllianceID; ?>" class="ajax">
-					<td class="sort_name">
-						<a href="<?php echo $Alliance['ViewHREF']; ?>"><?php echo $Alliance['Name']; ?></a>
-					</td>
+					<td class="sort_name"><?php echo $Alliance['Name']; ?></td>
 					<td class="sort_totExp right"><?php echo number_format($Alliance['TotalExperience']); ?></td>
 					<td class="sort_avgExp right"><?php echo number_format($Alliance['AverageExperience']); ?></td>
 					<td class="sort_members right"><?php echo number_format($Alliance['Members']); ?></td>

--- a/src/templates/Default/engine/Default/alliance_list.php
+++ b/src/templates/Default/engine/Default/alliance_list.php
@@ -12,6 +12,7 @@ if (count($Alliances) > 0) { ?>
 	<table id="alliance-list" class="standard inset centered">
 		<thead>
 			<tr>
+				<th class="sort shrink" data-sort="sort_recruit">Open Recruitment</th>
 				<th class="sort" data-sort="sort_name">Alliance Name</th>
 				<th class="sort shrink" data-sort="sort_totExp">Total Experience</th>
 				<th class="sort shrink" data-sort="sort_avgExp">Average Experience</th>
@@ -22,6 +23,7 @@ if (count($Alliances) > 0) { ?>
 		<tbody class="list"><?php
 			foreach ($Alliances as $AllianceID => $Alliance) { ?>
 				<tr id="alliance-<?php echo $AllianceID; ?>" class="ajax">
+					<td class="sort_recruit center"><?php if ($Alliance['OpenRecruitment']) { ?><span class="green">Yes</span><?php } else { ?><span class="red">No</span><?php } ?></td>
 					<td class="sort_name"><?php echo $Alliance['Name']; ?></td>
 					<td class="sort_totExp right"><?php echo number_format($Alliance['TotalExperience']); ?></td>
 					<td class="sort_avgExp right"><?php echo number_format($Alliance['AverageExperience']); ?></td>

--- a/src/templates/Default/engine/Default/rankings_alliance_vs_alliance.php
+++ b/src/templates/Default/engine/Default/rankings_alliance_vs_alliance.php
@@ -24,8 +24,7 @@
 			<tr>
 				<td <?php echo $data['Style']; ?>>
 					<select name="alliancer[]" style="width:155px"><?php
-						foreach ($ActiveAlliances as $activeID) {
-							$curr_alliance = SmrAlliance::getAlliance($activeID, $ThisPlayer->getGameID());
+						foreach ($ActiveAlliances as $activeID => $curr_alliance) {
 							$attr = ($data['ID'] == $activeID) ? 'selected' : ''; ?>
 							<option value="<?php echo $activeID; ?>" <?php echo $attr; ?>><?php echo $curr_alliance->getAllianceDisplayName(); ?></option><?php
 						} ?>

--- a/test/SmrTest/lib/DefaultGame/SmrAllianceIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/SmrAllianceIntegrationTest.php
@@ -21,6 +21,12 @@ class SmrAllianceIntegrationTest extends BaseIntegrationSpec {
 		SmrAlliance::clearCache();
 	}
 
+	public function test_getAlliance_throws_when_no_record_found(): void {
+		$this->expectException(AllianceNotFound::class);
+		$this->expectExceptionMessage('Invalid allianceID: 2 OR gameID: 3');
+		SmrAlliance::getAlliance(2, 3);
+	}
+
 	public function test_getAllianceByIrcChannel(): void {
 		// Create an Alliance and set its IRC channel
 		$gameID = 1;
@@ -62,9 +68,9 @@ class SmrAllianceIntegrationTest extends BaseIntegrationSpec {
 
 		$alliance = SmrAlliance::createAlliance($gameID, $name);
 
-		$this->assertSame($gameID, $alliance->getGameID());
-		$this->assertSame($name, $alliance->getAllianceName());
-		$this->assertSame(1, $alliance->getAllianceID());
+		self::assertSame($gameID, $alliance->getGameID());
+		self::assertSame($name, $alliance->getAllianceName());
+		self::assertSame(1, $alliance->getAllianceID());
 	}
 
 	public function test_createAlliance_duplicate_name(): void {
@@ -84,7 +90,7 @@ class SmrAllianceIntegrationTest extends BaseIntegrationSpec {
 	public function test_createAlliance_increment_allianceID(): void {
 		SmrAlliance::createAlliance(1, 'test1');
 		$alliance = SmrAlliance::createAlliance(1, 'test2');
-		$this->assertSame(2, $alliance->getAllianceID());
+		self::assertSame(2, $alliance->getAllianceID());
 	}
 
 	public function test_isNHA(): void {
@@ -95,6 +101,16 @@ class SmrAllianceIntegrationTest extends BaseIntegrationSpec {
 		// Create an alliance that is the NHA
 		$alliance = SmrAlliance::createAlliance(1, NHA_ALLIANCE_NAME, true);
 		self::assertTrue($alliance->isNHA());
+	}
+
+	public function test_isNone(): void {
+		// Create an alliance that is not "none"
+		$alliance = SmrAlliance::createAlliance(1, 'Some alliance');
+		self::assertFalse($alliance->isNone());
+
+		// Create an alliance that is "none"
+		$alliance = SmrAlliance::getAlliance(0, 1);
+		self::assertTrue($alliance->isNone());
 	}
 
 }


### PR DESCRIPTION
This should make it easier for new players to find alliances that they
can join without needing a password.

We might want to consider putting the "Join" button right on this page,
but for now it will just say "Yes"/"No".

Also improved efficiency of constructing multiple SmrAlliance instances.

![image](https://user-images.githubusercontent.com/846186/183269710-9427053c-a35c-42c8-a15e-372bff715fd5.png)
