### PR TITLE
Update phpstan from 1.8.2 to 1.8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
 	"require-dev": {
 		"fig-r/psr2r-sniffer": "1.4.0",
 		"overtrue/phplint": "5.3.0",
-		"phpstan/phpstan": "1.8.2",
+		"phpstan/phpstan": "1.8.5",
 		"phpunit/phpunit": "9.5.24",
 		"phpunit/php-code-coverage": "9.2.17",
 		"squizlabs/php_codesniffer": "3.7.1"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -73,6 +73,12 @@ parameters:
                 - src/bootstrap.php
                 - src/engine/Default/bug_report_processing.php
         -
+            # https://github.com/phpstan/phpstan/issues/7913
+            message: '#Empty array passed to foreach.#'
+            paths:
+                - src/bootstrap.php
+                - src/engine/Default/bug_report_processing.php
+        -
             # https://github.com/thephpleague/oauth2-client/issues/897
             message: '#Parameter \#1 \$token of method .*::getResourceOwner\(\) expects .*AccessToken, .*AccessTokenInterface given.#'
             path: src/lib/Smr/SocialLogin


### PR DESCRIPTION
Manually update phpstan because it induces some new warnings. Note that these warnings are due to a limitation of dynamicConstantNames and empty constant arrays.

Related to https://github.com/phpstan/phpstan/issues/7913.

Closes https://github.com/smrealms/smr/pull/1432.