### PR TITLE
Redact account passwords from error logs

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -125,6 +125,11 @@
         <severity>0</severity>
     </rule>
 
+    <!-- Conflicts with PSR2R.Namespaces.NoInlineFullyQualifiedClassName.Signature -->
+    <rule ref="Spryker.Commenting.Attributes.ExpectedFQCN">
+        <severity>0</severity>
+    </rule>
+
     <!-- Allow assignment in else-if where it is really needed. -->
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition">
         <exclude-pattern>src/templates/Default/engine/Default/alliance_roster\.php</exclude-pattern>

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -36,8 +36,17 @@ function logException(Throwable $err): void {
 	}
 
 	// Don't display passwords input by users in the log message!
-	if (isset($_REQUEST['password'])) {
-		$_REQUEST['password'] = '*****';
+	$sensitiveRequestFields = [
+		'password',
+		'pass_verify',
+		'old_password',
+		'new_password',
+		'retype_password',
+	];
+	foreach ($sensitiveRequestFields as $field) {
+		if (isset($_REQUEST[$field])) {
+			$_REQUEST[$field] = '*****';
+		}
 	}
 	$message .= '$_REQUEST: ' . var_export($_REQUEST, true);
 	$message .= $delim;

--- a/src/lib/Smr/Account.php
+++ b/src/lib/Smr/Account.php
@@ -3,6 +3,7 @@
 namespace Smr;
 
 use Exception;
+use SensitiveParameter;
 use Smr\Exceptions\AccountNotFound;
 use Smr\Exceptions\UserError;
 use Smr\Pages\Account\HallOfFamePersonal;
@@ -185,7 +186,7 @@ class Account {
 		throw new AccountNotFound('Account social login not found.');
 	}
 
-	public static function createAccount(string $login, string $password, string $email, int $timez, int $referral): self {
+	public static function createAccount(string $login, #[SensitiveParameter] string $password, string $email, int $timez, int $referral): self {
 		if ($referral != 0) {
 			// Will throw if referral account doesn't exist
 			self::getAccount($referral);
@@ -970,7 +971,7 @@ class Account {
 	 * Check if the given (plain-text) password is correct.
 	 * Updates the password hash if necessary.
 	 */
-	public function checkPassword(string $password): bool {
+	public function checkPassword(#[SensitiveParameter] string $password): bool {
 		// New (safe) password hashes will start with a $, but accounts logging
 		// in for the first time since the transition from md5 will still have
 		// hex-only hashes.
@@ -993,7 +994,7 @@ class Account {
 	/**
 	 * Set the (plain-text) password for this account.
 	 */
-	public function setPassword(string $password): void {
+	public function setPassword(#[SensitiveParameter] string $password): void {
 		$hash = password_hash($password, PASSWORD_DEFAULT);
 		if ($this->passwordHash === $hash) {
 			return;


### PR DESCRIPTION
* Use the PHP 8.2 SensitiveParameter attribute to prevent account passwords from being included in backtraces.

* Use a more comprehensive list of request fields that can include account passwords, which get redacted when dumping `$_REQUEST` in `logException`.