### PR TITLE
Extend Rankings to game_stats.php

### DIFF
--- a/src/engine/Default/rankings_alliance_experience.php
+++ b/src/engine/Default/rankings_alliance_experience.php
@@ -7,18 +7,7 @@ $player = $session->getPlayer();
 $template->assign('PageTopic', 'Alliance Experience Rankings');
 Menu::rankings(1, 0);
 
-$db = Smr\Database::getInstance();
-$rankedStats = [];
-$dbResult = $db->read('SELECT alliance.*, COALESCE(SUM(experience), 0) amount
-		FROM alliance
-		LEFT JOIN player USING (game_id, alliance_id)
-		WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-		GROUP BY alliance_id
-		ORDER BY amount DESC, alliance_name ASC');
-foreach ($dbResult->records() as $dbRecord) {
-	$rankedStats[$dbRecord->getInt('alliance_id')] = $dbRecord;
-}
-
+$rankedStats = Rankings::allianceStats('experience', $player->getGameID());
 $ourRank = 0;
 if ($player->hasAlliance()) {
 	$ourRank = Rankings::ourRank($rankedStats, $player->getAllianceID());

--- a/src/engine/Default/rankings_alliance_kills.php
+++ b/src/engine/Default/rankings_alliance_kills.php
@@ -8,7 +8,6 @@ $template->assign('PageTopic', 'Alliance Kill Rankings');
 Menu::rankings(1, 2);
 
 $rankedStats = Rankings::allianceStats('kills', $player->getGameID());
-
 $ourRank = 0;
 if ($player->hasAlliance()) {
 	$ourRank = Rankings::ourRank($rankedStats, $player->getAllianceID());

--- a/src/engine/Default/rankings_alliance_profit.php
+++ b/src/engine/Default/rankings_alliance_profit.php
@@ -7,21 +7,8 @@ $player = $session->getPlayer();
 $template->assign('PageTopic', 'Alliance Profit Rankings');
 Menu::rankings(1, 1);
 
-$profitType = implode(':', ['Trade', 'Money', 'Profit']);
-
-$db = Smr\Database::getInstance();
-$rankedStats = [];
-$dbResult = $db->read('SELECT alliance.*, COALESCE(SUM(amount), 0) amount
-	FROM alliance
-	LEFT JOIN player p USING (game_id, alliance_id)
-	LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $db->escapeString($profitType) . '
-	WHERE p.game_id = ' . $db->escapeNumber($player->getGameID()) . '
-	GROUP BY alliance_id
-	ORDER BY amount DESC, alliance_name');
-foreach ($dbResult->records() as $dbRecord) {
-	$rankedStats[$dbRecord->getInt('alliance_id')] = $dbRecord;
-}
-
+$hofCategory = ['Trade', 'Money', 'Profit'];
+$rankedStats = Rankings::allianceStatsFromHOF($hofCategory, $player->getGameID());
 $ourRank = 0;
 if ($player->hasAlliance()) {
 	$ourRank = Rankings::ourRank($rankedStats, $player->getAllianceID());

--- a/src/templates/Default/engine/Default/game_stats.php
+++ b/src/templates/Default/engine/Default/game_stats.php
@@ -139,10 +139,10 @@
 							<th>Experience</th>
 						</tr><?php
 						foreach ($ExperienceRankings as $Rank => $RankedPlayer) { ?>
-							<tr>
+							<tr <?php echo $RankedPlayer['Class']; ?>>
 								<td><?php echo $Rank; ?></td>
-								<td><?php echo $RankedPlayer->getDisplayName(); ?></td>
-								<td><?php echo number_format($RankedPlayer->getExperience()); ?></td>
+								<td><?php echo $RankedPlayer['Player']->getDisplayName(); ?></td>
+								<td><?php echo number_format($RankedPlayer['Value']); ?></td>
 							</tr><?php
 						} ?>
 					</table><?php
@@ -157,10 +157,10 @@
 							<th>Kills</th>
 						</tr><?php
 						foreach ($KillRankings as $Rank => $RankedPlayer) { ?>
-							<tr>
+							<tr <?php echo $RankedPlayer['Class']; ?>>
 								<td><?php echo $Rank; ?></td>
-								<td><?php echo $RankedPlayer->getDisplayName(); ?></td>
-								<td><?php echo number_format($RankedPlayer->getKills()); ?></td>
+								<td><?php echo $RankedPlayer['Player']->getDisplayName(); ?></td>
+								<td><?php echo number_format($RankedPlayer['Value']); ?></td>
 							</tr><?php
 						} ?>
 					</table><?php
@@ -176,41 +176,37 @@
 			<td>Top 10 Alliances in Kills</td>
 		</tr>
 		<tr>
-			<td><?php
-				if (isset($AllianceExpRankings)) { ?>
-					<table class="nobord">
-						<tr>
-							<th>Rank</th>
-							<th>Alliance</th>
-							<th>Experience</th>
+			<td>
+				<table class="nobord">
+					<tr>
+						<th>Rank</th>
+						<th>Alliance</th>
+						<th>Experience</th>
+					</tr><?php
+					foreach ($AllianceExpRankings as $Rank => $RankedAlliance) { ?>
+						<tr <?php echo $RankedAlliance['Class']; ?>>
+							<td><?php echo $Rank; ?></td>
+							<td><?php echo $RankedAlliance['AllianceName']; ?></td>
+							<td><?php echo number_format($RankedAlliance['Value']); ?></td>
 						</tr><?php
-						foreach ($AllianceExpRankings as $Rank => $RankedAlliance) { ?>
-							<tr>
-								<td><?php echo $Rank; ?></td>
-								<td><?php echo $RankedAlliance['AllianceName']; ?></td>
-								<td><?php echo number_format($RankedAlliance['Amount']); ?></td>
-							</tr><?php
-						} ?>
-					</table><?php
-				} ?>
+					} ?>
+				</table>
 			</td>
-			<td><?php
-				if (isset($AllianceKillRankings)) { ?>
-					<table class="nobord">
-						<tr>
-							<th>Rank</th>
-							<th>Alliance</th>
-							<th>Kills</th>
+			<td>
+				<table class="nobord">
+					<tr>
+						<th>Rank</th>
+						<th>Alliance</th>
+						<th>Kills</th>
+					</tr><?php
+					foreach ($AllianceKillRankings as $Rank => $RankedAlliance) { ?>
+						<tr <?php echo $RankedAlliance['Class']; ?>>
+							<td><?php echo $Rank; ?></td>
+							<td><?php echo $RankedAlliance['AllianceName']; ?></td>
+							<td><?php echo number_format($RankedAlliance['Value']); ?></td>
 						</tr><?php
-						foreach ($AllianceKillRankings as $Rank => $RankedAlliance) { ?>
-							<tr>
-								<td><?php echo $Rank; ?></td>
-								<td><?php echo $RankedAlliance['AllianceName']; ?></td>
-								<td><?php echo number_format($RankedAlliance['Amount']); ?></td>
-							</tr><?php
-						} ?>
-					</table><?php
-				} ?>
+					} ?>
+				</table>
 			</td>
 		</tr>
 	</table>


### PR DESCRIPTION
All remaining raw SQL queries are moved from the rankings_*.php pages
to the Rankings class. The game_stats.php page is re-implemented with
the Rankings class methods.

* Fix SQL error in alliance experience rankings in game_stats.php. In
  disbanded alliances (i.e. no players), we would be calling `SUM` on
  `NULL` due to a missing `COALESCE`, which was present in the
  (otherwise) identical query in rankings_alliance_experience.php
  in d9fca79617661.

* Fix bug calculating alliance kill counts in game_stats.php. We must
  get the count from the `alliance.alliance_kills` column instead of
  from the individual player kill counts. This way, only the kills
  awarded while the player was a member of the alliance will count
  toward the alliance total.

* The game_stats.php rankings automatically inherit the rank row
  styles from the Rankings class methods, so players will see their
  own trader/alliance highlighted.