### PR TITLE
Add rector infrastructure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
 		"phpstan/phpstan": "1.9.14",
 		"phpunit/phpunit": "9.5.28",
 		"phpunit/php-code-coverage": "9.2.20",
+		"rector/rector": "0.15.8",
 		"squizlabs/php_codesniffer": "3.7.1"
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ x-smr-test: &smr-test
         - ./phpunit.xml:/smr/phpunit.xml:ro
         - ./phpstan.neon.dist:/smr/phpstan.neon.dist:ro
         - ./phpcs.xml:/smr/phpcs.xml:ro
+        - ./rector.php:/smr/rector.php:ro
         # Mount the source code instead of copying it.
         - ./src:/smr/src:rw
         - ./test:/smr/test:rw
@@ -179,6 +180,10 @@ services:
     phpcbf:
         <<: *smr-test
         entrypoint: vendor/bin/phpcbf
+
+    rector:
+        <<: *smr-test
+        entrypoint: vendor/bin/rector process
 
     pma:
         image: phpmyadmin/phpmyadmin

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -37,9 +37,6 @@
         <!-- Jump statements on a single line can help keep code compact. -->
         <exclude name="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing" />
 
-        <!-- Trailing comma in multi-line function calls can be misleading. -->
-        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall" />
-
         <!-- Erroneous sniff. Disables a real language feature. -->
         <exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,9 +25,6 @@
         <!-- Erroneous sniff. Static and self are not interchangeable. -->
         <exclude name="PSR2R.PHP.PreferStaticOverSelf" />
 
-        <!-- Multiple empty lines can be useful for readability. -->
-        <exclude name="PSR2R.WhiteSpace.EmptyLines" />
-
         <!-- Personal preference for parentheses around require/echo. -->
         <exclude name="PSR2R.WhiteSpace.LanguageConstructSpacing" />
 

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 use Rector\Config\RectorConfig;
 use Rector\Php53\Rector\FuncCall\DirNameFileConstantToDirConstantRector;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
 use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
@@ -13,6 +14,7 @@ return static function (RectorConfig $rectorConfig): void {
 	]);
 	$rectorConfig->importNames(true, false);
 	$rectorConfig->rule(DirNameFileConstantToDirConstantRector::class);
+	$rectorConfig->rule(JsonThrowOnErrorRector::class);
 	$rectorConfig->rule(NullCoalescingOperatorRector::class);
 	$rectorConfig->rule(ClassOnObjectRector::class);
 	$rectorConfig->rule(FirstClassCallableRector::class);

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 use Rector\Config\RectorConfig;
 use Rector\Php53\Rector\FuncCall\DirNameFileConstantToDirConstantRector;
 use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
+use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -13,5 +14,6 @@ return static function (RectorConfig $rectorConfig): void {
 	$rectorConfig->importNames(true, false);
 	$rectorConfig->rule(DirNameFileConstantToDirConstantRector::class);
 	$rectorConfig->rule(NullCoalescingOperatorRector::class);
+	$rectorConfig->rule(ClassOnObjectRector::class);
 	$rectorConfig->rule(FirstClassCallableRector::class);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php53\Rector\FuncCall\DirNameFileConstantToDirConstantRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -9,5 +10,6 @@ return static function (RectorConfig $rectorConfig): void {
 		__DIR__ . '/src',
 	]);
 	$rectorConfig->importNames(true, false);
+	$rectorConfig->rule(DirNameFileConstantToDirConstantRector::class);
 	$rectorConfig->rule(FirstClassCallableRector::class);
 };

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 use Rector\Config\RectorConfig;
 use Rector\Php53\Rector\FuncCall\DirNameFileConstantToDirConstantRector;
+use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -11,5 +12,6 @@ return static function (RectorConfig $rectorConfig): void {
 	]);
 	$rectorConfig->importNames(true, false);
 	$rectorConfig->rule(DirNameFileConstantToDirConstantRector::class);
+	$rectorConfig->rule(NullCoalescingOperatorRector::class);
 	$rectorConfig->rule(FirstClassCallableRector::class);
 };

--- a/rector.php
+++ b/rector.php
@@ -8,5 +8,6 @@ return static function (RectorConfig $rectorConfig): void {
 		__DIR__ . '/test',
 		__DIR__ . '/src',
 	]);
+	$rectorConfig->importNames(true, false);
 	$rectorConfig->rule(FirstClassCallableRector::class);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 
 return static function (RectorConfig $rectorConfig): void {
 	$rectorConfig->paths([
 		__DIR__ . '/test',
 		__DIR__ . '/src',
 	]);
+	$rectorConfig->rule(FirstClassCallableRector::class);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+	$rectorConfig->paths([
+		__DIR__ . '/test',
+		__DIR__ . '/src',
+	]);
+};

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use PHPMailer\PHPMailer\PHPMailer;
 use Smr\Account;
 use Smr\Container\DiContainer;
 use Smr\Exceptions\UserError;
@@ -139,8 +140,8 @@ function exception_error_handler(int $errno, string $errstr, string $errfile, in
 	throw new ErrorException($errstr, $errno, E_ERROR, $errfile, $errline);
 }
 
