### PR TITLE
Refactor ChessGame into Board class

### DIFF
--- a/db/patches/V1_6_68_07__drop_chess_game_pieces.sql
+++ b/db/patches/V1_6_68_07__drop_chess_game_pieces.sql
@@ -1,0 +1,2 @@
+-- This table is redundant with `chess_game_moves`
+DROP TABLE `chess_game_pieces`;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -142,4 +142,10 @@
         <exclude-pattern>src/tools/irc/irc\.php</exclude-pattern>
         <exclude-pattern>src/tools/npc/npc\.php</exclude-pattern>
     </rule>
+
+    <!-- Ignore bug in PSR12. Will be fixed in PHP_CodeSniffer 3.7.2.
+      See https://github.com/squizlabs/PHP_CodeSniffer/pull/3653. -->
+    <rule ref="PSR12.Operators.OperatorSpacing">
+        <exclude-pattern>src/lib/Smr/Chess/ChessPiece\.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -232,6 +232,21 @@ function array_rand_value(array $arr): mixed {
 }
 
 /**
+ * Remove an element from an array by value.
+ *
+ * @template T
+ * @param array<T> $arr
+ * @param T $valueToRemove
+ */
+function array_remove_value(array &$arr, mixed $valueToRemove): void {
+	foreach ($arr as $key => $value) {
+		if ($value === $valueToRemove) {
+			unset($arr[$key]);
+		}
+	}
+}
+
+/**
  * Check if two objects are strictly equal, without requiring that they are
  * same object (or any of their properties are the same object). This fills
  * the gap between == (loose equality of all object properties) and ===

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -863,13 +863,13 @@ abstract class AbstractPlayer {
 		self::doMessageSending(ACCOUNT_ID_ALLIANCE_AMBASSADOR, $receiverID, $gameID, MSG_ALLIANCE, $message, $expires);
 	}
 
-	public static function sendMessageFromCasino(int $gameID, int $receiverID, string $message, int $expires = null): void {
+	public function sendMessageFromCasino(string $message, int $expires = null): void {
 		//get expire time
 		if ($expires === null) {
 			$expires = Epoch::time() + 86400 * 7;
 		}
 		// send him the message
-		self::doMessageSending(ACCOUNT_ID_CASINO, $receiverID, $gameID, MSG_CASINO, $message, $expires);
+		self::doMessageSending(ACCOUNT_ID_CASINO, $this->getAccountID(), $this->getGameID(), MSG_CASINO, $message, $expires);
 	}
 
 	public static function sendMessageFromRace(int $raceID, int $gameID, int $receiverID, string $message, int $expires = null): void {

--- a/src/lib/Smr/Chess/Board.php
+++ b/src/lib/Smr/Chess/Board.php
@@ -1,0 +1,302 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Chess;
+
+use Exception;
+
+class Board {
+
+	public const NX = 8; // number of x-coordinates
+	public const NY = 8; // number of y-coordinates
+
+	/** @var array<value-of<Colour>, array<Castling>> */
+	private array $canCastle;
+	/** @var array{X: int, Y: int}> */
+	private array $enPassantPawn;
+	/** @var array<int, array<int, ?ChessPiece>> */
+	private array $board;
+	private int $numMoves = 0;
+
+	public function __construct(bool $initialize = true) {
+		if ($initialize) {
+			$this->initialize();
+		}
+	}
+
+	private function initialize(): void {
+		// Set up the pieces on the board
+		$pieces = ChessGame::getStandardGame();
+		$row = array_fill(0, self::NX, null);
+		$board = array_fill(0, self::NY, $row);
+		foreach ($pieces as $piece) {
+			if ($board[$piece->y][$piece->x] != null) {
+				throw new Exception('Two pieces found in the same tile.');
+			}
+			$board[$piece->y][$piece->x] = $piece;
+		}
+		$this->board = $board;
+
+		// Initialize metadata (castling/en passant)
+		$this->canCastle = [
+			Colour::White->value => Castling::cases(),
+			Colour::Black->value => Castling::cases(),
+		];
+		$this->enPassantPawn = ['X' => -1, 'Y' => -1];
+	}
+
+	public function deepCopy(): self {
+		$copy = new self(initialize: false);
+		$copy->board = [];
+		foreach ($this->board as $y => $row) {
+			foreach ($row as $x => $piece) {
+				if ($piece === null) {
+					$copy->board[$y][$x] = null;
+				} else {
+					$copy->board[$y][$x] = clone $piece;
+				}
+			}
+		}
+		$copy->canCastle = $this->canCastle;
+		$copy->enPassantPawn = $this->enPassantPawn;
+		$copy->numMoves = $this->numMoves;
+		return $copy;
+	}
+
+	public function getFEN(): string {
+		$fen = '';
+		$blanks = 0;
+		foreach (range(self::NY - 1, 0, -1) as $y) {
+			foreach (range(0, self::NX - 1) as $x) {
+				if (!$this->hasPiece($x, $y)) {
+					$blanks++;
+				} else {
+					if ($blanks > 0) {
+						$fen .= $blanks;
+						$blanks = 0;
+					}
+					$fen .= $this->getPiece($x, $y)->getPieceLetter();
+				}
+			}
+			if ($blanks > 0) {
+				$fen .= $blanks;
+				$blanks = 0;
+			}
+			if ($y > 0) {
+				$fen .= '/';
+			}
+		}
+		$fen .= match ($this->getCurrentTurnColour()) {
+			Colour::White => ' w ',
+			Colour::Black => ' b ',
+		};
+
+		// Castling
+		$castling = '';
+		foreach (Colour::cases() as $colour) {
+			if ($this->canCastle($colour, Castling::Kingside)) {
+				$castling .= ChessPiece::getLetterForPiece(ChessPiece::KING, $colour);
+			}
+			if ($this->canCastle($colour, Castling::Queenside)) {
+				$castling .= ChessPiece::getLetterForPiece(ChessPiece::QUEEN, $colour);
+			}
+		}
+		if ($castling == '') {
+			$castling = '-';
+		}
+		$fen .= $castling . ' ';
+
+		// En passant
+		['X' => $pawnX, 'Y' => $pawnY] = $this->getEnPassantPawn();
+		if ($pawnX != -1) {
+			$fen .= chr(ord('a') + $pawnX);
+			$fen .= match ($pawnY) {
+				3 => '3', // white pawn on rank 4
+				4 => '6', // black pawn on rank 5
+				default => throw new Exception('Invalid en passant rank: ' . $pawnY),
+			};
+		} else {
+			$fen .= '-';
+		}
+		$fen .= ' 0 ' . floor($this->numMoves / 2);
+
+		return $fen;
+	}
+
+	public function getCurrentTurnColour(): Colour {
+		return $this->numMoves % 2 == 0 ? Colour::White : Colour::Black;
+	}
+
+	/**
+	 * Get the board from the colour's perspective as an array.
+	 * The first dimension is the y-coordinate, second is x-coordinate.
+	 *
+	 * @return array<int, array<int, ?ChessPiece>>
+	 */
+	public function getBoardDisplay(bool $playerIsWhite): array {
+		if ($playerIsWhite) {
+			// Reverse rows
+			$board = array_reverse($this->board, true);
+		} else {
+			// Reverse columns
+			$board = $this->board;
+			foreach ($board as $key => $row) {
+				$board[$key] = array_reverse($row, true);
+			}
+		}
+		return $board;
+	}
+
+	public static function isValidCoord(int $x, int $y): bool {
+		return ($x >= 0 && $x < self::NX) && ($y >= 0 && $y < self::NY);
+	}
+
+	/**
+	 * @return array<ChessPiece>
+	 */
+	public function getPieces(?Colour $colour = null): array {
+		$pieces = [];
+		foreach ($this->board as $row) {
+			foreach ($row as $piece) {
+				if ($piece !== null && ($colour === null || $colour === $piece->colour)) {
+					$pieces[] = $piece;
+				}
+			}
+		}
+		return $pieces;
+	}
+
+	public function hasPiece(int $x, int $y): bool {
+		return $this->board[$y][$x] !== null;
+	}
+
+	public function getPiece(int $x, int $y): ChessPiece {
+		if ($this->board[$y][$x] === null) {
+			throw new Exception('No piece found on: ' . $x . ', ' . $y);
+		}
+		return $this->board[$y][$x];
+	}
+
+	public function getKing(Colour $colour): ChessPiece {
+		foreach ($this->getPieces($colour) as $piece) {
+			if ($piece->pieceID === ChessPiece::KING) {
+				return $piece;
+			}
+		}
+		throw new Exception('Could not find the ' . $colour->value . ' King!');
+	}
+
+	public function canCastle(Colour $colour, Castling $type): bool {
+		return in_array($type, $this->canCastle[$colour->value]);
+	}
+
+	/**
+	 * @return array{'X': int, 'Y': int}
+	 */
+	public function getEnPassantPawn(): array {
+		return $this->enPassantPawn;
+	}
+
+	/**
+	 * Is the $colour King being attacked by any enemy pieces?
+	 */
+	public function isChecked(Colour $colour): bool {
+		$king = $this->getKing($colour);
+		foreach ($this->getPieces($colour->opposite()) as $piece) {
+			if ($piece->isAttacking($this, x: $king->x, y: $king->y)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Change the position of a piece on the board
+	 */
+	public function setSquare(int $x, int $y, ChessPiece $piece): void {
+		$this->board[$y][$x] = $piece;
+		$piece->x = $x;
+		$piece->y = $y;
+	}
+
+	public function clearSquare(int $x, int $y): void {
+		$this->board[$y][$x] = null;
+	}
+
+	/**
+	 * Move a piece. Note that legality of the move is not checked here.
+	 *
+	 * @return array{Castling: ?Castling, PieceTaken: ?ChessPiece, EnPassant: bool, PawnPromotion: bool}
+	 */
+	public function movePiece(int $x, int $y, int $toX, int $toY, int $pawnPromotionPiece = ChessPiece::QUEEN): array {
+		if (!$this->isValidCoord($x, $y)) {
+			throw new Exception('Invalid from coordinates, x=' . $x . ', y=' . $y);
+		}
+		if (!$this->isValidCoord($toX, $toY)) {
+			throw new Exception('Invalid to coordinates, x=' . $toX . ', y=' . $toY);
+		}
+		$piece = $this->getPiece($x, $y);
+		$pieceTaken = $this->board[$toY][$toX];
+		if ($pieceTaken?->pieceID === ChessPiece::KING) {
+			throw new Exception('King cannot be taken');
+		}
+
+		// Update the board state
+		$this->setSquare($toX, $toY, $piece);
+		$this->clearSquare($x, $y);
+
+		$canEnPassant = $this->getEnPassantPawn();
+		$enPassant = false;
+		$enPassantPawn = ['X' => -1, 'Y' => -1];
+		$castlingType = null;
+		$pawnPromotion = false;
+
+		if ($piece->pieceID == ChessPiece::KING) {
+			// We've moved the King, so no more castling
+			$this->canCastle[$piece->colour->value] = [];
+
+			// If castling, also update the Rook position
+			$castling = ChessGame::isCastling($x, $toX);
+			if ($castling !== false) {
+				$castlingType = $castling['Type'];
+				$rook = $this->getPiece($castling['X'], $y);
+				$this->setSquare($castling['ToX'], $y, $rook);
+				$this->clearSquare($castling['X'], $y);
+			}
+		} elseif ($piece->pieceID == ChessPiece::ROOK) {
+			// We've moved a Rook, so can no longer castle with it
+			if ($x == 0) {
+				array_remove_value($this->canCastle[$piece->colour->value], Castling::Queenside);
+			} elseif ($x == 7) {
+				array_remove_value($this->canCastle[$piece->colour->value], Castling::Kingside);
+			}
+		} elseif ($piece->pieceID == ChessPiece::PAWN) {
+			if ($toY == 0 || $toY == 7) {
+				// Pawn was promoted
+				$pawnPromotion = true;
+				$piece->pieceID = $pawnPromotionPiece;
+			} elseif ($y == 1 && $toY == 3 || $y == 6 && $toY == 4) {
+				// Double move to track?
+				$enPassantPawn = ['X' => $toX, 'Y' => $toY];
+			} elseif ($canEnPassant['X'] == $toX && ($canEnPassant['Y'] == 3 && $toY == 2 || $canEnPassant['Y'] == 4 && $toY == 5)) {
+				// En passant? Update the taken pawn.
+				$enPassant = true;
+				$pieceTaken = $this->getPiece($canEnPassant['X'], $canEnPassant['Y']);
+				$this->clearSquare($canEnPassant['X'], $canEnPassant['Y']);
+			}
+		}
+
+		// Track if the move we just made allows the opponent to take en passant
+		$this->enPassantPawn = $enPassantPawn;
+
+		// Increment the move counter
+		$this->numMoves++;
+
+		return [
+			'Castling' => $castlingType,
+			'PieceTaken' => $pieceTaken,
+			'EnPassant' => $enPassant,
+			'PawnPromotion' => $pawnPromotion,
+		];
+	}
+
+}

--- a/src/lib/Smr/Chess/Castling.php
+++ b/src/lib/Smr/Chess/Castling.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Chess;
+
+/**
+ * Enum values are database types and must not be changed.
+ */
+enum Castling: string {
+
+	case Kingside = 'King';
+	case Queenside = 'Queen';
+
+}

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -29,10 +29,7 @@ class ChessGame {
 	private ?int $endDate;
 	private int $winner;
 
-	/** @var array<mixed> */
-	private array $hasMoved;
-	/** @var array<int, array<int, ?ChessPiece>> */
-	private array $board;
+	private Board $board;
 	/** @var array<string> */
 	private array $moves;
 
@@ -94,49 +91,6 @@ class ChessGame {
 		$this->whiteID = $dbRecord->getInt('white_id');
 		$this->blackID = $dbRecord->getInt('black_id');
 		$this->winner = $dbRecord->getInt('winner_id');
-		$this->resetHasMoved();
-	}
-
-	/**
-	 * @param array<int, array<int, ?ChessPiece>> $board
-	 */
-	public static function isValidCoord(int $x, int $y, array $board): bool {
-		return $y < count($board) && $y >= 0 && $x < count($board[$y]) && $x >= 0;
-	}
-
-	/**
-	 * @param array<int, array<int, ?ChessPiece>> $board
-	 * @param array<mixed> $hasMoved
-	 */
-	public static function isPlayerChecked(array $board, array $hasMoved, Colour $colour): bool {
-		foreach ($board as $row) {
-			foreach ($row as $p) {
-				if ($p != null && $p->colour != $colour && $p->isAttacking($board, $hasMoved, true)) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	private function resetHasMoved(): void {
-		$this->hasMoved = [
-			Colour::White->value => [
-				ChessPiece::KING => false,
-				ChessPiece::ROOK => [
-					'Queen' => false,
-					'King' => false,
-				],
-			],
-			Colour::Black->value => [
-				ChessPiece::KING => false,
-				ChessPiece::ROOK => [
-					'Queen' => false,
-					'King' => false,
-				],
-			],
-			ChessPiece::PAWN => [-1, -1],
-		];
 	}
 
 	public function rerunGame(bool $debugInfo = false): void {
@@ -146,15 +100,13 @@ class ChessGame {
 					SET end_time = NULL, winner_id = 0
 					WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ';');
 		$db->write('DELETE FROM chess_game_pieces WHERE chess_game_id = ' . $this->db->escapeNumber($this->chessGameID) . ';');
-		self::insertPieces($this->chessGameID);
 
 		$dbResult = $db->read('SELECT * FROM chess_game_moves WHERE chess_game_id = ' . $this->db->escapeNumber($this->chessGameID) . ' ORDER BY move_id;');
 		$db->write('DELETE FROM chess_game_moves WHERE chess_game_id = ' . $this->db->escapeNumber($this->chessGameID) . ';');
 		$this->moves = [];
-		unset($this->board);
+		$this->board = new Board();
 		unset($this->endDate);
-		unset($this->winner);
-		$this->resetHasMoved();
+		$this->winner = 0;
 
 		try {
 			foreach ($dbResult->records() as $dbRecord) {
@@ -179,33 +131,11 @@ class ChessGame {
 		}
 	}
 
-	/**
-	 * @return array<int, array<int, ?ChessPiece>>
-	 */
-	public function getBoard(): array {
+	public function getBoard(): Board {
 		if (!isset($this->board)) {
-			$dbResult = $this->db->read('SELECT * FROM chess_game_pieces WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ';');
-			$pieces = [];
-			foreach ($dbResult->records() as $dbRecord) {
-				$pieces[] = new ChessPiece(Colour::from($dbRecord->getString('colour')), $dbRecord->getInt('piece_id'), $dbRecord->getInt('x'), $dbRecord->getInt('y'), $dbRecord->getInt('piece_no'));
-			}
-			$this->board = $this->parsePieces($pieces);
+			$this->getMoves();
 		}
 		return $this->board;
-	}
-
-	/**
-	 * Get the board from black's perspective
-	 *
-	 * @return array<int, array<int, ?ChessPiece>>
-	 */
-	public function getBoardReversed(): array {
-		// Need to reverse both the rows and the files to rotate the board
-		$board = array_reverse($this->getBoard(), true);
-		foreach ($board as $key => $row) {
-			$board[$key] = array_reverse($row, true);
-		}
-		return $board;
 	}
 
 	/**
@@ -235,27 +165,39 @@ class ChessGame {
 		if (!isset($this->moves)) {
 			$dbResult = $this->db->read('SELECT * FROM chess_game_moves WHERE chess_game_id = ' . $this->db->escapeNumber($this->chessGameID) . ' ORDER BY move_id;');
 			$this->moves = [];
+			$this->board = new Board();
 			$mate = false;
 			foreach ($dbResult->records() as $dbRecord) {
-				$pieceTakenID = $dbRecord->getNullableInt('piece_taken');
 				$promotionPieceID = $dbRecord->getNullableInt('promote_piece_id');
+				$startX = $dbRecord->getInt('start_x');
+				$startY = $dbRecord->getInt('start_y');
+				$endX = $dbRecord->getInt('end_x');
+				$endY = $dbRecord->getInt('end_y');
+				// Update the board state
+				$moveInfo = $this->board->movePiece(
+					x: $startX,
+					y: $startY,
+					toX: $endX,
+					toY: $endY,
+					pawnPromotionPiece: $promotionPieceID ?? ChessPiece::QUEEN,
+				);
 				$this->moves[] = $this->createMove(
-					$dbRecord->getInt('piece_id'),
-					$dbRecord->getInt('start_x'),
-					$dbRecord->getInt('start_y'),
-					$dbRecord->getInt('end_x'),
-					$dbRecord->getInt('end_y'),
-					$pieceTakenID,
-					$dbRecord->getNullableString('checked'),
-					$dbRecord->getInt('move_id') % 2 == 1 ? Colour::White : Colour::Black,
-					$dbRecord->getNullableString('castling'),
-					$dbRecord->getBoolean('en_passant'),
-					$promotionPieceID
+					pieceID: $dbRecord->getInt('piece_id'),
+					startX: $startX,
+					startY: $startY,
+					endX: $endX,
+					endY: $endY,
+					pieceTaken: $moveInfo['PieceTaken']?->pieceID,
+					checking: $dbRecord->getNullableString('checked'),
+					playerColour: $this->board->getCurrentTurnColour(),
+					castling: $moveInfo['Castling'],
+					enPassant: $moveInfo['EnPassant'],
+					promotionPieceID: $promotionPieceID,
 				);
 				$mate = $dbRecord->getNullableString('checked') == 'MATE';
 			}
 			if (!$mate && $this->hasEnded()) {
-				if ($this->getWinner() != 0) {
+				if ($this->hasWinner()) {
 					$this->moves[] = ($this->getWinner() == $this->getWhiteID() ? 'Black' : 'White') . ' Resigned.';
 				} elseif (count($this->moves) < 2) {
 					$this->moves[] = 'Game Cancelled.';
@@ -267,157 +209,61 @@ class ChessGame {
 		return $this->moves;
 	}
 
-	public function getFENString(): string {
-		$fen = '';
-		$board = $this->getBoard();
-		$blanks = 0;
-		for ($y = 0; $y < 8; $y++) {
-			if ($y > 0) {
-				$fen .= '/';
-			}
-			for ($x = 0; $x < 8; $x++) {
-				if ($board[$y][$x] === null) {
-					$blanks++;
-				} else {
-					if ($blanks > 0) {
-						$fen .= $blanks;
-						$blanks = 0;
-					}
-					$fen .= $board[$y][$x]->getPieceLetter();
-				}
-			}
-			if ($blanks > 0) {
-				$fen .= $blanks;
-				$blanks = 0;
-			}
-		}
-		$fen .= match ($this->getCurrentTurnColour()) {
-			Colour::White => ' w ',
-			Colour::Black => ' b ',
-		};
-
-		// Castling
-		$castling = '';
-		foreach (Colour::cases() as $colour) {
-			if ($this->hasMoved[$colour->value][ChessPiece::KING] !== true) {
-				if ($this->hasMoved[$colour->value][ChessPiece::ROOK]['King'] !== true) {
-					$castling .= ChessPiece::getLetterForPiece(ChessPiece::KING, $colour);
-				}
-				if ($this->hasMoved[$colour->value][ChessPiece::ROOK]['Queen'] !== true) {
-					$castling .= ChessPiece::getLetterForPiece(ChessPiece::QUEEN, $colour);
-				}
-			}
-		}
-		if ($castling == '') {
-			$castling = '-';
-		}
-		$fen .= $castling . ' ';
-
-		// En passant
-		[$pawnX, $pawnY] = $this->hasMoved[ChessPiece::PAWN];
-		if ($pawnX != -1) {
-			$fen .= chr(ord('a') + $pawnX);
-			$fen .= match ($pawnY) {
-				3 => '6',
-				4 => '3',
-				default => throw new Exception('Invalid en passant rank: ' . $pawnY),
-			};
-		} else {
-			$fen .= '-';
-		}
-		$fen .= ' 0 ' . floor(count($this->moves) / 2);
-
-		return $fen;
-	}
-
-	/**
-	 * @param array<ChessPiece> $pieces
-	 * @return array<int, array<int, ?ChessPiece>>
-	 */
-	private static function parsePieces(array $pieces): array {
-		$row = array_fill(0, 8, null);
-		$board = array_fill(0, 8, $row);
-		foreach ($pieces as $piece) {
-			if ($board[$piece->y][$piece->x] != null) {
-				throw new Exception('Two pieces found in the same tile.');
-			}
-			$board[$piece->y][$piece->x] = $piece;
-		}
-		return $board;
-	}
-
 	/**
 	 * @return array<ChessPiece>
 	 */
 	public static function getStandardGame(): array {
 		return [
-				new ChessPiece(Colour::Black, ChessPiece::ROOK, 0, 0),
-				new ChessPiece(Colour::Black, ChessPiece::KNIGHT, 1, 0),
-				new ChessPiece(Colour::Black, ChessPiece::BISHOP, 2, 0),
-				new ChessPiece(Colour::Black, ChessPiece::QUEEN, 3, 0),
-				new ChessPiece(Colour::Black, ChessPiece::KING, 4, 0),
-				new ChessPiece(Colour::Black, ChessPiece::BISHOP, 5, 0),
-				new ChessPiece(Colour::Black, ChessPiece::KNIGHT, 6, 0),
-				new ChessPiece(Colour::Black, ChessPiece::ROOK, 7, 0),
+			new ChessPiece(Colour::White, ChessPiece::ROOK, 0, 0),
+			new ChessPiece(Colour::White, ChessPiece::KNIGHT, 1, 0),
+			new ChessPiece(Colour::White, ChessPiece::BISHOP, 2, 0),
+			new ChessPiece(Colour::White, ChessPiece::QUEEN, 3, 0),
+			new ChessPiece(Colour::White, ChessPiece::KING, 4, 0),
+			new ChessPiece(Colour::White, ChessPiece::BISHOP, 5, 0),
+			new ChessPiece(Colour::White, ChessPiece::KNIGHT, 6, 0),
+			new ChessPiece(Colour::White, ChessPiece::ROOK, 7, 0),
 
-				new ChessPiece(Colour::Black, ChessPiece::PAWN, 0, 1),
-				new ChessPiece(Colour::Black, ChessPiece::PAWN, 1, 1),
-				new ChessPiece(Colour::Black, ChessPiece::PAWN, 2, 1),
-				new ChessPiece(Colour::Black, ChessPiece::PAWN, 3, 1),
-				new ChessPiece(Colour::Black, ChessPiece::PAWN, 4, 1),
-				new ChessPiece(Colour::Black, ChessPiece::PAWN, 5, 1),
-				new ChessPiece(Colour::Black, ChessPiece::PAWN, 6, 1),
-				new ChessPiece(Colour::Black, ChessPiece::PAWN, 7, 1),
+			new ChessPiece(Colour::White, ChessPiece::PAWN, 0, 1),
+			new ChessPiece(Colour::White, ChessPiece::PAWN, 1, 1),
+			new ChessPiece(Colour::White, ChessPiece::PAWN, 2, 1),
+			new ChessPiece(Colour::White, ChessPiece::PAWN, 3, 1),
+			new ChessPiece(Colour::White, ChessPiece::PAWN, 4, 1),
+			new ChessPiece(Colour::White, ChessPiece::PAWN, 5, 1),
+			new ChessPiece(Colour::White, ChessPiece::PAWN, 6, 1),
+			new ChessPiece(Colour::White, ChessPiece::PAWN, 7, 1),
 
-				new ChessPiece(Colour::White, ChessPiece::PAWN, 0, 6),
-				new ChessPiece(Colour::White, ChessPiece::PAWN, 1, 6),
-				new ChessPiece(Colour::White, ChessPiece::PAWN, 2, 6),
-				new ChessPiece(Colour::White, ChessPiece::PAWN, 3, 6),
-				new ChessPiece(Colour::White, ChessPiece::PAWN, 4, 6),
-				new ChessPiece(Colour::White, ChessPiece::PAWN, 5, 6),
-				new ChessPiece(Colour::White, ChessPiece::PAWN, 6, 6),
-				new ChessPiece(Colour::White, ChessPiece::PAWN, 7, 6),
+			new ChessPiece(Colour::Black, ChessPiece::PAWN, 0, 6),
+			new ChessPiece(Colour::Black, ChessPiece::PAWN, 1, 6),
+			new ChessPiece(Colour::Black, ChessPiece::PAWN, 2, 6),
+			new ChessPiece(Colour::Black, ChessPiece::PAWN, 3, 6),
+			new ChessPiece(Colour::Black, ChessPiece::PAWN, 4, 6),
+			new ChessPiece(Colour::Black, ChessPiece::PAWN, 5, 6),
+			new ChessPiece(Colour::Black, ChessPiece::PAWN, 6, 6),
+			new ChessPiece(Colour::Black, ChessPiece::PAWN, 7, 6),
 
-				new ChessPiece(Colour::White, ChessPiece::ROOK, 0, 7),
-				new ChessPiece(Colour::White, ChessPiece::KNIGHT, 1, 7),
-				new ChessPiece(Colour::White, ChessPiece::BISHOP, 2, 7),
-				new ChessPiece(Colour::White, ChessPiece::QUEEN, 3, 7),
-				new ChessPiece(Colour::White, ChessPiece::KING, 4, 7),
-				new ChessPiece(Colour::White, ChessPiece::BISHOP, 5, 7),
-				new ChessPiece(Colour::White, ChessPiece::KNIGHT, 6, 7),
-				new ChessPiece(Colour::White, ChessPiece::ROOK, 7, 7),
-			];
+			new ChessPiece(Colour::Black, ChessPiece::ROOK, 0, 7),
+			new ChessPiece(Colour::Black, ChessPiece::KNIGHT, 1, 7),
+			new ChessPiece(Colour::Black, ChessPiece::BISHOP, 2, 7),
+			new ChessPiece(Colour::Black, ChessPiece::QUEEN, 3, 7),
+			new ChessPiece(Colour::Black, ChessPiece::KING, 4, 7),
+			new ChessPiece(Colour::Black, ChessPiece::BISHOP, 5, 7),
+			new ChessPiece(Colour::Black, ChessPiece::KNIGHT, 6, 7),
+			new ChessPiece(Colour::Black, ChessPiece::ROOK, 7, 7),
+		];
 	}
 
-	public static function insertNewGame(int $startDate, ?int $endDate, AbstractPlayer $whitePlayer, AbstractPlayer $blackPlayer): int {
+	public static function insertNewGame(int $startDate, ?int $endDate, AbstractPlayer $whitePlayer, AbstractPlayer $blackPlayer): void {
 		$db = Database::getInstance();
-		$chessGameID = $db->insert('chess_game', [
+		$db->insert('chess_game', [
 			'start_time' => $db->escapeNumber($startDate),
 			'end_time' => $endDate === null ? 'NULL' : $db->escapeNumber($endDate),
 			'white_id' => $db->escapeNumber($whitePlayer->getAccountID()),
 			'black_id' => $db->escapeNumber($blackPlayer->getAccountID()),
 			'game_id' => $db->escapeNumber($whitePlayer->getGameID()),
 		]);
-
-		self::insertPieces($chessGameID);
-		return $chessGameID;
 	}
 
-	private static function insertPieces(int $chessGameID): void {
-		$db = Database::getInstance();
-		$pieces = self::getStandardGame();
-		foreach ($pieces as $p) {
-			$db->insert('chess_game_pieces', [
-				'chess_game_id' => $db->escapeNumber($chessGameID),
-				'colour' => $db->escapeString($p->colour->value),
-				'piece_id' => $db->escapeNumber($p->pieceID),
-				'x' => $db->escapeNumber($p->x),
-				'y' => $db->escapeNumber($p->y),
-			]);
-		}
-	}
-
-	private function createMove(int $pieceID, int $startX, int $startY, int $endX, int $endY, ?int $pieceTaken, ?string $checking, Colour $playerColour, ?string $castling, bool $enPassant, ?int $promotionPieceID): string {
+	private function createMove(int $pieceID, int $startX, int $startY, int $endX, int $endY, ?int $pieceTaken, ?string $checking, Colour $playerColour, ?Castling $castling, bool $enPassant, ?int $promotionPieceID): string {
 		// This move will be set as the most recent move
 		$this->lastMove = [
 			'From' => ['X' => $startX, 'Y' => $startY],
@@ -425,30 +271,19 @@ class ChessGame {
 		];
 
 		$otherPlayerColour = $playerColour->opposite();
-		if ($pieceID == ChessPiece::KING) {
-			$this->hasMoved[$playerColour->value][ChessPiece::KING] = true;
-		}
-		// Check if the piece moving is a rook and mark it as moved to stop castling.
-		if ($pieceID == ChessPiece::ROOK && ($startX == 0 || $startX == 7) && ($startY == ($playerColour == Colour::White ? 7 : 0))) {
-			$this->hasMoved[$playerColour->value][ChessPiece::ROOK][$startX == 0 ? 'Queen' : 'King'] = true;
-		}
-		// Check if we've taken a rook and marked them as moved, if they've already moved this does nothing, but if they were taken before moving this stops an issue with trying to castle with a non-existent castle.
-		if ($pieceTaken == ChessPiece::ROOK && ($endX == 0 || $endX == 7) && $endY == ($otherPlayerColour == Colour::White ? 7 : 0)) {
-			$this->hasMoved[$otherPlayerColour->value][ChessPiece::ROOK][$endX == 0 ? 'Queen' : 'King'] = true;
-		}
-		if ($pieceID == ChessPiece::PAWN && ($startY == 1 || $startY == 6) && ($endY == 3 || $endY == 4)) {
-			$this->hasMoved[ChessPiece::PAWN] = [$endX, $endY];
-		} else {
-			$this->hasMoved[ChessPiece::PAWN] = [-1, -1];
-		}
-		return ($castling == 'Queen' ? '0-0-0' : ($castling == 'King' ? '0-0' : ''))
+		$castlingSymbol = match ($castling) {
+			Castling::Kingside => '0-0',
+			Castling::Queenside => '0-0-0',
+			null => '',
+		};
+		return $castlingSymbol
 			. ChessPiece::getSymbolForPiece($pieceID, $playerColour)
 			. chr(ord('a') + $startX)
-			. (8 - $startY)
+			. ($startY + 1)
 			. ' '
 			. ($pieceTaken === null ? '' : ChessPiece::getSymbolForPiece($pieceTaken, $otherPlayerColour))
 			. chr(ord('a') + $endX)
-			. (8 - $endY)
+			. ($endY + 1)
 			. ($promotionPieceID === null ? '' : ChessPiece::getSymbolForPiece($promotionPieceID, $playerColour))
 			. ' '
 			. ($checking === null ? '' : ($checking == 'CHECK' ? '+' : '++'))
@@ -457,130 +292,33 @@ class ChessGame {
 
 	public function isCheckmated(Colour $colour): bool {
 		$king = null;
-		foreach ($this->board as $row) {
-			foreach ($row as $piece) {
-				if ($piece != null && $piece->pieceID == ChessPiece::KING && $piece->colour == $colour) {
-					$king = $piece;
-					break;
-				}
+		foreach ($this->board->getPieces($colour) as $piece) {
+			if ($piece->pieceID == ChessPiece::KING) {
+				$king = $piece;
+				break;
 			}
 		}
 		if ($king === null) {
 			throw new Exception('Could not find the king: game id = ' . $this->chessGameID);
 		}
-		if (!self::isPlayerChecked($this->board, $this->hasMoved, $colour)) {
+		if (!$this->board->isChecked($colour)) {
 			return false;
 		}
-		foreach ($this->board as $row) {
-			foreach ($row as $piece) {
-				if ($piece != null && $piece->colour == $colour) {
-					$moves = $piece->getPossibleMoves($this->board, $this->hasMoved);
-					//There are moves we can make, we are clearly not checkmated.
-					if (count($moves) > 0) {
-						return false;
-					}
-				}
-			}
-		}
-		return true;
+		$moves = $king->getPossibleMoves($this->board);
+		// If there are no moves the King can make, they are checkmated.
+		return count($moves) === 0;
 	}
 
 	/**
-	 * @return array{Type: string, X: int, ToX: int}|false
+	 * @return array{Type: Castling, X: int, ToX: int}|false
 	 */
 	public static function isCastling(int $x, int $toX): array|false {
 		$movement = $toX - $x;
 		return match ($movement) {
-			-2 => ['Type' => 'Queen', 'X' => 0, 'ToX' => 3],
-			2 => ['Type' => 'King', 'X' => 7, 'ToX' => 5],
+			-2 => ['Type' => Castling::Queenside, 'X' => 0, 'ToX' => 3],
+			2 => ['Type' => Castling::Kingside, 'X' => 7, 'ToX' => 5],
 			default => false,
 		};
-	}
-
-	/**
-	 * @param array<int, array<int, ?ChessPiece>> $board
-	 * @param array<mixed> $hasMoved
-	 * @return array<string, mixed>
-	 */
-	public static function movePiece(array &$board, array &$hasMoved, int $x, int $y, int $toX, int $toY, int $pawnPromotionPiece = ChessPiece::QUEEN): array {
-		if (!self::isValidCoord($x, $y, $board)) {
-			throw new Exception('Invalid from coordinates, x=' . $x . ', y=' . $y);
-		}
-		if (!self::isValidCoord($toX, $toY, $board)) {
-			throw new Exception('Invalid to coordinates, x=' . $toX . ', y=' . $toY);
-		}
-		$pieceTaken = $board[$toY][$toX];
-		$board[$toY][$toX] = $board[$y][$x];
-		$p = $board[$toY][$toX];
-		$board[$y][$x] = null;
-		if ($p === null) {
-			throw new Exception('Trying to move non-existent piece: ' . var_export($board, true));
-		}
-		$p->x = $toX;
-		$p->y = $toY;
-
-		$oldPawnMovement = $hasMoved[ChessPiece::PAWN];
-		$nextPawnMovement = [-1, -1];
-		$castling = false;
-		$enPassant = false;
-		$rookMoved = false;
-		$rookTaken = false;
-		$pawnPromotion = false;
-		if ($p->pieceID == ChessPiece::KING) {
-			//Castling?
-			$castling = self::isCastling($x, $toX);
-			if ($castling !== false) {
-				$hasMoved[$p->colour->value][ChessPiece::KING] = true;
-				$hasMoved[$p->colour->value][ChessPiece::ROOK][$castling['Type']] = true;
-				if ($board[$y][$castling['X']] === null) {
-					throw new Exception('Cannot castle with non-existent rook.');
-				}
-				$board[$toY][$castling['ToX']] = $board[$y][$castling['X']];
-				$board[$toY][$castling['ToX']]->x = $castling['ToX'];
-				$board[$y][$castling['X']] = null;
-			}
-		} elseif ($p->pieceID == ChessPiece::PAWN) {
-			if ($toY == 0 || $toY == 7) {
-				$pawnPromotion = $p->promote($pawnPromotionPiece, $board);
-			} elseif (($y == 1 || $y == 6) && ($toY == 3 || $toY == 4)) {
-				//Double move to track?
-				$nextPawnMovement = [$toX, $toY];
-			} elseif ($hasMoved[ChessPiece::PAWN][0] == $toX &&
-					($hasMoved[ChessPiece::PAWN][1] == 3 && $toY == 2 || $hasMoved[ChessPiece::PAWN][1] == 4 && $toY == 5)) {
-				//En passant?
-				$enPassant = true;
-				$pieceTaken = $board[$hasMoved[ChessPiece::PAWN][1]][$hasMoved[ChessPiece::PAWN][0]];
-				if ($board[$hasMoved[ChessPiece::PAWN][1]][$hasMoved[ChessPiece::PAWN][0]] === null) {
-					throw new Exception('Cannot en passant a non-existent pawn.');
-				}
-				$board[$hasMoved[ChessPiece::PAWN][1]][$hasMoved[ChessPiece::PAWN][0]] = null;
-			}
-		} elseif ($p->pieceID == ChessPiece::ROOK && ($x == 0 || $x == 7) && $y == ($p->colour == Colour::White ? 7 : 0)) {
-			//Rook moved?
-			if ($hasMoved[$p->colour->value][ChessPiece::ROOK][$x == 0 ? 'Queen' : 'King'] === false) {
-				// We set rook moved in here as it's used for move info.
-				$rookMoved = $x == 0 ? 'Queen' : 'King';
-				$hasMoved[$p->colour->value][ChessPiece::ROOK][$rookMoved] = true;
-			}
-		}
-		// Check if we've taken a rook and marked them as moved, if they've already moved this does nothing, but if they were taken before moving this stops an issue with trying to castle with a non-existent castle.
-		if ($pieceTaken != null && $pieceTaken->pieceID == ChessPiece::ROOK && ($toX == 0 || $toX == 7) && $toY == ($pieceTaken->colour == Colour::White ? 7 : 0)) {
-			if ($hasMoved[$pieceTaken->colour->value][ChessPiece::ROOK][$toX == 0 ? 'Queen' : 'King'] === false) {
-				$rookTaken = $toX == 0 ? 'Queen' : 'King';
-				$hasMoved[$pieceTaken->colour->value][ChessPiece::ROOK][$rookTaken] = true;
-			}
-		}
-
-		$hasMoved[ChessPiece::PAWN] = $nextPawnMovement;
-		return [
-			'Castling' => $castling,
-			'PieceTaken' => $pieceTaken,
-			'EnPassant' => $enPassant,
-			'RookMoved' => $rookMoved,
-			'RookTaken' => $rookTaken,
-			'OldPawnMovement' => $oldPawnMovement,
-			'PawnPromotion' => $pawnPromotion,
-		];
 	}
 
 	/**
@@ -615,14 +353,13 @@ class ChessGame {
 		if ($this->getCurrentTurnColour() != $forColour) {
 			throw new UserError('It is not your turn to move');
 		}
-		$lastTurnPlayer = $this->getCurrentTurnPlayer();
-		$this->getBoard();
-		$p = $this->board[$y][$x];
-		if ($p === null || $p->colour != $forColour) {
-			throw new UserError('There is no piece on that square');
+
+		$p = $this->board->getPiece($x, $y);
+		if ($p->colour != $forColour) {
+			throw new UserError('That is not your piece to move!');
 		}
 
-		$moves = $p->getPossibleMoves($this->board, $this->hasMoved, $forColour);
+		$moves = $p->getPossibleMoves($this->board);
 		$moveIsLegal = false;
 		foreach ($moves as $move) {
 			if ($move[0] == $toX && $move[1] == $toY) {
@@ -637,41 +374,39 @@ class ChessGame {
 		$chessType = $this->isNPCGame() ? 'Chess (NPC)' : 'Chess';
 		$currentPlayer = $this->getCurrentTurnPlayer();
 
-		$moveInfo = self::movePiece($this->board, $this->hasMoved, $x, $y, $toX, $toY, $pawnPromotionPiece);
+		$moveInfo = $this->board->movePiece($x, $y, $toX, $toY, $pawnPromotionPiece);
 
-		//We have taken the move, we should refresh $p
-		$p = $this->board[$toY][$toX];
-
-		$pieceTakenID = null;
-		if ($moveInfo['PieceTaken'] != null) {
-			$pieceTakenID = $moveInfo['PieceTaken']->pieceID;
-			if ($moveInfo['PieceTaken']->pieceID == ChessPiece::KING) {
-				throw new Exception('King was taken.');
-			}
-		}
-
-		$pieceID = $p->pieceID;
-		$pieceNo = $p->pieceNo;
-		$promotionPieceID = null;
-		if ($moveInfo['PawnPromotion'] !== false) {
-			$p->pieceID = $moveInfo['PawnPromotion']['PieceID'];
-			$p->pieceNo = $moveInfo['PawnPromotion']['PieceNo'];
+		if ($moveInfo['PawnPromotion']) {
+			$pieceID = ChessPiece::PAWN;
 			$promotionPieceID = $p->pieceID;
+		} else {
+			$pieceID = $p->pieceID;
+			$promotionPieceID = null;
 		}
 
 		$checking = null;
-		if ($p->isAttacking($this->board, $this->hasMoved, true)) {
+		if ($this->board->isChecked($p->colour->opposite())) {
 			$checking = 'CHECK';
 		}
 		if ($this->isCheckmated($p->colour->opposite())) {
 			$checking = 'MATE';
 		}
 
-		$castlingType = $moveInfo['Castling'] === false ? null : $moveInfo['Castling']['Type'];
-
 		$this->getMoves(); // make sure $this->moves is initialized
-		$this->moves[] = $this->createMove($pieceID, $x, $y, $toX, $toY, $pieceTakenID, $checking, $this->getCurrentTurnColour(), $castlingType, $moveInfo['EnPassant'], $promotionPieceID);
-		if (self::isPlayerChecked($this->board, $this->hasMoved, $p->colour)) {
+		$this->moves[] = $this->createMove(
+			pieceID: $pieceID,
+			startX: $x,
+			startY: $y,
+			endX: $toX,
+			endY: $toY,
+			pieceTaken: $moveInfo['PieceTaken']?->pieceID,
+			checking: $checking,
+			playerColour: $forColour,
+			castling: $moveInfo['Castling'],
+			enPassant: $moveInfo['EnPassant'],
+			promotionPieceID: $promotionPieceID,
+		);
+		if ($this->board->isChecked($forColour)) {
 			throw new UserError('You cannot end your turn in check');
 		}
 
@@ -693,17 +428,13 @@ class ChessGame {
 			'end_y' => $this->db->escapeNumber($toY),
 			'checked' => $this->db->escapeString($checking, true),
 			'piece_taken' => $moveInfo['PieceTaken'] === null ? 'NULL' : $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID),
-			'castling' => $this->db->escapeString($castlingType, true),
+			'castling' => $this->db->escapeString($moveInfo['Castling']?->value, true),
 			'en_passant' => $this->db->escapeBoolean($moveInfo['EnPassant']),
-			'promote_piece_id' => $moveInfo['PawnPromotion'] == false ? 'NULL' : $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceID']),
+			'promote_piece_id' => $promotionPieceID ?? 'NULL',
 		]);
 
 		$currentPlayer->increaseHOF(1, [$chessType, 'Moves', 'Total Taken'], HOF_PUBLIC);
 		if ($moveInfo['PieceTaken'] != null) {
-			// Get the owner of the taken piece
-			$this->db->write('DELETE FROM chess_game_pieces
-							WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ' AND colour=' . $this->db->escapeString($moveInfo['PieceTaken']->colour->value) . ' AND piece_id=' . $this->db->escapeNumber($moveInfo['PieceTaken']->pieceID) . ' AND piece_no=' . $this->db->escapeNumber($moveInfo['PieceTaken']->pieceNo) . ';');
-
 			$pieceTakenSymbol = $moveInfo['PieceTaken']->getPieceSymbol();
 			$currentPlayer->increaseHOF(1, [$chessType, 'Moves', 'Opponent Pieces Taken', 'Total'], HOF_PUBLIC);
 			$otherPlayer->increaseHOF(1, [$chessType, 'Moves', 'Own Pieces Taken', 'Total'], HOF_PUBLIC);
@@ -711,23 +442,13 @@ class ChessGame {
 			$otherPlayer->increaseHOF(1, [$chessType, 'Moves', 'Own Pieces Taken', $pieceTakenSymbol], HOF_PUBLIC);
 		}
 
-		$this->db->write('UPDATE chess_game_pieces
-					SET x=' . $this->db->escapeNumber($toX) . ', y=' . $this->db->escapeNumber($toY) .
-						($moveInfo['PawnPromotion'] !== false ? ', piece_id=' . $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceID']) . ', piece_no=' . $this->db->escapeNumber($moveInfo['PawnPromotion']['PieceNo']) : '') . '
-					WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ' AND colour=' . $this->db->escapeString($p->colour->value) . ' AND piece_id=' . $this->db->escapeNumber($pieceID) . ' AND piece_no=' . $this->db->escapeNumber($pieceNo) . ';');
-		if ($moveInfo['Castling'] !== false) {
-			$this->db->write('UPDATE chess_game_pieces
-						SET x=' . $this->db->escapeNumber($moveInfo['Castling']['ToX']) . '
-						WHERE chess_game_id=' . $this->db->escapeNumber($this->chessGameID) . ' AND colour=' . $this->db->escapeString($p->colour->value) . ' AND x = ' . $this->db->escapeNumber($moveInfo['Castling']['X']) . ' AND y = ' . $this->db->escapeNumber($y) . ';');
-		}
-
 		if ($checking == 'MATE') {
 			$message = 'You have checkmated your opponent, congratulations!';
 			$this->setWinner($this->getColourID($forColour));
-			Player::sendMessageFromCasino($lastTurnPlayer->getGameID(), $this->getCurrentTurnAccountID(), 'You have just lost [chess=' . $this->getChessGameID() . '] against [player=' . $lastTurnPlayer->getPlayerID() . '].');
+			$otherPlayer->sendMessageFromCasino('You have just lost [chess=' . $this->getChessGameID() . '] against [player=' . $currentPlayer->getPlayerID() . '].');
 		} else {
 			$message = ''; // non-mating valid move, no message
-			Player::sendMessageFromCasino($lastTurnPlayer->getGameID(), $this->getCurrentTurnAccountID(), 'It is now your turn in [chess=' . $this->getChessGameID() . '] against [player=' . $lastTurnPlayer->getPlayerID() . '].');
+			$otherPlayer->sendMessageFromCasino('It is now your turn in [chess=' . $this->getChessGameID() . '] against [player=' . $currentPlayer->getPlayerID() . '].');
 			if ($checking == 'CHECK') {
 				$currentPlayer->increaseHOF(1, [$chessType, 'Moves', 'Check Given'], HOF_PUBLIC);
 				$otherPlayer->increaseHOF(1, [$chessType, 'Moves', 'Check Received'], HOF_PUBLIC);
@@ -796,6 +517,10 @@ class ChessGame {
 		return $this->endDate !== null && $this->endDate <= Epoch::time();
 	}
 
+	public function hasWinner(): bool {
+		return $this->winner !== 0;
+	}
+
 	public function getWinner(): int {
 		return $this->winner;
 	}
@@ -818,19 +543,15 @@ class ChessGame {
 		return ['Winner' => $winningPlayer, 'Loser' => $losingPlayer];
 	}
 
-	/**
-	 * @return array<mixed>
-	 */
-	public function &getHasMoved(): array {
-		return $this->hasMoved;
-	}
-
 	public function getCurrentTurnColour(): Colour {
-		return count($this->getMoves()) % 2 == 0 ? Colour::White : Colour::Black;
+		return $this->getBoard()->getCurrentTurnColour();
 	}
 
 	public function getCurrentTurnAccountID(): int {
-		return count($this->getMoves()) % 2 == 0 ? $this->whiteID : $this->blackID;
+		return match ($this->getCurrentTurnColour()) {
+			Colour::White => $this->whiteID,
+			Colour::Black => $this->blackID,
+		};
 	}
 
 	public function getCurrentTurnPlayer(): AbstractPlayer {
@@ -879,7 +600,7 @@ class ChessGame {
 		$results = $this->setWinner($winnerAccountID);
 		$chessType = $this->isNPCGame() ? 'Chess (NPC)' : 'Chess';
 		$results['Loser']->increaseHOF(1, [$chessType, 'Games', 'Resigned'], HOF_PUBLIC);
-		Player::sendMessageFromCasino($results['Winner']->getGameID(), $results['Winner']->getAccountID(), '[player=' . $results['Loser']->getPlayerID() . '] just resigned against you in [chess=' . $this->getChessGameID() . '].');
+		$results['Winner']->sendMessageFromCasino('[player=' . $results['Loser']->getPlayerID() . '] just resigned against you in [chess=' . $this->getChessGameID() . '].');
 		return self::END_RESIGN;
 	}
 

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -168,6 +168,7 @@ class ChessGame {
 			$this->board = new Board();
 			$mate = false;
 			foreach ($dbResult->records() as $dbRecord) {
+				$forColour = $this->board->getCurrentTurnColour();
 				$promotionPieceID = $dbRecord->getNullableInt('promote_piece_id');
 				$startX = $dbRecord->getInt('start_x');
 				$startY = $dbRecord->getInt('start_y');
@@ -189,7 +190,7 @@ class ChessGame {
 					endY: $endY,
 					pieceTaken: $moveInfo['PieceTaken']?->pieceID,
 					checking: $dbRecord->getNullableString('checked'),
-					playerColour: $this->board->getCurrentTurnColour(),
+					playerColour: $forColour,
 					castling: $moveInfo['Castling'],
 					enPassant: $moveInfo['EnPassant'],
 					promotionPieceID: $promotionPieceID,

--- a/src/pages/Player/Chess/MatchPlay.php
+++ b/src/pages/Player/Chess/MatchPlay.php
@@ -23,15 +23,11 @@ class MatchPlay extends PlayerPage {
 
 		// Board orientation depends on the player's color.
 		$playerIsWhite = $chessGame->getWhiteID() == $player->getAccountID();
-		if ($playerIsWhite) {
-			$board = $chessGame->getBoard();
-		} else {
-			$board = $chessGame->getBoardReversed();
-		}
+		$board = $chessGame->getBoard()->getBoardDisplay($playerIsWhite);
 		$template->assign('Board', $board);
 
 		// Check if there is a winner
-		if ($chessGame->hasEnded()) {
+		if ($chessGame->hasWinner()) {
 			$winningPlayer = Player::getPlayer($chessGame->getWinner(), $player->getGameID());
 			$template->assign('Winner', $winningPlayer->getLinkedDisplayName(false));
 		}

--- a/src/templates/Default/engine/Default/chess_play.php
+++ b/src/templates/Default/engine/Default/chess_play.php
@@ -26,11 +26,11 @@
 				<table class="chess chessFont"><?php
 					foreach ($Board as $Y => $Row) { ?>
 						<tr>
-							<td class="chessOutline"><?php echo 8 - $Y; ?></td><?php
-							foreach ($Row as $X => $Cell) { ?>
-								<td id="c<?php echo $X . $Y; ?>" data-x="<?php echo $X; ?>" data-y="<?php echo $Y; ?>" class="ajax<?php if (($X + $Y) % 2 == 0) { ?> whiteSquare<?php } else { ?> blackSquare<?php } ?>" onClick="highlightMoves.call(this)">
+							<td class="chessOutline"><?php echo $Y + 1; ?></td><?php
+							foreach ($Row as $X => $Piece) { ?>
+								<td id="c<?php echo $X . $Y; ?>" data-x="<?php echo $X; ?>" data-y="<?php echo $Y; ?>" class="ajax<?php if (($X + $Y) % 2 != 0) { ?> whiteSquare<?php } else { ?> blackSquare<?php } ?>" onClick="highlightMoves.call(this)">
 									<div<?php if ($ChessGame->isLastMoveSquare($X, $Y)) { ?> class="lastMove"<?php } ?>><?php
-										if ($Cell !== null) { ?><span class="pointer lastMove"><?php echo $Cell->getPieceSymbol(); ?></span><?php } ?>
+										if ($Piece !== null) { ?><span class="pointer lastMove"><?php echo $Piece->getPieceSymbol(); ?></span><?php } ?>
 									</div>
 								</td><?php
 							} ?>
@@ -67,17 +67,12 @@
 	$AvailableMoves = array_pad([], count($Board), []);
 	if ($ChessGame->isCurrentTurn($ThisAccount->getAccountID())) {
 		$Colour = $ChessGame->getColourForAccountID($ThisAccount->getAccountID());
-		foreach ($Board as $Y => $Row) {
-			foreach ($Row as $X => $Cell) {
-				$AvailableMoves[$Y][$X] = [];
-				if ($Cell != null) {
-					$Moves = $Cell->getPossibleMoves($Board, $ChessGame->getHasMoved(), $Colour);
-					foreach ($Moves as $Move) {
-						$AvailableMoves[$Y][$X][] = '#c' . $Move[0] . $Move[1];
-					}
-					$AvailableMoves[$Y][$X] = implode(',', $AvailableMoves[$Y][$X]);
-				}
+		foreach ($ChessGame->getBoard()->getPieces($Colour) as $Piece) {
+			$Moves = [];
+			foreach ($Piece->getPossibleMoves($ChessGame->getBoard()) as $Move) {
+				$Moves[] = '#c' . $Move[0] . $Move[1];
 			}
+			$AvailableMoves[$Piece->y][$Piece->x] = implode(',', $Moves);
 		}
 	} ?>
 	var submitMoveHREF = <?php echo $this->addJavascriptForAjax('submitMoveHREF', $ChessMoveHREF); ?>;

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -71,7 +71,7 @@ try {
 
 		foreach (ChessGame::getNPCMoveGames(true) as $chessGame) {
 			debug('Looking at game: ' . $chessGame->getChessGameID());
-			writeToEngine('position fen ' . $chessGame->getFENString(), false);
+			writeToEngine('position fen ' . $chessGame->getBoard()->getFEN(), false);
 			writeToEngine('go ' . ($chessGame->getCurrentTurnColour() == Colour::White ? 'w' : 'b') . 'time ' . UCI_TIME_PER_MOVE_MS, true, false);
 			stream_set_blocking($fromEngine, true);
 			$move = '';

--- a/test/SmrTest/lib/Chess/BoardTest.php
+++ b/test/SmrTest/lib/Chess/BoardTest.php
@@ -1,0 +1,318 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\Chess;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Smr\Chess\Board;
+use Smr\Chess\Castling;
+use Smr\Chess\ChessGame;
+use Smr\Chess\ChessPiece;
+use Smr\Chess\Colour;
+
+/**
+ * @covers Smr\Chess\Board
+ */
+class BoardTest extends TestCase {
+
+	public function test_getFEN(): void {
+		// Note that this does not test castling, promotion, or non-e.p.
+		$board = new Board();
+		$board->movePiece(6, 0, 5, 2); // Nf3 (for space in back row)
+		$board->movePiece(3, 6, 3, 4); // d5 (for space in pawn row, and e.p.)
+		$expected = 'rnbqkbnr/ppp1pppp/8/3p4/8/5N2/PPPPPPPP/RNBQKB1R w KQkq d6 0 1';
+		self::assertSame($expected, $board->getFEN());
+	}
+
+	public function test_getCurrentTurnColour(): void {
+		// White moves first in a new game
+		$board = new Board();
+		self::assertSame(Colour::White, $board->getCurrentTurnColour());
+
+		// Black to move after White moves
+		$board->movePiece(3, 1, 3, 3); // d4
+		self::assertSame(Colour::Black, $board->getCurrentTurnColour());
+	}
+
+	/**
+	 * @testWith [0, 0, true]
+	 *           [7, 7, true]
+	 *           [-1, 0, false]
+	 *           [0, -1, false]
+	 *           [8, 0, false]
+	 *           [0, 8, false]
+	 */
+	public function test_isValidCoord(int $x, int $y, bool $valid): void {
+		self::assertSame($valid, Board::isValidCoord($x, $y));
+	}
+
+	public function test_getPieces(): void {
+		// New board should have all the standard pieces
+		$board = new Board();
+		self::assertEquals(ChessGame::getStandardGame(), $board->getPieces());
+
+		// Getting only pieces of a specific colour should be consistent
+		foreach (Colour::cases() as $colour) {
+			foreach ($board->getPieces($colour) as $piece) {
+				self::assertSame($colour, $piece->colour);
+			}
+		}
+	}
+
+	public function test_hasPiece(): void {
+		$board = new Board();
+		self::assertTrue($board->hasPiece(0, 1)); // a2
+		self::assertFalse($board->hasPiece(0, 2)); // a3
+	}
+
+	public function test_getPiece(): void {
+		// Get a piece that exists
+		$board = new Board();
+		$expected = new ChessPiece(Colour::White, ChessPiece::PAWN, 0, 1); // a2
+		self::assertEquals($expected, $board->getPiece(0, 1));
+
+		// Get an error if the piece doesn't exist
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('No piece found on: 0, 2');
+		$board->getPiece(0, 2); // a3
+	}
+
+	public function test_getKing(): void {
+		$board = new Board();
+		foreach (Colour::cases() as $colour) {
+			$y = match ($colour) {
+				Colour::White => 0,
+				Colour::Black => 7,
+			};
+			$expected = new ChessPiece($colour, ChessPiece::KING, 4, $y);
+			self::assertEquals($expected, $board->getKing($colour));
+		}
+	}
+
+	public function test_canCastle_default(): void {
+		// Can castle by default
+		$board = new Board();
+		foreach (Colour::cases() as $colour) {
+			foreach (Castling::cases() as $type) {
+				self::assertTrue($board->canCastle($colour, $type));
+			}
+		}
+	}
+
+	public function test_canCastle_move_king(): void {
+		// Moving King disables all castling
+		$board = new Board();
+		$board->movePiece(4, 1, 4, 2); // e3
+		$board->movePiece(4, 6, 4, 5); // e6
+		$board->movePiece(4, 0, 4, 1); // Ke2
+		$board->movePiece(4, 7, 4, 6); // Ke7
+		foreach (Colour::cases() as $colour) {
+			foreach (Castling::cases() as $type) {
+				self::assertFalse($board->canCastle($colour, $type));
+			}
+		}
+	}
+
+	/**
+	 * @dataProvider dataProvider_canCastle_move_rook
+	 */
+	public function test_canCastle_move_rook(Castling $type): void {
+		// Moving Rook disables castling only on that side
+		$board = new Board();
+		$x = match ($type) {
+			Castling::Kingside => 7,
+			Castling::Queenside => 0,
+		};
+		$otherType = match ($type) {
+			Castling::Kingside => Castling::Queenside,
+			Castling::Queenside => Castling::Kingside,
+		};
+		$board->movePiece($x, 1, $x, 2); // a3|h3
+		$board->movePiece($x, 6, $x, 5); // a6|h6
+		$board->movePiece($x, 0, $x, 1); // Ra2|Rh2
+		$board->movePiece($x, 7, $x, 6); // Ra7|Rh7
+		foreach (Colour::cases() as $colour) {
+			self::assertFalse($board->canCastle($colour, $type));
+			self::assertTrue($board->canCastle($colour, $otherType));
+		}
+	}
+
+	/**
+	 * @return array<array{0: Castling}>
+	 */
+	public function dataProvider_canCastle_move_rook(): array {
+		return [
+			[Castling::Kingside],
+			[Castling::Queenside],
+		];
+	}
+
+	public function test_getEnPassantPawn(): void {
+		// No en passant pawn by default
+		$board = new Board();
+		$none = ['X' => -1, 'Y' => -1];
+		self::assertSame($none, $board->getEnPassantPawn());
+
+		// Double moving a pawn allows en passant
+		$board->movePiece(0, 1, 0, 3); // a4
+		$expected = ['X' => 0, 'Y' => 3];
+		self::assertSame($expected, $board->getEnPassantPawn());
+
+		// Moving any other piece declines en passant
+		$board->movePiece(1, 7, 0, 5); // Na6
+		self::assertSame($none, $board->getEnPassantPawn());
+
+		// Single moving a pawn does not allow en passant
+		$board->movePiece(1, 1, 1, 2); // b3
+		self::assertSame($none, $board->getEnPassantPawn());
+	}
+
+	public function test_isChecked(): void {
+		// Not in check by default
+		$board = new Board();
+		foreach (Colour::cases() as $colour) {
+			self::assertFalse($board->isChecked($colour));
+		}
+
+		// Put the black king in check
+		$board->movePiece(4, 1, 4, 2); // e3
+		$board->movePiece(3, 6, 3, 5); // d6
+		$board->movePiece(5, 0, 1, 4); // Bb5+
+		self::assertTrue($board->isChecked(Colour::Black));
+		self::assertFalse($board->isChecked(Colour::White));
+
+		// Blocking the check results in no longer being checked
+		$board->movePiece(3, 7, 3, 6); // Qd7
+		foreach (Colour::cases() as $colour) {
+			self::assertFalse($board->isChecked($colour));
+		}
+	}
+
+	public function test_setSquare(): void {
+		// Add a White Rook to d5
+		$board = new Board();
+		$piece = new ChessPiece(Colour::White, ChessPiece::ROOK, 0, 0);
+		$board->setSquare(3, 4, $piece);
+
+		// The piece is now set on the board
+		self::assertSame($piece, $board->getPiece(3, 4));
+
+		// The piece has its coords updates
+		$expected = new ChessPiece(Colour::White, ChessPiece::ROOK, 3, 4);
+		self::assertEquals($piece, $expected);
+	}
+
+	public function test_clearSquare(): void {
+		$board = new Board();
+		self::assertTrue($board->hasPiece(1, 0));
+		$board->clearSquare(1, 0);
+		self::assertFalse($board->hasPiece(1, 0));
+	}
+
+	public function test_movePiece_castling_kingside(): void {
+		$board = new Board();
+		// Make room for castling kinside
+		$board->clearSquare(5, 0); // remove f1
+		$board->clearSquare(6, 0); // remove g1
+		$result = $board->movePiece(4, 0, 6, 0); // O-O
+		$expected = [
+			'Castling' => Castling::Kingside,
+			'PieceTaken' => null,
+			'EnPassant' => false,
+			'PawnPromotion' => false,
+		];
+		self::assertSame($expected, $result);
+
+		// Make sure pieces are in the right spot
+		$expectedKing = new ChessPiece(Colour::White, ChessPiece::KING, 6, 0);
+		self::assertEquals($expectedKing, $board->getPiece(6, 0));
+		$expectedRook = new ChessPiece(Colour::White, ChessPiece::ROOK, 5, 0);
+		self::assertEquals($expectedRook, $board->getPiece(5, 0));
+		self::assertFalse($board->hasPiece(4, 0));
+		self::assertFalse($board->hasPiece(7, 0));
+	}
+
+	public function test_movePiece_castling_queenside(): void {
+		$board = new Board();
+		// Make room for castling queenside
+		$board->clearSquare(1, 0); // remove b1
+		$board->clearSquare(2, 0); // remove c1
+		$board->clearSquare(3, 0); // remove d1
+		$result = $board->movePiece(4, 0, 2, 0); // O-O-O
+		$expected = [
+			'Castling' => Castling::Queenside,
+			'PieceTaken' => null,
+			'EnPassant' => false,
+			'PawnPromotion' => false,
+		];
+		self::assertSame($expected, $result);
+
+		// Make sure pieces are in the right spot
+		$expectedKing = new ChessPiece(Colour::White, ChessPiece::KING, 2, 0);
+		self::assertEquals($expectedKing, $board->getPiece(2, 0));
+		$expectedRook = new ChessPiece(Colour::White, ChessPiece::ROOK, 3, 0);
+		self::assertEquals($expectedRook, $board->getPiece(3, 0));
+		self::assertFalse($board->hasPiece(0, 0));
+		self::assertFalse($board->hasPiece(1, 0));
+		self::assertFalse($board->hasPiece(4, 0));
+	}
+
+	public function test_movePiece_capturing(): void {
+		$board = new Board();
+		// Remove pawn on d2
+		$board->clearSquare(3, 1);
+		$capturee = $board->getPiece(3, 6); // pawn on d7
+		$result = $board->movePiece(3, 0, 3, 6); // Qxd7
+		$expected = [
+			'Castling' => null,
+			'PieceTaken' => $capturee,
+			'EnPassant' => false,
+			'PawnPromotion' => false,
+		];
+		self::assertSame($expected, $result);
+	}
+
+	public function test_movePiece_capturing_en_passant(): void {
+		$board = new Board();
+		$capturer = new ChessPiece(Colour::Black, ChessPiece::PAWN, 0, 0);
+		$board->setSquare(3, 3, $capturer); // add Black pawn to d4
+		$board->movePiece(4, 1, 4, 3); // e4
+		$capturee = $board->getPiece(4, 3); // pawn on e4
+		$result = $board->movePiece(3, 3, 4, 2); // dxe4 e.p.
+		$expected = [
+			'Castling' => null,
+			'PieceTaken' => $capturee,
+			'EnPassant' => true,
+			'PawnPromotion' => false,
+		];
+		self::assertSame($expected, $result);
+
+		// Make sure pieces are in the right spot
+		$expectedPawn = new ChessPiece(Colour::Black, ChessPiece::PAWN, 4, 2);
+		self::assertEquals($expectedPawn, $board->getPiece(4, 2));
+		self::assertFalse($board->hasPiece(4, 3));
+	}
+
+	public function test_movePiece_promoting(): void {
+		$board = new Board();
+		// Clear path for pawn promotion
+		$board->clearSquare(0, 6); // a7
+		$board->clearSquare(0, 7); // a8
+		// Add pawn to a7
+		$pawn = new ChessPiece(Colour::White, ChessPiece::PAWN, 0, 0);
+		$board->setSquare(0, 6, $pawn);
+		$result = $board->movePiece(0, 6, 0, 7);
+		$expected = [
+			'Castling' => null,
+			'PieceTaken' => null,
+			'EnPassant' => false,
+			'PawnPromotion' => true,
+		];
+		self::assertSame($expected, $result);
+
+		// Make sure pieces are in the right spot
+		$expectedQueen = new ChessPiece(Colour::White, ChessPiece::QUEEN, 0, 7);
+		self::assertEquals($expectedQueen, $board->getPiece(0, 7));
+	}
+
+}

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -72,7 +72,7 @@ class DatabaseIntegrationTest extends TestCase {
 		// added that modify the base table size. If that becomes too onerous,
 		// we can do a fuzzier comparison. Until then, this is a useful check
 		// that the test database is properly reset between invocations.
-		self::assertSame($bytes, 730840);
+		self::assertSame($bytes, 729816);
 	}
 
 	public function test_escapeBoolean(): void {


### PR DESCRIPTION
* The Board class encapsulates all the information that is necessary to fully represent any given board state (i.e. an FEN string). It helps to disentangle game metadata vs. board state from ChessGame, and allows us to pass a single object to methods instead of passing a board array (`$board`) and a bookkeeping array (`$hasMoved`).

* The Board class has a bunch of new methods that help to simplify the logical operations (like finding the King piece, or getting all the pieces of a particular colour).

* The array returned by Board::movePiece removes a bunch of fields we weren't using.

* Remove the `chess_game_pieces` table, because it is not sufficient information on its own to reproduce the board state, and so we just need to use `chess_game_moves` for complete info anyway.

* Add a `Castling` enum to avoid hard-coding strings. The enum names (Kingside/Queenside) are also more clearly defining castling types than the backing values (King/Queen).

* Flip the orientation of the y-coordinate in the internal `$board` storage array. Previously, this mapped Rank 1 to y=7, and Rank 8 to y=0. This was way too confusing. The new mapping is Rank 1 to y=0 and Rank 8 to y=7; it's still a bit confusing, but makes _some_ sense!

* When constructing the build state, we replay all moves from the move history. This is less efficient than storing a FEN board state, but we need to display the move history anyway, so it's not too bad.

* Remove the `$pieceNo` property of the ChessPiece class. It served no purpose.