### PR TITLE
Upgrade to PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,8 +81,8 @@
 		"fig-r/psr2r-sniffer": "1.4.0",
 		"overtrue/phplint": "6.1.0",
 		"phpstan/phpstan": "1.9.17",
-		"phpunit/phpunit": "9.5.28",
-		"phpunit/php-code-coverage": "9.2.20",
+		"phpunit/phpunit": "10.0.7",
+		"phpunit/php-code-coverage": "10.0.0",
 		"rector/rector": "0.15.13",
 		"squizlabs/php_codesniffer": "3.7.1"
 	}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.4/phpunit.xsd"
-	beStrictAboutTodoAnnotatedTests="true"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+	beStrictAboutChangesToGlobalState="true"
 	bootstrap="src/bootstrap.php"
-	cacheResultFile=".phpunit.cache/test-results"
+	cacheDirectory=".phpunit.cache"
 	colors="true"
-	convertDeprecationsToExceptions="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
 	executionOrder="depends,defects"
 	failOnRisky="true"
 	failOnWarning="true"
-	forceCoversAnnotation="true"
-	verbose="true">
+	requireCoverageMetadata="true">
 	<testsuites>
 		<testsuite name="default">
 			<directory suffix="Test.php">test</directory>
@@ -20,16 +22,17 @@
 	<php>
 		<env name="DISABLE_PHPDI_COMPILATION" value="true" force="true" />
 	</php>
-	<coverage
-		cacheDirectory=".phpunit.cache/code-coverage"
-		includeUncoveredFiles="true">
+	<coverage includeUncoveredFiles="true">
 		<include>
 			<directory suffix=".php">src/lib</directory>
 		</include>
 		<report>
 			<clover outputFile="test/coverage/clover.xml" />
 			<text outputFile="php://stdout" showOnlySummary="true" />
-			<html outputDirectory="test/coverage/html" />
+			<html
+				outputDirectory="test/coverage/html"
+				customCssFile="test/coverage-report.css"
+			/>
 		</report>
 	</coverage>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,7 @@ use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
 use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
 	$rectorConfig->paths([
@@ -13,9 +14,14 @@ return static function (RectorConfig $rectorConfig): void {
 		__DIR__ . '/src',
 	]);
 	$rectorConfig->importNames(true, false);
+
 	$rectorConfig->rule(DirNameFileConstantToDirConstantRector::class);
 	$rectorConfig->rule(JsonThrowOnErrorRector::class);
 	$rectorConfig->rule(NullCoalescingOperatorRector::class);
 	$rectorConfig->rule(ClassOnObjectRector::class);
 	$rectorConfig->rule(FirstClassCallableRector::class);
+
+	$rectorConfig->sets([
+		PHPUnitSetList::PHPUNIT_100,
+	]);
 };

--- a/test/SmrTest/BaseIntegrationSpec.php
+++ b/test/SmrTest/BaseIntegrationSpec.php
@@ -5,6 +5,9 @@ namespace SmrTest;
 use Exception;
 use mysqli;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
 
