### PR TITLE
docker-compose.yml: turn off xdebug by default for test services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ x-smr-test: &smr-test
     # Note that this may corrupt the test database and require a reset.
     # (see https://github.com/docker-library/php/issues/505)
     init: true
+    environment:
+        - XDEBUG_MODE=off
     volumes:
         - ./config/config.specific.sample.php:/smr/config/config.specific.php:ro
         - ./test/env:/smr/config/env:ro


### PR DESCRIPTION
Set `XDEBUG_MODE=off` on the `smr-test` YAML anchor so that it is inherited by the test services that do not explicitly turn it on.

* PHPStan turns off xdebug if the `--xdebug` flag is not explicitly passed, so we were never using xdebug here. However, this silences the warning about xdebug being active but unused.

* PHP_CodeSniffer _was_ being slowed down by xdebug. The `phpcs` service now runs about 3x faster (~30s -> ~10s).