-function setupMailer(): \PHPMailer\PHPMailer\PHPMailer {
-	$mail = new \PHPMailer\PHPMailer\PHPMailer(true);
+function setupMailer(): PHPMailer {
+	$mail = new PHPMailer(true);
 	if (!empty(SMTP_HOSTNAME)) {
 		$mail->isSMTP();
 		$mail->Host = SMTP_HOSTNAME;

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -256,7 +256,7 @@ function array_remove_value(array &$arr, mixed $valueToRemove): void {
 function objects_equal(object $obj1, object $obj2): bool {
 	// Return early if the objects are different classes, to avoid the expense
 	// of serialization.
-	return get_class($obj1) === get_class($obj2) && serialize($obj1) === serialize($obj2);
+	return $obj1::class === $obj2::class && serialize($obj1) === serialize($obj2);
 }
 
 // Defines all constants

--- a/src/htdocs/album/album_comment_processing.php
+++ b/src/htdocs/album/album_comment_processing.php
@@ -4,12 +4,13 @@ use Smr\Database;
 use Smr\Epoch;
 use Smr\Pages\Admin\AlbumModerate;
 use Smr\Request;
+use Smr\Session;
 
 try {
 	require_once('../../bootstrap.php');
 	require_once(LIB . 'Album/album_functions.php');
 
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 
 	if (!$session->hasAccount()) {
 		create_error('You need to be logged in to post comments!');

--- a/src/htdocs/error.php
+++ b/src/htdocs/error.php
@@ -1,11 +1,12 @@
 <?php declare(strict_types=1);
 
 use Smr\Request;
+use Smr\Template;
 
 try {
 	require_once('../bootstrap.php');
 
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 	$template->assign('Body', 'login/error.php');
 	$template->assign('ErrorMessage', Request::get('msg', 'No error message found!'));
 	$template->display('login/skeleton.php');

--- a/src/htdocs/loader.php
+++ b/src/htdocs/loader.php
@@ -5,6 +5,7 @@ use Smr\Pages\Account\InvalidEmail;
 use Smr\Pages\Account\InvalidEmailProcessor;
 use Smr\Pages\Account\ReopenAccount;
 use Smr\Pages\Account\ReopenAccountProcessor;
+use Smr\Session;
 
 try {
 	require_once('../bootstrap.php');
@@ -24,7 +25,7 @@ try {
 	// ********************************
 
 	// do we have a session?
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 	if (!$session->hasAccount()) {
 		header('Location: /login.php');
 		exit;

--- a/src/htdocs/login.php
+++ b/src/htdocs/login.php
@@ -3,6 +3,8 @@
 use Smr\Database;
 use Smr\Pages\Account\LoginCheckValidatedProcessor;
 use Smr\Request;
+use Smr\Session;
+use Smr\Template;
 
 try {
 
@@ -14,7 +16,7 @@ try {
 	// *
 	// ********************************
 
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 	if ($session->hasAccount()) {
 		$href = (new LoginCheckValidatedProcessor())->href(true);
 		$session->update();
@@ -23,7 +25,7 @@ try {
 		exit;
 	}
 
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 	if (Request::has('msg')) {
 		$template->assign('Message', htmlentities(Request::get('msg'), ENT_COMPAT, 'utf-8'));
 	} elseif (Request::has('status')) {

--- a/src/htdocs/login_create.php
+++ b/src/htdocs/login_create.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Template;
+
 try {
 	require_once('../bootstrap.php');
 
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 	$template->assign('Body', 'login/login_create.php');
 	$template->display('login/skeleton.php');
 

--- a/src/htdocs/login_create_processing.php
+++ b/src/htdocs/login_create_processing.php
@@ -1,14 +1,16 @@
 <?php declare(strict_types=1);
 
+use ReCaptcha\ReCaptcha;
 use Smr\Account;
 use Smr\Exceptions\AccountNotFound;
 use Smr\Request;
+use Smr\Session;
 
 try {
 
 	require_once('../bootstrap.php');
 
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 
 	if ($session->hasAccount()) {
 		create_error('You\'re already logged in! Creating multis is against the rules!');
@@ -23,7 +25,7 @@ try {
 
 	//Check the captcha if it's a standard registration.
 	if (!$socialLogin && !empty(RECAPTCHA_PRIVATE)) {
-		$reCaptcha = new \ReCaptcha\ReCaptcha(RECAPTCHA_PRIVATE);
+		$reCaptcha = new ReCaptcha(RECAPTCHA_PRIVATE);
 		// Was there a reCAPTCHA response?
 		$resp = $reCaptcha->verify(
 			Request::get('g-recaptcha-response', ''),

--- a/src/htdocs/login_create_processing.php
+++ b/src/htdocs/login_create_processing.php
@@ -29,7 +29,7 @@ try {
 		// Was there a reCAPTCHA response?
 		$resp = $reCaptcha->verify(
 			Request::get('g-recaptcha-response', ''),
-			$_SERVER['REMOTE_ADDR']
+			$_SERVER['REMOTE_ADDR'],
 		);
 
 		if (!$resp->isSuccess()) {
@@ -99,7 +99,7 @@ try {
 	if ($socialLogin) {
 		$account->addAuthMethod(
 			$_SESSION['socialLogin']->getLoginType(),
-			$_SESSION['socialLogin']->getUserID()
+			$_SESSION['socialLogin']->getUserID(),
 		);
 		if ($validatedBySocial) {
 			$account->setValidated(true);

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -7,6 +7,7 @@ use Smr\Exceptions\AccountNotFound;
 use Smr\Login\Redirect;
 use Smr\Pages\Account\LoginCheckValidatedProcessor;
 use Smr\Request;
+use Smr\Session;
 use Smr\SocialLogin\SocialLogin;
 
 try {
@@ -19,7 +20,7 @@ try {
 	// *
 	// ********************************
 
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 	if (!$session->hasAccount()) {
 		if (Request::has('loginType')) {
 			$socialLogin = SocialLogin::get(Request::get('loginType'))->login();

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -85,7 +85,7 @@ try {
 		}
 		$account->addAuthMethod(
 			$_SESSION['socialLogin']->getLoginType(),
-			$_SESSION['socialLogin']->getUserID()
+			$_SESSION['socialLogin']->getUserID(),
 		);
 		session_destroy();
 	}

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -191,7 +191,6 @@ try {
 	//now we update their cookie with the newest info
 	setcookie('Session_Info', $new, Epoch::time() + 157680000);
 
-
 	//get rid of expired messages
 	$db->write('UPDATE message SET receiver_delete = \'TRUE\', sender_delete = \'TRUE\', expire_time = 0 WHERE expire_time < ' . $db->escapeNumber(Epoch::time()) . ' AND expire_time != 0');
 	// Mark message as read if it was sent to self as a mass mail.

--- a/src/htdocs/login_social_create.php
+++ b/src/htdocs/login_social_create.php
@@ -2,6 +2,7 @@
 
 use Smr\Account;
 use Smr\Exceptions\AccountNotFound;
+use Smr\Template;
 
 try {
 	require_once('../bootstrap.php');
@@ -16,7 +17,7 @@ try {
 	}
 	$socialLogin = $_SESSION['socialLogin'];
 
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 	$template->assign('SocialLogin', $socialLogin);
 
 	// Pre-populate the login field if an account with this email exists.

--- a/src/htdocs/map_galaxy.php
+++ b/src/htdocs/map_galaxy.php
@@ -4,6 +4,8 @@ use Smr\Exceptions\GalaxyNotFound;
 use Smr\Exceptions\SectorNotFound;
 use Smr\Galaxy;
 use Smr\Request;
+use Smr\Session;
+use Smr\Template;
 
 try {
 	require_once('../bootstrap.php');
@@ -22,7 +24,7 @@ try {
 	// ********************************
 
 	// do we have a session?
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 	if (!$session->hasAccount() || !$session->hasGame()) {
 		header('Location: /login.php');
 		exit;
@@ -54,7 +56,7 @@ try {
 	}
 
 	// Initialize the template
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 
 	// Set temporary options
 	if ($player->hasAlliance()) {

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -5,11 +5,13 @@ use Smr\Galaxy;
 use Smr\Game;
 use Smr\Request;
 use Smr\Sector;
+use Smr\Session;
+use Smr\Template;
 
 try {
 	require_once('../bootstrap.php');
 
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 
 	$gameID = Request::getInt('game');
 	if (!$session->hasAccount() || !Game::gameExists($gameID)) {
@@ -54,7 +56,7 @@ try {
 		'links' => $links,
 	]);
 
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 	$template->assign('GameName', $game->getName());
 	$template->assign('GraphData', $data);
 	$template->display('map_warps.php');

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -54,7 +54,7 @@ try {
 	$data = json_encode([
 		'nodes' => $nodes,
 		'links' => $links,
-	]);
+	], JSON_THROW_ON_ERROR);
 
 	$template = Template::getInstance();
 	$template->assign('GameName', $game->getName());

--- a/src/htdocs/resend_password.php
+++ b/src/htdocs/resend_password.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Template;
+
 try {
 	require_once('../bootstrap.php');
 
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 	$template->assign('Body', 'login/resend_password.php');
 	$template->display('login/skeleton.php');
 

--- a/src/htdocs/reset_password.php
+++ b/src/htdocs/reset_password.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 
+use Smr\Template;
+
 try {
 	require_once('../bootstrap.php');
 
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 	$template->assign('Body', 'login/reset_password.php');
 	$template->display('login/skeleton.php');
 

--- a/src/htdocs/ship_list.php
+++ b/src/htdocs/ship_list.php
@@ -4,11 +4,12 @@ use Smr\Database;
 use Smr\Location;
 use Smr\Race;
 use Smr\ShipType;
+use Smr\Template;
 
 try {
 	require_once('../bootstrap.php');
 
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 
 	// Get a list of all the shops that sell each ship
 	$shipLocs = [];

--- a/src/htdocs/weapon_list.php
+++ b/src/htdocs/weapon_list.php
@@ -3,12 +3,13 @@
 use Smr\Combat\Weapon\Weapon;
 use Smr\Database;
 use Smr\Location;
+use Smr\Template;
 use Smr\WeaponType;
 
 try {
 	require_once('../bootstrap.php');
 
-	$template = Smr\Template::getInstance();
+	$template = Template::getInstance();
 
 	// Get a list of all the shops that sell each weapon
 	$weaponLocs = [];

--- a/src/lib/Album/album_functions.php
+++ b/src/lib/Album/album_functions.php
@@ -301,8 +301,6 @@ function create_link_list(): void {
 	echo('<hr class="center">');
 }
 
-
-
 function get_album_nick(int $album_id): string {
 	if ($album_id == 0) {
 		return 'System';

--- a/src/lib/Album/album_functions.php
+++ b/src/lib/Album/album_functions.php
@@ -2,10 +2,11 @@
 
 use Smr\Account;
 use Smr\Database;
+use Smr\Session;
 
 function main_page(): void {
 	$db = Database::getInstance();
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 
 	// list of all first letter nicks
 	create_link_list();
@@ -63,7 +64,7 @@ function main_page(): void {
 
 function album_entry(int $album_id): void {
 	$db = Database::getInstance();
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 
 	// list of all first letter nicks
 	create_link_list();

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -768,7 +768,6 @@ function number_colour_format(float $number, bool $justSign = false): string {
 	return $formatted;
 }
 
-
 /**
  * Randomly choose an array key weighted by the array values.
  * Probabilities are relative to the total weight. For example:

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Nbbc\BBCode;
 use Smr\AbstractPlayer;
 use Smr\Alliance;
 use Smr\Chess\ChessGame;
@@ -79,20 +80,20 @@ function linkCombatLog(int $logID): string {
  *
  * @param array<string, string> $tagParams
  */
-function smrBBCode(\Nbbc\BBCode $bbParser, int $action, string $tagName, string $default, array $tagParams, string $tagContent): bool|string {
+function smrBBCode(BBCode $bbParser, int $action, string $tagName, string $default, array $tagParams, string $tagContent): bool|string {
 	global $overrideGameID, $disableBBLinks;
 	$session = Session::getInstance();
 	try {
 		switch ($tagName) {
 			case 'combatlog':
-				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+				if ($action == BBCode::BBCODE_CHECK) {
 					return is_numeric($default);
 				}
 				$logID = (int)$default;
 				return linkCombatLog($logID);
 
 			case 'player':
-				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+				if ($action == BBCode::BBCODE_CHECK) {
 					return is_numeric($default);
 				}
 				$playerID = (int)$default;
@@ -104,7 +105,7 @@ function smrBBCode(\Nbbc\BBCode $bbParser, int $action, string $tagName, string 
 				return $bbPlayer->getDisplayName($showAlliance);
 
 			case 'alliance':
-				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+				if ($action == BBCode::BBCODE_CHECK) {
 					return is_numeric($default);
 				}
 				$allianceID = (int)$default;
@@ -124,7 +125,7 @@ function smrBBCode(\Nbbc\BBCode $bbParser, int $action, string $tagName, string 
 				foreach (Race::getAllNames() as $raceID => $raceName) {
 					if ((is_numeric($raceNameID) && $raceNameID == $raceID)
 						|| $raceNameID == $raceName) {
-						if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+						if ($action == BBCode::BBCODE_CHECK) {
 							return true;
 						}
 						$linked = $disableBBLinks === false && $overrideGameID == $session->getGameID();
@@ -135,7 +136,7 @@ function smrBBCode(\Nbbc\BBCode $bbParser, int $action, string $tagName, string 
 				break;
 
 			case 'servertimetouser':
-				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+				if ($action == BBCode::BBCODE_CHECK) {
 					return true;
 				}
 				$time = strtotime($default);
@@ -146,7 +147,7 @@ function smrBBCode(\Nbbc\BBCode $bbParser, int $action, string $tagName, string 
 				break;
 
 			case 'chess':
-				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+				if ($action == BBCode::BBCODE_CHECK) {
 					return is_numeric($default);
 				}
 				$chessGameID = (int)$default;
@@ -154,7 +155,7 @@ function smrBBCode(\Nbbc\BBCode $bbParser, int $action, string $tagName, string 
 				return '<a href="' . $chessGame->getPlayGameHREF() . '">chess game (' . $chessGame->getChessGameID() . ')</a>';
 
 			case 'sector':
-				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+				if ($action == BBCode::BBCODE_CHECK) {
 					return is_numeric($default);
 				}
 
@@ -170,7 +171,7 @@ function smrBBCode(\Nbbc\BBCode $bbParser, int $action, string $tagName, string 
 				return $sectorTag;
 
 			case 'join_alliance':
-				if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+				if ($action == BBCode::BBCODE_CHECK) {
 					return is_numeric($default);
 				}
 				$allianceID = (int)$default;
@@ -181,7 +182,7 @@ function smrBBCode(\Nbbc\BBCode $bbParser, int $action, string $tagName, string 
 	} catch (Throwable) {
 		// If there's an error, we will silently display the original text
 	}
-	if ($action == \Nbbc\BBCode::BBCODE_CHECK) {
+	if ($action == BBCode::BBCODE_CHECK) {
 		return false;
 	}
 	return htmlspecialchars($tagParams['_tag']) . $tagContent . htmlspecialchars($tagParams['_endtag']);
@@ -194,7 +195,7 @@ function inify(string $text): string {
 function bbifyMessage(string $message, int $gameID = null, bool $noLinks = false): string {
 	static $bbParser;
 	if (!isset($bbParser)) {
-		$bbParser = new \Nbbc\BBCode();
+		$bbParser = new BBCode();
 		$bbParser->setEnableSmileys(false);
 		$bbParser->removeRule('wiki');
 		$bbParser->removeRule('img');
@@ -202,12 +203,12 @@ function bbifyMessage(string $message, int $gameID = null, bool $noLinks = false
 		$bbParser->setURLTargetable('override');
 		$bbParser->setEscapeContent(false); // don't escape HTML, needed for News etc.
 		$smrRule = [
-				'mode' => \Nbbc\BBCode::BBCODE_MODE_CALLBACK,
+				'mode' => BBCode::BBCODE_MODE_CALLBACK,
 				'method' => 'smrBBCode',
 				'class' => 'link',
 				'allow_in' => ['listitem', 'block', 'columns', 'inline'],
-				'end_tag' => \Nbbc\BBCode::BBCODE_PROHIBIT,
-				'content' => \Nbbc\BBCode::BBCODE_PROHIBIT,
+				'end_tag' => BBCode::BBCODE_PROHIBIT,
+				'content' => BBCode::BBCODE_PROHIBIT,
 			];
 		$bbParser->addRule('combatlog', $smrRule);
 		$bbParser->addRule('player', $smrRule);

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -267,7 +267,7 @@ function handleUserError(string $message): never {
 		$errorHREF = $container->href();
 		// json_encode the HREF as a safety precaution
 		$template = Template::getInstance();
-		$template->addJavascriptForAjax('EVAL', 'location.href = ' . json_encode($errorHREF));
+		$template->addJavascriptForAjax('EVAL', 'location.href = ' . json_encode($errorHREF, JSON_THROW_ON_ERROR));
 	}
 	$container->go();
 }

--- a/src/lib/Smr/AbstractShip.php
+++ b/src/lib/Smr/AbstractShip.php
@@ -174,8 +174,6 @@ class AbstractShip {
 	public function getCDsLow(): int { return IFloor($this->getCDs() / 100) * 100; }
 	public function getCDsHigh(): int { return $this->getCDsLow() + 100; }
 
-
-
 	public function addWeapon(Weapon $weapon): Weapon|false {
 		if ($this->hasOpenWeaponSlots() && $this->checkPowerAvailable($weapon->getPowerLevel())) {
 			$this->weapons[] = $weapon;

--- a/src/lib/Smr/Container/DiContainer.php
+++ b/src/lib/Smr/Container/DiContainer.php
@@ -11,6 +11,7 @@ use Smr\SectorLock;
 use Smr\Session;
 use Smr\Template;
 use function DI\autowire;
+use function DI\get;
 
 /**
  * A wrapper around the DI\Container functionality that will allow
@@ -52,7 +53,7 @@ class DiContainer {
 			Epoch::class => autowire(),
 			DatabaseProperties::class => autowire(),
 			Database::class => autowire()
-				->constructorParameter('dbName', \DI\get('DatabaseName')),
+				->constructorParameter('dbName', get('DatabaseName')),
 			SectorLock::class => autowire(),
 			Session::class => autowire(),
 			Template::class => autowire(),

--- a/src/lib/Smr/Discord/Command.php
+++ b/src/lib/Smr/Discord/Command.php
@@ -87,7 +87,7 @@ abstract class Command {
 			[
 				'description' => $this->description(),
 				'usage' => $usage,
-			]
+			],
 		);
 	}
 

--- a/src/lib/Smr/Discord/Commands/Turns.php
+++ b/src/lib/Smr/Discord/Commands/Turns.php
@@ -2,8 +2,8 @@
 
 namespace Smr\Discord\Commands;
 
+use Smr\AbstractPlayer;
 use Smr\Discord\DatabaseCommand;
-use Smr\Player;
 
 class Turns extends DatabaseCommand {
 
@@ -16,10 +16,10 @@ class Turns extends DatabaseCommand {
 	}
 
 	public function databaseResponse(string ...$args): array {
-		return array_map([$this, 'getTurnsMessage'], $this->player->getSharingPlayers(true));
+		return array_map($this->getTurnsMessage(...), $this->player->getSharingPlayers(true));
 	}
 
-	private function getTurnsMessage(Player $player): string {
+	private function getTurnsMessage(AbstractPlayer $player): string {
 		// turns only update when the player is active, so calculate current turns
 		$turns = min(
 			$player->getTurns() + $player->getTurnsGained(time(), true),

--- a/src/lib/Smr/Discord/Commands/Turns.php
+++ b/src/lib/Smr/Discord/Commands/Turns.php
@@ -23,7 +23,7 @@ class Turns extends DatabaseCommand {
 		// turns only update when the player is active, so calculate current turns
 		$turns = min(
 			$player->getTurns() + $player->getTurnsGained(time(), true),
-			$player->getMaxTurns()
+			$player->getMaxTurns(),
 		);
 		$msg = $player->getPlayerName() . " has $turns/" . $player->getMaxTurns() . ' turns.';
 

--- a/src/lib/Smr/Exceptions/AccountNotFound.php
+++ b/src/lib/Smr/Exceptions/AccountNotFound.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when an account cannot be found in the database
  */
-class AccountNotFound extends \Exception {
+class AccountNotFound extends Exception {
 }

--- a/src/lib/Smr/Exceptions/AllianceInvitationNotFound.php
+++ b/src/lib/Smr/Exceptions/AllianceInvitationNotFound.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when an alliance invitation cannot be found in the database
  */
-class AllianceInvitationNotFound extends \Exception {
+class AllianceInvitationNotFound extends Exception {
 }

--- a/src/lib/Smr/Exceptions/AllianceNotFound.php
+++ b/src/lib/Smr/Exceptions/AllianceNotFound.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when an alliance cannot be found in the database
  */
-class AllianceNotFound extends \Exception {
+class AllianceNotFound extends Exception {
 }

--- a/src/lib/Smr/Exceptions/CachedPortNotFound.php
+++ b/src/lib/Smr/Exceptions/CachedPortNotFound.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when a CachedPort cannot be found in the database
  */
-class CachedPortNotFound extends \Exception {
+class CachedPortNotFound extends Exception {
 }

--- a/src/lib/Smr/Exceptions/GalaxyNotFound.php
+++ b/src/lib/Smr/Exceptions/GalaxyNotFound.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when a galaxy cannot be found in the database
  */
-class GalaxyNotFound extends \Exception {
+class GalaxyNotFound extends Exception {
 }

--- a/src/lib/Smr/Exceptions/GameNotFound.php
+++ b/src/lib/Smr/Exceptions/GameNotFound.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when a game cannot be found in the database
  */
-class GameNotFound extends \Exception {
+class GameNotFound extends Exception {
 }

--- a/src/lib/Smr/Exceptions/PathNotFound.php
+++ b/src/lib/Smr/Exceptions/PathNotFound.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when Plotter cannot find a Path
  */
-class PathNotFound extends \Exception {
+class PathNotFound extends Exception {
 }

--- a/src/lib/Smr/Exceptions/PlayerNotFound.php
+++ b/src/lib/Smr/Exceptions/PlayerNotFound.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when a player cannot be found in the database
  */
-class PlayerNotFound extends \Exception {
+class PlayerNotFound extends Exception {
 }

--- a/src/lib/Smr/Exceptions/SectorNotFound.php
+++ b/src/lib/Smr/Exceptions/SectorNotFound.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when a sector cannot be found in the database
  */
-class SectorNotFound extends \Exception {
+class SectorNotFound extends Exception {
 }

--- a/src/lib/Smr/Exceptions/SocialLoginInvalidType.php
+++ b/src/lib/Smr/Exceptions/SocialLoginInvalidType.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Exceptions;
 
+use Exception;
+
 /**
  * Exception thrown when a SocialLogin type is not valid
  */
-class SocialLoginInvalidType extends \Exception {
+class SocialLoginInvalidType extends Exception {
 }

--- a/src/lib/Smr/Exceptions/UserError.php
+++ b/src/lib/Smr/Exceptions/UserError.php
@@ -2,10 +2,12 @@
 
 namespace Smr\Exceptions;
 
+use RuntimeException;
+
 /**
  * This exception should be used to pass an error message to the user.
  * It should only encompass errors that can be triggered by otherwise
  * valid user input (i.e. NOT internal errors, request forgery, etc.).
  */
-class UserError extends \RuntimeException {
+class UserError extends RuntimeException {
 }

--- a/src/lib/Smr/HallOfFame.php
+++ b/src/lib/Smr/HallOfFame.php
@@ -2,6 +2,7 @@
 
 namespace Smr;
 
+use Smr\Exceptions\PlayerNotFound;
 use Smr\Pages\Account\HallOfFameAll;
 use Smr\Pages\Account\HallOfFamePersonal;
 
@@ -143,7 +144,7 @@ class HallOfFame {
 		if ($gameID !== null && Game::gameExists($gameID)) {
 			try {
 				$hofPlayer = Player::getPlayer($accountID, $gameID);
-			} catch (Exceptions\PlayerNotFound) {
+			} catch (PlayerNotFound) {
 				$hofAccount = Account::getAccount($accountID);
 			}
 		} else {

--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -562,7 +562,6 @@ class Planet {
 		$this->swapMountedWeapons($orderID + 1, $orderID);
 	}
 
-
 	public function isDestroyed(): bool {
 		return !$this->hasCDs() && !$this->hasShields() && !$this->hasArmour();
 	}
@@ -1129,7 +1128,6 @@ class Planet {
 			}
 		}
 	}
-
 
 	/**
 	 * @return array<int, Player>

--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -1193,7 +1193,7 @@ class Planet {
 		return array_pad(
 			$weapons,
 			count($weapons) + $this->getBuilding(PLANET_TURRET),
-			Weapon::getWeapon(WEAPON_PLANET_TURRET)
+			Weapon::getWeapon(WEAPON_PLANET_TURRET),
 		);
 	}
 

--- a/src/lib/Smr/Request.php
+++ b/src/lib/Smr/Request.php
@@ -119,14 +119,14 @@ class Request {
 	 * Note that this does not save the result in $var (see Smr\Session).
 	 */
 	public static function getVar(string $index, string $default = null): string {
-		return self::getVarX($index, $default, [self::class, 'get']);
+		return self::getVarX($index, $default, self::get(...));
 	}
 
 	/**
 	 * Like getVar, but returns an int instead of a string.
 	 */
 	public static function getVarInt(string $index, int $default = null): int {
-		return self::getVarX($index, $default, [self::class, 'getInt']);
+		return self::getVarX($index, $default, self::getInt(...));
 	}
 
 	/**
@@ -136,7 +136,7 @@ class Request {
 	 * @return array<int>
 	 */
 	public static function getVarIntArray(string $index, array $default = null): array {
-		return self::getVarX($index, $default, [self::class, 'getIntArray']);
+		return self::getVarX($index, $default, self::getIntArray(...));
 	}
 
 	/**

--- a/src/lib/Smr/ShipType.php
+++ b/src/lib/Smr/ShipType.php
@@ -111,7 +111,7 @@ class ShipType {
 				- $this->speed * 5
 				+ $this->hardpoints * 5
 				+ $this->maxHardware[HARDWARE_COMBAT] / 5
-			)
+			),
 		));
 	}
 

--- a/src/lib/Smr/SocialLogin/Twitter.php
+++ b/src/lib/Smr/SocialLogin/Twitter.php
@@ -20,7 +20,7 @@ class Twitter extends SocialLogin {
 			TWITTER_CONSUMER_KEY,
 			TWITTER_CONSUMER_SECRET,
 			$token['oauth_token'] ?? null,
-			$token['oauth_token_secret'] ?? null
+			$token['oauth_token_secret'] ?? null,
 		);
 	}
 
@@ -43,7 +43,7 @@ class Twitter extends SocialLogin {
 		$helper = self::getTwitterObj($_SESSION['TwitterToken']);
 		$accessToken = $helper->oauth(
 			'oauth/access_token',
-			['oauth_verifier' => Request::get('oauth_verifier')]
+			['oauth_verifier' => Request::get('oauth_verifier')],
 		);
 		$auth = self::getTwitterObj($accessToken);
 		/** @var \stdClass $userInfo */

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -170,10 +170,7 @@ class Template {
 		if (isset($this->ajaxJS[$varName])) {
 			throw new Exception('Trying to set javascript val twice: ' . $varName);
 		}
-		$json = json_encode($obj);
-		if ($json === false) {
-			throw new Exception('Failed to encode to json: ' . $varName);
-		}
+		$json = json_encode($obj, JSON_THROW_ON_ERROR);
 		return $this->ajaxJS[$varName] = $json;
 	}
 
@@ -275,7 +272,7 @@ class Template {
 			}
 		}
 		if ($returnXml && count($this->jsAlerts) > 0) {
-			$js = '<ALERT>' . json_encode($this->jsAlerts) . '</ALERT>';
+			$js = '<ALERT>' . json_encode($this->jsAlerts, JSON_THROW_ON_ERROR) . '</ALERT>';
 		}
 		if (strlen($js) > 0) {
 			$xml .= '<JS>' . $js . '</JS>';

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -93,7 +93,6 @@ class Template {
 		echo $output;
 	}
 
-
 	protected function getTemplateLocation(string $templateName): string {
 		if (isset($this->data['ThisAccount'])) {
 			$templateDir = $this->data['ThisAccount']->getTemplate() . '/';

--- a/src/pages/Admin/ChangelogAddProcessor.php
+++ b/src/pages/Admin/ChangelogAddProcessor.php
@@ -22,7 +22,7 @@ class ChangelogAddProcessor extends AccountPageProcessor {
 			$container = new Changelog(
 				changeTitle: $change_title,
 				changeMessage: $change_message,
-				affectedDb: $affected_db
+				affectedDb: $affected_db,
 			);
 			$container->go();
 		}

--- a/src/pages/Admin/CheatingShipCheck.php
+++ b/src/pages/Admin/CheatingShipCheck.php
@@ -29,7 +29,7 @@ class CheatingShipCheck extends AccountPage {
 				accountID: $dbRecord->getInt('account_id'),
 				hardwareTypeID: $dbRecord->getInt('hardware_type_id'),
 				gameID: $dbRecord->getInt('game_id'),
-				maxAmount: $dbRecord->getInt('max_amount')
+				maxAmount: $dbRecord->getInt('max_amount'),
 			);
 
 			$excessHardware[] = [

--- a/src/pages/Admin/FormOpen.php
+++ b/src/pages/Admin/FormOpen.php
@@ -19,7 +19,7 @@ class FormOpen extends AccountPage {
 
 		$container = new FormOpenProcessor(
 			isOpen: Globals::isFeatureRequestOpen(),
-			type: 'FEATURE'
+			type: 'FEATURE',
 		);
 		$template->assign('ToggleHREF', $container->href());
 

--- a/src/pages/Admin/MessageBoxReply.php
+++ b/src/pages/Admin/MessageBoxReply.php
@@ -28,7 +28,7 @@ class MessageBoxReply extends AccountPage {
 		$container = new MessageBoxReplyProcessor(
 			senderAccountID: $this->senderAccountID,
 			gameID: $this->gameID,
-			boxTypeID: $this->boxTypeID
+			boxTypeID: $this->boxTypeID,
 		);
 		$template->assign('BoxReplyFormHref', $container->href());
 		$template->assign('Sender', Player::getPlayer($this->senderAccountID, $this->gameID));

--- a/src/pages/Admin/MessageBoxReplyProcessor.php
+++ b/src/pages/Admin/MessageBoxReplyProcessor.php
@@ -26,7 +26,7 @@ class MessageBoxReplyProcessor extends AccountPageProcessor {
 				gameID: $this->gameID,
 				preview: $message,
 				banPoints: $banPoints,
-				rewardCredits: $rewardCredits
+				rewardCredits: $rewardCredits,
 			);
 			$container->go();
 		}

--- a/src/pages/Admin/MessageBoxView.php
+++ b/src/pages/Admin/MessageBoxView.php
@@ -74,7 +74,7 @@ class MessageBoxView extends AccountPage {
 								$container = new MessageBoxReply(
 									boxTypeID: $this->boxTypeID,
 									senderAccountID: $senderID,
-									gameID: $gameID
+									gameID: $gameID,
 								);
 								$messages[$messageID]['ReplyHREF'] = $container->href();
 							}

--- a/src/pages/Admin/NewsletterSendProcessor.php
+++ b/src/pages/Admin/NewsletterSendProcessor.php
@@ -54,7 +54,7 @@ class NewsletterSendProcessor extends AccountPageProcessor {
 			$mail,
 			$this->newsletterHtml,
 			$this->newsletterText,
-			Request::get('salutation')
+			Request::get('salutation'),
 		);
 
 		if (Request::get('to_email') == '*') {

--- a/src/pages/Admin/NpcManage.php
+++ b/src/pages/Admin/NpcManage.php
@@ -55,7 +55,7 @@ class NpcManage extends AccountPage {
 			$container = new NpcManageProcessor(
 				selectedGameID: $selectedGameID,
 				login: $login,
-				accountID: $accountID
+				accountID: $accountID,
 			);
 
 			$npcs[$accountID] = [

--- a/src/pages/Admin/ReportedMessageReply.php
+++ b/src/pages/Admin/ReportedMessageReply.php
@@ -27,7 +27,7 @@ class ReportedMessageReply extends AccountPage {
 		$container = new ReportedMessageReplyProcessor(
 			gameID: $this->gameID,
 			offenderAccountID: $this->offenderAccountID,
-			offendedAccountID: $this->offendedAccountID
+			offendedAccountID: $this->offendedAccountID,
 		);
 		$template->assign('NotifyReplyFormHref', $container->href());
 

--- a/src/pages/Admin/ReportedMessageReplyProcessor.php
+++ b/src/pages/Admin/ReportedMessageReplyProcessor.php
@@ -28,7 +28,7 @@ class ReportedMessageReplyProcessor extends AccountPageProcessor {
 				offenderPreview: $offenderReply,
 				offenderBanPoints: $offenderBanPoints,
 				offendedPreview: $offendedReply,
-				offendedBanPoints: $offendedBanPoints
+				offendedBanPoints: $offendedBanPoints,
 			);
 			$container->go();
 		}

--- a/src/pages/Admin/ReportedMessageView.php
+++ b/src/pages/Admin/ReportedMessageView.php
@@ -31,7 +31,7 @@ class ReportedMessageView extends AccountPage {
 			$container = new ReportedMessageReply(
 				offenderAccountID: $dbRecord->getInt('from_id'),
 				offendedAccountID: $dbRecord->getInt('to_id'),
-				gameID: $gameID
+				gameID: $gameID,
 			);
 
 			$getName = function(Player|string $messagePlayer) use ($container, $account): string {

--- a/src/pages/Admin/UniGen/CheckMap.php
+++ b/src/pages/Admin/UniGen/CheckMap.php
@@ -44,7 +44,7 @@ class CheckMap extends AccountPage {
 		}
 		$missingLocs = array_diff(
 			array_keys(Location::getAllLocations($this->gameID)),
-			array_keys($existingLocs)
+			array_keys($existingLocs),
 		);
 		$missingLocNames = [];
 		foreach ($missingLocs as $locID) {

--- a/src/pages/Admin/UniGen/EditSector.php
+++ b/src/pages/Admin/UniGen/EditSector.php
@@ -54,7 +54,7 @@ class EditSector extends AccountPage {
 		$sectorLocationIDs = array_pad(
 			array_keys($editSector->getLocations()),
 			UNI_GEN_LOCATION_SLOTS,
-			0
+			0,
 		);
 		$template->assign('SectorLocationIDs', $sectorLocationIDs);
 

--- a/src/pages/Admin/UniGen/SaveProcessor.php
+++ b/src/pages/Admin/UniGen/SaveProcessor.php
@@ -81,7 +81,6 @@ function addLocationToSector(Location $location, Sector $sector): void {
 	}
 }
 
-
 class SaveProcessor extends AccountPageProcessor {
 
 	public function __construct(

--- a/src/pages/Admin/VoteCreateProcessor.php
+++ b/src/pages/Admin/VoteCreateProcessor.php
@@ -15,14 +15,14 @@ class VoteCreateProcessor extends AccountPageProcessor {
 		if ($action == 'Preview Vote') {
 			$container = new VoteCreate(
 				previewVote: Request::get('question'),
-				days: Request::getInt('days')
+				days: Request::getInt('days'),
 			);
 			$container->go();
 		}
 		if ($action == 'Preview Option') {
 			$container = new VoteCreate(
 				previewOption: Request::get('option'),
-				voteID: Request::getInt('vote')
+				voteID: Request::getInt('vote'),
 			);
 			$container->go();
 		}

--- a/src/pages/Player/Bar/PlayBlackjack.php
+++ b/src/pages/Player/Bar/PlayBlackjack.php
@@ -117,7 +117,7 @@ class PlayBlackjack extends PlayerPage {
 			$container = new PlayBlackjackProcessor(
 				locationID: $this->locationID,
 				action: 'new game',
-				bet: $this->bet
+				bet: $this->bet,
 			);
 			$template->assign('Winnings', $this->winningsMsg);
 			$template->assign('BetHREF', $container->href());
@@ -127,7 +127,7 @@ class PlayBlackjack extends PlayerPage {
 				locationID: $this->locationID,
 				action: 'HIT',
 				table: $table,
-				bet: $this->bet
+				bet: $this->bet,
 			);
 			$template->assign('HitHREF', $container->href());
 
@@ -135,7 +135,7 @@ class PlayBlackjack extends PlayerPage {
 				locationID: $this->locationID,
 				action: 'STAY',
 				table: $table,
-				bet: $this->bet
+				bet: $this->bet,
 			);
 			$template->assign('StayHREF', $container->href());
 		}

--- a/src/pages/Player/Bar/PlayBlackjackProcessor.php
+++ b/src/pages/Player/Bar/PlayBlackjackProcessor.php
@@ -79,7 +79,7 @@ class PlayBlackjackProcessor extends PlayerPageProcessor {
 			table: $table,
 			gameEnded: $gameEnded,
 			bet: $bet,
-			winningsMsg: $winningsMsg
+			winningsMsg: $winningsMsg,
 		);
 		$container->go();
 	}

--- a/src/pages/Player/CargoDumpProcessor.php
+++ b/src/pages/Player/CargoDumpProcessor.php
@@ -67,7 +67,7 @@ class CargoDumpProcessor extends PlayerPageProcessor {
 			// Don't lose more exp than you have
 			$lost_xp = min(
 				$player->getExperience(),
-				IRound(Port::getBaseExperience($amount, $good_distance))
+				IRound(Port::getBaseExperience($amount, $good_distance)),
 			);
 			$player->decreaseExperience($lost_xp);
 			$player->increaseHOF($lost_xp, ['Trade', 'Experience', 'Jettisoned'], HOF_PUBLIC);

--- a/src/pages/Player/CurrentSector.php
+++ b/src/pages/Player/CurrentSector.php
@@ -192,7 +192,6 @@ class CurrentSector extends PlayerPage {
 
 }
 
-
 function getForceRefreshMessage(AbstractPlayer $player): string {
 	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT refresh_at FROM sector_has_forces WHERE refresh_at > ' . $db->escapeNumber(Epoch::time()) . ' AND sector_id = ' . $db->escapeNumber($player->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND refresher = ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY refresh_at DESC LIMIT 1');

--- a/src/pages/Player/Headquarters/BountyPlaceConfirm.php
+++ b/src/pages/Player/Headquarters/BountyPlaceConfirm.php
@@ -35,7 +35,7 @@ class BountyPlaceConfirm extends PlayerPage {
 			locationID: $this->locationID,
 			otherAccountID: $bountyPlayer->getAccountID(),
 			credits: $this->credits,
-			smrCredits: $this->smrCredits
+			smrCredits: $this->smrCredits,
 		);
 		$template->assign('ProcessingHREF', $container->href());
 	}

--- a/src/pages/Player/MessageView.php
+++ b/src/pages/Player/MessageView.php
@@ -117,7 +117,6 @@ class MessageView extends PlayerPage {
 
 }
 
-
 /**
  * @return array{0: array<array{ID: string, Unread: bool, SenderID: int, SendTime: string, Text: string}>, 1: array<int, array<array{ID: int, Text: string, Unread: bool, SendTime: string, Sender?: \Smr\AbstractPlayer, SenderDisplayName?: string, ReportHref?: string, BlacklistHref?: string, ReplyHREF?: string, ReceiverDisplayName?: string}>>, 2: int}
  */

--- a/src/pages/Player/SearchForTraderResult.php
+++ b/src/pages/Player/SearchForTraderResult.php
@@ -87,7 +87,7 @@ class SearchForTraderResult extends PlayerPage {
 			$container = new NewsReadAdvanced(
 				gameID: $linkPlayer->getGameID(),
 				submit: 'Search For Player',
-				accountIDs: [$linkPlayer->getAccountID()]
+				accountIDs: [$linkPlayer->getAccountID()],
 			);
 			$result['NewsHREF'] = $container->href();
 

--- a/src/pages/Player/ShopGoodsNegotiate.php
+++ b/src/pages/Player/ShopGoodsNegotiate.php
@@ -47,7 +47,7 @@ class ShopGoodsNegotiate extends PlayerPage {
 			bargainNumber: $this->bargainNumber + 1,
 			bargainPrice: null,
 			offeredPrice: $this->offeredPrice,
-			idealPrice: $this->idealPrice
+			idealPrice: $this->idealPrice,
 		);
 		$template->assign('BargainHREF', $container->href());
 

--- a/src/pages/Player/ShopGoodsProcessor.php
+++ b/src/pages/Player/ShopGoodsProcessor.php
@@ -93,7 +93,7 @@ class ShopGoodsProcessor extends PlayerPageProcessor {
 				bargainNumber: $this->bargainNumber,
 				bargainPrice: $offered_price,
 				offeredPrice: $offered_price,
-				idealPrice: $ideal_price
+				idealPrice: $ideal_price,
 			);
 			$container->go();
 		}
@@ -260,7 +260,7 @@ class ShopGoodsProcessor extends PlayerPageProcessor {
 				bargainNumber: $this->bargainNumber,
 				bargainPrice: $bargain_price,
 				offeredPrice: $offered_price,
-				idealPrice: $ideal_price
+				idealPrice: $ideal_price,
 			);
 		}
 

--- a/src/templates/Default/engine/Default/admin/account_edit.php
+++ b/src/templates/Default/engine/Default/admin/account_edit.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+
 /**
  * @var Smr\Account $EditingAccount
  * @var Smr\Account $ThisAccount
@@ -192,7 +194,7 @@
 			<td>
 				Current mail ban: <?php
 				if ($EditingAccount->isMailBanned()) { ?>
-					<span class="red">For <?php echo format_time($EditingAccount->getMailBanned() - Smr\Epoch::time()); ?></span><?php
+					<span class="red">For <?php echo format_time($EditingAccount->getMailBanned() - Epoch::time()); ?></span><?php
 				} else { ?>
 					<span class="green">None</span><?php
 				} ?>

--- a/src/templates/Default/engine/Default/admin/admin_message_send.php
+++ b/src/templates/Default/engine/Default/admin/admin_message_send.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Pages\Admin\AdminMessageSend;
+
 if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbifyMessage($Preview, $MessageGameID); ?></td></tr></table><?php } ?>
 <form name="AdminMessageSendForm" method="POST" action="<?php echo $AdminMessageSendFormHref; ?>">
 	<p>
 	<b>From: </b><span class="admin">Administrator</span><br />
 	<b>To: </b><?php
-		if ($MessageGameID != Smr\Pages\Admin\AdminMessageSend::ALL_GAMES_ID) { ?>
+		if ($MessageGameID != AdminMessageSend::ALL_GAMES_ID) { ?>
 			<select name="account_id" required size="1"><?php
 				foreach ($GamePlayers as $GamePlayer) {
 					?><option <?php if ($SelectedAccountID === $GamePlayer['AccountID']) { echo 'selected'; } ?> value="<?php echo $GamePlayer['AccountID']; ?>"><?php echo $GamePlayer['Name']; ?></option><?php

--- a/src/templates/Default/engine/Default/admin/admin_message_send_select.php
+++ b/src/templates/Default/engine/Default/admin/admin_message_send_select.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 
+use Smr\Pages\Admin\AdminMessageSend;
+
 ?>
 <form name="AdminMessageChooseGameForm" method="POST" action="<?php echo $AdminMessageChooseGameFormHref; ?>">
 	<p>Please select a game:</p>
 	<select name="SendGameID" size="1">
-		<option value="<?php echo Smr\Pages\Admin\AdminMessageSend::ALL_GAMES_ID; ?>">Send to All Players</option><?php
+		<option value="<?php echo AdminMessageSend::ALL_GAMES_ID; ?>">Send to All Players</option><?php
 		foreach ($ActiveGames as $Game) {
 			?><option value="<?php echo $Game->getGameID(); ?>"><?php echo $Game->getDisplayName(); ?></option><?php
 		} ?>

--- a/src/templates/Default/engine/Default/admin/admin_tools.php
+++ b/src/templates/Default/engine/Default/admin/admin_tools.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\AdminPermissions;
+
 if (isset($ErrorMessage)) {
 	echo $ErrorMessage; ?><br /><br /><?php
 }
@@ -10,7 +12,7 @@ if (isset($AdminPermissions)) { ?>
 	<h1>Admin Tools</h1>
 	<br /><?php
 	foreach ($AdminPermissions as $CategoryID => $Permissions) { ?>
-		<h2><?php echo Smr\AdminPermissions::getCategoryName($CategoryID); ?></h2>
+		<h2><?php echo AdminPermissions::getCategoryName($CategoryID); ?></h2>
 		<ul><?php
 		foreach ($Permissions as $Permission) { ?>
 			<li><?php

--- a/src/templates/Default/engine/Default/admin/npc_manage.php
+++ b/src/templates/Default/engine/Default/admin/npc_manage.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+
 ?>
 <form method="POST" action="<?php echo $SelectGameHREF; ?>">
 	<select name="selected_game_id" onchange="this.form.submit()"><?php
@@ -37,8 +39,8 @@ if (!empty($SelectedGameID)) { ?>
 						<td><input required name="player_name" value="<?php echo $npc['default_player_name']; ?>" /></td>
 						<td>
 							<select name="race_id"><?php
-								foreach (Smr\Race::getPlayableIDs() as $raceID) { ?>
-									<option value="<?php echo $raceID; ?>"><?php echo Smr\Race::getName($raceID); ?></option><?php
+								foreach (Race::getPlayableIDs() as $raceID) { ?>
+									<option value="<?php echo $raceID; ?>"><?php echo Race::getName($raceID); ?></option><?php
 								} ?>
 							</select>
 						</td>

--- a/src/templates/Default/engine/Default/admin/permission_manage.php
+++ b/src/templates/Default/engine/Default/admin/permission_manage.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\AdminPermissions;
+
 ?>
 List of Accounts with Permissions:<br />
 <small>Click to select</small>
@@ -30,7 +32,7 @@ if (!isset($EditAccount)) { ?>
 	Change permissions for the Account of <u><?php echo $EditAccount->getLogin(); ?></u>!
 	<form method="POST" action="<?php echo $ProcessingHREF; ?>"><?php
 		foreach ($PermissionCategories as $categoryID => $permissions) { ?>
-			<br /><h2><?php echo Smr\AdminPermissions::getCategoryName($categoryID); ?></h2>
+			<br /><h2><?php echo AdminPermissions::getCategoryName($categoryID); ?></h2>
 			<div style="padding-left:20px;"><?php
 				foreach ($permissions as $permissionID => $permissionName) {
 					$checked = $EditAccount->hasPermission($permissionID) ? 'checked' : ''; ?>

--- a/src/templates/Default/engine/Default/admin/unigen/universe_create_ports.php
+++ b/src/templates/Default/engine/Default/admin/unigen/universe_create_ports.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+
 ?>
 <form method="POST" action="<?php echo $JumpGalaxyHREF; ?>">
 	Working on Galaxy:
@@ -49,7 +51,7 @@
 						<th>Port Race</th>
 						<th>% Distribution</th>
 					</tr><?php
-					foreach (Smr\Race::getAllNames() as $raceID => $raceName) { ?>
+					foreach (Race::getAllNames() as $raceID => $raceName) { ?>
 						<tr>
 							<td class="right"><?php echo $raceName; ?></td>
 							<td><input class="center" type="number" size="5" name="race<?php echo $raceID; ?>" value="<?php echo $RacePercents[$raceID]; ?>" onInput="raceCalc();" /></td>

--- a/src/templates/Default/engine/Default/admin/unigen/universe_create_sector_details.php
+++ b/src/templates/Default/engine/Default/admin/unigen/universe_create_sector_details.php
@@ -1,7 +1,11 @@
 <?php declare(strict_types=1);
 
 use Smr\Location;
+use Smr\PlanetTypes\PlanetType;
 use Smr\Port;
+use Smr\Race;
+use Smr\TradeGood;
+use Smr\TransactionType;
 
 /**
  * @var Smr\Account $ThisAccount
@@ -15,8 +19,8 @@ use Smr\Port;
 	<b>Type: </b>
 	<select name="plan_type">
 		<option value="0">No Planet</option><?php
-		foreach (array_keys(Smr\PlanetTypes\PlanetType::PLANET_TYPES) as $type) { ?>
-			<option value="<?php echo $type; ?>" <?php echo ($type == $SelectedPlanetType ? 'selected' : ''); ?>><?php echo Smr\PlanetTypes\PlanetType::getTypeInfo($type)->name(); ?></option><?php
+		foreach (array_keys(PlanetType::PLANET_TYPES) as $type) { ?>
+			<option value="<?php echo $type; ?>" <?php echo ($type == $SelectedPlanetType ? 'selected' : ''); ?>><?php echo PlanetType::getTypeInfo($type)->name(); ?></option><?php
 		} ?>
 	</select><br /><?php
 	if ($SelectedPlanetType) { ?>
@@ -34,7 +38,7 @@ use Smr\Port;
 	</select>&nbsp;
 
 	<select name="port_race"><?php
-		foreach (Smr\Race::getAllNames() as $raceID => $raceName) { ?>
+		foreach (Race::getAllNames() as $raceID => $raceName) { ?>
 		<option value="<?php echo $raceID; ?>" <?php echo ($raceID == $SelectedPortRaceID ? 'selected' : ''); ?>><?php echo $raceName; ?></option><?php
 	} ?>
 	</select>
@@ -50,14 +54,14 @@ use Smr\Port;
 				foreach ([1, 2, 3] as $class) { ?>
 					<td class="top">
 					<table class="nobord"><?php
-						foreach (Smr\TradeGood::getAll() as $goodID => $good) {
+						foreach (TradeGood::getAll() as $goodID => $good) {
 							if ($good->class == $class) { ?>
 								<tr>
 								<td>
 									<?php echo $good->getImageHTML(); ?>&nbsp;
 									<select name="good<?php echo $goodID; ?>">
 										<option value="None">--</option><?php
-										foreach (Smr\TransactionType::cases() as $trans) { ?>
+										foreach (TransactionType::cases() as $trans) { ?>
 											<option <?php if ($Port->hasGood($goodID, $trans)) { ?> selected <?php } ?> value="<?php echo $trans->value; ?>"><?php echo $trans->value; ?></option><?php
 										} ?>
 									</select>

--- a/src/templates/Default/engine/Default/alliance_mod.php
+++ b/src/templates/Default/engine/Default/alliance_mod.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+
 /**
  * @var Smr\Account $ThisAccount
  * @var Smr\Alliance $Alliance
@@ -16,7 +18,7 @@ if (isset($OpTime)) { ?>
 	<table class="center nobord opResponse">
 		<tr><th>ENCRYPTED ALLIANCE TELEGRAM</th></tr>
 		<tr><td>Your leader has scheduled an important alliance operation for <?php echo date($ThisAccount->getDateTimeFormat(), $OpTime); ?></td></tr>
-		<tr><td><span id="countdown"><?php echo format_time($OpTime - Smr\Epoch::time()); ?></span></td></tr>
+		<tr><td><span id="countdown"><?php echo format_time($OpTime - Epoch::time()); ?></span></td></tr>
 		<tr><td><b>Will you join the operation?</b></td></tr>
 		<tr><td>
 			<form method="POST" action="<?php echo $OpResponseHREF; ?>"><?php

--- a/src/templates/Default/engine/Default/beta_functions.php
+++ b/src/templates/Default/engine/Default/beta_functions.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+
 /**
  * @var Smr\Player $ThisPlayer
  * @var Smr\Sector $ThisSector
@@ -92,7 +94,7 @@
 <form method="POST" action="<?php echo $PersonalRelationsHREF; ?>">
 	<input type="number" name="amount" value="0" style="width:75px" />&nbsp;
 	<select name="race"><?php
-		foreach (Smr\Race::getAllNames() as $raceID => $raceName) { ?>
+		foreach (Race::getAllNames() as $raceID => $raceName) { ?>
 			<option value="<?php echo $raceID; ?>"><?php echo $raceName; ?></option><?php
 		} ?>
 	</select>&nbsp;&nbsp;
@@ -103,7 +105,7 @@
 <form method="POST" action="<?php echo $RaceRelationsHREF; ?>">
 	<input type="number" name="amount" value="0" min="<?php echo MIN_GLOBAL_RELATIONS; ?>" max="<?php echo MAX_GLOBAL_RELATIONS; ?>" style="width:75px" />&nbsp;
 	<select name="race"><?php
-		foreach (Smr\Race::getPlayableNames() as $raceID => $raceName) {
+		foreach (Race::getPlayableNames() as $raceID => $raceName) {
 			if ($raceID == $ThisPlayer->getRaceID()) continue; ?>
 			<option value="<?php echo $raceID; ?>"><?php echo $raceName; ?></option><?php
 		} ?>
@@ -114,7 +116,7 @@
 
 <form method="POST" action="<?php echo $ChangeRaceHREF; ?>">
 	<select name="race"><?php
-		foreach (Smr\Race::getPlayableNames() as $raceID => $raceName) {
+		foreach (Race::getPlayableNames() as $raceID => $raceName) {
 			if ($raceID == $ThisPlayer->getRaceID()) continue; ?>
 			<option value="<?php echo $raceID; ?>"><?php echo $raceName; ?></option><?php
 		} ?>

--- a/src/templates/Default/engine/Default/council_embassy.php
+++ b/src/templates/Default/engine/Default/council_embassy.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+
 /**
  * @var Smr\Player $ThisPlayer
  * @var array<int, string> $VoteRaceHrefs
@@ -21,7 +23,7 @@
 
 	foreach ($VoteRaceHrefs as $RaceID => $FormHref) { ?>
 		<tr>
-			<td><img src="<?php echo Smr\Race::getHeadImage($RaceID); ?>" width="60" height="64" /><br /><?php echo $ThisPlayer->getColouredRaceName($RaceID, true); ?></td>
+			<td><img src="<?php echo Race::getHeadImage($RaceID); ?>" width="60" height="64" /><br /><?php echo $ThisPlayer->getColouredRaceName($RaceID, true); ?></td>
 			<td>
 				<form method="POST" action="<?php echo $FormHref; ?>">
 					<input type="submit" name="action" value="Peace" />

--- a/src/templates/Default/engine/Default/council_list.php
+++ b/src/templates/Default/engine/Default/council_list.php
@@ -2,6 +2,7 @@
 
 use Smr\Council;
 use Smr\Player;
+use Smr\Race;
 
 /**
  * @var Smr\Player $ThisPlayer
@@ -39,7 +40,7 @@ use Smr\Player;
 	} ?>
 	<br /><br />
 
-	<img src="<?php echo Smr\Race::getImage($RaceID); ?>" width="212" height="270" /><br /><br />
+	<img src="<?php echo Race::getImage($RaceID); ?>" width="212" height="270" /><br /><br />
 
 	<h3>Council Members</h3><br /><?php
 	$CouncilMembers = Council::getRaceCouncil($ThisPlayer->getGameID(), $RaceID);
@@ -75,7 +76,7 @@ use Smr\Player;
 <br /><br />
 
 <b>View Council For:</b><br /><?php
-foreach (Smr\Race::getPlayableIDs() as $RaceID) { ?>
+foreach (Race::getPlayableIDs() as $RaceID) { ?>
 	<span class="smallFont"><?php
 		echo $ThisPlayer->getColouredRaceName($RaceID, true); ?>
 	</span><br /><?php

--- a/src/templates/Default/engine/Default/council_politics.php
+++ b/src/templates/Default/engine/Default/council_politics.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\Globals;
+use Smr\Race;
 
 /**
  * @var Smr\Player $ThisPlayer
@@ -25,7 +26,7 @@ use Smr\Globals;
 					foreach ($PeaceRaces as $RaceID) { ?>
 						<tr>
 							<td>
-								<img src="<?php echo Smr\Race::getHeadImage($RaceID); ?>" width="100" height="106" /><br /><?php
+								<img src="<?php echo Race::getHeadImage($RaceID); ?>" width="100" height="106" /><br /><?php
 								echo Globals::getColouredRaceNameForRace($RaceID, $ThisPlayer->getGameID(), $ThisPlayer->getRaceID()); ?>
 							</td>
 						</tr><?php
@@ -37,7 +38,7 @@ use Smr\Globals;
 					foreach ($NeutralRaces as $RaceID) { ?>
 						<tr>
 							<td>
-								<img src="<?php echo Smr\Race::getHeadImage($RaceID); ?>" width="100" height="106" /><br /><?php
+								<img src="<?php echo Race::getHeadImage($RaceID); ?>" width="100" height="106" /><br /><?php
 								echo Globals::getColouredRaceNameForRace($RaceID, $ThisPlayer->getGameID(), $ThisPlayer->getRaceID()); ?>
 							</td>
 						</tr><?php
@@ -49,7 +50,7 @@ use Smr\Globals;
 					foreach ($WarRaces as $RaceID) { ?>
 						<tr>
 							<td>
-								<img src="<?php echo Smr\Race::getHeadImage($RaceID); ?>" width="100" height="106" /><br /><?php
+								<img src="<?php echo Race::getHeadImage($RaceID); ?>" width="100" height="106" /><br /><?php
 								echo Globals::getColouredRaceNameForRace($RaceID, $ThisPlayer->getGameID(), $ThisPlayer->getRaceID()); ?>
 							</td>
 						</tr><?php

--- a/src/templates/Default/engine/Default/council_vote.php
+++ b/src/templates/Default/engine/Default/council_vote.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Smr\Globals;
+use Smr\Race;
 
 /**
  * @var Smr\Account $ThisAccount
@@ -76,7 +77,7 @@ if (!$VoteTreaties) { ?>
 		<tr>
 			<td>
 				<a href="<?php echo Globals::getCouncilHREF($RaceID); ?>">
-					<img src="<?php echo Smr\Race::getHeadImage($RaceID); ?>" width="60" height="64" /><br /><?php
+					<img src="<?php echo Race::getHeadImage($RaceID); ?>" width="60" height="64" /><br /><?php
 					echo $ThisPlayer->getColouredRaceName($RaceID); ?>
 				</a>
 			</td>

--- a/src/templates/Default/engine/Default/game_join.php
+++ b/src/templates/Default/engine/Default/game_join.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+
 /**
  * @var Smr\Account $ThisAccount
  * @var Smr\Game $Game
@@ -63,7 +65,7 @@ if ($Game->getDescription()) { ?>
 <?php
 if (!isset($JoinGameFormHref)) { ?>
 	<p class="bold big">
-		Time until you can join this game: <?php echo format_time($Game->getJoinTime() - Smr\Epoch::time()); ?>
+		Time until you can join this game: <?php echo format_time($Game->getJoinTime() - Epoch::time()); ?>
 		<br /><br /><?php
 		if ($Game->getStartTime() == $Game->getJoinTime()) { ?>
 			The game will start immediately at this time!<?php

--- a/src/templates/Default/engine/Default/game_play.php
+++ b/src/templates/Default/engine/Default/game_play.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+
 /**
  * @var Smr\Template $this
  * @var string $UserRankName
@@ -69,7 +71,7 @@ You are ranked as <?php echo $this->doAn($UserRankName); ?> <a style="font-size:
 			foreach ($Games['Join'] as $Game) { ?>
 				<tr>
 					<td class="center">
-						<div class="buttonA"><a id="game_join_<?php echo $Game['ID']; ?>" class="buttonA" href="<?php echo $Game['JoinGameLink']; ?>"><?php if (Smr\Epoch::time() < $Game['JoinTime']) {?>View Info<?php } else { ?>Join Game<?php } ?></a></div>
+						<div class="buttonA"><a id="game_join_<?php echo $Game['ID']; ?>" class="buttonA" href="<?php echo $Game['JoinGameLink']; ?>"><?php if (Epoch::time() < $Game['JoinTime']) {?>View Info<?php } else { ?>Join Game<?php } ?></a></div>
 					</td>
 					<td width="35%"><?php echo $Game['Name']; ?> (<?php echo $Game['ID']; ?>)</td>
 					<td class="noWrap"><?php echo $Game['StartDate']; ?></td>

--- a/src/templates/Default/engine/Default/includes/EndingJavascript.inc.php
+++ b/src/templates/Default/engine/Default/includes/EndingJavascript.inc.php
@@ -18,7 +18,7 @@ foreach ($this->jsSources as $src) { ?>
 }
 
 foreach ($this->jsAlerts as $string) {
-	?>alert(<?php echo json_encode($string); ?>);<?php
+	?>alert(<?php echo json_encode($string, JSON_THROW_ON_ERROR); ?>);<?php
 }
 
 if (!empty($this->listjsInclude)) { ?>

--- a/src/templates/Default/engine/Default/includes/Head.inc.php
+++ b/src/templates/Default/engine/Default/includes/Head.inc.php
@@ -8,7 +8,6 @@
  * @var int $FontSize
  */
 
-
 ?>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 <title><?php echo PAGE_TITLE; ?><?php if (isset($GameName)) echo ": $GameName"; ?></title>

--- a/src/templates/Default/engine/Default/includes/PlanetListFinancial.inc.php
+++ b/src/templates/Default/engine/Default/includes/PlanetListFinancial.inc.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
 use Smr\Globals;
+use Smr\PlanetMenuOption;
 
 /**
  * @var array<Smr\Planet> $Planets
@@ -37,13 +39,13 @@ if (count($Planets) > 0) { ?>
 					<td class="sort_sector"><a href="<?php echo Globals::getPlotCourseHREF($ThisPlayer->getSectorID(), $Planet->getSectorID()); ?>"><?php echo $Planet->getSectorID(); ?></a>&nbsp;(<a href="<?php echo $Planet->getGalaxy()->getGalaxyMapHREF(); ?>" target="gal_map"><?php echo $Planet->getGalaxy()->getDisplayName(); ?></a>)</td>
 
 					<?php
-					if ($Planet->hasMenuOption(Smr\PlanetMenuOption::FINANCE)) { ?>
+					if ($Planet->hasMenuOption(PlanetMenuOption::FINANCE)) { ?>
 						<td class="sort_credits"><?php echo number_format($Planet->getCredits()); ?></td>
 						<td class="sort_bonds"><?php echo number_format($Planet->getBonds()); ?></td>
 						<td class="sort_interest"><?php echo $Planet->getInterestRate() * 100; ?>%</td>
 						<?php
 						if ($Planet->getBonds() > 0) {
-							$matureTime = $Planet->getMaturity() - Smr\Epoch::time(); ?>
+							$matureTime = $Planet->getMaturity() - Epoch::time(); ?>
 							<td class="sort_mature noWrap" data-sort_mature="<?php echo $matureTime; ?>">
 								<?php echo format_time($matureTime, true); ?>
 							</td><?php

--- a/src/templates/Default/engine/Default/includes/PlottedCourse.inc.php
+++ b/src/templates/Default/engine/Default/includes/PlottedCourse.inc.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Pages\Player\PlotCourseCancelProcessor;
+use Smr\Pages\Player\PlotCourseConventionalProcessor;
 use Smr\Sector;
 
 /**
@@ -10,8 +12,8 @@ use Smr\Sector;
 
 if ($ThisPlayer->hasPlottedCourse()) {
 	$PlottedCourse = $ThisPlayer->getPlottedCourse();
-	$CancelCourseHREF = (new Smr\Pages\Player\PlotCourseCancelProcessor())->href();
-	$ReplotCourseHREF = (new Smr\Pages\Player\PlotCourseConventionalProcessor(to: $PlottedCourse->getEndSectorID(), from: $ThisSector->getSectorID()))->href();
+	$CancelCourseHREF = (new PlotCourseCancelProcessor())->href();
+	$ReplotCourseHREF = (new PlotCourseConventionalProcessor(to: $PlottedCourse->getEndSectorID(), from: $ThisSector->getSectorID()))->href();
 	$NextSector = Sector::getSector($ThisPlayer->getGameID(), $PlottedCourse->getNextOnPath()); ?>
 	<table class="nobord fullwidth">
 		<tr>

--- a/src/templates/Default/engine/Default/includes/SectorMap.inc.php
+++ b/src/templates/Default/engine/Default/includes/SectorMap.inc.php
@@ -17,7 +17,7 @@ use Smr\Globals;
 ?>
 <table class="lmt centered"><?php
 	$GalaxyMap = isset($GalaxyMap) && $GalaxyMap;
-	$UniGen = $UniGen ?? false;
+	$UniGen ??= false;
 	$MapPlayer = $UniGen ? null : $ThisPlayer;
 	$MovementTypes = ['Up', 'Left', 'Right', 'Down'];
 	foreach ($MapSectors as $MapSector) { ?>

--- a/src/templates/Default/engine/Default/includes/SectorNavigation.inc.php
+++ b/src/templates/Default/engine/Default/includes/SectorNavigation.inc.php
@@ -33,7 +33,6 @@ if ($Sectors) { ?>
 				}
 			}
 
-
 			if ($Sectors['Left']['ID'] != 0) { ?>
 				<div class="move_left move_text move_hover" id="moveLeft">
 					<a href="<?php echo Globals::getCurrentSectorMoveHREF($ThisPlayer, $Sectors['Left']['ID']); ?>" class="<?php echo $Sectors['Left']['Class']; ?>">
@@ -86,7 +85,6 @@ if ($Sectors) { ?>
 				}
 			}
 
-
 			if ($Sectors['Down']['ID'] != 0) { ?>
 				<div class="move_down move_text move_hover" id="moveDown">
 					<a href="<?php echo Globals::getCurrentSectorMoveHREF($ThisPlayer, $Sectors['Down']['ID']); ?>" class="<?php echo $Sectors['Down']['Class']; ?>">
@@ -106,7 +104,6 @@ if ($Sectors) { ?>
 					?><div class="scan_down scan_hover scan_text_hor"></div><?php
 				}
 			}
-
 
 			if ($Sectors['Warp']['ID'] != 0) { ?>
 				<div class="move_warp move_text move_hover" id="moveWarp">

--- a/src/templates/Default/engine/Default/includes/VoteLinks.inc.php
+++ b/src/templates/Default/engine/Default/includes/VoteLinks.inc.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use Smr\Session;
+
 /**
  * @var array<array{img: string, url: string, sn: string|false}> $VoteLinks
  * @var string $TimeToNextVote
  */
 
-if (Smr\Session::getInstance()->hasGame()) { ?>
+if (Session::getInstance()->hasGame()) { ?>
 	<div>Get <b><u>FREE TURNS</u></b> for voting if you see the star, available <span id="v"><?php echo $TimeToNextVote ?></span>.</div><?php
 } ?>
 <span id="vote_links"><?php

--- a/src/templates/Default/engine/Default/message_view.php
+++ b/src/templates/Default/engine/Default/message_view.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\ScoutMessageGroupType;
+
 /**
  * @var Smr\Player $ThisPlayer
  * @var ?string $PreferencesFormHREF
@@ -17,7 +19,7 @@ if ($MessageBox['Type'] == MSG_GLOBAL) { ?>
 	<form name="FORM" method="POST" action="<?php echo $PreferencesFormHREF; ?>">
 		<div class="center">
 			Group scout messages?&nbsp;&nbsp;<?php
-			foreach (Smr\ScoutMessageGroupType::cases() as $groupType) { ?>
+			foreach (ScoutMessageGroupType::cases() as $groupType) { ?>
 				<button type="submit" name="group_scouts" value="<?php echo $groupType->value; ?>" <?php if ($ThisPlayer->getScoutMessageGroupType() === $groupType) { ?> style="background-color:green;" <?php } ?>><?php echo $groupType->name; ?></button>&nbsp;<?php
 			} ?>
 		</div>

--- a/src/templates/Default/engine/Default/planet_financial.php
+++ b/src/templates/Default/engine/Default/planet_financial.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+
 /**
  * @var Smr\Planet $ThisPlanet
  */
@@ -34,7 +36,7 @@ if (!$ThisPlanet->hasOwner()) {
 	if ($ThisPlanet->getBonds() > 0) { ?>
 		Right now there are <?php echo number_format($ThisPlanet->getBonds()); ?> credits bonded<?php
 		if ($ThisPlanet->getMaturity() > 0) { ?>
-			and will come to maturity in <?php echo format_time($ThisPlanet->getMaturity() - Smr\Epoch::time()); ?>.
+			and will come to maturity in <?php echo format_time($ThisPlanet->getMaturity() - Epoch::time()); ?>.
 			<br /><br /> <?php
 		}
 	} ?>

--- a/src/templates/Default/engine/Default/port_attack_warning.php
+++ b/src/templates/Default/engine/Default/port_attack_warning.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
 use Smr\Globals;
 
 /**
@@ -65,6 +66,6 @@ Are you sure you want to attack this port?<br /><br />
 if ($Port->isUnderAttack()) { ?>
 	The port is under attack and has activated its distress beacon!<br />
 	Federal reinforcements will arrive to defend the port in
-	<?php echo format_time($Port->getReinforceTime() - Smr\Epoch::time()) . '.';
+	<?php echo format_time($Port->getReinforceTime() - Epoch::time()) . '.';
 }
 ?></span>

--- a/src/templates/Default/engine/Default/preferences.php
+++ b/src/templates/Default/engine/Default/preferences.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
 use Smr\Globals;
+use Smr\Race;
 
 /**
  * @var Smr\Account $ThisAccount
@@ -81,7 +83,7 @@ if (isset($GameID)) { ?>
 					<td>
 						<select name="race_id"><?php
 							foreach ($ThisPlayer->getGame()->getPlayableRaceIDs() as $RaceID) {
-								?><option value="<?php echo $RaceID; ?>" <?php if ($RaceID == $ThisPlayer->getRaceID()) { ?> selected<?php } ?>><?php echo Smr\Race::getName($RaceID); ?></option><?php
+								?><option value="<?php echo $RaceID; ?>" <?php if ($RaceID == $ThisPlayer->getRaceID()) { ?> selected<?php } ?>><?php echo Race::getName($RaceID); ?></option><?php
 							} ?>
 						</select>
 						<br />
@@ -248,7 +250,7 @@ if (isset($GameID)) { ?>
 			<td>Timezone:</td>
 			<td>
 				<select name="timez"><?php
-				$time = Smr\Epoch::time();
+				$time = Epoch::time();
 				$offset = $ThisAccount->getOffset();
 				for ($i = -12; $i <= 11; $i++) {
 					?><option value="<?php echo $i; ?>"<?php if ($offset == $i) { ?> selected="selected"<?php } ?>><?php echo date($ThisAccount->getTimeFormat(), $time + $i * 3600); ?></option><?php

--- a/src/templates/Default/engine/Default/rankings_view.php
+++ b/src/templates/Default/engine/Default/rankings_view.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Session;
+use Smr\UserRanking;
+
 /**
  * @var Smr\Account $ThisAccount
  * @var Smr\Player $ThisPlayer
@@ -14,7 +17,7 @@ You are ranked as a <span style="font-size: 125%; color: greenyellow;"><?php ech
 		<th>Points Required</th>
 	</tr>
 	<?php
-	foreach (Smr\UserRanking::cases() as $rank) { ?>
+	foreach (UserRanking::cases() as $rank) { ?>
 		<tr>
 			<td><?php echo $rank->name; ?></td>
 			<td class="center"><?php echo $rank->getMinScore(); ?></td>
@@ -29,7 +32,7 @@ foreach ($ThisAccount->getIndividualScores() as $statScore) {
 	echo implode(' - ', $statScore['Stat']); ?>, has a stat of <?php echo number_format($ThisAccount->getHOF($statScore['Stat'])); ?> and a score of <span class="green"><?php echo number_format(round($statScore['Score'])); ?></span><br /><?php
 }
 
-if (Smr\Session::getInstance()->hasGame()) { ?>
+if (Session::getInstance()->hasGame()) { ?>
 	<br />
 	<b>Current Game Extended Stats</b>
 	<br /><?php

--- a/src/templates/Default/engine/Default/shop_goods.php
+++ b/src/templates/Default/engine/Default/shop_goods.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\TransactionType;
+
 /**
  * @var Smr\Player $ThisPlayer
  * @var Smr\Port $Port
@@ -56,9 +58,9 @@ if ($BoughtGoods) { ?>
 				<td><input form="form<?php echo $goodID; ?>" type="number" name="amount" value="<?php echo $good['Amount']; ?>" required min="1" size="4" class="center"></td>
 				<td>
 					<form id="form<?php echo $goodID; ?>" method="POST" action="<?php echo $good['HREF']; ?>">
-						<input type="submit" name="action" value="<?php echo Smr\TransactionType::Buy->value; ?>"><?php
+						<input type="submit" name="action" value="<?php echo TransactionType::Buy->value; ?>"><?php
 						if ($ThisShip->isUnderground()) { ?>
-							<input type="submit" name="action" value="<?php echo Smr\TransactionType::STEAL; ?>"><?php
+							<input type="submit" name="action" value="<?php echo TransactionType::STEAL; ?>"><?php
 						} ?>
 					</form>
 				</td>
@@ -88,7 +90,7 @@ if ($SoldGoods) { ?>
 				<td><input form="form<?php echo $goodID; ?>" type="number" name="amount" value="<?php echo $good['Amount']; ?>" required min="1" size="4" class="center"></td>
 				<td>
 					<form id="form<?php echo $goodID; ?>" method="POST" action="<?php echo $good['HREF']; ?>">
-						<input type="submit" name="action" value="<?php echo Smr\TransactionType::Sell->value; ?>">
+						<input type="submit" name="action" value="<?php echo TransactionType::Sell->value; ?>">
 					</form>
 				</td>
 			</tr><?php

--- a/src/templates/Default/engine/Default/trader_search_result.php
+++ b/src/templates/Default/engine/Default/trader_search_result.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
 use Smr\Globals;
 use Smr\Player;
 
@@ -39,7 +40,7 @@ function DisplayResult(array $Links, Player $Player): void { ?>
 				} else { ?>
 					<td width="10%" class="center red">NO</td><?php
 				}
-				if ($Link['Player']->getLastCPLAction() > Smr\Epoch::time() - 600) { ?>
+				if ($Link['Player']->getLastCPLAction() > Epoch::time() - 600) { ?>
 					<td width="10%" class="center dgreen">YES</td><?php
 				} else { ?>
 					<td width="10%" class="center red">NO</td><?php

--- a/src/templates/Default/engine/Default/trader_status.php
+++ b/src/templates/Default/engine/Default/trader_status.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\BountyType;
+use Smr\Epoch;
 use Smr\Globals;
+use Smr\Race;
 
 /**
  * @var Smr\Account $ThisAccount
@@ -50,7 +53,7 @@ use Smr\Globals;
 			</a>
 
 			<br /><?php
-			foreach (Smr\Race::getAllNames() as $raceID => $raceName) {
+			foreach (Race::getAllNames() as $raceID => $raceName) {
 				if ($ThisPlayer->getPersonalRelation($raceID) != 0) {
 					echo $raceName . ' : ' . get_colored_text($ThisPlayer->getPersonalRelation($raceID)) . '<br />';
 				}
@@ -109,10 +112,10 @@ use Smr\Globals;
 			<br />You can claim <span class="yellow"><?php echo $BountiesClaimable; ?></span> bounties.
 
 			<?php
-			if ($ThisPlayer->hasActiveBounty(Smr\BountyType::HQ)) { ?>
+			if ($ThisPlayer->hasActiveBounty(BountyType::HQ)) { ?>
 				<br />You are <span class="red">wanted</span> by the <span class="green">Federal Government</span>!<?php
 			}
-			if ($ThisPlayer->hasActiveBounty(Smr\BountyType::UG)) { ?>
+			if ($ThisPlayer->hasActiveBounty(BountyType::UG)) { ?>
 				<br />You are <span class="red">wanted</span> by the <span class="red">Underground</span>!<?php
 			} ?>
 
@@ -125,7 +128,7 @@ use Smr\Globals;
 			<br />Name: <?php echo $ThisShip->getName(); ?>
 			<br />Speed: <?php echo $ThisShip->getRealSpeed(); ?> turns/hour
 			<br />Max: <?php echo $ThisPlayer->getMaxTurns(); ?> turns
-			<br />At max turns <span id="max_turns"><?php echo in_time_or_now($ThisPlayer->getTimeUntilMaxTurns(Smr\Epoch::time()), true); ?></span>.
+			<br />At max turns <span id="max_turns"><?php echo in_time_or_now($ThisPlayer->getTimeUntilMaxTurns(Epoch::time()), true); ?></span>.
 			Next turn in <span id="next_turn"><?php echo format_time($ThisPlayer->getTimeUntilNextTurn(), true); ?></span>.
 			<br /><br />
 

--- a/src/templates/Default/login/login.php
+++ b/src/templates/Default/login/login.php
@@ -1,5 +1,9 @@
 <?php declare(strict_types=1);
 
+use Smr\SocialLogin\Facebook;
+use Smr\SocialLogin\Google;
+use Smr\SocialLogin\Twitter;
+
 ?>
 <table class="center nobord" style="width:690px; border-spacing:30px;">
 	<tr>
@@ -64,13 +68,13 @@
 			<span style="font-size: 14px;">Or register &amp; login with:</span>
 			<br />
 			<span>
-				<a class="btn-social" href="login_social_processing.php?type=<?php echo Smr\SocialLogin\Facebook::getLoginType(); ?>">
+				<a class="btn-social" href="login_social_processing.php?type=<?php echo Facebook::getLoginType(); ?>">
 					<img alt="Facebook" title="Facebook" src="images/login/facebook.svg" width="32" height="32">
 				</a>
-				<a class="btn-social" href="login_social_processing.php?type=<?php echo Smr\SocialLogin\Twitter::getLoginType(); ?>">
+				<a class="btn-social" href="login_social_processing.php?type=<?php echo Twitter::getLoginType(); ?>">
 					<img alt="Twitter" title="Twitter" src="images/login/twitter.svg" width="32" height="32">
 				</a>
-				<a class="btn-social" href="login_social_processing.php?type=<?php echo Smr\SocialLogin\Google::getLoginType(); ?>">
+				<a class="btn-social" href="login_social_processing.php?type=<?php echo Google::getLoginType(); ?>">
 					<img alt="Google" title="Google" src="images/login/google.svg" width="32" height="32">
 				</a>
 			</span>

--- a/src/templates/Default/login/login_create.php
+++ b/src/templates/Default/login/login_create.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+use Smr\Request;
+
 ?>
 <div class="centered" style="width: 630px;">
 	<h1>Create Login</h1>
@@ -46,7 +49,7 @@
 				<td width='27%'>Local Time:</td>
 				<td width='73%'>
 					<select name="timez" class="InputFields"><?php
-						$time = Smr\Epoch::time();
+						$time = Epoch::time();
 						for ($i = -12; $i <= 11; $i++) {
 							?><option value="<?php echo $i; ?>"><?php echo date(DEFAULT_TIME_FORMAT, $time + $i * 3600); ?></option><?php
 						} ?>
@@ -55,7 +58,7 @@
 			</tr>
 			<tr>
 				<td width='27%'>Referral ID (Optional):</td>
-				<td width='73%'><input type='number' name='referral_id' size='10' maxlength='20' class="InputFields" <?php if (Smr\Request::has('ref')) { echo 'value="' . Smr\Request::getInt('ref') . '"'; }?>></td>
+				<td width='73%'><input type='number' name='referral_id' size='10' maxlength='20' class="InputFields" <?php if (Request::has('ref')) { echo 'value="' . Request::getInt('ref') . '"'; }?>></td>
 			</tr>
 		</table>
 		<br />

--- a/src/templates/Default/login/login_social_create.php
+++ b/src/templates/Default/login/login_social_create.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Epoch;
+use Smr\Request;
+
 /**
  * @var Smr\SocialLogin\SocialLogin $SocialLogin
  */
@@ -71,7 +74,7 @@
 					<td width="73%">
 						<select name="timez" class="InputFields">
 							<?php
-							$time = Smr\Epoch::time();
+							$time = Epoch::time();
 								for ($i = -12; $i <= 11; $i++) {
 									echo('<option value="' . $i . '">' . date(DEFAULT_TIME_FORMAT, $time + $i * 3600));
 								}
@@ -81,7 +84,7 @@
 				</tr>
 				<tr>
 					<td width="27%">Referral ID (Optional):</td>
-					<td width="73%"><input type="number" name="referral_id" size="10" maxlength="20" class="InputFields"<?php if (Smr\Request::has('ref')) { echo 'value="' . Smr\Request::getInt('ref') . '"'; }?>></td>
+					<td width="73%"><input type="number" name="referral_id" size="10" maxlength="20" class="InputFields"<?php if (Request::has('ref')) { echo 'value="' . Request::getInt('ref') . '"'; }?>></td>
 				</tr>
 				<tr>
 					<td colspan="2">&nbsp;</td>

--- a/src/templates/Default/login/reset_password.php
+++ b/src/templates/Default/login/reset_password.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Request;
+
 ?>
 <div class="center centered">
 	<h1>Password Reset</h1>
@@ -11,11 +13,11 @@
 					<table class="center" border="0">
 						<tr>
 								<th class="right">Username:</th>
-								<td><input required name="login" type="text" class="InputFields" value="<?php echo Smr\Request::has('login') ? htmlspecialchars(Smr\Request::get('login')) : ''; ?>" /></td>
+								<td><input required name="login" type="text" class="InputFields" value="<?php echo Request::has('login') ? htmlspecialchars(Request::get('login')) : ''; ?>" /></td>
 						</tr>
 						<tr>
 								<th class="right">Password Reset Code:</th>
-								<td><input required name="password_reset" type="text" class="InputFields" value="<?php echo Smr\Request::has('resetcode') ? htmlspecialchars(Smr\Request::get('resetcode')) : ''; ?>" /></td>
+								<td><input required name="password_reset" type="text" class="InputFields" value="<?php echo Request::has('resetcode') ? htmlspecialchars(Request::get('resetcode')) : ''; ?>" /></td>
 						</tr>
 						<tr>
 								<th class="right">New Password:</th>

--- a/src/templates/Default/ship_list.php
+++ b/src/templates/Default/ship_list.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+use Smr\ShipClass;
+
 /**
  * @var array<int> $Speeds
  * @var array<int> $Hardpoints
@@ -44,7 +47,7 @@
 							<span class="sort" data-sort="race">Race</span><br />
 							<select onchange="filterSelect(this)">
 								<option>All</option><?php
-								foreach (Smr\Race::getAllNames() as $raceId => $raceName) { ?>
+								foreach (Race::getAllNames() as $raceId => $raceName) { ?>
 									<option class="race<?php echo $raceId; ?>"><?php echo $raceName; ?></option><?php
 								} ?>
 							</select>
@@ -53,7 +56,7 @@
 							<span class="sort" data-sort="class_">Class</span><br />
 							<select onchange="filterSelect(this)">
 								<option value="All">All</option><?php
-								foreach (Smr\ShipClass::cases() as $shipClass) { ?>
+								foreach (ShipClass::cases() as $shipClass) { ?>
 									<option><?php echo $shipClass->name; ?></option><?php
 								} ?>
 							</select>

--- a/src/templates/Default/weapon_list.php
+++ b/src/templates/Default/weapon_list.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Smr\Race;
+
 /**
  * @var array<int> $PowerLevels
  * @var array<string> $AllLocs
@@ -32,7 +34,7 @@
 	<body onload="resetBoxes()">
 		<div id="container">
 			<form id="raceform" name="raceform" style="text-align:center;"><?php
-				foreach (Smr\Race::getAllNames() as $raceID => $raceName) { ?>
+				foreach (Race::getAllNames() as $raceID => $raceName) { ?>
 					<input type="checkbox" id="race<?php echo $raceID; ?>" name="races" value="<?php echo $raceName; ?>" onClick="raceToggle()">
 					<label for="race<?php echo $raceID; ?>" class="race<?php echo $raceID; ?>"><?php echo $raceName; ?></label>&thinsp;<?php
 				} ?>
@@ -48,7 +50,7 @@
 							<span class="sort" data-sort="race">Race</span><br />
 							<select onchange="filterSelect(this)">
 								<option>All</option><?php
-								foreach (Smr\Race::getAllNames() as $raceId => $raceName) { ?>
+								foreach (Race::getAllNames() as $raceId => $raceName) { ?>
 									<option class="race<?php echo $raceId; ?>"><?php echo $raceName; ?></option><?php
 								} ?>
 							</select>

--- a/src/tools/chat_helpers/channel_msg_op_turns.php
+++ b/src/tools/chat_helpers/channel_msg_op_turns.php
@@ -32,7 +32,7 @@ function shared_channel_msg_op_turns(AbstractPlayer $player): array {
 		}
 		$turns = min(
 			$attendeePlayer->getTurns() + $attendeePlayer->getTurnsGained(time(), true),
-			$attendeePlayer->getMaxTurns()
+			$attendeePlayer->getMaxTurns(),
 		);
 		$oppers[$attendeePlayer->getPlayerName()] = $turns;
 	}

--- a/src/tools/discord/bot.php
+++ b/src/tools/discord/bot.php
@@ -1,5 +1,8 @@
 <?php declare(strict_types=1);
 
+use Discord\Discord;
+use Discord\DiscordCommandClient;
+use Discord\Parts\User\Activity;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Smr\Database;
@@ -24,10 +27,10 @@ error_reporting(E_ALL);
 $logger = new Logger('discord');
 $logger->pushHandler(new StreamHandler('php://stdout', DISCORD_LOGGER_LEVEL));
 
-$discord = new Discord\DiscordCommandClient([
+$discord = new DiscordCommandClient([
 	'token' => DISCORD_TOKEN,
 	'prefix' => DISCORD_COMMAND_PREFIX,
-	'description' => 'Your automated co-pilot in the Space Merchant Realms universe. Made with DiscordPHP ' . Discord\Discord::VERSION . '.',
+	'description' => 'Your automated co-pilot in the Space Merchant Realms universe. Made with DiscordPHP ' . Discord::VERSION . '.',
 	'caseInsensitiveCommands' => true,
 	'discordOptions' => [
 		'logger' => $logger,
@@ -36,9 +39,9 @@ $discord = new Discord\DiscordCommandClient([
 
 // Set bot presence to "Listening to <help command>"
 $discord->on('ready', function($discord) {
-	$activity = $discord->factory(Discord\Parts\User\Activity::class, [
+	$activity = $discord->factory(Activity::class, [
 		'name' => DISCORD_COMMAND_PREFIX . 'help',
-		'type' => Discord\Parts\User\Activity::TYPE_LISTENING,
+		'type' => Activity::TYPE_LISTENING,
 	]);
 	$discord->updatePresence($activity);
 });

--- a/src/tools/irc/Exceptions/Timeout.php
+++ b/src/tools/irc/Exceptions/Timeout.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Irc\Exceptions;
 
+use Exception;
+
 /**
  * Used when the IRC client times out so that we can reconnect.
  */
-class Timeout extends \Exception {
+class Timeout extends Exception {
 }

--- a/src/tools/irc/channel_msg.php
+++ b/src/tools/irc/channel_msg.php
@@ -155,7 +155,6 @@ function channel_msg_with_registration($fp, Message $msg): bool {
 	return false;
 }
 
-
 /**
  * @param resource $fp
  */

--- a/src/tools/irc/channel_msg.php
+++ b/src/tools/irc/channel_msg.php
@@ -29,7 +29,7 @@ function check_for_registration($fp, string $nick, string $channel, Closure $cal
 			nick: $nick,
 			callback: $callback,
 			time: time(),
-			validate: $validationMessages
+			validate: $validationMessages,
 		));
 
 		return false;

--- a/src/tools/irc/irc.php
+++ b/src/tools/irc/irc.php
@@ -8,7 +8,7 @@ function echo_r(string $message): void {
 }
 
 // config file
-require_once(realpath(dirname(__FILE__)) . '/../../bootstrap.php');
+require_once(realpath(__DIR__) . '/../../bootstrap.php');
 
 // timer events
 $events = [];

--- a/src/tools/irc/server.php
+++ b/src/tools/irc/server.php
@@ -106,7 +106,7 @@ function server_msg_318($fp, string $rdata): bool {
 						nick: $event->nick,
 						callback: $event->callback,
 						time: time(),
-						validate: $event->validate
+						validate: $event->validate,
 					));
 				} elseif ($event->validate) {
 					fwrite($fp, 'PRIVMSG ' . $event->channel . ' :' . $nick . ', you are not using a registered nick. Please identify with NICKSERV and try the last command again.' . EOL);

--- a/src/tools/npc/Exceptions/FinalAction.php
+++ b/src/tools/npc/Exceptions/FinalAction.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Npc\Exceptions;
 
+use Exception;
+
 /**
  * Use this exception to indicate that an NPC has taken its final action.
  */
-class FinalAction extends \Exception {
+class FinalAction extends Exception {
 }

--- a/src/tools/npc/Exceptions/ForwardAction.php
+++ b/src/tools/npc/Exceptions/ForwardAction.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Npc\Exceptions;
 
+use Exception;
+
 /**
  * Use this exception to help override container forwarding for NPC's.
  */
-class ForwardAction extends \Exception {
+class ForwardAction extends Exception {
 }

--- a/src/tools/npc/Exceptions/TradeRouteDrained.php
+++ b/src/tools/npc/Exceptions/TradeRouteDrained.php
@@ -2,8 +2,10 @@
 
 namespace Smr\Npc\Exceptions;
 
+use Exception;
+
 /**
  * Use this exception when an NPC encounters a drained trade route.
  */
-class TradeRouteDrained extends \Exception {
+class TradeRouteDrained extends Exception {
 }

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -27,7 +27,7 @@ function debug(string $message, mixed $debugObject = null): void {
 
 try {
 	// global config
-	require_once(realpath(dirname(__FILE__)) . '/../../bootstrap.php');
+	require_once(realpath(__DIR__) . '/../../bootstrap.php');
 
 	debug('Script started');
 

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -49,7 +49,7 @@ function overrideForward(Page $container): never {
 const OVERRIDE_FORWARD = true;
 
 // global config
-require_once(realpath(dirname(__FILE__)) . '/../../bootstrap.php');
+require_once(realpath(__DIR__) . '/../../bootstrap.php');
 
 // Enable NPC-specific conditions
 DiContainer::getContainer()->set('NPC_SCRIPT', true);

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -117,7 +117,6 @@ const SHIP_UPGRADE_PATH = [
 	],
 ];
 
-
 try {
 	while (npcDriver() === false) {
 		// No actions taken, try another NPC
@@ -127,7 +126,6 @@ try {
 }
 // Try to shut down cleanly
 exitNPC();
-
 
 /**
  * @return bool If the NPC performed any actions

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -344,7 +344,7 @@ function tradeGoods(int $goodID, AbstractPlayer $player, Port $port): Page {
 		goodID: $goodID,
 		amount: $amount,
 		bargainNumber: 1,
-		bargainPrice: $offeredPrice // take the offered price
+		bargainPrice: $offeredPrice, // take the offered price
 	);
 }
 

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -28,6 +28,7 @@ use Smr\Race;
 use Smr\Routes\RouteGenerator;
 use Smr\Sector;
 use Smr\SectorLock;
+use Smr\Session;
 use Smr\Ship;
 use Smr\TradeGood;
 use Smr\TransactionType;
@@ -134,7 +135,7 @@ exitNPC();
 function npcDriver(): bool {
 	global $previousContainer;
 
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 	$session->setCurrentVar(new Page()); // initialize fake var
 
 	// Load the first available NPC
@@ -185,7 +186,7 @@ function clearCaches(): void {
 function debug(string $message, mixed $debugObject = null): void {
 	echo date('Y-m-d H:i:s - ') . $message . ($debugObject !== null ? EOL . var_export($debugObject, true) : '') . EOL;
 	if (NPC_LOG_TO_DATABASE) {
-		$session = Smr\Session::getInstance();
+		$session = Session::getInstance();
 		$accountID = $session->getAccountID();
 		$var = $session->getCurrentVar();
 		$db = Database::getInstance();
@@ -219,7 +220,7 @@ function checkStartConditions(AbstractPlayer $player): void {
 
 function processContainer(Page $container): never {
 	global $forwardedContainer, $previousContainer;
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 	$player = $session->getPlayer();
 	if ($container == $previousContainer && $forwardedContainer->file != 'forces_attack.php') {
 		debug('We are executing the same container twice?', ['ForwardedContainer' => $forwardedContainer, 'Container' => $container]);
@@ -246,7 +247,7 @@ function sleepNPC(): void {
 
 // Releases an NPC when it is done working
 function releaseNPC(): void {
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 	if (!$session->hasAccount()) {
 		debug('releaseNPC: no NPC to release');
 		return;
@@ -280,7 +281,7 @@ function changeNPCLogin(): void {
 	static $availableNpcs = null;
 
 	$db = Database::getInstance();
-	$session = Smr\Session::getInstance();
+	$session = Session::getInstance();
 
 	if ($availableNpcs === null) {
 		// Make sure NPC's have been set up in the database

--- a/test/SmrTest/lib/BountyTest.php
+++ b/test/SmrTest/lib/BountyTest.php
@@ -113,7 +113,7 @@ class BountyTest extends BaseIntegrationSpec {
 			type: BountyType::HQ,
 			time: 0,
 			credits: 1,
-			claimerID: 1
+			claimerID: 1,
 		);
 		// Same as bounty1, except claimable by player 1 and for the UG
 		$bounty3 = new Bounty(

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -154,7 +154,7 @@ class DatabaseIntegrationTest extends TestCase {
 		$this->expectExceptionMessage("Table 'account' was not locked with LOCK TABLES");
 		try {
 			$db->read('SELECT 1 FROM account LIMIT 1');
-		} catch (\RuntimeException $err) {
+		} catch (RuntimeException $err) {
 			// Avoid leaving database in a locked state
 			$db->unlock();
 			throw $err;

--- a/test/SmrTest/lib/ShipIntegrationTest.php
+++ b/test/SmrTest/lib/ShipIntegrationTest.php
@@ -36,7 +36,6 @@ class ShipIntegrationTest extends BaseIntegrationSpec {
 			->willReturn(SHIP_TYPE_DEMONICA);
 	}
 
-
 	public function test_getShip(): void {
 		// Get the ship associated with this player
 		$original = Ship::getShip($this->player);
@@ -56,7 +55,6 @@ class ShipIntegrationTest extends BaseIntegrationSpec {
 		// but it is still the same ship
 		self::assertEquals($original, $ship);
 	}
-
 
 	public function test_updateHardware(): void {
 		$original = Ship::getShip($this->player);
@@ -90,7 +88,6 @@ class ShipIntegrationTest extends BaseIntegrationSpec {
 		self::assertEquals($original, $ship);
 	}
 
-
 	public function test_updateWeapons(): void {
 		$original = Ship::getShip($this->player);
 
@@ -123,7 +120,6 @@ class ShipIntegrationTest extends BaseIntegrationSpec {
 		self::assertNotSame($original, $ship);
 		self::assertEquals($original, $ship);
 	}
-
 
 	public function test_updateCargo(): void {
 		$original = Ship::getShip($this->player);
@@ -160,7 +156,6 @@ class ShipIntegrationTest extends BaseIntegrationSpec {
 		self::assertEquals($original, $ship);
 	}
 
-
 	public function test_updateCloak(): void {
 		$original = Ship::getShip($this->player);
 		$original->setHardwareToMax();
@@ -183,7 +178,6 @@ class ShipIntegrationTest extends BaseIntegrationSpec {
 		self::assertNotSame($original, $ship);
 		self::assertEquals($original, $ship);
 	}
-
 
 	public function test_updateIllusion(): void {
 		$original = Ship::getShip($this->player);

--- a/test/SmrTest/lib/TemplateTest.php
+++ b/test/SmrTest/lib/TemplateTest.php
@@ -34,7 +34,7 @@ class TemplateTest extends TestCase {
 		$this->expectExceptionMessage('Cannot re-assign template variable \'foo\'!');
 		try {
 			$template->assign('foo', 'barbar');
-		} catch (\Exception $err) {
+		} catch (Exception $err) {
 			$template->unassign('foo'); // avoid destructor warning
 			throw $err;
 		}


### PR DESCRIPTION
Rector is a refactoring tool. It can help reduce the manual effort
needed for upgrading to new PHP versions or other major libraries.
We add the basic infrastructure for its use, though it will take some
time to get it to the point where we would consider using it in CI.

Add a handful of rules that looked useful. It will be used to upgrade to PHPUnit 10 shortly.

Also removed some phpcs sniff exclusions.