### PR TITLE
Fix combat results template for CombatSimulator

### DIFF
--- a/src/pages/Admin/CombatSimulator.php
+++ b/src/pages/Admin/CombatSimulator.php
@@ -47,6 +47,8 @@ class CombatSimulator extends AccountPage {
 		$template->assign('CombatSimHREF', (new CombatSimulatorProcessor())->href());
 
 		$template->assign('TraderCombatResults', $this->results);
+		$template->assign('MinimalDisplay', false);
+		$template->assign('ThisPlayer', null);
 	}
 
 }

--- a/src/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 /**
- * @var Smr\Player $ThisPlayer
+ * @var ?Smr\Player $ThisPlayer
  * @var Smr\Template $this
  * @var bool $MinimalDisplay
  * @var array<string, mixed> $TraderTeamCombatResults
@@ -152,11 +152,12 @@ $TotalDamage = $TraderTeamCombatResults['TotalDamage'];
 $TotalDamageToThisPlayer = 0;
 foreach ($TraderTeamCombatResults['Traders'] as $TraderResults) {
 	// Check if ThisPlayer was a target in this round of combat
-	if (!isset($TraderResults['TotalDamagePerTargetPlayer'][$ThisPlayer->getAccountID()])) {
+	$ThisAccountID = $ThisPlayer?->getAccountID();
+	if (!isset($TraderResults['TotalDamagePerTargetPlayer'][$ThisAccountID])) {
 		$TotalDamageToThisPlayer = null;
 		break;
 	}
-	$TotalDamageToThisPlayer += $TraderResults['TotalDamagePerTargetPlayer'][$ThisPlayer->getAccountID()];
+	$TotalDamageToThisPlayer += $TraderResults['TotalDamagePerTargetPlayer'][$ThisAccountID];
 } ?>
 
 This fleet <?php


### PR DESCRIPTION
As a result of adding the "minimal display" option to player vs player combat in 93c6e67e01e6b, we need to add a couple template variables to the CombatSimulator display page.

We rework the TraderTeamCombatResults template to allow `$ThisPlayer` to be null, in which case we don't display how much damage was done to "you".