@@ -24,9 +27,8 @@ abstract class BaseIntegrationSpec extends TestCase {
 
 	/**
 	 * Get checksums for the initial state of the database tables.
-	 *
-	 * @beforeClass
 	 */
+	#[BeforeClass]
 	final public static function initializeTableRowCounts(): void {
 		if (!isset(self::$conn)) {
 			self::$conn = DiContainer::make(mysqli::class);
@@ -38,9 +40,8 @@ abstract class BaseIntegrationSpec extends TestCase {
 	 * Any table that is modified during a test class should be declared in the
 	 * `tablesToTruncate()` method, and those tables will be reset after each
 	 * test method.
-	 *
-	 * @after
 	 */
+	#[After]
 	final protected function truncateTables(): void {
 		foreach ($this->tablesToTruncate() as $name) {
 			// Include hard-coded test database name as a safety precaution
@@ -52,9 +53,8 @@ abstract class BaseIntegrationSpec extends TestCase {
 	 * All modified tables should be reset after each test, but here we perform
 	 * a final sanity check to make sure that no tables have changed checksums.
 	 * This is only done once per class because it is expensive!
-	 *
-	 * @afterClass
 	 */
+	#[AfterClass]
 	final public static function checkTables(): void {
 		$checksums = self::getChecksums();
 		$errors = [];

--- a/test/SmrTest/Container/DiContainerTest.php
+++ b/test/SmrTest/Container/DiContainerTest.php
@@ -2,13 +2,13 @@
 
 namespace SmrTest\Container;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
 use Smr\DatabaseProperties;
 
-/**
- * @covers \Smr\Container\DiContainer
- */
+#[CoversClass(DiContainer::class)]
 class DiContainerTest extends TestCase {
 
 	private const PHPDI_COMPILED_CONTAINER_FILE = '/tmp/CompiledContainer.php';
@@ -60,9 +60,7 @@ class DiContainerTest extends TestCase {
 		self::assertSame($dbName, 'smr_live_test');
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 */
+	#[RunInSeparateProcess]
 	public function test_initialized(): void {
 		// Note that we need to run in a separate process since this is the
 		// only way to ensure that the DiContainer is not yet initialized

--- a/test/SmrTest/Container/ResettableContainerTraitTest.php
+++ b/test/SmrTest/Container/ResettableContainerTraitTest.php
@@ -2,12 +2,12 @@
 
 namespace SmrTest\Container;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\ResettableContainer;
+use Smr\Container\ResettableContainerTrait;
 
-/**
- * @covers \Smr\Container\ResettableContainerTrait
- */
+#[CoversClass(ResettableContainerTrait::class)]
 class ResettableContainerTraitTest extends TestCase {
 
 	public function test_not_initialized_by_definition(): void {

--- a/test/SmrTest/PhpFileInspectionTest.php
+++ b/test/SmrTest/PhpFileInspectionTest.php
@@ -3,11 +3,10 @@
 namespace SmrTest;
 
 use Overtrue\PHPLint\Linter;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversNothing
- */
+#[CoversNothing]
 class PhpFileInspectionTest extends TestCase {
 
 	public function test_all_files_pass_phplint(): void {

--- a/test/SmrTest/lib/AbstractPlayerIntegrationTest.php
+++ b/test/SmrTest/lib/AbstractPlayerIntegrationTest.php
@@ -2,15 +2,15 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Smr\AbstractPlayer;
 use Smr\Exceptions\PlayerNotFound;
 use Smr\Exceptions\UserError;
 use Smr\Game;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\AbstractPlayer
- */
+#[CoversClass(AbstractPlayer::class)]
 class AbstractPlayerIntegrationTest extends BaseIntegrationSpec {
 
 	private static int $gameID = 42;
@@ -134,9 +134,7 @@ class AbstractPlayerIntegrationTest extends BaseIntegrationSpec {
 		self::assertTrue($player->isNameChanged());
 	}
 
-	/**
-	 * @dataProvider dataProvider_alignment
-	 */
+	#[DataProvider('dataProvider_alignment')]
 	public function test_alignment(int $alignment, bool $isGood, bool $isEvil, bool $isNeutral): void {
 		// Create a player with a specific alignment
 		$player = AbstractPlayer::createPlayer(1, self::$gameID, 'test', RACE_HUMAN, false);
@@ -152,7 +150,7 @@ class AbstractPlayerIntegrationTest extends BaseIntegrationSpec {
 	/**
 	 * @return array<array{int, bool, bool, bool}>
 	 */
-	public function dataProvider_alignment(): array {
+	public static function dataProvider_alignment(): array {
 		// Test at, above, and below alignment thresholds
 		return [
 			[0, false, false, true],

--- a/test/SmrTest/lib/AbstractShipTest.php
+++ b/test/SmrTest/lib/AbstractShipTest.php
@@ -3,6 +3,8 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Smr\AbstractPlayer;
@@ -12,9 +14,8 @@ use Smr\ShipIllusion;
 
 /**
  * This test is expected to not make any changes to the database.
- *
- * @covers Smr\AbstractShip
  */
+#[CoversClass(AbstractShip::class)]
 class AbstractShipTest extends TestCase {
 
 	private AbstractPlayer&MockObject $player; // will be mocked
@@ -185,11 +186,10 @@ class AbstractShipTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataProvider_takeDamage
-	 *
 	 * @param WeaponDamageData $damage
 	 * @param TakenDamageData $expected
 	 */
+	#[DataProvider('dataProvider_takeDamage')]
 	public function test_takeDamage(string $case, array $damage, array $expected, int $shields, int $cds, int $armour): void {
 		// Set up a ship with a fixed amount of defenses
 		$this->player
@@ -207,7 +207,7 @@ class AbstractShipTest extends TestCase {
 	/**
 	 * @return array<array{0: string, 1: WeaponDamageData, 2: TakenDamageData, 3: int, 4: int, 5: int}>
 	 */
-	public function dataProvider_takeDamage(): array {
+	public static function dataProvider_takeDamage(): array {
 		return [
 			[
 				'Do overkill damage (e.g. 1000 drone damage)',
@@ -365,10 +365,9 @@ class AbstractShipTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataProvider_takeDamageFromMines
-	 *
 	 * @param TakenDamageData $expected
 	 */
+	#[DataProvider('dataProvider_takeDamageFromMines')]
 	public function test_takeDamageFromMines(string $case, int $damage, array $expected, int $shields, int $cds, int $armour): void {
 		// Set up a ship with a fixed amount of defenses
 		$this->player
@@ -391,7 +390,7 @@ class AbstractShipTest extends TestCase {
 	/**
 	 * @return array<array{0: string, 1: int, 2: TakenDamageData, 3: int, 4: int, 5: int}>
 	 */
-	public function dataProvider_takeDamageFromMines(): array {
+	public static function dataProvider_takeDamageFromMines(): array {
 		return [
 			[
 				'Do overkill damage (e.g. 1000 mine damage)',

--- a/test/SmrTest/lib/AccountTest.php
+++ b/test/SmrTest/lib/AccountTest.php
@@ -2,14 +2,13 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\Account;
 use Smr\Exceptions\AccountNotFound;
 use Smr\SocialLogin\Facebook;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\Account
- */
+#[CoversClass(Account::class)]
 class AccountTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {

--- a/test/SmrTest/lib/AdminPermissionsTest.php
+++ b/test/SmrTest/lib/AdminPermissionsTest.php
@@ -2,13 +2,12 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\AdminPermissions;
 use Smr\Pages\Admin\EnableGame;
 
-/**
- * @covers Smr\AdminPermissions
- */
+#[CoversClass(AdminPermissions::class)]
 class AdminPermissionsTest extends TestCase {
 
 	public function test_getPermissionInfo(): void {

--- a/test/SmrTest/lib/AllianceIntegrationTest.php
+++ b/test/SmrTest/lib/AllianceIntegrationTest.php
@@ -2,14 +2,13 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\Alliance;
 use Smr\Exceptions\AllianceNotFound;
 use Smr\Exceptions\UserError;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\Alliance
- */
+#[CoversClass(Alliance::class)]
 class AllianceIntegrationTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {

--- a/test/SmrTest/lib/BarDrinkTest.php
+++ b/test/SmrTest/lib/BarDrinkTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\BarDrink;
 
-/**
- * @covers Smr\BarDrink
- */
+#[CoversClass(BarDrink::class)]
 class BarDrinkTest extends TestCase {
 
 	public function test_getAll(): void {

--- a/test/SmrTest/lib/Blackjack/CardTest.php
+++ b/test/SmrTest/lib/Blackjack/CardTest.php
@@ -2,12 +2,12 @@
 
 namespace SmrTest\lib\Blackjack;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Smr\Blackjack\Card;
 
-/**
- * @covers Smr\Blackjack\Card
- */
+#[CoversClass(Card::class)]
 class CardTest extends TestCase {
 
 	public function test_getCardID(): void {
@@ -34,9 +34,7 @@ class CardTest extends TestCase {
 		}
 	}
 
-	/**
-	 * @dataProvider card_details_provider
-	 */
+	#[DataProvider('card_details_provider')]
 	public function test_card_details(int $cardID, string $rankName, string $suitName, int $value): void {
 		// check various details of a card
 		$card = new Card($cardID);
@@ -48,7 +46,7 @@ class CardTest extends TestCase {
 	/**
 	 * @return array<array{int, string, string, int}>
 	 */
-	public function card_details_provider(): array {
+	public static function card_details_provider(): array {
 		// spot check a handful of cards
 		return [
 			[0, 'A', 'hearts', 11],

--- a/test/SmrTest/lib/Blackjack/DeckTest.php
+++ b/test/SmrTest/lib/Blackjack/DeckTest.php
@@ -3,12 +3,11 @@
 namespace SmrTest\lib\Blackjack;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Blackjack\Deck;
 
-/**
- * @covers Smr\Blackjack\Deck
- */
+#[CoversClass(Deck::class)]
 class DeckTest extends TestCase {
 
 	public function test_drawCard(): void {

--- a/test/SmrTest/lib/Blackjack/HandTest.php
+++ b/test/SmrTest/lib/Blackjack/HandTest.php
@@ -2,13 +2,12 @@
 
 namespace SmrTest\lib\Blackjack;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Blackjack\Card;
 use Smr\Blackjack\Hand;
 
-/**
- * @covers Smr\Blackjack\Hand
- */
+#[CoversClass(Hand::class)]
 class HandTest extends TestCase {
 
 	public function test_getValue(): void {

--- a/test/SmrTest/lib/Blackjack/TableTest.php
+++ b/test/SmrTest/lib/Blackjack/TableTest.php
@@ -2,14 +2,14 @@
 
 namespace SmrTest\lib\Blackjack;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\Blackjack\Card;
 use Smr\Blackjack\Result;
 use Smr\Blackjack\Table;
 
-/**
- * @covers Smr\Blackjack\Table
- */
+#[CoversClass(Table::class)]
 class TableTest extends TestCase {
 
 	public function test_initial_state(): void {
@@ -59,11 +59,13 @@ class TableTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider provider_gameOver
-	 *
 	 * @param array<int> $playerCardIDs
 	 * @param array<int> $dealerCardIDs
 	 */
+	#[TestWith([[12, 13], [], true])] // player 21, dealer 0
+	#[TestWith([[], [12, 13], true])] // player 0, dealer 21
+	#[TestWith([[12, 13], [12, 13], true])] // player 21, dealer 21
+	#[TestWith([[12, 12], [12, 12], false])] // player 20, dealer 20
 	public function test_gameOver(array $playerCardIDs, array $dealerCardIDs, bool $expected): void {
 		$table = new Table(false);
 		foreach ($playerCardIDs as $cardID) {
@@ -76,23 +78,17 @@ class TableTest extends TestCase {
 	}
 
 	/**
-	 * @return array<array{array<int>, array<int>, bool}>
-	 */
-	public function provider_gameOver(): array {
-		return [
-			[[12, 13], [], true], // player 21, dealer 0
-			[[], [12, 13], true], // player 0, dealer 21
-			[[12, 13], [12, 13], true], // player 21, dealer 21
-			[[12, 12], [12, 12], false], // player 20, dealer 20
-		];
-	}
-
-	/**
-	 * @dataProvider provider_getPlayerResult
-	 *
 	 * @param array<int> $playerCardIDs
 	 * @param array<int> $dealerCardIDs
 	 */
+	#[TestWith([[12, 13], [], Result::Blackjack])] // player has blackjack
+	#[TestWith([[12, 13], [12, 13], Result::Blackjack])] // both blackjack, player takes precedence
+	#[TestWith([[12], [12], Result::Tie])] // equal score, no one busted
+	#[TestWith([[12, 12, 12], [], Result::Lose])] // player busts, dealer does not
+	#[TestWith([[], [12, 12, 12], Result::Win])] // dealer busts, player does not
+	#[TestWith([[12, 12, 12], [12, 12, 12], Result::Lose])] // both bust, player takes precedence
+	#[TestWith([[13], [12], Result::Win])] // player higher score, no one busted
+	#[TestWith([[12], [13], Result::Lose])] // dealer higher score, no one busted
 	public function test_getPlayerResult(array $playerCardIDs, array $dealerCardIDs, Result $expected): void {
 		$table = new Table(false);
 		foreach ($playerCardIDs as $cardID) {
@@ -102,22 +98,6 @@ class TableTest extends TestCase {
 			$table->dealerHand->addCard(new Card($cardID));
 		}
 		self::assertSame($expected, $table->getPlayerResult());
-	}
-
-	/**
-	 * @return array<array{array<int>, array<int>, Result}>
-	 */
-	public function provider_getPlayerResult(): array {
-		return [
-			[[12, 13], [], Result::Blackjack], // player has blackjack
-			[[12, 13], [12, 13], Result::Blackjack], // both blackjack, player takes precedence
-			[[12], [12], Result::Tie], // equal score, no one busted
-			[[12, 12, 12], [], Result::Lose], // player busts, dealer does not
-			[[], [12, 12, 12], Result::Win], // dealer busts, player does not
-			[[12, 12, 12], [12, 12, 12], Result::Lose], // both bust, player takes precedence
-			[[13], [12], Result::Win], // player higher score, no one busted
-			[[12], [13], Result::Lose], // dealer higher score, no one busted
-		];
 	}
 
 }

--- a/test/SmrTest/lib/BountyTest.php
+++ b/test/SmrTest/lib/BountyTest.php
@@ -2,15 +2,14 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\AbstractPlayer;
 use Smr\Bounty;
 use Smr\BountyType;
 use Smr\Database;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\Bounty
- */
+#[CoversClass(Bounty::class)]
 class BountyTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {

--- a/test/SmrTest/lib/BuyerRestrictionTest.php
+++ b/test/SmrTest/lib/BuyerRestrictionTest.php
@@ -2,13 +2,12 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\AbstractPlayer;
 use Smr\BuyerRestriction;
 
-/**
- * @covers Smr\BuyerRestriction
- */
+#[CoversClass(BuyerRestriction::class)]
 class BuyerRestrictionTest extends TestCase {
 
 	private static bool $original_libxml_use_internal_errors;

--- a/test/SmrTest/lib/Chess/BoardTest.php
+++ b/test/SmrTest/lib/Chess/BoardTest.php
@@ -3,6 +3,8 @@
 namespace SmrTest\lib\Chess;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\Chess\Board;
 use Smr\Chess\Castling;
@@ -10,9 +12,7 @@ use Smr\Chess\ChessGame;
 use Smr\Chess\ChessPiece;
 use Smr\Chess\Colour;
 
-/**
- * @covers Smr\Chess\Board
- */
+#[CoversClass(Board::class)]
 class BoardTest extends TestCase {
 
 	public function test_getFEN(): void {
@@ -34,14 +34,12 @@ class BoardTest extends TestCase {
 		self::assertSame(Colour::Black, $board->getCurrentTurnColour());
 	}
 
-	/**
-	 * @testWith [0, 0, true]
-	 *           [7, 7, true]
-	 *           [-1, 0, false]
-	 *           [0, -1, false]
-	 *           [8, 0, false]
-	 *           [0, 8, false]
-	 */
+	#[TestWith([0, 0, true])]
+	#[TestWith([7, 7, true])]
+	#[TestWith([-1, 0, false])]
+	#[TestWith([0, -1, false])]
+	#[TestWith([8, 0, false])]
+	#[TestWith([0, 8, false])]
 	public function test_isValidCoord(int $x, int $y, bool $valid): void {
 		self::assertSame($valid, Board::isValidCoord($x, $y));
 	}
@@ -113,9 +111,8 @@ class BoardTest extends TestCase {
 		}
 	}
 
-	/**
-	 * @dataProvider dataProvider_canCastle_move_rook
-	 */
+	#[TestWith([Castling::Kingside])]
+	#[TestWith([Castling::Queenside])]
 	public function test_canCastle_move_rook(Castling $type): void {
 		// Moving Rook disables castling only on that side
 		$board = new Board();
@@ -135,16 +132,6 @@ class BoardTest extends TestCase {
 			self::assertFalse($board->canCastle($colour, $type));
 			self::assertTrue($board->canCastle($colour, $otherType));
 		}
-	}
-
-	/**
-	 * @return array<array{0: Castling}>
-	 */
-	public function dataProvider_canCastle_move_rook(): array {
-		return [
-			[Castling::Kingside],
-			[Castling::Queenside],
-		];
 	}
 
 	public function test_getEnPassantPawn(): void {

--- a/test/SmrTest/lib/Chess/ColourTest.php
+++ b/test/SmrTest/lib/Chess/ColourTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib\Chess;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Chess\Colour;
 
-/**
- * @covers Smr\Chess\Colour
- */
+#[CoversClass(Colour::class)]
 class ColourTest extends TestCase {
 
 	public function test_opposite(): void {

--- a/test/SmrTest/lib/Combat/Weapon/CombatDronesTest.php
+++ b/test/SmrTest/lib/Combat/Weapon/CombatDronesTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib\Combat\Weapon;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Combat\Weapon\CombatDrones;
 
-/**
- * @covers Smr\Combat\Weapon\CombatDrones
- */
+#[CoversClass(CombatDrones::class)]
 class CombatDronesTest extends TestCase {
 
 	public function test_getAmount(): void {

--- a/test/SmrTest/lib/Combat/Weapon/MinesTest.php
+++ b/test/SmrTest/lib/Combat/Weapon/MinesTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib\Combat\Weapon;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Combat\Weapon\Mines;
 
-/**
- * @covers Smr\Combat\Weapon\Mines
- */
+#[CoversClass(Mines::class)]
 class MinesTest extends TestCase {
 
 	public function test_getAmount(): void {

--- a/test/SmrTest/lib/Combat/Weapon/ScoutDronesTest.php
+++ b/test/SmrTest/lib/Combat/Weapon/ScoutDronesTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib\Combat\Weapon;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Combat\Weapon\ScoutDrones;
 
-/**
- * @covers Smr\Combat\Weapon\ScoutDrones
- */
+#[CoversClass(ScoutDrones::class)]
 class ScoutDronesTest extends TestCase {
 
 	public function test_getAmount(): void {

--- a/test/SmrTest/lib/CreateNHATest.php
+++ b/test/SmrTest/lib/CreateNHATest.php
@@ -2,14 +2,13 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversFunction;
 use Smr\Alliance;
 use SmrTest\BaseIntegrationSpec;
 
 require_once(LIB . 'Default/nha.inc.php');
 
-/**
- * @covers ::createNHA
- */
+#[CoversFunction('createNHA')]
 class CreateNHATest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {

--- a/test/SmrTest/lib/DatabaseInsertTest.php
+++ b/test/SmrTest/lib/DatabaseInsertTest.php
@@ -2,6 +2,7 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Database;
 
@@ -9,9 +10,8 @@ use Smr\Database;
  * This is an extension of DatabaseIntegrationTest. It is separate due to the
  * need for specific setUp and tearDown functions (which we do not want to use
  * for every other DatabaseIntegrationTest method).
- *
- * @covers \Smr\Database
  */
+#[CoversClass(Database::class)]
 class DatabaseInsertTest extends TestCase {
 
 	protected function setUp(): void {

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -4,6 +4,7 @@ namespace SmrTest\lib;
 
 use Error;
 use mysqli;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Smr\Container\DiContainer;
@@ -12,9 +13,8 @@ use Smr\DatabaseProperties;
 
 /**
  * This is an integration test, but does not need to extend BaseIntegrationTest since we are not writing any data.
- *
- * @covers \Smr\Database
  */
+#[CoversClass(Database::class)]
 class DatabaseIntegrationTest extends TestCase {
 
 	protected function setUp(): void {

--- a/test/SmrTest/lib/DatabasePropertiesTest.php
+++ b/test/SmrTest/lib/DatabasePropertiesTest.php
@@ -3,12 +3,12 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\DatabaseProperties;
 
-/**
- * @covers \Smr\DatabaseProperties
- */
+#[CoversClass(DatabaseProperties::class)]
 class DatabasePropertiesTest extends TestCase {
 
 	private const MYSQL_PASSWORD_FILE = '/tmp/phpunit_dummy_mysql_password';
@@ -72,12 +72,10 @@ class DatabasePropertiesTest extends TestCase {
 		self::assertEquals('database', $dbProperties->database);
 	}
 
-	/**
-	 * @testWith ["MYSQL_HOST"]
-	 *           ["MYSQL_USER"]
-	 *           ["MYSQL_DATABASE"]
-	 *           ["MYSQL_PASSWORD_FILE"]
-	 */
+	#[TestWith(['MYSQL_HOST'])]
+	#[TestWith(['MYSQL_USER'])]
+	#[TestWith(['MYSQL_DATABASE'])]
+	#[TestWith(['MYSQL_PASSWORD_FILE'])]
 	public function test_missing_environment_variable(string $name): void {
 		// Unset one of the required environment variables
 		putenv($name);

--- a/test/SmrTest/lib/DatabaseRecordTest.php
+++ b/test/SmrTest/lib/DatabaseRecordTest.php
@@ -4,13 +4,13 @@ namespace SmrTest\lib;
 
 use ArrayObject;
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\DatabaseRecord;
 use TypeError;
 
-/**
- * @covers \Smr\DatabaseRecord
- */
+#[CoversClass(DatabaseRecord::class)]
 class DatabaseRecordTest extends TestCase {
 
 	public function test_getNullableString(): void {
@@ -79,25 +79,14 @@ class DatabaseRecordTest extends TestCase {
 		self::assertSame(3, $record->getInt('name'));
 	}
 
-	/**
-	 * @dataProvider provider_getInt_with_non_int_field
-	 */
+	#[TestWith(['1a', 'Failed to convert \'1a\' to int'])]
+	#[TestWith(['3.14', 'Failed to convert \'3.14\' to int'])]
+	#[TestWith([null, 'Failed to convert NULL to int'])]
 	public function test_getInt_with_non_int_field(mixed $value, string $error): void {
 		$record = new DatabaseRecord(['name' => $value]);
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage($error);
 		$record->getInt('name');
-	}
-
-	/**
-	 * @return array<array{?string, string}>
-	 */
-	public function provider_getInt_with_non_int_field(): array {
-		return [
-			['1a', 'Failed to convert \'1a\' to int'],
-			['3.14', 'Failed to convert \'3.14\' to int'],
-			[null, 'Failed to convert NULL to int'],
-		];
 	}
 
 	//------------------------------------------------------------------------
@@ -107,24 +96,13 @@ class DatabaseRecordTest extends TestCase {
 		self::assertSame(3.14, $record->getFloat('name'));
 	}
 
-	/**
-	 * @dataProvider provider_getFloat_with_non_float_field
-	 */
+	#[TestWith(['1a', 'Failed to convert \'1a\' to float'])]
+	#[TestWith([null, 'Failed to convert NULL to float'])]
 	public function test_getFloat_with_non_float_field(mixed $value, string $error): void {
 		$record = new DatabaseRecord(['name' => $value]);
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage($error);
 		$record->getFloat('name');
-	}
-
-	/**
-	 * @return array<array{?string, string}>
-	 */
-	public function provider_getFloat_with_non_float_field(): array {
-		return [
-			['1a', 'Failed to convert \'1a\' to float'],
-			[null, 'Failed to convert NULL to float'],
-		];
 	}
 
 	//------------------------------------------------------------------------

--- a/test/SmrTest/lib/DatabaseResultTest.php
+++ b/test/SmrTest/lib/DatabaseResultTest.php
@@ -2,14 +2,13 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Smr\Database;
 use Smr\DatabaseResult;
 
-/**
- * @covers \Smr\DatabaseResult
- */
+#[CoversClass(DatabaseResult::class)]
 class DatabaseResultTest extends TestCase {
 
 	/**

--- a/test/SmrTest/lib/Discord/CommandTest.php
+++ b/test/SmrTest/lib/Discord/CommandTest.php
@@ -6,14 +6,14 @@ use Discord\CommandClient\Command as DiscordCommand;
 use Discord\DiscordCommandClient;
 use Discord\Parts\Channel\Message;
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use React\Promise\ExtendedPromiseInterface;
+use Smr\Discord\Command;
 use Smr\Discord\Commands\MagicEightBall;
 use Smr\Exceptions\UserError;
 
-/**
- * @covers Smr\Discord\Command
- */
+#[CoversClass(Command::class)]
 class CommandTest extends TestCase {
 
 	public function test_callback_happy_path(): void {

--- a/test/SmrTest/lib/DisplayNameValidatorTest.php
+++ b/test/SmrTest/lib/DisplayNameValidatorTest.php
@@ -2,18 +2,16 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Smr\DisplayNameValidator;
 use Smr\Exceptions\UserError;
 
-/**
- * @covers Smr\DisplayNameValidator
- */
+#[CoversClass(DisplayNameValidator::class)]
 class DisplayNameValidatorTest extends TestCase {
 
-	/**
-	 * @dataProvider invalid_name_provider
-	 */
+	#[DataProvider('invalid_name_provider')]
 	public function test_invalid_name(string $name, string $exception): void {
 		$this->expectException(UserError::class);
 		$this->expectExceptionMessage($exception);
@@ -23,7 +21,7 @@ class DisplayNameValidatorTest extends TestCase {
 	/**
 	 * @return array<array{string, string}>
 	 */
-	public function invalid_name_provider(): array {
+	public static function invalid_name_provider(): array {
 		return [
 			// empty string
 			['', 'You must enter a name!'],
@@ -43,9 +41,7 @@ class DisplayNameValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider valid_name_provider
-	 */
+	#[DataProvider('valid_name_provider')]
 	public function test_valid_name(string $name): void {
 		// test that an exception is not thrown
 		DisplayNameValidator::validate($name);
@@ -55,7 +51,7 @@ class DisplayNameValidatorTest extends TestCase {
 	/**
 	 * @return array<array<string>>
 	 */
-	public function valid_name_provider(): array {
+	public static function valid_name_provider(): array {
 		return [
 			// normal alphanumeric
 			['aBc123'],

--- a/test/SmrTest/lib/EnhancedWeaponEventTest.php
+++ b/test/SmrTest/lib/EnhancedWeaponEventTest.php
@@ -2,6 +2,7 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClassConstant;
 use Smr\Container\DiContainer;
 use Smr\EnhancedWeaponEvent;
@@ -9,9 +10,7 @@ use Smr\Epoch;
 use Smr\Location;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\EnhancedWeaponEvent
- */
+#[CoversClass(EnhancedWeaponEvent::class)]
 class EnhancedWeaponEventTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {

--- a/test/SmrTest/lib/EpochTest.php
+++ b/test/SmrTest/lib/EpochTest.php
@@ -3,13 +3,12 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
 use Smr\Epoch;
 
-/**
- * @covers Smr\Epoch
- */
+#[CoversClass(Epoch::class)]
 class EpochTest extends TestCase {
 
 	protected function tearDown(): void {

--- a/test/SmrTest/lib/ForceTest.php
+++ b/test/SmrTest/lib/ForceTest.php
@@ -2,15 +2,16 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\AbstractShip;
 use Smr\Force;
 use Smr\Galaxy;
 use SmrTest\TestUtils;
 
-/**
- * @covers Smr\Force
- */
+#[CoversClass(Force::class)]
 class ForceTest extends TestCase {
 
 	private Force $force;
@@ -27,9 +28,14 @@ class ForceTest extends TestCase {
 		self::assertSame(3, $this->force->getOwnerID());
 	}
 
-	/**
-	 * @dataProvider provider_getBumpTurnCost
-	 */
+	#[TestWith([0, false, 0])]
+	#[TestWith([0, true, 0])]
+	#[TestWith([9, false, 1])]
+	#[TestWith([9, true, 0])]
+	#[TestWith([24, false, 2])]
+	#[TestWith([24, true, 1])]
+	#[TestWith([25, false, 3])]
+	#[TestWith([25, true, 2])]
 	public function test_getBumpTurnCost(int $mines, bool $hasDCS, int $expected): void {
 		$this->force->setMines($mines);
 		$ship = $this->createPartialMock(AbstractShip::class, ['hasDCS', 'isFederal']);
@@ -38,40 +44,13 @@ class ForceTest extends TestCase {
 		self::assertSame($expected, $this->force->getBumpTurnCost($ship));
 	}
 
-	/**
-	 * @return array<array{int, bool, int}>
-	 */
-	public function provider_getBumpTurnCost(): array {
-		return [
-			[0, false, 0],
-			[0, true, 0],
-			[9, false, 1],
-			[9, true, 0],
-			[24, false, 2],
-			[24, true, 1],
-			[25, false, 3],
-			[25, true, 2],
-		];
-	}
-
-	/**
-	 * @dataProvider provider_getAttackTurnCost
-	 */
+	#[TestWith([false, 3])]
+	#[TestWith([true, 2])]
 	public function test_getAttackTurnCost(bool $hasDCS, int $expected): void {
 		$ship = $this->createPartialMock(AbstractShip::class, ['hasDCS', 'isFederal']);
 		$ship->method('hasDCS')->willReturn($hasDCS);
 		$ship->method('isFederal')->willReturn(false); // redundant with hasDCS
 		self::assertSame($expected, $this->force->getAttackTurnCost($ship));
-	}
-
-	/**
-	 * @return array<array{bool, int}>
-	 */
-	public function provider_getAttackTurnCost(): array {
-		return [
-			[false, 3],
-			[true, 2],
-		];
 	}
 
 	public function test_add_and_take_SDs(): void {
@@ -114,11 +93,10 @@ class ForceTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataProvider_takeDamage
-	 *
 	 * @param WeaponDamageData $damage
 	 * @param ForceTakenDamageData $expected
 	 */
+	#[DataProvider('dataProvider_takeDamage')]
 	public function test_takeDamage(string $case, array $damage, array $expected, int $mines, int $cds, int $sds): void {
 		// Set up an unexpired stack with a specific number of forces
 		$force = $this->createPartialMock($this->force::class, ['hasExpired']);
@@ -134,7 +112,7 @@ class ForceTest extends TestCase {
 	/**
 	 * @return array<array{0: string, 1: WeaponDamageData, 2: ForceTakenDamageData, 3: int, 4: int, 5: int}>
 	 */
-	public function dataProvider_takeDamage(): array {
+	public static function dataProvider_takeDamage(): array {
 		return [
 			[
 				'Do overkill damage (e.g. 1000 drone damage)',
@@ -300,9 +278,7 @@ class ForceTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataProvider_getMaxExpireTime
-	 */
+	#[DataProvider('dataProvider_getMaxExpireTime')]
 	public function test_getMaxExpireTime(int $sds, int $cds, int $mines, int $galMaxForceTime, int $expected): void {
 		// Stub the galaxy that this force is inside
 		$galaxy = $this->createStub(Galaxy::class);
@@ -322,7 +298,7 @@ class ForceTest extends TestCase {
 	/**
 	 * @return array<array<int>>
 	 */
-	public function dataProvider_getMaxExpireTime(): array {
+	public static function dataProvider_getMaxExpireTime(): array {
 		$above = Force::LOWEST_MAX_EXPIRE_SCOUTS_ONLY + 1;
 		$below = Force::LOWEST_MAX_EXPIRE_SCOUTS_ONLY - 1;
 		return [

--- a/test/SmrTest/lib/GalaxyTest.php
+++ b/test/SmrTest/lib/GalaxyTest.php
@@ -2,14 +2,13 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\Exceptions\GalaxyNotFound;
 use Smr\Galaxy;
 use Smr\Sector;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\Galaxy
- */
+#[CoversClass(Galaxy::class)]
 class GalaxyTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {

--- a/test/SmrTest/lib/GameIntegrationTest.php
+++ b/test/SmrTest/lib/GameIntegrationTest.php
@@ -2,14 +2,13 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\Game;
 use Smr\Globals;
 use Smr\Race;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\Game
- */
+#[CoversClass(Game::class)]
 class GameIntegrationTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {

--- a/test/SmrTest/lib/HardwareTypeTest.php
+++ b/test/SmrTest/lib/HardwareTypeTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\HardwareType;
 
-/**
- * @covers Smr\HardwareType
- */
+#[CoversClass(HardwareType::class)]
 class HardwareTypeTest extends TestCase {
 
 	public static function setUpBeforeClass(): void {

--- a/test/SmrTest/lib/LocationTest.php
+++ b/test/SmrTest/lib/LocationTest.php
@@ -3,12 +3,12 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\Location;
 
-/**
- * @covers Smr\Location
- */
+#[CoversClass(Location::class)]
 class LocationTest extends TestCase {
 
 	public function test_getLocation_and_basic_properties(): void {
@@ -26,104 +26,49 @@ class LocationTest extends TestCase {
 		Location::getLocation(gameID: 0, locationTypeID: 999);
 	}
 
-	/**
-	 * @dataProvider provider_isFed
-	 */
+	#[TestWith([UNDERGROUND, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_BEACON, true])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_HQ, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_MINT, false])]
 	public function test_isFed(int $typeID, bool $expected): void {
 		$loc = Location::getLocation(gameID: 0, locationTypeID: $typeID);
 		self::assertSame($expected, $loc->isFed());
 	}
 
-	/**
-	 * @return array<array{int, bool}>
-	 */
-	public function provider_isFed(): array {
-		return [
-			[UNDERGROUND, false],
-			[LOCATION_TYPE_FEDERAL_BEACON, true],
-			[LOCATION_TYPE_FEDERAL_HQ, false],
-			[LOCATION_TYPE_FEDERAL_MINT, false],
-		];
-	}
-
-	/**
-	 * @dataProvider provider_isHQ
-	 */
+	#[TestWith([UNDERGROUND, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_BEACON, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_HQ, true])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_MINT, false])]
 	public function test_isHQ(int $typeID, bool $expected): void {
 		$loc = Location::getLocation(gameID: 0, locationTypeID: $typeID);
 		self::assertSame($expected, $loc->isHQ());
 	}
 
-	/**
-	 * @return array<array{int, bool}>
-	 */
-	public function provider_isHQ(): array {
-		return [
-			[UNDERGROUND, false],
-			[LOCATION_TYPE_FEDERAL_BEACON, false],
-			[LOCATION_TYPE_FEDERAL_HQ, true],
-			[LOCATION_TYPE_FEDERAL_MINT, false],
-		];
-	}
-
-	/**
-	 * @dataProvider provider_isBank
-	 */
+	#[TestWith([UNDERGROUND, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_BEACON, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_HQ, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_MINT, true])]
 	public function test_isBank(int $typeID, bool $expected): void {
 		$loc = Location::getLocation(gameID: 0, locationTypeID: $typeID);
 		self::assertSame($expected, $loc->isBank());
 	}
 
-	/**
-	 * @return array<array{int, bool}>
-	 */
-	public function provider_isBank(): array {
-		return [
-			[UNDERGROUND, false],
-			[LOCATION_TYPE_FEDERAL_BEACON, false],
-			[LOCATION_TYPE_FEDERAL_HQ, false],
-			[LOCATION_TYPE_FEDERAL_MINT, true],
-		];
-	}
-
-	/**
-	 * @dataProvider provider_isUG
-	 */
+	#[TestWith([UNDERGROUND, true])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_BEACON, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_HQ, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_MINT, false])]
 	public function test_isUG(int $typeID, bool $expected): void {
 		$loc = Location::getLocation(gameID: 0, locationTypeID: $typeID);
 		self::assertSame($expected, $loc->isUG());
 	}
 
-	/**
-	 * @return array<array{int, bool}>
-	 */
-	public function provider_isUG(): array {
-		return [
-			[UNDERGROUND, true],
-			[LOCATION_TYPE_FEDERAL_BEACON, false],
-			[LOCATION_TYPE_FEDERAL_HQ, false],
-			[LOCATION_TYPE_FEDERAL_MINT, false],
-		];
-	}
-
-	/**
-	 * @dataProvider provider_hasAction
-	 */
+	#[TestWith([UNDERGROUND, true])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_BEACON, false])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_HQ, true])]
+	#[TestWith([LOCATION_TYPE_FEDERAL_MINT, true])]
 	public function test_hasAction(int $typeID, bool $expected): void {
 		$loc = Location::getLocation(gameID: 0, locationTypeID: $typeID);
 		self::assertSame($expected, $loc->hasAction());
-	}
-
-	/**
-	 * @return array<array{int, bool}>
-	 */
-	public function provider_hasAction(): array {
-		return [
-			[UNDERGROUND, true],
-			[LOCATION_TYPE_FEDERAL_BEACON, false],
-			[LOCATION_TYPE_FEDERAL_HQ, true],
-			[LOCATION_TYPE_FEDERAL_MINT, true],
-		];
 	}
 
 	public function test_isShipSold(): void {

--- a/test/SmrTest/lib/PageIntegrationTest.php
+++ b/test/SmrTest/lib/PageIntegrationTest.php
@@ -2,6 +2,8 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\AbstractPlayer;
 use Smr\Container\DiContainer;
@@ -11,9 +13,8 @@ use Smr\Session;
 /**
  * This is an integration test, but does not need to extend BaseIntegrationTest
  * since we are not (or should not be!) writing any data.
- *
- * @covers Smr\Page\Page
  */
+#[CoversClass(Page::class)]
 class PageIntegrationTest extends TestCase {
 
 	protected function setUp(): void {
@@ -42,13 +43,12 @@ class PageIntegrationTest extends TestCase {
 	 * Tests the showUnderAttack method in a variety of scenarios. We test
 	 * consecutive page loads to ensure that a positive result persists
 	 * across page loads (both ajax and non-ajax).
-	 *
-	 * @testWith [true, true, null, false, true, true]
-	 *           [true, false, null, true, true, true]
-	 *           [true, true, null, true, true, true]
-	 *           [false, false, true, true, false, true]
-	 *           [false, true, true, true, false, true]
 	 */
+	#[TestWith([true, true, null, false, true, true])]
+	#[TestWith([true, false, null, true, true, true])]
+	#[TestWith([true, true, null, true, true, true])]
+	#[TestWith([false, false, true, true, false, true])]
+	#[TestWith([false, true, true, true, false, true])]
 	public function test_showUnderAttack(bool $underAttack1, bool $ajax1, ?bool $underAttack2, bool $ajax2, bool $expected1, bool $expected2): void {
 		$getPlayer = function(bool $underAttack, bool $ajax): AbstractPlayer {
 			$mockPlayer = $this->createMock(AbstractPlayer::class);

--- a/test/SmrTest/lib/PathTest.php
+++ b/test/SmrTest/lib/PathTest.php
@@ -3,12 +3,11 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Path;
 
-/**
- * @covers Smr\Path
- */
+#[CoversClass(Path::class)]
 class PathTest extends TestCase {
 
 	private static function make_complex_path(): Path {

--- a/test/SmrTest/lib/PlanetIntegrationTest.php
+++ b/test/SmrTest/lib/PlanetIntegrationTest.php
@@ -3,13 +3,13 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Smr\Planet;
 use Smr\TradeGood;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\Planet
- */
+#[CoversClass(Planet::class)]
 class PlanetIntegrationTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {
@@ -323,11 +323,10 @@ class PlanetIntegrationTest extends BaseIntegrationSpec {
 	}
 
 	/**
-	 * @dataProvider provider_getMaxBuildings
-	 *
 	 * @param int $planetType
 	 * @param array<int, int> $expected
 	 */
+	#[DataProvider('provider_getMaxBuildings')]
 	public function test_getMaxBuildings(int $planetType, array $expected): void {
 		$planet = Planet::createPlanet(1, 1, $planetType, 1);
 		self::assertSame($expected, $planet->getMaxBuildings());
@@ -336,7 +335,7 @@ class PlanetIntegrationTest extends BaseIntegrationSpec {
 	/**
 	 * @return array<array{int, array<int, int>}>
 	 */
-	public function provider_getMaxBuildings(): array {
+	public static function provider_getMaxBuildings(): array {
 		return [
 			[
 				1,
@@ -358,11 +357,10 @@ class PlanetIntegrationTest extends BaseIntegrationSpec {
 	}
 
 	/**
-	 * @dataProvider dataProvider_takeDamage
-	 *
 	 * @param WeaponDamageData $damage
 	 * @param TakenDamageData $expected
 	 */
+	#[DataProvider('dataProvider_takeDamage')]
 	public function test_takeDamage(string $case, array $damage, array $expected, int $shields, int $cds, int $armour): void {
 		// Set up a port with a fixed amount of defenses
 		$planet = Planet::createPlanet(1, 1, 4, 1);
@@ -380,7 +378,7 @@ class PlanetIntegrationTest extends BaseIntegrationSpec {
 	/**
 	 * @return array<array{0: string, 1: WeaponDamageData, 2: TakenDamageData, 3: int, 4: int, 5: int}>
 	 */
-	public function dataProvider_takeDamage(): array {
+	public static function dataProvider_takeDamage(): array {
 		return [
 			[
 				'Do overkill damage (e.g. 1000 drone damage)',

--- a/test/SmrTest/lib/PlayerLevelTest.php
+++ b/test/SmrTest/lib/PlayerLevelTest.php
@@ -3,12 +3,12 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\PlayerLevel;
 
-/**
- * @covers Smr\PlayerLevel
- */
+#[CoversClass(PlayerLevel::class)]
 class PlayerLevelTest extends TestCase {
 
 	public static function setUpBeforeClass(): void {
@@ -39,11 +39,9 @@ class PlayerLevelTest extends TestCase {
 		self::assertSame(50, PlayerLevel::getMax());
 	}
 
-	/**
-	 * @testWith [1, 2]
-	 *           [49, 50]
-	 *           [50, 50]
-	 */
+	#[TestWith([1, 2])]
+	#[TestWith([49, 50])]
+	#[TestWith([50, 50])]
 	public function test_next(int $levelID, int $nextLevelID): void {
 		$level = new PlayerLevel($levelID, '', 0);
 		self::assertSame($nextLevelID, $level->next()->id);

--- a/test/SmrTest/lib/PluraliseTest.php
+++ b/test/SmrTest/lib/PluraliseTest.php
@@ -2,33 +2,22 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers ::pluralise
- */
+#[CoversFunction('pluralise')]
 class PluraliseTest extends TestCase {
 
-	/**
-	 * @dataProvider pluralise_provider
-	 */
+	#[TestWith([3, true, '3 tests'])]
+	#[TestWith([1, true, '1 test'])]
+	#[TestWith([0, true, '0 tests'])]
+	#[TestWith([0.5, true, '0.5 tests'])]
+	#[TestWith([3, false, 'tests'])]
+	#[TestWith([1, false, 'test'])]
 	public function test_pluralise(float|int $amount, bool $includeAmount, string $expect): void {
 		$result = pluralise($amount, 'test', $includeAmount);
 		$this->assertSame($expect, $result);
-	}
-
-	/**
-	 * @return array<array{float|int, bool, string}>
-	 */
-	public function pluralise_provider(): array {
-		return [
-			[3, true, '3 tests'],
-			[1, true, '1 test'],
-			[0, true, '0 tests'],
-			[0.5, true, '0.5 tests'],
-			[3, false, 'tests'],
-			[1, false, 'test'],
-		];
 	}
 
 }

--- a/test/SmrTest/lib/PortTest.php
+++ b/test/SmrTest/lib/PortTest.php
@@ -3,6 +3,9 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\Bounty;
 use Smr\BountyType;
@@ -14,9 +17,7 @@ use Smr\Port;
 use Smr\Sector;
 use Smr\TransactionType;
 
-/**
- * @covers Smr\Port
- */
+#[CoversClass(Port::class)]
 class PortTest extends TestCase {
 
 	protected function tearDown(): void {
@@ -64,12 +65,11 @@ class PortTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider provider_removePortGood
-	 *
 	 * @param array<int> $removeGoodIDs
 	 * @param array<int> $sellRemain
 	 * @param array<int> $buyRemain
 	 */
+	#[DataProvider('provider_removePortGood')]
 	public function test_removePortGood(array $removeGoodIDs, array $sellRemain, array $buyRemain): void {
 		// Set up a port with a couple goods
 		$port = Port::createPort(1, 1);
@@ -86,7 +86,7 @@ class PortTest extends TestCase {
 	/**
 	 * @return array<array<array<int>>>
 	 */
-	public function provider_removePortGood(): array {
+	public static function provider_removePortGood(): array {
 		return [
 			// Remove a good that the port doesn't have
 			[[GOODS_CIRCUITRY], [GOODS_WOOD], [GOODS_ORE]],
@@ -99,20 +99,12 @@ class PortTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider provider_getGoodTransaction
-	 */
+	#[TestWith([TransactionType::Buy])]
+	#[TestWith([TransactionType::Sell])]
 	public function test_getGoodTransaction(TransactionType $transaction): void {
 		$port = Port::createPort(1, 1);
 		$port->addPortGood(GOODS_ORE, $transaction);
 		self::assertSame($transaction, $port->getGoodTransaction(GOODS_ORE));
-	}
-
-	/**
-	 * @return array<array<TransactionType>>
-	 */
-	public function provider_getGoodTransaction(): array {
-		return [[TransactionType::Buy], [TransactionType::Sell]];
 	}
 
 	public function test_getGoodTransaction_throws_if_port_does_not_have_good(): void {
@@ -207,11 +199,10 @@ class PortTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataProvider_takeDamage
-	 *
 	 * @param WeaponDamageData $damage
 	 * @param TakenDamageData $expected
 	 */
+	#[DataProvider('dataProvider_takeDamage')]
 	public function test_takeDamage(string $case, array $damage, array $expected, int $shields, int $cds, int $armour): void {
 		// Set up a port with a fixed amount of defenses
 		$port = Port::createPort(1, 1);
@@ -226,7 +217,7 @@ class PortTest extends TestCase {
 	/**
 	 * @return array<array{0: string, 1: WeaponDamageData, 2: TakenDamageData, 3: int, 4: int, 5: int}>
 	 */
-	public function dataProvider_takeDamage(): array {
+	public static function dataProvider_takeDamage(): array {
 		return [
 			[
 				'Do overkill damage (e.g. 1000 drone damage)',

--- a/test/SmrTest/lib/RaceDetailsTest.php
+++ b/test/SmrTest/lib/RaceDetailsTest.php
@@ -2,13 +2,12 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Race;
 use Smr\RaceDetails;
 
-/**
- * @covers Smr\RaceDetails
- */
+#[CoversClass(RaceDetails::class)]
 class RaceDetailsTest extends TestCase {
 
 	public function test_getShortDescription(): void {

--- a/test/SmrTest/lib/RaceTest.php
+++ b/test/SmrTest/lib/RaceTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Race;
 
-/**
- * @covers Smr\Race
- */
+#[CoversClass(Race::class)]
 class RaceTest extends TestCase {
 
 	public function test_getPlayableIDs(): void {

--- a/test/SmrTest/lib/RequestTest.php
+++ b/test/SmrTest/lib/RequestTest.php
@@ -3,14 +3,14 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
 use Smr\Request;
 use Smr\Session;
 
-/**
- * @covers Smr\Request
- */
+#[CoversClass(Request::class)]
 class RequestTest extends TestCase {
 
 	public static function setUpBeforeClass(): void {
@@ -80,16 +80,14 @@ class RequestTest extends TestCase {
 		Request::getBool('int');
 	}
 
-	/**
-	 * @testWith ["yes", true]
-	 *           [1, true]
-	 *           ["TRUE", true]
-	 *           ["on", true]
-	 *           ["no", false]
-	 *           [0, false]
-	 *           ["FALSE", false]
-	 *           ["off", false]
-	 */
+	#[TestWith(['yes', true])]
+	#[TestWith([1, true])]
+	#[TestWith(['TRUE', true])]
+	#[TestWith(['on', true])]
+	#[TestWith(['no', false])]
+	#[TestWith([0, false])]
+	#[TestWith(['FALSE', false])]
+	#[TestWith(['off', false])]
 	public function test_getBool_aliases(string|int $input, bool $expected): void {
 		$_REQUEST['bool_alias'] = $input;
 		self::assertSame($expected, Request::getBool('bool_alias'));

--- a/test/SmrTest/lib/Routes/MultiplePortRouteTest.php
+++ b/test/SmrTest/lib/Routes/MultiplePortRouteTest.php
@@ -2,15 +2,15 @@
 
 namespace SmrTest\lib\Routes;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Path;
 use Smr\Routes\MultiplePortRoute;
 use Smr\Routes\OneWayRoute;
+use Smr\Routes\Route;
 
-/**
- * @covers Smr\Routes\MultiplePortRoute
- * @covers Smr\Routes\Route
- */
+#[CoversClass(MultiplePortRoute::class)]
+#[CoversClass(Route::class)]
 class MultiplePortRouteTest extends TestCase {
 
 	public function test_three_port_routes(): void {

--- a/test/SmrTest/lib/Routes/OneWayRouteTest.php
+++ b/test/SmrTest/lib/Routes/OneWayRouteTest.php
@@ -2,13 +2,13 @@
 
 namespace SmrTest\lib\Routes;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\Path;
 use Smr\Routes\OneWayRoute;
 
-/**
- * @covers Smr\Routes\OneWayRoute
- */
+#[CoversClass(OneWayRoute::class)]
 class OneWayRouteTest extends TestCase {
 
 	private Path $path;
@@ -36,40 +36,18 @@ class OneWayRouteTest extends TestCase {
 		self::assertSame(3, $route->getExpMultiplierSum());
 	}
 
-	/**
-	 * @dataProvider dataProvider_getMoneyMultiplierSum
-	 */
+	#[TestWith([GOODS_NOTHING, 0])]
+	#[TestWith([GOODS_ORE, 54])]
 	public function test_getMoneyMultiplierSum(int $goodID, int $expected): void {
 		$route = new OneWayRoute(1, 3, RACE_HUMAN, RACE_NEUTRAL, 1, 2, $this->path, $goodID);
 		self::assertSame($expected, $route->getMoneyMultiplierSum());
 	}
 
-	/**
-	 * @return array<array{int, int}>
-	 */
-	public function dataProvider_getMoneyMultiplierSum(): array {
-		return [
-			[GOODS_NOTHING, 0],
-			[GOODS_ORE, 54],
-		];
-	}
-
-	/**
-	 * @dataProvider dataProvider_getTurnsForRoute
-	 */
+	#[TestWith([GOODS_NOTHING, 0])]
+	#[TestWith([GOODS_ORE, 2])]
 	public function test_getTurnsForRoute(int $goodID, int $expected): void {
 		$route = new OneWayRoute(1, 3, RACE_HUMAN, RACE_NEUTRAL, 0, 0, $this->path, $goodID);
 		self::assertSame($this->path->getTurns() + $expected, $route->getTurnsForRoute());
-	}
-
-	/**
-	 * @return array<array{int, int}>
-	 */
-	public function dataProvider_getTurnsForRoute(): array {
-		return [
-			[GOODS_NOTHING, 0],
-			[GOODS_ORE, 2],
-		];
 	}
 
 	public function test_getPortSectorIDs(): void {

--- a/test/SmrTest/lib/Routes/RouteGeneratorTest.php
+++ b/test/SmrTest/lib/Routes/RouteGeneratorTest.php
@@ -2,6 +2,7 @@
 
 namespace SmrTest\lib\Routes;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Path;
 use Smr\Port;
@@ -10,9 +11,7 @@ use Smr\Routes\OneWayRoute;
 use Smr\Routes\RouteGenerator;
 use Smr\TransactionType;
 
-/**
- * @covers Smr\Routes\RouteGenerator
- */
+#[CoversClass(RouteGenerator::class)]
 class RouteGeneratorTest extends TestCase {
 
 	private const EMPTY_ROUTES = [

--- a/test/SmrTest/lib/Routes/RouteIteratorTest.php
+++ b/test/SmrTest/lib/Routes/RouteIteratorTest.php
@@ -2,6 +2,7 @@
 
 namespace SmrTest\lib\Routes;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Path;
 use Smr\Routes\MultiplePortRoute;
@@ -9,9 +10,7 @@ use Smr\Routes\OneWayRoute;
 use Smr\Routes\RouteIterator;
 use Smr\TransactionType;
 
-/**
- * @covers Smr\Routes\RouteIterator
- */
+#[CoversClass(RouteIterator::class)]
 class RouteIteratorTest extends TestCase {
 
 	public function test_iterator_states(): void {

--- a/test/SmrTest/lib/SectorLockTest.php
+++ b/test/SmrTest/lib/SectorLockTest.php
@@ -3,14 +3,13 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\Container\DiContainer;
 use Smr\Exceptions\UserError;
 use Smr\SectorLock;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\SectorLock
- */
+#[CoversClass(SectorLock::class)]
 class SectorLockTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {

--- a/test/SmrTest/lib/SectorTest.php
+++ b/test/SmrTest/lib/SectorTest.php
@@ -3,12 +3,11 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\Sector;
 
-/**
- * @covers Smr\Sector
- */
+#[CoversClass(Sector::class)]
 class SectorTest extends TestCase {
 
 	protected function setUp(): void {

--- a/test/SmrTest/lib/SessionIntegrationTest.php
+++ b/test/SmrTest/lib/SessionIntegrationTest.php
@@ -3,15 +3,14 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\Account;
 use Smr\Container\DiContainer;
 use Smr\Page\Page;
 use Smr\Session;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\Session
- */
+#[CoversClass(Session::class)]
 class SessionIntegrationTest extends BaseIntegrationSpec {
 
 	private Session $session;

--- a/test/SmrTest/lib/ShipIllusionTest.php
+++ b/test/SmrTest/lib/ShipIllusionTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\ShipIllusion;
 
-/**
- * @covers Smr\ShipIllusion
- */
+#[CoversClass(ShipIllusion::class)]
 class ShipIllusionTest extends TestCase {
 
 	public function test_getName(): void {

--- a/test/SmrTest/lib/ShipIntegrationTest.php
+++ b/test/SmrTest/lib/ShipIntegrationTest.php
@@ -2,14 +2,13 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\AbstractPlayer;
 use Smr\Combat\Weapon\Weapon;
 use Smr\Ship;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\Ship
- */
+#[CoversClass(Ship::class)]
 class ShipIntegrationTest extends BaseIntegrationSpec {
 
 	private AbstractPlayer $player; // will be mocked

--- a/test/SmrTest/lib/ShipTypeTest.php
+++ b/test/SmrTest/lib/ShipTypeTest.php
@@ -2,14 +2,13 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\BuyerRestriction;
 use Smr\ShipClass;
 use Smr\ShipType;
 
-/**
- * @covers Smr\ShipType
- */
+#[CoversClass(ShipType::class)]
 class ShipTypeTest extends TestCase {
 
 	public static function setUpBeforeClass(): void {

--- a/test/SmrTest/lib/StoredDestinationTest.php
+++ b/test/SmrTest/lib/StoredDestinationTest.php
@@ -2,18 +2,16 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\StoredDestination;
 
-/**
- * @covers Smr\StoredDestination
- */
+#[CoversClass(StoredDestination::class)]
 class StoredDestinationTest extends TestCase {
 
-	/**
-	 * @testWith ["foo", "#42 - foo"]
-	 *           ["", "#42"]
-	 */
+	#[TestWith(['foo', '#42 - foo'])]
+	#[TestWith(['', '#42'])]
 	public function test_getDisplayName(string $label, string $expected): void {
 		$dest = new StoredDestination(
 			sectorID: 42,

--- a/test/SmrTest/lib/TemplateTest.php
+++ b/test/SmrTest/lib/TemplateTest.php
@@ -3,14 +3,14 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
 use Smr\Template;
 use SmrTest\TestUtils;
 
-/**
- * @covers Smr\Template
- */
+#[CoversClass(Template::class)]
 class TemplateTest extends TestCase {
 
 	protected function setUp(): void {
@@ -51,9 +51,7 @@ class TemplateTest extends TestCase {
 		$this->assertSame('an', $method->invoke($template, 'apple'));
 	}
 
-	/**
-	 * @dataProvider checkDisableAJAX_provider
-	 */
+	#[DataProvider('checkDisableAJAX_provider')]
 	public function test_checkDisableAJAX(string $html, bool $expected): void {
 		$template = Template::getInstance();
 		$method = TestUtils::getPrivateMethod($template, 'checkDisableAJAX');
@@ -63,7 +61,7 @@ class TemplateTest extends TestCase {
 	/**
 	 * @return array<array{string, bool}>
 	 */
-	public function checkDisableAJAX_provider(): array {
+	public static function checkDisableAJAX_provider(): array {
 		return [
 			// Special input types that do not disable ajax
 			['<input type="submit">', false],
@@ -77,9 +75,7 @@ class TemplateTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider convertHtmlToAjaxXml_provider
-	 */
+	#[DataProvider('convertHtmlToAjaxXml_provider')]
 	public function test_convertHtmlToAjaxXml(string $html, string $expected): void {
 		$template = Template::getInstance();
 		$method = TestUtils::getPrivateMethod($template, 'convertHtmlToAjaxXml');
@@ -89,7 +85,7 @@ class TemplateTest extends TestCase {
 	/**
 	 * @return array<array{string, string}>
 	 */
-	public function convertHtmlToAjaxXml_provider(): array {
+	public static function convertHtmlToAjaxXml_provider(): array {
 		return [
 			// Span with an id
 			['<span id="foo">Test</span>', '<foo>Test</foo>'],

--- a/test/SmrTest/lib/TradeGoodTest.php
+++ b/test/SmrTest/lib/TradeGoodTest.php
@@ -3,12 +3,11 @@
 namespace SmrTest\lib;
 
 use DOMDocument;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\TradeGood;
 
-/**
- * @covers Smr\TradeGood
- */
+#[CoversClass(TradeGood::class)]
 class TradeGoodTest extends TestCase {
 
 	private static bool $original_libxml_use_internal_errors;

--- a/test/SmrTest/lib/TransactionTypeTest.php
+++ b/test/SmrTest/lib/TransactionTypeTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\TransactionType;
 
-/**
- * @covers Smr\TransactionType
- */
+#[CoversClass(TransactionType::class)]
 class TransactionTypeTest extends TestCase {
 
 	public function test_opposite(): void {

--- a/test/SmrTest/lib/TurnsLevelTest.php
+++ b/test/SmrTest/lib/TurnsLevelTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\TurnsLevel;
 
-/**
- * @covers Smr\TurnsLevel
- */
+#[CoversClass(TurnsLevel::class)]
 class TurnsLevelTest extends TestCase {
 
 	private static bool $original_libxml_use_internal_errors;

--- a/test/SmrTest/lib/UserRankingTest.php
+++ b/test/SmrTest/lib/UserRankingTest.php
@@ -2,12 +2,11 @@
 
 namespace SmrTest\lib;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Smr\UserRanking;
 
-/**
- * @covers Smr\UserRanking
- */
+#[CoversClass(UserRanking::class)]
 class UserRankingTest extends TestCase {
 
 	public function test_rank_limits(): void {

--- a/test/SmrTest/lib/VoteSiteIntegrationTest.php
+++ b/test/SmrTest/lib/VoteSiteIntegrationTest.php
@@ -3,14 +3,13 @@
 namespace SmrTest\lib;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\VoteLink;
 use Smr\VoteSite;
 use SmrTest\BaseIntegrationSpec;
 
-/**
- * @covers Smr\VoteLink
- * @covers Smr\VoteSite
- */
+#[CoversClass(VoteLink::class)]
+#[CoversClass(VoteSite::class)]
 class VoteSiteIntegrationTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {

--- a/test/coverage-report.css
+++ b/test/coverage-report.css
@@ -1,0 +1,65 @@
+:root {
+	--text-color: #c7c7c7;
+}
+body {
+	background-color: #22272e;
+	color: var(--text-color);
+}
+a {
+	color: deepskyblue;
+}
+
+/* Header (breadcrumb) */
+.breadcrumb {
+	background-color: dimgrey !important;
+}
+.breadcrumb-item, .breadcrumb-item::before {
+	color: white !important;
+}
+
+/* Code colors */
+span.default, span.keyword {
+	color: var(--text-color) !important;
+}
+span.comment {
+	color: #727272 !important;
+	font-style: italic;
+}
+
+/* Coverage colors */
+.danger {
+	background-color: #260000 !important;
+}
+.success, .covered-by-large-tests {
+	background-color: #013c01 !important;
+	color: var(--text-color);
+}
+.warning {
+	background-color: #7b5916 !important;
+}
+
+/* Table */
+table {
+	color: var(--text-color) !important;
+}
+.table-bordered td, .table-bordered th {
+	border: 1px solid black;
+}
+.progress {
+	background-color: black;
+}
+
+/* Tooltip */
+.popover {
+	--tooltip-bg-color: #0d0d0d;
+}
+.popover-header {
+	border-bottom: 0px var(--tooltip-bg-color) !important;
+}
+.popover, .popover-header {
+	background-color: var(--tooltip-bg-color);
+}
+.arrow::after {
+	border-top-color: var(--tooltip-bg-color) !important;
+	border-bottom-color: var(--tooltip-bg-color) !important;
+}


### PR DESCRIPTION
The major functional changes from 9.5 to 10.0 are:

* Annotations are converted to attributes.
* Data providers must now be static.

Many data provider functions are converted to `TestWith` attributes. These are safer now as attributes, because they can contain real PHP objects (previously they had to be a JSON representation). When the data sets are trivial, this is much simpler and more compact.

PHPUnit no longer returns non-zero exit code on notices/deprecations, though they will still be printed in the results due to the use of the `displayDetailsOnTestsThatTrigger*` settings. For more info, see: https://github.com/sebastianbergmann/phpunit/issues/5196

All tests are upgraded using the PHPUNIT_100 rector ruleset. It didn't work perfectly, so some manual fixes were necessary.

Add custom CSS for phpunit HTML code coverage. This uses dark-mode and colorblind-friendly colors.