### PR TITLE
SmrPlayer: simplify removeUnderAttack

### DIFF
--- a/src/lib/Default/AbstractSmrPlayer.php
+++ b/src/lib/Default/AbstractSmrPlayer.php
@@ -2249,17 +2249,11 @@ abstract class AbstractSmrPlayer {
 		$this->hasChanged = true;
 	}
 
-	public function removeUnderAttack(): bool {
-		$session = Smr\Session::getInstance();
-		$var = $session->getCurrentVar();
-		if (isset($var['UnderAttack'])) {
-			return $var['UnderAttack'];
-		}
+	public function removeUnderAttack(bool $ajax): bool {
 		$underAttack = $this->isUnderAttack();
-		if ($underAttack && !$session->ajax) {
-			$var['UnderAttack'] = $underAttack; //Remember we are under attack for AJAX
+		if (!$ajax) {
+			$this->setUnderAttack(false); // only remove on a non-ajax page load
 		}
-		$this->setUnderAttack(false);
 		return $underAttack;
 	}
 

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -379,7 +379,7 @@ function do_voodoo(): never {
 	// Populate the template
 	$template = Template::getInstance();
 	if (isset($player)) {
-		$template->assign('UnderAttack', $player->removeUnderAttack());
+		$template->assign('UnderAttack', $player->removeUnderAttack($session->ajax));
 	}
 
 	//Nothing below this point should require the lock.

--- a/test/SmrTest/lib/DefaultGame/AbstractSmrPlayerIntegrationTest.php
+++ b/test/SmrTest/lib/DefaultGame/AbstractSmrPlayerIntegrationTest.php
@@ -154,4 +154,23 @@ class AbstractSmrPlayerIntegrationTest extends BaseIntegrationSpec {
 		];
 	}
 
+	public function test_UnderAttack(): void {
+		$player = AbstractSmrPlayer::createPlayer(1, 1, 'test', RACE_HUMAN, false);
+
+		// Not under attack by default
+		self::assertFalse($player->isUnderAttack());
+
+		// Value is changed by setting it
+		$player->setUnderAttack(true);
+		self::assertTrue($player->isUnderAttack());
+
+		// Value is not set to false on ajax page loads
+		self::assertTrue($player->removeUnderAttack(ajax: true));
+		self::assertTrue($player->isUnderAttack());
+
+		// Value is set to false on non-ajax page loads
+		self::assertTrue($player->removeUnderAttack(ajax: false));
+		self::assertFalse($player->isUnderAttack());
+	}
+
 }


### PR DESCRIPTION
Since the `player.under_attack` database column was added in #1020, this method does not need to (ab)use the session to cache its value. Instead, we can simply only change the value on non-ajax page loads.