### PR TITLE
Extend the DI container interface

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -77,3 +77,13 @@ parameters:
             message: '#Parameter \#1 \$token of method .*::getResourceOwner\(\) expects .*AccessToken, .*AccessTokenInterface given.#'
             path: src/lib/Smr/SocialLogin
             count: 2
+        -
+            # https://github.com/PHP-DI/PHP-DI/pull/827
+            message: '#Method Smr\\Container\\DiContainer::buildContainer\(\) should return Smr\\Container\\ResettableCompiledContainer|Smr\\Container\\ResettableContainer but returns DI\\Container.#'
+            path: src/lib/Smr/Container/DiContainer.php
+            count: 1
+        -
+            # https://github.com/PHP-DI/PHP-DI/pull/827
+            message: '#Call to an undefined method DI\\Container::(initialized|reset)\(\).#'
+            path: test/SmrTest/Container/ResettableContainerTraitTest.php
+            count: 9

--- a/src/lib/Smr/Container/ResettableCompiledContainer.php
+++ b/src/lib/Smr/Container/ResettableCompiledContainer.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Container;
+
+use DI\CompiledContainer;
+
+class ResettableCompiledContainer extends CompiledContainer {
+
+	use ResettableContainerTrait;
+
+}

--- a/src/lib/Smr/Container/ResettableContainer.php
+++ b/src/lib/Smr/Container/ResettableContainer.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Container;
+
+use DI\Container;
+
+class ResettableContainer extends Container {
+
+	use ResettableContainerTrait;
+
+}

--- a/src/lib/Smr/Container/ResettableContainerTrait.php
+++ b/src/lib/Smr/Container/ResettableContainerTrait.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Container;
+
+/**
+ * Extends a Di\Container to allow for introspection and resetting.
+ */
+trait ResettableContainerTrait {
+
+	/**
+	 * Test if the entry given by $name has been initialized in the container.
+	 *
+	 * @param string $name Entry name or a class name.
+	 * @return bool Whether or not the entry is initialized.
+	 */
+	public function initialized(string $name): bool {
+		return array_key_exists($name, $this->resolvedEntries);
+	}
+
+	/**
+	 * Unset the entry given by $name in the container.
+	 *
+	 * A subsequent call to get() will create a new instance of this entry,
+	 * according to its definition (if it has one). This can be useful to
+	 * release resources that are no longer in use or that need to be reset.
+	 *
+	 * @param string $name Entry name or a class name.
+	 */
+	public function reset(string $name): void {
+		unset($this->resolvedEntries[$name]);
+	}
+
+}

