### PR TITLE
Switch to docker compose plugin

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,6 @@ jobs:
 
     env:
       # Use buildkit for faster builds
-      COMPOSE_DOCKER_CLI_BUILD: 1
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 ## Dependencies
 Make sure the following software is installed:
-* docker (version 18.06.0+)
-* docker-compose (version 1.22.0+)
+* docker (version 19.03.0+)
+* docker compose plugin (v2)
 
 To run unit tests on your machine:
 * Composer (2.0.5+)
@@ -26,7 +26,7 @@ The options must be consistent between the various configuration files.
 ## Populate the mysql database
 To initialize the database or update it with new patches, run:
 ```
-docker-compose run --rm flyway
+docker compose run --rm flyway
 ```
 
 To modify the database, add a file called `V<VERSION_NUMBER>__<NAME>.sql` into
@@ -35,18 +35,18 @@ To modify the database, add a file called `V<VERSION_NUMBER>__<NAME>.sql` into
 You can optionally start up [phpMyAdmin](https://www.phpmyadmin.net/) to
 inspect your mysql database in a web browser at `http://localhost/pma/`:
 ```
-docker-compose up --build -d pma
+docker compose up --build -d pma
 ```
 
 ## Start up the services
 Then you can start up the persistent game services
 ```
-docker-compose up --build -d traefik smr
+docker compose up --build -d traefik smr
 ```
 
 For development, it may be desirable to automatically pick up source code changes without rebuilding the docker image. Simply use the `smr-dev` service instead of `smr`, i.e.:
 ```
-docker-compose up --build -d traefik smr-dev
+docker compose up --build -d traefik smr-dev
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -26,39 +26,39 @@
 	},
 	"scripts": {
 		"start:dev": [
-			"docker-compose up -d traefik smr-dev"
+			"docker compose up -d traefik smr-dev"
 		],
 		"rebuild:dev": [
-			"docker-compose up --build -d smr-dev"
+			"docker compose up --build -d smr-dev"
 		],
 		"start:test-services": [
-			"docker-compose --env-file test/env up -d mysql-test",
+			"docker compose --env-file test/env up -d mysql-test",
 			"@rebuild:test-services"
 		],
 		"reset:test-services": [
-			"docker-compose --env-file test/env stop mysql-test",
-			"docker-compose --env-file test/env rm -f -v mysql-test",
+			"docker compose --env-file test/env stop mysql-test",
+			"docker compose --env-file test/env rm -f -v mysql-test",
 			"@start:test-services"
 		],
 		"rebuild:test-services": [
-			"docker-compose --env-file test/env build phpunit",
-			"docker-compose --env-file test/env run --rm flyway-test"
+			"docker compose --env-file test/env build phpunit",
+			"docker compose --env-file test/env run --rm flyway-test"
 		],
 		"test": [
-			"docker-compose --env-file test/env run --rm phpunit"
+			"docker compose --env-file test/env run --rm phpunit"
 		],
 		"phpcs": [
-			"docker-compose --env-file test/env run --rm phpcs"
+			"docker compose --env-file test/env run --rm phpcs"
 		],
 		"phpcbf": [
-			"docker-compose --env-file test/env run --rm phpcbf"
+			"docker compose --env-file test/env run --rm phpcbf"
 		],
 		"phpstan": [
-			"docker-compose --env-file test/env run --rm phpstan"
+			"docker compose --env-file test/env run --rm phpstan"
 		],
 		"stop": [
-			"docker-compose stop",
-			"docker-compose rm --force"
+			"docker compose stop",
+			"docker compose rm --force"
 		]
 	},
 	"config": {

--- a/db/init_admin.sh
+++ b/db/init_admin.sh
@@ -5,4 +5,4 @@
 
 # Initialize the first account as an admin.
 # Will validate and grant "Manage Admins Permissions" permission.
-docker-compose exec -T mysql sh -c 'mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -e "use smr_live; REPLACE INTO account_has_permission (account_id, permission_id) VALUES (1, 1); UPDATE account SET validated=\"TRUE\" WHERE account_id=1;"'
+docker compose exec -T mysql sh -c 'mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -e "use smr_live; REPLACE INTO account_has_permission (account_id, permission_id) VALUES (1, 1); UPDATE account SET validated=\"TRUE\" WHERE account_id=1;"'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 networks:
     frontend:
         name: frontend
@@ -15,6 +13,7 @@ x-smr-builder: &smr-builder
         args:
             - NO_DEV
     image: local/smr
+    pull_policy: never
 
 # Base configuration for `smr` (production) and `smr-dev` (testing).
 x-smr-common: &smr-common
@@ -116,7 +115,7 @@ services:
     flyway: &flyway-common
         image: flyway/flyway:latest-alpine
         # Allow retries in case the mysql service is still spinning up
-        command: -connectRetries=20 -url=jdbc:mysql://${MYSQL_HOST}/${MYSQL_DATABASE}?allowPublicKeyRetrieval=true&useSSL=false -user=${MYSQL_USER} -password=${MYSQL_PASSWORD} migrate
+        command: ["-connectRetries=20", "-url=jdbc:mysql://${MYSQL_HOST}/${MYSQL_DATABASE}?allowPublicKeyRetrieval=true&useSSL=false", "-user=${MYSQL_USER}", "-password=${MYSQL_PASSWORD}", "migrate"]
         networks:
             - backend
         depends_on:


### PR DESCRIPTION
The docker compose plugin is a native docker subcommand rather than a separate program written in Python.

Use docker compose v2+ and the "Compose Specification" format of the configuration file instead of the legacy "Version 3" format. In this new format, the schema "version" element is deprecated.

* For services that specify both a `build` and `image` elements (i.e. all the services that use the `local/smr` image), we were getting an error during `docker compose pull` (because the image only exists locally). Specifying `pull_policy: build` resulted in rebuilding the image whenever the service was _run_, so we settled on never pulling the image (`pull_policy: never`).

* Even though the flyway service `command` worked properly with docker-compose 1.29, in v2.10.2 it was not being parsed correctly, and just returned the flyway help text (maybe something about the leading dash?). It works fine in the argument list style, however, so we switch to that. Docker-compose is _supposed_ to convert string commands to array syntax internally, so this looks like a bug in the new Docker-compose version.

* Remove COMPOSE_DOCKER_CLI_BUILD environment variable. This is not needed in Docker Compose v2 (see https://docs.docker.com/compose/reference/envvars/#compose_docker_cli_buildx).