### PR TITLE
Add phpcs rules for unused/useless variables

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -57,6 +57,11 @@
     </rule>
 
     <!-- Add sniffs not included by PSR2R. -->
+    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable">
+        <properties>
+            <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true" />
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Variables.UselessVariable" />
 
     <!-- Use more compact arrow functions, "fn()" instead of "fn ()". -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -56,6 +56,9 @@
         <exclude name="Squiz.WhiteSpace.MemberVarSpacing" />
     </rule>
 
+    <!-- Add sniffs not included by PSR2R. -->
+    <rule ref="SlevomatCodingStandard.Variables.UselessVariable" />
+
     <!-- Use more compact arrow functions, "fn()" instead of "fn ()". -->
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
         <properties>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -149,4 +149,11 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition">
         <exclude-pattern>src/templates/Default/engine/Default/alliance_roster\.php</exclude-pattern>
     </rule>
+
+    <!-- Ignore unused variable warnings for bad global variables. Fix ASAP! -->
+    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable">
+        <exclude-pattern>src/tools/npc/chess\.php</exclude-pattern>
+        <exclude-pattern>src/tools/irc/irc\.php</exclude-pattern>
+        <exclude-pattern>src/tools/npc/npc\.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/lib/Default/AbstractSmrPlayer.php
+++ b/src/lib/Default/AbstractSmrPlayer.php
@@ -2558,8 +2558,7 @@ abstract class AbstractSmrPlayer {
 	public function getTurnsGained(int $time, bool $forceUpdate = false): int {
 		$timeDiff = $time - $this->getLastTurnUpdate();
 		$ship = $this->getShip($forceUpdate);
-		$extraTurns = IFloor($timeDiff * $ship->getRealSpeed() / 3600);
-		return $extraTurns;
+		return IFloor($timeDiff * $ship->getRealSpeed() / 3600);
 	}
 
 	public function updateTurns(): void {

--- a/src/lib/Default/AbstractSmrPort.php
+++ b/src/lib/Default/AbstractSmrPort.php
@@ -1364,7 +1364,7 @@ class AbstractSmrPort {
 			}
 		}
 
-		$return = [
+		return [
 						'KillingShot' => !$alreadyDead && $this->isDestroyed(),
 						'TargetAlreadyDead' => $alreadyDead,
 						'Shield' => $shieldDamage,
@@ -1374,7 +1374,6 @@ class AbstractSmrPort {
 						'Armour' => $armourDamage,
 						'TotalDamage' => $shieldDamage + $cdDamage + $armourDamage,
 		];
-		return $return;
 	}
 
 	protected function takeDamageToShields(int $damage): int {

--- a/src/lib/Default/SmrAccount.php
+++ b/src/lib/Default/SmrAccount.php
@@ -706,10 +706,8 @@ class SmrAccount {
 			throw new UserError('The email is invalid! It cannot contain any spaces.');
 		}
 
-		// get user and host for the provided address
-		[$user, $host] = explode('@', $email);
-
 		// check if the host got a MX or at least an A entry
+		$host = explode('@', $email)[1];
 		if (!checkdnsrr($host, 'MX') && !checkdnsrr($host, 'A')) {
 			throw new UserError('This is not a valid email address! The domain ' . $host . ' does not exist.');
 		}

--- a/src/lib/Default/SmrCombatDrones.php
+++ b/src/lib/Default/SmrCombatDrones.php
@@ -21,8 +21,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 	}
 
 	public function getModifiedAccuracy(): float {
-		$modifiedAccuracy = $this->getBaseAccuracy();
-		return $modifiedAccuracy;
+		return $this->getBaseAccuracy();
 	}
 
 	protected function getModifiedAccuracyAgainstForcesUsingRandom(AbstractSmrPlayer $weaponPlayer, SmrForce $forces, int $random): float {
@@ -147,8 +146,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 
 	public function getModifiedDamageAgainstPlayer(AbstractSmrPlayer $weaponPlayer, AbstractSmrPlayer $targetPlayer): array {
 		if (!$this->canShootTraders()) { // If we can't shoot traders then just return a damageless array and don't waste resources calculated any damage mods.
-			$return = ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
-			return $return;
+			return ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
 		}
 		$damage = $this->getDamage();
 		$dcsMod = $targetPlayer->getShip()->hasDCS() ? DCS_PLAYER_DAMAGE_DECIMAL_PERCENT : 1;
@@ -160,8 +158,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 
 	public function getModifiedForceDamageAgainstPlayer(SmrForce $forces, AbstractSmrPlayer $targetPlayer): array {
 		if (!$this->canShootTraders()) { // If we can't shoot traders then just return a damageless array and don't waste resources calculated any damage mods.
-			$return = ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
-			return $return;
+			return ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
 		}
 		$damage = $this->getDamage();
 		$dcsMod = $targetPlayer->getShip()->hasDCS() ? DCS_FORCE_DAMAGE_DECIMAL_PERCENT : 1;
@@ -173,8 +170,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 
 	public function getModifiedPortDamageAgainstPlayer(AbstractSmrPort $port, AbstractSmrPlayer $targetPlayer): array {
 		if (!$this->canShootTraders()) { // If we can't shoot traders then just return a damageless array and don't waste resources calculated any damage mods.
-			$return = ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
-			return $return;
+			return ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
 		}
 		$damage = $this->getDamage();
 		$dcsMod = $targetPlayer->getShip()->hasDCS() ? DCS_PORT_DAMAGE_DECIMAL_PERCENT : 1;
@@ -186,8 +182,7 @@ class SmrCombatDrones extends AbstractSmrCombatWeapon {
 
 	public function getModifiedPlanetDamageAgainstPlayer(SmrPlanet $planet, AbstractSmrPlayer $targetPlayer): array {
 		if (!$this->canShootTraders()) { // If we can't shoot traders then just return a damageless array and don't waste resources calculated any damage mods.
-			$return = ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
-			return $return;
+			return ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
 		}
 		$damage = $this->getDamage();
 		$dcsMod = $targetPlayer->getShip()->hasDCS() ? DCS_PLANET_DAMAGE_DECIMAL_PERCENT : 1;

--- a/src/lib/Default/SmrForce.php
+++ b/src/lib/Default/SmrForce.php
@@ -507,7 +507,7 @@ class SmrForce {
 				}
 			}
 		}
-		$return = [
+		return [
 						'KillingShot' => !$alreadyDead && !$this->exists(),
 						'TargetAlreadyDead' => $alreadyDead,
 						'Mines' => $minesDamage,
@@ -521,7 +521,6 @@ class SmrForce {
 						'HasSDs' => $this->hasSDs(),
 						'TotalDamage' => $minesDamage + $cdDamage + $sdDamage,
 		];
-		return $return;
 	}
 
 	protected function takeDamageToMines(int $damage): int {

--- a/src/lib/Default/SmrGalaxy.php
+++ b/src/lib/Default/SmrGalaxy.php
@@ -382,8 +382,7 @@ class SmrGalaxy {
 			$totalLinks += $galSector->getNumberOfLinks();
 		}
 		// There are 4 possible links per sector
-		$connectivity = 100 * $totalLinks / (4 * $this->getSize());
-		return $connectivity;
+		return 100 * $totalLinks / (4 * $this->getSize());
 	}
 
 	/**

--- a/src/lib/Default/SmrMines.php
+++ b/src/lib/Default/SmrMines.php
@@ -18,8 +18,7 @@ class SmrMines extends AbstractSmrCombatWeapon {
 	}
 
 	public function getModifiedAccuracy(): float {
-		$modifiedAccuracy = $this->getBaseAccuracy();
-		return $modifiedAccuracy;
+		return $this->getBaseAccuracy();
 	}
 
 	public function getModifiedForceAccuracyAgainstPlayer(SmrForce $forces, AbstractSmrPlayer $targetPlayer, bool $minesAreAttacker): float {
@@ -70,8 +69,7 @@ class SmrMines extends AbstractSmrCombatWeapon {
 
 	public function getModifiedForceDamageAgainstPlayer(SmrForce $forces, AbstractSmrPlayer $targetPlayer, bool $minesAreAttacker = false): array {
 		if (!$this->canShootTraders()) { // If we can't shoot traders then just return a damageless array and don't waste resources calculated any damage mods.
-			$return = ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
-			return $return;
+			return ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
 		}
 		$damage = $this->getDamage();
 		if ($targetPlayer->getShip()->isFederal()) { // do less damage to fed ships

--- a/src/lib/Default/SmrPlanet.php
+++ b/src/lib/Default/SmrPlanet.php
@@ -962,15 +962,13 @@ class SmrPlanet {
 
 	// Amount of exp gained to build the next building of this type
 	private function getConstructionExp(int $constructionID): int {
-		$expGain = $this->getStructureTypes($constructionID)->expGain();
-		return $expGain;
+		return $this->getStructureTypes($constructionID)->expGain();
 	}
 
 	// Amount of time (in seconds) to build the next building of this type
 	public function getConstructionTime(int $constructionID): int {
 		$baseTime = $this->getStructureTypes($constructionID)->baseTime();
-		$constructionTime = ICeil($baseTime * $this->getCompletionModifier($constructionID) / $this->getGame()->getGameSpeed());
-		return $constructionTime;
+		return ICeil($baseTime * $this->getCompletionModifier($constructionID) / $this->getGame()->getGameSpeed());
 	}
 
 	/**
@@ -1287,7 +1285,7 @@ class SmrPlanet {
 			}
 		}
 
-		$return = [
+		return [
 			'KillingShot' => !$alreadyDead && $this->isDestroyed(),
 			'TargetAlreadyDead' => $alreadyDead,
 			'Shield' => $shieldDamage,
@@ -1297,7 +1295,6 @@ class SmrPlanet {
 			'Armour' => $armourDamage,
 			'TotalDamage' => $shieldDamage + $cdDamage + $armourDamage,
 		];
-		return $return;
 	}
 
 	protected function takeDamageToShields(int $damage): int {

--- a/src/lib/Default/SmrPlanet.php
+++ b/src/lib/Default/SmrPlanet.php
@@ -1012,7 +1012,7 @@ class SmrPlanet {
 	public function stopBuilding(int $constructionID): bool {
 		$matchingBuilding = false;
 		$latestFinish = 0;
-		foreach ($this->getCurrentlyBuilding() as $key => $building) {
+		foreach ($this->getCurrentlyBuilding() as $building) {
 			if ($building['ConstructionID'] == $constructionID && $building['Finishes'] > $latestFinish) {
 				$latestFinish = $building['Finishes'];
 				$matchingBuilding = $building;

--- a/src/lib/Default/SmrScoutDrones.php
+++ b/src/lib/Default/SmrScoutDrones.php
@@ -14,8 +14,7 @@ class SmrScoutDrones extends AbstractSmrCombatWeapon {
 	}
 
 	public function getModifiedAccuracy(): float {
-		$modifiedAccuracy = $this->getBaseAccuracy();
-		return $modifiedAccuracy;
+		return $this->getBaseAccuracy();
 	}
 
 	public function getModifiedForceAccuracyAgainstPlayer(SmrForce $forces, AbstractSmrPlayer $targetPlayer): float {
@@ -55,8 +54,7 @@ class SmrScoutDrones extends AbstractSmrCombatWeapon {
 
 	public function getModifiedForceDamageAgainstPlayer(SmrForce $forces, AbstractSmrPlayer $targetPlayer): array {
 		if (!$this->canShootTraders()) { // If we can't shoot traders then just return a damageless array and don't waste resources calculated any damage mods.
-			$return = ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
-			return $return;
+			return ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
 		}
 		$damage = $this->getDamage();
 		$damage['Launched'] = ICeil($this->getAmount() * $this->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer) / 100);

--- a/src/lib/Default/SmrWeapon.php
+++ b/src/lib/Default/SmrWeapon.php
@@ -165,8 +165,7 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	}
 
 	public function getModifiedAccuracyAgainstForces(AbstractSmrPlayer $weaponPlayer, SmrForce $forces): float {
-		$modifiedAccuracy = $this->getModifiedAccuracy($weaponPlayer);
-		return $modifiedAccuracy;
+		return $this->getModifiedAccuracy($weaponPlayer);
 	}
 
 	public function getModifiedAccuracyAgainstPort(AbstractSmrPlayer $weaponPlayer, SmrPort $port): float {
@@ -196,8 +195,7 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 	}
 
 	public function getModifiedPortAccuracy(AbstractSmrPort $port): float {
-		$modifiedAccuracy = $this->getBaseAccuracy();
-		return $modifiedAccuracy;
+		return $this->getBaseAccuracy();
 	}
 
 	public function getModifiedPortAccuracyAgainstPlayer(AbstractSmrPort $port, AbstractSmrPlayer $targetPlayer): float {
@@ -258,24 +256,21 @@ class SmrWeapon extends AbstractSmrCombatWeapon {
 
 	public function getModifiedDamageAgainstPlayer(AbstractSmrPlayer $weaponPlayer, AbstractSmrPlayer $targetPlayer): array {
 		if (!$this->canShootTraders()) { // If we can't shoot traders then just return a damageless array and don't waste resources calculating any damage mods.
-			$return = ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
-			return $return;
+			return ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
 		}
 		return $this->getDamage();
 	}
 
 	public function getModifiedPortDamageAgainstPlayer(AbstractSmrPort $port, AbstractSmrPlayer $targetPlayer): array {
 		if (!$this->canShootTraders()) { // If we can't shoot traders then just return a damageless array and don't waste resources calculating any damage mods.
-			$return = ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
-			return $return;
+			return ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
 		}
 		return $this->getDamage();
 	}
 
 	public function getModifiedPlanetDamageAgainstPlayer(SmrPlanet $planet, AbstractSmrPlayer $targetPlayer): array {
 		if (!$this->canShootTraders()) { // If we can't shoot traders then just return a damageless array and don't waste resources calculating any damage mods.
-			$return = ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
-			return $return;
+			return ['Shield' => 0, 'Armour' => 0, 'Rollover' => $this->isDamageRollover()];
 		}
 		return $this->getDamage();
 	}

--- a/src/lib/Default/help.inc.php
+++ b/src/lib/Default/help.inc.php
@@ -121,8 +121,6 @@ function echo_content(int $topic_id): void {
 	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $topic_id);
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
-		$parent_topic_id = $dbRecord->getInt('parent_topic_id');
-		$order_id = $dbRecord->getInt('order_id');
 		$topic = stripslashes($dbRecord->getString('topic'));
 		$text = stripslashes($dbRecord->getString('text'));
 
@@ -161,7 +159,6 @@ function echo_menu(int $topic_id): void {
 		echo ('<ul type="disc">');
 		foreach ($dbResult->records() as $dbRecord) {
 			$sub_topic_id = $dbRecord->getInt('topic_id');
-			$order_id = $dbRecord->getInt('order_id');
 			$sub_topic = stripslashes($dbRecord->getString('topic'));
 
 			echo ('<li><a href="/manual.php?' . $sub_topic_id . '">' . get_numbering($sub_topic_id) . $sub_topic . '</a></li>');

--- a/src/lib/Smr/Discord/Commands/Turns.php
+++ b/src/lib/Smr/Discord/Commands/Turns.php
@@ -29,9 +29,7 @@ class Turns extends DatabaseCommand {
 
 		// Calculate time to max turns
 		$timeToMax = $player->getTimeUntilMaxTurns(time(), true);
-		$msg .= ' At max turns ' . in_time_or_now($timeToMax, true) . '.';
-
-		return $msg;
+		return $msg . ' At max turns ' . in_time_or_now($timeToMax, true) . '.';
 	}
 
 }

--- a/src/lib/Smr/Routes/RouteGenerator.php
+++ b/src/lib/Smr/Routes/RouteGenerator.php
@@ -41,11 +41,10 @@ class RouteGenerator {
 			$totalTasks++;
 		}
 		self::trimRoutes($numberOfRoutes);
-		$allRoutes = [
+		return [
 			self::EXP_ROUTE => self::$expRoutes,
 			self::MONEY_ROUTE => self::$moneyRoutes,
 		];
-		return $allRoutes;
 	}
 
 	/**

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -124,13 +124,9 @@ class Template {
 		if ($this->nestedIncludes > 15) {
 			throw new Exception('Nested more than 15 template includes, is something wrong?');
 		}
-		foreach ($this->data as $key => $value) {
-			$$key = $value;
-		}
+		extract($this->data);
 		if ($assignVars !== null) {
-			foreach ($assignVars as $key => $value) {
-				$$key = $value;
-			}
+			extract($assignVars);
 		}
 		$this->nestedIncludes++;
 		require($this->getTemplateLocation($templateName));

--- a/src/pages/Admin/CombatSimulatorProcessor.php
+++ b/src/pages/Admin/CombatSimulatorProcessor.php
@@ -17,12 +17,12 @@ function runAnAttack(array $realAttackers, array $realDefenders): array {
 		'Attackers' => ['Traders' => [], 'TotalDamage' => 0],
 		'Defenders' => ['Traders' => [], 'TotalDamage' => 0],
 	];
-	foreach ($realAttackers as $accountID => $teamPlayer) {
+	foreach ($realAttackers as $teamPlayer) {
 		$playerResults = $teamPlayer->shootPlayers($realDefenders);
 		$results['Attackers']['Traders'][] = $playerResults;
 		$results['Attackers']['TotalDamage'] += $playerResults['TotalDamage'];
 	}
-	foreach ($realDefenders as $accountID => $teamPlayer) {
+	foreach ($realDefenders as $teamPlayer) {
 		$playerResults = $teamPlayer->shootPlayers($realAttackers);
 		$results['Defenders']['Traders'][] = $playerResults;
 		$results['Defenders']['TotalDamage'] += $playerResults['TotalDamage'];

--- a/src/pages/Admin/GameDeleteProcessor.php
+++ b/src/pages/Admin/GameDeleteProcessor.php
@@ -308,12 +308,8 @@ class GameDeleteProcessor extends AccountPageProcessor {
 			}
 			$db->switchDatabaseToLive();
 
-			// don't know why exactly we have to do that,
-			// but it seems that the db is used globally instead kept to each object
-			$db = Database::getInstance();
-
 		}
-		$db = Database::getInstance();
+
 		(new AdminTools())->go();
 	}
 

--- a/src/pages/Player/AttackPlayerProcessor.php
+++ b/src/pages/Player/AttackPlayerProcessor.php
@@ -74,7 +74,7 @@ class AttackPlayerProcessor extends PlayerPageProcessor {
 		 */
 		$teamAttack = function(array $fightingPlayers, string $attack, string $defend): array {
 			$results = ['Traders' => [], 'TotalDamage' => 0];
-			foreach ($fightingPlayers[$attack] as $accountID => $teamPlayer) {
+			foreach ($fightingPlayers[$attack] as $teamPlayer) {
 				$playerResults = $teamPlayer->shootPlayers($fightingPlayers[$defend]);
 				$results['Traders'][$teamPlayer->getAccountID()] = $playerResults;
 				$results['TotalDamage'] += $playerResults['TotalDamage'];

--- a/src/pages/Player/Headquarters/BountyClaimProcessor.php
+++ b/src/pages/Player/Headquarters/BountyClaimProcessor.php
@@ -4,7 +4,6 @@ namespace Smr\Pages\Player\Headquarters;
 
 use AbstractSmrPlayer;
 use Smr\BountyType;
-use Smr\Database;
 use Smr\Page\PlayerPageProcessor;
 use SmrLocation;
 
@@ -26,7 +25,6 @@ class BountyClaimProcessor extends PlayerPageProcessor {
 		if (!empty($bounties)) {
 			$claimText = ('You have claimed the following bounties<br /><br />');
 
-			$db = Database::getInstance();
 			foreach ($bounties as $bounty) {
 				// get bounty id from db
 				$amount = $bounty->getCredits();

--- a/src/pages/Player/Rankings/SectorKills.php
+++ b/src/pages/Player/Rankings/SectorKills.php
@@ -25,7 +25,7 @@ class SectorKills extends PlayerPage {
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT sector_id, battles as amount FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY battles DESC, sector_id');
 		$rankedStats = [];
-		foreach ($dbResult->records() as $index => $dbRecord) {
+		foreach ($dbResult->records() as $dbRecord) {
 			$rankedStats[$dbRecord->getInt('sector_id')] = $dbRecord;
 		}
 		$template->assign('TopTen', Rankings::collectSectorRankings($rankedStats, $player));

--- a/src/templates/Default/engine/Default/alliance_roles.php
+++ b/src/templates/Default/engine/Default/alliance_roles.php
@@ -1,5 +1,5 @@
 <h2>Current Roles</h2><br /><?php
-foreach ($AllianceRoles as $RoleID => $Role) {
+foreach ($AllianceRoles as $Role) {
 	$this->includeTemplate('includes/AllianceRole.inc.php', ['Role' => $Role]);
 } ?><br />
 <h2>Create Role</h2><br /><?php

--- a/src/templates/Default/engine/Default/bank_alliance.php
+++ b/src/templates/Default/engine/Default/bank_alliance.php
@@ -1,7 +1,7 @@
 <?php
 if (count($AlliedAllianceBanks) > 0) { ?>
 	<ul><?php
-	foreach ($AlliedAllianceBanks as $AlliedAllianceID => $AlliedAlliance) { ?>
+	foreach ($AlliedAllianceBanks as $AlliedAlliance) { ?>
 		<li>
 			<a class="bold" href="<?php echo Globals::getAllianceBankHREF($AlliedAlliance->getAllianceID()); ?>"><?php echo $AlliedAlliance->getAllianceDisplayName(); ?>'s Account</a>
 		</li><?php

--- a/src/templates/Default/engine/Default/includes/ForceTraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/ForceTraderTeamCombatResults.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 if (is_array($TraderTeamCombatResults['Traders'])) {
-	foreach ($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
+	foreach ($TraderTeamCombatResults['Traders'] as $TraderResults) {
 		$ShootingPlayer = $TraderResults['Player'];
 		$TotalDamage = $TraderResults['TotalDamage'];
 		if ($TraderResults['DeadBeforeShot']) {

--- a/src/templates/Default/engine/Default/includes/ForcesCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/ForcesCombatResults.inc.php
@@ -1,7 +1,6 @@
 <?php
 if (isset($ForcesCombatResults['Results']) && is_array($ForcesCombatResults['Results'])) {
 	foreach ($ForcesCombatResults['Results'] as $ForceType => $ForceResults) {
-		$ShootingWeapon = $ForceResults['Weapon'];
 		$ShotHit = $ForceResults['Hit'];
 		$ActualDamage = $ForceResults['ActualDamage'];
 		$WeaponDamage = $ForceResults['WeaponDamage'];

--- a/src/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc.php
@@ -1,5 +1,5 @@
 <?php
-foreach ($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
+foreach ($TraderTeamCombatResults['Traders'] as $TraderResults) {
 	$ShootingPlayer = $TraderResults['Player'];
 	$TotalDamage = $TraderResults['TotalDamage'];
 	if ($MinimalDisplay && !$ThisPlayer->equals($ShootingPlayer)) {

--- a/src/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc.php
@@ -1,5 +1,5 @@
 <?php
-foreach ($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
+foreach ($TraderTeamCombatResults['Traders'] as $TraderResults) {
 	$ShootingPlayer = $TraderResults['Player'];
 	$TotalDamage = $TraderResults['TotalDamage'];
 	if ($MinimalDisplay && !$ThisPlayer->equals($ShootingPlayer)) {

--- a/src/templates/Default/engine/Default/includes/SectorMap.inc.php
+++ b/src/templates/Default/engine/Default/includes/SectorMap.inc.php
@@ -87,13 +87,13 @@
 									} ?>
 									<img src="images/port/sell.png" width="5" height="16" alt="Sell (<?php echo $Port->getRaceName(); ?>)"
 										title="Sell (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-									foreach ($Port->getVisibleGoodsBought($MapPlayer) as $GoodID => $Good) {
+									foreach ($Port->getVisibleGoodsBought($MapPlayer) as $Good) {
 										echo $Good->getImageHTML();
 									} ?>
 									<br />
 									<img src="images/port/buy.png" width="5" height="16" alt="Buy (<?php echo $Port->getRaceName(); ?>)"
 										title="Buy (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-									foreach ($Port->getVisibleGoodsSold($MapPlayer) as $GoodID => $Good) {
+									foreach ($Port->getVisibleGoodsSold($MapPlayer) as $Good) {
 										echo $Good->getImageHTML();
 									}
 									if ($UniGen) { ?></div><?php }

--- a/src/templates/Default/engine/Default/includes/SectorPort.inc.php
+++ b/src/templates/Default/engine/Default/includes/SectorPort.inc.php
@@ -12,13 +12,13 @@
 						<div class="goods">
 							<img src="images/port/sell.png" width="5" height="16" alt="Sell (<?php echo $Port->getRaceName(); ?>)"
 								title="Sell (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-							foreach ($Port->getVisibleGoodsBought($ThisPlayer) as $GoodID => $Good) {
+							foreach ($Port->getVisibleGoodsBought($ThisPlayer) as $Good) {
 								echo $Good->getImageHTML();
 							} ?>
 							<br />
 							<img src="images/port/buy.png" width="5" height="16" alt="Buy (<?php echo $Port->getRaceName(); ?>)"
 								title="Buy (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-							foreach ($Port->getVisibleGoodsSold($ThisPlayer) as $GoodID => $Good) {
+							foreach ($Port->getVisibleGoodsSold($ThisPlayer) as $Good) {
 								echo $Good->getImageHTML();
 							} ?>
 						</div>

--- a/src/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc.php
@@ -1,6 +1,6 @@
 <?php
 if (is_array($TraderTeamCombatResults['Traders'])) {
-	foreach ($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
+	foreach ($TraderTeamCombatResults['Traders'] as $TraderResults) {
 		$ShootingPlayer = $TraderResults['Player'];
 		$TotalDamage = $TraderResults['TotalDamage'];
 
@@ -142,7 +142,7 @@ if (is_array($TraderTeamCombatResults['Traders'])) {
 $TotalDamage = $TraderTeamCombatResults['TotalDamage'];
 
 $TotalDamageToThisPlayer = 0;
-foreach ($TraderTeamCombatResults['Traders'] as $AccountID => $TraderResults) {
+foreach ($TraderTeamCombatResults['Traders'] as $TraderResults) {
 	// Check if ThisPlayer was a target in this round of combat
 	if (!isset($TraderResults['TotalDamagePerTargetPlayer'][$ThisPlayer->getAccountID()])) {
 		$TotalDamageToThisPlayer = null;

--- a/src/tools/irc/Message.php
+++ b/src/tools/irc/Message.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Irc;
+
+/**
+ * Data storage class for components of an IRC message.
+ * Intended for use with PRIVMSG message types.
+ */
+class Message {
+
+	public function __construct(
+		public readonly string $nick,
+		public readonly string $user,
+		public readonly string $host,
+		public readonly string $channel,
+		public readonly string $text,
+	) {}
+
+}

--- a/src/tools/irc/channel_action.php
+++ b/src/tools/irc/channel_action.php
@@ -1,17 +1,17 @@
 <?php declare(strict_types=1);
 
+use Smr\Irc\Message;
+
 /**
  * @param resource $fp
  */
-function channel_action_slap($fp, string $rdata): bool {
+function channel_action_slap($fp, Message $msg): bool {
 
 	// :MrSpock!mrspock@coldfront-25B201B9.dip.t-dialin.net PRIVMSG #rod : ACTION slaps Caretaker around a bit with a large trout
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:.ACTION slaps ' . IRC_BOT_NICK . '/i', $rdata, $msg)) {
+	if (preg_match('/^ACTION slaps ' . IRC_BOT_NICK . '/i', $msg->text)) {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[SLAP] by ' . $nick . ' in ' . $channel);
 

--- a/src/tools/irc/channel_msg_op.php
+++ b/src/tools/irc/channel_msg_op.php
@@ -1,18 +1,17 @@
 <?php declare(strict_types=1);
 
 use Smr\Database;
+use Smr\Irc\Message;
 
 /**
  * @param resource $fp
  */
-function channel_msg_op($fp, string $rdata): bool {
+function channel_msg_op($fp, Message $msg): bool {
 
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!op(\s*help)?\s$/i', $rdata, $msg)) {
+	if (preg_match('/^!op(\s*help)?$/i', $msg->text)) {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[OP] by ' . $nick . ' in ' . $channel);
 
@@ -34,13 +33,11 @@ function channel_msg_op($fp, string $rdata): bool {
 /**
  * @param resource $fp
  */
-function channel_msg_op_info($fp, string $rdata, AbstractSmrPlayer $player): bool {
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!op info\s$/i', $rdata, $msg)) {
+function channel_msg_op_info($fp, Message $msg, AbstractSmrPlayer $player): bool {
+	if ($msg->text == '!op info') {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[OP_INFO] by ' . $nick . ' in ' . $channel);
 
@@ -58,14 +55,12 @@ function channel_msg_op_info($fp, string $rdata, AbstractSmrPlayer $player): boo
 /**
  * @param resource $fp
  */
-function channel_msg_op_cancel($fp, string $rdata, AbstractSmrPlayer $player): bool {
+function channel_msg_op_cancel($fp, Message $msg, AbstractSmrPlayer $player): bool {
 
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!op cancel\s$/i', $rdata, $msg)) {
+	if ($msg->text == '!op cancel') {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[OP_CANCEL] by ' . $nick . ' in ' . $channel);
 
@@ -104,15 +99,13 @@ function channel_msg_op_cancel($fp, string $rdata, AbstractSmrPlayer $player): b
 /**
  * @param resource $fp
  */
-function channel_msg_op_set($fp, string $rdata, AbstractSmrPlayer $player): bool {
+function channel_msg_op_set($fp, Message $msg, AbstractSmrPlayer $player): bool {
 
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!op set (.*)\s$/i', $rdata, $msg)) {
+	if (preg_match('/^!op set (.*)$/i', $msg->text, $args)) {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
-		$op_time = $msg[5];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
+		$op_time = $args[1];
 
 		echo_r('[OP_SET] by ' . $nick . ' in ' . $channel);
 
@@ -155,13 +148,11 @@ function channel_msg_op_set($fp, string $rdata, AbstractSmrPlayer $player): bool
 /**
  * @param resource $fp
  */
-function channel_msg_op_turns($fp, string $rdata, AbstractSmrPlayer $player): bool {
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!op turns\s$/i', $rdata, $msg)) {
+function channel_msg_op_turns($fp, Message $msg, AbstractSmrPlayer $player): bool {
+	if ($msg->text == '!op turns') {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[OP_TURNS] by ' . $nick . ' in ' . $channel);
 
@@ -184,15 +175,13 @@ function channel_msg_op_turns($fp, string $rdata, AbstractSmrPlayer $player): bo
 /**
  * @param resource $fp
  */
-function channel_msg_op_response($fp, string $rdata, AbstractSmrPlayer $player): bool {
+function channel_msg_op_response($fp, Message $msg, AbstractSmrPlayer $player): bool {
 
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!op (yes|no|maybe)\s$/i', $rdata, $msg)) {
+	if (preg_match('/^!op (yes|no|maybe)$/i', $msg->text, $args)) {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
-		$response = strtoupper($msg[5]);
+		$nick = $msg->nick;
+		$channel = $msg->channel;
+		$response = strtoupper($args[1]);
 
 		echo_r('[OP_' . $response . '] by ' . $nick . ' in ' . $channel);
 
@@ -225,13 +214,11 @@ function channel_msg_op_response($fp, string $rdata, AbstractSmrPlayer $player):
 /**
  * @param resource $fp
  */
-function channel_msg_op_list($fp, string $rdata, AbstractSmrPlayer $player): bool {
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!op list\s$/i', $rdata, $msg)) {
+function channel_msg_op_list($fp, Message $msg, AbstractSmrPlayer $player): bool {
+	if ($msg->text == '!op list') {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[OP_LIST] by ' . $nick . ' in ' . $channel);
 

--- a/src/tools/irc/channel_msg_sd.php
+++ b/src/tools/irc/channel_msg_sd.php
@@ -1,16 +1,16 @@
 <?php declare(strict_types=1);
 
+use Smr\Irc\Message;
+
 /**
  * @param resource $fp
  */
-function channel_msg_sd($fp, string $rdata): bool {
+function channel_msg_sd($fp, Message $msg): bool {
 
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!sd(\s*help)?\s$/i', $rdata, $msg)) {
+	if (preg_match('/^!sd(\s*help)?$/i', $msg->text)) {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[SD] by ' . $nick . ' in ' . $channel);
 
@@ -29,18 +29,16 @@ function channel_msg_sd($fp, string $rdata): bool {
 /**
  * @param resource $fp
  */
-function channel_msg_sd_set($fp, string $rdata): bool {
+function channel_msg_sd_set($fp, Message $msg): bool {
 
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!sd set (\d+) (\d+)\s$/i', $rdata, $msg)) {
+	if (preg_match('/^!sd set (\d+) (\d+)$/i', $msg->text, $args)) {
 
 		global $sds;
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
-		$sector = $msg[5];
-		$sd = $msg[6];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
+		$sector = $args[1];
+		$sd = $args[2];
 
 		echo_r('[SD_SET] by ' . $nick . ' in ' . $channel);
 
@@ -71,17 +69,15 @@ function channel_msg_sd_set($fp, string $rdata): bool {
 /**
  * @param resource $fp
  */
-function channel_msg_sd_del($fp, string $rdata): bool {
+function channel_msg_sd_del($fp, Message $msg): bool {
 
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!sd del (\d+)\s$/i', $rdata, $msg)) {
+	if (preg_match('/^!sd del (\d+)$/i', $msg->text, $args)) {
 
 		global $sds;
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
-		$sector = $msg[5];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
+		$sector = $args[1];
 
 		echo_r('[SD_DEL] by ' . $nick . ' in ' . $channel);
 
@@ -107,16 +103,14 @@ function channel_msg_sd_del($fp, string $rdata): bool {
 /**
  * @param resource $fp
  */
-function channel_msg_sd_list($fp, string $rdata, AbstractSmrPlayer $player): bool {
+function channel_msg_sd_list($fp, Message $msg, AbstractSmrPlayer $player): bool {
 
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!sd list\s$/i', $rdata, $msg)) {
+	if ($msg->text == '!sd list') {
 
 		global $sds;
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[SD_LIST] by ' . $nick . ' in ' . $channel);
 

--- a/src/tools/irc/channel_msg_seed.php
+++ b/src/tools/irc/channel_msg_seed.php
@@ -1,15 +1,15 @@
 <?php declare(strict_types=1);
 
+use Smr\Irc\Message;
+
 /**
  * @param resource $fp
  */
-function channel_msg_seed($fp, string $rdata, AbstractSmrPlayer $player): bool {
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!seed\s$/i', $rdata, $msg)) {
+function channel_msg_seed($fp, Message $msg, AbstractSmrPlayer $player): bool {
+	if ($msg->text == '!seed') {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[SEED] by ' . $nick . ' in ' . $channel);
 
@@ -27,13 +27,11 @@ function channel_msg_seed($fp, string $rdata, AbstractSmrPlayer $player): bool {
 /**
  * @param resource $fp
  */
-function channel_msg_seedlist($fp, string $rdata): bool {
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!seedlist(\s*help)?\s$/i', $rdata, $msg)) {
+function channel_msg_seedlist($fp, Message $msg): bool {
+	if (preg_match('/^!seedlist(\s*help)?$/i', $msg->text)) {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
+		$nick = $msg->nick;
+		$channel = $msg->channel;
 
 		echo_r('[SEEDLIST] by ' . $nick . ' in ' . $channel);
 
@@ -51,14 +49,12 @@ function channel_msg_seedlist($fp, string $rdata): bool {
 /**
  * @param resource $fp
  */
-function channel_msg_seedlist_add($fp, string $rdata, AbstractSmrPlayer $player): bool {
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!seedlist add (.*)\s$/i', $rdata, $msg)) {
+function channel_msg_seedlist_add($fp, Message $msg, AbstractSmrPlayer $player): bool {
+	if (preg_match('/^!seedlist add (.*)$/i', $msg->text, $args)) {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
-		$sectors = explode(' ', $msg[5]);
+		$nick = $msg->nick;
+		$channel = $msg->channel;
+		$sectors = explode(' ', $args[1]);
 
 		echo_r('[SEEDLIST_ADD] by ' . $nick . ' in ' . $channel);
 
@@ -76,14 +72,12 @@ function channel_msg_seedlist_add($fp, string $rdata, AbstractSmrPlayer $player)
 /**
  * @param resource $fp
  */
-function channel_msg_seedlist_del($fp, string $rdata, AbstractSmrPlayer $player): bool {
-	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:!seedlist del (.*)\s$/i', $rdata, $msg)) {
+function channel_msg_seedlist_del($fp, Message $msg, AbstractSmrPlayer $player): bool {
+	if (preg_match('/^!seedlist del (.*)$/i', $msg->text, $args)) {
 
-		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$channel = $msg[4];
-		$sectors = explode(' ', $msg[5]);
+		$nick = $msg->nick;
+		$channel = $msg->channel;
+		$sectors = explode(' ', $args[1]);
 
 		echo_r('[SEEDLIST_DEL] by ' . $nick . ' in ' . $channel);
 

--- a/src/tools/irc/ctcp.php
+++ b/src/tools/irc/ctcp.php
@@ -5,12 +5,10 @@
  */
 function ctcp_version($fp, string $rdata): bool {
 
+	// :(nick)!(user)@(host) PRIVMSG (botnick)
 	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:' . chr(1) . 'VERSION' . chr(1) . '\s$/i', $rdata, $msg)) {
 
 		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$botnick = $msg[4];
 
 		echo_r('[CTCP_VERSION] by ' . $nick);
 
@@ -26,12 +24,10 @@ function ctcp_version($fp, string $rdata): bool {
  */
 function ctcp_finger($fp, string $rdata): bool {
 
+	// :(nick)!(user)@(host) PRIVMSG (botnick)
 	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:' . chr(1) . 'FINGER' . chr(1) . '\s$/i', $rdata, $msg)) {
 
 		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$botnick = $msg[4];
 
 		echo_r('[CTCP_FINGER] by ' . $nick);
 
@@ -47,12 +43,10 @@ function ctcp_finger($fp, string $rdata): bool {
  */
 function ctcp_time($fp, string $rdata): bool {
 
+	// :(nick)!(user)@(host) PRIVMSG (botnick)
 	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:' . chr(1) . 'TIME' . chr(1) . '\s$/i', $rdata, $msg)) {
 
 		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$botnick = $msg[4];
 
 		echo_r('[CTCP_TIME] by ' . $nick);
 
@@ -68,12 +62,10 @@ function ctcp_time($fp, string $rdata): bool {
  */
 function ctcp_ping($fp, string $rdata): bool {
 
+	// :(nick)!(user)@(host) PRIVMSG (botnick)
 	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:' . chr(1) . 'PING\s(.*)' . chr(1) . '\s$/i', $rdata, $msg)) {
 
 		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
-		$botnick = $msg[4];
 		$their_time = $msg[5];
 
 		echo_r('[CTCP_PING] by ' . $nick . ' at ' . $their_time);

--- a/src/tools/irc/invite.php
+++ b/src/tools/irc/invite.php
@@ -9,8 +9,6 @@ function invite($fp, string $rdata): bool {
 	if (preg_match('/^:(.*)!(.*)@(.*) INVITE ' . IRC_BOT_NICK . ' :(.*)\s$/i', $rdata, $msg)) {
 
 		$nick = $msg[1];
-		$user = $msg[2];
-		$host = $msg[3];
 		$channel = $msg[4];
 
 		echo_r('[INVITE] by ' . $nick . ' for ' . $channel);

--- a/src/tools/irc/server.php
+++ b/src/tools/irc/server.php
@@ -132,7 +132,6 @@ function server_msg_352($fp, string $rdata): bool {
 	// :ice.coldfront.net 352 Caretaker #KMFDM caretaker coldfront-425DB813.dip.t-dialin.net ice.coldfront.net Caretaker Hr :0 Official SMR bot
 	if (preg_match('/^:(.*?) 352 ' . IRC_BOT_NICK . ' (.*?) (.*?) (.*?) (.*?) (.*?) (.*?) (.*?) (.*?)$/i', $rdata, $msg)) {
 
-		$server = $msg[1];
 		$channel = $msg[2];
 		$user = $msg[3];
 		$host = $msg[4];

--- a/src/tools/irc/stream.php
+++ b/src/tools/irc/stream.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\Irc\Exceptions\Timeout;
+use Smr\Irc\Message;
 
 require_once(TOOLS . 'irc/server.php');
 require_once(TOOLS . 'irc/ctcp.php');
@@ -118,36 +119,46 @@ function readFromStream($fp): bool {
 		return true;
 	}
 
-	if (channel_action_slap($fp, $rdata)) {
-		return true;
-	}
+	if (preg_match('/^:(?P<nick>.*)!(?P<user>.*)@(?P<host>.*)\sPRIVMSG\s(?P<channel>.*)\s:(?P<text>.*)/i', $rdata, $args)) {
+		$msg = new Message(
+			nick: $args['nick'],
+			user: $args['user'],
+			host: $args['host'],
+			channel: $args['channel'],
+			text: strtolower(trim($args['text'])),
+		);
 
-	// channel msg (!xyz) without registration
-	if (channel_msg_help($fp, $rdata)) {
-		return true;
-	}
-	if (channel_msg_seedlist($fp, $rdata)) {
-		return true;
-	}
-	if (channel_msg_op($fp, $rdata)) {
-		return true;
-	}
-	if (channel_msg_timer($fp, $rdata)) {
-		return true;
-	}
-	if (channel_msg_8ball($fp, $rdata)) {
-		return true;
-	}
-	if (channel_msg_seen($fp, $rdata)) {
-		return true;
-	}
-	if (channel_msg_sd($fp, $rdata)) {
-		return true;
-	}
+		if (channel_action_slap($fp, $msg)) {
+			return true;
+		}
 
-	// channel msg (!xyz) with registration
-	if (channel_msg_with_registration($fp, $rdata)) {
-		return true;
+		// channel msg (!xyz) without registration
+		if (channel_msg_help($fp, $msg)) {
+			return true;
+		}
+		if (channel_msg_seedlist($fp, $msg)) {
+			return true;
+		}
+		if (channel_msg_op($fp, $msg)) {
+			return true;
+		}
+		if (channel_msg_timer($fp, $msg)) {
+			return true;
+		}
+		if (channel_msg_8ball($fp, $msg)) {
+			return true;
+		}
+		if (channel_msg_seen($fp, $msg)) {
+			return true;
+		}
+		if (channel_msg_sd($fp, $msg)) {
+			return true;
+		}
+
+		// channel msg (!xyz) with registration
+		if (channel_msg_with_registration($fp, $msg)) {
+			return true;
+		}
 	}
 
 	// MrSpock can use this to send commands as caretaker

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -38,7 +38,7 @@ try {
 		0 => ['pipe', 'r'], // stdin is a pipe that the child will read from
 		1 => ['pipe', 'w'], // stdout is a pipe that the child will write to
 	];
-	$engine = proc_open(UCI_CHESS_ENGINE, $descriptorSpec, $pipes);
+	proc_open(UCI_CHESS_ENGINE, $descriptorSpec, $pipes);
 	$toEngine =& $pipes[0];
 	$fromEngine =& $pipes[1];
 

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -507,7 +507,7 @@ function findRoutes(AbstractSmrPlayer $player): array {
 	unset($distances);
 
 	$routesMerged = [];
-	foreach ($allRoutes[RouteGenerator::MONEY_ROUTE] as $multi => $routesByMulti) {
+	foreach ($allRoutes[RouteGenerator::MONEY_ROUTE] as $routesByMulti) {
 		$routesMerged += $routesByMulti; //Merge arrays
 	}
 


### PR DESCRIPTION
Fix all the warnings that this generates. This was one of the last useful checks that Scrutinizer was performing that we were not.