### PR TITLE
GH Actions: update image from Ubuntu 20.04 to 22.04

### DIFF
--- a/.github/workflows/build-live.yml
+++ b/.github/workflows/build-live.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-live:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-test:
     name: Build and Test
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       # Use buildkit for faster builds


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/5998.