### PR TITLE
Fix port combat bug

### DIFF
--- a/src/lib/Default/AbstractSmrPort.php
+++ b/src/lib/Default/AbstractSmrPort.php
@@ -592,7 +592,9 @@ class AbstractSmrPort {
 		}
 
 		unset($this->goodAmounts[$goodID]);
+		unset($this->goodAmountsChanged[$goodID]);
 		unset($this->goodTransactions[$goodID]);
+		unset($this->goodDistances[$goodID]);
 
 		// Flag for update
 		$this->cacheIsValid = false;


### PR DESCRIPTION
If a port lost a level on the same attack where it is destroyed, then
it would throw an error when trying to update the good amounts in the
database. We now update the internal state properly when removing goods.