### PR TITLE
Simplify sector messages

### DIFF
--- a/src/engine/Default/current_sector.php
+++ b/src/engine/Default/current_sector.php
@@ -180,10 +180,7 @@ function checkForAttackMessage(string &$msg): void {
 	$msg = str_replace('[ATTACK_RESULTS]', '', $msg, $contains);
 	if ($contains > 0) {
 		// $msg now contains only the log_id, if there is one
-		if (!is_numeric($msg)) {
-			throw new Exception('Improperly formatted attack message: ' . $msg);
-		}
-		$logID = (int)$msg;
+		$logID = str2int($msg);
 
 		$session = Smr\Session::getInstance();
 		$var = $session->getCurrentVar();

--- a/src/engine/Default/forces_mass_refresh.php
+++ b/src/engine/Default/forces_mass_refresh.php
@@ -16,7 +16,6 @@ foreach ($sectorForces as $sectorForce) {
 	}
 }
 
-$message = '[Force Check]'; //this notifies the CS to look for info.
 $container = Page::create('current_sector.php');
-$container['msg'] = $message;
+$container['showForceRefreshMessage'] = true;
 $container->go();

--- a/src/lib/Default/AbstractSmrPlayer.php
+++ b/src/lib/Default/AbstractSmrPlayer.php
@@ -1834,7 +1834,7 @@ abstract class AbstractSmrPlayer {
 
 		$this->storedDestinations[] = [
 			'Label' => $label,
-			'SectorID' => (int)$sectorID,
+			'SectorID' => $sectorID,
 			'OffsetTop' => 1,
 			'OffsetLeft' => 1,
 		];

--- a/src/lib/Default/Plotter.php
+++ b/src/lib/Default/Plotter.php
@@ -17,7 +17,7 @@ class Plotter {
 		}
 
 		// In all other cases, X is a numeric ID
-		$X = (int)$X;
+		$X = str2int($X);
 
 		// Helper function for plots to trade goods
 		$getGoodWithTransaction = function(int $goodID) use ($xType, $player) {


### PR DESCRIPTION
The logic for displaying sector refresh/attack messages on the "Current Sector" page has been significantly simplified.