--- a/src/lib/Smr/Discord/DatabaseCommand.php
+++ b/src/lib/Smr/Discord/DatabaseCommand.php
@@ -26,11 +26,6 @@ abstract class DatabaseCommand extends Command {
 	 * Wrapper to properly handle a DatabaseCommand response.
 	 */
 	final public function response(string ...$args): array {
-		// Since we close the database connection after each call, we may
-		// need to reconnect here.
-		$db = Database::getInstance();
-		$db->reconnect();
-
 		try {
 			$link = new PlayerLink($this->message);
 			if (!$link->valid) {
@@ -41,7 +36,7 @@ abstract class DatabaseCommand extends Command {
 		} finally {
 			// Close the database connection after a command has executed.
 			// This is necessary to prevent a blocking database timeout error.
-			$db->close();
+			Database::resetInstance();
 		}
 	}
 

--- a/src/tools/discord/bot.php
+++ b/src/tools/discord/bot.php
@@ -2,6 +2,7 @@
 
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use Smr\Database;
 use Smr\Discord\Commands\Forces;
 use Smr\Discord\Commands\Game;
 use Smr\Discord\Commands\Invite;
@@ -59,6 +60,6 @@ $seedlistCmd = (new Seedlist())->register($discord);
 
 // Close the connection we may have opened during startup
 // to avoid a mysql timeout.
-Smr\Database::getInstance()->close();
+Database::resetInstance();
 
 $discord->run();

--- a/src/tools/irc/irc.php
+++ b/src/tools/irc/irc.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 function echo_r(string $message): void {
 	echo date('Y-m-d H:i:s => ') . $message . EOL;
 }
@@ -31,7 +33,7 @@ while (true) {
 
 	// delete all seen stats that appear to be on (we do not want to take
 	// something for granted that happend while we were away)
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$db->write('DELETE from irc_seen WHERE signed_off = 0');
 
 	// Reset last ping each time we try connecting.
@@ -89,7 +91,7 @@ while (true) {
 			readFromStream($fp);
 			// Close database connection between calls to avoid
 			// stale or timed out server errors.
-			$db->close();
+			Database::resetInstance();
 		}
 		fclose($fp); // close socket
 

--- a/src/tools/irc/stream.php
+++ b/src/tools/irc/stream.php
@@ -60,13 +60,6 @@ function readFromStream($fp): bool {
 		return true;
 	}
 
-	// Since we close the database connection between polls, we will need
-	// to reconnect before doing anything that requires the database. Note
-	// that everything above this point does *not* need the database, but
-	// we *may* need it beyond this point.
-	$db = Smr\Database::getInstance();
-	$db->reconnect();
-
 	// server msg
 	if (server_msg_307($fp, $rdata)) {
 		return true;

--- a/test/SmrTest/Container/DiContainerTest.php
+++ b/test/SmrTest/Container/DiContainerTest.php
@@ -60,4 +60,27 @@ class DiContainerTest extends TestCase {
 		self::assertSame($dbName, 'smr_live_test');
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_initialized(): void {
+		// Note that we need to run in a separate process since this is the
+		// only way to ensure that the DiContainer is not yet initialized
+		// (and static properties cannot be unset).
+
+		// Before the DiContainer is initialized, all entries should report
+		// that they are not initialized as well.
+		$entry = 'DatabaseName';
+		self::assertFalse(DiContainer::initialized($entry));
+
+		// After the DiContainer is initialized, all entries should still
+		// report that they are not initialized.
+		DiContainer::initialize(false);
+		self::assertFalse(DiContainer::initialized($entry));
+
+		// Only once the entry is requested should it be initialized.
+		DiContainer::get($entry);
+		self::assertTrue(DiContainer::initialized($entry));
+	}
+
 }

--- a/test/SmrTest/Container/ResettableContainerTraitTest.php
+++ b/test/SmrTest/Container/ResettableContainerTraitTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\Container;
+
+use DI\ContainerBuilder;
+use PHPUnit\Framework\TestCase;
+use Smr\Container\ResettableContainer;
+
+/**
+ * @covers \Smr\Container\ResettableContainerTrait
+ */
+class ResettableContainerTraitTest extends TestCase {
+
+	private ContainerBuilder $builder;
+
+	protected function setUp(): void {
+		$this->builder = new ContainerBuilder(ResettableContainer::class);
+	}
+
+	public function test_not_initialized_by_definition(): void {
+		$this->builder->addDefinitions([
+			'foo' => 'bar',
+		]);
+
+		// Unlike has(), entries are not initialized by definitions
+		self::assertFalse($this->builder->build()->initialized('foo'));
+	}
+
+	public function test_initialized_by_definition_after_get(): void {
+		$this->builder->addDefinitions([
+			'foo' => 'bar',
+		]);
+		$container = $this->builder->build();
+		$container->get('foo');
+
+		// Only once we get the entry for the first time is it initialized
+		self::assertTrue($container->initialized('foo'));
+	}
+
+	public function test_initialized_when_set_directly(): void {
+		$container = $this->builder->build();
+		$container->set('foo', 'bar');
+
+		// The entry is also initialized if set directly
+		self::assertTrue($container->initialized('foo'));
+	}
+
+	public function test_not_initialized_when_unknown(): void {
+		// Entry is not initialized in a default container
+		self::assertFalse($this->builder->build()->initialized('foo'));
+	}
+
+	public function test_reset_with_definition(): void {
+		$this->builder->addDefinitions([
+			'foo' => 'bar',
+		]);
+		$container = $this->builder->build();
+
+		// Sanity check the state of the entry prior to reset
+		self::assertTrue($container->has('foo'));
+		self::assertFalse($container->initialized('foo'));
+
+		// Now initialize the entry, and sanity check the state again
+		self::assertSame('bar', $container->get('foo'));
+		self::assertTrue($container->has('foo'));
+		self::assertTrue($container->initialized('foo'));
+
+		// Then reset the entry
+		$container->reset('foo');
+
+		// It should still be gettable, but it is no longer initialized
+		self::assertTrue($container->has('foo'));
+		self::assertFalse($container->initialized('foo'));
+		self::assertSame('bar', $container->get('foo'));
+	}
+
+	public function test_reset_when_set_directly(): void {
+		$container = $this->builder->build();
+		$container->set('foo', 'bar');
+
+		// After resetting an entry that does not have a definition (i.e. it is
+		// only set directly), it is no longer gettable.
+		$container->reset('foo');
+		self::assertFalse($container->has('foo'));
+	}
+
+}


### PR DESCRIPTION
Add introspection (`initialized`) and resetability (`reset`) to the DI container interface. This allows for two major infrastructural improvements:
1. The database connection can now be properly reset after use in daemonized services (Discord/IRC clients) in a way that doesn't initialize the connection unnecessarily during a request where it's not used. It can be recreated again on demand without any special reconnection logic.
2. Logging no longer initializes resources that were not used up until the logging facility was invoked. This also prevents issues with throwing during logging (in case the resources themselves are the source of the error).