### PR TITLE
Switch to the "use" syntax for class imports

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\Container\DiContainer;
+use Smr\Exceptions\UserError;
 use Smr\SectorLock;
 use Smr\Session;
 
@@ -103,7 +104,7 @@ function handleException(Throwable $e): void {
 	// The real error message may display sensitive information, so we
 	// need to catch any exceptions that are thrown while logging the error.
 	try {
-		if ($e instanceof Smr\Exceptions\UserError) {
+		if ($e instanceof UserError) {
 			create_error($e->getMessage());
 		}
 		logException($e);

--- a/src/engine/Default/admin/account_close.php
+++ b/src/engine/Default/admin/account_close.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
@@ -7,10 +9,10 @@ $account = $session->getAccount();
 $amount = 0;
 
 // Disabling from the "Computer Sharing" page
-if (Smr\Request::has('close')) {
+if (Request::has('close')) {
 	//never expire
 	$expire_time = 0;
-	foreach (Smr\Request::getArray('close') as $key => $value) {
+	foreach (Request::getArray('close') as $key => $value) {
 		$val = 'Match list:' . $value;
 		$bannedAccount = SmrAccount::getAccount($key);
 		$bannedAccount->banAccount($expire_time, $account, BAN_REASON_MULTI, $val);
@@ -18,8 +20,8 @@ if (Smr\Request::has('close')) {
 	}
 }
 
-if (Smr\Request::has('first')) {
-	$same_ip = Smr\Request::getIntArray('same_ip');
+if (Request::has('first')) {
+	$same_ip = Request::getIntArray('same_ip');
 	$val = 'Match list:' . implode(',', $same_ip);
 	foreach ($same_ip as $account_id) {
 		//never expire
@@ -30,18 +32,18 @@ if (Smr\Request::has('first')) {
 }
 
 // Disabling from the "List all IPs for a specific account" page
-if (Smr\Request::has('second')) {
+if (Request::has('second')) {
 	//never expire
-	$bannedAccount = SmrAccount::getAccount(Smr\Request::getInt('second'));
-	$bannedAccount->banAccount(0, $account, BAN_REASON_MULTI, Smr\Request::get('reason'));
+	$bannedAccount = SmrAccount::getAccount(Request::getInt('second'));
+	$bannedAccount->banAccount(0, $account, BAN_REASON_MULTI, Request::get('reason'));
 	$amount++;
 }
 
 // Disabling from the "List all IPs" page
-if (Smr\Request::has('disable_id')) {
-	$reasons = Smr\Request::getArray('suspicion');
-	$reasons2 = Smr\Request::getArray('suspicion2');
-	foreach (Smr\Request::getIntArray('disable_id') as $id) {
+if (Request::has('disable_id')) {
+	$reasons = Request::getArray('suspicion');
+	$reasons2 = Request::getArray('suspicion2');
+	foreach (Request::getIntArray('disable_id') as $id) {
 
 		$reason = $reasons[$id];
 		if (empty($reason)) {

--- a/src/engine/Default/admin/account_edit.php
+++ b/src/engine/Default/admin/account_edit.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 $template->assign('PageTopic', 'Edit Account');

--- a/src/engine/Default/admin/account_edit_processing.php
+++ b/src/engine/Default/admin/account_edit_processing.php
@@ -1,6 +1,11 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Exceptions\UserError;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
@@ -9,18 +14,18 @@ $account_id = $var['account_id'];
 $curr_account = SmrAccount::getAccount($account_id);
 
 // request
-$donation = Smr\Request::getInt('donation');
-$smr_credit = Smr\Request::has('smr_credit');
-$rewardCredits = Smr\Request::getInt('grant_credits');
-$choise = Smr\Request::get('choise', ''); // no radio button selected by default
-$reason_pre_select = Smr\Request::getInt('reason_pre_select');
-$reason_msg = Smr\Request::get('reason_msg');
-$veteran_status = Smr\Request::get('veteran_status') == 'TRUE';
-$logging_status = Smr\Request::get('logging_status') == 'TRUE';
-$except = Smr\Request::get('exception_add', ''); // missing if account already has an exception
-$points = Smr\Request::getInt('points');
-$names = Smr\Request::getArray('player_name', []); // missing when no games joined
-$delete = Smr\Request::getArray('delete', []); // missing when no games joined
+$donation = Request::getInt('donation');
+$smr_credit = Request::has('smr_credit');
+$rewardCredits = Request::getInt('grant_credits');
+$choise = Request::get('choise', ''); // no radio button selected by default
+$reason_pre_select = Request::getInt('reason_pre_select');
+$reason_msg = Request::get('reason_msg');
+$veteran_status = Request::get('veteran_status') == 'TRUE';
+$logging_status = Request::get('logging_status') == 'TRUE';
+$except = Request::get('exception_add', ''); // missing if account already has an exception
+$points = Request::getInt('points');
+$names = Request::getArray('player_name', []); // missing when no games joined
+$delete = Request::getArray('delete', []); // missing when no games joined
 
 $actions = [];
 
@@ -28,7 +33,7 @@ if (!empty($donation)) {
 	// add entry to account donated table
 	$db->insert('account_donated', [
 		'account_id' => $db->escapeNumber($account_id),
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 		'amount' => $db->escapeNumber($donation),
 	]);
 
@@ -45,8 +50,8 @@ if (!empty($rewardCredits)) {
 	$actions[] = 'added ' . $rewardCredits . ' reward credits';
 }
 
-if (Smr\Request::has('special_close')) {
-	$specialClose = Smr\Request::get('special_close');
+if (Request::has('special_close')) {
+	$specialClose = Request::get('special_close');
 	// Make sure the special closing reason exists
 	$dbResult = $db->read('SELECT reason_id FROM closing_reason WHERE reason=' . $db->escapeString($specialClose));
 	if ($dbResult->hasRecord()) {
@@ -57,7 +62,7 @@ if (Smr\Request::has('special_close')) {
 		]);
 	}
 
-	$closeByRequestNote = Smr\Request::get('close_by_request_note');
+	$closeByRequestNote = Request::get('close_by_request_note');
 	if (empty($closeByRequestNote)) {
 		$closeByRequestNote = $specialClose;
 	}
@@ -80,7 +85,7 @@ if ($choise == 'reopen') {
 		$reason_id = $reason_pre_select;
 	}
 
-	$suspicion = Smr\Request::get('suspicion');
+	$suspicion = Request::get('suspicion');
 	$bannedDays = $curr_account->addPoints($points, $account, $reason_id, $suspicion);
 	$actions[] = 'added ' . $points . ' ban points';
 
@@ -94,13 +99,13 @@ if ($choise == 'reopen') {
 	}
 }
 
-if (Smr\Request::has('mailban')) {
-	$mailban = Smr\Request::get('mailban');
+if (Request::has('mailban')) {
+	$mailban = Request::get('mailban');
 	if ($mailban == 'remove') {
-		$curr_account->setMailBanned(Smr\Epoch::time());
+		$curr_account->setMailBanned(Epoch::time());
 		$actions[] = 'removed mailban';
 	} elseif ($mailban == 'add_days') {
-		$days = Smr\Request::getInt('mailban_days');
+		$days = Request::getInt('mailban_days');
 		$curr_account->increaseMailBanned($days * 86400);
 		$actions[] = 'mail banned for ' . $days . ' days';
 	}
@@ -132,7 +137,7 @@ foreach ($names as $game_id => $new_name) {
 
 	try {
 		$editPlayer->changePlayerName($new_name);
-	} catch (Smr\Exceptions\UserError $err) {
+	} catch (UserError $err) {
 		$actions[] = 'have NOT changed player name to ' . htmlentities($new_name) . ' ( ' . $err->getMessage() . ')';
 		continue;
 	}
@@ -144,7 +149,7 @@ foreach ($names as $game_id => $new_name) {
 	$news = 'Please be advised that player ' . $editPlayer->getPlayerID() . ' has had their name changed to ' . $editPlayer->getBBLink();
 
 	$db->insert('news', [
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 		'news_message' => $db->escapeString($news),
 		'game_id' => $db->escapeNumber($game_id),
 		'type' => $db->escapeString('admin'),

--- a/src/engine/Default/admin/account_edit_search.php
+++ b/src/engine/Default/admin/account_edit_search.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -7,7 +9,7 @@ $var = $session->getCurrentVar();
 $template->assign('PageTopic', 'Edit Account');
 
 $games = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT game_id, game_name FROM game WHERE enabled = \'TRUE\' ORDER BY game_id DESC');
 foreach ($dbResult->records() as $dbRecord) {
 	$gameID = $dbRecord->getInt('game_id');

--- a/src/engine/Default/admin/account_edit_search_processing.php
+++ b/src/engine/Default/admin/account_edit_search_processing.php
@@ -1,10 +1,13 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Request;
 
-$account_id = Smr\Request::getInt('account_id');
-$player_name = Smr\Request::get('player_name');
-$searchGameID = Smr\Request::getInt('game_id');
+$db = Database::getInstance();
+
+$account_id = Request::getInt('account_id');
+$player_name = Request::get('player_name');
+$searchGameID = Request::getInt('game_id');
 
 if (!empty($player_name)) {
 	$gameIDClause = $searchGameID != 0 ? ' AND game_id = ' . $db->escapeNumber($searchGameID) . ' ' : '';
@@ -24,10 +27,10 @@ if (!empty($player_name)) {
 
 // get account from db
 $dbResult = $db->read('SELECT account_id FROM account WHERE account_id = ' . $db->escapeNumber($account_id) . ' OR ' .
-									   'login LIKE ' . $db->escapeString(Smr\Request::get('login')) . ' OR ' .
-									   'email LIKE ' . $db->escapeString(Smr\Request::get('email')) . ' OR ' .
-									   'hof_name LIKE ' . $db->escapeString(Smr\Request::get('hofname')) . ' OR ' .
-									   'validation_code LIKE ' . $db->escapeString(Smr\Request::get('val_code')) . ' LIMIT 1');
+									   'login LIKE ' . $db->escapeString(Request::get('login')) . ' OR ' .
+									   'email LIKE ' . $db->escapeString(Request::get('email')) . ' OR ' .
+									   'hof_name LIKE ' . $db->escapeString(Request::get('hofname')) . ' OR ' .
+									   'validation_code LIKE ' . $db->escapeString(Request::get('val_code')) . ' LIMIT 1');
 if ($dbResult->hasRecord()) {
 	$container = Page::create('admin/account_edit.php');
 	$container['account_id'] = $dbResult->record()->getInt('account_id');

--- a/src/engine/Default/admin/admin_message_send.php
+++ b/src/engine/Default/admin/admin_message_send.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -16,7 +18,7 @@ $template->assign('ExpireTime', $var['expire'] ?? 0.5);
 if ($gameID != 20000) {
 	$game = SmrGame::getGame($gameID);
 	$gamePlayers = [['AccountID' => 0, 'Name' => 'All Players (' . $game->getName() . ')']];
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT account_id,player_id,player_name FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY player_name');
 	foreach ($dbResult->records() as $dbRecord) {
 		$gamePlayers[] = [

--- a/src/engine/Default/admin/admin_message_send_processing.php
+++ b/src/engine/Default/admin/admin_message_send_processing.php
@@ -1,19 +1,23 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 const ALL_GAMES_ID = 20000;
-$message = Smr\Request::get('message');
-$expire = Smr\Request::getFloat('expire');
+$message = Request::get('message');
+$expire = Request::getFloat('expire');
 $game_id = $var['SendGameID'];
 
-if (Smr\Request::get('action') == 'Preview message') {
+if (Request::get('action') == 'Preview message') {
 	$container = Page::create('admin/admin_message_send.php');
 	$container->addVar('SendGameID');
 	$container['preview'] = $message;
 	$container['expire'] = $expire;
 	if ($game_id != ALL_GAMES_ID) {
-		$container['account_id'] = Smr\Request::getInt('account_id');
+		$container['account_id'] = Request::getInt('account_id');
 	}
 	$container->go();
 }
@@ -21,14 +25,14 @@ if (Smr\Request::get('action') == 'Preview message') {
 $expire = IRound($expire * 3600); // convert hours to seconds
 // When expire==0, message will not expire
 if ($expire > 0) {
-	$expire += Smr\Epoch::time();
+	$expire += Epoch::time();
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 
 $receivers = [];
 if ($game_id != ALL_GAMES_ID) {
-	$account_id = Smr\Request::getInt('account_id');
+	$account_id = Request::getInt('account_id');
 	if ($account_id == 0) {
 		// Send to all players in the requested game
 		$dbResult = $db->read('SELECT account_id FROM player WHERE game_id = ' . $db->escapeNumber($game_id));
@@ -40,7 +44,7 @@ if ($game_id != ALL_GAMES_ID) {
 	}
 } else {
 	//send to all players in games that haven't ended yet
-	$dbResult = $db->read('SELECT game_id,account_id FROM player JOIN game USING(game_id) WHERE end_time > ' . $db->escapeNumber(Smr\Epoch::time()));
+	$dbResult = $db->read('SELECT game_id,account_id FROM player JOIN game USING(game_id) WHERE end_time > ' . $db->escapeNumber(Epoch::time()));
 	foreach ($dbResult->records() as $dbRecord) {
 		$receivers[] = [$dbRecord->getInt('game_id'), $dbRecord->getInt('account_id')];
 	}

--- a/src/engine/Default/admin/admin_message_send_select.php
+++ b/src/engine/Default/admin/admin_message_send_select.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 
 $template->assign('PageTopic', 'Send Admin Message');
@@ -8,8 +11,8 @@ $template->assign('AdminMessageChooseGameFormHref', Page::create('admin/admin_me
 
 // Get a list of all games that have not yet ended
 $activeGames = [];
-$db = Smr\Database::getInstance();
-$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY end_time DESC');
+$db = Database::getInstance();
+$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Epoch::time()) . ' ORDER BY end_time DESC');
 foreach ($dbResult->records() as $dbRecord) {
 	$activeGames[] = SmrGame::getGame($dbRecord->getInt('game_id'));
 }

--- a/src/engine/Default/admin/admin_tools.php
+++ b/src/engine/Default/admin/admin_tools.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\AdminPermissions;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -14,7 +16,7 @@ if (isset($var['msg'])) {
 
 $adminPermissions = [];
 foreach (array_keys($account->getPermissions()) as $permissionID) {
-	[$name, $link, $categoryID] = Smr\AdminPermissions::getPermissionInfo($permissionID);
+	[$name, $link, $categoryID] = AdminPermissions::getPermissionInfo($permissionID);
 	$adminPermissions[$categoryID][] = [
 		'Link' => empty($link) ? false : Page::create($link)->href(),
 		'Name' => $name,

--- a/src/engine/Default/admin/album_approve.php
+++ b/src/engine/Default/admin/album_approve.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 function get_album_nick(int $album_id): string {
 	if ($album_id == 0) {
 		return 'System';
@@ -12,7 +15,7 @@ $template = Smr\Template::getInstance();
 
 $template->assign('PageTopic', 'Approve Album Entries');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT *
 			FROM album
 			WHERE approved = \'TBC\'
@@ -75,7 +78,7 @@ if ($dbResult->hasRecord()) {
 	$template->assign('Birthdate', $birthdate);
 
 	// get the time that passed since the entry was last changed
-	$time_passed = Smr\Epoch::time() - $last_changed;
+	$time_passed = Epoch::time() - $last_changed;
 	$template->assign('TimePassed', $time_passed);
 
 	$container = Page::create('admin/album_approve_processing.php');

--- a/src/engine/Default/admin/album_approve_processing.php
+++ b/src/engine/Default/admin/album_approve_processing.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 $approved = $var['approved'] ? 'YES' : 'NO';
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('UPDATE album
 			SET approved = ' . $db->escapeString($approved) . '
 			WHERE account_id = ' . $db->escapeNumber($var['album_id']));

--- a/src/engine/Default/admin/album_moderate.php
+++ b/src/engine/Default/admin/album_moderate.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
@@ -11,7 +13,7 @@ require_once(LIB . 'Album/album_functions.php');
 $account_id = $session->getRequestVarInt('account_id');
 
 // check if the given account really has an entry
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account_id) . ' AND Approved = \'YES\'');
 $dbRecord = $dbResult->record();
 

--- a/src/engine/Default/admin/album_moderate_processing.php
+++ b/src/engine/Default/admin/album_moderate_processing.php
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
+$db = Database::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 // get account_id from session
@@ -8,7 +12,7 @@ $account_id = $var['account_id'];
 
 // check for each task
 if ($var['task'] == 'reset_image') {
-	$email_txt = Smr\Request::get('email_txt');
+	$email_txt = Request::get('email_txt');
 	$db->write('UPDATE album SET disabled = \'TRUE\' WHERE account_id = ' . $db->escapeNumber($account_id));
 
 	$db->lockTable('album_has_comments');
@@ -18,7 +22,7 @@ if ($var['task'] == 'reset_image') {
 	$db->insert('album_has_comments', [
 		'album_id' => $db->escapeNumber($account_id),
 		'comment_id' => $db->escapeNumber($comment_id),
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 		'post_id' => 0,
 		'msg' => $db->escapeString('<span class="green">*** Picture disabled by an admin</span>'),
 	]);
@@ -47,11 +51,11 @@ if ($var['task'] == 'reset_image') {
 	$db->write('UPDATE album SET other = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
 } elseif ($var['task'] == 'delete_comment') {
 	// we just ignore if nothing was set
-	if (Smr\Request::has('comment_ids')) {
+	if (Request::has('comment_ids')) {
 		$db->write('DELETE
 					FROM album_has_comments
 					WHERE album_id = ' . $db->escapeNumber($account_id) . ' AND
-						  comment_id IN (' . $db->escapeArray(Smr\Request::getIntArray('comment_ids')) . ')');
+						  comment_id IN (' . $db->escapeArray(Request::getIntArray('comment_ids')) . ')');
 	}
 } else {
 	create_error('No action chosen!');

--- a/src/engine/Default/admin/album_moderate_select.php
+++ b/src/engine/Default/admin/album_moderate_select.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 
 $template->assign('PageTopic', 'Moderate Photo Album');
@@ -10,7 +12,7 @@ $moderateHREF = Page::create('admin/album_moderate.php')->href();
 $template->assign('ModerateHREF', $moderateHREF);
 
 // Get all accounts that are eligible for moderation
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT account_id FROM album WHERE Approved = \'YES\'');
 $approved = [];
 foreach ($dbResult->records() as $dbRecord) {

--- a/src/engine/Default/admin/announcement_create_processing.php
+++ b/src/engine/Default/admin/announcement_create_processing.php
@@ -1,19 +1,23 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
-$message = Smr\Request::get('message');
-if (Smr\Request::get('action') == 'Preview announcement') {
+$message = Request::get('message');
+if (Request::get('action') == 'Preview announcement') {
 	$container = Page::create('admin/announcement_create.php');
 	$container['preview'] = $message;
 	$container->go();
 }
 
 // put the msg into the database
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->insert('announcement', [
-	'time' => $db->escapeNumber(Smr\Epoch::time()),
+	'time' => $db->escapeNumber(Epoch::time()),
 	'admin_id' => $db->escapeNumber($account->getAccountID()),
 	'msg' => $db->escapeString($message),
 ]);

--- a/src/engine/Default/admin/anon_acc_view.php
+++ b/src/engine/Default/admin/anon_acc_view.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 
@@ -12,7 +14,7 @@ $template->assign('BackHREF', $container->href());
 $anonID = $session->getRequestVarInt('anon_account');
 $gameID = $session->getRequestVarInt('view_game_id');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT *
 			FROM anon_bank_transactions
 			JOIN player USING(account_id, game_id)

--- a/src/engine/Default/admin/box_delete_processing.php
+++ b/src/engine/Default/admin/box_delete_processing.php
@@ -1,15 +1,18 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Request;
+
+$db = Database::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 if ($action == 'Marked Messages') {
-	if (!Smr\Request::has('message_id')) {
+	if (!Request::has('message_id')) {
 		create_error('You must choose the messages you want to delete.');
 	}
 
-	foreach (Smr\Request::getIntArray('message_id') as $id) {
+	foreach (Request::getIntArray('message_id') as $id) {
 		$db->write('DELETE FROM message_boxes WHERE message_id = ' . $db->escapeNumber($id));
 	}
 } elseif ($action == 'All Messages') {

--- a/src/engine/Default/admin/box_reply.php
+++ b/src/engine/Default/admin/box_reply.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Messages;
+
 $template = Smr\Template::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
-$boxName = Smr\Messages::getAdminBoxNames()[$var['box_type_id']];
+$boxName = Messages::getAdminBoxNames()[$var['box_type_id']];
 $template->assign('PageTopic', 'Reply To ' . $boxName);
 
 $container = Page::create('admin/box_reply_processing.php');

--- a/src/engine/Default/admin/box_reply_processing.php
+++ b/src/engine/Default/admin/box_reply_processing.php
@@ -1,13 +1,15 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
 
-$message = Smr\Request::get('message');
-$banPoints = Smr\Request::getInt('BanPoints');
-$rewardCredits = Smr\Request::getInt('RewardCredits');
-if (Smr\Request::get('action') == 'Preview message') {
+$message = Request::get('message');
+$banPoints = Request::getInt('BanPoints');
+$rewardCredits = Request::getInt('RewardCredits');
+if (Request::get('action') == 'Preview message') {
 	$container = Page::create('admin/box_reply.php');
 	$container['BanPoints'] = $banPoints;
 	$container['RewardCredits'] = $rewardCredits;

--- a/src/engine/Default/admin/box_view.php
+++ b/src/engine/Default/admin/box_view.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Messages;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
@@ -11,7 +14,7 @@ if (!isset($var['box_type_id'])) {
 
 	$container = Page::create('admin/box_view.php');
 	$boxes = [];
-	foreach (Smr\Messages::getAdminBoxNames() as $boxTypeID => $boxName) {
+	foreach (Messages::getAdminBoxNames() as $boxTypeID => $boxName) {
 		$container['box_type_id'] = $boxTypeID;
 		$boxes[$boxTypeID] = [
 			'ViewHREF' => $container->href(),
@@ -27,7 +30,7 @@ if (!isset($var['box_type_id'])) {
 	}
 	$template->assign('Boxes', $boxes);
 } else {
-	$boxName = Smr\Messages::getAdminBoxNames()[$var['box_type_id']];
+	$boxName = Messages::getAdminBoxNames()[$var['box_type_id']];
 	$template->assign('PageTopic', 'Viewing ' . $boxName);
 
 	$template->assign('BackHREF', Page::create('admin/box_view.php')->href());

--- a/src/engine/Default/admin/changelog.php
+++ b/src/engine/Default/admin/changelog.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -14,7 +16,7 @@ $template->assign('AffectedDb', $var['affected_db'] ?? '');
 $first_entry = true;
 $link_set_live = true;
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM version ORDER BY version_id DESC');
 
 $versions = [];

--- a/src/engine/Default/admin/changelog_add_processing.php
+++ b/src/engine/Default/admin/changelog_add_processing.php
@@ -1,21 +1,24 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
-$change_title = Smr\Request::get('change_title');
-$change_message = Smr\Request::get('change_message');
-$affected_db = Smr\Request::get('affected_db');
+$change_title = Request::get('change_title');
+$change_message = Request::get('change_message');
+$affected_db = Request::get('affected_db');
 
 $container = Page::create('admin/changelog.php');
 
-if (Smr\Request::get('action') == 'Preview') {
+if (Request::get('action') == 'Preview') {
 	$container['change_title'] = $change_title;
 	$container['change_message'] = $change_message;
 	$container['affected_db'] = $affected_db;
 	$container->go();
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->lockTable('changelog');
 
 $dbResult = $db->read('SELECT IFNULL(MAX(changelog_id)+1, 0) AS next_changelog_id

--- a/src/engine/Default/admin/changelog_set_live_processing.php
+++ b/src/engine/Default/admin/changelog_set_live_processing.php
@@ -1,10 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('UPDATE version
-			SET went_live = ' . $db->escapeNumber(Smr\Epoch::time()) . '
+			SET went_live = ' . $db->escapeNumber(Epoch::time()) . '
 			WHERE version_id = ' . $db->escapeNumber($var['version_id']));
 
 // Initialize the next version (since the version set live is not always the

--- a/src/engine/Default/admin/combat_simulator_processing.php
+++ b/src/engine/Default/admin/combat_simulator_processing.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $usedNames = [];
 
 $i = 1;
 $attackers = [];
-if (Smr\Request::has('attackers')) {
-	foreach (Smr\Request::getArray('attackers') as $attackerName) {
+if (Request::has('attackers')) {
+	foreach (Request::getArray('attackers') as $attackerName) {
 		if ($attackerName == 'none') {
 			continue;
 		}
@@ -20,7 +22,7 @@ if (Smr\Request::has('attackers')) {
 
 $i = 1;
 $defenders = [];
-foreach (Smr\Request::getArray('defenders') as $defenderName) {
+foreach (Request::getArray('defenders') as $defenderName) {
 	if ($defenderName == 'none') {
 		continue;
 	}
@@ -32,15 +34,15 @@ foreach (Smr\Request::getArray('defenders') as $defenderName) {
 	++$i;
 }
 
-if (Smr\Request::has('repair')) {
+if (Request::has('repair')) {
 	foreach ([...$attackers, ...$defenders] as $player) {
 		$player->setDead(false);
 		$player->getShip()->setHardwareToMax();
 	}
 }
 
-if (Smr\Request::has('run') || Smr\Request::has('death_run')) {
-	if (Smr\Request::has('death_run')) {
+if (Request::has('run') || Request::has('death_run')) {
+	if (Request::has('death_run')) {
 		$maxRounds = 100;
 	} else {
 		$maxRounds = 1;
@@ -89,7 +91,7 @@ function runAnAttack(array $realAttackers, array $realDefenders): array {
 }
 
 // Save ships unless we're just updating the dummy list
-if (!Smr\Request::has('update')) {
+if (!Request::has('update')) {
 	DummyShip::saveDummyShips();
 }
 

--- a/src/engine/Default/admin/comp_share.php
+++ b/src/engine/Default/admin/comp_share.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
@@ -11,7 +14,7 @@ $unusedAfter = 86400 * 365; // 1 year
 $used = [];
 
 //check the db and get the info we need
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM multi_checking_cookie WHERE `use` = \'TRUE\'');
 $tables = [];
 foreach ($dbResult->records() as $dbRecord) {
@@ -35,7 +38,7 @@ foreach ($dbResult->records() as $dbRecord) {
 	}
 
 	if ($rows > 1) {
-		$dbResult2 = $db->read('SELECT login FROM account WHERE account_id =' . $db->escapeNumber($currTabAccId) . ' AND last_login > ' . $db->escapeNumber(Smr\Epoch::time() - $unusedAfter));
+		$dbResult2 = $db->read('SELECT login FROM account WHERE account_id =' . $db->escapeNumber($currTabAccId) . ' AND last_login > ' . $db->escapeNumber(Epoch::time() - $unusedAfter));
 		if (!$dbResult2->hasRecord()) {
 			continue;
 		}
@@ -44,7 +47,7 @@ foreach ($dbResult->records() as $dbRecord) {
 		$rows = [];
 		foreach ($accountIDs as $currLinkAccId) {
 			$currLinkAccId = (int)$currLinkAccId;
-			$dbResult2 = $db->read('SELECT account_id, login, email, validated, last_login, (SELECT ip FROM account_has_ip WHERE account_id = account.account_id GROUP BY ip ORDER BY COUNT(ip) DESC LIMIT 1) common_ip FROM account WHERE account_id = ' . $db->escapeNumber($currLinkAccId) . ' AND last_login > ' . $db->escapeNumber(Smr\Epoch::time() - $unusedAfter));
+			$dbResult2 = $db->read('SELECT account_id, login, email, validated, last_login, (SELECT ip FROM account_has_ip WHERE account_id = account.account_id GROUP BY ip ORDER BY COUNT(ip) DESC LIMIT 1) common_ip FROM account WHERE account_id = ' . $db->escapeNumber($currLinkAccId) . ' AND last_login > ' . $db->escapeNumber(Epoch::time() - $unusedAfter));
 			if (!$dbResult2->hasRecord()) {
 				continue;
 			}

--- a/src/engine/Default/admin/db_cleanup.php
+++ b/src/engine/Default/admin/db_cleanup.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -10,7 +12,7 @@ function bytesToMB(int $bytes): string {
 	return round($bytes / (1024 * 1024), 1) . ' MB';
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $template->assign('DbSizeMB', bytesToMB($db->getDbBytes()));
 
 if (isset($var['results'])) {

--- a/src/engine/Default/admin/db_cleanup_processing.php
+++ b/src/engine/Default/admin/db_cleanup_processing.php
@@ -1,13 +1,16 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 // Get initial storage size
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $initialBytes = $db->getDbBytes();
 
 $endedGameIDs = [];
-$dbResult = $db->read('SELECT game_id FROM game WHERE end_time < ' . $db->escapeNumber(Smr\Epoch::time()));
+$dbResult = $db->read('SELECT game_id FROM game WHERE end_time < ' . $db->escapeNumber(Epoch::time()));
 foreach ($dbResult->records() as $dbRecord) {
 	$endedGameIDs[] = $dbRecord->getInt('game_id');
 }

--- a/src/engine/Default/admin/edit_dummys.php
+++ b/src/engine/Default/admin/edit_dummys.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $template = Smr\Template::getInstance();
 
 $template->assign('PageTopic', 'Edit Dummys');
@@ -11,7 +13,7 @@ $template->assign('Weapons', SmrWeaponType::getAllWeaponTypes());
 $template->assign('SelectDummysLink', Page::create('admin/edit_dummys.php')->href());
 $template->assign('EditDummysLink', Page::create('admin/edit_dummys_processing.php')->href());
 
-$name = Smr\Request::get('dummy_name', 'New Dummy');
+$name = Request::get('dummy_name', 'New Dummy');
 $dummyShip = DummyShip::getCachedDummyShip($name);
 
 $template->assign('DummyPlayer', $dummyShip->getPlayer());

--- a/src/engine/Default/admin/edit_dummys_processing.php
+++ b/src/engine/Default/admin/edit_dummys_processing.php
@@ -1,15 +1,17 @@
 <?php declare(strict_types=1);
 
-$name = Smr\Request::get('dummy_name');
+use Smr\Request;
+
+$name = Request::get('dummy_name');
 $dummyShip = DummyShip::getCachedDummyShip($name);
 $dummyPlayer = $dummyShip->getPlayer();
 $dummyPlayer->setPlayerName($name);
-$dummyPlayer->setExperience(Smr\Request::getInt('exp'));
+$dummyPlayer->setExperience(Request::getInt('exp'));
 
-$dummyShip->setTypeID(Smr\Request::getInt('ship_type_id'));
+$dummyShip->setTypeID(Request::getInt('ship_type_id'));
 $dummyShip->setHardwareToMax();
 $dummyShip->removeAllWeapons();
-foreach (Smr\Request::getIntArray('weapons', []) as $weaponTypeID) {
+foreach (Request::getIntArray('weapons', []) as $weaponTypeID) {
 	if ($weaponTypeID != 0) {
 		$dummyShip->addWeapon(SmrWeapon::getWeapon($weaponTypeID));
 	}

--- a/src/engine/Default/admin/enable_game.php
+++ b/src/engine/Default/admin/enable_game.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -12,7 +14,7 @@ if (isset($var['processing_msg'])) {
 }
 
 // Get the list of disabled games
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT game_name, game_id FROM game WHERE enabled=' . $db->escapeBoolean(false));
 $disabledGames = [];
 foreach ($dbResult->records() as $dbRecord) {

--- a/src/engine/Default/admin/enable_game_processing.php
+++ b/src/engine/Default/admin/enable_game_processing.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-$game = SmrGame::getGame(Smr\Request::getInt('game_id'));
+use Smr\Request;
+
+$game = SmrGame::getGame(Request::getInt('game_id'));
 $game->setEnabled(true);
 $game->save(); // because next page queries database
 

--- a/src/engine/Default/admin/form_open_processing.php
+++ b/src/engine/Default/admin/form_open_processing.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('UPDATE open_forms SET open = ' . $db->escapeBoolean(!$var['is_open']) . ' WHERE type=' . $db->escapeString($var['type']));
 
 Page::create('admin/form_open.php')->go();

--- a/src/engine/Default/admin/game_delete.php
+++ b/src/engine/Default/admin/game_delete.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 
 $template->assign('PageTopic', 'Deleting A Game');
@@ -7,7 +9,7 @@ $template->assign('PageTopic', 'Deleting A Game');
 $container = Page::create('admin/game_delete_confirm.php');
 $template->assign('ConfirmHREF', $container->href());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT game_id, game_name FROM game ORDER BY game_id DESC');
 $games = [];
 foreach ($dbResult->records() as $dbRecord) {

--- a/src/engine/Default/admin/game_delete_processing.php
+++ b/src/engine/Default/admin/game_delete_processing.php
@@ -1,14 +1,18 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 create_error('Deleting games is disabled!');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 
 $smr_db_sql = [];
 $history_db_sql = [];
 
-$action = Smr\Request::get('action');
-if (Smr\Request::get('save') == 'Yes') {
+$action = Request::get('action');
+if (Request::get('save') == 'Yes') {
 	$save = true;
 } else {
 	$save = false;
@@ -279,7 +283,7 @@ if ($action == 'Yes') {
 	$smr_db_sql[] = 'DELETE FROM ship_has_illusion WHERE game_id = ' . $game_id;
 	$smr_db_sql[] = 'DELETE FROM ship_has_weapon WHERE game_id = ' . $game_id;
 	$smr_db_sql[] = 'DELETE FROM ship_is_cloaked WHERE game_id = ' . $game_id;
-	$smr_db_sql[] = 'UPDATE game SET end_time=' . Smr\Epoch::time() . ' WHERE game_id = ' . $game_id . ' AND end_time > ' . Smr\Epoch::time(); // Do not delete game placeholder, just make sure game is finished
+	$smr_db_sql[] = 'UPDATE game SET end_time=' . Epoch::time() . ' WHERE game_id = ' . $game_id . ' AND end_time > ' . Epoch::time(); // Do not delete game placeholder, just make sure game is finished
 	$smr_db_sql[] = 'UPDATE active_session SET game_id = 0 WHERE game_id = ' . $game_id;
 
 	// now do the sql stuff
@@ -298,8 +302,8 @@ if ($action == 'Yes') {
 
 	// don't know why exactly we have to do that,
 	// but it seems that the db is used globally instead kept to each object
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 
 }
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 Page::create('admin/admin_tools.php')->go();

--- a/src/engine/Default/admin/game_status.php
+++ b/src/engine/Default/admin/game_status.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 
 $processingHREF = Page::create('admin/game_status_processing.php')->href();
 $template->assign('ProcessingHREF', $processingHREF);
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT 1 FROM game_disable');
 if (!$dbResult->hasRecord()) {
 	$template->assign('PageTopic', 'Close Server');

--- a/src/engine/Default/admin/game_status_processing.php
+++ b/src/engine/Default/admin/game_status_processing.php
@@ -1,12 +1,15 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Request;
+
+$db = Database::getInstance();
 
 $container = Page::create('admin/admin_tools.php');
 
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 if ($action == 'Close') {
-	$reason = Smr\Request::get('close_reason');
+	$reason = Request::get('close_reason');
 	$db->replace('game_disable', [
 		'reason' => $db->escapeString($reason),
 	]);

--- a/src/engine/Default/admin/ip_view_results.php
+++ b/src/engine/Default/admin/ip_view_results.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
@@ -7,7 +9,7 @@ $account = $session->getAccount();
 $variable = $session->getRequestVar('variable');
 $type = $session->getRequestVar('type');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 
 $container = Page::create('admin/ip_view.php');
 $template->assign('BackHREF', $container->href());

--- a/src/engine/Default/admin/location_edit.php
+++ b/src/engine/Default/admin/location_edit.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -8,35 +10,35 @@ $template->assign('ViewAllLocationsLink', Page::create('admin/location_edit.php'
 
 if (isset($var['location_type_id'])) {
 	$location = SmrLocation::getLocation($var['location_type_id']);
-	if (Smr\Request::has('save')) {
-		$addShipID = Smr\Request::getInt('add_ship_id');
+	if (Request::has('save')) {
+		$addShipID = Request::getInt('add_ship_id');
 		if ($addShipID != 0) {
 			$location->addShipSold($addShipID);
 		}
-		$addWeaponID = Smr\Request::getInt('add_weapon_id');
+		$addWeaponID = Request::getInt('add_weapon_id');
 		if ($addWeaponID != 0) {
 			$location->addWeaponSold($addWeaponID);
 		}
-		$addHardwareID = Smr\Request::getInt('add_hardware_id');
+		$addHardwareID = Request::getInt('add_hardware_id');
 		if ($addHardwareID != 0) {
 			$location->addHardwareSold($addHardwareID);
 		}
 
-		foreach (Smr\Request::getIntArray('remove_ships', []) as $shipTypeID) {
+		foreach (Request::getIntArray('remove_ships', []) as $shipTypeID) {
 			$location->removeShipSold($shipTypeID);
 		}
-		foreach (Smr\Request::getIntArray('remove_weapons', []) as $weaponTypeID) {
+		foreach (Request::getIntArray('remove_weapons', []) as $weaponTypeID) {
 			$location->removeWeaponSold($weaponTypeID);
 		}
-		foreach (Smr\Request::getIntArray('remove_hardware', []) as $hardwareTypeID) {
+		foreach (Request::getIntArray('remove_hardware', []) as $hardwareTypeID) {
 			$location->removeHardwareSold($hardwareTypeID);
 		}
 
-		$location->setFed(Smr\Request::has('fed'));
-		$location->setBar(Smr\Request::has('bar'));
-		$location->setBank(Smr\Request::has('bank'));
-		$location->setHQ(Smr\Request::has('hq'));
-		$location->setUG(Smr\Request::has('ug'));
+		$location->setFed(Request::has('fed'));
+		$location->setBar(Request::has('bar'));
+		$location->setBank(Request::has('bank'));
+		$location->setHQ(Request::has('hq'));
+		$location->setUG(Request::has('ug'));
 	}
 
 	$template->assign('Location', $location);

--- a/src/engine/Default/admin/log_anonymous_account.php
+++ b/src/engine/Default/admin/log_anonymous_account.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
 $template->assign('PageTopic', 'Anonymous Account Access');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT account_id FROM account_has_logs GROUP BY account_id');
 $log_account_ids = [];
 foreach ($dbResult->records() as $dbRecord) {

--- a/src/engine/Default/admin/log_console.php
+++ b/src/engine/Default/admin/log_console.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -8,7 +10,7 @@ $template->assign('PageTopic', 'Log Console');
 
 $loggedAccounts = [];
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT account_id as account_id, login, count(*) as number_of_entries
 			FROM account_has_logs
 			JOIN account USING(account_id)

--- a/src/engine/Default/admin/log_console_detail.php
+++ b/src/engine/Default/admin/log_console_detail.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 
@@ -15,7 +17,7 @@ $log_type_ids = $session->getRequestVarIntArray('log_type_ids');
 if (count($account_ids) == 0) {
 	create_error('You have to select the log files you want to view/delete!');
 }
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $account_list = $db->escapeArray($account_ids);
 
 $action = $session->getRequestVar('action');

--- a/src/engine/Default/admin/log_notes_processing.php
+++ b/src/engine/Default/admin/log_notes_processing.php
@@ -1,15 +1,18 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Request;
+
+$db = Database::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 foreach ($var['account_ids'] as $account_id) {
-	if (empty(Smr\Request::get('notes'))) {
+	if (empty(Request::get('notes'))) {
 		$db->write('DELETE FROM log_has_notes WHERE account_id = ' . $db->escapeNumber($account_id));
 	} else {
 		$db->replace('log_has_notes', [
 			'account_id' => $db->escapeNumber($account_id),
-			'notes' => $db->escapeString(Smr\Request::get('notes')),
+			'notes' => $db->escapeString(Request::get('notes')),
 		]);
 	}
 }

--- a/src/engine/Default/admin/manage_draft_leaders.php
+++ b/src/engine/Default/admin/manage_draft_leaders.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -11,8 +15,8 @@ $template->assign('SelectGameHREF', $container->href());
 
 // Get the list of active Draft games ordered by reverse start date
 $activeGames = [];
-$db = Smr\Database::getInstance();
-$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE game_type=' . $db->escapeNumber(SmrGame::GAME_TYPE_DRAFT) . ' AND join_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY start_time DESC');
+$db = Database::getInstance();
+$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE game_type=' . $db->escapeNumber(SmrGame::GAME_TYPE_DRAFT) . ' AND join_time < ' . $db->escapeNumber(Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Epoch::time()) . ' ORDER BY start_time DESC');
 foreach ($dbResult->records() as $dbRecord) {
 	$activeGames[] = [
 		'game_name' => $dbRecord->getString('game_name'),
@@ -41,7 +45,7 @@ if ($activeGames) {
 }
 
 if (isset($var['processing_msg'])) {
-	if (Smr\Request::has('selected_game_id')) {
+	if (Request::has('selected_game_id')) {
 		// If we are selecting a different game, clear the processing message.
 		unset($var['processing_msg']);
 	} else {

--- a/src/engine/Default/admin/manage_draft_leaders_processing.php
+++ b/src/engine/Default/admin/manage_draft_leaders_processing.php
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Exceptions\PlayerNotFound;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
@@ -8,16 +12,16 @@ $var = $session->getCurrentVar();
 $gameId = $var['selected_game_id'];
 
 // Get the POST variables
-$playerId = Smr\Request::getInt('player_id');
-$homeSectorID = Smr\Request::getInt('home_sector_id');
-$action = Smr\Request::get('submit');
+$playerId = Request::getInt('player_id');
+$homeSectorID = Request::getInt('home_sector_id');
+$action = Request::get('submit');
 
 // Pass entire $var so that the selected game remains selected
 $container = Page::create('admin/manage_draft_leaders.php', $var);
 
 try {
 	$selectedPlayer = SmrPlayer::getPlayerByPlayerID($playerId, $gameId);
-} catch (Smr\Exceptions\PlayerNotFound $e) {
+} catch (PlayerNotFound $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
 	$container['processing_msg'] = $msg;
 	$container->go();

--- a/src/engine/Default/admin/manage_post_editors.php
+++ b/src/engine/Default/admin/manage_post_editors.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -11,8 +15,8 @@ $template->assign('SelectGameHREF', $container->href());
 
 // Get the list of active games ordered by reverse start date
 $activeGames = [];
-$db = Smr\Database::getInstance();
-$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE join_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY start_time DESC');
+$db = Database::getInstance();
+$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE join_time < ' . $db->escapeNumber(Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Epoch::time()) . ' ORDER BY start_time DESC');
 foreach ($dbResult->records() as $dbRecord) {
 	$activeGames[] = [
 		'game_name' => $dbRecord->getString('game_name'),
@@ -36,7 +40,7 @@ if ($activeGames) {
 }
 
 if (isset($var['processing_msg'])) {
-	if (Smr\Request::has('game_id')) {
+	if (Request::has('game_id')) {
 		// If we are selecting a different game, clear the processing message.
 		unset($var['processing_msg']);
 	} else {

--- a/src/engine/Default/admin/manage_post_editors_processing.php
+++ b/src/engine/Default/admin/manage_post_editors_processing.php
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Exceptions\PlayerNotFound;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
@@ -8,15 +12,15 @@ $var = $session->getCurrentVar();
 $game_id = $var['selected_game_id'];
 
 // Get the POST variables
-$player_id = Smr\Request::getInt('player_id');
-$action = Smr\Request::get('submit');
+$player_id = Request::getInt('player_id');
+$action = Request::get('submit');
 
 // Pass entire $var so that the selected game remains selected
 $container = Page::create('admin/manage_post_editors.php', $var);
 
 try {
 	$selected_player = SmrPlayer::getPlayerByPlayerID($player_id, $game_id);
-} catch (Smr\Exceptions\PlayerNotFound $e) {
+} catch (PlayerNotFound $e) {
 	$msg = "<span class='red'>ERROR: </span>" . $e->getMessage();
 	$container['processing_msg'] = $msg;
 	$container->go();

--- a/src/engine/Default/admin/newsletter_send.php
+++ b/src/engine/Default/admin/newsletter_send.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
@@ -11,7 +13,7 @@ $template->assign('CurrentEmail', $account->getEmail());
 $processingContainer = Page::create('admin/newsletter_send_processing.php');
 
 // Get the most recent newsletter text for preview
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT newsletter_id, newsletter_html, newsletter_text FROM newsletter ORDER BY newsletter_id DESC LIMIT 1');
 if ($dbResult->hasRecord()) {
 	$dbRecord = $dbResult->record();

--- a/src/engine/Default/admin/notify_delete_processing.php
+++ b/src/engine/Default/admin/notify_delete_processing.php
@@ -1,9 +1,13 @@
 <?php declare(strict_types=1);
-if (!Smr\Request::has('notify_id')) {
+
+use Smr\Database;
+use Smr\Request;
+
+if (!Request::has('notify_id')) {
 	create_error('You must choose the messages you want to delete.');
 }
 
-$db = Smr\Database::getInstance();
-$db->write('DELETE FROM message_notify WHERE notify_id IN (' . $db->escapeArray(Smr\Request::getIntArray('notify_id')) . ')');
+$db = Database::getInstance();
+$db->write('DELETE FROM message_notify WHERE notify_id IN (' . $db->escapeArray(Request::getIntArray('notify_id')) . ')');
 
 Page::create('admin/notify_view.php')->go();

--- a/src/engine/Default/admin/notify_reply.php
+++ b/src/engine/Default/admin/notify_reply.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Messages;
+
 $template = Smr\Template::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
@@ -11,13 +13,13 @@ $container->addVar('offended');
 $container->addVar('offender');
 $template->assign('NotifyReplyFormHref', $container->href());
 
-$offender = Smr\Messages::getMessagePlayer($var['offender'], $var['game_id']);
+$offender = Messages::getMessagePlayer($var['offender'], $var['game_id']);
 if (is_object($offender)) {
 	$offender = $offender->getDisplayName() . ' (Login: ' . $offender->getAccount()->getLogin() . ')';
 }
 $template->assign('Offender', $offender);
 
-$offended = Smr\Messages::getMessagePlayer($var['offended'], $var['game_id']);
+$offended = Messages::getMessagePlayer($var['offended'], $var['game_id']);
 if (is_object($offended)) {
 	$offended = $offended->getDisplayName() . ' (Login: ' . $offended->getAccount()->getLogin() . ')';
 }

--- a/src/engine/Default/admin/notify_reply_processing.php
+++ b/src/engine/Default/admin/notify_reply_processing.php
@@ -1,14 +1,16 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
 
-$offenderReply = Smr\Request::get('offenderReply');
-$offenderBanPoints = Smr\Request::getInt('offenderBanPoints');
-$offendedReply = Smr\Request::get('offendedReply');
-$offendedBanPoints = Smr\Request::getInt('offendedBanPoints');
-if (Smr\Request::get('action') == 'Preview messages') {
+$offenderReply = Request::get('offenderReply');
+$offenderBanPoints = Request::getInt('offenderBanPoints');
+$offendedReply = Request::get('offendedReply');
+$offendedBanPoints = Request::getInt('offendedBanPoints');
+if (Request::get('action') == 'Preview messages') {
 	$container = Page::create('admin/notify_reply.php');
 	$container->addVar('offender');
 	$container->addVar('offended');

--- a/src/engine/Default/admin/notify_view.php
+++ b/src/engine/Default/admin/notify_view.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Messages;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
@@ -9,13 +12,13 @@ $template->assign('PageTopic', 'Viewing Reported Messages');
 $container = Page::create('admin/notify_delete_processing.php');
 $template->assign('DeleteHREF', $container->href());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM message_notify');
 $messages = [];
 foreach ($dbResult->records() as $dbRecord) {
 	$gameID = $dbRecord->getInt('game_id');
-	$sender = Smr\Messages::getMessagePlayer($dbRecord->getInt('from_id'), $gameID);
-	$receiver = Smr\Messages::getMessagePlayer($dbRecord->getInt('to_id'), $gameID);
+	$sender = Messages::getMessagePlayer($dbRecord->getInt('from_id'), $gameID);
+	$receiver = Messages::getMessagePlayer($dbRecord->getInt('to_id'), $gameID);
 
 	$container = Page::create('admin/notify_reply.php');
 	$container['offender'] = $dbRecord->getInt('from_id');

--- a/src/engine/Default/admin/npc_manage.php
+++ b/src/engine/Default/admin/npc_manage.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 
@@ -11,8 +14,8 @@ $container = Page::create('admin/npc_manage.php');
 $template->assign('SelectGameHREF', $container->href());
 
 $games = [];
-$db = Smr\Database::getInstance();
-$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND enabled = ' . $db->escapeBoolean(true) . ' ORDER BY game_id DESC');
+$db = Database::getInstance();
+$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Epoch::time()) . ' AND enabled = ' . $db->escapeBoolean(true) . ' ORDER BY game_id DESC');
 foreach ($dbResult->records() as $dbRecord) {
 	$gameID = $dbRecord->getInt('game_id');
 	if (empty($selectedGameID)) {

--- a/src/engine/Default/admin/npc_manage_processing.php
+++ b/src/engine/Default/admin/npc_manage_processing.php
@@ -1,21 +1,25 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Exceptions\AllianceNotFound;
+use Smr\Request;
+
+$db = Database::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 // Change active status of an NPC
-if (Smr\Request::has('active-submit')) {
+if (Request::has('active-submit')) {
 	// Toggle the activity of this NPC
-	$active = Smr\Request::has('active');
+	$active = Request::has('active');
 	$db->write('UPDATE npc_logins SET active=' . $db->escapeBoolean($active) . ' WHERE login=' . $db->escapeString($var['login']));
 }
 
 // Create a new NPC player in a selected game
-if (Smr\Request::has('create_npc_player')) {
+if (Request::has('create_npc_player')) {
 	$accountID = $var['accountID'];
 	$gameID = $var['selected_game_id'];
-	$playerName = Smr\Request::get('player_name');
-	$raceID = Smr\Request::getInt('race_id');
+	$playerName = Request::get('player_name');
+	$raceID = Request::getInt('race_id');
 	$npcPlayer = SmrPlayer::createPlayer($accountID, $gameID, $playerName, $raceID, false, true);
 
 	$npcPlayer->getShip()->setHardwareToMax();
@@ -28,10 +32,10 @@ if (Smr\Request::has('create_npc_player')) {
 	// Give a random alignment
 	$npcPlayer->setAlignment(rand(-300, 300));
 
-	$allianceName = Smr\Request::get('player_alliance');
+	$allianceName = Request::get('player_alliance');
 	try {
 		$alliance = SmrAlliance::getAllianceByName($allianceName, $gameID);
-	} catch (Smr\Exceptions\AllianceNotFound) {
+	} catch (AllianceNotFound) {
 		$alliance = SmrAlliance::createAlliance($gameID, $allianceName);
 		$alliance->setLeaderID($npcPlayer->getAccountID());
 		$alliance->update();
@@ -45,16 +49,16 @@ if (Smr\Request::has('create_npc_player')) {
 }
 
 // Add a new NPC account
-if (Smr\Request::has('add_npc_account')) {
-	$login = Smr\Request::get('npc_login');
+if (Request::has('add_npc_account')) {
+	$login = Request::get('npc_login');
 	$email = $login . '@smrealms.de';
 	$npcAccount = SmrAccount::createAccount($login, '', $email, 0, 0);
 	$npcAccount->setValidated(true);
 	$npcAccount->update();
 	$db->insert('npc_logins', [
 		'login' => $db->escapeString($login),
-		'player_name' => $db->escapeString(Smr\Request::get('default_player_name')),
-		'alliance_name' => $db->escapeString(Smr\Request::get('default_alliance')),
+		'player_name' => $db->escapeString(Request::get('default_player_name')),
+		'alliance_name' => $db->escapeString(Request::get('default_alliance')),
 	]);
 }
 

--- a/src/engine/Default/admin/permission_manage.php
+++ b/src/engine/Default/admin/permission_manage.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\AdminPermissions;
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 
@@ -12,7 +15,7 @@ $selectAdminHREF = $container->href();
 $template->assign('SelectAdminHREF', $selectAdminHREF);
 
 $adminLinks = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT account_id, login
 			FROM account_has_permission JOIN account USING(account_id)
 			GROUP BY account_id');
@@ -50,5 +53,5 @@ if (empty($admin_id)) {
 	$processingHREF = $container->href();
 	$template->assign('ProcessingHREF', $processingHREF);
 
-	$template->assign('PermissionCategories', Smr\AdminPermissions::getPermissionsByCategory());
+	$template->assign('PermissionCategories', AdminPermissions::getPermissionsByCategory());
 }

--- a/src/engine/Default/admin/permission_manage_processing.php
+++ b/src/engine/Default/admin/permission_manage_processing.php
@@ -1,19 +1,22 @@
 <?php declare(strict_types=1);
 
-if (Smr\Request::get('action') == 'Change') {
+use Smr\Database;
+use Smr\Request;
+
+if (Request::get('action') == 'Change') {
 	$var = Smr\Session::getInstance()->getCurrentVar();
 
 	// Check to see if admin previously was displaying Admin tag
 	$hadAdminTag = SmrAccount::getAccount($var['admin_id'])->hasPermission(PERMISSION_DISPLAY_ADMIN_TAG);
 
 	// delete everything first
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$db->write('DELETE
 				FROM account_has_permission
 				WHERE account_id = ' . $db->escapeNumber($var['admin_id']));
 
 	// Grant permissions
-	$permissions = Smr\Request::getIntArray('permission_ids', []);
+	$permissions = Request::getIntArray('permission_ids', []);
 	foreach ($permissions as $permission_id) {
 		$db->replace('account_has_permission', [
 			'account_id' => $db->escapeNumber($var['admin_id']),

--- a/src/engine/Default/admin/ship_check.php
+++ b/src/engine/Default/admin/ship_check.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 
 $template->assign('PageTopic', 'Ship Integrity Check');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM ship_type_support_hardware, player, ship_has_hardware, hardware_type ' .
 		   'WHERE ship_type_support_hardware.ship_type_id = player.ship_type_id AND ' .
 				 'player.account_id = ship_has_hardware.account_id AND ' .

--- a/src/engine/Default/admin/ship_check_processing.php
+++ b/src/engine/Default/admin/ship_check_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 //get our variables
@@ -9,7 +11,7 @@ $max_amount = $var['max_amount'];
 $account_id = $var['account_id'];
 
 //update it so they arent cheating
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('UPDATE ship_has_hardware ' .
 		   'SET amount = ' . $db->escapeNumber($max_amount) . ' ' .
 		   'WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND ' .

--- a/src/engine/Default/admin/unigen/check_map.php
+++ b/src/engine/Default/admin/unigen/check_map.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+use Smr\Routes\RouteGenerator;
+
 $template = Smr\Template::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
@@ -38,7 +41,7 @@ foreach (array_keys(Globals::getGoods()) as $goodID) {
 	$tradeGoods[$goodID] = true;
 }
 $tradeRaces = [];
-foreach (Smr\Race::getAllIDs() as $raceID) {
+foreach (Race::getAllIDs() as $raceID) {
 	$tradeRaces[$raceID] = true;
 }
 
@@ -52,13 +55,13 @@ foreach ($galaxies as $galaxy) {
 	$galaxy->getSectors(); // Efficiently construct the sector cache
 	$ports = $galaxy->getPorts();
 	$distances = Plotter::calculatePortToPortDistances($ports, $tradeRaces, $maxDistance, $galaxy->getStartSector(), $galaxy->getEndSector());
-	$allGalaxyRoutes[$galaxy->getDisplayName()] = Smr\Routes\RouteGenerator::generateMultiPortRoutes($maxNumberOfPorts, $ports, $tradeGoods, $tradeRaces, $distances, $routesForPort, $numberOfRoutes);
+	$allGalaxyRoutes[$galaxy->getDisplayName()] = RouteGenerator::generateMultiPortRoutes($maxNumberOfPorts, $ports, $tradeGoods, $tradeRaces, $distances, $routesForPort, $numberOfRoutes);
 }
 $template->assign('AllGalaxyRoutes', $allGalaxyRoutes);
 
 $routeTypes = [
-	Smr\Routes\RouteGenerator::EXP_ROUTE => 'Experience',
-	Smr\Routes\RouteGenerator::MONEY_ROUTE => 'Profit',
+	RouteGenerator::EXP_ROUTE => 'Experience',
+	RouteGenerator::MONEY_ROUTE => 'Profit',
 ];
 $template->assign('RouteTypes', $routeTypes);
 

--- a/src/engine/Default/admin/unigen/drag_location.php
+++ b/src/engine/Default/admin/unigen/drag_location.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
 // Move a location from one sector to another
-$targetSectorID = Smr\Request::getInt('TargetSectorID');
-$origSectorID = Smr\Request::getInt('OrigSectorID');
-$locationTypeID = Smr\Request::getInt('LocationTypeID');
+$targetSectorID = Request::getInt('TargetSectorID');
+$origSectorID = Request::getInt('OrigSectorID');
+$locationTypeID = Request::getInt('LocationTypeID');
 $targetSector = SmrSector::getSector($var['game_id'], $targetSectorID);
 
 // Skip if target sector already has the same location

--- a/src/engine/Default/admin/unigen/drag_planet.php
+++ b/src/engine/Default/admin/unigen/drag_planet.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
 // Move a planet from one sector to another (note that this will
 // currently only retain the planet type and inhabitable time).
-$targetSectorID = Smr\Request::getInt('TargetSectorID');
-$origSectorID = Smr\Request::getInt('OrigSectorID');
+$targetSectorID = Request::getInt('TargetSectorID');
+$origSectorID = Request::getInt('OrigSectorID');
 $origPlanet = SmrPlanet::getPlanet($var['game_id'], $origSectorID);
 $targetSector = SmrSector::getSector($var['game_id'], $targetSectorID);
 

--- a/src/engine/Default/admin/unigen/drag_warp.php
+++ b/src/engine/Default/admin/unigen/drag_warp.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
 // Move a warp from one sector to another
-$targetSectorID = Smr\Request::getInt('TargetSectorID');
-$origSectorID = Smr\Request::getInt('OrigSectorID');
+$targetSectorID = Request::getInt('TargetSectorID');
+$origSectorID = Request::getInt('OrigSectorID');
 
 $origSector = SmrSector::getSector($var['game_id'], $origSectorID);
 $warpSector = $origSector->getWarpSector();

--- a/src/engine/Default/admin/unigen/galaxies_edit_processing.php
+++ b/src/engine/Default/admin/unigen/galaxies_edit_processing.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Request;
+
+$db = Database::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 $gameID = $var['game_id'];
@@ -23,12 +26,12 @@ foreach ($galaxies as $i => $galaxy) {
 
 // Modify the galaxy properties
 foreach ($galaxies as $i => $galaxy) {
-	$galaxy->setName(Smr\Request::get('gal' . $i));
-	$galaxy->setGalaxyType(Smr\Request::get('type' . $i));
-	$galaxy->setMaxForceTime(IFloor(Smr\Request::getFloat('forces' . $i) * 3600));
+	$galaxy->setName(Request::get('gal' . $i));
+	$galaxy->setGalaxyType(Request::get('type' . $i));
+	$galaxy->setMaxForceTime(IFloor(Request::getFloat('forces' . $i) * 3600));
 	if (!$game->isEnabled()) {
-		$galaxy->setWidth(Smr\Request::getInt('width' . $i));
-		$galaxy->setHeight(Smr\Request::getInt('height' . $i));
+		$galaxy->setWidth(Request::getInt('width' . $i));
+		$galaxy->setHeight(Request::getInt('height' . $i));
 	}
 }
 

--- a/src/engine/Default/admin/unigen/game_create.php
+++ b/src/engine/Default/admin/unigen/game_create.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
@@ -22,9 +25,9 @@ $defaultGame = [
 	'maxTurns' => DEFAULT_MAX_TURNS,
 	'startTurnHours' => DEFAULT_START_TURN_HOURS,
 	'maxPlayers' => 5000,
-	'joinDate' => date('d/m/Y', Smr\Epoch::time()),
+	'joinDate' => date('d/m/Y', Epoch::time()),
 	'startDate' => '',
-	'endDate' => date('d/m/Y', Smr\Epoch::time() + (2 * 31 * 86400)), // 3 months
+	'endDate' => date('d/m/Y', Epoch::time() + (2 * 31 * 86400)), // 3 months
 	'smrCredits' => 0,
 	'gameType' => 'Default',
 	'allianceMax' => 25,

--- a/src/engine/Default/admin/unigen/game_create_processing.php
+++ b/src/engine/Default/admin/unigen/game_create_processing.php
@@ -1,9 +1,12 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Request;
+
+$db = Database::getInstance();
 
 //first create the game
-$dbResult = $db->read('SELECT 1 FROM game WHERE game_name=' . $db->escapeString(Smr\Request::get('game_name')));
+$dbResult = $db->read('SELECT 1 FROM game WHERE game_name=' . $db->escapeString(Request::get('game_name')));
 if ($dbResult->hasRecord()) {
 	create_error('That game name is already taken.');
 }
@@ -12,37 +15,37 @@ $dbResult = $db->read('SELECT IFNULL(MAX(game_id), 0) AS max_game_id FROM game')
 $newID = $dbResult->record()->getInt('max_game_id') + 1;
 
 // Get the dates ("|" sets hr/min/sec to 0)
-$join = DateTime::createFromFormat('d/m/Y|', Smr\Request::get('game_join'));
+$join = DateTime::createFromFormat('d/m/Y|', Request::get('game_join'));
 if ($join === false) {
 	create_error('Join Date is not valid!');
 }
-$start = empty(Smr\Request::get('game_start')) ? $join :
-	DateTime::createFromFormat('d/m/Y|', Smr\Request::get('game_start'));
+$start = empty(Request::get('game_start')) ? $join :
+	DateTime::createFromFormat('d/m/Y|', Request::get('game_start'));
 if ($start === false) {
 	create_error('Start Date is not valid!');
 }
-$end = DateTime::createFromFormat('d/m/Y|', Smr\Request::get('game_end'));
+$end = DateTime::createFromFormat('d/m/Y|', Request::get('game_end'));
 if ($end === false) {
 	create_error('End Date is not valid!');
 }
 
 $game = SmrGame::createGame($newID);
-$game->setName(Smr\Request::get('game_name'));
-$game->setDescription(Smr\Request::get('desc'));
-$game->setGameTypeID(Smr\Request::getInt('game_type'));
-$game->setMaxTurns(Smr\Request::getInt('max_turns'));
-$game->setStartTurnHours(Smr\Request::getInt('start_turns'));
-$game->setMaxPlayers(Smr\Request::getInt('max_players'));
-$game->setAllianceMaxPlayers(Smr\Request::getInt('alliance_max_players'));
-$game->setAllianceMaxVets(Smr\Request::getInt('alliance_max_vets'));
+$game->setName(Request::get('game_name'));
+$game->setDescription(Request::get('desc'));
+$game->setGameTypeID(Request::getInt('game_type'));
+$game->setMaxTurns(Request::getInt('max_turns'));
+$game->setStartTurnHours(Request::getInt('start_turns'));
+$game->setMaxPlayers(Request::getInt('max_players'));
+$game->setAllianceMaxPlayers(Request::getInt('alliance_max_players'));
+$game->setAllianceMaxVets(Request::getInt('alliance_max_vets'));
 $game->setJoinTime($join->getTimestamp());
 $game->setStartTime($start->getTimestamp());
 $game->setEndTime($end->getTimestamp());
-$game->setGameSpeed(Smr\Request::getFloat('game_speed'));
-$game->setIgnoreStats(Smr\Request::get('ignore_stats') == 'Yes');
-$game->setStartingCredits(Smr\Request::getInt('starting_credits'));
-$game->setCreditsNeeded(Smr\Request::getInt('creds_needed'));
-$game->setStartingRelations(Smr\Request::getInt('relations'));
+$game->setGameSpeed(Request::getFloat('game_speed'));
+$game->setIgnoreStats(Request::get('ignore_stats') == 'Yes');
+$game->setStartingCredits(Request::getInt('starting_credits'));
+$game->setCreditsNeeded(Request::getInt('creds_needed'));
+$game->setStartingRelations(Request::getInt('relations'));
 
 // Start game disabled by default
 $game->setEnabled(false);

--- a/src/engine/Default/admin/unigen/game_edit_processing.php
+++ b/src/engine/Default/admin/unigen/game_edit_processing.php
@@ -1,31 +1,33 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 // Get the dates ("|" sets hr/min/sec to 0)
-$join = DateTime::createFromFormat('d/m/Y|', Smr\Request::get('game_join'));
-$start = empty(Smr\Request::get('game_start')) ? $join :
-	DateTime::createFromFormat('d/m/Y|', Smr\Request::get('game_start'));
-$end = DateTime::createFromFormat('d/m/Y|', Smr\Request::get('game_end'));
+$join = DateTime::createFromFormat('d/m/Y|', Request::get('game_join'));
+$start = empty(Request::get('game_start')) ? $join :
+	DateTime::createFromFormat('d/m/Y|', Request::get('game_start'));
+$end = DateTime::createFromFormat('d/m/Y|', Request::get('game_end'));
 
 $game = SmrGame::getGame($var['game_id']);
-$game->setName(Smr\Request::get('game_name'));
-$game->setDescription(Smr\Request::get('desc'));
-$game->setGameTypeID(Smr\Request::getInt('game_type'));
-$game->setMaxTurns(Smr\Request::getInt('max_turns'));
-$game->setStartTurnHours(Smr\Request::getInt('start_turns'));
-$game->setMaxPlayers(Smr\Request::getInt('max_players'));
-$game->setAllianceMaxPlayers(Smr\Request::getInt('alliance_max_players'));
-$game->setAllianceMaxVets(Smr\Request::getInt('alliance_max_vets'));
+$game->setName(Request::get('game_name'));
+$game->setDescription(Request::get('desc'));
+$game->setGameTypeID(Request::getInt('game_type'));
+$game->setMaxTurns(Request::getInt('max_turns'));
+$game->setStartTurnHours(Request::getInt('start_turns'));
+$game->setMaxPlayers(Request::getInt('max_players'));
+$game->setAllianceMaxPlayers(Request::getInt('alliance_max_players'));
+$game->setAllianceMaxVets(Request::getInt('alliance_max_vets'));
 $game->setJoinTime($join->getTimestamp());
 $game->setStartTime($start->getTimestamp());
 $game->setEndTime($end->getTimestamp());
-$game->setGameSpeed(Smr\Request::getFloat('game_speed'));
-$game->setIgnoreStats(Smr\Request::get('ignore_stats') == 'Yes');
-$game->setStartingCredits(Smr\Request::getInt('starting_credits'));
-$game->setCreditsNeeded(Smr\Request::getInt('creds_needed'));
+$game->setGameSpeed(Request::getFloat('game_speed'));
+$game->setIgnoreStats(Request::get('ignore_stats') == 'Yes');
+$game->setStartingCredits(Request::getInt('starting_credits'));
+$game->setCreditsNeeded(Request::getInt('creds_needed'));
 if (!$game->hasStarted()) {
-	$game->setStartingRelations(Smr\Request::getInt('relations'));
+	$game->setStartingRelations(Request::getInt('relations'));
 }
 $game->save();
 

--- a/src/engine/Default/admin/unigen/universe_create_planets.php
+++ b/src/engine/Default/admin/unigen/universe_create_planets.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\PlanetTypes\PlanetType;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -13,8 +15,8 @@ $template->assign('JumpGalaxyHREF', $container->href());
 
 // Get a list of all available planet types
 $allowedTypes = [];
-foreach (array_keys(Smr\PlanetTypes\PlanetType::PLANET_TYPES) as $PlanetTypeID) {
-	$allowedTypes[$PlanetTypeID] = Smr\PlanetTypes\PlanetType::getTypeInfo($PlanetTypeID)->name();
+foreach (array_keys(PlanetType::PLANET_TYPES) as $PlanetTypeID) {
+	$allowedTypes[$PlanetTypeID] = PlanetType::getTypeInfo($PlanetTypeID)->name();
 }
 $template->assign('AllowedTypes', $allowedTypes);
 

--- a/src/engine/Default/admin/unigen/universe_create_ports.php
+++ b/src/engine/Default/admin/unigen/universe_create_ports.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -16,7 +18,7 @@ $template->assign('Galaxy', $galaxy);
 
 // initialize totals
 $totalPorts = array_fill(1, SmrPort::MAX_LEVEL, 0);
-$totalRaces = array_fill_keys(Smr\Race::getAllIDs(), 0);
+$totalRaces = array_fill_keys(Race::getAllIDs(), 0);
 $racePercents = $totalRaces;
 
 foreach ($galaxy->getSectors() as $galSector) {

--- a/src/engine/Default/admin/unigen/universe_create_warps.php
+++ b/src/engine/Default/admin/unigen/universe_create_warps.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 

--- a/src/engine/Default/admin/vote_create.php
+++ b/src/engine/Default/admin/vote_create.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -9,8 +12,8 @@ $template->assign('PageTopic', 'Create Vote');
 $template->assign('VoteFormHREF', Page::create('admin/vote_create_processing.php')->href());
 
 $voting = [];
-$db = Smr\Database::getInstance();
-$dbResult = $db->read('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(Smr\Epoch::time()));
+$db = Database::getInstance();
+$dbResult = $db->read('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(Epoch::time()));
 foreach ($dbResult->records() as $dbRecord) {
 	$voteID = $dbRecord->getInt('vote_id');
 	$voting[$voteID]['ID'] = $voteID;

--- a/src/engine/Default/admin/vote_create_processing.php
+++ b/src/engine/Default/admin/vote_create_processing.php
@@ -1,30 +1,34 @@
 <?php declare(strict_types=1);
 
-$action = Smr\Request::get('action');
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
+$action = Request::get('action');
 if ($action == 'Preview Vote') {
 	$container = Page::create('admin/vote_create.php');
-	$container['PreviewVote'] = Smr\Request::get('question');
-	$container['Days'] = Smr\Request::getInt('days');
+	$container['PreviewVote'] = Request::get('question');
+	$container['Days'] = Request::getInt('days');
 	$container->go();
 }
 if ($action == 'Preview Option') {
 	$container = Page::create('admin/vote_create.php');
-	$container['PreviewOption'] = Smr\Request::get('option');
-	$container['VoteID'] = Smr\Request::getInt('vote');
+	$container['PreviewOption'] = Request::get('option');
+	$container['VoteID'] = Request::getInt('vote');
 	$container->go();
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 if ($action == 'Create Vote') {
-	$question = Smr\Request::get('question');
-	$end = Smr\Epoch::time() + 86400 * Smr\Request::getInt('days');
+	$question = Request::get('question');
+	$end = Epoch::time() + 86400 * Request::getInt('days');
 	$db->insert('voting', [
 		'question' => $db->escapeString($question),
 		'end' => $db->escapeNumber($end),
 	]);
 } elseif ($action == 'Add Option') {
-	$option = Smr\Request::get('option');
-	$voteID = Smr\Request::getInt('vote');
+	$option = Request::get('option');
+	$voteID = Request::getInt('vote');
 	$db->insert('voting_options', [
 		'vote_id' => $db->escapeNumber($voteID),
 		'text' => $db->escapeString($option),

--- a/src/engine/Default/admin/word_filter.php
+++ b/src/engine/Default/admin/word_filter.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -10,7 +12,7 @@ if (isset($var['msg'])) {
 	$template->assign('Message', $var['msg']);
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM word_filter');
 if ($dbResult->hasRecord()) {
 	$container = Page::create('admin/word_filter_del.php');

--- a/src/engine/Default/admin/word_filter_add.php
+++ b/src/engine/Default/admin/word_filter_add.php
@@ -1,11 +1,14 @@
 <?php declare(strict_types=1);
 
-$word = strtoupper(Smr\Request::get('Word'));
-$word_replacement = strtoupper(Smr\Request::get('WordReplacement'));
+use Smr\Database;
+use Smr\Request;
+
+$word = strtoupper(Request::get('Word'));
+$word_replacement = strtoupper(Request::get('WordReplacement'));
 
 $container = Page::create('admin/word_filter.php');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT 1 FROM word_filter WHERE word_value=' . $db->escapeString($word) . ' LIMIT 1');
 if ($dbResult->hasRecord()) {
 	$container['msg'] = '<span class="red bold">ERROR: </span>This word is already filtered!';

--- a/src/engine/Default/admin/word_filter_del.php
+++ b/src/engine/Default/admin/word_filter_del.php
@@ -1,8 +1,11 @@
 <?php declare(strict_types=1);
 
-if (Smr\Request::has('word_ids')) {
-	$db = Smr\Database::getInstance();
-	$db->write('DELETE FROM word_filter WHERE word_id IN (' . $db->escapeArray(Smr\Request::getIntArray('word_ids')) . ')');
+use Smr\Database;
+use Smr\Request;
+
+if (Request::has('word_ids')) {
+	$db = Database::getInstance();
+	$db->write('DELETE FROM word_filter WHERE word_id IN (' . $db->escapeArray(Request::getIntArray('word_ids')) . ')');
 }
 
 $container = Page::create('admin/word_filter.php');

--- a/src/engine/Default/album_delete_processing.php
+++ b/src/engine/Default/album_delete_processing.php
@@ -1,10 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
-if (Smr\Request::get('action') == 'Yes') {
-	$db = Smr\Database::getInstance();
+if (Request::get('action') == 'Yes') {
+	$db = Database::getInstance();
 	$db->write('DELETE
 				FROM album
 				WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));

--- a/src/engine/Default/album_edit.php
+++ b/src/engine/Default/album_edit.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -7,7 +9,7 @@ $account = $session->getAccount();
 
 $template->assign('PageTopic', 'Edit Photo');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 if ($dbResult->hasRecord()) {
 	$dbRecord = $dbResult->record();

--- a/src/engine/Default/album_edit_processing.php
+++ b/src/engine/Default/album_edit_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 function php_link_check(string $url): string|false {
 	/*	Purpose: Check HTTP Links
 	*	Usage:	$var = phpLinkCheck(absoluteURI)
@@ -62,11 +66,11 @@ function php_link_check(string $url): string|false {
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
-$location = Smr\Request::get('location');
-$email = Smr\Request::get('email');
+$location = Request::get('location');
+$email = Request::get('email');
 
 // get website (and validate it)
-$website = Smr\Request::get('website');
+$website = Request::get('website');
 if ($website != '') {
 	// add http:// if missing
 	if (!preg_match('=://=', $website)) {
@@ -81,11 +85,11 @@ if ($website != '') {
 	}
 }
 
-$other = Smr\Request::get('other');
+$other = Request::get('other');
 
-$day = Smr\Request::getInt('day');
-$month = Smr\Request::getInt('month');
-$year = Smr\Request::getInt('year');
+$day = Request::getInt('day');
+$month = Request::getInt('month');
+$year = Request::getInt('year');
 
 // check if we have an image
 $noPicture = true;
@@ -119,7 +123,7 @@ if ($_FILES['photo']['error'] == UPLOAD_ERR_OK) {
 
 
 // check if we had a album entry so far
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT 1 FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 if ($dbResult->hasRecord()) {
 	if (!$noPicture) {
@@ -135,7 +139,7 @@ if ($dbResult->hasRecord()) {
 					month = ' . $db->escapeNumber($month) . ',
 					year = ' . $db->escapeNumber($year) . ',
 					other = ' . $db->escapeString($other) . ',
-					last_changed = ' . $db->escapeNumber(Smr\Epoch::time()) . ',
+					last_changed = ' . $db->escapeNumber(Epoch::time()) . ',
 					approved = \'TBC\',
 					disabled = \'FALSE\'
 				WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
@@ -158,8 +162,8 @@ if ($dbResult->hasRecord()) {
 		'month' => $db->escapeNumber($month),
 		'year' => $db->escapeNumber($year),
 		'other' => $db->escapeString($other),
-		'created' => $db->escapeNumber(Smr\Epoch::time()),
-		'last_changed' => $db->escapeNumber(Smr\Epoch::time()),
+		'created' => $db->escapeNumber(Epoch::time()),
+		'last_changed' => $db->escapeNumber(Epoch::time()),
 		'approved' => $db->escapeString('TBC'),
 	]);
 }
@@ -174,7 +178,7 @@ if (!empty($comment)) {
 	$db->insert('album_has_comments', [
 		'album_id' => $db->escapeNumber($account->getAccountID()),
 		'comment_id' => $db->escapeNumber($comment_id),
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 		'post_id' => 0,
 		'msg' => $db->escapeString($comment),
 	]);

--- a/src/engine/Default/alliance_create_processing.php
+++ b/src/engine/Default/alliance_create_processing.php
@@ -1,13 +1,16 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-if ($player->getAllianceJoinable() > Smr\Epoch::time()) {
-	create_error('You cannot create an alliance for another ' . format_time($player->getAllianceJoinable() - Smr\Epoch::time()) . '.');
+if ($player->getAllianceJoinable() > Epoch::time()) {
+	create_error('You cannot create an alliance for another ' . format_time($player->getAllianceJoinable() - Epoch::time()) . '.');
 }
 
-$name = Smr\Request::get('name');
+$name = Request::get('name');
 if (empty($name)) {
 	throw new Exception('No alliance name entered');
 }
@@ -17,10 +20,10 @@ if (!ctype_print($name)) {
 	create_error('The alliance name contains invalid characters!');
 }
 
-$password = Smr\Request::get('password', '');
-$description = Smr\Request::get('description');
-$recruitType = Smr\Request::get('recruit_type');
-$perms = Smr\Request::get('Perms');
+$password = Request::get('password', '');
+$description = Request::get('description');
+$recruitType = Request::get('recruit_type');
+$perms = Request::get('Perms');
 
 $name2 = strtolower($name);
 if ($name2 == 'none' || $name2 == '(none)' || $name2 == '( none )' || $name2 == 'no alliance') {

--- a/src/engine/Default/alliance_exempt_authorize.php
+++ b/src/engine/Default/alliance_exempt_authorize.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -9,7 +11,7 @@ $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 
 //get rid of already approved entries
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('UPDATE alliance_bank_transactions SET request_exempt = 0 WHERE exempt = 1');
 
 

--- a/src/engine/Default/alliance_forces.php
+++ b/src/engine/Default/alliance_forces.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -11,7 +14,7 @@ $alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('
 SELECT
 	IFNULL(sum(mines), 0) as tot_mines,
@@ -20,7 +23,7 @@ SELECT
 FROM sector_has_forces JOIN player ON player.game_id=sector_has_forces.game_id AND sector_has_forces.owner_id=player.account_id
 WHERE player.game_id=' . $db->escapeNumber($alliance->getGameID()) . '
 	AND player.alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
-	AND expire_time >= ' . $db->escapeNumber(Smr\Epoch::time()));
+	AND expire_time >= ' . $db->escapeNumber(Epoch::time()));
 $dbRecord = $dbResult->record();
 
 // Get total number of forces
@@ -46,7 +49,7 @@ FROM player
 JOIN sector_has_forces ON player.game_id = sector_has_forces.game_id AND player.account_id = sector_has_forces.owner_id
 WHERE player.game_id=' . $db->escapeNumber($alliance->getGameID()) . '
 AND player.alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
-AND expire_time >= ' . $db->escapeNumber(Smr\Epoch::time()) . '
+AND expire_time >= ' . $db->escapeNumber(Epoch::time()) . '
 ORDER BY sector_id ASC');
 
 $forces = [];

--- a/src/engine/Default/alliance_invite_accept_processing.php
+++ b/src/engine/Default/alliance_invite_accept_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Exceptions\AllianceInvitationNotFound;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -7,7 +9,7 @@ $player = $session->getPlayer();
 // Check that the invitation is registered in the database
 try {
 	$invite = SmrInvitation::get($var['alliance_id'], $player->getGameID(), $player->getAccountID());
-} catch (Smr\Exceptions\AllianceInvitationNotFound) {
+} catch (AllianceInvitationNotFound) {
 	create_error('Your invitation to join this alliance has expired or been canceled!');
 }
 

--- a/src/engine/Default/alliance_invite_player.php
+++ b/src/engine/Default/alliance_invite_player.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -19,7 +22,7 @@ foreach (SmrInvitation::getAll($player->getAllianceID(), $player->getGameID()) a
 	$pendingInvites[$invited->getAccountID()] = [
 		'invited' => $invited->getDisplayName(true),
 		'invited_by' => $invite->getSender()->getDisplayName(),
-		'expires' => format_time($invite->getExpires() - Smr\Epoch::time(), true),
+		'expires' => format_time($invite->getExpires() - Epoch::time(), true),
 		'cancelHREF' => $container->href(),
 	];
 }
@@ -29,7 +32,7 @@ $template->assign('PendingInvites', $pendingInvites);
 // List those who joined the game most recently first.
 $invitePlayers = [];
 if ($alliance->getNumMembers() < $game->getAllianceMaxPlayers()) {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT * FROM player
 	            WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 	              AND alliance_id != ' . $db->escapeNumber($alliance->getAllianceID()) . '

--- a/src/engine/Default/alliance_invite_player_processing.php
+++ b/src/engine/Default/alliance_invite_player_processing.php
@@ -1,17 +1,21 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 $player = $session->getPlayer();
 
-$receiverID = Smr\Request::getInt('account_id');
-$addMessage = Smr\Request::get('message');
-$expireDays = Smr\Request::getInt('expire_days');
+$receiverID = Request::getInt('account_id');
+$addMessage = Request::get('message');
+$expireDays = Request::getInt('expire_days');
 
-$expires = Smr\Epoch::time() + 86400 * $expireDays;
+$expires = Epoch::time() + 86400 * $expireDays;
 
 // If sender is mail banned or blacklisted by receiver, omit the custom message
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT 1 FROM message_blacklist
             WHERE account_id=' . $db->escapeNumber($receiverID) . '
               AND blacklisted_id=' . $db->escapeNumber($player->getAccountID()));

--- a/src/engine/Default/alliance_join_processing.php
+++ b/src/engine/Default/alliance_join_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -11,7 +13,7 @@ if ($joinRestriction !== false) {
 	create_error($joinRestriction);
 }
 
-if (Smr\Request::get('password') != $alliance->getPassword()) {
+if (Request::get('password') != $alliance->getPassword()) {
 	create_error('Incorrect Password!');
 }
 

--- a/src/engine/Default/alliance_leadership_processing.php
+++ b/src/engine/Default/alliance_leadership_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
-$leader_id = Smr\Request::getInt('leader_id');
+
+use Smr\Database;
+use Smr\Request;
+
+$leader_id = Request::getInt('leader_id');
 
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -8,7 +12,7 @@ $alliance = $player->getAlliance();
 $alliance->setLeaderID($leader_id);
 $alliance->update();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ' WHERE ' . $player->getSQL() . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
 $db->write('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ' WHERE account_id = ' . $db->escapeNumber($leader_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
 

--- a/src/engine/Default/alliance_leave_processing.php
+++ b/src/engine/Default/alliance_leave_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
@@ -16,7 +18,7 @@ if ($action == 'YES') {
 	// Don't delete the Newbie Help Alliance!
 	if ($alliance->getNumMembers() == 1 && !$alliance->isNHA()) {
 		// Retain the alliance, but delete some auxilliary info
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$db->write('DELETE FROM alliance_bank_transactions
 		            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 		            AND game_id = ' . $db->escapeNumber($player->getGameID()));

--- a/src/engine/Default/alliance_list.php
+++ b/src/engine/Default/alliance_list.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -12,7 +14,7 @@ if (!$player->hasAlliance()) {
 }
 
 // get list of alliances
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT
 count(account_id) as alliance_member_count,
 sum(experience) as alliance_xp,

--- a/src/engine/Default/alliance_message.php
+++ b/src/engine/Default/alliance_message.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Exceptions\PlayerNotFound;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -80,7 +83,7 @@ if ($dbResult->hasRecord()) {
 			try {
 				$author = SmrPlayer::getPlayer($sender_id, $player->getGameID());
 				$playerName = $author->getLinkedDisplayName(false);
-			} catch (Smr\Exceptions\PlayerNotFound) {
+			} catch (PlayerNotFound) {
 				$playerName = 'Unknown'; // default
 			}
 		}

--- a/src/engine/Default/alliance_message_add_processing.php
+++ b/src/engine/Default/alliance_message_add_processing.php
@@ -1,15 +1,19 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$body = htmlentities(Smr\Request::get('body'), ENT_COMPAT, 'utf-8');
-$topic = Smr\Request::get('topic', ''); // only present for Create Thread
-$allEyesOnly = Smr\Request::has('allEyesOnly'); // only present for Create Thread
+$body = htmlentities(Request::get('body'), ENT_COMPAT, 'utf-8');
+$topic = Request::get('topic', ''); // only present for Create Thread
+$allEyesOnly = Request::has('allEyesOnly'); // only present for Create Thread
 
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 if ($action == 'Preview Thread' || $action == 'Preview Reply') {
 	if (!isset($var['thread_index'])) {
 		$container = Page::create('alliance_message.php', $var);
@@ -87,14 +91,14 @@ $db->insert('alliance_thread', [
 	'reply_id' => $db->escapeNumber($reply_id),
 	'text' => $db->escapeString($body),
 	'sender_id' => $db->escapeNumber($player->getAccountID()),
-	'time' => $db->escapeNumber(Smr\Epoch::time()),
+	'time' => $db->escapeNumber(Epoch::time()),
 ]);
 $db->replace('player_read_thread', [
 	'account_id' => $db->escapeNumber($player->getAccountID()),
 	'game_id' => $db->escapeNumber($player->getGameID()),
 	'alliance_id' => $db->escapeNumber($alliance_id),
 	'thread_id' => $db->escapeNumber($thread_id),
-	'time' => $db->escapeNumber(Smr\Epoch::time() + 2),
+	'time' => $db->escapeNumber(Epoch::time() + 2),
 ]);
 
 if (isset($var['thread_index'])) {

--- a/src/engine/Default/alliance_message_delete_processing.php
+++ b/src/engine/Default/alliance_message_delete_processing.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();

--- a/src/engine/Default/alliance_message_view.php
+++ b/src/engine/Default/alliance_message_view.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -16,13 +19,13 @@ $thread_id = $var['thread_ids'][$thread_index];
 $template->assign('PageTopic', $var['thread_topics'][$thread_index]);
 Menu::alliance($alliance->getAllianceID());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->replace('player_read_thread', [
 	'account_id' => $db->escapeNumber($player->getAccountID()),
 	'game_id' => $db->escapeNumber($player->getGameID()),
 	'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
 	'thread_id' => $db->escapeNumber($thread_id),
-	'time' => $db->escapeNumber(Smr\Epoch::time() + 2),
+	'time' => $db->escapeNumber(Epoch::time() + 2),
 ]);
 
 $mbWrite = true;

--- a/src/engine/Default/alliance_mod.php
+++ b/src/engine/Default/alliance_mod.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -17,8 +20,8 @@ Menu::alliance($alliance->getAllianceID());
 
 // Check to see if an alliance op is scheduled
 // Display it for 1 hour past start time (late arrivals, etc.)
-$db = Smr\Database::getInstance();
-$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND time > ' . $db->escapeNumber(Smr\Epoch::time() - 3600));
+$db = Database::getInstance();
+$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND time > ' . $db->escapeNumber(Epoch::time() - 3600));
 if ($dbResult->hasRecord()) {
 	$template->assign('OpTime', $dbResult->record()->getInt('time'));
 

--- a/src/engine/Default/alliance_op_response_processing.php
+++ b/src/engine/Default/alliance_op_response_processing.php
@@ -1,11 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$response = strtoupper(Smr\Request::get('op_response'));
+$response = strtoupper(Request::get('op_response'));
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->replace('alliance_has_op_response', [
 	'alliance_id' => $db->escapeNumber($player->getAllianceID()),
 	'game_id' => $db->escapeNumber($player->getGameID()),

--- a/src/engine/Default/alliance_option.php
+++ b/src/engine/Default/alliance_option.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -28,7 +30,7 @@ $links[] = [
 
 $role_id = $player->getAllianceRole($alliance->getAllianceID());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
 $dbRecord = $dbResult->record();
 

--- a/src/engine/Default/alliance_remove_member.php
+++ b/src/engine/Default/alliance_remove_member.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
@@ -20,7 +22,7 @@ foreach ($alliance->getMembers() as $alliancePlayer) {
 	}
 	// get the amount of time since last_active
 	$lastActive = $alliancePlayer->getLastCPLAction();
-	$diff = 864000 + max(-864000, $lastActive - Smr\Epoch::time());
+	$diff = 864000 + max(-864000, $lastActive - Epoch::time());
 	$lastActiveDate = get_colored_text_range($diff, 864000, date($account->getDateTimeFormat(), $lastActive));
 
 	$members[] = [

--- a/src/engine/Default/alliance_remove_member_processing.php
+++ b/src/engine/Default/alliance_remove_member_processing.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$accountIDs = Smr\Request::getIntArray('account_id', []);
+$accountIDs = Request::getIntArray('account_id', []);
 
 if (empty($accountIDs)) {
 	create_error('You have to choose someone to remove them!');

--- a/src/engine/Default/alliance_roles.php
+++ b/src/engine/Default/alliance_roles.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -11,7 +13,7 @@ $alliance = SmrAlliance::getAlliance($allianceID, $player->getGameID());
 $template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
 Menu::alliance($alliance->getAllianceID());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT *
 FROM alliance_has_roles
 WHERE game_id=' . $db->escapeNumber($alliance->getGameID()) . '

--- a/src/engine/Default/alliance_roles_processing.php
+++ b/src/engine/Default/alliance_roles_processing.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -8,23 +11,23 @@ $player = $session->getPlayer();
 $alliance_id = $var['alliance_id'] ?? $player->getAllianceID();
 
 // Checkbox inputs only post if they are checked
-$unlimited = Smr\Request::has('unlimited');
-$positiveBalance = Smr\Request::has('positive');
-$changePass = Smr\Request::has('changePW');
-$removeMember = Smr\Request::has('removeMember');
-$changeMOD = Smr\Request::has('changeMoD');
-$changeRoles = Smr\Request::has('changeRoles') || (isset($var['role_id']) && $var['role_id'] == ALLIANCE_ROLE_LEADER); //Leader can always change roles.
-$planetAccess = Smr\Request::has('planets');
-$mbMessages = Smr\Request::has('mbMessages');
-$exemptWith = Smr\Request::has('exemptWithdrawals');
-$sendAllMsg = Smr\Request::has('sendAllMsg');
-$viewBonds = Smr\Request::has('viewBonds');
-$opLeader = Smr\Request::has('opLeader');
+$unlimited = Request::has('unlimited');
+$positiveBalance = Request::has('positive');
+$changePass = Request::has('changePW');
+$removeMember = Request::has('removeMember');
+$changeMOD = Request::has('changeMoD');
+$changeRoles = Request::has('changeRoles') || (isset($var['role_id']) && $var['role_id'] == ALLIANCE_ROLE_LEADER); //Leader can always change roles.
+$planetAccess = Request::has('planets');
+$mbMessages = Request::has('mbMessages');
+$exemptWith = Request::has('exemptWithdrawals');
+$sendAllMsg = Request::has('sendAllMsg');
+$viewBonds = Request::has('viewBonds');
+$opLeader = Request::has('opLeader');
 
 if ($unlimited) {
 	$withPerDay = ALLIANCE_BANK_UNLIMITED;
 } else {
-	$withPerDay = Smr\Request::getInt('maxWith');
+	$withPerDay = Request::getInt('maxWith');
 }
 if ($withPerDay < 0 && $withPerDay != ALLIANCE_BANK_UNLIMITED) {
 	create_error('You must enter a number for max withdrawals per 24 hours.');
@@ -36,7 +39,7 @@ if ($withPerDay == ALLIANCE_BANK_UNLIMITED && $positiveBalance) {
 // with empty role the user wants to create a new entry
 if (!isset($var['role_id'])) {
 	// role empty too? that doesn't make sence
-	if (empty(Smr\Request::get('role'))) {
+	if (empty(Request::get('role'))) {
 		throw new Exception('Empty role name is not allowed');
 	}
 
@@ -53,7 +56,7 @@ if (!isset($var['role_id'])) {
 		'alliance_id' => $db->escapeNumber($alliance_id),
 		'game_id' => $db->escapeNumber($player->getGameID()),
 		'role_id' => $db->escapeNumber($role_id),
-		'role' => $db->escapeString(Smr\Request::get('role')),
+		'role' => $db->escapeString(Request::get('role')),
 		'with_per_day' => $db->escapeNumber($withPerDay),
 		'positive_balance' => $db->escapeBoolean($positiveBalance),
 		'remove_member' => $db->escapeBoolean($removeMember),
@@ -69,7 +72,7 @@ if (!isset($var['role_id'])) {
 	]);
 	$db->unlock();
 } else {
-	if (empty(Smr\Request::get('role'))) {
+	if (empty(Request::get('role'))) {
 		// if no role is given we delete that entry
 		if ($var['role_id'] == ALLIANCE_ROLE_LEADER) {
 			create_error('You cannot delete the leader role.');
@@ -83,7 +86,7 @@ if (!isset($var['role_id'])) {
 	} else {
 		// otherwise we update it
 		$db->write('UPDATE alliance_has_roles
-					SET role = ' . $db->escapeString(Smr\Request::get('role')) . ',
+					SET role = ' . $db->escapeString(Request::get('role')) . ',
 					with_per_day = ' . $db->escapeNumber($withPerDay) . ',
 					positive_balance = ' . $db->escapeBoolean($positiveBalance) . ',
 					remove_member = ' . $db->escapeBoolean($removeMember) . ',

--- a/src/engine/Default/alliance_roles_save_processing.php
+++ b/src/engine/Default/alliance_roles_save_processing.php
@@ -1,11 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-foreach (Smr\Request::getIntArray('role', []) as $accountID => $roleID) {
-	$db = Smr\Database::getInstance();
+foreach (Request::getIntArray('role', []) as $accountID => $roleID) {
+	$db = Database::getInstance();
 	$db->replace('player_has_alliance_role', [
 		'account_id' => $db->escapeNumber($accountID),
 		'game_id' => $db->escapeNumber($player->getGameID()),

--- a/src/engine/Default/alliance_roster.php
+++ b/src/engine/Default/alliance_roster.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();

--- a/src/engine/Default/alliance_set_flagship_processing.php
+++ b/src/engine/Default/alliance_set_flagship_processing.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 $alliance = $player->getAlliance();
 
-$flagshipID = Smr\Request::getInt('flagship_id');
+$flagshipID = Request::getInt('flagship_id');
 
 $alliance->setFlagshipID($flagshipID);
 $alliance->update();

--- a/src/engine/Default/alliance_set_op.php
+++ b/src/engine/Default/alliance_set_op.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -18,14 +21,14 @@ if (!empty($var['message'])) {
 }
 
 // get the op from db
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND  game_id=' . $db->escapeNumber($player->getGameID()));
 
 if ($dbResult->hasRecord()) {
 	// An op is already scheduled, so get the time
 	$time = $dbResult->record()->getInt('time');
 	$template->assign('OpDate', date($account->getDateTimeFormat(), $time));
-	$template->assign('OpCountdown', format_time($time - Smr\Epoch::time()));
+	$template->assign('OpCountdown', format_time($time - Epoch::time()));
 
 	// Add a cancel button
 	$container['cancel'] = true;

--- a/src/engine/Default/alliance_set_op_processing.php
+++ b/src/engine/Default/alliance_set_op_processing.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
@@ -23,7 +26,7 @@ if (!empty($var['cancel'])) {
 	// so they may get an errant alliance message icon if logged in.
 } else {
 	// schedule an op
-	$date = Smr\Request::get('date');
+	$date = Request::get('date');
 	if (empty($date)) {
 		error_on_page('You must specify a date for the operation!');
 	}

--- a/src/engine/Default/alliance_share_maps_processing.php
+++ b/src/engine/Default/alliance_share_maps_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
@@ -17,7 +19,7 @@ if (count($alliance_ids) == 0) {
 $unvisitedSectors = $player->getUnvisitedSectors();
 
 // delete all visited sectors from the table of all our alliance mates
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $query = 'DELETE
 			FROM player_visited_sector
 			WHERE account_id IN (' . $db->escapeArray($alliance_ids) . ')

--- a/src/engine/Default/alliance_stat.php
+++ b/src/engine/Default/alliance_stat.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
@@ -17,7 +19,7 @@ $container['alliance_id'] = $alliance_id;
 
 $role_id = $player->getAllianceRole($alliance->getAllianceID());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
 if ($dbResult->hasRecord()) {
 	$dbRecord = $dbResult->record();

--- a/src/engine/Default/alliance_stat_processing.php
+++ b/src/engine/Default/alliance_stat_processing.php
@@ -1,27 +1,30 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
 $alliance_id = $var['alliance_id'] ?? $player->getAllianceID();
-if (Smr\Request::has('description')) {
-	$description = Smr\Request::get('description');
+if (Request::has('description')) {
+	$description = Request::get('description');
 }
-if (Smr\Request::has('discord_server')) {
-	$discordServer = Smr\Request::get('discord_server');
+if (Request::has('discord_server')) {
+	$discordServer = Request::get('discord_server');
 }
-if (Smr\Request::has('discord_channel')) {
-	$discordChannel = Smr\Request::get('discord_channel');
+if (Request::has('discord_channel')) {
+	$discordChannel = Request::get('discord_channel');
 }
-if (Smr\Request::has('irc')) {
-	$irc = Smr\Request::get('irc');
+if (Request::has('irc')) {
+	$irc = Request::get('irc');
 }
-if (Smr\Request::has('mod')) {
-	$mod = Smr\Request::get('mod');
+if (Request::has('mod')) {
+	$mod = Request::get('mod');
 }
-if (Smr\Request::has('url')) {
-	$url = Smr\Request::get('url');
+if (Request::has('url')) {
+	$url = Request::get('url');
 }
 
 // Prevent XSS attacks
@@ -30,9 +33,9 @@ if (isset($url) && preg_match('/"/', $url)) {
 }
 
 $alliance = SmrAlliance::getAlliance($alliance_id, $player->getGameID());
-if (Smr\Request::has('recruit_type')) {
-	$recruitType = Smr\Request::get('recruit_type');
-	$password = Smr\Request::get('password', '');
+if (Request::has('recruit_type')) {
+	$recruitType = Request::get('recruit_type');
+	$password = Request::get('password', '');
 	$alliance->setRecruitType($recruitType, $password);
 }
 if (isset($description)) {
@@ -46,7 +49,7 @@ if (isset($discordChannel)) {
 		$alliance->setDiscordChannel(null);
 	} else {
 		// no duplicates in a given game
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT 1 FROM alliance WHERE discord_channel =' . $db->escapeString($discordChannel) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($alliance->getAllianceID()) . ' LIMIT 1');
 		if ($dbResult->hasRecord()) {
 			create_error('Another alliance is already using that Discord Channel ID!');

--- a/src/engine/Default/alliance_treaties.php
+++ b/src/engine/Default/alliance_treaties.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -10,7 +12,7 @@ $template->assign('PageTopic', 'Alliance Treaties');
 Menu::alliance($alliance->getAllianceID());
 
 $alliances = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($player->getAllianceID()) . ' ORDER BY alliance_name');
 foreach ($dbResult->records() as $dbRecord) {
 	$allianceID = $dbRecord->getInt('alliance_id');

--- a/src/engine/Default/alliance_treaties_confirm.php
+++ b/src/engine/Default/alliance_treaties_confirm.php
@@ -1,13 +1,16 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 $alliance_id_1 = $player->getAllianceID();
-$alliance_id_2 = Smr\Request::getInt('proposedAlliance');
+$alliance_id_2 = Request::getInt('proposedAlliance');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT 1 FROM alliance_treaties WHERE (alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_1 = ' . $alliance_id_2 . ') AND (alliance_id_2 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()));
 if ($dbResult->hasRecord()) {
 	$container = Page::create('alliance_treaties.php');
@@ -25,7 +28,7 @@ Menu::alliance($alliance1->getAllianceID());
 // Get the terms selected for this offer
 $terms = [];
 foreach (array_keys(SmrTreaty::TYPES) as $type) {
-	$terms[$type] = Smr\Request::has($type);
+	$terms[$type] = Request::has($type);
 }
 // A few terms get added automatically if a more restrictive term has
 // been selected.

--- a/src/engine/Default/alliance_treaties_confirm_processing.php
+++ b/src/engine/Default/alliance_treaties_confirm_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -10,7 +12,7 @@ $alliance2 = SmrAlliance::getAlliance($var['proposedAlliance'], $player->getGame
 $alliance_id_1 = $alliance1->getAllianceID();
 $alliance_id_2 = $alliance2->getAllianceID();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->insert('alliance_treaties', [
 	'alliance_id_1' => $db->escapeNumber($alliance_id_1),
 	'alliance_id_2' => $db->escapeNumber($alliance_id_2),

--- a/src/engine/Default/alliance_treaties_processing.php
+++ b/src/engine/Default/alliance_treaties_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -11,7 +13,7 @@ if (!$player->hasAlliance()) {
 $alliance_id_1 = $var['alliance_id_1'];
 $alliance_id_2 = $player->getAllianceID();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 if ($var['accept']) {
 	$db->write('UPDATE alliance_treaties SET official = \'TRUE\' WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 

--- a/src/engine/Default/announcements.php
+++ b/src/engine/Default/announcements.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 

--- a/src/engine/Default/bank_alliance.php
+++ b/src/engine/Default/bank_alliance.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -24,7 +27,7 @@ $template->assign('PageTopic', 'Bank');
 
 Menu::bank();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM alliance_treaties WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 			AND (alliance_id_1 = ' . $db->escapeNumber($player->getAllianceID()) . ' OR alliance_id_2 = ' . $db->escapeNumber($player->getAllianceID()) . ')
 			AND aa_access = 1 AND official = \'TRUE\'');
@@ -61,7 +64,7 @@ if ($dbRecord->getBoolean('positive_balance')) {
 	$template->assign('UnlimitedWithdrawal', true);
 } else {
 	$dbResult = $db->read('SELECT IFNULL(sum(amount), 0) as total FROM alliance_bank_transactions WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
-				AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND transaction = \'Payment\' AND exempt = 0 AND time > ' . $db->escapeNumber(Smr\Epoch::time() - 86400));
+				AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND transaction = \'Payment\' AND exempt = 0 AND time > ' . $db->escapeNumber(Epoch::time() - 86400));
 	$totalWithdrawn = $dbResult->record()->getInt('total');
 	$template->assign('WithdrawalPerDay', $withdrawalPerDay);
 	$template->assign('RemainingWithdrawal', $withdrawalPerDay - $totalWithdrawn);

--- a/src/engine/Default/bank_alliance_exempt_processing.php
+++ b/src/engine/Default/bank_alliance_exempt_processing.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -11,8 +14,8 @@ if (isset($var['minVal'])) {
 				AND transaction_id BETWEEN ' . $db->escapeNumber($var['minVal']) . ' AND ' . $db->escapeNumber($var['maxVal']));
 }
 
-if (Smr\Request::has('exempt')) {
-	$trans_ids = array_keys(Smr\Request::getArray('exempt'));
+if (Request::has('exempt')) {
+	$trans_ids = array_keys(Request::getArray('exempt'));
 	$db->write('UPDATE alliance_bank_transactions SET exempt = 1, request_exempt = 0 WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 				AND transaction_id IN (' . $db->escapeArray($trans_ids) . ')');
 }

--- a/src/engine/Default/bank_anon.php
+++ b/src/engine/Default/bank_anon.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
@@ -18,7 +20,7 @@ $template->assign('AccessHREF', $container->href());
 
 $template->assign('Message', $var['message'] ?? '');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM anon_bank
 			WHERE owner_id=' . $db->escapeNumber($player->getAccountID()) . '
 			AND game_id=' . $db->escapeNumber($player->getGameID()));

--- a/src/engine/Default/bank_anon_create_processing.php
+++ b/src/engine/Default/bank_anon_create_processing.php
@@ -1,15 +1,18 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$password = Smr\Request::get('password');
+$password = Request::get('password');
 
 if (empty($password)) {
 	create_error('You cannot use a blank password!');
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT IFNULL(MAX(anon_id), 0) as max_id FROM anon_bank WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
 $nextID = $dbResult->record()->getInt('max_id') + 1;
 

--- a/src/engine/Default/bank_anon_detail.php
+++ b/src/engine/Default/bank_anon_detail.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -10,7 +12,7 @@ $account_num = $session->getRequestVarInt('account_num');
 $session->getRequestVarInt('maxValue', 0);
 $session->getRequestVarInt('minValue', 0);
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT *
 			FROM anon_bank
 			WHERE anon_id=' . $db->escapeNumber($account_num) . '

--- a/src/engine/Default/bank_anon_detail_processing.php
+++ b/src/engine/Default/bank_anon_detail_processing.php
@@ -1,15 +1,19 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 if (!in_array($action, ['Deposit', 'Payment'])) {
 	throw new Exception('Invalid action submitted: ' . $action);
 }
 
-$amount = Smr\Request::getInt('amount');
+$amount = Request::getInt('amount');
 $account_num = $var['account_num'];
 // no negative amounts are allowed
 if ($amount <= 0) {
@@ -17,7 +21,7 @@ if ($amount <= 0) {
 }
 
 // Get the next transaction ID for this anon bank
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT IFNULL(MAX(transaction_id), 0) AS max_id FROM anon_bank_transactions WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND anon_id = ' . $db->escapeNumber($account_num));
 $trans_id = $dbResult->record()->getInt('max_id') + 1;
 
@@ -50,7 +54,7 @@ $db->insert('anon_bank_transactions', [
 	'transaction_id' => $db->escapeNumber($trans_id),
 	'transaction' => $db->escapeString($action),
 	'amount' => $db->escapeNumber($amount),
-	'time' => $db->escapeNumber(Smr\Epoch::time()),
+	'time' => $db->escapeNumber(Epoch::time()),
 ]);
 
 // Log the player action

--- a/src/engine/Default/bank_personal_processing.php
+++ b/src/engine/Default/bank_personal_processing.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$amount = Smr\Request::getInt('amount');
-$action = Smr\Request::get('action');
+$amount = Request::getInt('amount');
+$action = Request::get('action');
 
 // no negative amounts are allowed
 if ($amount <= 0) {

--- a/src/engine/Default/bank_report.php
+++ b/src/engine/Default/bank_report.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -10,7 +12,7 @@ const WITHDRAW = 0;
 const DEPOSIT = 1;
 
 //get all transactions
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM alliance_bank_transactions WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 if (!$dbResult->hasRecord()) {
 	create_error('Your alliance has no recorded transactions.');

--- a/src/engine/Default/bank_report_processing.php
+++ b/src/engine/Default/bank_report_processing.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -9,13 +12,13 @@ $alliance_id = $var['alliance_id'];
 $text = $var['text'];
 
 // Check if the "Bank Statement" thread exists yet
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT thread_id FROM alliance_thread_topic WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND topic = \'Bank Statement\' LIMIT 1');
 
 if ($dbResult->hasRecord()) {
 	// Update the existing "Bank Statement" thread
 	$thread_id = $dbResult->record()->getInt('thread_id');
-	$db->write('UPDATE alliance_thread SET time = ' . $db->escapeNumber(Smr\Epoch::time()) . ', text = ' . $db->escapeString($text) . ' WHERE thread_id = ' . $db->escapeNumber($thread_id) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND reply_id = 1');
+	$db->write('UPDATE alliance_thread SET time = ' . $db->escapeNumber(Epoch::time()) . ', text = ' . $db->escapeString($text) . ' WHERE thread_id = ' . $db->escapeNumber($thread_id) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND reply_id = 1');
 	$db->write('DELETE FROM player_read_thread WHERE thread_id = ' . $db->escapeNumber($thread_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($alliance_id));
 } else {
 	// There is no "Bank Statement" thread yet
@@ -34,7 +37,7 @@ if ($dbResult->hasRecord()) {
 		'reply_id' => 1,
 		'text' => $db->escapeString($text),
 		'sender_id' => $db->escapeNumber(ACCOUNT_ID_BANK_REPORTER),
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 	]);
 }
 

--- a/src/engine/Default/bar_buy_drink_processing.php
+++ b/src/engine/Default/bar_buy_drink_processing.php
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\BarDrink;
+use Smr\Database;
+use Smr\Epoch;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -28,9 +32,9 @@ if (isset($var['action']) && $var['action'] != 'drink') {
 	// choose which drink to serve
 	if (rand(1, 20) == 1) {
 		//only have a chance at special drinks if they are very lucky
-		$drinkList = Smr\BarDrink::getAll();
+		$drinkList = BarDrink::getAll();
 	} else {
-		$drinkList = Smr\BarDrink::getCommon();
+		$drinkList = BarDrink::getCommon();
 	}
 	$drinkName = array_rand_value($drinkList);
 
@@ -39,17 +43,17 @@ if (isset($var['action']) && $var['action'] != 'drink') {
 		'account_id' => $db->escapeNumber($player->getAccountID()),
 		'game_id' => $db->escapeNumber($player->getGameID()),
 		'drink_id' => $db->escapeNumber($curr_drink_id),
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 	]);
 
-	if (!Smr\BarDrink::isSpecial($drinkName)) {
+	if (!BarDrink::isSpecial($drinkName)) {
 		$message .= ('You have bought a ' . $drinkName . ' for $10');
 		$player->increaseHOF(1, ['Bar', 'Drinks', 'Alcoholic'], HOF_PUBLIC);
 	} else {
 		$message .= 'The bartender says, "I\'ve got something special for ya."<br />'
 			. 'They turn around for a minute and whip up a ' . $drinkName . '.<br />'
 			. 'You take a long, deep draught and feel like you have been drinking for hours.<br />'
-			. Smr\BarDrink::getSpecialMessage($drinkName) . '<br />';
+			. BarDrink::getSpecialMessage($drinkName) . '<br />';
 		$player->increaseHOF(1, ['Bar', 'Drinks', 'Special'], HOF_PUBLIC);
 	}
 

--- a/src/engine/Default/bar_galmap_buy.php
+++ b/src/engine/Default/bar_galmap_buy.php
@@ -1,12 +1,16 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
 $player = $session->getPlayer();
 
-$timeUntilMaps = $player->getGame()->getStartTime() + TIME_MAP_BUY_WAIT - Smr\Epoch::time();
+$timeUntilMaps = $player->getGame()->getStartTime() + TIME_MAP_BUY_WAIT - Epoch::time();
 if ($timeUntilMaps > 0) {
 	create_error('You cannot buy maps for another ' . format_time($timeUntilMaps) . '!');
 }
@@ -17,7 +21,7 @@ if ($account->getTotalSmrCredits() < CREDITS_PER_GAL_MAP) {
 
 //gal map buy
 if (isset($var['process'])) {
-	$galaxyID = Smr\Request::getInt('gal_id');
+	$galaxyID = Request::getInt('gal_id');
 
 	//get start sector
 	$galaxy = SmrGalaxy::getGalaxy($player->getGameID(), $galaxyID);
@@ -26,7 +30,7 @@ if (isset($var['process'])) {
 	$high = $galaxy->getEndSector();
 
 	// Have they already got this map? (Are there any unexplored sectors?
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT 1 FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND ' . $player->getSQL() . ' LIMIT 1');
 	if (!$dbResult->hasRecord()) {
 		create_error('You already have maps of this galaxy!');

--- a/src/engine/Default/bar_gambling_processing.php
+++ b/src/engine/Default/bar_gambling_processing.php
@@ -1,10 +1,15 @@
 <?php declare(strict_types=1);
 
+use Smr\Blackjack\Card;
+use Smr\Blackjack\Deck;
+use Smr\Blackjack\Hand;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-function display_card(Smr\Blackjack\Card $card, bool $show): string {
+function display_card(Card $card, bool $show): string {
 	//only display what the card really is if they want to
 	$card_height = 100;
 	$card_width = 125;
@@ -30,7 +35,7 @@ function display_card(Smr\Blackjack\Card $card, bool $show): string {
 	return $return;
 }
 
-function display_hand(Smr\Blackjack\Hand $hand, bool $revealHand): string {
+function display_hand(Hand $hand, bool $revealHand): string {
 	$html = '<table class="center"><tr>';
 	foreach ($hand->getCards() as $key => $card) {
 		//do we need a new row?
@@ -44,7 +49,7 @@ function display_hand(Smr\Blackjack\Hand $hand, bool $revealHand): string {
 	return $html;
 }
 
-function check_for_win(Smr\Blackjack\Hand $dealerHand, Smr\Blackjack\Hand $playerHand): string {
+function check_for_win(Hand $dealerHand, Hand $playerHand): string {
 	//does the player win
 	return match (true) {
 		$playerHand->hasBusted() => 'no',
@@ -56,12 +61,12 @@ function check_for_win(Smr\Blackjack\Hand $dealerHand, Smr\Blackjack\Hand $playe
 	};
 }
 
-$deck = $var['deck'] ?? new Smr\Blackjack\Deck();
-$playerHand = $var['player_hand'] ?? new Smr\Blackjack\Hand();
-$dealerHand = $var['dealer_hand'] ?? new Smr\Blackjack\Hand();
+$deck = $var['deck'] ?? new Deck();
+$playerHand = $var['player_hand'] ?? new Hand();
+$dealerHand = $var['dealer_hand'] ?? new Hand();
 
 $do = $var['player_does'] ?? 'new game';
-$bet = Smr\Request::getVarInt('bet');
+$bet = Request::getVarInt('bet');
 
 if ($do == 'new game') {
 	if ($player->getCredits() < $bet) {

--- a/src/engine/Default/bar_lotto_buy.php
+++ b/src/engine/Default/bar_lotto_buy.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Lotto;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -7,8 +9,8 @@ $player = $session->getPlayer();
 $template->assign('PageTopic', 'Galactic Lotto');
 Menu::bar();
 
-Smr\Lotto::checkForLottoWinner($player->getGameID());
-$lottoInfo = Smr\Lotto::getLottoInfo($player->getGameID());
+Lotto::checkForLottoWinner($player->getGameID());
+$lottoInfo = Lotto::getLottoInfo($player->getGameID());
 $template->assign('LottoInfo', $lottoInfo);
 
 $container = Page::create('bar_lotto_buy_processing.php');

--- a/src/engine/Default/bar_lotto_buy_processing.php
+++ b/src/engine/Default/bar_lotto_buy_processing.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Epoch;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
@@ -8,7 +11,7 @@ if ($player->getCredits() < 1000000) {
 	create_error('There once was a man with less than $1,000,000...wait...thats you!');
 }
 
-$time = Smr\Epoch::time();
+$time = Epoch::time();
 while (true) {
 	//avoid double entries (since table is unique on game,account,time)
 	$dbResult = $db->read('SELECT 1 FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '

--- a/src/engine/Default/bar_lotto_claim.php
+++ b/src/engine/Default/bar_lotto_claim.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 $message = '';
 //check if we really are a winner
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
 if ($dbResult->hasRecord()) {
 	$prize = $dbResult->record()->getInt('prize');

--- a/src/engine/Default/bar_main.php
+++ b/src/engine/Default/bar_main.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -19,7 +22,7 @@ if (isset($var['message'])) {
 
 $winningTicket = false;
 //check for winner
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT prize FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
 if ($dbResult->hasRecord()) {
 	$winningTicket = $dbResult->record()->getInt('prize');
@@ -31,7 +34,7 @@ if ($dbResult->hasRecord()) {
 $template->assign('WinningTicket', $winningTicket);
 
 //get rid of drinks older than 30 mins
-$db->write('DELETE FROM player_has_drinks WHERE time < ' . $db->escapeNumber(Smr\Epoch::time() - 1800));
+$db->write('DELETE FROM player_has_drinks WHERE time < ' . $db->escapeNumber(Epoch::time() - 1800));
 
 $container = Page::create('bar_talk_bartender.php');
 $container->addVar('LocationID');

--- a/src/engine/Default/bar_talk_bartender.php
+++ b/src/engine/Default/bar_talk_bartender.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -10,7 +12,7 @@ Menu::bar();
 
 // We save the displayed message in session since it is randomized
 if (!isset($var['Message'])) {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT message FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY rand() LIMIT 1');
 	if ($dbResult->hasRecord()) {
 		$message = 'I heard... ' . htmlentities(word_filter($dbResult->record()->getString('message'))) . '<br /><br />Got anything else to tell me?';

--- a/src/engine/Default/bar_talk_bartender_processing.php
+++ b/src/engine/Default/bar_talk_bartender_processing.php
@@ -1,17 +1,20 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 $container = Page::create('bar_talk_bartender.php');
 $container->addVar('LocationID');
 
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 
 if ($action == 'tell') {
-	$gossip = Smr\Request::get('gossip_tell');
+	$gossip = Request::get('gossip_tell');
 	if (!empty($gossip)) {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT IFNULL(MAX(message_id)+1, 0) AS next_message_id FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
 		$messageID = $dbResult->record()->getInt('next_message_id');
 
@@ -31,7 +34,7 @@ if ($action == 'tell') {
 	$cost = $event->getWeapon()->getCost();
 
 	// Tip needs to be more than a specific fraction of the weapon cost
-	$tip = Smr\Request::getInt('tip');
+	$tip = Request::getInt('tip');
 	$player->decreaseCredits($tip);
 	$container['Message'] = '<i>The bartender notices your ' . number_format($tip) . ' credit tip.</i><br /><br />';
 

--- a/src/engine/Default/bar_ticker_buy.php
+++ b/src/engine/Default/bar_ticker_buy.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -20,7 +22,7 @@ foreach ($player->getTickers() as $ticker) {
 	if ($ticker['Type'] == 'BLOCK') {
 		$type = 'Scout Message Blocker';
 	}
-	$tickers[$type] = $ticker['Expires'] - Smr\Epoch::time();
+	$tickers[$type] = $ticker['Expires'] - Epoch::time();
 }
 $template->assign('Tickers', $tickers);
 

--- a/src/engine/Default/bar_ticker_buy_processing.php
+++ b/src/engine/Default/bar_ticker_buy_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 $player = $session->getPlayer();
@@ -7,15 +11,15 @@ $player = $session->getPlayer();
 if ($account->getTotalSmrCredits() < CREDITS_PER_TICKER) {
 	create_error('You don\'t have enough SMR Credits. Donate to SMR to gain SMR Credits!');
 }
-$type = Smr\Request::get('type');
-$expires = Smr\Epoch::time();
+$type = Request::get('type');
+$expires = Epoch::time();
 $ticker = $player->getTicker($type);
 if ($ticker !== false) {
 	$expires = $ticker['Expires'];
 }
 $expires += 5 * 86400;
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->replace('player_has_ticker', [
 	'game_id' => $db->escapeNumber($player->getGameID()),
 	'account_id' => $db->escapeNumber($player->getAccountID()),

--- a/src/engine/Default/beta_func_processing.php
+++ b/src/engine/Default/beta_func_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+use Smr\SectorLock;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -10,7 +14,7 @@ if ($var['func'] == 'Map') {
 	$account_id = $player->getAccountID();
 	$game_id = $player->getGameID();
 	// delete all entries from the player_visited_sector/port table
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$db->write('DELETE FROM player_visited_sector WHERE ' . $player->getSQL());
 
 	// add port infos
@@ -23,7 +27,7 @@ if ($var['func'] == 'Map') {
 } elseif ($var['func'] == 'Money') {
 	$player->setCredits(50000000);
 } elseif ($var['func'] == 'Ship') {
-	$shipTypeID = Smr\Request::getInt('ship_type_id');
+	$shipTypeID = Request::getInt('ship_type_id');
 	if ($shipTypeID <= 75 && $shipTypeID != 68) {
 		// assign the new ship
 		$ship->decloak();
@@ -32,15 +36,15 @@ if ($var['func'] == 'Map') {
 		$ship->setHardwareToMax();
 	}
 } elseif ($var['func'] == 'Weapon') {
-	$weapon = SmrWeapon::getWeapon(Smr\Request::getInt('weapon_id'));
-	$amount = Smr\Request::getInt('amount');
+	$weapon = SmrWeapon::getWeapon(Request::getInt('weapon_id'));
+	$amount = Request::getInt('amount');
 	for ($i = 1; $i <= $amount; $i++) {
 		$ship->addWeapon($weapon);
 	}
 } elseif ($var['func'] == 'Uno') {
 	$ship->setHardwareToMax();
 } elseif ($var['func'] == 'Warp') {
-	$sector_to = Smr\Request::getInt('sector_to');
+	$sector_to = Request::getInt('sector_to');
 	if (!SmrSector::sectorExists($player->getGameID(), $sector_to)) {
 		create_error('Sector ID is not in any galaxy.');
 	}
@@ -48,38 +52,38 @@ if ($var['func'] == 'Map') {
 	$player->setLandedOnPlanet(false);
 	// Update sector lock
 	$player->update();
-	$lock = Smr\SectorLock::getInstance();
+	$lock = SectorLock::getInstance();
 	$lock->release();
 	$lock->acquireForPlayer($player);
 } elseif ($var['func'] == 'Turns') {
-	$player->setTurns(Smr\Request::getInt('turns'));
+	$player->setTurns(Request::getInt('turns'));
 } elseif ($var['func'] == 'Exp') {
-	$exp = min(500000, Smr\Request::getInt('exp'));
+	$exp = min(500000, Request::getInt('exp'));
 	$player->setExperience($exp);
 } elseif ($var['func'] == 'Align') {
-	$align = max(-500, min(500, Smr\Request::getInt('align')));
+	$align = max(-500, min(500, Request::getInt('align')));
 	$player->setAlignment($align);
 } elseif ($var['func'] == 'RemWeapon') {
 	$ship->removeAllWeapons();
 } elseif ($var['func'] == 'Hard_add') {
-	$type_hard = Smr\Request::getInt('type_hard');
-	$amount_hard = Smr\Request::getInt('amount_hard');
+	$type_hard = Request::getInt('type_hard');
+	$amount_hard = Request::getInt('amount_hard');
 	$ship->setHardware($type_hard, $amount_hard);
 } elseif ($var['func'] == 'Relations') {
-	$amount = Smr\Request::getInt('amount');
-	$race = Smr\Request::getInt('race');
+	$amount = Request::getInt('amount');
+	$race = Request::getInt('race');
 	$player->setRelations($amount, $race);
 } elseif ($var['func'] == 'Race_Relations') {
-	$amount = Smr\Request::getInt('amount');
-	$race = Smr\Request::getInt('race');
+	$amount = Request::getInt('amount');
+	$race = Request::getInt('race');
 	if ($player->getRaceID() == $race) {
 		create_error('You cannot change race relations with your own race.');
 	}
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$db->write('UPDATE race_has_relation SET relation = ' . $db->escapeNumber($amount) . ' WHERE race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . ' AND race_id_2 = ' . $db->escapeNumber($race) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	$db->write('UPDATE race_has_relation SET relation = ' . $db->escapeNumber($amount) . ' WHERE race_id_1 = ' . $db->escapeNumber($race) . ' AND race_id_2 = ' . $db->escapeNumber($player->getRaceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 } elseif ($var['func'] == 'Race') {
-	$race = Smr\Request::getInt('race');
+	$race = Request::getInt('race');
 	$player->setRaceID($race);
 } elseif ($var['func'] == 'planet_buildings') {
 	$planet = $sector->getPlanet();

--- a/src/engine/Default/bounty_claim.php
+++ b/src/engine/Default/bounty_claim.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\BountyType;
+use Smr\Database;
 
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
@@ -25,13 +26,13 @@ if (!isset($var['ClaimText'])) {
 	if (!empty($bounties)) {
 		$claimText .= ('You have claimed the following bounties<br /><br />');
 
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		foreach ($bounties as $bounty) {
 			// get bounty id from db
 			$amount = $bounty['credits'];
 			$smrCredits = $bounty['smr_credits'];
 			// no interest on bounties
-			// $time = Smr\Epoch::time();
+			// $time = Epoch::time();
 			// $days = ($time - $db->getField('time')) / 60 / 60 / 24;
 			// $amount = round($db->getField('amount') * pow(1.05,$days));
 

--- a/src/engine/Default/bounty_place.php
+++ b/src/engine/Default/bounty_place.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -14,7 +16,7 @@ $container->addVar('LocationID');
 $template->assign('SubmitHREF', $container->href());
 
 $bountyPlayers = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT player_id, player_name FROM player JOIN account USING(account_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id != ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY player_name');
 foreach ($dbResult->records() as $dbRecord) {
 	$bountyPlayers[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getString('player_name'));

--- a/src/engine/Default/bounty_place_confirm_processing.php
+++ b/src/engine/Default/bounty_place_confirm_processing.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\BountyType;
+use Smr\Request;
 
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
@@ -23,7 +24,7 @@ $container = Page::create($body);
 $container->addVar('LocationID');
 
 // if we don't have a yes we leave immediatly
-if (Smr\Request::get('action') != 'Yes') {
+if (Request::get('action') != 'Yes') {
 	$container->go();
 }
 

--- a/src/engine/Default/bounty_place_processing.php
+++ b/src/engine/Default/bounty_place_processing.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 $player = $session->getPlayer();
 
-$amount = Smr\Request::getInt('amount');
-$smrCredits = Smr\Request::getInt('smrcredits');
+$amount = Request::getInt('amount');
+$smrCredits = Request::getInt('smrcredits');
 
 if ($player->getCredits() < $amount) {
 	create_error('You dont have that much money.');
@@ -22,7 +24,7 @@ if ($amount <= 0 && $smrCredits <= 0) {
 $container = Page::create('bounty_place_confirm.php');
 $container['amount'] = $amount;
 $container['SmrCredits'] = $smrCredits;
-$container['player_id'] = Smr\Request::getInt('player_id');
+$container['player_id'] = Request::getInt('player_id');
 $container->addVar('LocationID');
 
 $container->go();

--- a/src/engine/Default/bug_report_processing.php
+++ b/src/engine/Default/bug_report_processing.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
-$steps = Smr\Request::get('steps');
-$subject = Smr\Request::get('subject');
-$error_msg = Smr\Request::get('error_msg');
-$description = Smr\Request::get('description');
+$steps = Request::get('steps');
+$subject = Request::get('subject');
+$error_msg = Request::get('error_msg');
+$description = Request::get('description');
 
 $delim = EOL . EOL . '-----------' . EOL . EOL;
 $message = 'Login: ' . $account->getLogin() . EOL .

--- a/src/engine/Default/buy_message_notifications.php
+++ b/src/engine/Default/buy_message_notifications.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Messages;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -19,7 +21,7 @@ $notifyTypeIDs = [MSG_PLAYER];
 $messageBoxes = [];
 foreach ($notifyTypeIDs as $messageTypeID) {
 	$messageBox = [];
-	$messageBox['Name'] = Smr\Messages::getMessageTypeNames($messageTypeID);
+	$messageBox['Name'] = Messages::getMessageTypeNames($messageTypeID);
 
 	$messageBox['MessagesRemaining'] = $account->getMessageNotifications($messageTypeID);
 	$messageBox['MessagesPerCredit'] = MESSAGES_PER_CREDIT[$messageTypeID];

--- a/src/engine/Default/buy_ship_name_processing.php
+++ b/src/engine/Default/buy_ship_name_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 function checkShipLogo(string $filename): void {
 	// check if we have an image
 	if ($_FILES['photo']['error'] != UPLOAD_ERR_OK) {
@@ -100,7 +102,7 @@ $var = $session->getCurrentVar();
 $account = $session->getAccount();
 $player = $session->getPlayer();
 
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 
 $cred_cost = $var['costs'][$action];
 if ($account->getTotalSmrCredits() < $cred_cost) {
@@ -113,7 +115,7 @@ if ($action == 'logo') {
 	$name = '<img style="padding:3px;" src="upload/' . $filename . '">';
 } else {
 	// Player submitted a text or HTML ship name
-	$name = Smr\Request::get('ship_name');
+	$name = Request::get('ship_name');
 	if ($action == 'text') {
 		checkTextShipName($name, 48);
 		$name = htmlentities($name, ENT_NOQUOTES, 'utf-8');

--- a/src/engine/Default/cargo_dump_processing.php
+++ b/src/engine/Default/cargo_dump_processing.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
 use Smr\TransactionType;
 
 $session = Smr\Session::getInstance();
@@ -11,7 +12,7 @@ $sector = $player->getSector();
 /** @var int $good_id */
 $good_id = $var['good_id'];
 $good_name = Globals::getGoodName($good_id);
-$amount = Smr\Request::getVarInt('amount');
+$amount = Request::getVarInt('amount');
 
 if ($amount <= 0) {
 	create_error('You must actually enter an amount > 0!');

--- a/src/engine/Default/changelog_view.php
+++ b/src/engine/Default/changelog_view.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -12,7 +14,7 @@ if (isset($var['Since'])) {
 	$template->assign('ContinueHREF', $container->href());
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 
 $dbResult = $db->read('SELECT *
 			FROM version

--- a/src/engine/Default/chat_sharing.php
+++ b/src/engine/Default/chat_sharing.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Exceptions\PlayerNotFound;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -12,14 +15,14 @@ if (isset($var['message'])) {
 }
 
 $shareFrom = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($player->getGameID()) . ')');
 foreach ($dbResult->records() as $dbRecord) {
 	$fromAccountId = $dbRecord->getInt('from_account_id');
 	$gameId = $dbRecord->getInt('game_id');
 	try {
 		$otherPlayer = SmrPlayer::getPlayer($fromAccountId, $player->getGameID());
-	} catch (Smr\Exceptions\PlayerNotFound) {
+	} catch (PlayerNotFound) {
 		// Player has not joined this game yet
 		$otherPlayer = null;
 	}
@@ -40,7 +43,7 @@ foreach ($dbResult->records() as $dbRecord) {
 	$toAccountId = $dbRecord->getInt('to_account_id');
 	try {
 		$otherPlayer = SmrPlayer::getPlayer($toAccountId, $player->getGameID());
-	} catch (Smr\Exceptions\PlayerNotFound) {
+	} catch (PlayerNotFound) {
 		// Player has not joined this game yet
 		$otherPlayer = null;
 	}

--- a/src/engine/Default/chat_sharing_processing.php
+++ b/src/engine/Default/chat_sharing_processing.php
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Exceptions\PlayerNotFound;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
@@ -10,8 +14,8 @@ function error_on_page(string $message): never {
 }
 
 // Process adding a "share to" account
-if (Smr\Request::has('add')) {
-	$addPlayerID = Smr\Request::getInt('add_player_id');
+if (Request::has('add')) {
+	$addPlayerID = Request::getInt('add_player_id');
 	if (empty($addPlayerID)) {
 		error_on_page('You must specify a Player ID to share with!');
 	}
@@ -22,7 +26,7 @@ if (Smr\Request::has('add')) {
 
 	try {
 		$accountId = SmrPlayer::getPlayerByPlayerID($addPlayerID, $player->getGameID())->getAccountID();
-	} catch (Smr\Exceptions\PlayerNotFound $e) {
+	} catch (PlayerNotFound $e) {
 		error_on_page($e->getMessage());
 	}
 
@@ -31,7 +35,7 @@ if (Smr\Request::has('add')) {
 		error_on_page('You are already sharing with this player!');
 	}
 
-	$gameId = Smr\Request::has('all_games') ? '0' : $player->getGameID();
+	$gameId = Request::has('all_games') ? '0' : $player->getGameID();
 	$db->insert('account_shares_info', [
 		'to_account_id' => $db->escapeNumber($accountId),
 		'from_account_id' => $db->escapeNumber($player->getAccountID()),
@@ -40,13 +44,13 @@ if (Smr\Request::has('add')) {
 }
 
 // Process removing a "share to" account
-if (Smr\Request::has('remove_share_to')) {
-	$db->write('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber(Smr\Request::getInt('remove_share_to')) . ' AND from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber(Smr\Request::getInt('game_id')));
+if (Request::has('remove_share_to')) {
+	$db->write('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber(Request::getInt('remove_share_to')) . ' AND from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber(Request::getInt('game_id')));
 }
 
 // Process removing a "share from" account
-if (Smr\Request::has('remove_share_from')) {
-	$db->write('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND from_account_id=' . $db->escapeNumber(Smr\Request::getInt('remove_share_from')) . ' AND game_id=' . $db->escapeNumber(Smr\Request::getInt('game_id')));
+if (Request::has('remove_share_from')) {
+	$db->write('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND from_account_id=' . $db->escapeNumber(Request::getInt('remove_share_from')) . ' AND game_id=' . $db->escapeNumber(Request::getInt('game_id')));
 }
 
 Page::create('chat_sharing.php')->go();

--- a/src/engine/Default/chess.php
+++ b/src/engine/Default/chess.php
@@ -1,10 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Chess\ChessGame;
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$chessGames = Smr\Chess\ChessGame::getOngoingPlayerGames($player);
+$chessGames = ChessGame::getOngoingPlayerGames($player);
 $template->assign('ChessGames', $chessGames);
 $template->assign('PageTopic', 'Casino');
 
@@ -15,7 +18,7 @@ foreach ($chessGames as $chessGame) {
 }
 
 $players = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) WHERE npc = ' . $db->escapeBoolean(false) . ' AND validated = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
 foreach ($dbResult->records() as $dbRecord) {
 	$players[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getString('player_name'));

--- a/src/engine/Default/chess_create_processing.php
+++ b/src/engine/Default/chess_create_processing.php
@@ -1,9 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Chess\ChessGame;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$challengePlayer = SmrPlayer::getPlayerByPlayerID(Smr\Request::getInt('player_id'), $player->getGameID());
-Smr\Chess\ChessGame::insertNewGame(Smr\Epoch::time(), null, $player, $challengePlayer);
+$challengePlayer = SmrPlayer::getPlayerByPlayerID(Request::getInt('player_id'), $player->getGameID());
+ChessGame::insertNewGame(Epoch::time(), null, $player, $challengePlayer);
 
 Page::create('chess.php')->go();

--- a/src/engine/Default/chess_move_processing.php
+++ b/src/engine/Default/chess_move_processing.php
@@ -1,5 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Chess\ChessGame;
+use Smr\Chess\ChessPiece;
+use Smr\Exceptions\UserError;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -7,15 +12,15 @@ $player = $session->getPlayer();
 $container = Page::create('chess_play.php');
 $container->addVar('ChessGameID');
 
-$chessGame = Smr\Chess\ChessGame::getChessGame($var['ChessGameID']);
-$x = Smr\Request::getInt('x');
-$y = Smr\Request::getInt('y');
-$toX = Smr\Request::getInt('toX');
-$toY = Smr\Request::getInt('toY');
+$chessGame = ChessGame::getChessGame($var['ChessGameID']);
+$x = Request::getInt('x');
+$y = Request::getInt('y');
+$toX = Request::getInt('toX');
+$toY = Request::getInt('toY');
 $colour = $chessGame->getColourForAccountID($player->getAccountID());
 try {
-	$message = $chessGame->tryMove($x, $y, $toX, $toY, $colour, Smr\Chess\ChessPiece::QUEEN);
-} catch (Smr\Exceptions\UserError $err) {
+	$message = $chessGame->tryMove($x, $y, $toX, $toY, $colour, ChessPiece::QUEEN);
+} catch (UserError $err) {
 	$message = $err->getMessage();
 }
 $container['MoveMessage'] = $message;

--- a/src/engine/Default/chess_play.php
+++ b/src/engine/Default/chess_play.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Chess\ChessGame;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$chessGame = Smr\Chess\ChessGame::getChessGame($var['ChessGameID']);
+$chessGame = ChessGame::getChessGame($var['ChessGameID']);
 $template->assign('ChessGame', $chessGame);
 
 // Board orientation depends on the player's color.

--- a/src/engine/Default/combat_log_list.php
+++ b/src/engine/Default/combat_log_list.php
@@ -1,9 +1,10 @@
 <?php declare(strict_types=1);
 
 use Smr\CombatLogType;
+use Smr\Database;
 
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();

--- a/src/engine/Default/combat_log_list_processing.php
+++ b/src/engine/Default/combat_log_list_processing.php
@@ -1,8 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 // If here, we have hit either the 'Save', 'Delete', or 'View' form buttons.
 // Immediately return to the log list if we haven't selected any logs.
-if (!Smr\Request::has('id')) {
+if (!Request::has('id')) {
 	$container = Page::create('combat_log_list.php');
 	$container['message'] = 'You must select at least one combat log!';
 	$container->addVar('old_action', 'action');
@@ -12,12 +15,12 @@ if (!Smr\Request::has('id')) {
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$submitAction = Smr\Request::get('action');
-$logIDs = array_keys(Smr\Request::getArray('id'));
+$submitAction = Request::get('action');
+$logIDs = array_keys(Request::getArray('id'));
 
 // Do we need to save any logs (or delete any saved logs)?
 if ($submitAction == 'Save' || $submitAction == 'Delete') {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	if ($submitAction == 'Save') {
 		//save the logs we checked
 		// Query means people can only save logs that they are allowd to view.

--- a/src/engine/Default/combat_log_viewer.php
+++ b/src/engine/Default/combat_log_viewer.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -11,7 +13,7 @@ if (!isset($var['log_ids']) && !isset($var['current_log'])) {
 
 // Set properties for the current display page
 $display_id = $var['log_ids'][$var['current_log']];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT timestamp,sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($display_id) . ' LIMIT 1');
 
 $dbRecord = $dbResult->record();

--- a/src/engine/Default/combat_log_viewer_verify.php
+++ b/src/engine/Default/combat_log_viewer_verify.php
@@ -1,10 +1,13 @@
 <?php declare(strict_types=1);
+
+use Smr\Database;
+
 // Verify that the player is permitted to view the requested combat log
 // Qualifications:
 //  * Log must be from the current game
 //  * Attacker or defender is the player OR in the player's alliance
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();

--- a/src/engine/Default/configure_hardware.php
+++ b/src/engine/Default/configure_hardware.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $ship = $session->getPlayer()->getShip();
@@ -22,7 +24,7 @@ if ($ship->hasIllusion()) {
 	$template->assign('SetIllusionFormHREF', $container->href());
 
 	$ships = [];
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT ship_type_id,ship_name FROM ship_type ORDER BY ship_name');
 	foreach ($dbResult->records() as $dbRecord) {
 		$ships[$dbRecord->getInt('ship_type_id')] = $dbRecord->getString('ship_name');

--- a/src/engine/Default/configure_hardware_processing.php
+++ b/src/engine/Default/configure_hardware_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -16,7 +18,7 @@ if ($var['action'] == 'Enable') {
 } elseif ($var['action'] == 'Disable') {
 	$ship->decloak();
 } elseif ($var['action'] == 'Set Illusion') {
-	$ship->setIllusion(Smr\Request::getInt('ship_type_id'), Smr\Request::getInt('attack'), Smr\Request::getInt('defense'));
+	$ship->setIllusion(Request::getInt('ship_type_id'), Request::getInt('attack'), Request::getInt('defense'));
 } elseif ($var['action'] == 'Disable Illusion') {
 	$ship->disableIllusion();
 }

--- a/src/engine/Default/contact_processing.php
+++ b/src/engine/Default/contact_processing.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
-$receiver = Smr\Request::get('receiver');
-$subject = Smr\Request::get('subject');
-$msg = Smr\Request::get('msg');
+$receiver = Request::get('receiver');
+$subject = Request::get('subject');
+$msg = Request::get('msg');
 
 $mail = setupMailer();
 $mail->Subject = PAGE_PREFIX . $subject;

--- a/src/engine/Default/council_embassy.php
+++ b/src/engine/Default/council_embassy.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Race;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
@@ -14,7 +17,7 @@ $template->assign('PageTopic', 'Ruling Council Of ' . $player->getRaceName());
 Menu::council($player->getRaceID());
 
 $voteRaces = [];
-foreach (Smr\Race::getPlayableIDs() as $raceID) {
+foreach (Race::getPlayableIDs() as $raceID) {
 	if ($raceID == $player->getRaceID()) {
 		continue;
 	}

--- a/src/engine/Default/council_embassy_processing.php
+++ b/src/engine/Default/council_embassy_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -9,10 +13,10 @@ if (!$player->isPresident()) {
 }
 
 $race_id = $var['race_id'];
-$type = strtoupper(Smr\Request::get('action'));
-$time = Smr\Epoch::time() + TIME_FOR_COUNCIL_VOTE;
+$type = strtoupper(Request::get('action'));
+$time = Epoch::time() + TIME_FOR_COUNCIL_VOTE;
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT count(*) FROM race_has_voting
 			WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 			AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()));

--- a/src/engine/Default/council_list.php
+++ b/src/engine/Default/council_list.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\CouncilVoting;
+use Smr\Race;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -7,11 +10,11 @@ $player = $session->getPlayer();
 
 $raceID = $var['race_id'] ?? $player->getRaceID();
 
-$template->assign('PageTopic', 'Ruling Council Of ' . Smr\Race::getName($raceID));
+$template->assign('PageTopic', 'Ruling Council Of ' . Race::getName($raceID));
 $template->assign('RaceID', $raceID);
 
 Menu::council($raceID);
 
 // check for relations here
-Smr\CouncilVoting::modifyRelations($raceID, $player->getGameID());
-Smr\CouncilVoting::checkPacts($raceID, $player->getGameID());
+CouncilVoting::modifyRelations($raceID, $player->getGameID());
+CouncilVoting::checkPacts($raceID, $player->getGameID());

--- a/src/engine/Default/council_politics.php
+++ b/src/engine/Default/council_politics.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -7,7 +9,7 @@ $player = $session->getPlayer();
 
 $raceID = $var['race_id'] ?? $player->getRaceID();
 
-$template->assign('PageTopic', 'Ruling Council Of ' . Smr\Race::getName($raceID));
+$template->assign('PageTopic', 'Ruling Council Of ' . Race::getName($raceID));
 
 // echo menu
 Menu::council($raceID);
@@ -17,7 +19,7 @@ $raceRelations = Globals::getRaceRelations($player->getGameID(), $raceID);
 $peaceRaces = [];
 $neutralRaces = [];
 $warRaces = [];
-foreach (Smr\Race::getPlayableIDs() as $otherRaceID) {
+foreach (Race::getPlayableIDs() as $otherRaceID) {
 	if ($raceID != $otherRaceID) {
 		if ($raceRelations[$otherRaceID] >= RELATIONS_PEACE) {
 			$peaceRaces[] = $otherRaceID;

--- a/src/engine/Default/council_send_message.php
+++ b/src/engine/Default/council_send_message.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+
 $template = Smr\Template::getInstance();
 $var = Smr\Session::getInstance()->getCurrentVar();
 
-$raceName = Smr\Race::getName($var['race_id']);
+$raceName = Race::getName($var['race_id']);
 $template->assign('RaceName', $raceName);
 
 $template->assign('PageTopic', 'Send message to Ruling Council of the ' . $raceName);

--- a/src/engine/Default/council_send_message_processing.php
+++ b/src/engine/Default/council_send_message_processing.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$message = htmlentities(Smr\Request::get('message'), ENT_COMPAT, 'utf-8');
+$message = htmlentities(Request::get('message'), ENT_COMPAT, 'utf-8');
 
 if (empty($message)) {
 	create_error('You have to enter text to send a message!');

--- a/src/engine/Default/council_vote.php
+++ b/src/engine/Default/council_vote.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Race;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -12,7 +16,7 @@ $template->assign('PageTopic', 'Ruling Council Of ' . $player->getRaceName());
 Menu::council($player->getRaceID());
 
 // determine for what we voted
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM player_votes_relation
 			WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
 				AND game_id = ' . $db->escapeNumber($player->getGameID()));
@@ -26,7 +30,7 @@ if ($dbResult->hasRecord()) {
 
 $voteRelations = [];
 $raceRelations = Globals::getRaceRelations($player->getGameID(), $player->getRaceID());
-foreach (Smr\Race::getPlayableIDs() as $raceID) {
+foreach (Race::getPlayableIDs() as $raceID) {
 	if ($raceID == $player->getRaceID()) {
 		continue;
 	}
@@ -42,7 +46,7 @@ $template->assign('VoteRelations', $voteRelations);
 
 $voteTreaties = [];
 $dbResult = $db->read('SELECT * FROM race_has_voting
-			WHERE ' . $db->escapeNumber(Smr\Epoch::time()) . ' < end_time
+			WHERE ' . $db->escapeNumber(Epoch::time()) . ' < end_time
 			AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
 			AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()));
 

--- a/src/engine/Default/council_vote_processing.php
+++ b/src/engine/Default/council_vote_processing.php
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -9,7 +13,7 @@ if (!$player->isOnCouncil()) {
 	create_error('You have to be on the council in order to vote.');
 }
 
-$action = strtoupper(Smr\Request::get('action'));
+$action = strtoupper(Request::get('action'));
 
 if ($action == 'INCREASE') {
 	$action = 'INC';
@@ -26,7 +30,7 @@ if ($action == 'INC' || $action == 'DEC') {
 		'race_id_1' => $db->escapeNumber($player->getRaceID()),
 		'race_id_2' => $db->escapeNumber($race_id),
 		'action' => $db->escapeString($action),
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 	]);
 } elseif ($action == 'YES' || $action == 'NO') {
 	$db->replace('player_votes_pact', [

--- a/src/engine/Default/course_destination_button_processing.php
+++ b/src/engine/Default/course_destination_button_processing.php
@@ -1,22 +1,24 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$type = Smr\Request::get('type');
-$sectorId = Smr\Request::getInt('sectorId');
+$type = Request::get('type');
+$sectorId = Request::getInt('sectorId');
 
 switch ($type) {
 	case 'add':
-		$label = Smr\Request::get('label');
+		$label = Request::get('label');
 		$player->addDestinationButton($sectorId, $label);
 		break;
 
 	case 'move':
 		// These are submitted as floats by ui.draggable.position JS, but
 		// we (and the browser) only accept integer positions.
-		$offsetTop = Smr\Request::getInt('offsetTop');
-		$offsetLeft = Smr\Request::getInt('offsetLeft');
+		$offsetTop = Request::getInt('offsetTop');
+		$offsetLeft = Request::getInt('offsetLeft');
 		$player->moveDestinationButton($sectorId, $offsetTop, $offsetLeft);
 		break;
 

--- a/src/engine/Default/course_plot_nearest_processing.php
+++ b/src/engine/Default/course_plot_nearest_processing.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\PlotGroup;
+use Smr\Request;
 
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -11,8 +12,8 @@ if (isset($var['RealX'])) {
 	// This is only used by NPC's
 	$realX = $var['RealX'];
 } else {
-	$xType = PlotGroup::from(Smr\Request::get('xtype'));
-	$X = Smr\Request::get('X');
+	$xType = PlotGroup::from(Request::get('xtype'));
+	$X = Request::get('X');
 	$realX = Plotter::getX($xType, $X, $player->getGameID(), $player);
 
 	$player->log(LOG_TYPE_MOVEMENT, 'Player plots to nearest ' . $xType->value . ': ' . $X . '.');

--- a/src/engine/Default/course_plot_processing.php
+++ b/src/engine/Default/course_plot_processing.php
@@ -1,10 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Exceptions\SectorNotFound;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$start = Smr\Request::getVarInt('from');
-$target = Smr\Request::getVarInt('to');
+$start = Request::getVarInt('from');
+$target = Request::getVarInt('to');
 
 // perform some basic checks on both numbers
 if (empty($start) || empty($target)) {
@@ -18,7 +21,7 @@ if ($start == $target) {
 try {
 	$startSector = SmrSector::getSector($player->getGameID(), $start);
 	$targetSector = SmrSector::getSector($player->getGameID(), $target);
-} catch (Smr\Exceptions\SectorNotFound) {
+} catch (SectorNotFound) {
 	create_error('The sectors have to exist!');
 }
 

--- a/src/engine/Default/current_players.php
+++ b/src/engine/Default/current_players.php
@@ -1,14 +1,17 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$inactiveTime = Smr\Epoch::time() - TIME_BEFORE_INACTIVE;
+$inactiveTime = Epoch::time() - TIME_BEFORE_INACTIVE;
 
 $template->assign('PageTopic', 'Current Players');
-$db = Smr\Database::getInstance();
-$db->write('DELETE FROM cpl_tag WHERE expires > 0 AND expires < ' . $db->escapeNumber(Smr\Epoch::time()));
+$db = Database::getInstance();
+$db->write('DELETE FROM cpl_tag WHERE expires > 0 AND expires < ' . $db->escapeNumber(Epoch::time()));
 
 $dbResult = $db->read('SELECT count(*) count FROM active_session
 			WHERE last_accessed >= ' . $db->escapeNumber($inactiveTime) . ' AND

--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -34,7 +37,7 @@ $links['Warp'] = ['ID' => $sector->getWarp()];
 
 $unvisited = [];
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT sector_id FROM player_visited_sector WHERE sector_id IN (' . $db->escapeArray($links) . ') AND ' . $player->getSQL());
 foreach ($dbResult->records() as $dbRecord) {
 	$unvisited[$dbRecord->getInt('sector_id')] = true;
@@ -69,7 +72,7 @@ $template->assign('UnreadMissions', $var['UnreadMissions']);
 // *******************************************
 $game = SmrGame::getGame($player->getGameID());
 if (!$game->hasStarted()) {
-	$turnsMessage = 'The game will start in ' . format_time($game->getStartTime() - Smr\Epoch::time()) . '!';
+	$turnsMessage = 'The game will start in ' . format_time($game->getStartTime() - Epoch::time()) . '!';
 } else {
 	$turnsMessage = $player->getTurnsLevel()->message();
 }
@@ -165,13 +168,13 @@ function checkForForceRefreshMessage(string &$msg): void {
 	if ($contains > 0) {
 		$template = Smr\Template::getInstance();
 		if (!$template->hasTemplateVar('ForceRefreshMessage')) {
-			$db = Smr\Database::getInstance();
+			$db = Database::getInstance();
 			$player = Smr\Session::getInstance()->getPlayer();
 
 			$forceRefreshMessage = '';
-			$dbResult = $db->read('SELECT refresh_at FROM sector_has_forces WHERE refresh_at > ' . $db->escapeNumber(Smr\Epoch::time()) . ' AND sector_id = ' . $db->escapeNumber($player->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND refresher = ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY refresh_at DESC LIMIT 1');
+			$dbResult = $db->read('SELECT refresh_at FROM sector_has_forces WHERE refresh_at > ' . $db->escapeNumber(Epoch::time()) . ' AND sector_id = ' . $db->escapeNumber($player->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND refresher = ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY refresh_at DESC LIMIT 1');
 			if ($dbResult->hasRecord()) {
-				$remainingTime = $dbResult->record()->getInt('refresh_at') - Smr\Epoch::time();
+				$remainingTime = $dbResult->record()->getInt('refresh_at') - Epoch::time();
 				$forceRefreshMessage = '<span class="green">REFRESH</span>: All forces will be refreshed in ' . $remainingTime . ' seconds.';
 				$db->replace('sector_message', [
 					'game_id' => $db->escapeNumber($player->getGameID()),
@@ -202,7 +205,7 @@ function checkForAttackMessage(string &$msg): void {
 
 		$template = Smr\Template::getInstance();
 		if (!$template->hasTemplateVar('AttackResults')) {
-			$db = Smr\Database::getInstance();
+			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($logID) . ' LIMIT 1');
 			if ($dbResult->hasRecord()) {
 				$dbRecord = $dbResult->record();

--- a/src/engine/Default/donation.php
+++ b/src/engine/Default/donation.php
@@ -1,8 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 
 $template->assign('PageTopic', 'Donations');
-$db = Smr\Database::getInstance();
-$dbResult = $db->read('SELECT IFNULL(SUM(amount), 0) as total_donation FROM account_donated WHERE time > ' . $db->escapeNumber(Smr\Epoch::time()) . ' - (86400 * 90)');
+$db = Database::getInstance();
+$dbResult = $db->read('SELECT IFNULL(SUM(amount), 0) as total_donation FROM account_donated WHERE time > ' . $db->escapeNumber(Epoch::time()) . ' - (86400 * 90)');
 $template->assign('TotalDonation', $dbResult->record()->getInt('total_donation'));

--- a/src/engine/Default/error.php
+++ b/src/engine/Default/error.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-$lock = Smr\SectorLock::getInstance();
+use Smr\SectorLock;
+
+$lock = SectorLock::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 

--- a/src/engine/Default/feature_request.php
+++ b/src/engine/Default/feature_request.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
@@ -59,7 +62,7 @@ $dbResult = $db->read('SELECT * ' .
 			'JOIN feature_request_comments super USING(feature_request_id) ' .
 			'WHERE comment_id = 1 ' .
 			'AND status = ' . $db->escapeString($thisStatus) .
-			($var['category'] == 'New' ? ' AND EXISTS(SELECT posting_time FROM feature_request_comments WHERE feature_request_id = super.feature_request_id AND posting_time > ' . (Smr\Epoch::time() - NEW_REQUEST_DAYS * 86400) . ')' : '') .
+			($var['category'] == 'New' ? ' AND EXISTS(SELECT posting_time FROM feature_request_comments WHERE feature_request_id = super.feature_request_id AND posting_time > ' . (Epoch::time() - NEW_REQUEST_DAYS * 86400) . ')' : '') .
 			' ORDER BY (SELECT MAX(posting_time) FROM feature_request_comments WHERE feature_request_id = super.feature_request_id) DESC');
 if ($dbResult->hasRecord()) {
 	$featureModerator = $account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST);
@@ -112,13 +115,13 @@ function statusFromCategory(string $category): string {
 }
 
 function getFeaturesCount(string $status, int|false $daysNew = false): int {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('
 		SELECT COUNT(*) AS count
 		FROM feature_request
 		JOIN feature_request_comments super USING(feature_request_id)
 		WHERE comment_id = 1
 		AND status = ' . $db->escapeString($status) .
-		($daysNew ? ' AND EXISTS(SELECT posting_time FROM feature_request_comments WHERE feature_request_id = super.feature_request_id AND posting_time > ' . (Smr\Epoch::time() - $daysNew * 86400) . ')' : ''));
+		($daysNew ? ' AND EXISTS(SELECT posting_time FROM feature_request_comments WHERE feature_request_id = super.feature_request_id AND posting_time > ' . (Epoch::time() - $daysNew * 86400) . ')' : ''));
 	return $dbResult->record()->getInt('count');
 }

--- a/src/engine/Default/feature_request_comment_processing.php
+++ b/src/engine/Default/feature_request_comment_processing.php
@@ -1,21 +1,25 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
 
-$comment = Smr\Request::get('comment');
+$comment = Request::get('comment');
 if (empty($comment)) {
 	create_error('We need a comment to add!');
 }
 
 // add this feature comment
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->insert('feature_request_comments', [
 	'feature_request_id' => $db->escapeNumber($var['RequestID']),
 	'poster_id' => $db->escapeNumber($account->getAccountID()),
-	'posting_time' => $db->escapeNumber(Smr\Epoch::time()),
-	'anonymous' => $db->escapeBoolean(Smr\Request::has('anon')),
+	'posting_time' => $db->escapeNumber(Epoch::time()),
+	'anonymous' => $db->escapeBoolean(Request::has('anon')),
 	'text' => $db->escapeString(word_filter($comment)),
 ]);
 

--- a/src/engine/Default/feature_request_comments.php
+++ b/src/engine/Default/feature_request_comments.php
@@ -1,4 +1,7 @@
 <?php declare(strict_types=1);
+
+use Smr\Database;
+
 if (!Globals::isFeatureRequestOpen()) {
 	create_error('Feature requests are currently not being accepted.');
 }
@@ -13,7 +16,7 @@ $template->assign('PageTopic', 'Feature Request Comments');
 $container = Page::create('feature_request.php', $var);
 $template->assign('BackHref', $container->href());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT *
 			FROM feature_request
 			JOIN feature_request_comments USING(feature_request_id)

--- a/src/engine/Default/feature_request_processing.php
+++ b/src/engine/Default/feature_request_processing.php
@@ -1,9 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
-$feature = Smr\Request::get('feature');
+$feature = Request::get('feature');
 if (empty($feature)) {
 	create_error('We need at least a feature description!');
 }
@@ -12,13 +16,13 @@ if (strlen($feature) > 500) {
 }
 
 // add this feature to db
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $featureRequestID = $db->insert('feature_request', []);
 $db->insert('feature_request_comments', [
 	'feature_request_id' => $db->escapeNumber($featureRequestID),
 	'poster_id' => $db->escapeNumber($account->getAccountID()),
-	'posting_time' => $db->escapeNumber(Smr\Epoch::time()),
-	'anonymous' => $db->escapeBoolean(Smr\Request::has('anon')),
+	'posting_time' => $db->escapeNumber(Epoch::time()),
+	'anonymous' => $db->escapeBoolean(Request::has('anon')),
 	'text' => $db->escapeString(word_filter($feature)),
 ]);
 

--- a/src/engine/Default/forces_attack_processing.php
+++ b/src/engine/Default/forces_attack_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\SectorLock;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -96,12 +100,12 @@ if (!$bump) {
 }
 
 // Add this log to the `combat_logs` database table
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $logId = $db->insert('combat_logs', [
 	'game_id' => $db->escapeNumber($player->getGameID()),
 	'type' => $db->escapeString('FORCE'),
 	'sector_id' => $db->escapeNumber($forces->getSectorID()),
-	'timestamp' => $db->escapeNumber(Smr\Epoch::time()),
+	'timestamp' => $db->escapeNumber(Epoch::time()),
 	'attacker_id' => $db->escapeNumber($player->getAccountID()),
 	'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
 	'defender_id' => $db->escapeNumber($forceOwner->getAccountID()),
@@ -118,7 +122,7 @@ if ($sendMessage) {
 if ($player->isDead()) {
 	saveAllAndReleaseLock(updateSession: false);
 	// Grab the lock in the new sector to avoid reloading session
-	Smr\SectorLock::getInstance()->acquireForPlayer($player);
+	SectorLock::getInstance()->acquireForPlayer($player);
 }
 
 // If they died on the shot they get to see the results

--- a/src/engine/Default/forces_drop_processing.php
+++ b/src/engine/Default/forces_drop_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -18,12 +20,12 @@ if ($player->getSector()->hasLocation()) {
 }
 
 // take either from container or request, prefer container
-$drop_mines = Smr\Request::getVarInt('drop_mines', 0);
-$take_mines = Smr\Request::getVarInt('take_mines', 0);
-$drop_combat_drones = Smr\Request::getVarInt('drop_combat_drones', 0);
-$take_combat_drones = Smr\Request::getVarInt('take_combat_drones', 0);
-$drop_scout_drones = Smr\Request::getVarInt('drop_scout_drones', 0);
-$take_scout_drones = Smr\Request::getVarInt('take_scout_drones', 0);
+$drop_mines = Request::getVarInt('drop_mines', 0);
+$take_mines = Request::getVarInt('take_mines', 0);
+$drop_combat_drones = Request::getVarInt('drop_combat_drones', 0);
+$take_combat_drones = Request::getVarInt('take_combat_drones', 0);
+$drop_scout_drones = Request::getVarInt('drop_scout_drones', 0);
+$take_scout_drones = Request::getVarInt('take_scout_drones', 0);
 
 // so how many forces do we take/add per type?
 $change_mines = $drop_mines - $take_mines;

--- a/src/engine/Default/forces_list.php
+++ b/src/engine/Default/forces_list.php
@@ -1,17 +1,20 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 $template->assign('PageTopic', 'View Forces');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT *
 			FROM sector_has_forces
 			WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . '
 			AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-			AND expire_time >= ' . $db->escapeNumber(Smr\Epoch::time()) . '
+			AND expire_time >= ' . $db->escapeNumber(Epoch::time()) . '
 			ORDER BY sector_id ASC');
 
 $forces = [];

--- a/src/engine/Default/forces_mass_refresh.php
+++ b/src/engine/Default/forces_mass_refresh.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 // Note: getSectorForces is cached and also called for sector display,
 // so it saves time to call it here instead of a new query.
 $sectorForces = SmrForce::getSectorForces($player->getGameID(), $player->getSectorID());
-$time = Smr\Epoch::time();
+$time = Epoch::time();
 foreach ($sectorForces as $sectorForce) {
 	if ($player->sharedForceAlliance($sectorForce->getOwner())) {
 		$time += SmrForce::REFRESH_ALL_TIME_PER_STACK;

--- a/src/engine/Default/galactic_post.php
+++ b/src/engine/Default/galactic_post.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -11,7 +13,7 @@ if (!$player->isGPEditor()) {
 $template->assign('PageTopic', 'Galactic Post');
 Menu::galacticPost();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 
 $container = Page::create('galactic_post_view_article.php');
 $template->assign('ViewArticlesHREF', $container->href());

--- a/src/engine/Default/galactic_post_add_article_to_paper.php
+++ b/src/engine/Default/galactic_post_add_article_to_paper.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
 //limit 4 per paper...make sure we arent over that
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT 1 FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['paper_id']));
 if ($dbResult->getNumRecords() >= 8) {
 	create_error('You can only have 8 articles per paper.');

--- a/src/engine/Default/galactic_post_current.php
+++ b/src/engine/Default/galactic_post_current.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY online_since DESC LIMIT 1');
 if ($dbResult->hasRecord()) {
 	$paper_id = $dbResult->record()->getInt('paper_id');

--- a/src/engine/Default/galactic_post_delete_confirm.php
+++ b/src/engine/Default/galactic_post_delete_confirm.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();

--- a/src/engine/Default/galactic_post_delete_processing.php
+++ b/src/engine/Default/galactic_post_delete_processing.php
@@ -1,20 +1,23 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 if (isset($var['article'])) {
-	if (Smr\Request::get('action') == 'Yes') {
+	if (Request::get('action') == 'Yes') {
 		$db->write('DELETE FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
 	}
 } else {
 	// Should we delete this paper?
-	if (Smr\Request::get('action') == 'Yes') {
+	if (Request::get('action') == 'Yes') {
 
 		// Should the articles associated with the paper be deleted as well?
-		if (Smr\Request::get('delete_articles') == 'Yes') {
+		if (Request::get('delete_articles') == 'Yes') {
 			$dbResult = $db->read('SELECT * FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
 			foreach ($dbResult->records() as $dbRecord) {
 				$db->write('DELETE FROM galactic_post_article WHERE article_id = ' . $db->escapeNumber($dbRecord->getInt('article_id')) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));

--- a/src/engine/Default/galactic_post_make_current.php
+++ b/src/engine/Default/galactic_post_make_current.php
@@ -1,18 +1,21 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
 // Make sure this paper hasn't been published before
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT 1 FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
 if ($dbResult->hasRecord()) {
 	create_error('Cannot publish a paper that has previously been published!');
 }
 
 // Update the online_since column
-$db->write('UPDATE galactic_post_paper SET online_since=' . $db->escapeNumber(Smr\Epoch::time()) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
+$db->write('UPDATE galactic_post_paper SET online_since=' . $db->escapeNumber(Epoch::time()) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($var['id']));
 
 //all done lets send back to the main GP page.
 $container = Page::create('galactic_post.php');

--- a/src/engine/Default/galactic_post_make_paper_processing.php
+++ b/src/engine/Default/galactic_post_make_paper_processing.php
@@ -1,16 +1,19 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY paper_id DESC');
 if ($dbResult->hasRecord()) {
 	$num = $dbResult->record()->getInt('paper_id') + 1;
 } else {
 	$num = 1;
 }
-$title = Smr\Request::get('title');
+$title = Request::get('title');
 $db->insert('galactic_post_paper', [
 	'game_id' => $db->escapeNumber($player->getGameID()),
 	'paper_id' => $db->escapeNumber($num),

--- a/src/engine/Default/galactic_post_paper_edit.php
+++ b/src/engine/Default/galactic_post_paper_edit.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -8,7 +10,7 @@ $player = $session->getPlayer();
 $template->assign('PageTopic', 'Edit Paper');
 Menu::galacticPost();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE paper_id = ' . $db->escapeNumber($var['id']) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 $template->assign('PaperTitle', bbifyMessage($dbResult->record()->getString('title')));
 

--- a/src/engine/Default/galactic_post_paper_edit_processing.php
+++ b/src/engine/Default/galactic_post_paper_edit_processing.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('DELETE FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['article_id']));
 
 $container = Page::create('galactic_post_paper_edit.php');

--- a/src/engine/Default/galactic_post_past.php
+++ b/src/engine/Default/galactic_post_past.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -16,7 +18,7 @@ $template->assign('SelectedGame', $selectedGameID);
 
 // Get the list of games with published papers
 // Add the current game to this list no matter what
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT game_name, game_id FROM game WHERE game_id IN (SELECT DISTINCT game_id FROM galactic_post_paper WHERE online_since IS NOT NULL) OR game_id=' . $db->escapeNumber($player->getGameID()) . ' ORDER BY game_id DESC');
 $publishedGames = [];
 foreach ($dbResult->records() as $dbRecord) {

--- a/src/engine/Default/galactic_post_read.php
+++ b/src/engine/Default/galactic_post_read.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -18,7 +20,7 @@ if (!empty($var['paper_id'])) {
 		$template->assign('BackHREF', $container->href());
 	}
 
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($var['game_id']) . ' AND paper_id = ' . $var['paper_id']);
 	$paper_name = bbifyMessage($dbResult->record()->getString('title'));
 	$template->assign('PageTopic', 'Reading <i>Galactic Post</i> Edition : ' . $paper_name);

--- a/src/engine/Default/galactic_post_view_article.php
+++ b/src/engine/Default/galactic_post_view_article.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -12,7 +15,7 @@ Menu::galacticPost();
 if (isset($var['news'])) {
 	$db->insert('news', [
 		'game_id' => $db->escapeNumber($player->getGameID()),
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 		'news_message' => $db->escapeString($var['news']),
 		'type' => $db->escapeString('breaking'),
 	]);

--- a/src/engine/Default/galactic_post_write_article.php
+++ b/src/engine/Default/galactic_post_write_article.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -12,7 +14,7 @@ if (isset($var['id'])) {
 	$container->addVar('id');
 	$template->assign('PageTopic', 'Editing An Article');
 	if (!isset($var['Preview'])) {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT title, text FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();

--- a/src/engine/Default/galactic_post_write_article_processing.php
+++ b/src/engine/Default/galactic_post_write_article_processing.php
@@ -1,17 +1,21 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$title = Smr\Request::get('title');
-$message = Smr\Request::get('message');
+$title = Request::get('title');
+$message = Request::get('message');
 if (!$player->isGPEditor()) {
 	$title = htmlentities($title, ENT_COMPAT, 'utf-8');
 	$message = htmlentities($message, ENT_COMPAT, 'utf-8');
 }
 
-if (Smr\Request::get('action') == 'Preview article') {
+if (Request::get('action') == 'Preview article') {
 	$container = Page::create('galactic_post_write_article.php');
 	$container['PreviewTitle'] = $title;
 	$container['Preview'] = $message;
@@ -21,10 +25,10 @@ if (Smr\Request::get('action') == 'Preview article') {
 	$container->go();
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 if (isset($var['id'])) {
 	// Editing an article
-	$db->write('UPDATE galactic_post_article SET last_modified = ' . $db->escapeNumber(Smr\Epoch::time()) . ', text = ' . $db->escapeString($message) . ', title = ' . $db->escapeString($title) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
+	$db->write('UPDATE galactic_post_article SET last_modified = ' . $db->escapeNumber(Epoch::time()) . ', text = ' . $db->escapeString($message) . ', title = ' . $db->escapeString($title) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($var['id']));
 	Page::create('galactic_post_view_article.php')->go();
 } else {
 	// Adding a new article
@@ -44,8 +48,8 @@ if (isset($var['id'])) {
 		'writer_id' => $db->escapeNumber($player->getAccountID()),
 		'title' => $db->escapeString($title),
 		'text' => $db->escapeString($message),
-		'last_modified' => $db->escapeNumber(Smr\Epoch::time()),
+		'last_modified' => $db->escapeNumber(Epoch::time()),
 	]);
-	$db->write('UPDATE galactic_post_writer SET last_wrote = ' . $db->escapeNumber(Smr\Epoch::time()) . ' WHERE account_id = ' . $db->escapeNumber($player->getAccountID()));
+	$db->write('UPDATE galactic_post_writer SET last_wrote = ' . $db->escapeNumber(Epoch::time()) . ' WHERE account_id = ' . $db->escapeNumber($player->getAccountID()));
 	Page::create('galactic_post_read.php')->go();
 }

--- a/src/engine/Default/game_join.php
+++ b/src/engine/Default/game_join.php
@@ -1,5 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Race;
+use Smr\RaceDetails;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -25,15 +30,15 @@ if ($game->hasEnded()) {
 }
 
 $races = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 foreach ($game->getPlayableRaceIDs() as $raceID) {
 	// get number of traders in game
 	$dbResult = $db->read('SELECT count(*) as number_of_race FROM player WHERE race_id = ' . $db->escapeNumber($raceID) . ' AND game_id = ' . $db->escapeNumber($var['game_id']));
 
 	$races[$raceID] = [
-		'Name' => Smr\Race::getName($raceID),
-		'ShortDescription' => Smr\RaceDetails::getShortDescription($raceID),
-		'LongDescription' => Smr\RaceDetails::getLongDescription($raceID),
+		'Name' => Race::getName($raceID),
+		'ShortDescription' => RaceDetails::getShortDescription($raceID),
+		'LongDescription' => RaceDetails::getLongDescription($raceID),
 		'NumberOfPlayers' => $dbResult->record()->getInt('number_of_race'),
 		'Selected' => false,
 	];
@@ -45,7 +50,7 @@ if (empty($races)) {
 $template->assign('PageTopic', 'Join Game: ' . $game->getDisplayName());
 $template->assign('Game', $game);
 
-if (Smr\Epoch::time() >= $game->getJoinTime()) {
+if (Epoch::time() >= $game->getJoinTime()) {
 	$container = Page::create('game_join_processing.php');
 	$container->addVar('game_id');
 	$template->assign('JoinGameFormHref', $container->href());

--- a/src/engine/Default/game_join_processing.php
+++ b/src/engine/Default/game_join_processing.php
@@ -1,17 +1,22 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\DisplayNameValidator;
+use Smr\Epoch;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
 
-$player_name = Smr\Request::get('player_name');
+$player_name = Request::get('player_name');
 
-Smr\DisplayNameValidator::validate($player_name);
+DisplayNameValidator::validate($player_name);
 
 $gameID = $var['game_id'];
 $game = SmrGame::getGame($gameID);
 
-$race_id = Smr\Request::getInt('race_id');
+$race_id = Request::getInt('race_id');
 if (!in_array($race_id, $game->getPlayableRaceIDs())) {
 	create_error('Please choose a race!');
 }
@@ -44,7 +49,7 @@ $player->giveStartingRelations();
 
 // The `player_visited_sector` table holds *unvisited* sectors, so that once
 // all sectors are visited (the majority of the game), the table is empty.
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('INSERT INTO player_visited_sector (account_id, game_id, sector_id)
             SELECT ' . $db->escapeNumber($account->getAccountID()) . ', game_id, sector_id
               FROM sector WHERE game_id = ' . $db->escapeNumber($gameID));
@@ -72,7 +77,7 @@ $player->getShip()->update();
 // Announce the player joining in the news
 $news = '[player=' . $player->getPlayerID() . '] has joined the game!';
 $db->insert('news', [
-	'time' => $db->escapeNumber(Smr\Epoch::time()),
+	'time' => $db->escapeNumber(Epoch::time()),
 	'news_message' => $db->escapeString($news),
 	'game_id' => $db->escapeNumber($gameID),
 	'type' => $db->escapeString('admin'),

--- a/src/engine/Default/game_play.php
+++ b/src/engine/Default/game_play.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -24,12 +27,12 @@ $template->assign('UserRankName', $account->getRank()->name);
 $games = [];
 $games['Play'] = [];
 $game_id_list = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT end_time, game_id, game_name, game_speed, game_type
 			FROM game JOIN player USING (game_id)
 			WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . '
 				AND enabled = \'TRUE\'
-				AND end_time >= ' . $db->escapeNumber(Smr\Epoch::time()) . '
+				AND end_time >= ' . $db->escapeNumber(Epoch::time()) . '
 			ORDER BY start_time, game_id DESC');
 foreach ($dbResult->records() as $dbRecord) {
 	$game_id = $dbRecord->getInt('game_id');
@@ -54,7 +57,7 @@ foreach ($dbResult->records() as $dbRecord) {
 
 	$result2 = $db->read('SELECT count(*) as num_playing
 					FROM player
-					WHERE last_cpl_action >= ' . $db->escapeNumber(Smr\Epoch::time() - TIME_BEFORE_INACTIVE) . '
+					WHERE last_cpl_action >= ' . $db->escapeNumber(Epoch::time() - TIME_BEFORE_INACTIVE) . '
 						AND game_id = ' . $db->escapeNumber($game_id));
 	$games['Play'][$game_id]['NumberPlaying'] = $result2->record()->getInt('num_playing');
 
@@ -64,7 +67,7 @@ foreach ($dbResult->records() as $dbRecord) {
 	$container_game['game_id'] = $game_id;
 	$games['Play'][$game_id]['GameStatsLink'] = $container_game->href();
 	$games['Play'][$game_id]['Turns'] = $curr_player->getTurns();
-	$games['Play'][$game_id]['LastMovement'] = format_time(Smr\Epoch::time() - $curr_player->getLastActive(), true);
+	$games['Play'][$game_id]['LastMovement'] = format_time(Epoch::time() - $curr_player->getLastActive(), true);
 
 }
 
@@ -81,13 +84,13 @@ if (count($game_id_list) > 0) {
 	$dbResult = $db->read('SELECT game_id
 				FROM game
 				WHERE game_id NOT IN (' . $db->escapeArray($game_id_list) . ')
-					AND end_time >= ' . $db->escapeNumber(Smr\Epoch::time()) . '
+					AND end_time >= ' . $db->escapeNumber(Epoch::time()) . '
 					AND enabled = ' . $db->escapeBoolean(true) . '
 				ORDER BY start_time DESC');
 } else {
 	$dbResult = $db->read('SELECT game_id
 				FROM game
-				WHERE end_time >= ' . $db->escapeNumber(Smr\Epoch::time()) . '
+				WHERE end_time >= ' . $db->escapeNumber(Epoch::time()) . '
 					AND enabled = ' . $db->escapeBoolean(true) . '
 				ORDER BY start_time DESC');
 }
@@ -122,7 +125,7 @@ $games['Previous'] = [];
 
 //New previous games
 $dbResult = $db->read('SELECT start_time, end_time, game_name, game_type, game_speed, game_id ' .
-		'FROM game WHERE enabled = \'TRUE\' AND end_time < ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY game_id DESC');
+		'FROM game WHERE enabled = \'TRUE\' AND end_time < ' . $db->escapeNumber(Epoch::time()) . ' ORDER BY game_id DESC');
 foreach ($dbResult->records() as $dbRecord) {
 	$game_id = $dbRecord->getInt('game_id');
 	$games['Previous'][$game_id]['ID'] = $game_id;
@@ -185,7 +188,7 @@ $template->assign('Games', $games);
 $container = Page::create('vote.php');
 $template->assign('VotingHref', $container->href());
 
-$dbResult = $db->read('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(Smr\Epoch::time()) . ' ORDER BY end DESC');
+$dbResult = $db->read('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(Epoch::time()) . ' ORDER BY end DESC');
 if ($dbResult->hasRecord()) {
 	$votedFor = [];
 	$dbResult2 = $db->read('SELECT * FROM voting_results WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
@@ -200,7 +203,7 @@ if ($dbResult->hasRecord()) {
 		$container['vote_id'] = $voteID;
 		$voting[$voteID]['HREF'] = $container->href();
 		$voting[$voteID]['Question'] = $dbRecord->getString('question');
-		$voting[$voteID]['TimeRemaining'] = format_time($dbRecord->getInt('end') - Smr\Epoch::time(), true);
+		$voting[$voteID]['TimeRemaining'] = format_time($dbRecord->getInt('end') - Epoch::time(), true);
 		$voting[$voteID]['Options'] = [];
 		$dbResult2 = $db->read('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = ' . $db->escapeNumber($dbRecord->getInt('vote_id')) . ' GROUP BY option_id');
 		foreach ($dbResult2->records() as $dbRecord2) {

--- a/src/engine/Default/game_play_processing.php
+++ b/src/engine/Default/game_play_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\SectorLock;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
@@ -10,7 +12,7 @@ $session->updateGame($var['game_id']);
 $player = SmrPlayer::getPlayer($account->getAccountID(), $var['game_id']);
 
 // skip var update in do_voodoo
-Smr\SectorLock::getInstance()->acquireForPlayer($player);
+SectorLock::getInstance()->acquireForPlayer($player);
 
 $player->updateLastCPLAction();
 

--- a/src/engine/Default/game_stats.php
+++ b/src/engine/Default/game_stats.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
 use Smr\Exceptions\PlayerNotFound;
 
 $template = Smr\Template::getInstance();
@@ -14,7 +15,7 @@ $template->assign('StatsGame', $statsGame);
 
 $template->assign('PageTopic', 'Game Stats: ' . $statsGame->getName() . ' (' . $gameID . ')');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT count(*) total_players, IFNULL(MAX(experience),0) max_exp, IFNULL(MAX(alignment),0) max_align, IFNULL(MIN(alignment),0) min_alignment, IFNULL(MAX(kills),0) max_kills FROM player WHERE game_id = ' . $gameID . ' ORDER BY experience DESC');
 if ($dbResult->hasRecord()) {
 	$dbRecord = $dbResult->record();

--- a/src/engine/Default/government.php
+++ b/src/engine/Default/government.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Bounties;
 use Smr\BountyType;
+use Smr\Race;
 
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
@@ -35,13 +37,13 @@ if ($raceID != RACE_NEUTRAL) {
 	$raceRelations = Globals::getRaceRelations($player->getGameID(), $raceID);
 	foreach ($raceRelations as $otherRaceID => $relation) {
 		if ($relation <= RELATIONS_WAR) {
-			$warRaces[] = Smr\Race::getName($otherRaceID);
+			$warRaces[] = Race::getName($otherRaceID);
 		}
 	}
 }
 $template->assign('WarRaces', $warRaces);
 
-$template->assign('AllBounties', Smr\Bounties::getMostWanted(BountyType::HQ));
+$template->assign('AllBounties', Bounties::getMostWanted(BountyType::HQ));
 $template->assign('MyBounties', $player->getClaimableBounties(BountyType::HQ));
 
 if ($player->hasNeutralAlignment()) {

--- a/src/engine/Default/hall_of_fame_new.php
+++ b/src/engine/Default/hall_of_fame_new.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\HallOfFame;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -20,7 +24,7 @@ if (isset($game_id)) {
 }
 $template->assign('PersonalHofHREF', $container->href());
 
-$breadcrumb = Smr\HallOfFame::buildBreadcrumb($var, isset($game_id) ? 'Current HoF' : 'Global HoF');
+$breadcrumb = HallOfFame::buildBreadcrumb($var, isset($game_id) ? 'Current HoF' : 'Global HoF');
 $template->assign('Breadcrumb', $breadcrumb);
 
 $viewType = $var['viewType'] ?? '';
@@ -29,13 +33,13 @@ $hofVis = SmrPlayer::getHOFVis();
 if (!isset($hofVis[$viewType])) {
 	// Not a complete HOF type, so continue to show categories
 	$allowedVis = [HOF_PUBLIC, HOF_ALLIANCE];
-	$categories = Smr\HallOfFame::getHofCategories($allowedVis, $game_id, $account->getAccountID());
+	$categories = HallOfFame::getHofCategories($allowedVis, $game_id, $account->getAccountID());
 	$template->assign('Categories', $categories);
 
 } else {
 	// Rankings page
-	$db = Smr\Database::getInstance();
-	$gameIDSql = ' AND game_id ' . (isset($game_id) ? '= ' . $db->escapeNumber($game_id) : 'IN (SELECT game_id FROM game WHERE end_time < ' . Smr\Epoch::time() . ' AND ignore_stats = ' . $db->escapeBoolean(false) . ')');
+	$db = Database::getInstance();
+	$gameIDSql = ' AND game_id ' . (isset($game_id) ? '= ' . $db->escapeNumber($game_id) : 'IN (SELECT game_id FROM game WHERE end_time < ' . Epoch::time() . ' AND ignore_stats = ' . $db->escapeBoolean(false) . ')');
 
 	$rank = 1;
 	$foundMe = false;
@@ -59,12 +63,12 @@ if (!isset($hofVis[$viewType])) {
 		if ($accountID == $account->getAccountID()) {
 			$foundMe = true;
 		}
-		$amount = Smr\HallOfFame::applyHofVisibilityMask($dbRecord->getFloat('amount'), $hofVis[$viewType], $game_id, $accountID);
-		$rows[] = Smr\HallOfFame::displayHOFRow($rank++, $accountID, $amount);
+		$amount = HallOfFame::applyHofVisibilityMask($dbRecord->getFloat('amount'), $hofVis[$viewType], $game_id, $accountID);
+		$rows[] = HallOfFame::displayHOFRow($rank++, $accountID, $amount);
 	}
 	if (!$foundMe) {
-		$rank = Smr\HallOfFame::getHofRank($viewType, $account->getAccountID(), $game_id);
-		$rows[] = Smr\HallOfFame::displayHOFRow($rank['Rank'], $account->getAccountID(), $rank['Amount']);
+		$rank = HallOfFame::getHofRank($viewType, $account->getAccountID(), $game_id);
+		$rows[] = HallOfFame::displayHOFRow($rank['Rank'], $account->getAccountID(), $rank['Amount']);
 	}
 	$template->assign('Rows', $rows);
 }

--- a/src/engine/Default/hall_of_fame_player_detail.php
+++ b/src/engine/Default/hall_of_fame_player_detail.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Exceptions\PlayerNotFound;
+use Smr\HallOfFame;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -12,7 +15,7 @@ $game_id = $var['game_id'] ?? null;
 if (isset($game_id)) {
 	try {
 		$hofPlayer = SmrPlayer::getPlayer($account_id, $game_id);
-	} catch (Smr\Exceptions\PlayerNotFound) {
+	} catch (PlayerNotFound) {
 		create_error('That player has not yet joined this game.');
 	}
 	$template->assign('PageTopic', htmlentities($hofPlayer->getPlayerName()) . '\'s Personal Hall of Fame: ' . SmrGame::getGame($game_id)->getDisplayName());
@@ -21,7 +24,7 @@ if (isset($game_id)) {
 	$template->assign('PageTopic', $hofName . '\'s All Time Personal Hall of Fame');
 }
 
-$breadcrumb = Smr\HallOfFame::buildBreadcrumb($var, 'Personal HoF');
+$breadcrumb = HallOfFame::buildBreadcrumb($var, 'Personal HoF');
 $template->assign('Breadcrumb', $breadcrumb);
 
 $viewType = $var['viewType'] ?? '';
@@ -36,18 +39,18 @@ if (!isset($hofVis[$viewType])) {
 	} elseif (isset($hofPlayer) && $hofPlayer->sameAlliance($player)) {
 		$allowedVis[] = HOF_ALLIANCE;
 	}
-	$categories = Smr\HallOfFame::getHofCategories($allowedVis, $game_id, $account_id);
+	$categories = HallOfFame::getHofCategories($allowedVis, $game_id, $account_id);
 	$template->assign('Categories', $categories);
 
 } else {
 	// Rankings page
-	$hofRank = Smr\HallOfFame::getHofRank($viewType, $account_id, $game_id);
-	$rows = [Smr\HallOfFame::displayHOFRow($hofRank['Rank'], $account_id, $hofRank['Amount'])];
+	$hofRank = HallOfFame::getHofRank($viewType, $account_id, $game_id);
+	$rows = [HallOfFame::displayHOFRow($hofRank['Rank'], $account_id, $hofRank['Amount'])];
 
 	if ($account->getAccountID() != $account_id) {
 		//current player's score.
-		$playerRank = Smr\HallOfFame::getHofRank($viewType, $account->getAccountID(), $game_id);
-		$row = Smr\HallOfFame::displayHOFRow($playerRank['Rank'], $account->getAccountID(), $playerRank['Amount']);
+		$playerRank = HallOfFame::getHofRank($viewType, $account->getAccountID(), $game_id);
+		$row = HallOfFame::displayHOFRow($playerRank['Rank'], $account->getAccountID(), $playerRank['Amount']);
 		if ($playerRank['Rank'] >= $hofRank['Rank']) {
 			$rows[] = $row;
 		} else {

--- a/src/engine/Default/history_alliance_detail.php
+++ b/src/engine/Default/history_alliance_detail.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Race;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -18,7 +21,7 @@ $template->assign('BackHREF', $container->href());
 $game_id = $var['view_game_id'];
 $id = $var['alliance_id'];
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->switchDatabases($var['HistoryDatabase']);
 $dbResult = $db->read('SELECT alliance_name, leader_id FROM alliance WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($game_id));
 $dbRecord = $dbResult->record();
@@ -37,7 +40,7 @@ foreach ($dbResult->records() as $dbRecord) {
 		'player_name' => htmlentities($dbRecord->getString('player_name')),
 		'experience' => $dbRecord->getInt('experience'),
 		'alignment' => $dbRecord->getInt('alignment'),
-		'race' => Smr\Race::getName($dbRecord->getInt('race')),
+		'race' => Race::getName($dbRecord->getInt('race')),
 		'kills' => $dbRecord->getInt('kills'),
 		'deaths' => $dbRecord->getInt('deaths'),
 		'bounty' => $dbRecord->getInt('bounty'),

--- a/src/engine/Default/history_games.php
+++ b/src/engine/Default/history_games.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -14,7 +16,7 @@ $game_id = $var['view_game_id'];
 $template->assign('PageTopic', 'Old SMR Game : ' . $game_name);
 Menu::historyGames(0);
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->switchDatabases($var['HistoryDatabase']);
 $dbResult = $db->read('SELECT start_date, type, end_date, game_name, speed, game_id ' .
 	'FROM game WHERE game_id = ' . $db->escapeNumber($game_id));

--- a/src/engine/Default/history_games_detail.php
+++ b/src/engine/Default/history_games_detail.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -20,7 +22,7 @@ $template->assign('SelfHREF', $container->href());
 $action = $session->getRequestVar('action', '');
 if (!empty($action)) {
 	$rankings = [];
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$db->switchDatabases($var['HistoryDatabase']);
 	if (in_array($action, ['Top Mined Sectors', 'Most Dangerous Sectors'], true)) {
 		[$sql, $header] = match ($action) {

--- a/src/engine/Default/history_games_hof.php
+++ b/src/engine/Default/history_games_hof.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 // NOTE: this is only for history database games
 
 $template = Smr\Template::getInstance();
@@ -7,7 +9,7 @@ $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->switchDatabases($var['HistoryDatabase']);
 
 $template->assign('PageTopic', 'Hall of Fame : ' . $var['game_name']);

--- a/src/engine/Default/history_games_news.php
+++ b/src/engine/Default/history_games_news.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -8,14 +11,14 @@ $account = $session->getAccount();
 $template->assign('PageTopic', 'Game News : ' . $var['game_name']);
 Menu::historyGames(3);
 
-$min = Smr\Request::getInt('min', 1);
-$max = Smr\Request::getInt('max', 50);
+$min = Request::getInt('min', 1);
+$max = Request::getInt('max', 50);
 $template->assign('Max', $max);
 $template->assign('Min', $min);
 
 $template->assign('ShowHREF', Page::copy($var)->href());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->switchDatabases($var['HistoryDatabase']);
 $dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($var['view_game_id']) . ' AND news_id >= ' . $db->escapeNumber($min) . ' AND news_id <= ' . $db->escapeNumber($max));
 $rows = [];

--- a/src/engine/Default/invalid_email_processing.php
+++ b/src/engine/Default/invalid_email_processing.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
-if (Smr\Request::get('action') == 'Resend Validation Code') {
+if (Request::get('action') == 'Resend Validation Code') {
 	$account->changeEmail($account->getEmail());
 } else {
-	$account->changeEmail(Smr\Request::get('email'));
+	$account->changeEmail(Request::get('email'));
 }
 $account->update();
 Page::create('validate.php')->go();

--- a/src/engine/Default/leave_newbie_processing.php
+++ b/src/engine/Default/leave_newbie_processing.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 if ($action == 'Yes!') {
 	$player->setNewbieTurns(0);
 	$player->setNewbieWarning(false);

--- a/src/engine/Default/login_check_processing.php
+++ b/src/engine/Default/login_check_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
@@ -15,7 +17,7 @@ if (!isset($var['CheckType']) || $var['CheckType'] == 'Validate') {
 
 $lastLogin = $account->getLastLogin();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 if ($var['CheckType'] == 'Announcements') {
 	$dbResult = $db->read('SELECT 1 FROM announcement WHERE time >= ' . $db->escapeNumber($lastLogin) . ' LIMIT 1');
 	// do we have announcements?

--- a/src/engine/Default/logoff.php
+++ b/src/engine/Default/logoff.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\SectorLock;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
 $account->log(LOG_TYPE_LOGIN, 'logged off from ' . getIpAddress());
 
 // Remove the lock if we're holding one (ie logged off from game screen)
-Smr\SectorLock::getInstance()->release();
+SectorLock::getInstance()->release();
 $session->destroy();
 
 // Send the player back to the login screen

--- a/src/engine/Default/map_local.php
+++ b/src/engine/Default/map_local.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -17,9 +19,9 @@ if (!session_start(['gc_probability' => 0, 'gc_maxlifetime' => 86400])) {
 
 // Set temporary options
 if ($player->hasAlliance()) {
-	if (Smr\Request::has('change_settings')) {
-		$_SESSION['show_seedlist_sectors'] = Smr\Request::has('show_seedlist_sectors');
-		$_SESSION['hide_allied_forces'] = Smr\Request::has('hide_allied_forces');
+	if (Request::has('change_settings')) {
+		$_SESSION['show_seedlist_sectors'] = Request::has('show_seedlist_sectors');
+		$_SESSION['hide_allied_forces'] = Request::has('hide_allied_forces');
 	}
 	$showSeedlistSectors = $_SESSION['show_seedlist_sectors'] ?? false;
 	$hideAlliedForces = $_SESSION['hide_allied_forces'] ?? false;

--- a/src/engine/Default/message_blacklist.php
+++ b/src/engine/Default/message_blacklist.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -13,7 +15,7 @@ if (isset($var['msg'])) {
 	$template->assign('Message', $var['msg']);
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT p.player_name, p.game_id, b.entry_id FROM player p JOIN message_blacklist b ON p.account_id = b.blacklisted_id AND b.game_id = p.game_id WHERE b.account_id=' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY p.game_id, p.player_name');
 
 $blacklist = [];

--- a/src/engine/Default/message_blacklist_add.php
+++ b/src/engine/Default/message_blacklist_add.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Exceptions\PlayerNotFound;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -10,14 +14,14 @@ if (isset($var['account_id'])) {
 	$blacklisted = SmrPlayer::getPlayer($var['account_id'], $player->getGameID());
 } else {
 	try {
-		$blacklisted = SmrPlayer::getPlayerByPlayerName(Smr\Request::get('PlayerName'), $player->getGameID());
-	} catch (Smr\Exceptions\PlayerNotFound) {
+		$blacklisted = SmrPlayer::getPlayerByPlayerName(Request::get('PlayerName'), $player->getGameID());
+	} catch (PlayerNotFound) {
 		$container['msg'] = '<span class="red bold">ERROR: </span>Player does not exist.';
 		$container->go();
 	}
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT 1 FROM message_blacklist WHERE ' . $player->getSQL() . ' AND blacklisted_id=' . $db->escapeNumber($blacklisted->getAccountID()) . ' LIMIT 1');
 
 if ($dbResult->hasRecord()) {

--- a/src/engine/Default/message_blacklist_del.php
+++ b/src/engine/Default/message_blacklist_del.php
@@ -1,16 +1,19 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 $container = Page::create('message_blacklist.php');
 
-$entry_ids = Smr\Request::getIntArray('entry_ids', []);
+$entry_ids = Request::getIntArray('entry_ids', []);
 if (empty($entry_ids)) {
 	$container['msg'] = '<span class="red bold">ERROR: </span>No entries selected for deletion.';
 	$container->go();
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('DELETE FROM message_blacklist WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND entry_id IN (' . $db->escapeArray($entry_ids) . ')');
 $container->go();

--- a/src/engine/Default/message_box.php
+++ b/src/engine/Default/message_box.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Messages;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
@@ -10,7 +13,7 @@ Menu::messages();
 $template->assign('PageTopic', 'View Messages');
 
 $messageBoxes = [];
-foreach (Smr\Messages::getMessageTypeNames() as $message_type_id => $message_type_name) {
+foreach (Messages::getMessageTypeNames() as $message_type_id => $message_type_name) {
 	$messageBox = [];
 	$messageBox['Name'] = $message_type_name;
 

--- a/src/engine/Default/message_box_delete_processing.php
+++ b/src/engine/Default/message_box_delete_processing.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();

--- a/src/engine/Default/message_delete_processing.php
+++ b/src/engine/Default/message_delete_processing.php
@@ -1,23 +1,26 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 
 // If not deleting marked messages, we are deleting entire folders
-if (Smr\Request::get('action') == 'All Messages') {
+if (Request::get('action') == 'All Messages') {
 	$container = Page::create('message_box_delete_processing.php');
 	$container->addVar('folder_id');
 	$container->go();
 }
 
-if (!Smr\Request::has('message_id') && !Smr\Request::has('group_id')) {
+if (!Request::has('message_id') && !Request::has('group_id')) {
 	create_error('You must choose the messages you want to delete.');
 }
 
 // Delete any individually selected messages
-$message_id_list = Smr\Request::getIntArray('message_id', []);
+$message_id_list = Request::getIntArray('message_id', []);
 if (!empty($message_id_list)) {
 	if ($var['folder_id'] == MSG_SENT) {
 		$db->write('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . ' WHERE message_id IN (' . $db->escapeArray($message_id_list) . ')');
@@ -27,7 +30,7 @@ if (!empty($message_id_list)) {
 }
 
 // Delete any scout message groups
-foreach (Smr\Request::getArray('group_id', []) as $groupID) {
+foreach (Request::getArray('group_id', []) as $groupID) {
 	[$senderID, $minTime, $maxTime] = unserialize(base64_decode($groupID));
 	$db->write('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . '
 				WHERE sender_id = ' . $db->escapeNumber($senderID) . '

--- a/src/engine/Default/message_notify_confirm.php
+++ b/src/engine/Default/message_notify_confirm.php
@@ -1,11 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
 if (!isset($var['notified_time'])) {
-	$var['notified_time'] = Smr\Epoch::time();
+	$var['notified_time'] = Epoch::time();
 }
 
 if (empty($var['message_id'])) {
@@ -13,7 +16,7 @@ if (empty($var['message_id'])) {
 }
 
 // get message form db
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT message_text
 			FROM message
 			WHERE message_id = ' . $db->escapeNumber($var['message_id']));

--- a/src/engine/Default/message_notify_processing.php
+++ b/src/engine/Default/message_notify_processing.php
@@ -1,11 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 $container = Page::create('message_view.php');
 $container->addVar('folder_id');
 
-if (Smr\Request::get('action') == 'No') {
+if (Request::get('action') == 'No') {
 	$container->go();
 }
 
@@ -17,7 +20,7 @@ $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 // get next id
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT IFNULL(max(notify_id)+1, 0) as next_notify_id FROM message_notify WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY notify_id DESC');
 $notify_id = $dbResult->record()->getInt('next_notify_id');
 

--- a/src/engine/Default/message_preference_processing.php
+++ b/src/engine/Default/message_preference_processing.php
@@ -1,14 +1,15 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
 use Smr\ScoutMessageGroupType;
 
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-if (Smr\Request::has('ignore_globals')) {
-	$player->setIgnoreGlobals(Smr\Request::get('ignore_globals') == 'Yes');
-} elseif (Smr\Request::has('group_scouts')) {
-	$groupType = ScoutMessageGroupType::from(Smr\Request::get('group_scouts'));
+if (Request::has('ignore_globals')) {
+	$player->setIgnoreGlobals(Request::get('ignore_globals') == 'Yes');
+} elseif (Request::has('group_scouts')) {
+	$groupType = ScoutMessageGroupType::from(Request::get('group_scouts'));
 	$player->setScoutMessageGroupType($groupType);
 }
 

--- a/src/engine/Default/message_send_processing.php
+++ b/src/engine/Default/message_send_processing.php
@@ -1,12 +1,15 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 
-$message = htmlentities(Smr\Request::get('message'), ENT_COMPAT, 'utf-8');
+$message = htmlentities(Request::get('message'), ENT_COMPAT, 'utf-8');
 
-if (Smr\Request::get('action') == 'Preview message') {
+if (Request::get('action') == 'Preview message') {
 	if (isset($var['alliance_id'])) {
 		$container = Page::create('alliance_broadcast.php');
 		$container->addVar('alliance_id');
@@ -25,7 +28,7 @@ if (empty($message)) {
 }
 
 if (isset($var['alliance_id'])) {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT account_id FROM player
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 				AND alliance_id = ' . $var['alliance_id'] . '

--- a/src/engine/Default/news_read.php
+++ b/src/engine/Default/news_read.php
@@ -1,13 +1,17 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\News;
+use Smr\Request;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
 $gameID = $var['GameID'] ?? $session->getPlayer()->getGameID();
 
-$min_news = Smr\Request::getInt('min_news', 1);
-$max_news = Smr\Request::getInt('max_news', 50);
+$min_news = Request::getInt('min_news', 1);
+$max_news = Request::getInt('max_news', 50);
 if ($min_news > $max_news) {
 	create_error('The first number must be lower than the second number!');
 }
@@ -18,11 +22,11 @@ $template->assign('PageTopic', 'Reading The News');
 
 Menu::news($gameID);
 
-Smr\News::doBreakingNewsAssign($gameID);
-Smr\News::doLottoNewsAssign($gameID);
+News::doBreakingNewsAssign($gameID);
+News::doLottoNewsAssign($gameID);
 
 $template->assign('ViewNewsFormHref', Page::create('news_read.php', ['GameID' => $gameID])->href());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type != \'lotto\' ORDER BY news_id DESC LIMIT ' . ($min_news - 1) . ', ' . ($max_news - $min_news + 1));
-$template->assign('NewsItems', Smr\News::getNewsItems($dbResult));
+$template->assign('NewsItems', News::getNewsItems($dbResult));

--- a/src/engine/Default/news_read_advanced.php
+++ b/src/engine/Default/news_read_advanced.php
@@ -1,12 +1,15 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\News;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
 $gameID = $var['GameID'] ?? $session->getPlayer()->getGameID();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT alliance_id, alliance_name
 			FROM alliance
 			WHERE game_id = ' . $db->escapeNumber($gameID));
@@ -65,7 +68,7 @@ if ($submit_value == 'Search For Player') {
 	$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY news_id DESC LIMIT 50');
 }
 
-$template->assign('NewsItems', Smr\News::getNewsItems($dbResult));
+$template->assign('NewsItems', News::getNewsItems($dbResult));
 
 $template->assign('PageTopic', 'Advanced News');
 Menu::news($gameID);

--- a/src/engine/Default/news_read_current.php
+++ b/src/engine/Default/news_read_current.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\News;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -10,15 +13,15 @@ $gameID = $var['GameID'] ?? $player->getGameID();
 $template->assign('PageTopic', 'Current News');
 Menu::news($gameID);
 
-Smr\News::doBreakingNewsAssign($gameID);
-Smr\News::doLottoNewsAssign($gameID);
+News::doBreakingNewsAssign($gameID);
+News::doLottoNewsAssign($gameID);
 
 if (!isset($var['LastNewsUpdate'])) {
 	$var['LastNewsUpdate'] = $player->getLastNewsUpdate();
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND time > ' . $db->escapeNumber($var['LastNewsUpdate']) . ' AND type != \'lotto\' ORDER BY news_id DESC');
-$template->assign('NewsItems', Smr\News::getNewsItems($dbResult));
+$template->assign('NewsItems', News::getNewsItems($dbResult));
 
 $player->updateLastNewsUpdate();

--- a/src/engine/Default/note_add_processing.php
+++ b/src/engine/Default/note_add_processing.php
@@ -1,17 +1,20 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
 // Adds a new note into the database
-$note = Smr\Request::get('note');
+$note = Request::get('note');
 if (strlen($note) > 1000) {
 	create_error('Note cannot be longer than 1000 characters.');
 }
 
 $note = htmlentities($note, ENT_QUOTES, 'utf-8');
 $note = nl2br($note);
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->insert('player_has_notes', [
 	'account_id' => $db->escapeNumber($player->getAccountID()),
 	'game_id' => $db->escapeNumber($player->getGameID()),

--- a/src/engine/Default/note_delete_processing.php
+++ b/src/engine/Default/note_delete_processing.php
@@ -1,11 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$note_ids = Smr\Request::getIntArray('note_id', []);
+$note_ids = Request::getIntArray('note_id', []);
 if (!empty($note_ids)) {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$db->write('DELETE FROM player_has_notes WHERE game_id=' . $db->escapeNumber($player->getGameID()) . '
 					AND account_id=' . $db->escapeNumber($player->getAccountID()) . '
 					AND note_id IN (' . $db->escapeArray($note_ids) . ')');

--- a/src/engine/Default/planet_attack_processing.php
+++ b/src/engine/Default/planet_attack_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\SectorLock;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 $player = $session->getPlayer();
@@ -80,12 +84,12 @@ $results['Planet'] = $planet->shootPlayers($attackers);
 $account->log(LOG_TYPE_PLANET_BUSTING, 'Player attacks planet, the planet does ' . $results['Planet']['TotalDamage'] . ', their team does ' . $results['Attackers']['TotalDamage'] . ' and downgrades: ' . var_export($results['Attackers']['Downgrades'], true), $planet->getSectorID());
 
 // Add this log to the `combat_logs` database table
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $logId = $db->insert('combat_logs', [
 	'game_id' => $db->escapeNumber($player->getGameID()),
 	'type' => $db->escapeString('PLANET'),
 	'sector_id' => $db->escapeNumber($planet->getSectorID()),
-	'timestamp' => $db->escapeNumber(Smr\Epoch::time()),
+	'timestamp' => $db->escapeNumber(Epoch::time()),
 	'attacker_id' => $db->escapeNumber($player->getAccountID()),
 	'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
 	'defender_id' => $db->escapeNumber($planetOwner->getAccountID()),
@@ -128,7 +132,7 @@ foreach ($attackers as $attacker) {
 if ($player->isDead()) {
 	saveAllAndReleaseLock(updateSession: false);
 	// Grab the lock in the new sector to avoid reloading session
-	Smr\SectorLock::getInstance()->acquireForPlayer($player);
+	SectorLock::getInstance()->acquireForPlayer($player);
 }
 
 // If they died on the shot they get to see the results

--- a/src/engine/Default/planet_defense_processing.php
+++ b/src/engine/Default/planet_defense_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -9,7 +11,7 @@ if (!$player->isLandedOnPlanet()) {
 	create_error('You are not on a planet!');
 }
 
-$amount = Smr\Request::getInt('amount');
+$amount = Request::getInt('amount');
 if ($amount <= 0) {
 	create_error('You must actually enter an amount > 0!');
 }
@@ -20,7 +22,7 @@ if ($player->getNewbieTurns() > 0) {
 $planet = $player->getSectorPlanet();
 
 $type_id = $var['type_id'];
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 // transfer to ship
 if ($action == 'Ship') {
 	if ($type_id == HARDWARE_SHIELDS) {

--- a/src/engine/Default/planet_defense_weapon_processing.php
+++ b/src/engine/Default/planet_defense_weapon_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
@@ -9,30 +11,30 @@ if (!$player->isLandedOnPlanet()) {
 
 $planet = $player->getSectorPlanet();
 
-if (Smr\Request::has('transfer')) {
-	$planetOrderID = Smr\Request::getInt('transfer');
+if (Request::has('transfer')) {
+	$planetOrderID = Request::getInt('transfer');
 	if ($planet->hasMountedWeapon($planetOrderID)) {
 		create_error('The planet already has a weapon mounted there!');
 	}
 	// transfer weapon to planet
-	if (!Smr\Request::has('ship_order' . $planetOrderID)) {
+	if (!Request::has('ship_order' . $planetOrderID)) {
 		create_error('You must select a weapon to transfer!');
 	}
-	$shipOrderID = Smr\Request::getInt('ship_order' . $planetOrderID);
+	$shipOrderID = Request::getInt('ship_order' . $planetOrderID);
 	$ship = $player->getShip();
 	$weapon = $ship->getWeapons()[$shipOrderID];
 	$planet->addMountedWeapon($weapon, $planetOrderID);
 	$ship->removeWeapon($shipOrderID);
-} elseif (Smr\Request::has('destroy')) {
+} elseif (Request::has('destroy')) {
 	// Destroy the weapon on the planet (but only if all mounts are filled)
 	if (count($planet->getMountedWeapons()) != $planet->getMaxMountedWeapons()) {
 		create_error('You can only destroy a mounted weapon once all mounts are filled!');
 	}
-	$planet->removeMountedWeapon(Smr\Request::getInt('destroy'));
-} elseif (Smr\Request::has('move_up')) {
-	$planet->moveMountedWeaponUp(Smr\Request::getInt('move_up'));
-} elseif (Smr\Request::has('move_down')) {
-	$planet->moveMountedWeaponDown(Smr\Request::getInt('move_down'));
+	$planet->removeMountedWeapon(Request::getInt('destroy'));
+} elseif (Request::has('move_up')) {
+	$planet->moveMountedWeaponUp(Request::getInt('move_up'));
+} elseif (Request::has('move_down')) {
+	$planet->moveMountedWeaponDown(Request::getInt('move_down'));
 }
 
 Page::create('planet_defense.php')->go();

--- a/src/engine/Default/planet_examine.php
+++ b/src/engine/Default/planet_examine.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -20,7 +22,7 @@ if (!$planetLand) {
 	if ($planet->hasOwner()) {
 		$ownerAllianceID = $planet->getOwner()->getAllianceID();
 	}
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('
 		SELECT 1
 		FROM alliance_treaties

--- a/src/engine/Default/planet_financial_processing.php
+++ b/src/engine/Default/planet_financial_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
@@ -7,11 +9,11 @@ if (!$player->isLandedOnPlanet()) {
 	create_error('You are not on a planet!');
 }
 $planet = $player->getSectorPlanet();
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 
 if ($action == 'Deposit' || $action == 'Withdraw') {
 	// Player has requested a planetary fund transaction
-	$amount = Smr\Request::getInt('amount');
+	$amount = Request::getInt('amount');
 	if ($amount <= 0) {
 		create_error('You must actually enter an amount > 0!');
 	}

--- a/src/engine/Default/planet_land_processing.php
+++ b/src/engine/Default/planet_land_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 $player = $session->getPlayer();
@@ -26,7 +28,7 @@ if ($planet->getMaxLanded() != 0 && $planet->getMaxLanded() <= $planet->countPla
 
 if ($player->hasAlliance()) {
 	$role_id = $player->getAllianceRole();
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
 	if (!$dbResult->record()->getBoolean('planet_access')) {
 		if ($planet->hasOwner() && $planet->getOwnerID() != $player->getAccountID()) {

--- a/src/engine/Default/planet_list.php
+++ b/src/engine/Default/planet_list.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\PlanetList;
+
 $var = Smr\Session::getInstance()->getCurrentVar();
 
 Menu::planetList($var['alliance_id'], 0);
 
-Smr\PlanetList::common($var['alliance_id'], true);
+PlanetList::common($var['alliance_id'], true);

--- a/src/engine/Default/planet_list_financial.php
+++ b/src/engine/Default/planet_list_financial.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\PlanetList;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -12,7 +15,7 @@ Menu::planetList($var['alliance_id'], 1);
 $viewBonds = true;
 if ($var['alliance_id'] != 0) {
 	$role_id = $player->getAllianceRole($var['alliance_id']);
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('
 		SELECT 1
 		FROM alliance_has_roles
@@ -24,4 +27,4 @@ if ($var['alliance_id'] != 0) {
 }
 $template->assign('CanViewBonds', $viewBonds);
 
-Smr\PlanetList::common($var['alliance_id'], $viewBonds);
+PlanetList::common($var['alliance_id'], $viewBonds);

--- a/src/engine/Default/planet_main.php
+++ b/src/engine/Default/planet_main.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 require_once(LIB . 'Default/planet.inc.php');
 planet_common();
 
@@ -17,7 +19,7 @@ if (isset($var['msg'])) {
 	$template->assign('Msg', bbifyMessage($var['msg']));
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 doTickerAssigns($template, $player, $db);
 
 $template->assign('LaunchLink', Page::create('planet_launch_processing.php')->href());

--- a/src/engine/Default/planet_ownership_processing.php
+++ b/src/engine/Default/planet_ownership_processing.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
@@ -8,15 +11,15 @@ if (!$player->isLandedOnPlanet()) {
 }
 // get a planet from the sector where the player is in
 $planet = $player->getSectorPlanet();
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 
 if ($action == 'Take Ownership') {
-	if ($planet->hasOwner() && $planet->getPassword() != Smr\Request::get('password')) {
+	if ($planet->hasOwner() && $planet->getPassword() != Request::get('password')) {
 		create_error('You entered an incorrect password for this planet!');
 	}
 
 	// delete all previous ownerships
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$db->write('UPDATE planet SET owner_id = 0, password = NULL
 				WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . '
 				AND game_id = ' . $db->escapeNumber($player->getGameID()));
@@ -26,7 +29,7 @@ if ($action == 'Take Ownership') {
 	$planet->removePassword();
 	$player->log(LOG_TYPE_PLANETS, 'Player takes ownership of planet.');
 } elseif ($action == 'Rename') {
-	$name = Smr\Request::get('name');
+	$name = Request::get('name');
 	if (empty($name)) {
 		create_error('You cannot leave your planet nameless!');
 	}
@@ -36,7 +39,7 @@ if ($action == 'Take Ownership') {
 
 } elseif ($action == 'Set Password') {
 	// set password
-	$password = Smr\Request::get('password');
+	$password = Request::get('password');
 	$planet->setPassword($password);
 	$player->log(LOG_TYPE_PLANETS, 'Player sets planet password to ' . $password);
 }

--- a/src/engine/Default/planet_stockpile_processing.php
+++ b/src/engine/Default/planet_stockpile_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -9,7 +11,7 @@ if (!$player->isLandedOnPlanet()) {
 	create_error('You are not on a planet!');
 }
 
-$amount = Smr\Request::getInt('amount');
+$amount = Request::getInt('amount');
 if ($amount <= 0) {
 	create_error('You must actually enter an amount > 0!');
 }
@@ -19,7 +21,7 @@ $goodID = $var['good_id'];
 
 // get a planet from the sector where the player is in
 $planet = $player->getSectorPlanet();
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 if ($action == 'Ship') {
 	// transfer to ship
 

--- a/src/engine/Default/port_attack_processing.php
+++ b/src/engine/Default/port_attack_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\SectorLock;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 $player = $session->getPlayer();
@@ -77,12 +81,12 @@ $account->log(LOG_TYPE_PORT_RAIDING, 'Player attacks port, the port does ' . $re
 
 $port->update();
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $logId = $db->insert('combat_logs', [
 	'game_id' => $db->escapeNumber($player->getGameID()),
 	'type' => $db->escapeString('PORT'),
 	'sector_id' => $db->escapeNumber($port->getSectorID()),
-	'timestamp' => $db->escapeNumber(Smr\Epoch::time()),
+	'timestamp' => $db->escapeNumber(Epoch::time()),
 	'attacker_id' => $db->escapeNumber($player->getAccountID()),
 	'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
 	'defender_id' => $db->escapeNumber(ACCOUNT_ID_PORT),
@@ -105,7 +109,7 @@ foreach ($attackers as $attacker) {
 if ($player->isDead()) {
 	saveAllAndReleaseLock(updateSession: false);
 	// Grab the lock in the new sector to avoid reloading session
-	Smr\SectorLock::getInstance()->acquireForPlayer($player);
+	SectorLock::getInstance()->acquireForPlayer($player);
 }
 
 // If they died on the shot they get to see the results

--- a/src/engine/Default/port_loot_processing.php
+++ b/src/engine/Default/port_loot_processing.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 $ship = $player->getShip();
 
 $good_id = $var['GoodID'];
-$amount = Smr\Request::getInt('amount');
+$amount = Request::getInt('amount');
 if ($amount <= 0) {
 	create_error('You must enter an amount > 0!');
 }

--- a/src/engine/Default/preferences.php
+++ b/src/engine/Default/preferences.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -16,7 +18,7 @@ $template->assign('PreferencesConfirmFormHREF', Page::create('preferences_confir
 $template->assign('ChatSharingHREF', Page::create('chat_sharing.php')->href());
 
 $transferAccounts = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT account_id,hof_name FROM account WHERE validated = ' . $db->escapeBoolean(true) . ' ORDER BY hof_name');
 foreach ($dbResult->records() as $dbRecord) {
 	$transferAccounts[$dbRecord->getInt('account_id')] = htmlspecialchars($dbRecord->getString('hof_name'));

--- a/src/engine/Default/preferences_account_processing.php
+++ b/src/engine/Default/preferences_account_processing.php
@@ -1,6 +1,11 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\DisplayNameValidator;
+use Smr\Exceptions\AccountNotFound;
+use Smr\Request;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
@@ -9,10 +14,10 @@ if ($session->hasGame()) {
 } else {
 	$container = Page::create('game_play.php');
 }
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 
 if ($action == 'Save and resend validation code') {
-	$email = Smr\Request::get('email');
+	$email = Request::get('email');
 
 	$account->changeEmail($email);
 
@@ -21,9 +26,9 @@ if ($action == 'Save and resend validation code') {
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your email address, you will now need to revalidate with the code sent to the new email address.';
 
 } elseif ($action == 'Change Password') {
-	$new_password = Smr\Request::get('new_password');
-	$old_password = Smr\Request::get('old_password');
-	$retype_password = Smr\Request::get('retype_password');
+	$new_password = Request::get('new_password');
+	$old_password = Request::get('old_password');
+	$retype_password = Request::get('retype_password');
 
 	if (empty($new_password)) {
 		create_error('You must enter a non empty password!');
@@ -45,9 +50,9 @@ if ($action == 'Save and resend validation code') {
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your password.';
 
 } elseif ($action == 'Change Name') {
-	$HoF_name = Smr\Request::get('HoF_name');
+	$HoF_name = Request::get('HoF_name');
 
-	Smr\DisplayNameValidator::validate($HoF_name);
+	DisplayNameValidator::validate($HoF_name);
 
 	//no duplicates
 	try {
@@ -55,7 +60,7 @@ if ($action == 'Save and resend validation code') {
 		if (!$account->equals($other)) {
 			create_error('Someone is already using that Hall of Fame name!');
 		}
-	} catch (Smr\Exceptions\AccountNotFound) {
+	} catch (AccountNotFound) {
 		// Proceed, this Hall of Fame name is not in use
 	}
 
@@ -64,7 +69,7 @@ if ($action == 'Save and resend validation code') {
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your Hall of Fame name.';
 
 } elseif ($action == 'Change Discord ID') {
-	$discordId = Smr\Request::get('discord_id');
+	$discordId = Request::get('discord_id');
 
 	if (empty($discordId)) {
 		$account->setDiscordId(null);
@@ -76,7 +81,7 @@ if ($action == 'Save and resend validation code') {
 			if (!$account->equals($other)) {
 				create_error('Someone is already using that Discord User ID!');
 			}
-		} catch (Smr\Exceptions\AccountNotFound) {
+		} catch (AccountNotFound) {
 			// Proceed, this Discord ID is not in use
 		}
 
@@ -85,7 +90,7 @@ if ($action == 'Save and resend validation code') {
 	}
 
 } elseif ($action == 'Change IRC Nick') {
-	$ircNick = Smr\Request::get('irc_nick');
+	$ircNick = Request::get('irc_nick');
 
 	// here you can delete your registered irc nick
 	if (empty($ircNick)) {
@@ -103,7 +108,7 @@ if ($action == 'Save and resend validation code') {
 			if (!$account->equals($other)) {
 				create_error('Someone is already using that IRC nick!');
 			}
-		} catch (Smr\Exceptions\AccountNotFound) {
+		} catch (AccountNotFound) {
 			// Proceed, this IRC nick is not in use
 		}
 
@@ -128,26 +133,26 @@ if ($action == 'Save and resend validation code') {
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have sent SMR credits.';
 
 } elseif ($action == 'Change Timezone') {
-	$timez = Smr\Request::getInt('timez');
+	$timez = Request::getInt('timez');
 
 	$db->write('UPDATE account SET offset = ' . $db->escapeNumber($timez) . ' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your time offset.';
 
 } elseif ($action == 'Change Date Formats') {
-	$account->setDateFormat(Smr\Request::get('dateformat'));
-	$account->setTimeFormat(Smr\Request::get('timeformat'));
+	$account->setDateFormat(Request::get('dateformat'));
+	$account->setTimeFormat(Request::get('timeformat'));
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your date formats.';
 
 } elseif ($action == 'Change Images') {
-	$account->setDisplayShipImages(Smr\Request::get('images') == 'Yes');
+	$account->setDisplayShipImages(Request::get('images') == 'Yes');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your ship images preferences.';
 
 } elseif ($action == 'Change Centering') {
-	$account->setCenterGalaxyMapOnPlayer(Smr\Request::get('centergalmap') == 'Yes');
+	$account->setCenterGalaxyMapOnPlayer(Request::get('centergalmap') == 'Yes');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your centering galaxy map preferences.';
 
 } elseif ($action == 'Change Size') {
-	$fontsize = Smr\Request::getInt('fontsize');
+	$fontsize = Request::getInt('fontsize');
 	if ($fontsize < 50) {
 		create_error('Minimum font size is 50%');
 	}
@@ -155,8 +160,8 @@ if ($action == 'Save and resend validation code') {
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your font size.';
 
 } elseif ($action == 'Change CSS Options') {
-	$account->setCssLink(Smr\Request::get('csslink'));
-	$cssTemplateAndColor = Smr\Request::get('template');
+	$account->setCssLink(Request::get('csslink'));
+	$cssTemplateAndColor = Request::get('template');
 	if ($cssTemplateAndColor == 'None') {
 		$account->setDefaultCSSEnabled(false);
 	} else {
@@ -169,14 +174,14 @@ if ($action == 'Save and resend validation code') {
 
 } elseif ($action == 'Save Hotkeys') {
 	foreach (SmrAccount::getDefaultHotkeys() as $hotkey => $binding) {
-		$account->setHotkey($hotkey, explode(' ', Smr\Request::get($hotkey)));
+		$account->setHotkey($hotkey, explode(' ', Request::get($hotkey)));
 	}
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have saved your hotkeys.';
 
 } elseif ($action == 'Update Colours') {
-	$friendlyColour = Smr\Request::get('friendly_color');
-	$neutralColour = Smr\Request::get('neutral_color');
-	$enemyColour = Smr\Request::get('enemy_color');
+	$friendlyColour = Request::get('friendly_color');
+	$neutralColour = Request::get('neutral_color');
+	$enemyColour = Request::get('enemy_color');
 
 	if (strlen($friendlyColour) == 6) {
 		$account->setFriendlyColour($friendlyColour);

--- a/src/engine/Default/preferences_player_processing.php
+++ b/src/engine/Default/preferences_player_processing.php
@@ -1,25 +1,30 @@
 <?php declare(strict_types=1);
 
-$db = Smr\Database::getInstance();
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+use Smr\SectorLock;
+
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 $player = $session->getPlayer();
 
 $container = Page::create('current_sector.php');
 
-$action = Smr\Request::get('action');
+$action = Request::get('action');
 
 if ($action == 'Change Kamikaze Setting') {
-	$player->setCombatDronesKamikazeOnMines(Smr\Request::get('kamikaze') == 'Yes');
+	$player->setCombatDronesKamikazeOnMines(Request::get('kamikaze') == 'Yes');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your combat drones options.';
 
 } elseif ($action == 'Change Message Setting') {
-	$player->setForceDropMessages(Smr\Request::get('forceDropMessages') == 'Yes');
+	$player->setForceDropMessages(Request::get('forceDropMessages') == 'Yes');
 	$container['msg'] = '<span class="green">SUCCESS: </span>You have changed your message options.';
 
 } elseif ($action == 'change_name') {
 	$old_name = $player->getDisplayName();
-	$player_name = Smr\Request::get('PlayerName');
+	$player_name = Request::get('PlayerName');
 
 	// Check that the player can afford the name change
 	$smrCreditCost = $player->isNameChanged() ? CREDITS_PER_NAME_CHANGE : 0;
@@ -32,7 +37,7 @@ if ($action == 'Change Kamikaze Setting') {
 
 	$news = 'Please be advised that ' . $old_name . ' has changed their name to ' . $player->getBBLink();
 	$db->insert('news', [
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 		'news_message' => $db->escapeString($news),
 		'game_id' => $db->escapeNumber($player->getGameID()),
 		'type' => $db->escapeString('admin'),
@@ -44,7 +49,7 @@ if ($action == 'Change Kamikaze Setting') {
 	if (!$player->canChangeRace()) {
 		throw new Exception('Player is not allowed to change their race!');
 	}
-	$newRaceID = Smr\Request::getInt('race_id');
+	$newRaceID = Request::getInt('race_id');
 	if (!in_array($newRaceID, $player->getGame()->getPlayableRaceIDs())) {
 		throw new Exception('Invalid race ID selected!');
 	}
@@ -70,13 +75,13 @@ if ($action == 'Change Kamikaze Setting') {
 	$player->setSectorID($player->getHome());
 	$player->getSector()->markVisited($player);
 	$player->update();
-	$lock = Smr\SectorLock::getInstance();
+	$lock = SectorLock::getInstance();
 	$lock->release();
 	$lock->acquireForPlayer($player);
 
 	$news = 'Please be advised that ' . $player->getBBLink() . ' has changed their race from [race=' . $oldRaceID . '] to [race=' . $player->getRaceID() . ']';
 	$db->insert('news', [
-		'time' => $db->escapeNumber(Smr\Epoch::time()),
+		'time' => $db->escapeNumber(Epoch::time()),
 		'news_message' => $db->escapeString($news),
 		'game_id' => $db->escapeNumber($player->getGameID()),
 		'type' => $db->escapeString('admin'),

--- a/src/engine/Default/previous_game_alliance_detail.php
+++ b/src/engine/Default/previous_game_alliance_detail.php
@@ -1,9 +1,10 @@
 <?php declare(strict_types=1);
 
 use Smr\BountyType;
+use Smr\Database;
 
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();

--- a/src/engine/Default/rankings_alliance_vs_alliance.php
+++ b/src/engine/Default/rankings_alliance_vs_alliance.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -8,7 +10,7 @@ $player = $session->getPlayer();
 $template->assign('PageTopic', 'Alliance VS Alliance Rankings');
 
 Menu::rankings(1, 4);
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $container = Page::create('rankings_alliance_vs_alliance.php');
 $template->assign('SubmitHREF', $container->href());
 

--- a/src/engine/Default/rankings_sector_kill.php
+++ b/src/engine/Default/rankings_sector_kill.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -8,7 +10,7 @@ $template->assign('PageTopic', 'Sector Death Rankings');
 
 Menu::rankings(3, 0);
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT sector_id, battles as amount FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY battles DESC, sector_id');
 $rankedStats = [];
 foreach ($dbResult->records() as $index => $dbRecord) {

--- a/src/engine/Default/sector_jump_processing.php
+++ b/src/engine/Default/sector_jump_processing.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 use Smr\MovementType;
+use Smr\Request;
+use Smr\SectorLock;
 
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -11,7 +13,7 @@ if (!$player->getGame()->hasStarted()) {
 	create_error('You cannot move until the game has started!');
 }
 
-$target = Smr\Request::getVarInt('target');
+$target = Request::getVarInt('target');
 
 //allow hidden players (admins that don't play) to move without pinging, hitting mines, losing turns
 if (in_array($player->getAccountID(), Globals::getHiddenPlayers())) {
@@ -40,7 +42,7 @@ if (!SmrSector::sectorExists($player->getGameID(), $target)) {
 }
 
 // If the Calculate Turn Cost button was pressed
-if (Smr\Request::get('action', '') == 'Calculate Turn Cost') {
+if (Request::get('action', '') == 'Calculate Turn Cost') {
 	$container = Page::create('sector_jump_calculate.php');
 	$container['target'] = $target;
 	$container->go();
@@ -92,7 +94,7 @@ $player->log(LOG_TYPE_MOVEMENT, 'Jumps to sector: ' . $target . ' but hits: ' . 
 $player->update();
 
 // We need to release the lock on our old sector
-$lock = Smr\SectorLock::getInstance();
+$lock = SectorLock::getInstance();
 $lock->release();
 
 // We need a lock on the new sector so that more than one person isn't hitting the same mines

--- a/src/engine/Default/sector_move_processing.php
+++ b/src/engine/Default/sector_move_processing.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\MovementType;
+use Smr\SectorLock;
 
 require_once(LIB . 'Default/sector_mines.inc.php');
 
@@ -72,7 +73,7 @@ $player->takeTurns($turns, $turns);
 $player->update();
 
 // We need to release the lock on our old sector
-$lock = Smr\SectorLock::getInstance();
+$lock = SectorLock::getInstance();
 $lock->release();
 
 // We need a lock on the new sector so that more than one person isn't hitting the same mines

--- a/src/engine/Default/shop_goods_processing.php
+++ b/src/engine/Default/shop_goods_processing.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
 use Smr\TransactionType;
 
 $session = Smr\Session::getInstance();
@@ -8,13 +9,13 @@ $player = $session->getPlayer();
 $ship = $player->getShip();
 $sector = $player->getSector();
 
-$amount = Smr\Request::getVarInt('amount');
+$amount = Request::getVarInt('amount');
 // no negative amounts are allowed
 if ($amount <= 0) {
 	create_error('You must enter an amount > 0!');
 }
 
-$bargain_price = Smr\Request::getVarInt('bargain_price', 0);
+$bargain_price = Request::getVarInt('bargain_price', 0);
 // no negative amounts are allowed
 if ($bargain_price < 0) {
 	create_error('Negative prices are not allowed!');
@@ -90,7 +91,7 @@ if ($ideal_price == 0 || $offered_price == 0) {
 }
 
 $stealing = false;
-if (Smr\Request::getVar('action') === TransactionType::STEAL) {
+if (Request::getVar('action') === TransactionType::STEAL) {
 	$stealing = true;
 	if (!$ship->isUnderground()) {
 		throw new Exception('Player tried to steal in a non-underground ship!');

--- a/src/engine/Default/shop_hardware_processing.php
+++ b/src/engine/Default/shop_hardware_processing.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
 $ship = $player->getShip();
 
-$action = Smr\Request::get('action');
-$amount = Smr\Request::getInt('amount');
+$action = Request::get('action');
+$amount = Request::getInt('amount');
 
 /** @var int $hardware_id */
 $hardware_id = $var['hardware_id'];

--- a/src/engine/Default/smr_file_create.php
+++ b/src/engine/Default/smr_file_create.php
@@ -1,8 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+use Smr\SectorLock;
+
 // We can release the sector lock now because we know that the following
 // code is read-only. This will help reduce sector lag and possible abuse.
-Smr\SectorLock::getInstance()->release();
+SectorLock::getInstance()->release();
 
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
@@ -18,7 +21,7 @@ $file = ';SMR1.6 Sectors File v' . SMR_FILE_VERSION . '
 ; Created on ' . date(DEFAULT_DATE_TIME_FORMAT) . '
 [Races]
 ; Name = ID' . EOL;
-foreach (Smr\Race::getAllNames() as $raceID => $raceName) {
+foreach (Race::getAllNames() as $raceID => $raceName) {
 	$file .= inify($raceName) . '=' . $raceID . EOL;
 }
 

--- a/src/engine/Default/trader_attack_processing.php
+++ b/src/engine/Default/trader_attack_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\SectorLock;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
@@ -89,12 +93,12 @@ $results = [
 
 $account->log(LOG_TYPE_TRADER_COMBAT, 'Player attacks player, their team does ' . $results['Attackers']['TotalDamage'] . ' and the other team does ' . $results['Defenders']['TotalDamage'], $sector->getSectorID());
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->insert('combat_logs', [
 	'game_id' => $db->escapeNumber($player->getGameID()),
 	'type' => $db->escapeString('PLAYER'),
 	'sector_id' => $db->escapeNumber($sector->getSectorID()),
-	'timestamp' => $db->escapeNumber(Smr\Epoch::time()),
+	'timestamp' => $db->escapeNumber(Epoch::time()),
 	'attacker_id' => $db->escapeNumber($player->getAccountID()),
 	'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
 	'defender_id' => $db->escapeNumber($var['target']),
@@ -106,7 +110,7 @@ $db->insert('combat_logs', [
 if ($player->isDead()) {
 	saveAllAndReleaseLock(updateSession: false);
 	// Grab the lock in the new sector to avoid reloading session
-	Smr\SectorLock::getInstance()->acquireForPlayer($player);
+	SectorLock::getInstance()->acquireForPlayer($player);
 }
 
 // If they died on the shot they get to see the results

--- a/src/engine/Default/trader_relations.php
+++ b/src/engine/Default/trader_relations.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -12,7 +14,7 @@ $politicalRelations = [];
 $personalRelations = [];
 
 $raceRelations = Globals::getRaceRelations($player->getGameID(), $player->getRaceID());
-foreach (Smr\Race::getAllNames() as $raceID => $raceName) {
+foreach (Race::getAllNames() as $raceID => $raceName) {
 	$politicalRelations[$raceName] = $raceRelations[$raceID];
 	$personalRelations[$raceName] = $player->getPersonalRelation($raceID);
 }

--- a/src/engine/Default/trader_savings.php
+++ b/src/engine/Default/trader_savings.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Lotto;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -9,7 +12,7 @@ $template->assign('PageTopic', 'Savings');
 Menu::trader();
 
 $anonAccounts = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM anon_bank WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 foreach ($dbResult->records() as $dbRecord) {
 	$anonAccounts[] = [
@@ -19,8 +22,8 @@ foreach ($dbResult->records() as $dbRecord) {
 }
 $template->assign('AnonAccounts', $anonAccounts);
 
-Smr\Lotto::checkForLottoWinner($player->getGameID());
-$template->assign('LottoInfo', Smr\Lotto::getLottoInfo($player->getGameID()));
+Lotto::checkForLottoWinner($player->getGameID());
+$template->assign('LottoInfo', Lotto::getLottoInfo($player->getGameID()));
 
 // Number of active lotto tickets this player has
 $dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0');

--- a/src/engine/Default/trader_search_result.php
+++ b/src/engine/Default/trader_search_result.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Exceptions\PlayerNotFound;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -15,17 +18,17 @@ if (empty($player_name) && empty($player_id)) {
 if (!empty($player_id)) {
 	try {
 		$resultPlayer = SmrPlayer::getPlayerByPlayerID($player_id, $player->getGameID());
-	} catch (Smr\Exceptions\PlayerNotFound) {
+	} catch (PlayerNotFound) {
 		// No player found, we'll return an empty result
 	}
 } else {
 	try {
 		$resultPlayer = SmrPlayer::getPlayerByPlayerName($player_name, $player->getGameID());
-	} catch (Smr\Exceptions\PlayerNotFound) {
+	} catch (PlayerNotFound) {
 		// No exact match, but that's okay
 	}
 
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT * FROM player
 				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
 					AND player_name LIKE ' . $db->escapeString('%' . $player_name . '%') . '

--- a/src/engine/Default/trader_status.php
+++ b/src/engine/Default/trader_status.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
@@ -60,7 +62,7 @@ $container = Page::create('note_delete_processing.php');
 $template->assign('NoteDeleteHREF', $container->href());
 
 $notes = [];
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM player_has_notes WHERE ' . $player->getSQL() . ' ORDER BY note_id DESC');
 foreach ($dbResult->records() as $dbRecord) {
 	$notes[$dbRecord->getInt('note_id')] = $dbRecord->getString('note');

--- a/src/engine/Default/underground.php
+++ b/src/engine/Default/underground.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Smr\Bounties;
 use Smr\BountyType;
 
 $template = Smr\Template::getInstance();
@@ -23,7 +24,7 @@ $template->assign('PageTopic', $location->getName());
 
 Menu::headquarters($var['LocationID']);
 
-$template->assign('AllBounties', Smr\Bounties::getMostWanted(BountyType::UG));
+$template->assign('AllBounties', Bounties::getMostWanted(BountyType::UG));
 $template->assign('MyBounties', $player->getClaimableBounties(BountyType::UG));
 
 if ($player->hasNeutralAlignment()) {

--- a/src/engine/Default/validate_processing.php
+++ b/src/engine/Default/validate_processing.php
@@ -1,19 +1,22 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
 $container = Page::create('validate.php');
 
-if (Smr\Request::get('action') == 'resend') {
+if (Request::get('action') == 'resend') {
 	$account->sendValidationEmail();
 	$container['msg'] = '<span class="green">The validation code has been resent to your e-mail address!</span>';
 	$container->go();
 }
 
 // Only skip validation check if we explicitly chose to validate later
-if (Smr\Request::get('action') != 'skip') {
-	if ($account->getValidationCode() != Smr\Request::get('validation_code')) {
+if (Request::get('action') != 'skip') {
+	if ($account->getValidationCode() != Request::get('validation_code')) {
 		$container['msg'] = '<span class="red">The validation code you entered is incorrect!</span>';
 		$container->go();
 	}
@@ -22,7 +25,7 @@ if (Smr\Request::get('action') != 'skip') {
 	$account->update();
 
 	// delete the notification (when send)
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$db->write('DELETE FROM notification
 				WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . '
 				AND notification_type = \'validation_code\'');

--- a/src/engine/Default/vote.php
+++ b/src/engine/Default/vote.php
@@ -1,12 +1,15 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $template = Smr\Template::getInstance();
 $session = Smr\Session::getInstance();
 $account = $session->getAccount();
 
 $template->assign('PageTopic', 'Voting');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT * FROM voting ORDER BY end DESC');
 if ($dbResult->hasRecord()) {
 	$votedFor = [];
@@ -24,8 +27,8 @@ if ($dbResult->hasRecord()) {
 		$container['vote_id'] = $voteID;
 		$voting[$voteID]['HREF'] = $container->href();
 		$voting[$voteID]['Question'] = $dbRecord->getString('question');
-		if ($dbRecord->getInt('end') > Smr\Epoch::time()) {
-			$voting[$voteID]['TimeRemaining'] = format_time($dbRecord->getInt('end') - Smr\Epoch::time(), true);
+		if ($dbRecord->getInt('end') > Epoch::time()) {
+			$voting[$voteID]['TimeRemaining'] = format_time($dbRecord->getInt('end') - Epoch::time(), true);
 		} else {
 			$voting[$voteID]['EndDate'] = date($account->getDateFormat(), $dbRecord->getInt('end'));
 		}

--- a/src/engine/Default/vote_link.php
+++ b/src/engine/Default/vote_link.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\VoteLink;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 
@@ -8,7 +10,7 @@ $container = Page::create('current_sector.php');
 $player = $session->getPlayer();
 if ($player->getGame()->hasStarted()) {
 	// Allow vote
-	$voteLink = new Smr\VoteLink($var['vote_site'], $player->getAccountID(), $player->getGameID());
+	$voteLink = new VoteLink($var['vote_site'], $player->getAccountID(), $player->getGameID());
 	$voteLink->setClicked();
 	$voting = '<b><span class="red">v</span>o<span class="blue">t</span><span class="red">i</span>n<span class="blue">g</span></b>';
 	$container['msg'] = "Thank you for $voting! You will receive bonus turns once your vote is processed.";

--- a/src/engine/Default/vote_processing.php
+++ b/src/engine/Default/vote_processing.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $account = $session->getAccount();
@@ -8,10 +11,10 @@ if ($account->getAccountID() == ACCOUNT_ID_NHL) {
 	create_error('This account is not allowed to cast a vote!');
 }
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->replace('voting_results', [
 	'account_id' => $db->escapeNumber($account->getAccountID()),
 	'vote_id' => $db->escapeNumber($var['vote_id']),
-	'option_id' => $db->escapeNumber(Smr\Request::getInt('vote')),
+	'option_id' => $db->escapeNumber(Request::getInt('vote')),
 ]);
 Page::create($var['forward_to'], $var)->go();

--- a/src/engine/Default/weapon_reorder_processing.php
+++ b/src/engine/Default/weapon_reorder_processing.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $ship = $session->getPlayer()->getShip();
@@ -13,7 +15,7 @@ if (isset($var['Down'])) {
 }
 
 if (isset($var['Form'])) {
-	$ship->setWeaponLocations(Smr\Request::getIntArray('weapon_reorder'));
+	$ship->setWeaponLocations(Request::getIntArray('weapon_reorder'));
 }
 
 Page::create('weapon_reorder.php')->go();

--- a/src/engine/Draft/alliance_pick.php
+++ b/src/engine/Draft/alliance_pick.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Exceptions\AllianceNotFound;
+
 $template = Smr\Template::getInstance();
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 $alliance = $player->getAlliance();
@@ -22,7 +25,7 @@ $template->assign('CanPick', $teams[$player->getAccountID()]['CanPick']);
 try {
 	$NHA = SmrAlliance::getAllianceByName(NHA_ALLIANCE_NAME, $player->getGameID());
 	$NHAID = $NHA->getAllianceID();
-} catch (Smr\Exceptions\AllianceNotFound) {
+} catch (AllianceNotFound) {
 	$NHAID = 0;
 }
 

--- a/src/engine/Draft/alliance_pick_processing.php
+++ b/src/engine/Draft/alliance_pick_processing.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 $session = Smr\Session::getInstance();
 $var = $session->getCurrentVar();
 $player = $session->getPlayer();
@@ -38,12 +41,12 @@ if ($pickedPlayer->getSectorID() === 1) {
 $pickedPlayer->update();
 
 // Update the draft history
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->insert('draft_history', [
 	'game_id' => $db->escapeNumber($player->getGameID()),
 	'leader_account_id' => $db->escapeNumber($player->getAccountID()),
 	'picked_account_id' => $db->escapeNumber($pickedPlayer->getAccountID()),
-	'time' => $db->escapeNumber(Smr\Epoch::time()),
+	'time' => $db->escapeNumber(Epoch::time()),
 ]);
 
 Page::create('alliance_pick.php')->go();

--- a/src/engine/Draft/alliance_remove_member_processing.php
+++ b/src/engine/Draft/alliance_remove_member_processing.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 $session = Smr\Session::getInstance();
 $player = $session->getPlayer();
 
-$accountIDs = Smr\Request::getIntArray('account_id', []);
+$accountIDs = Request::getIntArray('account_id', []);
 
 if (empty($accountIDs)) {
 	create_error('You have to choose someone to remove them!');

--- a/src/htdocs/album/album_comment_processing.php
+++ b/src/htdocs/album/album_comment_processing.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 try {
 	require_once('../../bootstrap.php');
 	require_once(LIB . 'Album/album_functions.php');
@@ -10,14 +14,14 @@ try {
 		create_error('You need to be logged in to post comments!');
 	}
 
-	$album_id = Smr\Request::getInt('album_id', 0);
+	$album_id = Request::getInt('album_id', 0);
 	if ($album_id <= 0) {
 		create_error('Whose album do you want to comment on?');
 	}
 
 	$account = $session->getAccount();
 
-	$action = Smr\Request::get('action');
+	$action = Request::get('action');
 	if ($action == 'Moderate') {
 		if (!$account->hasPermission(PERMISSION_MODERATE_PHOTO_ALBUM)) {
 			create_error('You do not have permission to do that!');
@@ -32,15 +36,15 @@ try {
 		exit;
 	}
 
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 
-	$comment = Smr\Request::get('comment');
+	$comment = Request::get('comment');
 	if (empty($comment)) {
 		create_error('Please enter a comment.');
 	}
 
 	// get current time
-	$curr_time = Smr\Epoch::time();
+	$curr_time = Epoch::time();
 
 	$comment = word_filter($comment);
 	$account->sendMessageToBox(BOX_ALBUM_COMMENTS, $comment);

--- a/src/htdocs/album/index.php
+++ b/src/htdocs/album/index.php
@@ -1,10 +1,15 @@
 <?php declare(strict_types=1);
+
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Request;
+
 try {
 	require_once('../../bootstrap.php');
 	require_once(LIB . 'Album/album_functions.php');
 
 	// database object
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	?>
 	<!DOCTYPE html>
 	<html>
@@ -38,8 +43,8 @@ try {
 	<tr>
 	<td valign="top">
 	<?php
-	if (Smr\Request::has('nick')) {
-		$query = urldecode(Smr\Request::get('nick'));
+	if (Request::has('nick')) {
+		$query = urldecode(Request::get('nick'));
 
 		$dbResult = $db->read('SELECT account_id as album_id
 					FROM album JOIN account USING(account_id)
@@ -134,7 +139,7 @@ Quick Search:<br />
 
 <tr>
 	<td class="left" style='font-size:65%;'>
-		&copy; 2002-<?php echo date('Y', Smr\Epoch::time()); ?> by <a href="<?php echo URL; ?>"><?php echo URL; ?></a><br />
+		&copy; 2002-<?php echo date('Y', Epoch::time()); ?> by <a href="<?php echo URL; ?>"><?php echo URL; ?></a><br />
 		Hosted by <a href='http://www.fem.tu-ilmenau.de/' target='fem'>FeM</a>
 	</td>
 </tr>

--- a/src/htdocs/error.php
+++ b/src/htdocs/error.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 try {
 	require_once('../bootstrap.php');
 
 	$template = Smr\Template::getInstance();
 	$template->assign('Body', 'login/error.php');
-	$template->assign('ErrorMessage', Smr\Request::get('msg', 'No error message found!'));
+	$template->assign('ErrorMessage', Request::get('msg', 'No error message found!'));
 	$template->display('login/skeleton.php');
 
 } catch (Throwable $e) {

--- a/src/htdocs/loader.php
+++ b/src/htdocs/loader.php
@@ -1,4 +1,7 @@
 <?php declare(strict_types=1);
+
+use Smr\Login\Redirect;
+
 try {
 	require_once('../bootstrap.php');
 
@@ -60,7 +63,7 @@ try {
 
 	$account = $session->getAccount();
 	// get reason for disabled user
-	$disabled = Smr\Login\Redirect::redirectIfDisabled($account);
+	$disabled = Redirect::redirectIfDisabled($account);
 	if ($disabled !== false) {
 		// save session (incase we forward)
 		$session->update();

--- a/src/htdocs/login.php
+++ b/src/htdocs/login.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 try {
 
 	require_once('../bootstrap.php');
@@ -23,9 +26,9 @@ try {
 	}
 
 	$template = Smr\Template::getInstance();
-	if (Smr\Request::has('msg')) {
-		$template->assign('Message', htmlentities(Smr\Request::get('msg'), ENT_COMPAT, 'utf-8'));
-	} elseif (Smr\Request::has('status')) {
+	if (Request::has('msg')) {
+		$template->assign('Message', htmlentities(Request::get('msg'), ENT_COMPAT, 'utf-8'));
+	} elseif (Request::has('status')) {
 		session_start();
 		if (isset($_SESSION['login_msg'])) {
 			$template->assign('Message', $_SESSION['login_msg']);
@@ -35,7 +38,7 @@ try {
 
 	// Get recent non-admin game news
 	$gameNews = [];
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT * FROM news WHERE type != \'admin\' ORDER BY time DESC LIMIT 4');
 	foreach ($dbResult->records() as $dbRecord) {
 		$overrideGameID = $dbRecord->getInt('game_id'); //for bbifyMessage

--- a/src/htdocs/login_social_create.php
+++ b/src/htdocs/login_social_create.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Exceptions\AccountNotFound;
+
 try {
 	require_once('../bootstrap.php');
 
@@ -22,7 +24,7 @@ try {
 	try {
 		$account = SmrAccount::getAccountByEmail($socialLogin->getEmail());
 		$template->assign('MatchingLogin', $account->getLogin());
-	} catch (Smr\Exceptions\AccountNotFound) {
+	} catch (AccountNotFound) {
 		// Proceed without matching account
 	}
 

--- a/src/htdocs/login_social_processing.php
+++ b/src/htdocs/login_social_processing.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Exceptions\SocialLoginInvalidType;
+use Smr\SocialLogin\SocialLogin;
+
 try {
 
 	if (isset($_GET['type'])) {
@@ -13,8 +16,8 @@ try {
 
 		require_once('../bootstrap.php');
 		try {
-			header('Location: ' . Smr\SocialLogin\SocialLogin::get($type)->getLoginUrl());
-		} catch (Smr\Exceptions\SocialLoginInvalidType) {
+			header('Location: ' . SocialLogin::get($type)->getLoginUrl());
+		} catch (SocialLoginInvalidType) {
 			create_error('Unknown social login type');
 		}
 	}

--- a/src/htdocs/map_galaxy.php
+++ b/src/htdocs/map_galaxy.php
@@ -1,4 +1,9 @@
 <?php declare(strict_types=1);
+
+use Smr\Exceptions\GalaxyNotFound;
+use Smr\Exceptions\SectorNotFound;
+use Smr\Request;
+
 try {
 	require_once('../bootstrap.php');
 
@@ -22,18 +27,18 @@ try {
 		exit;
 	}
 
-	if (Smr\Request::has('sector_id')) {
-		$sectorID = Smr\Request::getInt('sector_id');
+	if (Request::has('sector_id')) {
+		$sectorID = Request::getInt('sector_id');
 		try {
 			$galaxy = SmrGalaxy::getGalaxyContaining($session->getGameID(), $sectorID);
-		} catch (Smr\Exceptions\SectorNotFound) {
+		} catch (SectorNotFound) {
 			create_error('Invalid sector ID');
 		}
-	} elseif (Smr\Request::has('galaxy_id')) {
-		$galaxyID = Smr\Request::getInt('galaxy_id');
+	} elseif (Request::has('galaxy_id')) {
+		$galaxyID = Request::getInt('galaxy_id');
 		try {
 			$galaxy = SmrGalaxy::getGalaxy($session->getGameID(), $galaxyID);
-		} catch (Smr\Exceptions\GalaxyNotFound) {
+		} catch (GalaxyNotFound) {
 			create_error('Invalid galaxy ID');
 		}
 	}
@@ -52,9 +57,9 @@ try {
 
 	// Set temporary options
 	if ($player->hasAlliance()) {
-		if (Smr\Request::has('change_settings')) {
-			$_SESSION['show_seedlist_sectors'] = Smr\Request::has('show_seedlist_sectors');
-			$_SESSION['hide_allied_forces'] = Smr\Request::has('hide_allied_forces');
+		if (Request::has('change_settings')) {
+			$_SESSION['show_seedlist_sectors'] = Request::has('show_seedlist_sectors');
+			$_SESSION['hide_allied_forces'] = Request::has('hide_allied_forces');
 		}
 		$showSeedlistSectors = $_SESSION['show_seedlist_sectors'] ?? false;
 		$hideAlliedForces = $_SESSION['hide_allied_forces'] ?? false;

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -1,11 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Request;
+
 try {
 	require_once('../bootstrap.php');
 
 	$session = Smr\Session::getInstance();
 
-	$gameID = Smr\Request::getInt('game');
+	$gameID = Request::getInt('game');
 	if (!$session->hasAccount() || !SmrGame::gameExists($gameID)) {
 		header('Location: /login.php');
 		exit;
@@ -31,7 +34,7 @@ try {
 	}
 
 	// The d3 graph links are the warp connections between galaxies
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT sector_id, warp FROM sector WHERE warp !=0 AND game_id = ' . $db->escapeNumber($gameID));
 	foreach ($dbResult->records() as $dbRecord) {
 		$warp1 = SmrSector::getSector($gameID, $dbRecord->getInt('sector_id'));

--- a/src/htdocs/resend_password_processing.php
+++ b/src/htdocs/resend_password_processing.php
@@ -1,15 +1,19 @@
 <?php declare(strict_types=1);
+
+use Smr\Exceptions\AccountNotFound;
+use Smr\Request;
+
 try {
 	require_once('../bootstrap.php');
 
-	if (empty(Smr\Request::get('email'))) {
+	if (empty(Request::get('email'))) {
 		create_error('You must specify an e-mail address!');
 	}
 
 	// get this user from db
 	try {
-		$account = SmrAccount::getAccountByEmail(Smr\Request::get('email'));
-	} catch (Smr\Exceptions\AccountNotFound) {
+		$account = SmrAccount::getAccountByEmail(Request::get('email'));
+	} catch (AccountNotFound) {
 		// unknown user
 		create_error('The specified e-mail address is not registered!');
 	}

--- a/src/htdocs/reset_password_processing.php
+++ b/src/htdocs/reset_password_processing.php
@@ -1,29 +1,33 @@
 <?php declare(strict_types=1);
+
+use Smr\Exceptions\AccountNotFound;
+use Smr\Request;
+
 try {
 	require_once('../bootstrap.php');
 
-	$password = Smr\Request::get('password');
+	$password = Request::get('password');
 	if (empty($password)) {
 		create_error('Password is missing!');
 	}
 
-	$pass_verify = Smr\Request::get('pass_verify');
+	$pass_verify = Request::get('pass_verify');
 	if ($password != $pass_verify) {
 		create_error('The passwords you entered do not match.');
 	}
 
-	$login = Smr\Request::get('login');
+	$login = Request::get('login');
 	if ($login == $password) {
 		create_error('Your password cannot be the same as your login!');
 	}
 
-	$passwordReset = Smr\Request::get('password_reset');
+	$passwordReset = Request::get('password_reset');
 	try {
 		$account = SmrAccount::getAccountByLogin($login);
 		if (empty($passwordReset) || $account->getPasswordReset() != $passwordReset) {
-			throw new Smr\Exceptions\AccountNotFound('Wrong password reset code');
+			throw new AccountNotFound('Wrong password reset code');
 		}
-	} catch (Smr\Exceptions\AccountNotFound) {
+	} catch (AccountNotFound) {
 		create_error('User does not exist or reset password code is incorrect.');
 	}
 

--- a/src/htdocs/ship_list.php
+++ b/src/htdocs/ship_list.php
@@ -1,4 +1,8 @@
 <?php declare(strict_types=1);
+
+use Smr\Database;
+use Smr\Race;
+
 try {
 	require_once('../bootstrap.php');
 
@@ -6,7 +10,7 @@ try {
 
 	// Get a list of all the shops that sell each ship
 	$shipLocs = [];
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT ship_type_id, location_type.* FROM location_sells_ships JOIN ship_type USING (ship_type_id) JOIN location_type USING (location_type_id) WHERE location_type_id NOT IN (' . $db->escapeArray([RACE_WARS_SHIPS, LOCATION_TYPE_TEST_SHIPYARD]) . ')');
 	foreach ($dbResult->records() as $dbRecord) {
 		$shipTypeID = $dbRecord->getInt('ship_type_id');
@@ -50,7 +54,7 @@ function buildShipStats(SmrShipType $ship, array $shipLocs): array {
 	// We want to put them all in an array so we dont have to have 15 td rows.
 	$stat = [
 		'name' => $ship->getName(),
-		'race race' . $ship->getRaceID() => Smr\Race::getName($ship->getRaceID()),
+		'race race' . $ship->getRaceID() => Race::getName($ship->getRaceID()),
 		'class_' => $ship->getClass()->name,
 		'cost' => number_format($ship->getCost()),
 		'speed' => $ship->getSpeed(),

--- a/src/htdocs/vote_link_callback.php
+++ b/src/htdocs/vote_link_callback.php
@@ -1,20 +1,22 @@
 <?php declare(strict_types=1);
 // Callback script for player voting on external sites
 
+use Smr\Request;
+use Smr\SectorLock;
 use Smr\VoteLink;
 use Smr\VoteSite;
 
 try {
 	require_once('../bootstrap.php');
 
-	if (Smr\Request::has('account') && Smr\Request::has('game') && Smr\Request::has('link')) {
+	if (Request::has('account') && Request::has('game') && Request::has('link')) {
 		// callback from TWG
-		$accountId = Smr\Request::getInt('account');
-		$gameId = Smr\Request::getInt('game');
-		$linkId = Smr\Request::getInt('link');
-	} elseif (Smr\Request::has('votedef')) {
+		$accountId = Request::getInt('account');
+		$gameId = Request::getInt('game');
+		$linkId = Request::getInt('link');
+	} elseif (Request::has('votedef')) {
 		// callback from DOG
-		$data = explode(',', Smr\Request::get('votedef'));
+		$data = explode(',', Request::get('votedef'));
 		$accountId = (int)$data[0];
 		$gameId = (int)$data[1];
 		$linkId = (int)$data[2];
@@ -32,7 +34,7 @@ try {
 	// Lock the sector to ensure the player gets the turns
 	// Refresh player after lock is acquired in case any values are stale
 	$player = SmrPlayer::getPlayer($accountId, $gameId);
-	$lock = Smr\SectorLock::getInstance();
+	$lock = SectorLock::getInstance();
 	$lock->acquireForPlayer($player);
 	$player = SmrPlayer::getPlayer($accountId, $gameId, true);
 

--- a/src/htdocs/weapon_list.php
+++ b/src/htdocs/weapon_list.php
@@ -1,4 +1,7 @@
 <?php declare(strict_types=1);
+
+use Smr\Database;
+
 try {
 	require_once('../bootstrap.php');
 
@@ -6,7 +9,7 @@ try {
 
 	// Get a list of all the shops that sell each weapon
 	$weaponLocs = [];
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT weapon_type_id, location_type.* FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) JOIN location_type USING (location_type_id) WHERE location_type_id != ' . $db->escapeNumber(RACE_WARS_WEAPONS));
 	foreach ($dbResult->records() as $dbRecord) {
 		$weaponLocs[$dbRecord->getInt('weapon_type_id')][] = SmrLocation::getLocation($dbRecord->getInt('location_type_id'), false, $dbRecord)->getName();

--- a/src/lib/Album/album_functions.php
+++ b/src/lib/Album/album_functions.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 function main_page(): void {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$session = Smr\Session::getInstance();
 
 	// list of all first letter nicks
@@ -59,7 +61,7 @@ function main_page(): void {
 }
 
 function album_entry(int $album_id): void {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$session = Smr\Session::getInstance();
 
 	// list of all first letter nicks

--- a/src/lib/Default/AbstractMenu.php
+++ b/src/lib/Default/AbstractMenu.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\CombatLogType;
+use Smr\Database;
 
 /**
  * Creates menu navigation bars.
@@ -46,7 +47,7 @@ class AbstractMenu {
 	}
 
 	public static function alliance(int $alliance_id): void {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$player = Smr\Session::getInstance()->getPlayer();
 
 		$in_alliance = ($alliance_id == $player->getAllianceID() || in_array($player->getAccountID(), Globals::getHiddenPlayers()));

--- a/src/lib/Default/Council.php
+++ b/src/lib/Default/Council.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 class Council {
 
 	/** @var array<int, array<int, array<int, int>>> */
@@ -20,7 +22,7 @@ class Council {
 			// Require council members to have > 0 exp to ensure that players
 			// cannot perform council activities before the game starts.
 			$i = 1;
-			$db = Smr\Database::getInstance();
+			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT account_id, alignment
 								FROM player
 								WHERE game_id = ' . $db->escapeNumber($gameID) . '

--- a/src/lib/Default/DummyShip.php
+++ b/src/lib/Default/DummyShip.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 class DummyShip extends AbstractSmrShip {
 
 	/** @var array<string, self> */
@@ -17,7 +19,7 @@ class DummyShip extends AbstractSmrShip {
 	}
 
 	public function cacheDummyShip(): void {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$db->replace('cached_dummys', [
 			'type' => $db->escapeString('DummyShip'),
 			'id' => $db->escapeString($this->getPlayer()->getPlayerName()),
@@ -28,7 +30,7 @@ class DummyShip extends AbstractSmrShip {
 	public static function getCachedDummyShip(string $dummyName): self {
 		if (!isset(self::$CACHED_DUMMY_SHIPS[$dummyName])) {
 			// Load ship from the dummy database cache, if available
-			$db = Smr\Database::getInstance();
+			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT info FROM cached_dummys WHERE type = \'DummyShip\'
 						AND id = ' . $db->escapeString($dummyName));
 			if ($dbResult->hasRecord()) {
@@ -46,7 +48,7 @@ class DummyShip extends AbstractSmrShip {
 	 * @return array<string>
 	 */
 	public static function getDummyNames(): array {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT id FROM cached_dummys');
 		$dummyNames = [];
 		foreach ($dbResult->records() as $dbRecord) {

--- a/src/lib/Default/Globals.php
+++ b/src/lib/Default/Globals.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Exceptions\UserError;
+use Smr\Race;
+
 class Globals {
 
 	/** @var array<int> */
@@ -15,11 +19,11 @@ class Globals {
 	protected static array $RACE_RELATIONS;
 	/** @var array<string, string> */
 	protected static array $AVAILABLE_LINKS = [];
-	protected static Smr\Database $db;
+	protected static Database $db;
 
 	protected static function initialiseDatabase(): void {
 		if (!isset(self::$db)) {
-			self::$db = Smr\Database::getInstance();
+			self::$db = Database::getInstance();
 		}
 	}
 
@@ -38,7 +42,7 @@ class Globals {
 			case 'AllianceMOTD':
 				if ($player->getAllianceID() != $extraInfo['AllianceID']) {
 					logException(new Exception('Tried to access page without permission.'));
-					throw new Smr\Exceptions\UserError('You cannot access this page.');
+					throw new UserError('You cannot access this page.');
 				}
 				break;
 		}
@@ -98,7 +102,7 @@ class Globals {
 	}
 
 	public static function getColouredRaceName(int $raceID, int $relations, bool $linked = true): string {
-		$raceName = get_colored_text($relations, Smr\Race::getName($raceID));
+		$raceName = get_colored_text($relations, Race::getName($raceID));
 		if ($linked === true) {
 			$container = Page::create('council_list.php', ['race_id' => $raceID]);
 			$raceName = create_link($container, $raceName);
@@ -197,7 +201,7 @@ class Globals {
 			self::initialiseDatabase();
 			//get relations
 			self::$RACE_RELATIONS[$gameID][$raceID] = [];
-			foreach (Smr\Race::getAllIDs() as $otherRaceID) {
+			foreach (Race::getAllIDs() as $otherRaceID) {
 				self::$RACE_RELATIONS[$gameID][$raceID][$otherRaceID] = 0;
 			}
 			$dbResult = self::$db->read('SELECT race_id_2,relation FROM race_has_relation WHERE race_id_1=' . self::$db->escapeNumber($raceID) . ' AND game_id=' . self::$db->escapeNumber($gameID));

--- a/src/lib/Default/Plotter.php
+++ b/src/lib/Default/Plotter.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Exceptions\UserError;
+use Smr\Path;
 use Smr\PlotGroup;
 use Smr\TransactionType;
 
@@ -43,7 +45,7 @@ class Plotter {
 	 * is not true for findDistanceToX. If $x is not a SmrSector, then this
 	 * function does 2x the work.
 	 */
-	public static function findReversiblePathToX(mixed $x, SmrSector $sector, bool $useFirst, AbstractSmrPlayer $needsToHaveBeenExploredBy = null, AbstractSmrPlayer $player = null): Smr\Path {
+	public static function findReversiblePathToX(mixed $x, SmrSector $sector, bool $useFirst, AbstractSmrPlayer $needsToHaveBeenExploredBy = null, AbstractSmrPlayer $player = null): Path {
 		if ($x instanceof SmrSector) {
 
 			// To ensure reversibility, always plot lowest to highest.
@@ -57,7 +59,7 @@ class Plotter {
 			}
 			$path = self::findDistanceToX($end, $start, $useFirst, $needsToHaveBeenExploredBy, $player);
 			if ($path === false) {
-				throw new Smr\Exceptions\UserError('Unable to plot from ' . $sector->getSectorID() . ' to ' . $x->getSectorID() . '.');
+				throw new UserError('Unable to plot from ' . $sector->getSectorID() . ' to ' . $x->getSectorID() . '.');
 			}
 			// Reverse if we plotted $x -> $sector (since we want $sector -> $x)
 			if ($reverse) {
@@ -69,7 +71,7 @@ class Plotter {
 			// At this point we don't know what sector $x will be at
 			$path = self::findDistanceToX($x, $sector, $useFirst, $needsToHaveBeenExploredBy, $player);
 			if ($path === false) {
-				throw new Smr\Exceptions\UserError('Unable to find what you\'re looking for, it either hasn\'t been added to this game or you haven\'t explored it yet.');
+				throw new UserError('Unable to find what you\'re looking for, it either hasn\'t been added to this game or you haven\'t explored it yet.');
 			}
 			// Now that we know where $x is, make sure path is reversible
 			// (i.e. start sector < end sector)
@@ -91,7 +93,7 @@ class Plotter {
 	 *
 	 * @return Smr\Path|array<int, array<int, Smr\Path>>|false
 	 */
-	public static function findDistanceToX(mixed $x, SmrSector $sector, bool $useFirst, AbstractSmrPlayer $needsToHaveBeenExploredBy = null, AbstractSmrPlayer $player = null, int $distanceLimit = 10000, int $lowLimit = 0, int $highLimit = 100000): Smr\Path|array|false {
+	public static function findDistanceToX(mixed $x, SmrSector $sector, bool $useFirst, AbstractSmrPlayer $needsToHaveBeenExploredBy = null, AbstractSmrPlayer $player = null, int $distanceLimit = 10000, int $lowLimit = 0, int $highLimit = 100000): Path|array|false {
 		$warpAddIndex = TURNS_WARP_SECTOR_EQUIVALENCE - 1;
 
 		$checkSector = $sector;
@@ -101,7 +103,7 @@ class Plotter {
 		$visitedSectors = [];
 		$visitedSectors[$checkSector->getSectorID()] = true;
 		if ($x == 'Distance') {
-			$distances[0][$checkSector->getSectorID()] = new Smr\Path($checkSector->getSectorID());
+			$distances[0][$checkSector->getSectorID()] = new Path($checkSector->getSectorID());
 		}
 
 		$distanceQ = [];
@@ -110,13 +112,13 @@ class Plotter {
 		}
 		//Warps first as a slight optimisation due to how visitedSectors is set.
 		if ($checkSector->hasWarp() === true) {
-			$d = new Smr\Path($checkSector->getSectorID());
+			$d = new Path($checkSector->getSectorID());
 			$d->addWarp($checkSector->getWarp());
 			$distanceQ[$warpAddIndex][] = $d;
 		}
 		foreach ($checkSector->getLinks() as $nextSector) {
 			$visitedSectors[$nextSector] = true;
-			$d = new Smr\Path($checkSector->getSectorID());
+			$d = new Path($checkSector->getSectorID());
 			$d->addLink($nextSector);
 			$distanceQ[0][] = $d;
 		}

--- a/src/lib/Default/Rankings.php
+++ b/src/lib/Default/Rankings.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Template;
+
 class Rankings {
 
 	/**
@@ -128,7 +131,7 @@ class Rankings {
 	 * @return array<int, Smr\DatabaseRecord>
 	 */
 	public static function raceStats(string $stat, int $gameID): array {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$raceStats = [];
 		$dbResult = $db->read('SELECT race_id, COALESCE(SUM(' . $stat . '), 0) as amount, count(*) as num_players FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' GROUP BY race_id ORDER BY amount DESC');
 		foreach ($dbResult->records() as $dbRecord) {
@@ -143,7 +146,7 @@ class Rankings {
 	 * @return array<int, Smr\DatabaseRecord>
 	 */
 	public static function playerStats(string $stat, int $gameID, ?int $limit = null): array {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$playerStats = [];
 		$query = 'SELECT player.*, ' . $stat . ' AS amount FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY amount DESC, player_name';
 		if ($limit !== null) {
@@ -163,7 +166,7 @@ class Rankings {
 	 * @return array<int, Smr\DatabaseRecord>
 	 */
 	public static function playerStatsFromHOF(array $category, int $gameID): array {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$playerStats = [];
 		$dbResult = $db->read('SELECT p.*, COALESCE(ph.amount,0) amount FROM player p LEFT JOIN player_hof ph ON p.account_id = ph.account_id AND p.game_id = ph.game_id AND ph.type = ' . $db->escapeString(implode(':', $category)) . ' WHERE p.game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY amount DESC, player_name');
 		foreach ($dbResult->records() as $dbRecord) {
@@ -179,7 +182,7 @@ class Rankings {
 	 * @return array<int, Smr\DatabaseRecord>
 	 */
 	public static function allianceStatsFromHOF(array $category, int $gameID): array {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$allianceStats = [];
 		$dbResult = $db->read('SELECT alliance.*, COALESCE(SUM(amount), 0) amount
 			FROM alliance
@@ -200,7 +203,7 @@ class Rankings {
 	 * @return array<int, Smr\DatabaseRecord>
 	 */
 	public static function allianceStats(string $stat, int $gameID, ?int $limit = null): array {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$allianceStats = [];
 		if ($stat === 'experience') {
 			$query = 'SELECT alliance.*, COALESCE(SUM(experience), 0) amount
@@ -247,7 +250,7 @@ class Rankings {
 
 		$maxRank = min($maxRank, $totalRanks);
 
-		$template = Smr\Template::getInstance();
+		$template = Template::getInstance();
 		$template->assign('MinRank', $minRank);
 		$template->assign('MaxRank', $maxRank);
 		$template->assign('TotalRanks', $totalRanks);

--- a/src/lib/Default/SmrEnhancedWeaponEvent.php
+++ b/src/lib/Default/SmrEnhancedWeaponEvent.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\DatabaseRecord;
+use Smr\Epoch;
+
 /**
  * Defines enhanced weapon sale events for weapon shops.
  */
@@ -17,8 +21,8 @@ class SmrEnhancedWeaponEvent {
 	 */
 	public static function getShopEvents(int $gameID, int $sectorID, int $locationID): array {
 		$events = [];
-		$db = Smr\Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM location_sells_special WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND location_type_id = ' . $db->escapeNumber($locationID) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' AND expires > ' . $db->escapeNumber(Smr\Epoch::time()));
+		$db = Database::getInstance();
+		$dbResult = $db->read('SELECT * FROM location_sells_special WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND location_type_id = ' . $db->escapeNumber($locationID) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' AND expires > ' . $db->escapeNumber(Epoch::time()));
 		foreach ($dbResult->records() as $dbRecord) {
 			$events[] = self::getEventFromDatabase($dbRecord);
 		}
@@ -33,16 +37,16 @@ class SmrEnhancedWeaponEvent {
 	 */
 	public static function getLatestEvent(int $gameID): self {
 		// First, remove any expired events from the database
-		$db = Smr\Database::getInstance();
-		$db->write('DELETE FROM location_sells_special WHERE expires < ' . $db->escapeNumber(Smr\Epoch::time()));
+		$db = Database::getInstance();
+		$db->write('DELETE FROM location_sells_special WHERE expires < ' . $db->escapeNumber(Epoch::time()));
 
 		// Next, check if an existing event can be advertised
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM location_sells_special WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY expires DESC LIMIT 1');
 		if ($dbResult->hasRecord()) {
 			$event = self::getEventFromDatabase($dbResult->record());
 			// Don't advertise if the event expires within one GRACE_PERIOD
-			if (Smr\Epoch::time() < $event->getExpireTime() - self::GRACE_PERIOD) {
+			if (Epoch::time() < $event->getExpireTime() - self::GRACE_PERIOD) {
 				return $event;
 			}
 		}
@@ -61,13 +65,13 @@ class SmrEnhancedWeaponEvent {
 		// First, randomly select a weapon type to enhance
 		$weaponTypeID = array_rand(SmrWeaponType::getAllSoldWeaponTypes($gameID));
 
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT location_type_id, sector_id FROM location JOIN location_sells_weapons USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND weapon_type_id = ' . $db->escapeNumber($weaponTypeID) . ' ORDER BY RAND() LIMIT 1');
 		$dbRecord = $dbResult->record();
 		$locationTypeID = $dbRecord->getInt('location_type_id');
 		$sectorID = $dbRecord->getInt('sector_id');
 
-		$expires = Smr\Epoch::time() + self::DURATION;
+		$expires = Epoch::time() + self::DURATION;
 
 		// Determine which bonuses the weapon should have
 		$random = rand(1, 100);
@@ -100,7 +104,7 @@ class SmrEnhancedWeaponEvent {
 	/**
 	 * Convenience function to instantiate an event from a query result.
 	 */
-	private static function getEventFromDatabase(Smr\DatabaseRecord $dbRecord): self {
+	private static function getEventFromDatabase(DatabaseRecord $dbRecord): self {
 		return new self(
 			$dbRecord->getInt('game_id'),
 			$dbRecord->getInt('weapon_type_id'),
@@ -143,7 +147,7 @@ class SmrEnhancedWeaponEvent {
 	 * total duration of the event.
 	 */
 	public function getDurationRemainingPercent(): float {
-		return max(0, min(100, ($this->expires - Smr\Epoch::time()) / self::DURATION * 100));
+		return max(0, min(100, ($this->expires - Epoch::time()) / self::DURATION * 100));
 	}
 
 }

--- a/src/lib/Default/SmrGalaxy.php
+++ b/src/lib/Default/SmrGalaxy.php
@@ -1,4 +1,9 @@
 <?php declare(strict_types=1);
+
+use Smr\Database;
+use Smr\DatabaseRecord;
+use Smr\Exceptions\GalaxyNotFound;
+
 class SmrGalaxy {
 
 	/** @var array<int, array<int, self>> */
@@ -11,7 +16,7 @@ class SmrGalaxy {
 	public const TYPE_PLANET = 'Planet';
 	public const TYPES = [self::TYPE_RACIAL, self::TYPE_NEUTRAL, self::TYPE_PLANET];
 
-	protected Smr\Database $db;
+	protected Database $db;
 	protected readonly string $SQL;
 
 	protected string $name;
@@ -35,7 +40,7 @@ class SmrGalaxy {
 	 */
 	public static function getGameGalaxies(int $gameID, bool $forceUpdate = false): array {
 		if ($forceUpdate || !isset(self::$CACHE_GAME_GALAXIES[$gameID])) {
-			$db = Smr\Database::getInstance();
+			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT * FROM game_galaxy WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY galaxy_id ASC');
 			$galaxies = [];
 			foreach ($dbResult->records() as $dbRecord) {
@@ -47,7 +52,7 @@ class SmrGalaxy {
 		return self::$CACHE_GAME_GALAXIES[$gameID];
 	}
 
-	public static function getGalaxy(int $gameID, int $galaxyID, bool $forceUpdate = false, Smr\DatabaseRecord $dbRecord = null): self {
+	public static function getGalaxy(int $gameID, int $galaxyID, bool $forceUpdate = false, DatabaseRecord $dbRecord = null): self {
 		if ($forceUpdate || !isset(self::$CACHE_GALAXIES[$gameID][$galaxyID])) {
 			$g = new self($gameID, $galaxyID, false, $dbRecord);
 			self::$CACHE_GALAXIES[$gameID][$galaxyID] = $g;
@@ -75,9 +80,9 @@ class SmrGalaxy {
 		protected readonly int $gameID,
 		protected readonly int $galaxyID,
 		bool $create = false,
-		Smr\DatabaseRecord $dbRecord = null
+		DatabaseRecord $dbRecord = null
 	) {
-		$this->db = Smr\Database::getInstance();
+		$this->db = Database::getInstance();
 		$this->SQL = 'game_id = ' . $this->db->escapeNumber($gameID) . '
 		              AND galaxy_id = ' . $this->db->escapeNumber($galaxyID);
 
@@ -96,7 +101,7 @@ class SmrGalaxy {
 			$this->galaxyType = $dbRecord->getString('galaxy_type');
 			$this->maxForceTime = $dbRecord->getInt('max_force_time');
 		} elseif ($create === false) {
-			throw new Smr\Exceptions\GalaxyNotFound('No such galaxy: ' . $gameID . '-' . $galaxyID);
+			throw new GalaxyNotFound('No such galaxy: ' . $gameID . '-' . $galaxyID);
 		}
 	}
 

--- a/src/lib/Default/SmrGame.php
+++ b/src/lib/Default/SmrGame.php
@@ -1,11 +1,16 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+use Smr\Exceptions\GameNotFound;
+use Smr\Race;
+
 class SmrGame {
 
 	/** @var array<int, self> */
 	protected static array $CACHE_GAMES = [];
 
-	protected Smr\Database $db;
+	protected Database $db;
 
 	protected string $name;
 	protected string $description;
@@ -53,7 +58,7 @@ class SmrGame {
 		try {
 			self::getGame($gameID);
 			return true;
-		} catch (Smr\Exceptions\GameNotFound) {
+		} catch (GameNotFound) {
 			return false;
 		}
 	}
@@ -86,7 +91,7 @@ class SmrGame {
 		protected readonly int $gameID,
 		bool $create = false
 	) {
-		$this->db = Smr\Database::getInstance();
+		$this->db = Database::getInstance();
 
 		$dbResult = $this->db->read('SELECT * FROM game WHERE game_id = ' . $this->db->escapeNumber($gameID));
 		if ($dbResult->hasRecord()) {
@@ -110,7 +115,7 @@ class SmrGame {
 		} elseif ($create === true) {
 			$this->isNew = true;
 		} else {
-			throw new Smr\Exceptions\GameNotFound('No such game: ' . $gameID);
+			throw new GameNotFound('No such game: ' . $gameID);
 		}
 	}
 
@@ -187,7 +192,7 @@ class SmrGame {
 	}
 
 	public function hasStarted(): bool {
-		return Smr\Epoch::time() >= $this->getStartTime();
+		return Epoch::time() >= $this->getStartTime();
 	}
 
 	/**
@@ -222,7 +227,7 @@ class SmrGame {
 	}
 
 	public function hasEnded(): bool {
-		return $this->getEndTime() < Smr\Epoch::time();
+		return $this->getEndTime() < Epoch::time();
 	}
 
 	/**
@@ -407,8 +412,8 @@ class SmrGame {
 		if ($relations < MIN_GLOBAL_RELATIONS || $relations > MAX_GLOBAL_RELATIONS) {
 			throw new Exception('Invalid relations: ' . $relations);
 		}
-		foreach (Smr\Race::getAllIDs() as $raceID1) {
-			foreach (Smr\Race::getAllIDs() as $raceID2) {
+		foreach (Race::getAllIDs() as $raceID1) {
+			foreach (Race::getAllIDs() as $raceID2) {
 				if ($raceID1 == $raceID2) {
 					// Max relations for a race with itself
 					$amount = MAX_GLOBAL_RELATIONS;
@@ -454,7 +459,7 @@ class SmrGame {
 	 * Returns the time (in seconds) until restricted ships are unlocked.
 	 */
 	public function timeUntilShipUnlock(): int {
-		return $this->getStartTime() + TIME_FOR_RAIDER_UNLOCK - Smr\Epoch::time();
+		return $this->getStartTime() + TIME_FOR_RAIDER_UNLOCK - Epoch::time();
 	}
 
 }

--- a/src/lib/Default/SmrShip.php
+++ b/src/lib/Default/SmrShip.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * Adds a database layer to an AbstractSmrShip instance.
  * Loads and saves ship properties from/to the database.
@@ -33,7 +35,7 @@ class SmrShip extends AbstractSmrShip {
 
 	protected function __construct(AbstractSmrPlayer $player) {
 		parent::__construct($player);
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$this->SQL = 'account_id=' . $db->escapeNumber($this->getAccountID()) . ' AND game_id=' . $db->escapeNumber($this->getGameID());
 
 		$this->loadHardware();
@@ -58,7 +60,7 @@ class SmrShip extends AbstractSmrShip {
 	 */
 	protected function loadWeapons(): void {
 		// determine weapon
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM ship_has_weapon JOIN weapon_type USING (weapon_type_id)
 							WHERE ' . $this->SQL . '
 							ORDER BY order_id LIMIT ' . $db->escapeNumber($this->getHardpoints()));
@@ -80,7 +82,7 @@ class SmrShip extends AbstractSmrShip {
 		$this->hardware = [];
 
 		// get currently hardware from db
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT *
 							FROM ship_has_hardware
 							JOIN hardware_type USING(hardware_type_id)
@@ -100,7 +102,7 @@ class SmrShip extends AbstractSmrShip {
 		$this->cargo = [];
 
 		// get cargo from db
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM ship_has_cargo WHERE ' . $this->SQL);
 		foreach ($dbResult->records() as $dbRecord) {
 			// adding cargo and amount to array
@@ -114,7 +116,7 @@ class SmrShip extends AbstractSmrShip {
 			return;
 		}
 		// write cargo info
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		foreach ($this->getCargo() as $id => $amount) {
 			if ($amount > 0) {
 				$db->replace('ship_has_cargo', [
@@ -135,7 +137,7 @@ class SmrShip extends AbstractSmrShip {
 
 	public function updateHardware(): void {
 		// write hardware info only for hardware that has changed
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		foreach ($this->hasChangedHardware as $hardwareTypeID => $hasChanged) {
 			if ($hasChanged === false) {
 				continue;
@@ -160,7 +162,7 @@ class SmrShip extends AbstractSmrShip {
 			return;
 		}
 		// write weapon info
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$db->write('DELETE FROM ship_has_weapon WHERE ' . $this->SQL);
 		foreach ($this->weapons as $orderID => $weapon) {
 			$db->insert('ship_has_weapon', [
@@ -180,7 +182,7 @@ class SmrShip extends AbstractSmrShip {
 		if ($this->hasCloak() === false) {
 			return;
 		}
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT 1 FROM ship_is_cloaked WHERE ' . $this->SQL);
 		$this->isCloaked = $dbResult->hasRecord();
 	}
@@ -189,7 +191,7 @@ class SmrShip extends AbstractSmrShip {
 		if ($this->hasChangedCloak === false) {
 			return;
 		}
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		if ($this->isCloaked === false) {
 			$db->write('DELETE FROM ship_is_cloaked WHERE ' . $this->SQL);
 		} else {
@@ -206,7 +208,7 @@ class SmrShip extends AbstractSmrShip {
 		if ($this->hasIllusion() === false) {
 			return;
 		}
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM ship_has_illusion WHERE ' . $this->SQL);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
@@ -222,7 +224,7 @@ class SmrShip extends AbstractSmrShip {
 		if ($this->hasChangedIllusion === false) {
 			return;
 		}
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		if ($this->illusionShip === false) {
 			$db->write('DELETE FROM ship_has_illusion WHERE ' . $this->SQL);
 		} else {

--- a/src/lib/Default/SmrShipType.php
+++ b/src/lib/Default/SmrShipType.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 use Smr\BuyerRestriction;
+use Smr\Database;
+use Smr\DatabaseRecord;
 use Smr\ShipClass;
 
 /**
@@ -30,10 +32,10 @@ class SmrShipType {
 		self::$CACHE_SHIP_TYPES = [];
 	}
 
-	public static function get(int $shipTypeID, Smr\DatabaseRecord $dbRecord = null): self {
+	public static function get(int $shipTypeID, DatabaseRecord $dbRecord = null): self {
 		if (!isset(self::$CACHE_SHIP_TYPES[$shipTypeID])) {
 			if ($dbRecord === null) {
-				$db = Smr\Database::getInstance();
+				$db = Database::getInstance();
 				$dbResult = $db->read('SELECT * FROM ship_type WHERE ship_type_id = ' . $db->escapeNumber($shipTypeID));
 				$dbRecord = $dbResult->record();
 			} elseif ($shipTypeID !== $dbRecord->getInt('ship_type_id')) {
@@ -48,7 +50,7 @@ class SmrShipType {
 	 * @return array<int, self>
 	 */
 	public static function getAll(): array {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM ship_type ORDER BY ship_type_id ASC');
 		foreach ($dbResult->records() as $dbRecord) {
 			// populate the cache
@@ -57,7 +59,7 @@ class SmrShipType {
 		return self::$CACHE_SHIP_TYPES;
 	}
 
-	protected function __construct(Smr\DatabaseRecord $dbRecord) {
+	protected function __construct(DatabaseRecord $dbRecord) {
 		$this->name = $dbRecord->getString('ship_name');
 		$this->typeID = $dbRecord->getInt('ship_type_id');
 		$this->class = ShipClass::from($dbRecord->getInt('ship_class_id'));
@@ -85,7 +87,7 @@ class SmrShipType {
 		};
 
 		// get supported hardware from db
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT hardware_type_id, max_amount FROM ship_type_support_hardware ' .
 			'WHERE ship_type_id = ' . $db->escapeNumber($this->typeID) . ' ORDER BY hardware_type_id');
 

--- a/src/lib/Default/SmrWeapon.php
+++ b/src/lib/Default/SmrWeapon.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\BuyerRestriction;
+use Smr\DatabaseRecord;
 
 /**
  * Defines a concrete realization of a weapon type for ships/planets.
@@ -19,13 +20,13 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	protected bool $bonusDamage = false; // default
 	protected bool $damageRollover = false; // fixed for all SmrWeapons
 
-	public static function getWeapon(int $weaponTypeID, Smr\DatabaseRecord $dbRecord = null): self {
+	public static function getWeapon(int $weaponTypeID, DatabaseRecord $dbRecord = null): self {
 		return new self($weaponTypeID, $dbRecord);
 	}
 
 	protected function __construct(
 		protected readonly int $weaponTypeID,
-		Smr\DatabaseRecord $dbRecord = null
+		DatabaseRecord $dbRecord = null
 	) {
 		$this->weaponType = SmrWeaponType::getWeaponType($weaponTypeID, $dbRecord);
 		$this->raceID = $this->weaponType->getRaceID();

--- a/src/lib/Default/SmrWeaponType.php
+++ b/src/lib/Default/SmrWeaponType.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 use Smr\BuyerRestriction;
+use Smr\Database;
+use Smr\DatabaseRecord;
 
 /**
  * Defines the base weapon types for ships/planets.
@@ -20,10 +22,10 @@ class SmrWeaponType {
 	protected readonly int $powerLevel;
 	protected readonly BuyerRestriction $buyerRestriction;
 
-	public static function getWeaponType(int $weaponTypeID, Smr\DatabaseRecord $dbRecord = null): self {
+	public static function getWeaponType(int $weaponTypeID, DatabaseRecord $dbRecord = null): self {
 		if (!isset(self::$CACHE_WEAPON_TYPES[$weaponTypeID])) {
 			if ($dbRecord === null) {
-				$db = Smr\Database::getInstance();
+				$db = Database::getInstance();
 				$dbResult = $db->read('SELECT * FROM weapon_type WHERE weapon_type_id = ' . $db->escapeNumber($weaponTypeID));
 				$dbRecord = $dbResult->record();
 			}
@@ -37,7 +39,7 @@ class SmrWeaponType {
 	 * @return array<int, self>
 	 */
 	public static function getAllWeaponTypes(): array {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM weapon_type');
 		$weapons = [];
 		foreach ($dbResult->records() as $dbRecord) {
@@ -53,7 +55,7 @@ class SmrWeaponType {
 	 * @return array<int, self>
 	 */
 	public static function getAllSoldWeaponTypes(int $gameID): array {
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT DISTINCT weapon_type.* FROM weapon_type JOIN location_sells_weapons USING (weapon_type_id) JOIN location USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID));
 		$weapons = [];
 		foreach ($dbResult->records() as $dbRecord) {
@@ -65,7 +67,7 @@ class SmrWeaponType {
 
 	protected function __construct(
 		protected readonly int $weaponTypeID,
-		Smr\DatabaseRecord $dbRecord
+		DatabaseRecord $dbRecord
 	) {
 		$this->name = $dbRecord->getString('weapon_name');
 		$this->raceID = $dbRecord->getInt('race_id');

--- a/src/lib/Default/WeightedRandom.php
+++ b/src/lib/Default/WeightedRandom.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * Weighted random number generator used to make events achieve their expected
  * rate of success faster than a pure random number generator.
@@ -17,7 +19,7 @@ class WeightedRandom {
 
 	protected const WEIGHTING_CHANGE = 50; // as a percent
 
-	protected Smr\Database $db;
+	protected Database $db;
 
 	protected float $weighting;
 
@@ -52,7 +54,7 @@ class WeightedRandom {
 		protected readonly string $type,
 		protected readonly int $typeID
 	) {
-		$this->db = Smr\Database::getInstance();
+		$this->db = Database::getInstance();
 		$dbResult = $this->db->read('SELECT weighting FROM weighted_random WHERE game_id = ' . $this->db->escapeNumber($gameID) . ' AND account_id = ' . $this->db->escapeNumber($accountID) . ' AND type = ' . $this->db->escapeString($type) . ' AND type_id = ' . $this->db->escapeNumber($typeID));
 		if ($dbResult->hasRecord()) {
 			$this->weighting = $dbResult->record()->getInt('weighting');

--- a/src/lib/Default/course_plot.inc.php
+++ b/src/lib/Default/course_plot.inc.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Path;
+
 /**
  * This function is called by "Conventional" and "Plot To Nearest" pages.
  */
-function course_plot_forward(AbstractSmrPlayer $player, Smr\Path $path): never {
+function course_plot_forward(AbstractSmrPlayer $player, Path $path): never {
 
 	if ($player->getSectorID() == $path->getStartSectorID()) {
 		$player->setPlottedCourse($path);

--- a/src/lib/Default/help.inc.php
+++ b/src/lib/Default/help.inc.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 function echo_nav(int $topic_id): void {
 	// database object
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 
 	// get current entry
 	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($topic_id));
@@ -113,7 +115,7 @@ function echo_nav(int $topic_id): void {
 
 function echo_content(int $topic_id): void {
 	// database object
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 
 	// get current entry
 	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $topic_id);
@@ -135,7 +137,7 @@ function echo_content(int $topic_id): void {
 
 function echo_subsection(int $topic_id): void {
 	// database object
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 
 	// check if there are subsections
 	$dbResult = $db->read('SELECT 1 FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' ORDER BY order_id');
@@ -152,7 +154,7 @@ function echo_subsection(int $topic_id): void {
 
 function echo_menu(int $topic_id): void {
 	// database object
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 
 	$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' ORDER BY order_id');
 	if ($dbResult->hasRecord()) {
@@ -170,7 +172,7 @@ function echo_menu(int $topic_id): void {
 }
 
 function get_numbering(int $topic_id): string {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 
 	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($topic_id));
 	if (!$dbResult->hasRecord()) {

--- a/src/lib/Default/missions.inc.php
+++ b/src/lib/Default/missions.inc.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Smr\BarDrink;
 use Smr\PlotGroup;
 
 const MISSION_ACTIONS = [
@@ -68,7 +69,7 @@ const MISSIONS = [
 				'Detail' => [
 					'SectorID' => '<Sector>',
 				],
-				'Text' => '*Hiccup* Hey! I need you to...*Hiccup* do me a favor. All the ' . Smr\BarDrink::SALVENE_SWAMP_SODA . ' in this bar is awful! Go to the Sal...*Hiccup*...the Salvene HQ, they\'ll know a good bar.',
+				'Text' => '*Hiccup* Hey! I need you to...*Hiccup* do me a favor. All the ' . BarDrink::SALVENE_SWAMP_SODA . ' in this bar is awful! Go to the Sal...*Hiccup*...the Salvene HQ, they\'ll know a good bar.',
 				'Task' => 'Go to the Salvene HQ at [sector=<Sector>]',
 			],
 			[
@@ -80,24 +81,24 @@ const MISSIONS = [
 				'Detail' => [
 					'SectorID' => '<Sector>',
 				],
-				'Text' => 'Here we are! The Salvene HQ! You ask around a bit and find that the bar in [sector=<Sector>] does the best ' . Smr\BarDrink::SALVENE_SWAMP_SODA . ' around!',
-				'Task' => 'Go to the bar at [sector=<Sector>] and buy a ' . Smr\BarDrink::SALVENE_SWAMP_SODA . ' from the bartender. This may take many tries.',
+				'Text' => 'Here we are! The Salvene HQ! You ask around a bit and find that the bar in [sector=<Sector>] does the best ' . BarDrink::SALVENE_SWAMP_SODA . ' around!',
+				'Task' => 'Go to the bar at [sector=<Sector>] and buy a ' . BarDrink::SALVENE_SWAMP_SODA . ' from the bartender. This may take many tries.',
 			],
 			[
 				'Step' => 'BuyDrink',
 				'Detail' => [
 					'SectorID' => '<Sector>',
-					'Drink' => Smr\BarDrink::SALVENE_SWAMP_SODA,
+					'Drink' => BarDrink::SALVENE_SWAMP_SODA,
 				],
-				'Text' => 'Here we are! Now let\'s get this ' . Smr\BarDrink::SALVENE_SWAMP_SODA . '.',
-				'Task' => 'Go to the bar at [sector=<Sector>] and buy a ' . Smr\BarDrink::SALVENE_SWAMP_SODA . ' from the bartender. This may take many tries.',
+				'Text' => 'Here we are! Now let\'s get this ' . BarDrink::SALVENE_SWAMP_SODA . '.',
+				'Task' => 'Go to the bar at [sector=<Sector>] and buy a ' . BarDrink::SALVENE_SWAMP_SODA . ' from the bartender. This may take many tries.',
 			],
 			[
 				'Step' => 'EnterSector',
 				'Detail' => [
 					'SectorID' => '<Starting Sector>',
 				],
-				'Text' => 'Finally! A true ' . Smr\BarDrink::SALVENE_SWAMP_SODA . ', let\'s return to that drunk!',
+				'Text' => 'Finally! A true ' . BarDrink::SALVENE_SWAMP_SODA . ', let\'s return to that drunk!',
 				'Task' => 'Return to [sector=<Starting Sector>] to claim your reward.',
 			],
 			[
@@ -110,7 +111,7 @@ const MISSIONS = [
 				'Detail' => [
 					'SectorID' => '<Starting Sector>',
 				],
-				'Text' => 'You hand the ' . Smr\BarDrink::SALVENE_SWAMP_SODA . ' to the drunk!',
+				'Text' => 'You hand the ' . BarDrink::SALVENE_SWAMP_SODA . ' to the drunk!',
 			],
 		],
 	],

--- a/src/lib/Default/nha.inc.php
+++ b/src/lib/Default/nha.inc.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+use Smr\Epoch;
+
 /**
  * Create the Newbie Help Alliance and populate its Message Board
  */
@@ -213,7 +216,7 @@ function createNHA(int $gameID): void {
 	It is important to note that weakly defended planets should NOT be considered safe parking spots.',
 	];
 
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$threadID = 1;
 	foreach ($threads as $topic => $text) {
 		$db->replace('alliance_thread_topic', [
@@ -229,7 +232,7 @@ function createNHA(int $gameID): void {
 			'reply_id' => 1,
 			'text' => $db->escapeString($text),
 			'sender_id' => $db->escapeNumber(ACCOUNT_ID_NHL),
-			'time' => $db->escapeNumber(Smr\Epoch::time()),
+			'time' => $db->escapeNumber(Epoch::time()),
 		]);
 		$threadID++;
 	}

--- a/src/lib/Default/shop_goods.inc.php
+++ b/src/lib/Default/shop_goods.inc.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Exceptions\UserError;
+
 function check_bargain_number(int $amount, int $ideal_price, int $offered_price, int $bargain_price, Page $container, AbstractSmrPlayer $player): void {
 	$var = Smr\Session::getInstance()->getCurrentVar();
 
@@ -19,7 +21,7 @@ function check_bargain_number(int $amount, int $ideal_price, int $offered_price,
 		if ($container['number_of_bargains'] > $container['overall_number_of_bargains']) {
 			$player->decreaseRelationsByTrade($amount, $port->getRaceID());
 			$player->increaseHOF(1, ['Trade', 'Results', 'Epic Fail'], HOF_PUBLIC);
-			throw new Smr\Exceptions\UserError('You don\'t want to accept my offer? I\'m sick of you! Get out of here!');
+			throw new UserError('You don\'t want to accept my offer? I\'m sick of you! Get out of here!');
 		}
 
 		$port_off = IRound($offered_price * 100 / $ideal_price);

--- a/src/lib/Draft/alliance_pick.inc.php
+++ b/src/lib/Draft/alliance_pick.inc.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * Returns an array with all relevant information about draft teams,
  * including their current size and if the leader can pick teammates.
@@ -7,7 +9,7 @@
  * @return array<int, array<string, mixed>>
  */
 function get_draft_teams(int $gameId): array {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT account_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($gameId));
 
 	// Get team leader, alliance, and alliance size

--- a/src/lib/SemiWars/SmrPlayer.php
+++ b/src/lib/SemiWars/SmrPlayer.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\DatabaseRecord;
+
 class SmrPlayer extends AbstractSmrPlayer {
 
 	protected function __construct(
 		protected readonly int $gameID,
 		protected readonly int $accountID,
-		Smr\DatabaseRecord $dbRecord = null
+		DatabaseRecord $dbRecord = null
 	) {
 		parent::__construct($gameID, $accountID, $dbRecord);
 		$this->newbieStatus = true;

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -5,7 +5,6 @@ namespace Smr\Chess;
 use AbstractSmrPlayer;
 use Exception;
 use Page;
-use Smr;
 use Smr\Database;
 use Smr\Epoch;
 use Smr\Exceptions\UserError;
@@ -20,7 +19,7 @@ class ChessGame {
 	/** @var array<int, self> */
 	protected static array $CACHE_CHESS_GAMES = [];
 
-	private Smr\Database $db;
+	private Database $db;
 
 	private readonly int $whiteID;
 	private readonly int $blackID;

--- a/src/tools/chat_helpers/channel_msg_forces.php
+++ b/src/tools/chat_helpers/channel_msg_forces.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 require_once(TOOLS . 'chat_helpers/channel_msg_seedlist.php');
 
 /**
  * @return array<string>
  */
 function shared_channel_msg_forces(AbstractSmrPlayer $player, ?string $option = null): array {
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	if (empty($option)) {
 		$dbResult = $db->read('SELECT sector_has_forces.sector_id AS sector, expire_time
 			FROM sector_has_forces

--- a/src/tools/chat_helpers/channel_msg_money.php
+++ b/src/tools/chat_helpers/channel_msg_money.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * @return array<string>
  */
@@ -16,7 +18,7 @@ function shared_channel_msg_money(AbstractSmrPlayer $player): array {
 	$result[] = 'The alliance has ' . number_format($player->getAlliance(true)->getBank()) . ' credits in the bank account.';
 
 	// get money on ships and personal bank accounts
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT sum(credits) as total_onship, sum(bank) as total_onbank FROM player WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID());
 
 	if ($dbResult->hasRecord()) {

--- a/src/tools/chat_helpers/channel_msg_op_info.php
+++ b/src/tools/chat_helpers/channel_msg_op_info.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * @return array<string>
  */
 function shared_channel_msg_op_info(AbstractSmrPlayer $player): array {
 	// get the op from db
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
 	if (!$dbResult->hasRecord()) {
 		return ['Your leader has not scheduled an operation.'];
@@ -20,7 +22,7 @@ function shared_channel_msg_op_info(AbstractSmrPlayer $player): array {
 	// function to return op info message for each player
 	$getOpInfoMessage = function($player) use ($opTime) {
 		// have we signed up?
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT response FROM alliance_has_op_response WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND ' . $player->getSQL());
 		if ($dbResult->hasRecord()) {
 			$msg = $player->getPlayerName() . ' is on the ' . $dbResult->record()->getString('response') . ' list.';

--- a/src/tools/chat_helpers/channel_msg_op_list.php
+++ b/src/tools/chat_helpers/channel_msg_op_list.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * @return array<string>
  */
 function shared_channel_msg_op_list(AbstractSmrPlayer $player): array {
 	// get the op info from db
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT 1
 				FROM alliance_has_op
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '

--- a/src/tools/chat_helpers/channel_msg_op_turns.php
+++ b/src/tools/chat_helpers/channel_msg_op_turns.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * @return array<string>
  */
 function shared_channel_msg_op_turns(AbstractSmrPlayer $player): array {
 	// get the op from db
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT 1
 				FROM alliance_has_op
 				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '

--- a/src/tools/chat_helpers/channel_msg_seed.php
+++ b/src/tools/chat_helpers/channel_msg_seed.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 function get_seed_message(AbstractSmrPlayer $player): string {
 	// get a list of seedlist sectors that the player hasn't seeded
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT sector_id
 		FROM alliance_has_seedlist
 		WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
@@ -30,7 +32,7 @@ function get_seed_message(AbstractSmrPlayer $player): string {
  */
 function shared_channel_msg_seed(AbstractSmrPlayer $player): array {
 	// Check to see how many sectors are in the seedlist
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT count(*)
 		FROM alliance_has_seedlist
 		WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '

--- a/src/tools/chat_helpers/channel_msg_seedlist.php
+++ b/src/tools/chat_helpers/channel_msg_seedlist.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * @return array<int>
  */
 function get_seedlist(AbstractSmrPlayer $player): array {
 	// Return the seedlist
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT sector_id FROM alliance_has_seedlist
 						WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
 							AND game_id = ' . $db->escapeNumber($player->getGameID()));
@@ -58,7 +60,7 @@ function shared_channel_msg_seedlist_add(AbstractSmrPlayer $player, ?array $sect
 	$currentSeedlist = get_seedlist($player);
 	$initSizeSeedlist = count($currentSeedlist);
 
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	foreach ($sectors as $sector) {
 		// check if the sector is a part of the game
 		$dbResult = $db->read('SELECT 1
@@ -119,7 +121,7 @@ function shared_channel_msg_seedlist_del(AbstractSmrPlayer $player, ?array $sect
 	}
 
 	// remove sectors from the db
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$db->write('DELETE FROM alliance_has_seedlist
 				WHERE alliance_id = ' . $player->getAllianceID() . '
 					AND game_id = ' . $player->getGameID() . '

--- a/src/tools/irc/channel.php
+++ b/src/tools/irc/channel.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * @param resource $fp
  */
@@ -14,7 +16,7 @@ function channel_join($fp, string $rdata): bool {
 
 		echo_r('[JOIN] ' . $nick . '!' . $user . '@' . $host . ' joined ' . $channel);
 
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 
 		// check if we have seen this user before
 		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND channel = ' . $db->escapeString($channel));
@@ -84,7 +86,7 @@ function channel_part($fp, string $rdata): bool {
 		echo_r('[PART] ' . $nick . '!' . $user . '@' . $host . ' ' . $channel);
 
 		// database object
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 
 		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND channel = ' . $db->escapeString($channel));
 

--- a/src/tools/irc/channel_msg_op.php
+++ b/src/tools/irc/channel_msg_op.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * @param resource $fp
  */
@@ -74,7 +76,7 @@ function channel_msg_op_cancel($fp, string $rdata, AbstractSmrPlayer $player): b
 		}
 
 		// get the op from db
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT 1
 					FROM alliance_has_op
 					WHERE alliance_id = ' . $player->getAllianceID() . '
@@ -121,7 +123,7 @@ function channel_msg_op_set($fp, string $rdata, AbstractSmrPlayer $player): bool
 		}
 
 		// get the op from db
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT 1
 					FROM alliance_has_op
 					WHERE alliance_id = ' . $player->getAllianceID() . '
@@ -195,7 +197,7 @@ function channel_msg_op_response($fp, string $rdata, AbstractSmrPlayer $player):
 		echo_r('[OP_' . $response . '] by ' . $nick . ' in ' . $channel);
 
 		// get the op info from db
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT 1
 					FROM alliance_has_op
 					WHERE alliance_id = ' . $player->getAllianceID() . '
@@ -258,7 +260,7 @@ function channel_op_notification($fp, string $rdata, string $nick, string $chann
 		return true;
 	}
 
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	// check if there is an upcoming op
 	$dbResult = $db->read('SELECT 1
 				FROM alliance_has_op

--- a/src/tools/irc/irc.php
+++ b/src/tools/irc/irc.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\Database;
+use Smr\Irc\Exceptions\Timeout;
 
 function echo_r(string $message): void {
 	echo date('Y-m-d H:i:s => ') . $message . EOL;
@@ -95,7 +96,7 @@ while (true) {
 		}
 		fclose($fp); // close socket
 
-	} catch (Smr\Irc\Exceptions\Timeout) {
+	} catch (Timeout) {
 		// Ignore the timeout exception, we'll loop round and reconnect.
 	}
 } // end of while running

--- a/src/tools/irc/notice.php
+++ b/src/tools/irc/notice.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * @param resource $fp
  */
@@ -13,7 +15,7 @@ function notice_nickserv_registered_user($fp, string $rdata): bool {
 
 		echo_r('[NOTICE_NICKSERV_REGISTERED_NICK] ' . $nick . ' is ' . $registeredNick);
 
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 
 		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick));
 		foreach ($dbResult->records() as $dbRecord) {

--- a/src/tools/irc/server.php
+++ b/src/tools/irc/server.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 /**
  * Very important!
  * If we do not answer the ping from server we will be disconnected
@@ -43,7 +45,7 @@ function server_msg_307($fp, string $rdata): bool {
 
 		echo_r('[SERVER_307] ' . $server . ' said that ' . $nick . ' is registered');
 
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick));
 		foreach ($dbResult->records() as $dbRecord) {
 			$seen_id = $dbRecord->getInt('seen_id');
@@ -74,7 +76,7 @@ function server_msg_318($fp, string $rdata): bool {
 
 		echo_r('[SERVER_318] ' . $server . ' end of /WHOIS for ' . $nick);
 
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 
 		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND registered IS NULL');
 		foreach ($dbResult->records() as $dbRecord) {
@@ -133,7 +135,7 @@ function server_msg_352($fp, string $rdata): bool {
 
 		echo_r('[WHO] ' . $channel . ': ' . $nick);
 
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 
 		// check if we have seen this user before
 		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND channel = ' . $db->escapeString($channel));
@@ -182,7 +184,7 @@ function server_msg_401($fp, string $rdata): bool {
 
 		echo_r('[SERVER_401] ' . $server . ' said: "No such nick/channel" for ' . $nick);
 
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 
 		// get the user in question
 		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND signed_off = 0');

--- a/src/tools/irc/stream.php
+++ b/src/tools/irc/stream.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Irc\Exceptions\Timeout;
+
 require_once(TOOLS . 'irc/server.php');
 require_once(TOOLS . 'irc/ctcp.php');
 require_once(TOOLS . 'irc/invite.php');
@@ -42,7 +44,7 @@ function readFromStream($fp): bool {
 	if ($last_ping < time() - 300) {
 		echo_r('TIMEOUT detected!');
 		fclose($fp); // close socket
-		throw new Smr\Irc\Exceptions\Timeout();
+		throw new Timeout();
 	}
 
 	// we simply do some poll stuff here

--- a/src/tools/irc/user.php
+++ b/src/tools/irc/user.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 function user_quit(string $rdata): bool {
 
 	// :Fubar!Mibbit@coldfront-77C78B7B.dyn.optonline.net QUIT :Quit: http://www.mibbit.com ajax IRC Client
@@ -13,7 +15,7 @@ function user_quit(string $rdata): bool {
 		echo_r('[QUIT] ' . $nick . '!' . $user . '@' . $host . ' stated ' . $quit_msg);
 
 		// database object
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 
 		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick));
 
@@ -49,7 +51,7 @@ function user_nick(string $rdata): bool {
 		echo_r('[NICK] ' . $nick . ' -> ' . $new_nick);
 
 		// database object
-		$db = Smr\Database::getInstance();
+		$db = Database::getInstance();
 
 		$channel_list = [];
 

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -1,10 +1,14 @@
 <?php declare(strict_types=1);
 
+use Smr\Chess\ChessGame;
 use Smr\Chess\Colour;
+use Smr\Container\DiContainer;
+use Smr\Database;
+use Smr\Epoch;
 
 function debug(string $message, mixed $debugObject = null): void {
 	echo date('Y-m-d H:i:s - ') . $message . ($debugObject !== null ? EOL . var_export($debugObject, true) : '') . EOL;
-	$db = Smr\Database::getInstance();
+	$db = Database::getInstance();
 	$logID = $db->insert('npc_logs', [
 		'script_id' => defined('SCRIPT_ID') ? SCRIPT_ID : 0,
 		'npc_id' => 0,
@@ -28,7 +32,7 @@ try {
 	debug('Script started');
 
 	// Enable NPC-specific conditions
-	Smr\Container\DiContainer::getContainer()->set('NPC_SCRIPT', true);
+	DiContainer::getContainer()->set('NPC_SCRIPT', true);
 
 	$descriptorSpec = [
 		0 => ['pipe', 'r'], // stdin is a pipe that the child will read from
@@ -63,9 +67,9 @@ try {
 
 	while (true) {
 		// The next "page request" must occur at an updated time.
-		Smr\Epoch::update();
+		Epoch::update();
 
-		foreach (Smr\Chess\ChessGame::getNPCMoveGames(true) as $chessGame) {
+		foreach (ChessGame::getNPCMoveGames(true) as $chessGame) {
 			debug('Looking at game: ' . $chessGame->getChessGameID());
 			writeToEngine('position fen ' . $chessGame->getFENString(), false);
 			writeToEngine('go ' . ($chessGame->getCurrentTurnColour() == Colour::White ? 'w' : 'b') . 'time ' . UCI_TIME_PER_MOVE_MS, true, false);

--- a/src/tools/rerunChessGames.php
+++ b/src/tools/rerunChessGames.php
@@ -1,14 +1,19 @@
 <?php declare(strict_types=1);
+
+use Smr\Chess\ChessGame;
+use Smr\Database;
+use Smr\Session;
+
 require_once('../bootstrap.php');
 
-Smr\Session::getInstance()->updateGame(44);
+Session::getInstance()->updateGame(44);
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $db->write('DELETE FROM player_hof WHERE type LIKE \'Chess%\'');
 $dbResult = $db->read('SELECT chess_game_id FROM chess_game');
 foreach ($dbResult->records() as $dbRecord) {
 	$chessGameID = $dbRecord->getInt('chess_game_id');
-	$game = Smr\Chess\ChessGame::getChessGame($chessGameID);
+	$game = ChessGame::getChessGame($chessGameID);
 	echo 'Running game ' . $chessGameID . ' for white id "' . $game->getWhiteID() . '", black id "' . $game->getBlackID() . '", winner "' . $game->getWinner() . '"' . EOL;
 	echoChessMoves($game);
 
@@ -17,7 +22,7 @@ foreach ($dbResult->records() as $dbRecord) {
 	echoChessMoves($game);
 }
 
-function echoChessMoves(Smr\Chess\ChessGame $game): void {
+function echoChessMoves(ChessGame $game): void {
 	echo 'Moves: ' . EOL;
 	$moves = $game->getMoves();
 	foreach ($moves as $move) {

--- a/src/tools/reserializeCombatLogs.php
+++ b/src/tools/reserializeCombatLogs.php
@@ -1,8 +1,10 @@
 <?php declare(strict_types=1);
 
+use Smr\Database;
+
 require_once('../bootstrap.php');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 
 $dbResult = $db->read('SELECT result,log_id FROM combat_logs');
 foreach ($dbResult->records() as $dbRecord) {

--- a/src/tools/updatePortCache.php
+++ b/src/tools/updatePortCache.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
+
+use Smr\Database;
+
 require_once('../bootstrap.php');
 
-$db = Smr\Database::getInstance();
+$db = Database::getInstance();
 $dbResult = $db->read('SELECT account_id,sector_id,game_id FROM player_visited_port');
 foreach ($dbResult->records() as $dbRecord) {
 	SmrPort::getCachedPort($dbRecord->getInt('game_id'), $dbRecord->getInt('sector_id'), $dbRecord->getInt('account_id'))->addCachePort($dbRecord->getInt('account_id'));


### PR DESCRIPTION
It is a more common convention to explicitly import all classes that
are not in the current namespace. While many of our classes are not
namespaced (i.e. implicitly in the global namespace), the goal is to
eventually move everything into the `Smr` namespace.