### PR TITLE
Switch to prepared statements for SQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM php:8.2.5-apache
 RUN apt-get --quiet=2 update \
 	&& apt-get --quiet=2 install zip unzip \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install mysqli opcache > /dev/null
+	&& docker-php-ext-install pdo_mysql opcache > /dev/null
 
 # Set the baseline php.ini version (default to production)
 ARG NO_DEV=1

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,10 @@
 	"license": "AGPL-3.0",
 	"require": {
 		"abraham/twitteroauth": "5.0.0",
+		"doctrine/dbal": "3.6.0",
 		"ext-curl": "*",
 		"ext-json": "*",
-		"ext-mysqli": "*",
+		"ext-pdo_mysql": "*",
 		"google/recaptcha": "1.3.0",
 		"league/oauth2-facebook": "2.2.0",
 		"league/oauth2-google": "4.0.1",

--- a/db/patches/V1_6_68_08__fix_column_types.sql
+++ b/db/patches/V1_6_68_08__fix_column_types.sql
@@ -1,0 +1,6 @@
+-- Convert nullable columns to not null
+ALTER TABLE `planet_has_cargo` MODIFY `amount` smallint unsigned NOT NULL;
+ALTER TABLE `ship_has_cargo` MODIFY `amount` smallint unsigned NOT NULL;
+
+-- Convert int column to float
+ALTER TABLE `weighted_random` MODIFY `weighting` float NOT NULL;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,10 @@ x-mysql-common: &mysql-common
     command: [ "mysqld", "--sql-mode=NO_ENGINE_SUBSTITUTION",
                "--character-set-server=utf8",
                "--collation-server=utf8_general_ci" ]
+    healthcheck:
+        test: mysql -uroot -p$$(cat $$MYSQL_ROOT_PASSWORD_FILE) -e 'SHOW DATABASES'
+        interval: 5s
+        timeout: 20s
 
 services:
     smr:
@@ -167,7 +171,8 @@ services:
             <<: *smr-base-env
             XDEBUG_MODE: coverage
         depends_on:
-            - mysql-test
+            mysql-test:
+                condition: service_healthy
 
     phpstan:
         <<: *smr-test

--- a/src/htdocs/album/album_comment_processing.php
+++ b/src/htdocs/album/album_comment_processing.php
@@ -59,11 +59,11 @@ try {
 	$comment_id = $dbResult->record()->getInt('next_comment_id');
 
 	$db->insert('album_has_comments', [
-		'album_id' => $db->escapeNumber($album_id),
-		'comment_id' => $db->escapeNumber($comment_id),
-		'time' => $db->escapeNumber($curr_time),
-		'post_id' => $db->escapeNumber($account->getAccountID()),
-		'msg' => $db->escapeString($comment),
+		'album_id' => $album_id,
+		'comment_id' => $comment_id,
+		'time' => $curr_time,
+		'post_id' => $account->getAccountID(),
+		'msg' => $comment,
 	]);
 	$db->unlock();
 

--- a/src/htdocs/album/album_comment_processing.php
+++ b/src/htdocs/album/album_comment_processing.php
@@ -53,7 +53,9 @@ try {
 	// check if we have comments for this album already
 	$db->lockTable('album_has_comments');
 
-	$dbResult = $db->read('SELECT IFNULL(MAX(comment_id)+1, 0) AS next_comment_id FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($album_id));
+	$dbResult = $db->read('SELECT IFNULL(MAX(comment_id)+1, 0) AS next_comment_id FROM album_has_comments WHERE album_id = :album_id', [
+		'album_id' => $db->escapeNumber($album_id),
+	]);
 	$comment_id = $dbResult->record()->getInt('next_comment_id');
 
 	$db->insert('album_has_comments', [

--- a/src/htdocs/album/index.php
+++ b/src/htdocs/album/index.php
@@ -48,16 +48,20 @@ try {
 
 		$dbResult = $db->read('SELECT account_id as album_id
 					FROM album JOIN account USING(account_id)
-					WHERE hof_name LIKE ' . $db->escapeString($query . '%') . ' AND
+					WHERE hof_name LIKE :hof_name_like AND
 						  approved = \'YES\'
-					ORDER BY hof_name');
+					ORDER BY hof_name', [
+			'hof_name_like' => $db->escapeString($query . '%'),
+		]);
 
 		if ($dbResult->getNumRecords() > 1) {
 			$dbResult2 = $db->read('SELECT account_id as album_id
 					FROM album JOIN account USING(account_id)
-					WHERE hof_name = ' . $db->escapeString($query) . ' AND
+					WHERE hof_name = :hof_name AND
 						  approved = \'YES\'
-					ORDER BY hof_name');
+					ORDER BY hof_name', [
+				'hof_name' => $db->escapeString($query),
+			]);
 
 			if ($dbResult2->hasRecord()) {
 				album_entry($dbResult2->record()->getInt('album_id'));

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -209,7 +209,7 @@ try {
 		'message_type_ids' => $db->escapeArray([MSG_ALLIANCE, MSG_GLOBAL, MSG_POLITICAL]),
 	]);
 	//check to see if we need to remove player_has_unread
-	$db->write('DELETE FROM player_has_unread_messages WHERE account_id = :account_id', [
+	$db->delete('player_has_unread_messages', [
 		'account_id' => $db->escapeNumber($account->getAccountID()),
 	]);
 	$db->write('

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -105,8 +105,10 @@ try {
 	// *
 	// *********************************
 	$db = Database::getInstance();
-	$dbResult = $db->read('SELECT * FROM active_session ' .
-			   'WHERE last_accessed > ' . $db->escapeNumber(Epoch::time() - TIME_BEFORE_NEWBIE_TIME));
+	$dbResult = $db->read('SELECT * FROM active_session
+			WHERE last_accessed > :newbie_turn_time', [
+		'newbie_turn_time' => $db->escapeNumber(Epoch::time() - TIME_BEFORE_NEWBIE_TIME),
+	]);
 	if (!$dbResult->hasRecord()) {
 		$db->write('UPDATE player SET newbie_turns = 1
 					WHERE newbie_turns = 0 AND
@@ -119,7 +121,9 @@ try {
 	// *
 	// ******************************************
 
-	$db->write('DELETE FROM player_has_ticker WHERE expires <= ' . $db->escapeNumber(Epoch::time()));
+	$db->write('DELETE FROM player_has_ticker WHERE expires <= :now', [
+		'now' => $db->escapeNumber(Epoch::time()),
+	]);
 
 	// save ip
 	$account->updateIP();
@@ -127,7 +131,9 @@ try {
 	//now we set a cookie that we can use for mult checking
 	if (!isset($_COOKIE['Session_Info'])) {
 		//we get their info from db if they have any
-		$dbResult = $db->read('SELECT * FROM multi_checking_cookie WHERE account_id = ' . $account->getAccountID());
+		$dbResult = $db->read('SELECT * FROM multi_checking_cookie WHERE account_id = :account_id', [
+			'account_id' => $account->getAccountID(),
+		]);
 		if ($dbResult->hasRecord()) {
 			//convert to array
 			$old = explode('-', $dbResult->record()->getString('array'));
@@ -157,7 +163,9 @@ try {
 			$cookie[] = $account->getAccountID();
 		}
 
-		$dbResult = $db->read('SELECT * FROM multi_checking_cookie WHERE account_id = ' . $account->getAccountID());
+		$dbResult = $db->read('SELECT * FROM multi_checking_cookie WHERE account_id = :account_id', [
+			'account_id' => $account->getAccountID(),
+		]);
 		if ($dbResult->hasRecord()) {
 			//convert to array
 			$old = explode('-', $dbResult->record()->getString('array'));
@@ -192,14 +200,25 @@ try {
 	setcookie('Session_Info', $new, Epoch::time() + 157680000);
 
 	//get rid of expired messages
-	$db->write('UPDATE message SET receiver_delete = \'TRUE\', sender_delete = \'TRUE\', expire_time = 0 WHERE expire_time < ' . $db->escapeNumber(Epoch::time()) . ' AND expire_time != 0');
+	$db->write('UPDATE message SET receiver_delete = \'TRUE\', sender_delete = \'TRUE\', expire_time = 0 WHERE expire_time < :now AND expire_time != 0', [
+		'now' => $db->escapeNumber(Epoch::time()),
+	]);
 	// Mark message as read if it was sent to self as a mass mail.
-	$db->write('UPDATE message SET msg_read = \'TRUE\' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' AND account_id = sender_id AND message_type_id IN (' . $db->escapeArray([MSG_ALLIANCE, MSG_GLOBAL, MSG_POLITICAL]) . ');');
+	$db->write('UPDATE message SET msg_read = \'TRUE\' WHERE account_id = :account_id AND account_id = sender_id AND message_type_id IN (:message_type_ids)', [
+		'account_id' => $db->escapeNumber($account->getAccountID()),
+		'message_type_ids' => $db->escapeArray([MSG_ALLIANCE, MSG_GLOBAL, MSG_POLITICAL]),
+	]);
 	//check to see if we need to remove player_has_unread
-	$db->write('DELETE FROM player_has_unread_messages WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+	$db->write('DELETE FROM player_has_unread_messages WHERE account_id = :account_id', [
+		'account_id' => $db->escapeNumber($account->getAccountID()),
+	]);
 	$db->write('
 		INSERT INTO player_has_unread_messages (game_id, account_id, message_type_id)
-		SELECT game_id, account_id, message_type_id FROM message WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . ' AND msg_read = ' . $db->escapeBoolean(false) . ' AND receiver_delete = ' . $db->escapeBoolean(false));
+		SELECT game_id, account_id, message_type_id FROM message WHERE account_id = :account_id AND msg_read = :msg_read AND receiver_delete = :receiver_delete', [
+		'account_id' => $db->escapeNumber($account->getAccountID()),
+		'msg_read' => $db->escapeBoolean(false),
+		'receiver_delete' => $db->escapeBoolean(false),
+	]);
 
 	header('Location: ' . $href);
 	exit;

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -110,9 +110,14 @@ try {
 		'newbie_turn_time' => $db->escapeNumber(Epoch::time() - TIME_BEFORE_NEWBIE_TIME),
 	]);
 	if (!$dbResult->hasRecord()) {
-		$db->write('UPDATE player SET newbie_turns = 1
-					WHERE newbie_turns = 0 AND
-						  land_on_planet = \'FALSE\'');
+		$db->update(
+			'player',
+			['newbie_turns' => 1],
+			[
+				'newbie_turns' => 0,
+				'land_on_planet' => 'FALSE',
+			],
+		);
 	}
 
 	// ******************************************

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -197,9 +197,9 @@ try {
 		}
 	}
 	$db->replace('multi_checking_cookie', [
-		'account_id' => $db->escapeNumber($account->getAccountID()),
-		'array' => $db->escapeString($new),
-		'`use`' => $db->escapeString($use),
+		'account_id' => $account->getAccountID(),
+		'array' => $new,
+		'`use`' => $use,
 	]);
 	//now we update their cookie with the newest info
 	setcookie('Session_Info', $new, Epoch::time() + 157680000);
@@ -215,7 +215,7 @@ try {
 	]);
 	//check to see if we need to remove player_has_unread
 	$db->delete('player_has_unread_messages', [
-		'account_id' => $db->escapeNumber($account->getAccountID()),
+		'account_id' => $account->getAccountID(),
 	]);
 	$db->write('
 		INSERT INTO player_has_unread_messages (game_id, account_id, message_type_id)

--- a/src/htdocs/map_warps.php
+++ b/src/htdocs/map_warps.php
@@ -40,7 +40,9 @@ try {
 
 	// The d3 graph links are the warp connections between galaxies
 	$db = Database::getInstance();
-	$dbResult = $db->read('SELECT sector_id, warp FROM sector WHERE warp !=0 AND game_id = ' . $db->escapeNumber($gameID));
+	$dbResult = $db->read('SELECT sector_id, warp FROM sector WHERE warp !=0 AND game_id = :game_id', [
+		'game_id' => $db->escapeNumber($gameID),
+	]);
 	foreach ($dbResult->records() as $dbRecord) {
 		$warp1 = Sector::getSector($gameID, $dbRecord->getInt('sector_id'));
 		$warp2 = Sector::getSector($gameID, $dbRecord->getInt('warp'));

--- a/src/htdocs/ship_list.php
+++ b/src/htdocs/ship_list.php
@@ -14,7 +14,9 @@ try {
 	// Get a list of all the shops that sell each ship
 	$shipLocs = [];
 	$db = Database::getInstance();
-	$dbResult = $db->read('SELECT ship_type_id, location_type.* FROM location_sells_ships JOIN ship_type USING (ship_type_id) JOIN location_type USING (location_type_id) WHERE location_type_id NOT IN (' . $db->escapeArray([RACE_WARS_SHIPS, LOCATION_TYPE_TEST_SHIPYARD]) . ')');
+	$dbResult = $db->read('SELECT ship_type_id, location_type.* FROM location_sells_ships JOIN ship_type USING (ship_type_id) JOIN location_type USING (location_type_id) WHERE location_type_id NOT IN (:location_type_ids)', [
+		'location_type_ids' => $db->escapeArray([RACE_WARS_SHIPS, LOCATION_TYPE_TEST_SHIPYARD]),
+	]);
 	foreach ($dbResult->records() as $dbRecord) {
 		$shipTypeID = $dbRecord->getInt('ship_type_id');
 		$locTypeID = $dbRecord->getInt('location_type_id');

--- a/src/htdocs/weapon_list.php
+++ b/src/htdocs/weapon_list.php
@@ -14,7 +14,9 @@ try {
 	// Get a list of all the shops that sell each weapon
 	$weaponLocs = [];
 	$db = Database::getInstance();
-	$dbResult = $db->read('SELECT weapon_type_id, location_type.* FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) JOIN location_type USING (location_type_id) WHERE location_type_id != ' . $db->escapeNumber(RACE_WARS_WEAPONS));
+	$dbResult = $db->read('SELECT weapon_type_id, location_type.* FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) JOIN location_type USING (location_type_id) WHERE location_type_id != :location_type_id', [
+		'location_type_id' => $db->escapeNumber(RACE_WARS_WEAPONS),
+	]);
 	foreach ($dbResult->records() as $dbRecord) {
 		$gameID = 0; // doesn't matter for weapon list (yet)
 		$weaponLocs[$dbRecord->getInt('weapon_type_id')][] = Location::getLocation($gameID, $dbRecord->getInt('location_type_id'), false, $dbRecord)->getName();

--- a/src/lib/Album/album_functions.php
+++ b/src/lib/Album/album_functions.php
@@ -72,14 +72,18 @@ function album_entry(int $album_id): void {
 	if ($session->hasAccount() && $album_id != $session->getAccountID()) {
 		$db->write('UPDATE album
 				SET page_views = page_views + 1
-				WHERE account_id = ' . $db->escapeNumber($album_id) . ' AND
-					approved = \'YES\'');
+				WHERE account_id = :account_id AND
+					approved = \'YES\'', [
+			'account_id' => $db->escapeNumber($album_id),
+		]);
 	}
 
 	$dbResult = $db->read('SELECT *
 				FROM album
-				WHERE account_id = ' . $db->escapeNumber($album_id) . ' AND
-					approved = \'YES\'');
+				WHERE account_id = :account_id AND
+					approved = \'YES\'', [
+		'account_id' => $db->escapeNumber($album_id),
+	]);
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
 		$location = $dbRecord->getNullableString('location');
@@ -109,10 +113,12 @@ function album_entry(int $album_id): void {
 
 	$dbResult = $db->read('SELECT hof_name
 				FROM album JOIN account USING(account_id)
-				WHERE hof_name < ' . $db->escapeString($nick) . ' AND
+				WHERE hof_name < :hof_name AND
 					approved = \'YES\'
 				ORDER BY hof_name DESC
-				LIMIT 1');
+				LIMIT 1', [
+		'hof_name' => $db->escapeString($nick),
+	]);
 	echo '<td class="center" style="width: 30%" valign="middle">';
 	if ($dbResult->hasRecord()) {
 		$priv_nick = $dbResult->record()->getString('hof_name');
@@ -123,10 +129,12 @@ function album_entry(int $album_id): void {
 
 	$dbResult = $db->read('SELECT hof_name
 				FROM album JOIN account USING(account_id)
-				WHERE hof_name > ' . $db->escapeString($nick) . ' AND
+				WHERE hof_name > :hof_name AND
 					approved = \'YES\'
 				ORDER BY hof_name
-				LIMIT 1');
+				LIMIT 1', [
+		'hof_name' => $db->escapeString($nick),
+	]);
 	echo '<td class="center" style="width: 30%" valign="middle">';
 	if ($dbResult->hasRecord()) {
 		$next_nick = $dbResult->record()->getString('hof_name');
@@ -201,7 +209,9 @@ function album_entry(int $album_id): void {
 	$dateFormat = $session->hasAccount() ? $session->getAccount()->getDateTimeFormat() : DEFAULT_DATE_TIME_FORMAT;
 	$dbResult = $db->read('SELECT *
 				FROM album_has_comments
-				WHERE album_id = ' . $db->escapeNumber($album_id));
+				WHERE album_id = :album_id', [
+		'album_id' => $db->escapeNumber($album_id),
+	]);
 	foreach ($dbResult->records() as $dbRecord) {
 		$time = $dbRecord->getInt('time');
 		$postee = get_album_nick($dbRecord->getInt('post_id'));
@@ -220,8 +230,11 @@ function album_entry(int $album_id): void {
 		echo('<td style="color:green; font-size:70%;"><br /><input type="submit" name="action" value="Send"></td>');
 		$dbResult = $db->read('SELECT 1
 					FROM account_has_permission
-					WHERE account_id = ' . $db->escapeNumber($session->getAccountID()) . ' AND
-						permission_id = ' . $db->escapeNumber(PERMISSION_MODERATE_PHOTO_ALBUM));
+					WHERE account_id = :account_id AND
+						permission_id = :permission_id', [
+			'account_id' => $db->escapeNumber($session->getAccountID()),
+			'permission_id' => $db->escapeNumber(PERMISSION_MODERATE_PHOTO_ALBUM),
+		]);
 		if ($dbResult->hasRecord()) {
 			echo('<td style="color:green; font-size:70%;"><br /><input type="submit" name="action" value="Moderate"></td>');
 		}

--- a/src/lib/Default/alliance_pick.inc.php
+++ b/src/lib/Default/alliance_pick.inc.php
@@ -11,7 +11,9 @@ use Smr\Player;
  */
 function get_draft_teams(int $gameId): array {
 	$db = Database::getInstance();
-	$dbResult = $db->read('SELECT account_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($gameId));
+	$dbResult = $db->read('SELECT account_id FROM draft_leaders WHERE game_id = :game_id', [
+		'game_id' => $db->escapeNumber($gameId),
+	]);
 
 	// Get team leader, alliance, and alliance size
 	$teams = [];

--- a/src/lib/Default/help.inc.php
+++ b/src/lib/Default/help.inc.php
@@ -7,7 +7,9 @@ function echo_nav(int $topic_id): void {
 	$db = Database::getInstance();
 
 	// get current entry
-	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($topic_id));
+	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = :topic_id', [
+		'topic_id' => $db->escapeNumber($topic_id),
+	]);
 	if (!$dbResult->hasRecord()) {
 		echo ('Invalid Topic!');
 		return;
@@ -18,7 +20,9 @@ function echo_nav(int $topic_id): void {
 	$topic = stripslashes($dbRecord->getString('topic'));
 
 	$parent_topic_id = $dbRecord->getInt('parent_topic_id');
-	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($parent_topic_id));
+	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = :topic_id', [
+		'topic_id' => $db->escapeNumber($parent_topic_id),
+	]);
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
 		$parent = [
@@ -35,7 +39,10 @@ function echo_nav(int $topic_id): void {
 	// **************************
 	// **  PREVIOUS
 	// **************************
-	$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($parent_topic_id) . ' AND order_id = ' . $db->escapeNumber($order_id - 1));
+	$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = :parent_topic_id AND order_id = :order_id', [
+		'parent_topic_id' => $db->escapeNumber($parent_topic_id),
+		'order_id' => $db->escapeNumber($order_id - 1),
+	]);
 	echo ('<th width="32">');
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
@@ -69,14 +76,22 @@ function echo_nav(int $topic_id): void {
 	// **************************
 	// **  NEXT
 	// **************************
-	$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' AND order_id = 1');
+	$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = :parent_topic_id AND order_id = 1', [
+		'parent_topic_id' => $db->escapeNumber($topic_id),
+	]);
 
 	if (!$dbResult->hasRecord()) {
-		$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($parent_topic_id) . ' AND order_id = ' . $db->escapeNumber($order_id + 1));
+		$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = :parent_topic_id AND order_id = :order_id', [
+			'parent_topic_id' => $db->escapeNumber($parent_topic_id),
+			'order_id' => $db->escapeNumber($order_id + 1),
+		]);
 	}
 
 	if (!$dbResult->hasRecord() && isset($parent)) {
-		$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($parent['parent_topic_id']) . ' AND order_id = ' . $db->escapeNumber($parent['order_id'] + 1));
+		$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = :parent_topic_id AND order_id = :order_id', [
+			'parent_topic_id' => $db->escapeNumber($parent['parent_topic_id']),
+			'order_id' => $db->escapeNumber($parent['order_id'] + 1),
+		]);
 	}
 
 	echo ('<th width="32">');
@@ -118,7 +133,9 @@ function echo_content(int $topic_id): void {
 	$db = Database::getInstance();
 
 	// get current entry
-	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $topic_id);
+	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = :topic_id', [
+		'topic_id' => $topic_id,
+	]);
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
 		$topic = stripslashes($dbRecord->getString('topic'));
@@ -138,7 +155,9 @@ function echo_subsection(int $topic_id): void {
 	$db = Database::getInstance();
 
 	// check if there are subsections
-	$dbResult = $db->read('SELECT 1 FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' ORDER BY order_id');
+	$dbResult = $db->read('SELECT 1 FROM manual WHERE parent_topic_id = :parent_topic_id ORDER BY order_id', [
+		'parent_topic_id' => $db->escapeNumber($topic_id),
+	]);
 	if ($dbResult->hasRecord()) {
 		echo ('<hr noshade width="75%" size="1" class="center"/>');
 		echo ('<div id="help_menu">');
@@ -154,7 +173,9 @@ function echo_menu(int $topic_id): void {
 	// database object
 	$db = Database::getInstance();
 
-	$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = ' . $db->escapeNumber($topic_id) . ' ORDER BY order_id');
+	$dbResult = $db->read('SELECT * FROM manual WHERE parent_topic_id = :parent_topic_id ORDER BY order_id', [
+		'parent_topic_id' => $db->escapeNumber($topic_id),
+	]);
 	if ($dbResult->hasRecord()) {
 		echo ('<ul type="disc">');
 		foreach ($dbResult->records() as $dbRecord) {
@@ -171,7 +192,9 @@ function echo_menu(int $topic_id): void {
 function get_numbering(int $topic_id): string {
 	$db = Database::getInstance();
 
-	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = ' . $db->escapeNumber($topic_id));
+	$dbResult = $db->read('SELECT * FROM manual WHERE topic_id = :topic_id', [
+		'topic_id' => $db->escapeNumber($topic_id),
+	]);
 	if (!$dbResult->hasRecord()) {
 		return '';
 	}

--- a/src/lib/Default/nha.inc.php
+++ b/src/lib/Default/nha.inc.php
@@ -221,19 +221,19 @@ function createNHA(int $gameID): void {
 	$threadID = 1;
 	foreach ($threads as $topic => $text) {
 		$db->replace('alliance_thread_topic', [
-			'game_id' => $db->escapeNumber($gameID),
-			'alliance_id' => $db->escapeNumber($allianceID),
-			'thread_id' => $db->escapeNumber($threadID),
-		'topic' => $db->escapeString($topic),
+			'game_id' => $gameID,
+			'alliance_id' => $allianceID,
+			'thread_id' => $threadID,
+			'topic' => $topic,
 		]);
 		$db->replace('alliance_thread', [
-			'game_id' => $db->escapeNumber($gameID),
-			'alliance_id' => $db->escapeNumber($allianceID),
-			'thread_id' => $db->escapeNumber($threadID),
+			'game_id' => $gameID,
+			'alliance_id' => $allianceID,
+			'thread_id' => $threadID,
 			'reply_id' => 1,
-			'text' => $db->escapeString($text),
-			'sender_id' => $db->escapeNumber(ACCOUNT_ID_NHL),
-			'time' => $db->escapeNumber(Epoch::time()),
+			'text' => $text,
+			'sender_id' => ACCOUNT_ID_NHL,
+			'time' => Epoch::time(),
 		]);
 		$threadID++;
 	}

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -371,8 +371,8 @@ function do_voodoo(): never {
 					if (ENABLE_DEBUG) {
 						$db = Database::getInstance();
 						$db->insert('debug', [
-							'debug_type' => $db->escapeString('SPAM'),
-							'account_id' => $db->escapeNumber($account->getAccountID()),
+							'debug_type' => 'SPAM',
+							'account_id' => $account->getAccountID(),
 							'value' => 0,
 							'value_2' => 0,
 						]);

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -479,7 +479,10 @@ function doTickerAssigns(Template $template, AbstractPlayer $player, Database $d
 		$dateFormat = $player->getAccount()->getDateTimeFormat();
 		if ($player->hasTicker('NEWS')) {
 			//get recent news (5 mins)
-			$dbResult = $db->read('SELECT time,news_message FROM news WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND time >= ' . $max . ' ORDER BY time DESC LIMIT 4');
+			$dbResult = $db->read('SELECT time,news_message FROM news WHERE game_id = :game_id AND time >= :max_time ORDER BY time DESC LIMIT 4', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'max_time' => $db->escapeNumber($max),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$ticker[] = [
 					'Time' => date($dateFormat, $dbRecord->getInt('time')),
@@ -489,13 +492,18 @@ function doTickerAssigns(Template $template, AbstractPlayer $player, Database $d
 		}
 		if ($player->hasTicker('SCOUT')) {
 			$dbResult = $db->read('SELECT message_text,send_time FROM message
-						WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . '
-						AND game_id=' . $db->escapeNumber($player->getGameID()) . '
-						AND message_type_id=' . $db->escapeNumber(MSG_SCOUT) . '
-						AND send_time>=' . $db->escapeNumber($max) . '
-						AND sender_id NOT IN (SELECT account_id FROM player_has_ticker WHERE type=' . $db->escapeString('BLOCK') . ' AND expires > ' . $db->escapeNumber(Epoch::time()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ') AND receiver_delete = \'FALSE\'
+						WHERE ' . AbstractPlayer::SQL . '
+						AND message_type_id = :message_type_id
+						AND send_time >= :max_time
+						AND sender_id NOT IN (SELECT account_id FROM player_has_ticker WHERE type = :type AND expires > :now AND game_id = :game_id) AND receiver_delete = \'FALSE\'
 						ORDER BY send_time DESC
-						LIMIT 4');
+						LIMIT 4', [
+				...$player->SQLID,
+				'message_type_id' => $db->escapeNumber(MSG_SCOUT),
+				'max_time' => $db->escapeNumber($max),
+				'type' => $db->escapeString('BLOCK'),
+				'now' => $db->escapeNumber(Epoch::time()),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$ticker[] = [
 					'Time' => date($dateFormat, $dbRecord->getInt('send_time')),
@@ -584,7 +592,7 @@ function doSkeletonAssigns(Template $template): void {
 		$template->assign('CurrentHallOfFameLink', $container->href());
 
 		$unreadMessages = [];
-		$dbResult = $db->read('SELECT message_type_id,COUNT(*) FROM player_has_unread_messages WHERE ' . $player->getSQL() . ' GROUP BY message_type_id');
+		$dbResult = $db->read('SELECT message_type_id,COUNT(*) FROM player_has_unread_messages WHERE ' . AbstractPlayer::SQL . ' GROUP BY message_type_id', $player->SQLID);
 		foreach ($dbResult->records() as $dbRecord) {
 			$messageTypeID = $dbRecord->getInt('message_type_id');
 			$container = new MessageView($messageTypeID);

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -41,7 +41,9 @@ abstract class AbstractPlayer {
 	/** @var array<int, array<int, Player>> */
 	protected static array $CACHE_PLAYERS = [];
 
-	protected readonly string $SQL;
+	public const SQL = 'account_id = :account_id AND game_id = :game_id';
+	/** @var array{account_id: int, game_id: int} */
+	public readonly array $SQLID;
 
 	protected string $playerName;
 	protected int $playerID;
@@ -158,7 +160,12 @@ abstract class AbstractPlayer {
 	 */
 	public static function getGalaxyPlayers(int $gameID, int $galaxyID, bool $forceUpdate = false): array {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT player.* FROM player LEFT JOIN sector USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(false) . ' AND (last_cpl_action > ' . $db->escapeNumber(Epoch::time() - TIME_BEFORE_HIDDEN) . ' OR newbie_turns = 0) AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT player.* FROM player LEFT JOIN sector USING(game_id, sector_id) WHERE game_id = :game_id AND land_on_planet = :land_on_planet AND (last_cpl_action > :hidden_time OR newbie_turns = 0) AND galaxy_id = :galaxy_id', [
+			'game_id' => $db->escapeNumber($gameID),
+			'land_on_planet' => $db->escapeBoolean(false),
+			'hidden_time' => $db->escapeNumber(Epoch::time() - TIME_BEFORE_HIDDEN),
+			'galaxy_id' => $db->escapeNumber($galaxyID),
+		]);
 		$galaxyPlayers = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$sectorID = $dbRecord->getInt('sector_id');
@@ -176,10 +183,18 @@ abstract class AbstractPlayer {
 	public static function getSectorPlayers(int $gameID, int $sectorID, bool $forceUpdate = false): array {
 		if ($forceUpdate || !isset(self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID])) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM player WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(false) . ' AND (last_cpl_action > ' . $db->escapeNumber(Epoch::time() - TIME_BEFORE_HIDDEN) . ' OR newbie_turns = 0) AND account_id NOT IN (' . $db->escapeArray(Globals::getHiddenPlayers()) . ') ORDER BY last_cpl_action DESC');
+			$dbResult = $db->read('SELECT * FROM player WHERE sector_id = :sector_id AND game_id = :game_id AND land_on_planet = :land_on_planet AND (last_cpl_action > :hidden_time OR newbie_turns = 0) ORDER BY last_cpl_action DESC', [
+				'sector_id' => $db->escapeNumber($sectorID),
+				'game_id' => $db->escapeNumber($gameID),
+				'land_on_planet' => $db->escapeBoolean(false),
+				'hidden_time' => $db->escapeNumber(Epoch::time() - TIME_BEFORE_HIDDEN),
+			]);
 			$players = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$accountID = $dbRecord->getInt('account_id');
+				if (in_array($accountID, Globals::getHiddenPlayers())) {
+					continue;
+				}
 				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $dbRecord);
 			}
 			self::$CACHE_SECTOR_PLAYERS[$gameID][$sectorID] = $players;
@@ -193,10 +208,17 @@ abstract class AbstractPlayer {
 	public static function getPlanetPlayers(int $gameID, int $sectorID, bool $forceUpdate = false): array {
 		if ($forceUpdate || !isset(self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID])) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM player WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' AND land_on_planet = ' . $db->escapeBoolean(true) . ' AND account_id NOT IN (' . $db->escapeArray(Globals::getHiddenPlayers()) . ') ORDER BY last_cpl_action DESC');
+			$dbResult = $db->read('SELECT * FROM player WHERE sector_id = :sector_id AND game_id = :game_id AND land_on_planet = :land_on_planet ORDER BY last_cpl_action DESC', [
+				'sector_id' => $db->escapeNumber($sectorID),
+				'game_id' => $db->escapeNumber($gameID),
+				'land_on_planet' => $db->escapeBoolean(true),
+			]);
 			$players = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$accountID = $dbRecord->getInt('account_id');
+				if (in_array($accountID, Globals::getHiddenPlayers())) {
+					continue;
+				}
 				$players[$accountID] = self::getPlayer($accountID, $gameID, $forceUpdate, $dbRecord);
 			}
 			self::$CACHE_PLANET_PLAYERS[$gameID][$sectorID] = $players;
@@ -210,7 +232,10 @@ abstract class AbstractPlayer {
 	public static function getAlliancePlayers(int $gameID, int $allianceID, bool $forceUpdate = false): array {
 		if ($forceUpdate || !isset(self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID])) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM player WHERE alliance_id = ' . $db->escapeNumber($allianceID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' ORDER BY experience DESC');
+			$dbResult = $db->read('SELECT * FROM player WHERE alliance_id = :alliance_id AND game_id = :game_id ORDER BY experience DESC', [
+				'alliance_id' => $db->escapeNumber($allianceID),
+				'game_id' => $db->escapeNumber($gameID),
+			]);
 			$players = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$accountID = $dbRecord->getInt('account_id');
@@ -230,7 +255,10 @@ abstract class AbstractPlayer {
 
 	public static function getPlayerByPlayerID(int $playerID, int $gameID, bool $forceUpdate = false): Player {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND player_id = ' . $db->escapeNumber($playerID));
+		$dbResult = $db->read('SELECT * FROM player WHERE game_id = :game_id AND player_id = :player_id', [
+			'game_id' => $db->escapeNumber($gameID),
+			'player_id' => $db->escapeNumber($playerID),
+		]);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			return self::getPlayer($dbRecord->getInt('account_id'), $gameID, $forceUpdate, $dbRecord);
@@ -240,7 +268,10 @@ abstract class AbstractPlayer {
 
 	public static function getPlayerByPlayerName(string $playerName, int $gameID, bool $forceUpdate = false): Player {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND player_name = ' . $db->escapeString($playerName));
+		$dbResult = $db->read('SELECT * FROM player WHERE game_id = :game_id AND player_name = :player_name', [
+			'game_id' => $db->escapeNumber($gameID),
+			'player_name' => $db->escapeString($playerName),
+		]);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			return self::getPlayer($dbRecord->getInt('account_id'), $gameID, $forceUpdate, $dbRecord);
@@ -254,10 +285,13 @@ abstract class AbstractPlayer {
 		DatabaseRecord $dbRecord = null
 	) {
 		$db = Database::getInstance();
-		$this->SQL = 'account_id = ' . $db->escapeNumber($accountID) . ' AND game_id = ' . $db->escapeNumber($gameID);
+		$this->SQLID = [
+			'account_id' => $db->escapeNumber($accountID),
+			'game_id' => $db->escapeNumber($gameID),
+		];
 
 		if ($dbRecord === null) {
-			$dbResult = $db->read('SELECT * FROM player WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM player WHERE ' . self::SQL, $this->SQLID);
 			if ($dbResult->hasRecord()) {
 				$dbRecord = $dbResult->record();
 			}
@@ -325,7 +359,9 @@ abstract class AbstractPlayer {
 		}
 
 		// Get the next available player ID (start at 1 if no players yet)
-		$dbResult = $db->read('SELECT IFNULL(MAX(player_id), 0) AS player_id FROM player WHERE game_id = ' . $db->escapeNumber($gameID));
+		$dbResult = $db->read('SELECT IFNULL(MAX(player_id), 0) AS player_id FROM player WHERE game_id = :game_id', [
+			'game_id' => $db->escapeNumber($gameID),
+		]);
 		$playerID = $dbResult->record()->getInt('player_id') + 1;
 
 		$startSectorID = 0; // Temporarily put player into non-existent sector
@@ -365,7 +401,7 @@ abstract class AbstractPlayer {
 		// Get other players who are sharing info for this game.
 		// NOTE: game_id=0 means that player shares info for all games.
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT from_account_id FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($this->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($this->getGameID()) . ')');
+		$dbResult = $db->read('SELECT from_account_id FROM account_shares_info WHERE to_account_id = :account_id AND (game_id=0 OR game_id = :game_id)', $this->SQLID);
 		foreach ($dbResult->records() as $dbRecord) {
 			try {
 				$otherPlayer = self::getPlayer($dbRecord->getInt('from_account_id'), $this->getGameID(), $forceUpdate);
@@ -380,10 +416,6 @@ abstract class AbstractPlayer {
 			}
 		}
 		return $results;
-	}
-
-	public function getSQL(): string {
-		return $this->SQL;
 	}
 
 	public function getZoom(): int {
@@ -499,7 +531,7 @@ abstract class AbstractPlayer {
 	public function getCustomShipName(): string|false {
 		if (!isset($this->customShipName)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM ship_has_name WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM ship_has_name WHERE ' . self::SQL, $this->SQLID);
 			if ($dbResult->hasRecord()) {
 				$this->customShipName = $dbResult->record()->getString('ship_name');
 			} else {
@@ -512,8 +544,7 @@ abstract class AbstractPlayer {
 	public function setCustomShipName(string $name): void {
 		$db = Database::getInstance();
 		$db->replace('ship_has_name', [
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'account_id' => $db->escapeNumber($this->getAccountID()),
+			...$this->SQLID,
 			'ship_name' => $db->escapeString($name),
 		]);
 	}
@@ -524,7 +555,7 @@ abstract class AbstractPlayer {
 	 */
 	public function getPlanet(): ?Planet {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM planet WHERE game_id=' . $db->escapeNumber($this->getGameID()) . ' AND owner_id=' . $db->escapeNumber($this->getAccountID()));
+		$dbResult = $db->read('SELECT * FROM planet WHERE game_id = :game_id AND owner_id = :account_id', $this->SQLID);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			return Planet::getPlanet($this->getGameID(), $dbRecord->getInt('sector_id'), false, $dbRecord);
@@ -583,7 +614,10 @@ abstract class AbstractPlayer {
 		if ($this->getGame()->isGameType(Game::GAME_TYPE_DRAFT) && $this->hasAlliance()) {
 			$leaderID = $this->getAlliance()->getLeaderID();
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT home_sector_id FROM draft_leaders WHERE account_id = ' . $db->escapeNumber($leaderID) . ' AND game_id = ' . $db->escapeNumber($this->getGameID()));
+			$dbResult = $db->read('SELECT home_sector_id FROM draft_leaders WHERE ' . self::SQL, [
+				'account_id' => $db->escapeNumber($leaderID),
+				'game_id' => $db->escapeNumber($this->getGameID()),
+			]);
 			if ($dbResult->hasRecord()) {
 				return $dbResult->record()->getInt('home_sector_id');
 			}
@@ -645,7 +679,7 @@ abstract class AbstractPlayer {
 	public function isDraftLeader(): bool {
 		if (!isset($this->draftLeader)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT 1 FROM draft_leaders WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT 1 FROM draft_leaders WHERE ' . self::SQL, $this->SQLID);
 			$this->draftLeader = $dbResult->hasRecord();
 		}
 		return $this->draftLeader;
@@ -655,7 +689,7 @@ abstract class AbstractPlayer {
 		if (!isset($this->gpWriter)) {
 			$this->gpWriter = false;
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT position FROM galactic_post_writer WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT position FROM galactic_post_writer WHERE ' . self::SQL, $this->SQLID);
 			if ($dbResult->hasRecord()) {
 				$this->gpWriter = $dbResult->record()->getString('position');
 			}
@@ -769,10 +803,13 @@ abstract class AbstractPlayer {
 		$dbResult = $db->read('SELECT account_id
 					FROM active_session
 					JOIN player USING (game_id, account_id)
-					WHERE active_session.last_accessed >= ' . $db->escapeNumber(Epoch::time() - TIME_BEFORE_INACTIVE) . '
-						AND game_id = ' . $db->escapeNumber($this->getGameID()) . '
+					WHERE active_session.last_accessed >= :hidden_time
+						AND game_id = :game_id
 						AND ignore_globals = \'FALSE\'
-						AND account_id != ' . $db->escapeNumber($this->getAccountID()));
+						AND account_id != :account_id', [
+			'hidden_time' => $db->escapeNumber(Epoch::time() - TIME_BEFORE_INACTIVE),
+			...$this->SQLID,
+		]);
 
 		foreach ($dbResult->records() as $dbRecord) {
 			$this->sendMessage($dbRecord->getInt('account_id'), MSG_GLOBAL, $message, $canBeIgnored);
@@ -791,7 +828,10 @@ abstract class AbstractPlayer {
 			}
 			// Don't send messages to players ignoring us
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT 1 FROM message_blacklist WHERE account_id=' . $db->escapeNumber($receiverID) . ' AND blacklisted_id=' . $db->escapeNumber($this->getAccountID()) . ' LIMIT 1');
+			$dbResult = $db->read('SELECT 1 FROM message_blacklist WHERE account_id = :receiver_id AND blacklisted_id = :sender_id LIMIT 1', [
+				'receiver_id' => $db->escapeNumber($receiverID),
+				'sender_id' => $db->escapeNumber($this->getAccountID()),
+			]);
 			if ($dbResult->hasRecord()) {
 				return false;
 			}
@@ -895,9 +935,16 @@ abstract class AbstractPlayer {
 	public function setMessagesRead(int $messageTypeID): void {
 		$db = Database::getInstance();
 		$db->write('DELETE FROM player_has_unread_messages
-							WHERE ' . $this->SQL . ' AND message_type_id = ' . $db->escapeNumber($messageTypeID));
-		$db->write('UPDATE message SET msg_read = ' . $db->escapeBoolean(true) . '
-				WHERE message_type_id = ' . $db->escapeNumber($messageTypeID) . ' AND ' . $this->SQL);
+							WHERE ' . self::SQL . ' AND message_type_id = :message_type_id', [
+			'message_type_id' => $db->escapeNumber($messageTypeID),
+			...$this->SQLID,
+		]);
+		$db->write('UPDATE message SET msg_read = :msg_read
+				WHERE message_type_id = :message_type_id AND ' . self::SQL, [
+			'msg_read' => $db->escapeBoolean(true),
+			'message_type_id' => $db->escapeNumber($messageTypeID),
+			...$this->SQLID,
+		]);
 	}
 
 	public function getSafeAttackRating(): int {
@@ -934,7 +981,10 @@ abstract class AbstractPlayer {
 			}
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT race_id, allowed FROM player_can_fed
-								WHERE ' . $this->SQL . ' AND expiry > ' . $db->escapeNumber(Epoch::time()));
+								WHERE ' . self::SQL . ' AND expiry > :now', [
+				'now' => $db->escapeNumber(Epoch::time()),
+				...$this->SQLID,
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$this->canFed[$dbRecord->getInt('race_id')] = $dbRecord->getBoolean('allowed');
 			}
@@ -1403,8 +1453,13 @@ abstract class AbstractPlayer {
 		if ($this->allianceID != 0) {
 			$status = $this->hasNewbieStatus() ? 'NEWBIE' : 'VETERAN';
 			$db = Database::getInstance();
-			$db->write('INSERT IGNORE INTO player_joined_alliance (account_id,game_id,alliance_id,status) ' .
-				'VALUES (' . $db->escapeNumber($this->getAccountID()) . ',' . $db->escapeNumber($this->getGameID()) . ',' . $db->escapeNumber($this->getAllianceID()) . ',' . $db->escapeString($status) . ')');
+			$db->write('INSERT IGNORE INTO player_joined_alliance (account_id,game_id,alliance_id,status)
+				VALUES (:account_id, :game_id, :alliance_id, :status)', [
+				'account_id' => $db->escapeNumber($this->getAccountID()),
+				'game_id' => $db->escapeNumber($this->getGameID()),
+				'alliance_id' => $db->escapeNumber($this->getAllianceID()),
+				'status' => $db->escapeString($status),
+			]);
 		}
 		$this->hasChanged = true;
 	}
@@ -1429,8 +1484,11 @@ abstract class AbstractPlayer {
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT role_id
 						FROM player_has_alliance_role
-						WHERE ' . $this->SQL . '
-						AND alliance_id=' . $db->escapeNumber($allianceID));
+						WHERE ' . self::SQL . '
+						AND alliance_id = :alliance_id', [
+				'alliance_id' => $db->escapeNumber($allianceID),
+				...$this->SQLID,
+			]);
 			if ($dbResult->hasRecord()) {
 				$this->allianceRoles[$allianceID] = $dbResult->record()->getInt('role_id');
 			}
@@ -1461,7 +1519,7 @@ abstract class AbstractPlayer {
 
 		$this->setAllianceID(0);
 		$db = Database::getInstance();
-		$db->write('DELETE FROM player_has_alliance_role WHERE ' . $this->SQL);
+		$db->write('DELETE FROM player_has_alliance_role WHERE ' . self::SQL, $this->SQLID);
 
 		// Update the alliance cache
 		unset(self::$CACHE_ALLIANCE_PLAYERS[$this->gameID][$alliance->getAllianceID()][$this->accountID]);
@@ -1490,8 +1548,7 @@ abstract class AbstractPlayer {
 		}
 		$db = Database::getInstance();
 		$db->insert('player_has_alliance_role', [
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'account_id' => $db->escapeNumber($this->getAccountID()),
+			...$this->SQLID,
 			'role_id' => $db->escapeNumber($roleID),
 			'alliance_id' => $db->escapeNumber($this->getAllianceID()),
 		]);
@@ -1543,7 +1600,7 @@ abstract class AbstractPlayer {
 				$this->personalRelations[$raceID] = 0;
 			}
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT race_id,relation FROM player_has_relation WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT race_id,relation FROM player_has_relation WHERE ' . self::SQL, $this->SQLID);
 			foreach ($dbResult->records() as $dbRecord) {
 				$this->personalRelations[$dbRecord->getInt('race_id')] = $dbRecord->getInt('relation');
 			}
@@ -1658,8 +1715,7 @@ abstract class AbstractPlayer {
 		$this->relations[$raceID] += $relationsDiff;
 		$db = Database::getInstance();
 		$db->replace('player_has_relation', [
-			'account_id' => $db->escapeNumber($this->getAccountID()),
-			'game_id' => $db->escapeNumber($this->getGameID()),
+			...$this->SQLID,
 			'race_id' => $db->escapeNumber($raceID),
 			'relation' => $db->escapeNumber($this->personalRelations[$raceID]),
 		]);
@@ -1709,7 +1765,7 @@ abstract class AbstractPlayer {
 		if (!isset($this->plottedCourse)) {
 			// check if we have a course plotted
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT course FROM player_plotted_course WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT course FROM player_plotted_course WHERE ' . self::SQL, $this->SQLID);
 
 			if ($dbResult->hasRecord()) {
 				// get the course back
@@ -1741,8 +1797,7 @@ abstract class AbstractPlayer {
 		$this->plottedCourse = $plottedCourse;
 		$db = Database::getInstance();
 		$db->replace('player_plotted_course', [
-			'account_id' => $db->escapeNumber($this->getAccountID()),
-			'game_id' => $db->escapeNumber($this->getGameID()),
+			...$this->SQLID,
 			'course' => $db->escapeObject($this->plottedCourse),
 		]);
 	}
@@ -1761,7 +1816,7 @@ abstract class AbstractPlayer {
 	public function deletePlottedCourse(): void {
 		$this->plottedCourse = false;
 		$db = Database::getInstance();
-		$db->write('DELETE FROM player_plotted_course WHERE ' . $this->SQL);
+		$db->write('DELETE FROM player_plotted_course WHERE ' . self::SQL, $this->SQLID);
 	}
 
 	/**
@@ -1790,7 +1845,7 @@ abstract class AbstractPlayer {
 		if (!isset($this->storedDestinations)) {
 			$this->storedDestinations = [];
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM player_stored_sector WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM player_stored_sector WHERE ' . self::SQL, $this->SQLID);
 			foreach ($dbResult->records() as $dbRecord) {
 				$sectorID = $dbRecord->getInt('sector_id');
 				$this->storedDestinations[$sectorID] = new StoredDestination(
@@ -1825,8 +1880,13 @@ abstract class AbstractPlayer {
 		$db = Database::getInstance();
 		$db->write('
 			UPDATE player_stored_sector
-				SET offset_left = ' . $db->escapeNumber($offsetLeft) . ', offset_top=' . $db->escapeNumber($offsetTop) . '
-			WHERE ' . $this->SQL . ' AND sector_id = ' . $db->escapeNumber($sectorID));
+				SET offset_left = :offset_left, offset_top = :offset_top
+			WHERE ' . self::SQL . ' AND sector_id = :sector_id', [
+			'offset_left' => $db->escapeNumber($offsetLeft),
+			'offset_top' => $db->escapeNumber($offsetTop),
+			'sector_id' => $db->escapeNumber($sectorID),
+			...$this->SQLID,
+		]);
 	}
 
 	public function addDestinationButton(int $sectorID, string $label): void {
@@ -1850,8 +1910,7 @@ abstract class AbstractPlayer {
 
 		$db = Database::getInstance();
 		$db->insert('player_stored_sector', [
-			'account_id' => $db->escapeNumber($this->getAccountID()),
-			'game_id' => $db->escapeNumber($this->getGameID()),
+			...$this->SQLID,
 			'sector_id' => $db->escapeNumber($sectorID),
 			'label' => $db->escapeString($label),
 			'offset_top' => 1,
@@ -1869,8 +1928,11 @@ abstract class AbstractPlayer {
 		$db = Database::getInstance();
 		$db->write('
 			DELETE FROM player_stored_sector
-			WHERE ' . $this->SQL . '
-			AND sector_id = ' . $db->escapeNumber($sectorID));
+			WHERE ' . self::SQL . '
+			AND sector_id = :sector_id', [
+			'sector_id' => $db->escapeNumber($sectorID),
+			...$this->SQLID,
+		]);
 		unset($this->storedDestinations[$sectorID]);
 	}
 
@@ -1882,7 +1944,10 @@ abstract class AbstractPlayer {
 			$this->tickers = [];
 			//get ticker info
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT type,time,expires,recent FROM player_has_ticker WHERE ' . $this->SQL . ' AND expires > ' . $db->escapeNumber(Epoch::time()));
+			$dbResult = $db->read('SELECT type,time,expires,recent FROM player_has_ticker WHERE ' . self::SQL . ' AND expires > :now', [
+				'now' => $db->escapeNumber(Epoch::time()),
+				...$this->SQLID,
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$this->tickers[$dbRecord->getString('type')] = [
 					'Type' => $dbRecord->getString('type'),
@@ -2016,7 +2081,7 @@ abstract class AbstractPlayer {
 		if (!isset($this->HOF)) {
 			//Get Player HOF
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT type,amount FROM player_hof WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT type,amount FROM player_hof WHERE ' . self::SQL, $this->SQLID);
 			$this->HOF = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$this->HOF[$dbRecord->getString('type')] = $dbRecord->getFloat('amount');
@@ -2133,7 +2198,10 @@ abstract class AbstractPlayer {
 		if ($this->hasAlliance()) {
 			$db = Database::getInstance();
 			$db->write('UPDATE alliance SET alliance_deaths = alliance_deaths + 1
-							WHERE game_id = ' . $db->escapeNumber($this->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($this->getAllianceID()));
+							WHERE game_id = :game_id AND alliance_id = :alliance_id', [
+				'game_id' => $db->escapeNumber($this->getGameID()),
+				'alliance_id' => $db->escapeNumber($this->getAllianceID()),
+			]);
 		}
 
 		// record death stat
@@ -2224,13 +2292,15 @@ abstract class AbstractPlayer {
 		}
 
 		//check for federal bounty being offered for current port raiders;
-		$db->write('DELETE FROM player_attacks_port WHERE time < ' . $db->escapeNumber(Epoch::time() - self::TIME_FOR_FEDERAL_BOUNTY_ON_PR));
+		$db->write('DELETE FROM player_attacks_port WHERE time < :bounty_time', [
+			'bounty_time' => $db->escapeNumber(Epoch::time() - self::TIME_FOR_FEDERAL_BOUNTY_ON_PR),
+		]);
 		$query = 'SELECT 1
 					FROM player_attacks_port
 					JOIN port USING(game_id, sector_id)
 					JOIN player USING(game_id, account_id)
-					WHERE armour > 0 AND ' . $this->SQL . ' LIMIT 1';
-		$dbResult = $db->read($query);
+					WHERE armour > 0 AND ' . self::SQL . ' LIMIT 1';
+		$dbResult = $db->read($query, $this->SQLID);
 		if ($dbResult->hasRecord()) {
 			$bounty = IFloor(DEFEND_PORT_BOUNTY_PER_LEVEL * $this->getLevelID());
 			$this->getActiveBounty(BountyType::HQ)->increaseCredits($bounty);
@@ -2283,7 +2353,10 @@ abstract class AbstractPlayer {
 			$killer->increaseHOF(1, ['Killing', 'Kills'], HOF_PUBLIC);
 
 			if ($killer->hasAlliance()) {
-				$db->write('UPDATE alliance SET alliance_kills=alliance_kills+1 WHERE alliance_id=' . $db->escapeNumber($killer->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($killer->getGameID()));
+				$db->write('UPDATE alliance SET alliance_kills=alliance_kills+1 WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+					'alliance_id' => $db->escapeNumber($killer->getAllianceID()),
+					'game_id' => $db->escapeNumber($killer->getGameID()),
+				]);
 			}
 
 			// alliance vs. alliance stats
@@ -2450,15 +2523,23 @@ abstract class AbstractPlayer {
 	}
 
 	public function incrementAllianceVsKills(int $otherID): void {
-		$values = [$this->getGameID(), $this->getAllianceID(), $otherID, 1];
 		$db = Database::getInstance();
-		$db->write('INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) VALUES (' . $db->escapeArray($values) . ') ON DUPLICATE KEY UPDATE kills = kills + 1');
+		$db->write('INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) VALUES (:game_id, :alliance_id_1, :alliance_id_2, :kills) ON DUPLICATE KEY UPDATE kills = kills + 1', [
+			'game_id' => $this->getGameID(),
+			'alliance_id_1' => $this->getAllianceID(),
+			'alliance_id_2' => $otherID,
+			'kills' => 1,
+		]);
 	}
 
 	public function incrementAllianceVsDeaths(int $otherID): void {
-		$values = [$this->getGameID(), $otherID, $this->getAllianceID(), 1];
 		$db = Database::getInstance();
-		$db->write('INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) VALUES (' . $db->escapeArray($values) . ') ON DUPLICATE KEY UPDATE kills = kills + 1');
+		$db->write('INSERT INTO alliance_vs_alliance (game_id, alliance_id_1, alliance_id_2, kills) VALUES (:game_id, :alliance_id_1, :alliance_id_2, :kills) ON DUPLICATE KEY UPDATE kills = kills + 1', [
+			'game_id' => $this->getGameID(),
+			'alliance_id_1' => $otherID,
+			'alliance_id_2' => $this->getAllianceID(),
+			'kills' => 1,
+		]);
 	}
 
 	public function getTurnsLevel(): TurnsLevel {
@@ -2645,7 +2726,7 @@ abstract class AbstractPlayer {
 	public function getMissions(): array {
 		if (!isset($this->missions)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM player_has_mission WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM player_has_mission WHERE ' . self::SQL, $this->SQLID);
 			$this->missions = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$missionID = $dbRecord->getInt('mission_id');
@@ -2696,13 +2777,22 @@ abstract class AbstractPlayer {
 			$db = Database::getInstance();
 			$db->write('
 				UPDATE player_has_mission
-				SET on_step = ' . $db->escapeNumber($mission['On Step']) . ',
-					progress = ' . $db->escapeNumber($mission['Progress']) . ',
-					unread = ' . $db->escapeBoolean($mission['Unread']) . ',
-					starting_sector = ' . $db->escapeNumber($mission['Starting Sector']) . ',
-					mission_sector = ' . $db->escapeNumber($mission['Sector']) . ',
-					step_fails = ' . $db->escapeNumber($mission['Expires']) . '
-				WHERE ' . $this->SQL . ' AND mission_id = ' . $db->escapeNumber($missionID));
+				SET on_step = :on_step,
+					progress = :progress,
+					unread = :unread,
+					starting_sector = :starting_sector,
+					mission_sector = :mission_sector,
+					step_fails = :step_fails
+				WHERE ' . self::SQL . ' AND mission_id = :mission_id', [
+				'on_step' => $db->escapeNumber($mission['On Step']),
+				'progress' => $db->escapeNumber($mission['Progress']),
+				'unread' => $db->escapeBoolean($mission['Unread']),
+				'starting_sector' => $db->escapeNumber($mission['Starting Sector']),
+				'mission_sector' => $db->escapeNumber($mission['Sector']),
+				'step_fails' => $db->escapeNumber($mission['Expires']),
+				'mission_id' => $db->escapeNumber($missionID),
+				...$this->SQLID,
+			]);
 			return true;
 		}
 		return false;
@@ -2760,8 +2850,7 @@ abstract class AbstractPlayer {
 
 		$db = Database::getInstance();
 		$db->replace('player_has_mission', [
-			'game_id' => $db->escapeNumber($this->gameID),
-			'account_id' => $db->escapeNumber($this->accountID),
+			...$this->SQLID,
 			'mission_id' => $db->escapeNumber($missionID),
 			'on_step' => $db->escapeNumber($mission['On Step']),
 			'progress' => $db->escapeNumber($mission['Progress']),
@@ -2792,7 +2881,10 @@ abstract class AbstractPlayer {
 		if (isset($this->missions[$missionID])) {
 			unset($this->missions[$missionID]);
 			$db = Database::getInstance();
-			$db->write('DELETE FROM player_has_mission WHERE ' . $this->SQL . ' AND mission_id = ' . $db->escapeNumber($missionID));
+			$db->write('DELETE FROM player_has_mission WHERE ' . self::SQL . ' AND mission_id = :mission_id', [
+				'mission_id' => $db->escapeNumber($missionID),
+				...$this->SQLID,
+			]);
 			return;
 		}
 		throw new Exception('Mission with ID not found: ' . $missionID);
@@ -3020,7 +3112,7 @@ abstract class AbstractPlayer {
 			$this->unvisitedSectors = [];
 			// Note that this table actually has entries for the *unvisited* sectors!
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT sector_id FROM player_visited_sector WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT sector_id FROM player_visited_sector WHERE ' . self::SQL, $this->SQLID);
 			foreach ($dbResult->records() as $dbRecord) {
 				$this->unvisitedSectors[] = $dbRecord->getInt('sector_id');
 			}
@@ -3084,7 +3176,10 @@ abstract class AbstractPlayer {
 		}
 		$this->displayWeapons = $bool;
 		$db = Database::getInstance();
-		$db->write('UPDATE player SET display_weapons=' . $db->escapeBoolean($this->displayWeapons) . ' WHERE ' . $this->SQL);
+		$db->write('UPDATE player SET display_weapons = :display_weapons WHERE ' . self::SQL, [
+			'display_weapons' => $db->escapeBoolean($this->displayWeapons),
+			...$this->SQLID,
+		]);
 	}
 
 	public function update(): void {
@@ -3094,44 +3189,83 @@ abstract class AbstractPlayer {
 	public function save(): void {
 		if ($this->hasChanged === true) {
 			$db = Database::getInstance();
-			$db->write('UPDATE player SET player_name=' . $db->escapeString($this->playerName) .
-				', player_id=' . $db->escapeNumber($this->playerID) .
-				', sector_id=' . $db->escapeNumber($this->sectorID) .
-				', last_sector_id=' . $db->escapeNumber($this->lastSectorID) .
-				', turns=' . $db->escapeNumber($this->turns) .
-				', last_turn_update=' . $db->escapeNumber($this->lastTurnUpdate) .
-				', newbie_turns=' . $db->escapeNumber($this->newbieTurns) .
-				', last_news_update=' . $db->escapeNumber($this->lastNewsUpdate) .
-				', attack_warning=' . $db->escapeString($this->attackColour) .
-				', dead=' . $db->escapeBoolean($this->dead) .
-				', newbie_status=' . $db->escapeBoolean($this->newbieStatus) .
-				', land_on_planet=' . $db->escapeBoolean($this->landedOnPlanet) .
-				', last_active=' . $db->escapeNumber($this->lastActive) .
-				', last_cpl_action=' . $db->escapeNumber($this->lastCPLAction) .
-				', race_id=' . $db->escapeNumber($this->raceID) .
-				', credits=' . $db->escapeNumber($this->credits) .
-				', experience=' . $db->escapeNumber($this->experience) .
-				', alignment=' . $db->escapeNumber($this->alignment) .
-				', military_payment=' . $db->escapeNumber($this->militaryPayment) .
-				', alliance_id=' . $db->escapeNumber($this->allianceID) .
-				', alliance_join=' . $db->escapeNumber($this->allianceJoinable) .
-				', ship_type_id=' . $db->escapeNumber($this->shipID) .
-				', kills=' . $db->escapeNumber($this->kills) .
-				', deaths=' . $db->escapeNumber($this->deaths) .
-				', assists=' . $db->escapeNumber($this->assists) .
-				', last_port=' . $db->escapeNumber($this->lastPort) .
-				', bank=' . $db->escapeNumber($this->bank) .
-				', zoom=' . $db->escapeNumber($this->zoom) .
-				', display_missions=' . $db->escapeBoolean($this->displayMissions) .
-				', force_drop_messages=' . $db->escapeBoolean($this->forceDropMessages) .
-				', group_scout_messages=' . $db->escapeString($this->scoutMessageGroupType->value) .
-				', ignore_globals=' . $db->escapeBoolean($this->ignoreGlobals) .
-				', newbie_warning = ' . $db->escapeBoolean($this->newbieWarning) .
-				', name_changed = ' . $db->escapeBoolean($this->nameChanged) .
-				', race_changed = ' . $db->escapeBoolean($this->raceChanged) .
-				', combat_drones_kamikaze_on_mines = ' . $db->escapeBoolean($this->combatDronesKamikazeOnMines) .
-				', under_attack = ' . $db->escapeBoolean($this->underAttack) .
-				' WHERE ' . $this->SQL);
+			$db->write('UPDATE player SET player_name = :player_name,
+				player_id = :player_id,
+				sector_id = :sector_id,
+				last_sector_id = :last_sector_id,
+				turns = :turns,
+				last_turn_update = :last_turn_update,
+				newbie_turns = :newbie_turns,
+				last_news_update = :last_news_update,
+				attack_warning = :attack_warning,
+				dead = :dead,
+				newbie_status = :newbie_status,
+				land_on_planet = :land_on_planet,
+				last_active = :last_active,
+				last_cpl_action = :last_cpl_action,
+				race_id = :race_id,
+				credits = :credits,
+				experience = :experience,
+				alignment = :alignment,
+				military_payment = :military_payment,
+				alliance_id = :alliance_id,
+				alliance_join = :alliance_join,
+				ship_type_id = :ship_type_id,
+				kills = :kills,
+				deaths = :deaths,
+				assists = :assists,
+				last_port = :last_port,
+				bank = :bank,
+				zoom = :zoom,
+				display_missions = :display_missions,
+				force_drop_messages = :force_drop_messages,
+				group_scout_messages = :group_scout_messages,
+				ignore_globals = :ignore_globals,
+				newbie_warning = :newbie_warning,
+				name_changed = :name_changed,
+				race_changed = :race_changed,
+				combat_drones_kamikaze_on_mines = :combat_drones_kamikaze_on_mines,
+				under_attack = :under_attack
+				WHERE ' . self::SQL, [
+				'player_name' => $db->escapeString($this->playerName),
+				'player_id' => $db->escapeNumber($this->playerID),
+				'sector_id' => $db->escapeNumber($this->sectorID),
+				'last_sector_id' => $db->escapeNumber($this->lastSectorID),
+				'turns' => $db->escapeNumber($this->turns),
+				'last_turn_update' => $db->escapeNumber($this->lastTurnUpdate),
+				'newbie_turns' => $db->escapeNumber($this->newbieTurns),
+				'last_news_update' => $db->escapeNumber($this->lastNewsUpdate),
+				'attack_warning' => $db->escapeString($this->attackColour),
+				'dead' => $db->escapeBoolean($this->dead),
+				'newbie_status' => $db->escapeBoolean($this->newbieStatus),
+				'land_on_planet' => $db->escapeBoolean($this->landedOnPlanet),
+				'last_active' => $db->escapeNumber($this->lastActive),
+				'last_cpl_action' => $db->escapeNumber($this->lastCPLAction),
+				'race_id' => $db->escapeNumber($this->raceID),
+				'credits' => $db->escapeNumber($this->credits),
+				'experience' => $db->escapeNumber($this->experience),
+				'alignment' => $db->escapeNumber($this->alignment),
+				'military_payment' => $db->escapeNumber($this->militaryPayment),
+				'alliance_id' => $db->escapeNumber($this->allianceID),
+				'alliance_join' => $db->escapeNumber($this->allianceJoinable),
+				'ship_type_id' => $db->escapeNumber($this->shipID),
+				'kills' => $db->escapeNumber($this->kills),
+				'deaths' => $db->escapeNumber($this->deaths),
+				'assists' => $db->escapeNumber($this->assists),
+				'last_port' => $db->escapeNumber($this->lastPort),
+				'bank' => $db->escapeNumber($this->bank),
+				'zoom' => $db->escapeNumber($this->zoom),
+				'display_missions' => $db->escapeBoolean($this->displayMissions),
+				'force_drop_messages' => $db->escapeBoolean($this->forceDropMessages),
+				'group_scout_messages' => $db->escapeString($this->scoutMessageGroupType->value),
+				'ignore_globals' => $db->escapeBoolean($this->ignoreGlobals),
+				'newbie_warning' => $db->escapeBoolean($this->newbieWarning),
+				'name_changed' => $db->escapeBoolean($this->nameChanged),
+				'race_changed' => $db->escapeBoolean($this->raceChanged),
+				'combat_drones_kamikaze_on_mines' => $db->escapeBoolean($this->combatDronesKamikazeOnMines),
+				'under_attack' => $db->escapeBoolean($this->underAttack),
+				...$this->SQLID,
+			]);
 			$this->hasChanged = false;
 		}
 		$bounties = $this->bounties ?? []; // no need to fetch if unset
@@ -3150,7 +3284,10 @@ abstract class AbstractPlayer {
 					'visibility' => $db->escapeString(self::$HOFVis[$hofType]),
 				]);
 			} else {
-				$db->write('UPDATE hof_visibility SET visibility = ' . $db->escapeString(self::$HOFVis[$hofType]) . ' WHERE type = ' . $db->escapeString($hofType));
+				$db->write('UPDATE hof_visibility SET visibility = :visibility WHERE type = :type', [
+					'visibility' => $db->escapeString(self::$HOFVis[$hofType]),
+					'type' => $db->escapeString($hofType),
+				]);
 			}
 			unset(self::$hasHOFVisChanged[$hofType]);
 		}
@@ -3160,16 +3297,19 @@ abstract class AbstractPlayer {
 			if ($changeType === self::HOF_NEW) {
 				if ($amount > 0) {
 					$db->insert('player_hof', [
-						'account_id' => $db->escapeNumber($this->getAccountID()),
-						'game_id' => $db->escapeNumber($this->getGameID()),
+						...$this->SQLID,
 						'type' => $db->escapeString($hofType),
 						'amount' => $db->escapeNumber($amount),
 					]);
 				}
 			} elseif ($changeType === self::HOF_CHANGED) {
 				$db->write('UPDATE player_hof
-					SET amount=' . $db->escapeNumber($amount) . '
-					WHERE ' . $this->SQL . ' AND type = ' . $db->escapeString($hofType));
+					SET amount = :amount
+					WHERE ' . self::SQL . ' AND type = :type', [
+					...$this->SQLID,
+					'type' => $db->escapeString($hofType),
+					'amount' => $db->escapeNumber($amount),
+				]);
 			}
 			unset($this->hasHOFChanged[$hofType]);
 		}

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -934,8 +934,7 @@ abstract class AbstractPlayer {
 
 	public function setMessagesRead(int $messageTypeID): void {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM player_has_unread_messages
-							WHERE ' . self::SQL . ' AND message_type_id = :message_type_id', [
+		$db->delete('player_has_unread_messages', [
 			'message_type_id' => $db->escapeNumber($messageTypeID),
 			...$this->SQLID,
 		]);
@@ -1519,7 +1518,7 @@ abstract class AbstractPlayer {
 
 		$this->setAllianceID(0);
 		$db = Database::getInstance();
-		$db->write('DELETE FROM player_has_alliance_role WHERE ' . self::SQL, $this->SQLID);
+		$db->delete('player_has_alliance_role', $this->SQLID);
 
 		// Update the alliance cache
 		unset(self::$CACHE_ALLIANCE_PLAYERS[$this->gameID][$alliance->getAllianceID()][$this->accountID]);
@@ -1816,7 +1815,7 @@ abstract class AbstractPlayer {
 	public function deletePlottedCourse(): void {
 		$this->plottedCourse = false;
 		$db = Database::getInstance();
-		$db->write('DELETE FROM player_plotted_course WHERE ' . self::SQL, $this->SQLID);
+		$db->delete('player_plotted_course', $this->SQLID);
 	}
 
 	/**
@@ -1926,10 +1925,7 @@ abstract class AbstractPlayer {
 		}
 
 		$db = Database::getInstance();
-		$db->write('
-			DELETE FROM player_stored_sector
-			WHERE ' . self::SQL . '
-			AND sector_id = :sector_id', [
+		$db->delete('player_stored_sector', [
 			'sector_id' => $db->escapeNumber($sectorID),
 			...$this->SQLID,
 		]);
@@ -2881,7 +2877,7 @@ abstract class AbstractPlayer {
 		if (isset($this->missions[$missionID])) {
 			unset($this->missions[$missionID]);
 			$db = Database::getInstance();
-			$db->write('DELETE FROM player_has_mission WHERE ' . self::SQL . ' AND mission_id = :mission_id', [
+			$db->delete('player_has_mission', [
 				'mission_id' => $db->escapeNumber($missionID),
 				...$this->SQLID,
 			]);

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -938,12 +938,14 @@ abstract class AbstractPlayer {
 			'message_type_id' => $db->escapeNumber($messageTypeID),
 			...$this->SQLID,
 		]);
-		$db->write('UPDATE message SET msg_read = :msg_read
-				WHERE message_type_id = :message_type_id AND ' . self::SQL, [
-			'msg_read' => $db->escapeBoolean(true),
-			'message_type_id' => $db->escapeNumber($messageTypeID),
-			...$this->SQLID,
-		]);
+		$db->update(
+			'message',
+			['msg_read' => $db->escapeBoolean(true)],
+			[
+				'message_type_id' => $db->escapeNumber($messageTypeID),
+				...$this->SQLID,
+			],
+		);
 	}
 
 	public function getSafeAttackRating(): int {
@@ -1877,15 +1879,17 @@ abstract class AbstractPlayer {
 			offsetLeft: $offsetLeft,
 		);
 		$db = Database::getInstance();
-		$db->write('
-			UPDATE player_stored_sector
-				SET offset_left = :offset_left, offset_top = :offset_top
-			WHERE ' . self::SQL . ' AND sector_id = :sector_id', [
-			'offset_left' => $db->escapeNumber($offsetLeft),
-			'offset_top' => $db->escapeNumber($offsetTop),
-			'sector_id' => $db->escapeNumber($sectorID),
-			...$this->SQLID,
-		]);
+		$db->update(
+			'player_stored_sector',
+			[
+				'offset_left' => $db->escapeNumber($offsetLeft),
+				'offset_top' => $db->escapeNumber($offsetTop),
+			],
+			[
+				'sector_id' => $db->escapeNumber($sectorID),
+				...$this->SQLID,
+			],
+		);
 	}
 
 	public function addDestinationButton(int $sectorID, string $label): void {
@@ -2771,24 +2775,21 @@ abstract class AbstractPlayer {
 		if (isset($this->missions[$missionID])) {
 			$mission = $this->missions[$missionID];
 			$db = Database::getInstance();
-			$db->write('
-				UPDATE player_has_mission
-				SET on_step = :on_step,
-					progress = :progress,
-					unread = :unread,
-					starting_sector = :starting_sector,
-					mission_sector = :mission_sector,
-					step_fails = :step_fails
-				WHERE ' . self::SQL . ' AND mission_id = :mission_id', [
-				'on_step' => $db->escapeNumber($mission['On Step']),
-				'progress' => $db->escapeNumber($mission['Progress']),
-				'unread' => $db->escapeBoolean($mission['Unread']),
-				'starting_sector' => $db->escapeNumber($mission['Starting Sector']),
-				'mission_sector' => $db->escapeNumber($mission['Sector']),
-				'step_fails' => $db->escapeNumber($mission['Expires']),
-				'mission_id' => $db->escapeNumber($missionID),
-				...$this->SQLID,
-			]);
+			$db->update(
+				'player_has_mission',
+				[
+					'on_step' => $db->escapeNumber($mission['On Step']),
+					'progress' => $db->escapeNumber($mission['Progress']),
+					'unread' => $db->escapeBoolean($mission['Unread']),
+					'starting_sector' => $db->escapeNumber($mission['Starting Sector']),
+					'mission_sector' => $db->escapeNumber($mission['Sector']),
+					'step_fails' => $db->escapeNumber($mission['Expires']),
+				],
+				[
+					'mission_id' => $db->escapeNumber($missionID),
+					...$this->SQLID,
+				],
+			);
 			return true;
 		}
 		return false;
@@ -3172,10 +3173,11 @@ abstract class AbstractPlayer {
 		}
 		$this->displayWeapons = $bool;
 		$db = Database::getInstance();
-		$db->write('UPDATE player SET display_weapons = :display_weapons WHERE ' . self::SQL, [
-			'display_weapons' => $db->escapeBoolean($this->displayWeapons),
-			...$this->SQLID,
-		]);
+		$db->update(
+			'player',
+			['display_weapons' => $db->escapeBoolean($this->displayWeapons)],
+			$this->SQLID,
+		);
 	}
 
 	public function update(): void {
@@ -3185,83 +3187,49 @@ abstract class AbstractPlayer {
 	public function save(): void {
 		if ($this->hasChanged === true) {
 			$db = Database::getInstance();
-			$db->write('UPDATE player SET player_name = :player_name,
-				player_id = :player_id,
-				sector_id = :sector_id,
-				last_sector_id = :last_sector_id,
-				turns = :turns,
-				last_turn_update = :last_turn_update,
-				newbie_turns = :newbie_turns,
-				last_news_update = :last_news_update,
-				attack_warning = :attack_warning,
-				dead = :dead,
-				newbie_status = :newbie_status,
-				land_on_planet = :land_on_planet,
-				last_active = :last_active,
-				last_cpl_action = :last_cpl_action,
-				race_id = :race_id,
-				credits = :credits,
-				experience = :experience,
-				alignment = :alignment,
-				military_payment = :military_payment,
-				alliance_id = :alliance_id,
-				alliance_join = :alliance_join,
-				ship_type_id = :ship_type_id,
-				kills = :kills,
-				deaths = :deaths,
-				assists = :assists,
-				last_port = :last_port,
-				bank = :bank,
-				zoom = :zoom,
-				display_missions = :display_missions,
-				force_drop_messages = :force_drop_messages,
-				group_scout_messages = :group_scout_messages,
-				ignore_globals = :ignore_globals,
-				newbie_warning = :newbie_warning,
-				name_changed = :name_changed,
-				race_changed = :race_changed,
-				combat_drones_kamikaze_on_mines = :combat_drones_kamikaze_on_mines,
-				under_attack = :under_attack
-				WHERE ' . self::SQL, [
-				'player_name' => $db->escapeString($this->playerName),
-				'player_id' => $db->escapeNumber($this->playerID),
-				'sector_id' => $db->escapeNumber($this->sectorID),
-				'last_sector_id' => $db->escapeNumber($this->lastSectorID),
-				'turns' => $db->escapeNumber($this->turns),
-				'last_turn_update' => $db->escapeNumber($this->lastTurnUpdate),
-				'newbie_turns' => $db->escapeNumber($this->newbieTurns),
-				'last_news_update' => $db->escapeNumber($this->lastNewsUpdate),
-				'attack_warning' => $db->escapeString($this->attackColour),
-				'dead' => $db->escapeBoolean($this->dead),
-				'newbie_status' => $db->escapeBoolean($this->newbieStatus),
-				'land_on_planet' => $db->escapeBoolean($this->landedOnPlanet),
-				'last_active' => $db->escapeNumber($this->lastActive),
-				'last_cpl_action' => $db->escapeNumber($this->lastCPLAction),
-				'race_id' => $db->escapeNumber($this->raceID),
-				'credits' => $db->escapeNumber($this->credits),
-				'experience' => $db->escapeNumber($this->experience),
-				'alignment' => $db->escapeNumber($this->alignment),
-				'military_payment' => $db->escapeNumber($this->militaryPayment),
-				'alliance_id' => $db->escapeNumber($this->allianceID),
-				'alliance_join' => $db->escapeNumber($this->allianceJoinable),
-				'ship_type_id' => $db->escapeNumber($this->shipID),
-				'kills' => $db->escapeNumber($this->kills),
-				'deaths' => $db->escapeNumber($this->deaths),
-				'assists' => $db->escapeNumber($this->assists),
-				'last_port' => $db->escapeNumber($this->lastPort),
-				'bank' => $db->escapeNumber($this->bank),
-				'zoom' => $db->escapeNumber($this->zoom),
-				'display_missions' => $db->escapeBoolean($this->displayMissions),
-				'force_drop_messages' => $db->escapeBoolean($this->forceDropMessages),
-				'group_scout_messages' => $db->escapeString($this->scoutMessageGroupType->value),
-				'ignore_globals' => $db->escapeBoolean($this->ignoreGlobals),
-				'newbie_warning' => $db->escapeBoolean($this->newbieWarning),
-				'name_changed' => $db->escapeBoolean($this->nameChanged),
-				'race_changed' => $db->escapeBoolean($this->raceChanged),
-				'combat_drones_kamikaze_on_mines' => $db->escapeBoolean($this->combatDronesKamikazeOnMines),
-				'under_attack' => $db->escapeBoolean($this->underAttack),
-				...$this->SQLID,
-			]);
+			$db->update(
+				'player',
+				[
+					'player_name' => $db->escapeString($this->playerName),
+					'player_id' => $db->escapeNumber($this->playerID),
+					'sector_id' => $db->escapeNumber($this->sectorID),
+					'last_sector_id' => $db->escapeNumber($this->lastSectorID),
+					'turns' => $db->escapeNumber($this->turns),
+					'last_turn_update' => $db->escapeNumber($this->lastTurnUpdate),
+					'newbie_turns' => $db->escapeNumber($this->newbieTurns),
+					'last_news_update' => $db->escapeNumber($this->lastNewsUpdate),
+					'attack_warning' => $db->escapeString($this->attackColour),
+					'dead' => $db->escapeBoolean($this->dead),
+					'newbie_status' => $db->escapeBoolean($this->newbieStatus),
+					'land_on_planet' => $db->escapeBoolean($this->landedOnPlanet),
+					'last_active' => $db->escapeNumber($this->lastActive),
+					'last_cpl_action' => $db->escapeNumber($this->lastCPLAction),
+					'race_id' => $db->escapeNumber($this->raceID),
+					'credits' => $db->escapeNumber($this->credits),
+					'experience' => $db->escapeNumber($this->experience),
+					'alignment' => $db->escapeNumber($this->alignment),
+					'military_payment' => $db->escapeNumber($this->militaryPayment),
+					'alliance_id' => $db->escapeNumber($this->allianceID),
+					'alliance_join' => $db->escapeNumber($this->allianceJoinable),
+					'ship_type_id' => $db->escapeNumber($this->shipID),
+					'kills' => $db->escapeNumber($this->kills),
+					'deaths' => $db->escapeNumber($this->deaths),
+					'assists' => $db->escapeNumber($this->assists),
+					'last_port' => $db->escapeNumber($this->lastPort),
+					'bank' => $db->escapeNumber($this->bank),
+					'zoom' => $db->escapeNumber($this->zoom),
+					'display_missions' => $db->escapeBoolean($this->displayMissions),
+					'force_drop_messages' => $db->escapeBoolean($this->forceDropMessages),
+					'group_scout_messages' => $db->escapeString($this->scoutMessageGroupType->value),
+					'ignore_globals' => $db->escapeBoolean($this->ignoreGlobals),
+					'newbie_warning' => $db->escapeBoolean($this->newbieWarning),
+					'name_changed' => $db->escapeBoolean($this->nameChanged),
+					'race_changed' => $db->escapeBoolean($this->raceChanged),
+					'combat_drones_kamikaze_on_mines' => $db->escapeBoolean($this->combatDronesKamikazeOnMines),
+					'under_attack' => $db->escapeBoolean($this->underAttack),
+				],
+				$this->SQLID,
+			);
 			$this->hasChanged = false;
 		}
 		$bounties = $this->bounties ?? []; // no need to fetch if unset
@@ -3280,10 +3248,11 @@ abstract class AbstractPlayer {
 					'visibility' => $db->escapeString(self::$HOFVis[$hofType]),
 				]);
 			} else {
-				$db->write('UPDATE hof_visibility SET visibility = :visibility WHERE type = :type', [
-					'visibility' => $db->escapeString(self::$HOFVis[$hofType]),
-					'type' => $db->escapeString($hofType),
-				]);
+				$db->update(
+					'hof_visibility',
+					['visibility' => $db->escapeString(self::$HOFVis[$hofType])],
+					['type' => $db->escapeString($hofType)],
+				);
 			}
 			unset(self::$hasHOFVisChanged[$hofType]);
 		}
@@ -3299,13 +3268,14 @@ abstract class AbstractPlayer {
 					]);
 				}
 			} elseif ($changeType === self::HOF_CHANGED) {
-				$db->write('UPDATE player_hof
-					SET amount = :amount
-					WHERE ' . self::SQL . ' AND type = :type', [
-					...$this->SQLID,
-					'type' => $db->escapeString($hofType),
-					'amount' => $db->escapeNumber($amount),
-				]);
+				$db->update(
+					'player_hof',
+					['amount' => $db->escapeNumber($amount)],
+					[
+						...$this->SQLID,
+						'type' => $db->escapeString($hofType),
+					],
+				);
 			}
 			unset($this->hasHOFChanged[$hofType]);
 		}

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -366,14 +366,14 @@ abstract class AbstractPlayer {
 
 		$startSectorID = 0; // Temporarily put player into non-existent sector
 		$db->insert('player', [
-			'account_id' => $db->escapeNumber($accountID),
-			'game_id' => $db->escapeNumber($gameID),
-			'player_id' => $db->escapeNumber($playerID),
-			'player_name' => $db->escapeString($playerName),
-			'race_id' => $db->escapeNumber($raceID),
-			'sector_id' => $db->escapeNumber($startSectorID),
-			'last_cpl_action' => $db->escapeNumber($time),
-			'last_active' => $db->escapeNumber($time),
+			'account_id' => $accountID,
+			'game_id' => $gameID,
+			'player_id' => $playerID,
+			'player_name' => $playerName,
+			'race_id' => $raceID,
+			'sector_id' => $startSectorID,
+			'last_cpl_action' => $time,
+			'last_active' => $time,
 			'npc' => $db->escapeBoolean($npc),
 			'newbie_status' => $db->escapeBoolean($isNewbie),
 		]);
@@ -545,7 +545,7 @@ abstract class AbstractPlayer {
 		$db = Database::getInstance();
 		$db->replace('ship_has_name', [
 			...$this->SQLID,
-			'ship_name' => $db->escapeString($name),
+			'ship_name' => $name,
 		]);
 	}
 
@@ -741,22 +741,22 @@ abstract class AbstractPlayer {
 		$db = Database::getInstance();
 		// Keep track of the message_id so it can be returned
 		$insertID = $db->insert('message', [
-			'account_id' => $db->escapeNumber($receiverID),
-			'game_id' => $db->escapeNumber($gameID),
-			'message_type_id' => $db->escapeNumber($messageTypeID),
-			'message_text' => $db->escapeString($message),
-			'sender_id' => $db->escapeNumber($senderID),
-			'send_time' => $db->escapeNumber(Epoch::time()),
-			'expire_time' => $db->escapeNumber($expires),
+			'account_id' => $receiverID,
+			'game_id' => $gameID,
+			'message_type_id' => $messageTypeID,
+			'message_text' => $message,
+			'sender_id' => $senderID,
+			'send_time' => Epoch::time(),
+			'expire_time' => $expires,
 			'sender_delete' => $db->escapeBoolean($senderDelete),
 		]);
 
 		if ($unread === true) {
 			// give him the message icon
 			$db->replace('player_has_unread_messages', [
-				'game_id' => $db->escapeNumber($gameID),
-				'account_id' => $db->escapeNumber($receiverID),
-				'message_type_id' => $db->escapeNumber($messageTypeID),
+				'game_id' => $gameID,
+				'account_id' => $receiverID,
+				'message_type_id' => $messageTypeID,
 			]);
 		}
 
@@ -935,14 +935,14 @@ abstract class AbstractPlayer {
 	public function setMessagesRead(int $messageTypeID): void {
 		$db = Database::getInstance();
 		$db->delete('player_has_unread_messages', [
-			'message_type_id' => $db->escapeNumber($messageTypeID),
+			'message_type_id' => $messageTypeID,
 			...$this->SQLID,
 		]);
 		$db->update(
 			'message',
 			['msg_read' => $db->escapeBoolean(true)],
 			[
-				'message_type_id' => $db->escapeNumber($messageTypeID),
+				'message_type_id' => $messageTypeID,
 				...$this->SQLID,
 			],
 		);
@@ -1550,8 +1550,8 @@ abstract class AbstractPlayer {
 		$db = Database::getInstance();
 		$db->insert('player_has_alliance_role', [
 			...$this->SQLID,
-			'role_id' => $db->escapeNumber($roleID),
-			'alliance_id' => $db->escapeNumber($this->getAllianceID()),
+			'role_id' => $roleID,
+			'alliance_id' => $this->getAllianceID(),
 		]);
 
 		$this->actionTaken('JoinAlliance', ['Alliance' => $alliance]);
@@ -1717,8 +1717,8 @@ abstract class AbstractPlayer {
 		$db = Database::getInstance();
 		$db->replace('player_has_relation', [
 			...$this->SQLID,
-			'race_id' => $db->escapeNumber($raceID),
-			'relation' => $db->escapeNumber($this->personalRelations[$raceID]),
+			'race_id' => $raceID,
+			'relation' => $this->personalRelations[$raceID],
 		]);
 	}
 
@@ -1882,11 +1882,11 @@ abstract class AbstractPlayer {
 		$db->update(
 			'player_stored_sector',
 			[
-				'offset_left' => $db->escapeNumber($offsetLeft),
-				'offset_top' => $db->escapeNumber($offsetTop),
+				'offset_left' => $offsetLeft,
+				'offset_top' => $offsetTop,
 			],
 			[
-				'sector_id' => $db->escapeNumber($sectorID),
+				'sector_id' => $sectorID,
 				...$this->SQLID,
 			],
 		);
@@ -1914,8 +1914,8 @@ abstract class AbstractPlayer {
 		$db = Database::getInstance();
 		$db->insert('player_stored_sector', [
 			...$this->SQLID,
-			'sector_id' => $db->escapeNumber($sectorID),
-			'label' => $db->escapeString($label),
+			'sector_id' => $sectorID,
+			'label' => $label,
 			'offset_top' => 1,
 			'offset_left' => 1,
 		]);
@@ -1930,7 +1930,7 @@ abstract class AbstractPlayer {
 
 		$db = Database::getInstance();
 		$db->delete('player_stored_sector', [
-			'sector_id' => $db->escapeNumber($sectorID),
+			'sector_id' => $sectorID,
 			...$this->SQLID,
 		]);
 		unset($this->storedDestinations[$sectorID]);
@@ -2246,13 +2246,13 @@ abstract class AbstractPlayer {
 		$this->getSector()->increaseBattles(1);
 		$db = Database::getInstance();
 		$db->insert('news', [
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'time' => $db->escapeNumber(Epoch::time()),
-			'news_message' => $db->escapeString($msg),
-			'killer_id' => $db->escapeNumber($killer->getAccountID()),
-			'killer_alliance' => $db->escapeNumber($killer->getAllianceID()),
-			'dead_id' => $db->escapeNumber($this->getAccountID()),
-			'dead_alliance' => $db->escapeNumber($this->getAllianceID()),
+			'game_id' => $this->getGameID(),
+			'time' => Epoch::time(),
+			'news_message' => $msg,
+			'killer_id' => $killer->getAccountID(),
+			'killer_alliance' => $killer->getAllianceID(),
+			'dead_id' => $this->getAccountID(),
+			'dead_alliance' => $this->getAllianceID(),
 		]);
 
 		self::sendMessageFromFedClerk($this->getGameID(), $this->getAccountID(), 'You were <span class="red">DESTROYED</span> by ' . $killer->getBBLink() . ' in sector ' . Globals::getSectorBBLink($this->getSectorID()));
@@ -2398,13 +2398,13 @@ abstract class AbstractPlayer {
 		// insert the news entry
 		$db = Database::getInstance();
 		$db->insert('news', [
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'time' => $db->escapeNumber(Epoch::time()),
-			'news_message' => $db->escapeString($news_message),
-			'killer_id' => $db->escapeNumber($owner->getAccountID()),
-			'killer_alliance' => $db->escapeNumber($owner->getAllianceID()),
-			'dead_id' => $db->escapeNumber($this->getAccountID()),
-			'dead_alliance' => $db->escapeNumber($this->getAllianceID()),
+			'game_id' => $this->getGameID(),
+			'time' => Epoch::time(),
+			'news_message' => $news_message,
+			'killer_id' => $owner->getAccountID(),
+			'killer_alliance' => $owner->getAllianceID(),
+			'dead_id' => $this->getAccountID(),
+			'dead_alliance' => $this->getAllianceID(),
 		]);
 
 		// Player loses 15% experience
@@ -2445,12 +2445,12 @@ abstract class AbstractPlayer {
 		// insert the news entry
 		$db = Database::getInstance();
 		$db->insert('news', [
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'time' => $db->escapeNumber(Epoch::time()),
-			'news_message' => $db->escapeString($news_message),
-			'killer_id' => $db->escapeNumber(ACCOUNT_ID_PORT),
-			'dead_id' => $db->escapeNumber($this->getAccountID()),
-			'dead_alliance' => $db->escapeNumber($this->getAllianceID()),
+			'game_id' => $this->getGameID(),
+			'time' => Epoch::time(),
+			'news_message' => $news_message,
+			'killer_id' => ACCOUNT_ID_PORT,
+			'dead_id' => $this->getAccountID(),
+			'dead_alliance' => $this->getAllianceID(),
 		]);
 
 		// Player loses between 15% and 20% experience
@@ -2492,13 +2492,13 @@ abstract class AbstractPlayer {
 		// insert the news entry
 		$db = Database::getInstance();
 		$db->insert('news', [
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'time' => $db->escapeNumber(Epoch::time()),
-			'news_message' => $db->escapeString($news_message),
-			'killer_id' => $db->escapeNumber($planetOwner->getAccountID()),
-			'killer_alliance' => $db->escapeNumber($planetOwner->getAllianceID()),
-			'dead_id' => $db->escapeNumber($this->getAccountID()),
-			'dead_alliance' => $db->escapeNumber($this->getAllianceID()),
+			'game_id' => $this->getGameID(),
+			'time' => Epoch::time(),
+			'news_message' => $news_message,
+			'killer_id' => $planetOwner->getAccountID(),
+			'killer_alliance' => $planetOwner->getAllianceID(),
+			'dead_id' => $this->getAccountID(),
+			'dead_alliance' => $this->getAllianceID(),
 		]);
 
 		// Player loses between 15% and 20% experience
@@ -2778,15 +2778,15 @@ abstract class AbstractPlayer {
 			$db->update(
 				'player_has_mission',
 				[
-					'on_step' => $db->escapeNumber($mission['On Step']),
-					'progress' => $db->escapeNumber($mission['Progress']),
+					'on_step' => $mission['On Step'],
+					'progress' => $mission['Progress'],
 					'unread' => $db->escapeBoolean($mission['Unread']),
-					'starting_sector' => $db->escapeNumber($mission['Starting Sector']),
-					'mission_sector' => $db->escapeNumber($mission['Sector']),
-					'step_fails' => $db->escapeNumber($mission['Expires']),
+					'starting_sector' => $mission['Starting Sector'],
+					'mission_sector' => $mission['Sector'],
+					'step_fails' => $mission['Expires'],
 				],
 				[
-					'mission_id' => $db->escapeNumber($missionID),
+					'mission_id' => $missionID,
 					...$this->SQLID,
 				],
 			);
@@ -2848,13 +2848,13 @@ abstract class AbstractPlayer {
 		$db = Database::getInstance();
 		$db->replace('player_has_mission', [
 			...$this->SQLID,
-			'mission_id' => $db->escapeNumber($missionID),
-			'on_step' => $db->escapeNumber($mission['On Step']),
-			'progress' => $db->escapeNumber($mission['Progress']),
+			'mission_id' => $missionID,
+			'on_step' => $mission['On Step'],
+			'progress' => $mission['Progress'],
 			'unread' => $db->escapeBoolean($mission['Unread']),
-			'starting_sector' => $db->escapeNumber($mission['Starting Sector']),
-			'mission_sector' => $db->escapeNumber($mission['Sector']),
-			'step_fails' => $db->escapeNumber($mission['Expires']),
+			'starting_sector' => $mission['Starting Sector'],
+			'mission_sector' => $mission['Sector'],
+			'step_fails' => $mission['Expires'],
 		]);
 	}
 
@@ -2879,7 +2879,7 @@ abstract class AbstractPlayer {
 			unset($this->missions[$missionID]);
 			$db = Database::getInstance();
 			$db->delete('player_has_mission', [
-				'mission_id' => $db->escapeNumber($missionID),
+				'mission_id' => $missionID,
 				...$this->SQLID,
 			]);
 			return;
@@ -3190,37 +3190,37 @@ abstract class AbstractPlayer {
 			$db->update(
 				'player',
 				[
-					'player_name' => $db->escapeString($this->playerName),
-					'player_id' => $db->escapeNumber($this->playerID),
-					'sector_id' => $db->escapeNumber($this->sectorID),
-					'last_sector_id' => $db->escapeNumber($this->lastSectorID),
-					'turns' => $db->escapeNumber($this->turns),
-					'last_turn_update' => $db->escapeNumber($this->lastTurnUpdate),
-					'newbie_turns' => $db->escapeNumber($this->newbieTurns),
-					'last_news_update' => $db->escapeNumber($this->lastNewsUpdate),
-					'attack_warning' => $db->escapeString($this->attackColour),
+					'player_name' => $this->playerName,
+					'player_id' => $this->playerID,
+					'sector_id' => $this->sectorID,
+					'last_sector_id' => $this->lastSectorID,
+					'turns' => $this->turns,
+					'last_turn_update' => $this->lastTurnUpdate,
+					'newbie_turns' => $this->newbieTurns,
+					'last_news_update' => $this->lastNewsUpdate,
+					'attack_warning' => $this->attackColour,
 					'dead' => $db->escapeBoolean($this->dead),
 					'newbie_status' => $db->escapeBoolean($this->newbieStatus),
 					'land_on_planet' => $db->escapeBoolean($this->landedOnPlanet),
-					'last_active' => $db->escapeNumber($this->lastActive),
-					'last_cpl_action' => $db->escapeNumber($this->lastCPLAction),
-					'race_id' => $db->escapeNumber($this->raceID),
-					'credits' => $db->escapeNumber($this->credits),
-					'experience' => $db->escapeNumber($this->experience),
-					'alignment' => $db->escapeNumber($this->alignment),
-					'military_payment' => $db->escapeNumber($this->militaryPayment),
-					'alliance_id' => $db->escapeNumber($this->allianceID),
-					'alliance_join' => $db->escapeNumber($this->allianceJoinable),
-					'ship_type_id' => $db->escapeNumber($this->shipID),
-					'kills' => $db->escapeNumber($this->kills),
-					'deaths' => $db->escapeNumber($this->deaths),
-					'assists' => $db->escapeNumber($this->assists),
-					'last_port' => $db->escapeNumber($this->lastPort),
-					'bank' => $db->escapeNumber($this->bank),
-					'zoom' => $db->escapeNumber($this->zoom),
+					'last_active' => $this->lastActive,
+					'last_cpl_action' => $this->lastCPLAction,
+					'race_id' => $this->raceID,
+					'credits' => $this->credits,
+					'experience' => $this->experience,
+					'alignment' => $this->alignment,
+					'military_payment' => $this->militaryPayment,
+					'alliance_id' => $this->allianceID,
+					'alliance_join' => $this->allianceJoinable,
+					'ship_type_id' => $this->shipID,
+					'kills' => $this->kills,
+					'deaths' => $this->deaths,
+					'assists' => $this->assists,
+					'last_port' => $this->lastPort,
+					'bank' => $this->bank,
+					'zoom' => $this->zoom,
 					'display_missions' => $db->escapeBoolean($this->displayMissions),
 					'force_drop_messages' => $db->escapeBoolean($this->forceDropMessages),
-					'group_scout_messages' => $db->escapeString($this->scoutMessageGroupType->value),
+					'group_scout_messages' => $this->scoutMessageGroupType->value,
 					'ignore_globals' => $db->escapeBoolean($this->ignoreGlobals),
 					'newbie_warning' => $db->escapeBoolean($this->newbieWarning),
 					'name_changed' => $db->escapeBoolean($this->nameChanged),
@@ -3244,14 +3244,14 @@ abstract class AbstractPlayer {
 		foreach (self::$hasHOFVisChanged as $hofType => $changeType) {
 			if ($changeType == self::HOF_NEW) {
 				$db->insert('hof_visibility', [
-					'type' => $db->escapeString($hofType),
-					'visibility' => $db->escapeString(self::$HOFVis[$hofType]),
+					'type' => $hofType,
+					'visibility' => self::$HOFVis[$hofType],
 				]);
 			} else {
 				$db->update(
 					'hof_visibility',
-					['visibility' => $db->escapeString(self::$HOFVis[$hofType])],
-					['type' => $db->escapeString($hofType)],
+					['visibility' => self::$HOFVis[$hofType]],
+					['type' => $hofType],
 				);
 			}
 			unset(self::$hasHOFVisChanged[$hofType]);
@@ -3263,17 +3263,17 @@ abstract class AbstractPlayer {
 				if ($amount > 0) {
 					$db->insert('player_hof', [
 						...$this->SQLID,
-						'type' => $db->escapeString($hofType),
-						'amount' => $db->escapeNumber($amount),
+						'type' => $hofType,
+						'amount' => $amount,
 					]);
 				}
 			} elseif ($changeType === self::HOF_CHANGED) {
 				$db->update(
 					'player_hof',
-					['amount' => $db->escapeNumber($amount)],
+					['amount' => $amount],
 					[
 						...$this->SQLID,
-						'type' => $db->escapeString($hofType),
+						'type' => $hofType,
 					],
 				);
 			}

--- a/src/lib/Smr/Account.php
+++ b/src/lib/Smr/Account.php
@@ -42,7 +42,9 @@ class Account {
 		'AttackTrader' => ['f'],
 	];
 
-	protected readonly string $SQL;
+	public const SQL = 'account_id = :account_id';
+	/** @var array{account_id: int} */
+	protected readonly array $SQLID;
 
 	protected string $login;
 	protected string $passwordHash;
@@ -115,7 +117,9 @@ class Account {
 	public static function getAccountByLogin(string $login, bool $forceUpdate = false): self {
 		if (!empty($login)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT account_id FROM account WHERE login = ' . $db->escapeString($login));
+			$dbResult = $db->read('SELECT account_id FROM account WHERE login = :login', [
+				'login' => $db->escapeString($login),
+			]);
 			if ($dbResult->hasRecord()) {
 				$accountID = $dbResult->record()->getInt('account_id');
 				return self::getAccount($accountID, $forceUpdate);
@@ -127,7 +131,9 @@ class Account {
 	public static function getAccountByHofName(string $hofName, bool $forceUpdate = false): self {
 		if (!empty($hofName)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT account_id FROM account WHERE hof_name = ' . $db->escapeString($hofName));
+			$dbResult = $db->read('SELECT account_id FROM account WHERE hof_name = :hof_name', [
+				'hof_name' => $db->escapeString($hofName),
+			]);
 			if ($dbResult->hasRecord()) {
 				$accountID = $dbResult->record()->getInt('account_id');
 				return self::getAccount($accountID, $forceUpdate);
@@ -139,7 +145,9 @@ class Account {
 	public static function getAccountByEmail(?string $email, bool $forceUpdate = false): self {
 		if (!empty($email)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT account_id FROM account WHERE email = ' . $db->escapeString($email));
+			$dbResult = $db->read('SELECT account_id FROM account WHERE email = :email', [
+				'email' => $db->escapeString($email),
+			]);
 			if ($dbResult->hasRecord()) {
 				$accountID = $dbResult->record()->getInt('account_id');
 				return self::getAccount($accountID, $forceUpdate);
@@ -151,7 +159,9 @@ class Account {
 	public static function getAccountByDiscordId(?string $id, bool $forceUpdate = false): self {
 		if (!empty($id)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT account_id FROM account where discord_id = ' . $db->escapeString($id));
+			$dbResult = $db->read('SELECT account_id FROM account where discord_id = :discord_id', [
+				'discord_id' => $db->escapeString($id),
+			]);
 			if ($dbResult->hasRecord()) {
 				$accountID = $dbResult->record()->getInt('account_id');
 				return self::getAccount($accountID, $forceUpdate);
@@ -163,7 +173,9 @@ class Account {
 	public static function getAccountByIrcNick(?string $nick, bool $forceUpdate = false): self {
 		if (!empty($nick)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT account_id FROM account WHERE irc_nick = ' . $db->escapeString($nick));
+			$dbResult = $db->read('SELECT account_id FROM account WHERE irc_nick = :irc_nick', [
+				'irc_nick' => $db->escapeString($nick),
+			]);
 			if ($dbResult->hasRecord()) {
 				$accountID = $dbResult->record()->getInt('account_id');
 				return self::getAccount($accountID, $forceUpdate);
@@ -176,8 +188,11 @@ class Account {
 		if ($social->isValid()) {
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT account_id FROM account JOIN account_auth USING(account_id)
-				WHERE login_type = ' . $db->escapeString($social->getLoginType()) . '
-				AND auth_key = ' . $db->escapeString($social->getUserID()));
+				WHERE login_type = :login_type
+				AND auth_key = :auth_key', [
+				'login_type' => $db->escapeString($social->getLoginType()),
+				'auth_key' => $db->escapeString($social->getUserID()),
+			]);
 			if ($dbResult->hasRecord()) {
 				$accountID = $dbResult->record()->getInt('account_id');
 				return self::getAccount($accountID, $forceUpdate);
@@ -224,8 +239,8 @@ class Account {
 
 	protected function __construct(protected readonly int $accountID) {
 		$db = Database::getInstance();
-		$this->SQL = 'account_id = ' . $db->escapeNumber($accountID);
-		$dbResult = $db->read('SELECT * FROM account WHERE ' . $this->SQL);
+		$this->SQLID = ['account_id' => $db->escapeNumber($accountID)];
+		$dbResult = $db->read('SELECT * FROM account WHERE ' . self::SQL, $this->SQLID);
 
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
@@ -295,7 +310,7 @@ class Account {
 	 */
 	public function isDisabled(): array|false {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM account_is_closed JOIN closing_reason USING(reason_id) WHERE ' . $this->SQL);
+		$dbResult = $db->read('SELECT * FROM account_is_closed JOIN closing_reason USING(reason_id) WHERE ' . self::SQL, $this->SQLID);
 		if (!$dbResult->hasRecord()) {
 			return false;
 		}
@@ -318,34 +333,63 @@ class Account {
 
 	public function update(): void {
 		$db = Database::getInstance();
-		$db->write('UPDATE account SET email = ' . $db->escapeString($this->email) .
-			', validation_code = ' . $db->escapeString($this->validation_code) .
-			', validated = ' . $db->escapeBoolean($this->validated) .
-			', password = ' . $db->escapeString($this->passwordHash) .
-			', images = ' . $db->escapeBoolean($this->images) .
-			', password_reset = ' . $db->escapeString($this->passwordReset) .
-			', use_ajax=' . $db->escapeBoolean($this->useAJAX) .
-			', mail_banned=' . $db->escapeNumber($this->mailBanned) .
-			', max_rank_achieved=' . $db->escapeNumber($this->maxRankAchieved) .
-			', default_css_enabled=' . $db->escapeBoolean($this->defaultCSSEnabled) .
-			', center_galaxy_map_on_player=' . $db->escapeBoolean($this->centerGalaxyMapOnPlayer) .
-			', message_notifications=' . $db->escapeNullableObject($this->messageNotifications) .
-			', hotkeys=' . $db->escapeObject($this->hotkeys) .
-			', last_login = ' . $db->escapeNumber($this->last_login) .
-			', logging = ' . $db->escapeBoolean($this->logging) .
-			', time_format = ' . $db->escapeString($this->timeFormat) .
-			', date_format = ' . $db->escapeString($this->dateFormat) .
-			', discord_id = ' . $db->escapeNullableString($this->discordId) .
-			', irc_nick = ' . $db->escapeNullableString($this->ircNick) .
-			', hof_name = ' . $db->escapeString($this->hofName) .
-			', template = ' . $db->escapeString($this->template) .
-			', colour_scheme = ' . $db->escapeString($this->colourScheme) .
-			', fontsize = ' . $db->escapeNumber($this->fontSize) .
-			', css_link = ' . $db->escapeNullableString($this->cssLink) .
-			', friendly_colour = ' . $db->escapeNullableString($this->friendlyColour) .
-			', neutral_colour = ' . $db->escapeNullableString($this->neutralColour) .
-			', enemy_colour = ' . $db->escapeNullableString($this->enemyColour) .
-			' WHERE ' . $this->SQL);
+		$db->write('UPDATE account SET email = :email,
+			validation_code = :validation_code,
+			validated = :validated,
+			password = :password,
+			images = :images,
+			password_reset = :password_reset,
+			use_ajax = :use_ajax,
+			mail_banned = :mail_banned,
+			max_rank_achieved = :max_rank_achieved,
+			default_css_enabled = :default_css_enabled,
+			center_galaxy_map_on_player = :center_galaxy_map_on_player,
+			message_notifications = :message_notifications,
+			hotkeys = :hotkeys,
+			last_login = :last_login,
+			logging = :logging,
+			time_format = :time_format,
+			date_format = :date_format,
+			discord_id = :discord_id,
+			irc_nick = :irc_nick,
+			hof_name = :hof_name,
+			template = :template,
+			colour_scheme = :colour_scheme,
+			fontsize = :fontsize,
+			css_link = :css_link,
+			friendly_colour = :friendly_colour,
+			neutral_colour = :neutral_colour,
+			enemy_colour = :enemy_colour
+			WHERE ' . self::SQL, [
+			'email' => $db->escapeString($this->email),
+			'validation_code' => $db->escapeString($this->validation_code),
+			'validated' => $db->escapeBoolean($this->validated),
+			'password' => $db->escapeString($this->passwordHash),
+			'images' => $db->escapeBoolean($this->images),
+			'password_reset' => $db->escapeString($this->passwordReset),
+			'use_ajax' => $db->escapeBoolean($this->useAJAX),
+			'mail_banned' => $db->escapeNumber($this->mailBanned),
+			'max_rank_achieved' => $db->escapeNumber($this->maxRankAchieved),
+			'default_css_enabled' => $db->escapeBoolean($this->defaultCSSEnabled),
+			'center_galaxy_map_on_player' => $db->escapeBoolean($this->centerGalaxyMapOnPlayer),
+			'message_notifications' => $db->escapeNullableObject($this->messageNotifications),
+			'hotkeys' => $db->escapeObject($this->hotkeys),
+			'last_login' => $db->escapeNumber($this->last_login),
+			'logging' => $db->escapeBoolean($this->logging),
+			'time_format' => $db->escapeString($this->timeFormat),
+			'date_format' => $db->escapeString($this->dateFormat),
+			'discord_id' => $db->escapeNullableString($this->discordId),
+			'irc_nick' => $db->escapeNullableString($this->ircNick),
+			'hof_name' => $db->escapeString($this->hofName),
+			'template' => $db->escapeString($this->template),
+			'colour_scheme' => $db->escapeString($this->colourScheme),
+			'fontsize' => $db->escapeNumber($this->fontSize),
+			'css_link' => $db->escapeNullableString($this->cssLink),
+			'friendly_colour' => $db->escapeNullableString($this->friendlyColour),
+			'neutral_colour' => $db->escapeNullableString($this->neutralColour),
+			'enemy_colour' => $db->escapeNullableString($this->enemyColour),
+			...$this->SQLID,
+		]);
 		$this->hasChanged = false;
 	}
 
@@ -356,16 +400,20 @@ class Account {
 		// more than 50 elements in it?
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT time,ip FROM account_has_ip WHERE ' . $this->SQL . ' ORDER BY time ASC');
+		$dbResult = $db->read('SELECT time,ip FROM account_has_ip WHERE ' . self::SQL . ' ORDER BY time ASC', $this->SQLID);
 		if ($dbResult->getNumRecords() > 50) {
 			$dbRecord = $dbResult->records()->current();
 			$delete_time = $dbRecord->getInt('time');
 			$delete_ip = $dbRecord->getString('ip');
 
 			$db->write('DELETE FROM account_has_ip
-				WHERE ' . $this->SQL . ' AND
-				time = ' . $db->escapeNumber($delete_time) . ' AND
-				ip = ' . $db->escapeString($delete_ip));
+				WHERE ' . self::SQL . ' AND
+				time = :time AND
+				ip = :ip', [
+				...$this->SQLID,
+				'time' => $db->escapeNumber($delete_time),
+				'ip' => $db->escapeString($delete_ip),
+			]);
 		}
 
 		// Determine host from IP address
@@ -425,7 +473,9 @@ class Account {
 	public function isNPC(): bool {
 		if (!isset($this->npc)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT 1 FROM npc_logins WHERE login = ' . $db->escapeString($this->getLogin()));
+			$dbResult = $db->read('SELECT 1 FROM npc_logins WHERE login = :login', [
+				'login' => $db->escapeString($this->getLogin()),
+			]);
 			$this->npc = $dbResult->hasRecord();
 		}
 		return $this->npc;
@@ -435,7 +485,7 @@ class Account {
 		if (!isset($this->HOF)) {
 			//Get Player HOF
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT type,sum(amount) as amount FROM player_hof WHERE ' . $this->SQL . ' AND game_id IN (SELECT game_id FROM game WHERE ignore_stats = \'FALSE\') GROUP BY type');
+			$dbResult = $db->read('SELECT type,sum(amount) as amount FROM player_hof WHERE ' . self::SQL . ' AND game_id IN (SELECT game_id FROM game WHERE ignore_stats = \'FALSE\') GROUP BY type', $this->SQLID);
 			$this->HOF = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$this->HOF[$dbRecord->getString('type')] = $dbRecord->getFloat('amount');
@@ -538,7 +588,7 @@ class Account {
 			$this->credits = 0;
 			$this->rewardCredits = 0;
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM account_has_credits WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM account_has_credits WHERE ' . self::SQL, $this->SQLID);
 			if ($dbResult->hasRecord()) {
 				$dbRecord = $dbResult->record();
 				$this->credits = $dbRecord->getInt('credits_left');
@@ -572,12 +622,16 @@ class Account {
 		$db = Database::getInstance();
 		if ($this->credits == 0 && $this->rewardCredits == 0) {
 			$db->replace('account_has_credits', [
-				'account_id' => $db->escapeNumber($this->getAccountID()),
+				...$this->SQLID,
 				'credits_left' => $db->escapeNumber($credits),
 				'reward_credits' => $db->escapeNumber($rewardCredits),
 			]);
 		} else {
-			$db->write('UPDATE account_has_credits SET credits_left=' . $db->escapeNumber($credits) . ', reward_credits=' . $db->escapeNumber($rewardCredits) . ' WHERE ' . $this->SQL);
+			$db->write('UPDATE account_has_credits SET credits_left = :credits_left, reward_credits = :reward_credits WHERE ' . self::SQL, [
+				'credits_left' => $db->escapeNumber($credits),
+				'reward_credits' => $db->escapeNumber($rewardCredits),
+				...$this->SQLID,
+			]);
 		}
 		$this->credits = $credits;
 		$this->rewardCredits = $rewardCredits;
@@ -604,7 +658,10 @@ class Account {
 				'credits_left' => $db->escapeNumber($credits),
 			]);
 		} else {
-			$db->write('UPDATE account_has_credits SET credits_left=' . $db->escapeNumber($credits) . ' WHERE ' . $this->SQL);
+			$db->write('UPDATE account_has_credits SET credits_left = :credits_left WHERE ' . self::SQL, [
+				'credits_left' => $db->escapeNumber($credits),
+				...$this->SQLID,
+			]);
 		}
 		$this->credits = $credits;
 	}
@@ -643,7 +700,10 @@ class Account {
 				'reward_credits' => $db->escapeNumber($credits),
 			]);
 		} else {
-			$db->write('UPDATE account_has_credits SET reward_credits=' . $db->escapeNumber($credits) . ' WHERE ' . $this->SQL);
+			$db->write('UPDATE account_has_credits SET reward_credits = :reward_credits WHERE ' . self::SQL, [
+				'reward_credits' => $db->escapeNumber($credits),
+				...$this->SQLID,
+			]);
 		}
 		$this->rewardCredits = $credits;
 	}
@@ -963,7 +1023,10 @@ class Account {
 
 	public function isActive(): bool {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM active_session WHERE account_id = ' . $db->escapeNumber($this->getAccountID()) . ' AND last_accessed >= ' . $db->escapeNumber(Epoch::time() - TIME_BEFORE_INACTIVE) . ' LIMIT 1');
+		$dbResult = $db->read('SELECT 1 FROM active_session WHERE ' . self::SQL . ' AND last_accessed >= :inactive_time LIMIT 1', [
+			...$this->SQLID,
+			'inactive_time' => $db->escapeNumber(Epoch::time() - TIME_BEFORE_INACTIVE),
+		]);
 		return $dbResult->hasRecord();
 	}
 
@@ -1006,7 +1069,11 @@ class Account {
 
 	public function addAuthMethod(string $loginType, string $authKey): void {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT account_id FROM account_auth WHERE login_type=' . $db->escapeString($loginType) . ' AND auth_key = ' . $db->escapeString($authKey) . ';');
+		$params = [
+			'login_type' => $db->escapeString($loginType),
+			'auth_key' => $db->escapeString($authKey),
+		];
+		$dbResult = $db->read('SELECT account_id FROM account_auth WHERE login_type = :login_type AND auth_key = :auth_key', $params);
 		if ($dbResult->hasRecord()) {
 			if ($dbResult->record()->getInt('account_id') != $this->getAccountID()) {
 				throw new Exception('Another account already uses this form of auth.');
@@ -1015,8 +1082,7 @@ class Account {
 		}
 		$db->insert('account_auth', [
 			'account_id' => $db->escapeNumber($this->getAccountID()),
-			'login_type' => $db->escapeString($loginType),
-			'auth_key' => $db->escapeString($authKey),
+			...$params,
 		]);
 	}
 
@@ -1169,7 +1235,7 @@ class Account {
 		if (!isset($this->permissions)) {
 			$this->permissions = [];
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT permission_id FROM account_has_permission WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT permission_id FROM account_has_permission WHERE ' . self::SQL, $this->SQLID);
 			foreach ($dbResult->records() as $dbRecord) {
 				$this->permissions[$dbRecord->getInt('permission_id')] = true;
 			}
@@ -1190,7 +1256,7 @@ class Account {
 			$this->points = 0;
 			$db = Database::getInstance();
 			$db->lockTable('account_has_points');
-			$dbResult = $db->read('SELECT * FROM account_has_points WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM account_has_points WHERE ' . self::SQL, $this->SQLID);
 			if ($dbResult->hasRecord()) {
 				$dbRecord = $dbResult->record();
 				$this->points = $dbRecord->getInt('points');
@@ -1218,14 +1284,17 @@ class Account {
 		$db = Database::getInstance();
 		if ($this->points == 0) {
 			$db->insert('account_has_points', [
-				'account_id' => $db->escapeNumber($this->getAccountID()),
+				...$this->SQLID,
 				'points' => $db->escapeNumber($numPoints),
 				'last_update' => $db->escapeNumber($lastUpdate ?? Epoch::time()),
 			]);
 		} elseif ($numPoints <= 0) {
-			$db->write('DELETE FROM account_has_points WHERE ' . $this->SQL);
+			$db->write('DELETE FROM account_has_points WHERE ' . self::SQL, $this->SQLID);
 		} else {
-			$db->write('UPDATE account_has_points SET points = ' . $db->escapeNumber($numPoints) . (isset($lastUpdate) ? ', last_update = ' . $db->escapeNumber(Epoch::time()) : '') . ' WHERE ' . $this->SQL);
+			$db->write('UPDATE account_has_points SET points = :points' . (isset($lastUpdate) ? ', last_update = ' . $db->escapeNumber(Epoch::time()) : '') . ' WHERE ' . self::SQL, [
+				...$this->SQLID,
+				'points' => $db->escapeNumber($numPoints),
+			]);
 		}
 		$this->points = $numPoints;
 	}
@@ -1299,27 +1368,30 @@ class Account {
 	public function banAccount(int $expireTime, self $admin, int $reasonID, string $suspicion, bool $removeExceptions = false): void {
 		$db = Database::getInstance();
 		$db->replace('account_is_closed', [
-			'account_id' => $db->escapeNumber($this->getAccountID()),
+			...$this->SQLID,
 			'reason_id' => $db->escapeNumber($reasonID),
 			'suspicion' => $db->escapeString($suspicion),
 			'expires' => $db->escapeNumber($expireTime),
 		]);
-		$db->write('DELETE FROM active_session WHERE ' . $this->SQL . ' LIMIT 1');
+		$db->write('DELETE FROM active_session WHERE ' . self::SQL . ' LIMIT 1', $this->SQLID);
 
 		$db->insert('account_has_closing_history', [
-			'account_id' => $db->escapeNumber($this->getAccountID()),
+			...$this->SQLID,
 			'time' => $db->escapeNumber(Epoch::time()),
 			'admin_id' => $db->escapeNumber($admin->getAccountID()),
 			'action' => $db->escapeString('Closed'),
 		]);
 		$db->write('UPDATE player SET newbie_turns = 1
-						WHERE ' . $this->SQL . '
+						WHERE ' . self::SQL . '
 						AND newbie_turns = 0
-						AND land_on_planet = ' . $db->escapeBoolean(false));
+						AND land_on_planet = \'FALSE\'', $this->SQLID);
 
 		$dbResult = $db->read('SELECT game_id FROM game JOIN player USING (game_id)
-						WHERE ' . $this->SQL . '
-						AND end_time >= ' . $db->escapeNumber(Epoch::time()));
+						WHERE ' . self::SQL . '
+						AND end_time >= :now', [
+			...$this->SQLID,
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$player = Player::getPlayer($this->getAccountID(), $dbRecord->getInt('game_id'));
 			$player->updateTurns();
@@ -1327,7 +1399,7 @@ class Account {
 		}
 		$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account closed by ' . $admin->getLogin() . '.');
 		if ($removeExceptions !== false) {
-			$db->write('DELETE FROM account_exceptions WHERE ' . $this->SQL);
+			$db->write('DELETE FROM account_exceptions WHERE ' . self::SQL, $this->SQLID);
 		}
 	}
 
@@ -1337,14 +1409,17 @@ class Account {
 			$adminID = $admin->getAccountID();
 		}
 		$db = Database::getInstance();
-		$db->write('DELETE FROM account_is_closed WHERE ' . $this->SQL);
+		$db->write('DELETE FROM account_is_closed WHERE ' . self::SQL, $this->SQLID);
 		$db->insert('account_has_closing_history', [
-			'account_id' => $db->escapeNumber($this->getAccountID()),
+			...$this->SQLID,
 			'time' => $db->escapeNumber(Epoch::time()),
 			'admin_id' => $db->escapeNumber($adminID),
 			'action' => $db->escapeString('Opened'),
 		]);
-		$db->write('UPDATE player SET last_turn_update = GREATEST(' . $db->escapeNumber(Epoch::time()) . ', last_turn_update) WHERE ' . $this->SQL);
+		$db->write('UPDATE player SET last_turn_update = GREATEST(:now, last_turn_update) WHERE ' . self::SQL, [
+			'now' => $db->escapeNumber(Epoch::time()),
+			...$this->SQLID,
+		]);
 		if ($admin !== null) {
 			$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account reopened by ' . $admin->getLogin() . '.');
 		} else {
@@ -1352,7 +1427,7 @@ class Account {
 		}
 		if ($currException !== null) {
 			$db->replace('account_exceptions', [
-				'account_id' => $db->escapeNumber($this->getAccountID()),
+				...$this->SQLID,
 				'reason' => $db->escapeString($currException),
 			]);
 		}

--- a/src/lib/Smr/Account.php
+++ b/src/lib/Smr/Account.php
@@ -333,63 +333,39 @@ class Account {
 
 	public function update(): void {
 		$db = Database::getInstance();
-		$db->write('UPDATE account SET email = :email,
-			validation_code = :validation_code,
-			validated = :validated,
-			password = :password,
-			images = :images,
-			password_reset = :password_reset,
-			use_ajax = :use_ajax,
-			mail_banned = :mail_banned,
-			max_rank_achieved = :max_rank_achieved,
-			default_css_enabled = :default_css_enabled,
-			center_galaxy_map_on_player = :center_galaxy_map_on_player,
-			message_notifications = :message_notifications,
-			hotkeys = :hotkeys,
-			last_login = :last_login,
-			logging = :logging,
-			time_format = :time_format,
-			date_format = :date_format,
-			discord_id = :discord_id,
-			irc_nick = :irc_nick,
-			hof_name = :hof_name,
-			template = :template,
-			colour_scheme = :colour_scheme,
-			fontsize = :fontsize,
-			css_link = :css_link,
-			friendly_colour = :friendly_colour,
-			neutral_colour = :neutral_colour,
-			enemy_colour = :enemy_colour
-			WHERE ' . self::SQL, [
-			'email' => $db->escapeString($this->email),
-			'validation_code' => $db->escapeString($this->validation_code),
-			'validated' => $db->escapeBoolean($this->validated),
-			'password' => $db->escapeString($this->passwordHash),
-			'images' => $db->escapeBoolean($this->images),
-			'password_reset' => $db->escapeString($this->passwordReset),
-			'use_ajax' => $db->escapeBoolean($this->useAJAX),
-			'mail_banned' => $db->escapeNumber($this->mailBanned),
-			'max_rank_achieved' => $db->escapeNumber($this->maxRankAchieved),
-			'default_css_enabled' => $db->escapeBoolean($this->defaultCSSEnabled),
-			'center_galaxy_map_on_player' => $db->escapeBoolean($this->centerGalaxyMapOnPlayer),
-			'message_notifications' => $db->escapeNullableObject($this->messageNotifications),
-			'hotkeys' => $db->escapeObject($this->hotkeys),
-			'last_login' => $db->escapeNumber($this->last_login),
-			'logging' => $db->escapeBoolean($this->logging),
-			'time_format' => $db->escapeString($this->timeFormat),
-			'date_format' => $db->escapeString($this->dateFormat),
-			'discord_id' => $db->escapeNullableString($this->discordId),
-			'irc_nick' => $db->escapeNullableString($this->ircNick),
-			'hof_name' => $db->escapeString($this->hofName),
-			'template' => $db->escapeString($this->template),
-			'colour_scheme' => $db->escapeString($this->colourScheme),
-			'fontsize' => $db->escapeNumber($this->fontSize),
-			'css_link' => $db->escapeNullableString($this->cssLink),
-			'friendly_colour' => $db->escapeNullableString($this->friendlyColour),
-			'neutral_colour' => $db->escapeNullableString($this->neutralColour),
-			'enemy_colour' => $db->escapeNullableString($this->enemyColour),
-			...$this->SQLID,
-		]);
+		$db->update(
+			'account',
+			[
+				'email' => $db->escapeString($this->email),
+				'validation_code' => $db->escapeString($this->validation_code),
+				'validated' => $db->escapeBoolean($this->validated),
+				'password' => $db->escapeString($this->passwordHash),
+				'images' => $db->escapeBoolean($this->images),
+				'password_reset' => $db->escapeString($this->passwordReset),
+				'use_ajax' => $db->escapeBoolean($this->useAJAX),
+				'mail_banned' => $db->escapeNumber($this->mailBanned),
+				'max_rank_achieved' => $db->escapeNumber($this->maxRankAchieved),
+				'default_css_enabled' => $db->escapeBoolean($this->defaultCSSEnabled),
+				'center_galaxy_map_on_player' => $db->escapeBoolean($this->centerGalaxyMapOnPlayer),
+				'message_notifications' => $db->escapeNullableObject($this->messageNotifications),
+				'hotkeys' => $db->escapeObject($this->hotkeys),
+				'last_login' => $db->escapeNumber($this->last_login),
+				'logging' => $db->escapeBoolean($this->logging),
+				'time_format' => $db->escapeString($this->timeFormat),
+				'date_format' => $db->escapeString($this->dateFormat),
+				'discord_id' => $db->escapeNullableString($this->discordId),
+				'irc_nick' => $db->escapeNullableString($this->ircNick),
+				'hof_name' => $db->escapeString($this->hofName),
+				'template' => $db->escapeString($this->template),
+				'colour_scheme' => $db->escapeString($this->colourScheme),
+				'fontsize' => $db->escapeNumber($this->fontSize),
+				'css_link' => $db->escapeNullableString($this->cssLink),
+				'friendly_colour' => $db->escapeNullableString($this->friendlyColour),
+				'neutral_colour' => $db->escapeNullableString($this->neutralColour),
+				'enemy_colour' => $db->escapeNullableString($this->enemyColour),
+			],
+			$this->SQLID,
+		);
 		$this->hasChanged = false;
 	}
 
@@ -624,11 +600,14 @@ class Account {
 				'reward_credits' => $db->escapeNumber($rewardCredits),
 			]);
 		} else {
-			$db->write('UPDATE account_has_credits SET credits_left = :credits_left, reward_credits = :reward_credits WHERE ' . self::SQL, [
-				'credits_left' => $db->escapeNumber($credits),
-				'reward_credits' => $db->escapeNumber($rewardCredits),
-				...$this->SQLID,
-			]);
+			$db->update(
+				'account_has_credits',
+				[
+					'credits_left' => $db->escapeNumber($credits),
+					'reward_credits' => $db->escapeNumber($rewardCredits),
+				],
+				$this->SQLID,
+			);
 		}
 		$this->credits = $credits;
 		$this->rewardCredits = $rewardCredits;
@@ -655,10 +634,11 @@ class Account {
 				'credits_left' => $db->escapeNumber($credits),
 			]);
 		} else {
-			$db->write('UPDATE account_has_credits SET credits_left = :credits_left WHERE ' . self::SQL, [
-				'credits_left' => $db->escapeNumber($credits),
-				...$this->SQLID,
-			]);
+			$db->update(
+				'account_has_credits',
+				['credits_left' => $db->escapeNumber($credits)],
+				$this->SQLID,
+			);
 		}
 		$this->credits = $credits;
 	}
@@ -697,10 +677,11 @@ class Account {
 				'reward_credits' => $db->escapeNumber($credits),
 			]);
 		} else {
-			$db->write('UPDATE account_has_credits SET reward_credits = :reward_credits WHERE ' . self::SQL, [
-				'reward_credits' => $db->escapeNumber($credits),
-				...$this->SQLID,
-			]);
+			$db->update(
+				'account_has_credits',
+				['reward_credits' => $db->escapeNumber($credits)],
+				$this->SQLID,
+			);
 		}
 		$this->rewardCredits = $credits;
 	}
@@ -1288,10 +1269,11 @@ class Account {
 		} elseif ($numPoints <= 0) {
 			$db->delete('account_has_points', $this->SQLID);
 		} else {
-			$db->write('UPDATE account_has_points SET points = :points' . (isset($lastUpdate) ? ', last_update = ' . $db->escapeNumber(Epoch::time()) : '') . ' WHERE ' . self::SQL, [
-				...$this->SQLID,
-				'points' => $db->escapeNumber($numPoints),
-			]);
+			$data = ['points' => $db->escapeNumber($numPoints)];
+			if ($lastUpdate !== null) {
+				$data['last_update'] = $db->escapeNumber(Epoch::time());
+			}
+			$db->update('account_has_points', $data, $this->SQLID);
 		}
 		$this->points = $numPoints;
 	}
@@ -1378,10 +1360,15 @@ class Account {
 			'admin_id' => $db->escapeNumber($admin->getAccountID()),
 			'action' => $db->escapeString('Closed'),
 		]);
-		$db->write('UPDATE player SET newbie_turns = 1
-						WHERE ' . self::SQL . '
-						AND newbie_turns = 0
-						AND land_on_planet = \'FALSE\'', $this->SQLID);
+		$db->update(
+			'player',
+			['newbie_turns' => 1],
+			[
+				...$this->SQLID,
+				'newbie_turns' => 0,
+				'land_on_planet' => 'FALSE',
+			],
+		);
 
 		$dbResult = $db->read('SELECT game_id FROM game JOIN player USING (game_id)
 						WHERE ' . self::SQL . '

--- a/src/lib/Smr/Account.php
+++ b/src/lib/Smr/Account.php
@@ -406,10 +406,7 @@ class Account {
 			$delete_time = $dbRecord->getInt('time');
 			$delete_ip = $dbRecord->getString('ip');
 
-			$db->write('DELETE FROM account_has_ip
-				WHERE ' . self::SQL . ' AND
-				time = :time AND
-				ip = :ip', [
+			$db->delete('account_has_ip', [
 				...$this->SQLID,
 				'time' => $db->escapeNumber($delete_time),
 				'ip' => $db->escapeString($delete_ip),
@@ -1289,7 +1286,7 @@ class Account {
 				'last_update' => $db->escapeNumber($lastUpdate ?? Epoch::time()),
 			]);
 		} elseif ($numPoints <= 0) {
-			$db->write('DELETE FROM account_has_points WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('account_has_points', $this->SQLID);
 		} else {
 			$db->write('UPDATE account_has_points SET points = :points' . (isset($lastUpdate) ? ', last_update = ' . $db->escapeNumber(Epoch::time()) : '') . ' WHERE ' . self::SQL, [
 				...$this->SQLID,
@@ -1373,7 +1370,7 @@ class Account {
 			'suspicion' => $db->escapeString($suspicion),
 			'expires' => $db->escapeNumber($expireTime),
 		]);
-		$db->write('DELETE FROM active_session WHERE ' . self::SQL . ' LIMIT 1', $this->SQLID);
+		$db->delete('active_session', $this->SQLID);
 
 		$db->insert('account_has_closing_history', [
 			...$this->SQLID,
@@ -1399,7 +1396,7 @@ class Account {
 		}
 		$this->log(LOG_TYPE_ACCOUNT_CHANGES, 'Account closed by ' . $admin->getLogin() . '.');
 		if ($removeExceptions !== false) {
-			$db->write('DELETE FROM account_exceptions WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('account_exceptions', $this->SQLID);
 		}
 	}
 
@@ -1409,7 +1406,7 @@ class Account {
 			$adminID = $admin->getAccountID();
 		}
 		$db = Database::getInstance();
-		$db->write('DELETE FROM account_is_closed WHERE ' . self::SQL, $this->SQLID);
+		$db->delete('account_is_closed', $this->SQLID);
 		$db->insert('account_has_closing_history', [
 			...$this->SQLID,
 			'time' => $db->escapeNumber(Epoch::time()),

--- a/src/lib/Smr/Account.php
+++ b/src/lib/Smr/Account.php
@@ -209,14 +209,14 @@ class Account {
 		$db = Database::getInstance();
 		$passwordHash = password_hash($password, PASSWORD_DEFAULT);
 		$db->insert('account', [
-			'login' => $db->escapeString($login),
-			'password' => $db->escapeString($passwordHash),
-			'email' => $db->escapeString($email),
-			'validation_code' => $db->escapeString(random_string(10)),
-			'last_login' => $db->escapeNumber(Epoch::time()),
-			'offset' => $db->escapeNumber($timez),
-			'referral_id' => $db->escapeNumber($referral),
-			'hof_name' => $db->escapeString($login),
+			'login' => $login,
+			'password' => $passwordHash,
+			'email' => $email,
+			'validation_code' => random_string(10),
+			'last_login' => Epoch::time(),
+			'offset' => $timez,
+			'referral_id' => $referral,
+			'hof_name' => $login,
 			'hotkeys' => $db->escapeObject([]),
 		]);
 		return self::getAccountByLogin($login);
@@ -336,33 +336,33 @@ class Account {
 		$db->update(
 			'account',
 			[
-				'email' => $db->escapeString($this->email),
-				'validation_code' => $db->escapeString($this->validation_code),
+				'email' => $this->email,
+				'validation_code' => $this->validation_code,
 				'validated' => $db->escapeBoolean($this->validated),
-				'password' => $db->escapeString($this->passwordHash),
+				'password' => $this->passwordHash,
 				'images' => $db->escapeBoolean($this->images),
-				'password_reset' => $db->escapeString($this->passwordReset),
+				'password_reset' => $this->passwordReset,
 				'use_ajax' => $db->escapeBoolean($this->useAJAX),
-				'mail_banned' => $db->escapeNumber($this->mailBanned),
-				'max_rank_achieved' => $db->escapeNumber($this->maxRankAchieved),
+				'mail_banned' => $this->mailBanned,
+				'max_rank_achieved' => $this->maxRankAchieved,
 				'default_css_enabled' => $db->escapeBoolean($this->defaultCSSEnabled),
 				'center_galaxy_map_on_player' => $db->escapeBoolean($this->centerGalaxyMapOnPlayer),
 				'message_notifications' => $db->escapeNullableObject($this->messageNotifications),
 				'hotkeys' => $db->escapeObject($this->hotkeys),
-				'last_login' => $db->escapeNumber($this->last_login),
+				'last_login' => $this->last_login,
 				'logging' => $db->escapeBoolean($this->logging),
-				'time_format' => $db->escapeString($this->timeFormat),
-				'date_format' => $db->escapeString($this->dateFormat),
-				'discord_id' => $db->escapeNullableString($this->discordId),
-				'irc_nick' => $db->escapeNullableString($this->ircNick),
-				'hof_name' => $db->escapeString($this->hofName),
-				'template' => $db->escapeString($this->template),
-				'colour_scheme' => $db->escapeString($this->colourScheme),
-				'fontsize' => $db->escapeNumber($this->fontSize),
-				'css_link' => $db->escapeNullableString($this->cssLink),
-				'friendly_colour' => $db->escapeNullableString($this->friendlyColour),
-				'neutral_colour' => $db->escapeNullableString($this->neutralColour),
-				'enemy_colour' => $db->escapeNullableString($this->enemyColour),
+				'time_format' => $this->timeFormat,
+				'date_format' => $this->dateFormat,
+				'discord_id' => $this->discordId,
+				'irc_nick' => $this->ircNick,
+				'hof_name' => $this->hofName,
+				'template' => $this->template,
+				'colour_scheme' => $this->colourScheme,
+				'fontsize' => $this->fontSize,
+				'css_link' => $this->cssLink,
+				'friendly_colour' => $this->friendlyColour,
+				'neutral_colour' => $this->neutralColour,
+				'enemy_colour' => $this->enemyColour,
 			],
 			$this->SQLID,
 		);
@@ -384,8 +384,8 @@ class Account {
 
 			$db->delete('account_has_ip', [
 				...$this->SQLID,
-				'time' => $db->escapeNumber($delete_time),
-				'ip' => $db->escapeString($delete_ip),
+				'time' => $delete_time,
+				'ip' => $delete_ip,
 			]);
 		}
 
@@ -401,10 +401,10 @@ class Account {
 		// save...first make sure there isn't one for these keys (someone could double click and get error)
 		$db = Database::getInstance();
 		$db->replace('account_has_ip', [
-			'account_id' => $db->escapeNumber($this->accountID),
-			'time' => $db->escapeNumber(Epoch::time()),
-			'ip' => $db->escapeString($curr_ip),
-			'host' => $db->escapeString($host),
+			'account_id' => $this->accountID,
+			'time' => Epoch::time(),
+			'ip' => $curr_ip,
+			'host' => $host,
 		]);
 	}
 
@@ -547,11 +547,11 @@ class Account {
 		if ($this->isLoggingEnabled()) {
 			$db = Database::getInstance();
 			$db->insert('account_has_logs', [
-				'account_id' => $db->escapeNumber($this->accountID),
-				'microtime' => $db->escapeNumber(Epoch::microtime()),
-				'log_type_id' => $db->escapeNumber($log_type_id),
-				'message' => $db->escapeString($msg),
-				'sector_id' => $db->escapeNumber($sector_id),
+				'account_id' => $this->accountID,
+				'microtime' => Epoch::microtime(),
+				'log_type_id' => $log_type_id,
+				'message' => $msg,
+				'sector_id' => $sector_id,
 			]);
 		}
 	}
@@ -596,15 +596,15 @@ class Account {
 		if ($this->credits == 0 && $this->rewardCredits == 0) {
 			$db->replace('account_has_credits', [
 				...$this->SQLID,
-				'credits_left' => $db->escapeNumber($credits),
-				'reward_credits' => $db->escapeNumber($rewardCredits),
+				'credits_left' => $credits,
+				'reward_credits' => $rewardCredits,
 			]);
 		} else {
 			$db->update(
 				'account_has_credits',
 				[
-					'credits_left' => $db->escapeNumber($credits),
-					'reward_credits' => $db->escapeNumber($rewardCredits),
+					'credits_left' => $credits,
+					'reward_credits' => $rewardCredits,
 				],
 				$this->SQLID,
 			);
@@ -630,13 +630,13 @@ class Account {
 		$db = Database::getInstance();
 		if ($this->credits == 0 && $this->rewardCredits == 0) {
 			$db->replace('account_has_credits', [
-				'account_id' => $db->escapeNumber($this->getAccountID()),
-				'credits_left' => $db->escapeNumber($credits),
+				'account_id' => $this->getAccountID(),
+				'credits_left' => $credits,
 			]);
 		} else {
 			$db->update(
 				'account_has_credits',
-				['credits_left' => $db->escapeNumber($credits)],
+				['credits_left' => $credits],
 				$this->SQLID,
 			);
 		}
@@ -673,13 +673,13 @@ class Account {
 		$db = Database::getInstance();
 		if ($this->credits == 0 && $this->rewardCredits == 0) {
 			$db->replace('account_has_credits', [
-				'account_id' => $db->escapeNumber($this->getAccountID()),
-				'reward_credits' => $db->escapeNumber($credits),
+				'account_id' => $this->getAccountID(),
+				'reward_credits' => $credits,
 			]);
 		} else {
 			$db->update(
 				'account_has_credits',
-				['reward_credits' => $db->escapeNumber($credits)],
+				['reward_credits' => $credits],
 				$this->SQLID,
 			);
 		}
@@ -704,11 +704,11 @@ class Account {
 	public static function doMessageSendingToBox(int $senderID, int $boxTypeID, string $message, int $gameID = 0): void {
 		$db = Database::getInstance();
 		$db->insert('message_boxes', [
-			'box_type_id' => $db->escapeNumber($boxTypeID),
-			'game_id' => $db->escapeNumber($gameID),
-			'message_text' => $db->escapeString($message),
-			'sender_id' => $db->escapeNumber($senderID),
-			'send_time' => $db->escapeNumber(Epoch::time()),
+			'box_type_id' => $boxTypeID,
+			'game_id' => $gameID,
+			'message_text' => $message,
+			'sender_id' => $senderID,
+			'send_time' => Epoch::time(),
 		]);
 	}
 
@@ -796,9 +796,9 @@ class Account {
 		// remember when we sent validation code
 		$db = Database::getInstance();
 		$db->replace('notification', [
-			'notification_type' => $db->escapeString('validation_code'),
-			'account_id' => $db->escapeNumber($this->getAccountID()),
-			'time' => $db->escapeNumber(Epoch::time()),
+			'notification_type' => 'validation_code',
+			'account_id' => $this->getAccountID(),
+			'time' => Epoch::time(),
 		]);
 
 		$emailMessage =
@@ -1059,7 +1059,7 @@ class Account {
 			return;
 		}
 		$db->insert('account_auth', [
-			'account_id' => $db->escapeNumber($this->getAccountID()),
+			'account_id' => $this->getAccountID(),
 			...$params,
 		]);
 	}
@@ -1263,15 +1263,15 @@ class Account {
 		if ($this->points == 0) {
 			$db->insert('account_has_points', [
 				...$this->SQLID,
-				'points' => $db->escapeNumber($numPoints),
-				'last_update' => $db->escapeNumber($lastUpdate ?? Epoch::time()),
+				'points' => $numPoints,
+				'last_update' => $lastUpdate ?? Epoch::time(),
 			]);
 		} elseif ($numPoints <= 0) {
 			$db->delete('account_has_points', $this->SQLID);
 		} else {
-			$data = ['points' => $db->escapeNumber($numPoints)];
+			$data = ['points' => $numPoints];
 			if ($lastUpdate !== null) {
-				$data['last_update'] = $db->escapeNumber(Epoch::time());
+				$data['last_update'] = Epoch::time();
 			}
 			$db->update('account_has_points', $data, $this->SQLID);
 		}
@@ -1348,17 +1348,17 @@ class Account {
 		$db = Database::getInstance();
 		$db->replace('account_is_closed', [
 			...$this->SQLID,
-			'reason_id' => $db->escapeNumber($reasonID),
-			'suspicion' => $db->escapeString($suspicion),
-			'expires' => $db->escapeNumber($expireTime),
+			'reason_id' => $reasonID,
+			'suspicion' => $suspicion,
+			'expires' => $expireTime,
 		]);
 		$db->delete('active_session', $this->SQLID);
 
 		$db->insert('account_has_closing_history', [
 			...$this->SQLID,
-			'time' => $db->escapeNumber(Epoch::time()),
-			'admin_id' => $db->escapeNumber($admin->getAccountID()),
-			'action' => $db->escapeString('Closed'),
+			'time' => Epoch::time(),
+			'admin_id' => $admin->getAccountID(),
+			'action' => 'Closed',
 		]);
 		$db->update(
 			'player',
@@ -1396,9 +1396,9 @@ class Account {
 		$db->delete('account_is_closed', $this->SQLID);
 		$db->insert('account_has_closing_history', [
 			...$this->SQLID,
-			'time' => $db->escapeNumber(Epoch::time()),
-			'admin_id' => $db->escapeNumber($adminID),
-			'action' => $db->escapeString('Opened'),
+			'time' => Epoch::time(),
+			'admin_id' => $adminID,
+			'action' => 'Opened',
 		]);
 		$db->write('UPDATE player SET last_turn_update = GREATEST(:now, last_turn_update) WHERE ' . self::SQL, [
 			'now' => $db->escapeNumber(Epoch::time()),
@@ -1412,7 +1412,7 @@ class Account {
 		if ($currException !== null) {
 			$db->replace('account_exceptions', [
 				...$this->SQLID,
-				'reason' => $db->escapeString($currException),
+				'reason' => $currException,
 			]);
 		}
 	}

--- a/src/lib/Smr/Account.php
+++ b/src/lib/Smr/Account.php
@@ -223,18 +223,21 @@ class Account {
 	}
 
 	/**
-	 * @return array<string, string>
+	 * @return array{CASE: string, IN: array<string>}
 	 */
-	public static function getUserScoreCaseStatement(Database $db): array {
+	public static function getUserScoreCaseStatement(): array {
 		$userRankingTypes = [];
 		$case = 'IFNULL(FLOOR(SUM(CASE type ';
 		foreach (self::USER_RANKINGS_SCORE as [$stat, $a, $b]) {
-			$userRankingType = $db->escapeString(implode(':', $stat));
+			$userRankingType = implode(':', $stat);
 			$userRankingTypes[] = $userRankingType;
-			$case .= ' WHEN ' . $userRankingType . ' THEN POW(amount*' . $a . ',' . self::USER_RANKINGS_EACH_STAT_POW . ')*' . $b;
+			$case .= ' WHEN \'' . $userRankingType . '\' THEN POW(amount*' . $a . ',' . self::USER_RANKINGS_EACH_STAT_POW . ')*' . $b;
 		}
 		$case .= ' END)), 0)';
-		return ['CASE' => $case, 'IN' => implode(',', $userRankingTypes)];
+		return [
+			'CASE' => $case,
+			'IN' => $userRankingTypes,
+		];
 	}
 
 	protected function __construct(protected readonly int $accountID) {

--- a/src/lib/Smr/Alliance.php
+++ b/src/lib/Smr/Alliance.php
@@ -286,7 +286,7 @@ class Alliance {
 				'game_id' => $db->escapeNumber($this->getGameID()),
 			]);
 		} else {
-			$db->write('DELETE FROM irc_alliance_has_channel WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('irc_alliance_has_channel', $this->SQLID);
 		}
 		$this->ircChannel = $ircChannel;
 	}

--- a/src/lib/Smr/Alliance.php
+++ b/src/lib/Smr/Alliance.php
@@ -513,34 +513,24 @@ class Alliance {
 
 	public function update(): void {
 		$db = Database::getInstance();
-		$db->write('UPDATE alliance SET
-								alliance_password = :alliance_password,
-								recruiting = :recruiting,
-								alliance_account = :alliance_account,
-								alliance_description = :alliance_description,
-								`mod` = :motd,
-								img_src = :img_src,
-								alliance_kills = :alliance_kills,
-								alliance_deaths = :alliance_deaths,
-								discord_server = :discord_server,
-								discord_channel = :discord_channel,
-								flagship_id = :flagship_id,
-								leader_id = :leader_id
-							WHERE ' . self::SQL, [
-			'alliance_password' => $db->escapeString($this->password),
-			'recruiting' => $db->escapeBoolean($this->recruiting),
-			'alliance_account' => $db->escapeNumber($this->bank),
-			'alliance_description' => $db->escapeNullableString($this->description),
-			'motd' => $db->escapeString($this->motd),
-			'img_src' => $db->escapeString($this->imgSrc),
-			'alliance_kills' => $db->escapeNumber($this->kills),
-			'alliance_deaths' => $db->escapeNumber($this->deaths),
-			'discord_server' => $db->escapeNullableString($this->discordServer),
-			'discord_channel' => $db->escapeNullableString($this->discordChannel),
-			'flagship_id' => $db->escapeNumber($this->flagshipID),
-			'leader_id' => $db->escapeNumber($this->leaderID),
-			...$this->SQLID,
-		]);
+		$db->update(
+			'alliance',
+			[
+				'alliance_password' => $db->escapeString($this->password),
+				'recruiting' => $db->escapeBoolean($this->recruiting),
+				'alliance_account' => $db->escapeNumber($this->bank),
+				'alliance_description' => $db->escapeNullableString($this->description),
+				'`mod`' => $db->escapeString($this->motd),
+				'img_src' => $db->escapeString($this->imgSrc),
+				'alliance_kills' => $db->escapeNumber($this->kills),
+				'alliance_deaths' => $db->escapeNumber($this->deaths),
+				'discord_server' => $db->escapeNullableString($this->discordServer),
+				'discord_channel' => $db->escapeNullableString($this->discordChannel),
+				'flagship_id' => $db->escapeNumber($this->flagshipID),
+				'leader_id' => $db->escapeNumber($this->leaderID),
+			],
+			$this->SQLID,
+		);
 	}
 
 	/**

--- a/src/lib/Smr/Alliance.php
+++ b/src/lib/Smr/Alliance.php
@@ -157,10 +157,10 @@ class Alliance {
 
 		// actually create the alliance here
 		$db->insert('alliance', [
-			'alliance_id' => $db->escapeNumber($allianceID),
-			'game_id' => $db->escapeNumber($gameID),
-			'alliance_name' => $db->escapeString($name),
-			'alliance_password' => $db->escapeString(''),
+			'alliance_id' => $allianceID,
+			'game_id' => $gameID,
+			'alliance_name' => $name,
+			'alliance_password' => '',
 			'recruiting' => $db->escapeBoolean(false),
 		]);
 		$db->unlock();
@@ -281,9 +281,9 @@ class Alliance {
 			}
 
 			$db->replace('irc_alliance_has_channel', [
-				'channel' => $db->escapeString($ircChannel),
-				'alliance_id' => $db->escapeNumber($this->getAllianceID()),
-				'game_id' => $db->escapeNumber($this->getGameID()),
+				'channel' => $ircChannel,
+				'alliance_id' => $this->getAllianceID(),
+				'game_id' => $this->getGameID(),
 			]);
 		} else {
 			$db->delete('irc_alliance_has_channel', $this->SQLID);
@@ -516,18 +516,18 @@ class Alliance {
 		$db->update(
 			'alliance',
 			[
-				'alliance_password' => $db->escapeString($this->password),
+				'alliance_password' => $this->password,
 				'recruiting' => $db->escapeBoolean($this->recruiting),
-				'alliance_account' => $db->escapeNumber($this->bank),
-				'alliance_description' => $db->escapeNullableString($this->description),
-				'`mod`' => $db->escapeString($this->motd),
-				'img_src' => $db->escapeString($this->imgSrc),
-				'alliance_kills' => $db->escapeNumber($this->kills),
-				'alliance_deaths' => $db->escapeNumber($this->deaths),
-				'discord_server' => $db->escapeNullableString($this->discordServer),
-				'discord_channel' => $db->escapeNullableString($this->discordChannel),
-				'flagship_id' => $db->escapeNumber($this->flagshipID),
-				'leader_id' => $db->escapeNumber($this->leaderID),
+				'alliance_account' => $this->bank,
+				'alliance_description' => $this->description,
+				'`mod`' => $this->motd,
+				'img_src' => $this->imgSrc,
+				'alliance_kills' => $this->kills,
+				'alliance_deaths' => $this->deaths,
+				'discord_server' => $this->discordServer,
+				'discord_channel' => $this->discordChannel,
+				'flagship_id' => $this->flagshipID,
+				'leader_id' => $this->leaderID,
 			],
 			$this->SQLID,
 		);
@@ -645,11 +645,11 @@ class Alliance {
 		$viewBonds = true;
 		$db = Database::getInstance();
 		$db->insert('alliance_has_roles', [
-			'alliance_id' => $db->escapeNumber($this->getAllianceID()),
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'role_id' => $db->escapeNumber(ALLIANCE_ROLE_LEADER),
-			'role' => $db->escapeString('Leader'),
-			'with_per_day' => $db->escapeNumber($withPerDay),
+			'alliance_id' => $this->getAllianceID(),
+			'game_id' => $this->getGameID(),
+			'role_id' => ALLIANCE_ROLE_LEADER,
+			'role' => 'Leader',
+			'with_per_day' => $withPerDay,
 			'remove_member' => $db->escapeBoolean($removeMember),
 			'change_pass' => $db->escapeBoolean($changePass),
 			'change_mod' => $db->escapeBoolean($changeMOD),
@@ -695,11 +695,11 @@ class Alliance {
 				break;
 		}
 		$db->insert('alliance_has_roles', [
-			'alliance_id' => $db->escapeNumber($this->getAllianceID()),
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'role_id' => $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER),
-			'role' => $db->escapeString('New Member'),
-			'with_per_day' => $db->escapeNumber($withPerDay),
+			'alliance_id' => $this->getAllianceID(),
+			'game_id' => $this->getGameID(),
+			'role_id' => ALLIANCE_ROLE_NEW_MEMBER,
+			'role' => 'New Member',
+			'with_per_day' => $withPerDay,
 			'remove_member' => $db->escapeBoolean($removeMember),
 			'change_pass' => $db->escapeBoolean($changePass),
 			'change_mod' => $db->escapeBoolean($changeMOD),

--- a/src/lib/Smr/AllianceInvite.php
+++ b/src/lib/Smr/AllianceInvite.php
@@ -83,12 +83,12 @@ class AllianceInvite {
 
 	public function delete(): void {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM alliance_invites_player WHERE alliance_id = :alliance_id AND game_id = :game_id AND account_id = :account_id', [
+		$db->delete('alliance_invites_player', [
 			'alliance_id' => $db->escapeNumber($this->allianceID),
 			'game_id' => $db->escapeNumber($this->gameID),
 			'account_id' => $db->escapeNumber($this->receiverAccountID),
 		]);
-		$db->write('DELETE FROM message WHERE message_id = :message_id', [
+		$db->delete('message', [
 			'message_id' => $db->escapeNumber($this->messageID),
 		]);
 	}

--- a/src/lib/Smr/AllianceInvite.php
+++ b/src/lib/Smr/AllianceInvite.php
@@ -19,12 +19,12 @@ class AllianceInvite {
 	public static function send(int $allianceID, int $gameID, int $receiverAccountID, int $senderAccountID, int $messageID, int $expires): void {
 		$db = Database::getInstance();
 		$db->insert('alliance_invites_player', [
-			'game_id' => $db->escapeNumber($gameID),
-			'account_id' => $db->escapeNumber($receiverAccountID),
-			'alliance_id' => $db->escapeNumber($allianceID),
-			'invited_by_id' => $db->escapeNumber($senderAccountID),
-			'expires' => $db->escapeNumber($expires),
-			'message_id' => $db->escapeNumber($messageID),
+			'game_id' => $gameID,
+			'account_id' => $receiverAccountID,
+			'alliance_id' => $allianceID,
+			'invited_by_id' => $senderAccountID,
+			'expires' => $expires,
+			'message_id' => $messageID,
 		]);
 	}
 
@@ -84,12 +84,12 @@ class AllianceInvite {
 	public function delete(): void {
 		$db = Database::getInstance();
 		$db->delete('alliance_invites_player', [
-			'alliance_id' => $db->escapeNumber($this->allianceID),
-			'game_id' => $db->escapeNumber($this->gameID),
-			'account_id' => $db->escapeNumber($this->receiverAccountID),
+			'alliance_id' => $this->allianceID,
+			'game_id' => $this->gameID,
+			'account_id' => $this->receiverAccountID,
 		]);
 		$db->delete('message', [
-			'message_id' => $db->escapeNumber($this->messageID),
+			'message_id' => $this->messageID,
 		]);
 	}
 

--- a/src/lib/Smr/AllianceInvite.php
+++ b/src/lib/Smr/AllianceInvite.php
@@ -36,9 +36,14 @@ class AllianceInvite {
 	public static function getAll(int $allianceID, int $gameID): array {
 		// Remove any expired invitations
 		$db = Database::getInstance();
-		$db->write('DELETE FROM alliance_invites_player WHERE expires < ' . $db->escapeNumber(Epoch::time()));
+		$db->write('DELETE FROM alliance_invites_player WHERE expires < :now', [
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 
-		$dbResult = $db->read('SELECT * FROM alliance_invites_player WHERE alliance_id=' . $db->escapeNumber($allianceID) . ' AND game_id=' . $db->escapeNumber($gameID));
+		$dbResult = $db->read('SELECT * FROM alliance_invites_player WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+			'alliance_id' => $db->escapeNumber($allianceID),
+			'game_id' => $db->escapeNumber($gameID),
+		]);
 		$invites = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$invites[] = new self($dbRecord);
@@ -52,9 +57,15 @@ class AllianceInvite {
 	public static function get(int $allianceID, int $gameID, int $receiverAccountID): self {
 		// Remove any expired invitations
 		$db = Database::getInstance();
-		$db->write('DELETE FROM alliance_invites_player WHERE expires < ' . $db->escapeNumber(Epoch::time()));
+		$db->write('DELETE FROM alliance_invites_player WHERE expires < :now', [
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 
-		$dbResult = $db->read('SELECT * FROM alliance_invites_player WHERE alliance_id=' . $db->escapeNumber($allianceID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' AND account_id=' . $db->escapeNumber($receiverAccountID));
+		$dbResult = $db->read('SELECT * FROM alliance_invites_player WHERE alliance_id = :alliance_id AND game_id = :game_id AND account_id = :account_id', [
+			'alliance_id' => $db->escapeNumber($allianceID),
+			'game_id' => $db->escapeNumber($gameID),
+			'account_id' => $db->escapeNumber($receiverAccountID),
+		]);
 		if ($dbResult->hasRecord()) {
 			return new self($dbResult->record());
 		}
@@ -72,8 +83,14 @@ class AllianceInvite {
 
 	public function delete(): void {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM alliance_invites_player WHERE alliance_id=' . $db->escapeNumber($this->allianceID) . ' AND game_id=' . $db->escapeNumber($this->gameID) . ' AND account_id=' . $db->escapeNumber($this->receiverAccountID));
-		$db->write('DELETE FROM message WHERE message_id=' . $db->escapeNumber($this->messageID));
+		$db->write('DELETE FROM alliance_invites_player WHERE alliance_id = :alliance_id AND game_id = :game_id AND account_id = :account_id', [
+			'alliance_id' => $db->escapeNumber($this->allianceID),
+			'game_id' => $db->escapeNumber($this->gameID),
+			'account_id' => $db->escapeNumber($this->receiverAccountID),
+		]);
+		$db->write('DELETE FROM message WHERE message_id = :message_id', [
+			'message_id' => $db->escapeNumber($this->messageID),
+		]);
 	}
 
 	public function getSender(): AbstractPlayer {

--- a/src/lib/Smr/Bounty.php
+++ b/src/lib/Smr/Bounty.php
@@ -13,7 +13,10 @@ class Bounty {
 	 */
 	public static function getMostWanted(BountyType $type, int $gameID): array {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM bounty WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type =' . $db->escapeString($type->value) . ' AND claimer_id = 0 ORDER BY amount DESC');
+		$dbResult = $db->read('SELECT * FROM bounty WHERE game_id = :game_id AND type = :type AND claimer_id = 0 ORDER BY amount DESC', [
+			'game_id' => $db->escapeNumber($gameID),
+			'type' => $db->escapeString($type->value),
+		]);
 		$bounties = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$bounties[] = self::getFromRecord($dbRecord);
@@ -28,7 +31,7 @@ class Bounty {
 	 */
 	public static function getPlacedOnPlayer(AbstractPlayer $player): array {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM bounty WHERE ' . $player->getSQL());
+		$dbResult = $db->read('SELECT * FROM bounty WHERE ' . AbstractPlayer::SQL, $player->SQLID);
 		$bounties = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			// Recall that bounty_id is only unique to a given player
@@ -44,12 +47,17 @@ class Bounty {
 	 */
 	public static function getClaimableByPlayer(AbstractPlayer $player, ?BountyType $type = null): array {
 		$db = Database::getInstance();
-		$query = 'SELECT * FROM bounty WHERE claimer_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID());
-		$query .= match ($type) {
-			null => '',
-			default => ' AND type=' . $db->escapeString($type->value),
-		};
-		$dbResult = $db->read($query);
+		$query = 'SELECT * FROM bounty WHERE claimer_id = :claimer_id AND game_id = :game_id';
+		$sqlParams = [
+			'claimer_id' => $db->escapeNumber($player->getAccountID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		];
+		if ($type === null) {
+			$dbResult = $db->read($query, $sqlParams);
+		} else {
+			$sqlParams['type'] = $db->escapeString($type->value);
+			$dbResult = $db->read($query . ' AND type = :type', $sqlParams);
+		}
 		$bounties = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$bounties[] = self::getFromRecord($dbRecord);
@@ -166,7 +174,11 @@ class Bounty {
 				'smr_credits' => $db->escapeNumber($this->smrCredits),
 			]);
 		} else {
-			$db->write('DELETE FROM bounty WHERE bounty_id=' . $db->escapeNumber($this->bountyID) . ' AND account_id=' . $db->escapeNumber($this->targetID) . ' AND game_id=' . $db->escapeNumber($this->gameID));
+			$db->write('DELETE FROM bounty WHERE bounty_id = :bounty_id AND account_id = :account_id AND game_id = :game_id', [
+				'bounty_id' => $db->escapeNumber($this->bountyID),
+				'account_id' => $db->escapeNumber($this->targetID),
+				'game_id' => $db->escapeNumber($this->gameID),
+			]);
 		}
 		$this->hasChanged = false;
 		return true;

--- a/src/lib/Smr/Bounty.php
+++ b/src/lib/Smr/Bounty.php
@@ -164,20 +164,20 @@ class Bounty {
 		$db = Database::getInstance();
 		if ($this->credits > 0 || $this->smrCredits > 0) {
 			$db->replace('bounty', [
-				'account_id' => $db->escapeNumber($this->targetID),
-				'bounty_id' => $db->escapeNumber($this->bountyID),
-				'game_id' => $db->escapeNumber($this->gameID),
-				'type' => $db->escapeString($this->type->value),
-				'time' => $db->escapeNumber($this->time),
-				'claimer_id' => $db->escapeNumber($this->claimerID),
-				'amount' => $db->escapeNumber($this->credits),
-				'smr_credits' => $db->escapeNumber($this->smrCredits),
+				'account_id' => $this->targetID,
+				'bounty_id' => $this->bountyID,
+				'game_id' => $this->gameID,
+				'type' => $this->type->value,
+				'time' => $this->time,
+				'claimer_id' => $this->claimerID,
+				'amount' => $this->credits,
+				'smr_credits' => $this->smrCredits,
 			]);
 		} else {
 			$db->delete('bounty', [
-				'bounty_id' => $db->escapeNumber($this->bountyID),
-				'account_id' => $db->escapeNumber($this->targetID),
-				'game_id' => $db->escapeNumber($this->gameID),
+				'bounty_id' => $this->bountyID,
+				'account_id' => $this->targetID,
+				'game_id' => $this->gameID,
 			]);
 		}
 		$this->hasChanged = false;

--- a/src/lib/Smr/Bounty.php
+++ b/src/lib/Smr/Bounty.php
@@ -174,7 +174,7 @@ class Bounty {
 				'smr_credits' => $db->escapeNumber($this->smrCredits),
 			]);
 		} else {
-			$db->write('DELETE FROM bounty WHERE bounty_id = :bounty_id AND account_id = :account_id AND game_id = :game_id', [
+			$db->delete('bounty', [
 				'bounty_id' => $db->escapeNumber($this->bountyID),
 				'account_id' => $db->escapeNumber($this->targetID),
 				'game_id' => $db->escapeNumber($this->gameID),

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -111,7 +111,7 @@ class ChessGame {
 		$dbResult = $db->read('SELECT * FROM chess_game_moves WHERE chess_game_id = :chess_game_id ORDER BY move_id', [
 			'chess_game_id' => $db->escapeNumber($this->chessGameID),
 		]);
-		$db->write('DELETE FROM chess_game_moves WHERE chess_game_id = :chess_game_id', [
+		$db->delete('chess_game_moves', [
 			'chess_game_id' => $db->escapeNumber($this->chessGameID),
 		]);
 		$this->moves = [];

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -108,14 +108,14 @@ class ChessGame {
 				'end_time' => null,
 				'winner_id' => 0,
 			],
-			['chess_game_id' => $db->escapeNumber($this->chessGameID)],
+			['chess_game_id' => $this->chessGameID],
 		);
 
 		$dbResult = $db->read('SELECT * FROM chess_game_moves WHERE chess_game_id = :chess_game_id ORDER BY move_id', [
 			'chess_game_id' => $db->escapeNumber($this->chessGameID),
 		]);
 		$db->delete('chess_game_moves', [
-			'chess_game_id' => $db->escapeNumber($this->chessGameID),
+			'chess_game_id' => $this->chessGameID,
 		]);
 		$this->moves = [];
 		$this->board = new Board();
@@ -273,11 +273,11 @@ class ChessGame {
 	public static function insertNewGame(int $startDate, ?int $endDate, AbstractPlayer $whitePlayer, AbstractPlayer $blackPlayer): void {
 		$db = Database::getInstance();
 		$db->insert('chess_game', [
-			'start_time' => $db->escapeNumber($startDate),
+			'start_time' => $startDate,
 			'end_time' => $endDate,
-			'white_id' => $db->escapeNumber($whitePlayer->getAccountID()),
-			'black_id' => $db->escapeNumber($blackPlayer->getAccountID()),
-			'game_id' => $db->escapeNumber($whitePlayer->getGameID()),
+			'white_id' => $whitePlayer->getAccountID(),
+			'black_id' => $blackPlayer->getAccountID(),
+			'game_id' => $whitePlayer->getGameID(),
 		]);
 	}
 
@@ -439,15 +439,15 @@ class ChessGame {
 
 		$db = Database::getInstance();
 		$db->insert('chess_game_moves', [
-			'chess_game_id' => $db->escapeNumber($this->chessGameID),
-			'piece_id' => $db->escapeNumber($pieceID),
-			'start_x' => $db->escapeNumber($x),
-			'start_y' => $db->escapeNumber($y),
-			'end_x' => $db->escapeNumber($toX),
-			'end_y' => $db->escapeNumber($toY),
-			'checked' => $db->escapeNullableString($checking),
+			'chess_game_id' => $this->chessGameID,
+			'piece_id' => $pieceID,
+			'start_x' => $x,
+			'start_y' => $y,
+			'end_x' => $toX,
+			'end_y' => $toY,
+			'checked' => $checking,
 			'piece_taken' => $moveInfo['PieceTaken']?->pieceID,
-			'castling' => $db->escapeNullableString($moveInfo['Castling']?->value),
+			'castling' => $moveInfo['Castling']?->value,
 			'en_passant' => $db->escapeBoolean($moveInfo['EnPassant']),
 			'promote_piece_id' => $promotionPieceID,
 		]);
@@ -554,10 +554,10 @@ class ChessGame {
 		$db->update(
 			'chess_game',
 			[
-				'end_time' => $db->escapeNumber(Epoch::time()),
-				'winner_id' => $db->escapeNumber($this->winner),
+				'end_time' => Epoch::time(),
+				'winner_id' => $this->winner,
 			],
-			['chess_game_id' => $db->escapeNumber($this->chessGameID)],
+			['chess_game_id' => $this->chessGameID],
 		);
 		$winnerColour = $this->getColourForAccountID($accountID);
 		$winningPlayer = $this->getColourPlayer($winnerColour);
@@ -617,8 +617,8 @@ class ChessGame {
 			$db = Database::getInstance();
 			$db->update(
 				'chess_game',
-				['end_time' => $db->escapeNumber(Epoch::time())],
-				['chess_game_id' => $db->escapeNumber($this->chessGameID)],
+				['end_time' => Epoch::time()],
+				['chess_game_id' => $this->chessGameID],
 			);
 			return self::END_CANCEL;
 		}

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -102,11 +102,14 @@ class ChessGame {
 	public function rerunGame(bool $debugInfo = false): void {
 		$db = Database::getInstance();
 
-		$db->write('UPDATE chess_game
-					SET end_time = NULL, winner_id = 0
-					WHERE chess_game_id = :chess_game_id', [
-			'chess_game_id' => $db->escapeNumber($this->chessGameID),
-		]);
+		$db->update(
+			'chess_game',
+			[
+				'end_time' => null,
+				'winner_id' => 0,
+			],
+			['chess_game_id' => $db->escapeNumber($this->chessGameID)],
+		);
 
 		$dbResult = $db->read('SELECT * FROM chess_game_moves WHERE chess_game_id = :chess_game_id ORDER BY move_id', [
 			'chess_game_id' => $db->escapeNumber($this->chessGameID),
@@ -548,13 +551,14 @@ class ChessGame {
 		$this->winner = $accountID;
 		$this->endDate = Epoch::time();
 		$db = Database::getInstance();
-		$db->write('UPDATE chess_game
-						SET end_time = :now, winner_id = :winner_id
-						WHERE chess_game_id = :chess_game_id', [
-			'now' => $db->escapeNumber(Epoch::time()),
-			'winner_id' => $db->escapeNumber($this->winner),
-			'chess_game_id' => $db->escapeNumber($this->chessGameID),
-		]);
+		$db->update(
+			'chess_game',
+			[
+				'end_time' => $db->escapeNumber(Epoch::time()),
+				'winner_id' => $db->escapeNumber($this->winner),
+			],
+			['chess_game_id' => $db->escapeNumber($this->chessGameID)],
+		);
 		$winnerColour = $this->getColourForAccountID($accountID);
 		$winningPlayer = $this->getColourPlayer($winnerColour);
 		$losingPlayer = $this->getColourPlayer($winnerColour->opposite());
@@ -611,12 +615,11 @@ class ChessGame {
 		if (count($this->getMoves()) < 2) {
 			$this->endDate = Epoch::time();
 			$db = Database::getInstance();
-			$db->write('UPDATE chess_game
-							SET end_time = :now
-							WHERE chess_game_id = :chess_game_id', [
-				'now' => $db->escapeNumber(Epoch::time()),
-				'chess_game_id' => $db->escapeNumber($this->chessGameID),
-			]);
+			$db->update(
+				'chess_game',
+				['end_time' => $db->escapeNumber(Epoch::time())],
+				['chess_game_id' => $db->escapeNumber($this->chessGameID)],
+			);
 			return self::END_CANCEL;
 		}
 

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -271,7 +271,7 @@ class ChessGame {
 		$db = Database::getInstance();
 		$db->insert('chess_game', [
 			'start_time' => $db->escapeNumber($startDate),
-			'end_time' => $endDate === null ? 'NULL' : $db->escapeNumber($endDate),
+			'end_time' => $endDate,
 			'white_id' => $db->escapeNumber($whitePlayer->getAccountID()),
 			'black_id' => $db->escapeNumber($blackPlayer->getAccountID()),
 			'game_id' => $db->escapeNumber($whitePlayer->getGameID()),
@@ -443,10 +443,10 @@ class ChessGame {
 			'end_x' => $db->escapeNumber($toX),
 			'end_y' => $db->escapeNumber($toY),
 			'checked' => $db->escapeNullableString($checking),
-			'piece_taken' => $moveInfo['PieceTaken'] === null ? 'NULL' : $db->escapeNumber($moveInfo['PieceTaken']->pieceID),
+			'piece_taken' => $moveInfo['PieceTaken']?->pieceID,
 			'castling' => $db->escapeNullableString($moveInfo['Castling']?->value),
 			'en_passant' => $db->escapeBoolean($moveInfo['EnPassant']),
-			'promote_piece_id' => $promotionPieceID ?? 'NULL',
+			'promote_piece_id' => $promotionPieceID,
 		]);
 
 		$currentPlayer->increaseHOF(1, [$chessType, 'Moves', 'Total Taken'], HOF_PUBLIC);

--- a/src/lib/Smr/Container/DiContainer.php
+++ b/src/lib/Smr/Container/DiContainer.php
@@ -3,7 +3,7 @@
 namespace Smr\Container;
 
 use DI\ContainerBuilder;
-use mysqli;
+use Doctrine\DBAL\Connection;
 use Smr\Database;
 use Smr\DatabaseProperties;
 use Smr\Epoch;
@@ -31,18 +31,8 @@ class DiContainer {
 	 */
 	private function getDefinitions(): array {
 		return [
-			/*
-			 * mysqli is a 3rd party library, and we do not have control over its constructor.
-			 * In order for PHP-DI to construct an instance of a class, each constructor argument must
-			 * be able to be constructed.
-			 * PHP-DI cannot construct mysqli by itself, because all of its arguments are primitive types.
-			 * Therefore, we need to declare a provider factory for the container to use when constructing new instances.
-			 *
-			 * The factories themselves are able to use dependency injection as well, so we can provide the DatabaseProperties
-			 * typehint to make sure the container constructs an instance and provides it to the factory.
-			 */
-			mysqli::class => function(DatabaseProperties $dbProperties): mysqli {
-				return Database::mysqliFactory($dbProperties);
+			Connection::class => function(DatabaseProperties $dbProperties): Connection {
+				return Database::connectionFactory($dbProperties);
 			},
 			'DatabaseName' => function(DatabaseProperties $dbProperties): string {
 				return $dbProperties->database;

--- a/src/lib/Smr/Council.php
+++ b/src/lib/Smr/Council.php
@@ -25,12 +25,16 @@ class Council {
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT account_id, alignment
 								FROM player
-								WHERE game_id = ' . $db->escapeNumber($gameID) . '
-									AND race_id = ' . $db->escapeNumber($raceID) . '
+								WHERE game_id = :game_id
+									AND race_id = :race_id
 									AND npc = \'FALSE\'
 									AND experience > 0
 								ORDER by experience DESC
-								LIMIT ' . MAX_COUNCIL_MEMBERS);
+								LIMIT :limit', [
+				'game_id' => $db->escapeNumber($gameID),
+				'race_id' => $db->escapeNumber($raceID),
+				'limit' => MAX_COUNCIL_MEMBERS,
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				// Add this player to the council
 				self::$COUNCILS[$gameID][$raceID][$i++] = $dbRecord->getInt('account_id');

--- a/src/lib/Smr/CouncilVoting.php
+++ b/src/lib/Smr/CouncilVoting.php
@@ -70,9 +70,7 @@ class CouncilVoting {
 				'race_id_2' => $db->escapeNumber($race_id_2),
 			]);
 
-			$db->write('DELETE FROM player_votes_relation
-					WHERE account_id = :account_id
-						AND game_id = :game_id', [
+			$db->delete('player_votes_relation', [
 				'account_id' => $db->escapeNumber($account_id),
 				'game_id' => $db->escapeNumber($gameID),
 			]);
@@ -241,23 +239,16 @@ class CouncilVoting {
 				'race_id_1' => $db->escapeNumber($race_id_1),
 				'race_id_2' => $db->escapeNumber($race_id_2),
 			];
-			$db->write('DELETE FROM race_has_voting
-					WHERE game_id = :game_id
-						AND race_id_1 = :race_id_1
-						AND race_id_2 = :race_id_2', $sqlParams);
-			$db->write('DELETE FROM player_votes_pact
-					WHERE game_id = :game_id
-						AND race_id_1 = :race_id_1
-						AND race_id_2 = :race_id_2', $sqlParams);
+			$db->delete('race_has_voting', $sqlParams);
+			$db->delete('player_votes_pact', $sqlParams);
 			// delete vote and user votes
-			$db->write('DELETE FROM race_has_voting
-					WHERE game_id = :game_id
-						AND race_id_1 = :race_id_2
-						AND race_id_2 = :race_id_1', $sqlParams);
-			$db->write('DELETE FROM player_votes_pact
-					WHERE game_id = :game_id
-						AND race_id_1 = :race_id_2
-						AND race_id_2 = :race_id_1', $sqlParams);
+			$sqlParams2 = [
+				'game_id' => $db->escapeNumber($gameID),
+				'race_id_1' => $db->escapeNumber($race_id_2),
+				'race_id_2' => $db->escapeNumber($race_id_1),
+			];
+			$db->delete('race_has_voting', $sqlParams2);
+			$db->delete('player_votes_pact', $sqlParams2);
 		}
 	}
 

--- a/src/lib/Smr/CouncilVoting.php
+++ b/src/lib/Smr/CouncilVoting.php
@@ -71,8 +71,8 @@ class CouncilVoting {
 			]);
 
 			$db->delete('player_votes_relation', [
-				'account_id' => $db->escapeNumber($account_id),
-				'game_id' => $db->escapeNumber($gameID),
+				'account_id' => $account_id,
+				'game_id' => $gameID,
 			]);
 		}
 	}
@@ -175,9 +175,9 @@ class CouncilVoting {
 					// get news message
 					$news = 'The [race=' . $race_id_1 . '] have declared <span class="red">WAR</span> on the [race=' . $race_id_2 . ']';
 					$db->insert('news', [
-						'game_id' => $db->escapeNumber($gameID),
-						'time' => $db->escapeNumber(Epoch::time()),
-						'news_message' => $db->escapeString($news),
+						'game_id' => $gameID,
+						'time' => Epoch::time(),
+						'news_message' => $news,
 					]);
 				} elseif ($type == 'PEACE') {
 					// get 'yes' votes
@@ -225,9 +225,9 @@ class CouncilVoting {
 						//get news message
 						$news = 'The [race=' . $race_id_1 . '] have signed a <span class="dgreen">PEACE</span> treaty with the [race=' . $race_id_2 . ']';
 						$db->insert('news', [
-							'game_id' => $db->escapeNumber($gameID),
-							'time' => $db->escapeNumber(Epoch::time()),
-							'news_message' => $db->escapeString($news),
+							'game_id' => $gameID,
+							'time' => Epoch::time(),
+							'news_message' => $news,
 						]);
 					}
 				}

--- a/src/lib/Smr/CouncilVoting.php
+++ b/src/lib/Smr/CouncilVoting.php
@@ -20,9 +20,13 @@ class CouncilVoting {
 		$db = Database::getInstance();
 
 		$dbResult = $db->read('SELECT * FROM player_votes_relation
-				WHERE time < ' . $db->escapeNumber($endtime) . '
-					AND game_id = ' . $db->escapeNumber($gameID) . '
-					AND race_id_1 = ' . $db->escapeNumber($race_id_1));
+				WHERE time < :end_time
+					AND game_id = :game_id
+					AND race_id_1 = :race_id_1', [
+			'end_time' => $db->escapeNumber($endtime),
+			'game_id' => $db->escapeNumber($gameID),
+			'race_id_1' => $db->escapeNumber($race_id_1),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$account_id = $dbRecord->getInt('account_id');
 			$race_id_2 = $dbRecord->getInt('race_id_2');
@@ -34,10 +38,14 @@ class CouncilVoting {
 				$relation_modifier = -RELATIONS_VOTE_CHANGE;
 			}
 
-			$dbResult2 = $db->read('SELECT * FROM race_has_relation ' .
-					'WHERE race_id_1 = ' . $db->escapeNumber($race_id_1) . '
-						AND race_id_2 = ' . $db->escapeNumber($race_id_2) . '
-						AND game_id = ' . $db->escapeNumber($gameID));
+			$dbResult2 = $db->read('SELECT * FROM race_has_relation
+					WHERE race_id_1 = :race_id_1
+						AND race_id_2 = :race_id_2
+						AND game_id = :game_id', [
+				'race_id_1' => $db->escapeNumber($race_id_1),
+				'race_id_2' => $db->escapeNumber($race_id_2),
+				'game_id' => $db->escapeNumber($gameID),
+			]);
 			$relation = $dbResult2->record()->getInt('relation') + $relation_modifier;
 
 			if ($relation < MIN_GLOBAL_RELATIONS) {
@@ -47,19 +55,27 @@ class CouncilVoting {
 			}
 
 			$db->write('UPDATE race_has_relation
-					SET relation = ' . $db->escapeNumber($relation) . '
-					WHERE game_id = ' . $db->escapeNumber($gameID) . '
+					SET relation = :relation
+					WHERE game_id = :game_id
 						AND (
-								race_id_1 = ' . $db->escapeNumber($race_id_1) . '
-								AND race_id_2 = ' . $db->escapeNumber($race_id_2) . '
+								race_id_1 = :race_id_1
+								AND race_id_2 = :race_id_2
 							OR
-								race_id_1 = ' . $db->escapeNumber($race_id_2) . '
-								AND race_id_2 = ' . $db->escapeNumber($race_id_1) . '
-						)');
+								race_id_1 = :race_id_2
+								AND race_id_2 = :race_id_1
+						)', [
+				'relation' => $db->escapeNumber($relation),
+				'game_id' => $db->escapeNumber($gameID),
+				'race_id_1' => $db->escapeNumber($race_id_1),
+				'race_id_2' => $db->escapeNumber($race_id_2),
+			]);
 
 			$db->write('DELETE FROM player_votes_relation
-					WHERE account_id = ' . $db->escapeNumber($account_id) . '
-						AND game_id = ' . $db->escapeNumber($gameID));
+					WHERE account_id = :account_id
+						AND game_id = :game_id', [
+				'account_id' => $db->escapeNumber($account_id),
+				'game_id' => $db->escapeNumber($gameID),
+			]);
 		}
 	}
 
@@ -68,27 +84,39 @@ class CouncilVoting {
 		$db = Database::getInstance();
 
 		$dbResult = $db->read('SELECT * FROM race_has_voting
-				WHERE end_time < ' . $db->escapeNumber(Epoch::time()) . '
-					AND game_id = ' . $db->escapeNumber($gameID) . '
-					AND race_id_1 = ' . $db->escapeNumber($race_id_1));
+				WHERE end_time < :now
+					AND game_id = :game_id
+					AND race_id_1 = :race_id_1', [
+			'now' => $db->escapeNumber(Epoch::time()),
+			'game_id' => $db->escapeNumber($gameID),
+			'race_id_1' => $db->escapeNumber($race_id_1),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$race_id_2 = $dbRecord->getInt('race_id_2');
 			$type = $dbRecord->getString('type');
 
 			// get 'yes' votes
 			$dbResult2 = $db->read('SELECT 1 FROM player_votes_pact
-					WHERE game_id = ' . $db->escapeNumber($gameID) . '
-						AND race_id_1 = ' . $db->escapeNumber($race_id_1) . '
-						AND race_id_2 = ' . $db->escapeNumber($race_id_2) . '
-						AND vote = \'YES\'');
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_1
+						AND race_id_2 = :race_id_2
+						AND vote = \'YES\'', [
+				'game_id' => $db->escapeNumber($gameID),
+				'race_id_1' => $db->escapeNumber($race_id_1),
+				'race_id_2' => $db->escapeNumber($race_id_2),
+			]);
 			$yes_votes = $dbResult2->getNumRecords();
 
 			// get 'no' votes
 			$dbResult2 = $db->read('SELECT 1 FROM player_votes_pact
-					WHERE game_id = ' . $db->escapeNumber($gameID) . '
-						AND race_id_1 = ' . $db->escapeNumber($race_id_1) . '
-						AND race_id_2 = ' . $db->escapeNumber($race_id_2) . '
-						AND vote = \'NO\'');
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_1
+						AND race_id_2 = :race_id_2
+						AND vote = \'NO\'', [
+				'game_id' => $db->escapeNumber($gameID),
+				'race_id_1' => $db->escapeNumber($race_id_1),
+				'race_id_2' => $db->escapeNumber($race_id_2),
+			]);
 			$no_votes = $dbResult2->getNumRecords();
 
 			// more yes than no?
@@ -131,15 +159,20 @@ class CouncilVoting {
 					}
 
 					$db->write('UPDATE race_has_relation
-							SET relation = LEAST(relation,' . $db->escapeNumber(RELATIONS_VOTE_WAR) . ')
-							WHERE game_id = ' . $db->escapeNumber($gameID) . '
+							SET relation = LEAST(relation, :relations_war)
+							WHERE game_id = :game_id
 								AND (
-										race_id_1 = ' . $db->escapeNumber($race_id_1) . '
-										AND race_id_2 = ' . $db->escapeNumber($race_id_2) . '
+										race_id_1 = :race_id_1
+										AND race_id_2 = :race_id_2
 									OR
-										race_id_1 = ' . $db->escapeNumber($race_id_2) . '
-										AND race_id_2 = ' . $db->escapeNumber($race_id_1) . '
-								)');
+										race_id_1 = :race_id_2
+										AND race_id_2 = :race_id_1
+								)', [
+						'relations_war' => $db->escapeNumber(RELATIONS_VOTE_WAR),
+						'game_id' => $db->escapeNumber($gameID),
+						'race_id_1' => $db->escapeNumber($race_id_1),
+						'race_id_2' => $db->escapeNumber($race_id_2),
+					]);
 
 					// get news message
 					$news = 'The [race=' . $race_id_1 . '] have declared <span class="red">WAR</span> on the [race=' . $race_id_2 . ']';
@@ -151,32 +184,45 @@ class CouncilVoting {
 				} elseif ($type == 'PEACE') {
 					// get 'yes' votes
 					$dbResult2 = $db->read('SELECT 1 FROM player_votes_pact
-							WHERE game_id = ' . $db->escapeNumber($gameID) . '
-								AND race_id_1 = ' . $db->escapeNumber($race_id_2) . '
-								AND race_id_2 = ' . $db->escapeNumber($race_id_1) . '
-								AND vote = \'YES\'');
+							WHERE game_id = :game_id
+								AND race_id_1 = :race_id_1
+								AND race_id_2 = :race_id_2
+								AND vote = \'YES\'', [
+						'game_id' => $db->escapeNumber($gameID),
+						'race_id_1' => $db->escapeNumber($race_id_2),
+						'race_id_2' => $db->escapeNumber($race_id_1),
+					]);
 					$rev_yes_votes = $dbResult2->getNumRecords();
 
 					// get 'no' votes
 					$dbResult2 = $db->read('SELECT 1 FROM player_votes_pact
-							WHERE game_id = ' . $db->escapeNumber($gameID) . '
-								AND race_id_1 = ' . $db->escapeNumber($race_id_2) . '
-								AND race_id_2 = ' . $db->escapeNumber($race_id_1) . '
-								AND vote = \'NO\'');
+							WHERE game_id = :game_id
+								AND race_id_1 = :race_id_1
+								AND race_id_2 = :race_id_2
+								AND vote = \'NO\'', [
+						'game_id' => $db->escapeNumber($gameID),
+						'race_id_1' => $db->escapeNumber($race_id_2),
+						'race_id_2' => $db->escapeNumber($race_id_1),
+					]);
 					$rev_no_votes = $dbResult2->getNumRecords();
 
 					// more yes than no?
 					if ($rev_yes_votes > $rev_no_votes) {
 						$db->write('UPDATE race_has_relation
-								SET relation = GREATEST(relation,' . $db->escapeNumber(RELATIONS_VOTE_PEACE) . ')
-								WHERE game_id = ' . $db->escapeNumber($gameID) . '
+								SET relation = GREATEST(relation, :relations_peace)
+								WHERE game_id = :game_id
 									AND (
-											race_id_1 = ' . $db->escapeNumber($race_id_1) . '
-											AND race_id_2 = ' . $db->escapeNumber($race_id_2) . '
+											race_id_1 = :race_id_1
+											AND race_id_2 = :race_id_2
 										OR
-											race_id_1 = ' . $db->escapeNumber($race_id_2) . '
-											AND race_id_2 = ' . $db->escapeNumber($race_id_1) . '
-									)');
+											race_id_1 = :race_id_2
+											AND race_id_2 = :race_id_1
+									)', [
+							'relations_peace' => $db->escapeNumber(RELATIONS_VOTE_PEACE),
+							'game_id' => $db->escapeNumber($gameID),
+							'race_id_1' => $db->escapeNumber($race_id_1),
+							'race_id_2' => $db->escapeNumber($race_id_2),
+						]);
 
 						//get news message
 						$news = 'The [race=' . $race_id_1 . '] have signed a <span class="dgreen">PEACE</span> treaty with the [race=' . $race_id_2 . ']';
@@ -190,23 +236,28 @@ class CouncilVoting {
 			}
 
 			// delete vote and user votes
+			$sqlParams = [
+				'game_id' => $db->escapeNumber($gameID),
+				'race_id_1' => $db->escapeNumber($race_id_1),
+				'race_id_2' => $db->escapeNumber($race_id_2),
+			];
 			$db->write('DELETE FROM race_has_voting
-					WHERE game_id = ' . $db->escapeNumber($gameID) . '
-						AND race_id_1 = ' . $db->escapeNumber($race_id_1) . '
-						AND race_id_2 = ' . $db->escapeNumber($race_id_2));
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_1
+						AND race_id_2 = :race_id_2', $sqlParams);
 			$db->write('DELETE FROM player_votes_pact
-					WHERE game_id = ' . $db->escapeNumber($gameID) . '
-						AND race_id_1 = ' . $db->escapeNumber($race_id_1) . '
-						AND race_id_2 = ' . $db->escapeNumber($race_id_2));
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_1
+						AND race_id_2 = :race_id_2', $sqlParams);
 			// delete vote and user votes
 			$db->write('DELETE FROM race_has_voting
-					WHERE game_id = ' . $db->escapeNumber($gameID) . '
-						AND race_id_1 = ' . $db->escapeNumber($race_id_2) . '
-						AND race_id_2 = ' . $db->escapeNumber($race_id_1));
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_2
+						AND race_id_2 = :race_id_1', $sqlParams);
 			$db->write('DELETE FROM player_votes_pact
-					WHERE game_id = ' . $db->escapeNumber($gameID) . '
-						AND race_id_1 = ' . $db->escapeNumber($race_id_2) . '
-						AND race_id_2 = ' . $db->escapeNumber($race_id_1));
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_2
+						AND race_id_2 = :race_id_1', $sqlParams);
 		}
 	}
 

--- a/src/lib/Smr/Database.php
+++ b/src/lib/Smr/Database.php
@@ -150,6 +150,17 @@ class Database {
 	}
 
 	/**
+	 * UPDATE $fields in $table for rows that meet $criteria.
+	 *
+	 * @param array<string, mixed> $fields
+	 * @param array<string, mixed> $criteria
+	 * @return int Number of updated rows
+	 */
+	public function update(string $table, array $fields, array $criteria) {
+		return (int)$this->dbConn->update($table, $fields, $criteria);
+	}
+
+	/**
 	 * DELETE row(s) from $table that meet $criteria.
 	 *
 	 * @param array<string, mixed> $criteria

--- a/src/lib/Smr/Database.php
+++ b/src/lib/Smr/Database.php
@@ -150,6 +150,16 @@ class Database {
 	}
 
 	/**
+	 * DELETE row(s) from $table that meet $criteria.
+	 *
+	 * @param array<string, mixed> $criteria
+	 * @return int Number of deleted rows
+	 */
+	public function delete(string $table, array $criteria): int {
+		return (int)$this->dbConn->delete($table, $criteria);
+	}
+
+	/**
 	 * INSERT a row into $table.
 	 *
 	 * @param string $table

--- a/src/lib/Smr/Discord/PlayerLink.php
+++ b/src/lib/Smr/Discord/PlayerLink.php
@@ -45,14 +45,14 @@ class PlayerLink {
 		if ($channel->is_private) {
 			// Get the most recent enabled game, since there is no other way to determine the game ID
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT MAX(game_id) FROM game WHERE enabled = :enabled AND end_time > :now GROUP BY enabled', [
+			$dbResult = $db->read('SELECT MAX(game_id) FROM game WHERE enabled = :enabled AND end_time > :now', [
 				'enabled' => $db->escapeBoolean(true),
 				'now' => $db->escapeNumber(time()),
 			]);
-			if (!$dbResult->hasRecord()) {
+			$game_id = $dbResult->record()->getNullableInt('MAX(game_id)');
+			if ($game_id === null) {
 				throw new UserError('Could not find any games!');
 			}
-			$game_id = $dbResult->record()->getInt('MAX(game_id)');
 		} else {
 			// Find the alliance associated with this public channel
 			// force update in case the ID has been changed in-game

--- a/src/lib/Smr/Discord/PlayerLink.php
+++ b/src/lib/Smr/Discord/PlayerLink.php
@@ -45,7 +45,10 @@ class PlayerLink {
 		if ($channel->is_private) {
 			// Get the most recent enabled game, since there is no other way to determine the game ID
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT MAX(game_id) FROM game WHERE enabled=' . $db->escapeBoolean(true) . ' AND end_time > ' . $db->escapeNumber(time()) . ' GROUP BY enabled');
+			$dbResult = $db->read('SELECT MAX(game_id) FROM game WHERE enabled = :enabled AND end_time > :now GROUP BY enabled', [
+				'enabled' => $db->escapeBoolean(true),
+				'now' => $db->escapeNumber(time()),
+			]);
 			if (!$dbResult->hasRecord()) {
 				throw new UserError('Could not find any games!');
 			}

--- a/src/lib/Smr/DummyShip.php
+++ b/src/lib/Smr/DummyShip.php
@@ -32,7 +32,9 @@ class DummyShip extends AbstractShip {
 			// Load ship from the dummy database cache, if available
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT info FROM cached_dummys WHERE type = \'DummyShip\'
-						AND id = ' . $db->escapeString($dummyName));
+						AND id = :dummy_name', [
+				'dummy_name' => $db->escapeString($dummyName),
+			]);
 			if ($dbResult->hasRecord()) {
 				$ship = $dbResult->record()->getObject('info');
 			} else {

--- a/src/lib/Smr/DummyShip.php
+++ b/src/lib/Smr/DummyShip.php
@@ -21,8 +21,8 @@ class DummyShip extends AbstractShip {
 	public function cacheDummyShip(): void {
 		$db = Database::getInstance();
 		$db->replace('cached_dummys', [
-			'type' => $db->escapeString('DummyShip'),
-			'id' => $db->escapeString($this->getPlayer()->getPlayerName()),
+			'type' => 'DummyShip',
+			'id' => $this->getPlayer()->getPlayerName(),
 			'info' => $db->escapeObject($this),
 		]);
 	}

--- a/src/lib/Smr/EnhancedWeaponEvent.php
+++ b/src/lib/Smr/EnhancedWeaponEvent.php
@@ -101,11 +101,11 @@ class EnhancedWeaponEvent {
 		// We replace instead of insert in the very unlikely case that we have
 		// selected the same configuration twice in a row.
 		$db->replace('location_sells_special', [
-			'game_id' => $db->escapeNumber($gameID),
-			'sector_id' => $db->escapeNumber($sectorID),
-			'location_type_id' => $db->escapeNumber($locationTypeID),
-			'weapon_type_id' => $db->escapeNumber($weaponTypeID),
-			'expires' => $db->escapeNumber($expires),
+			'game_id' => $gameID,
+			'sector_id' => $sectorID,
+			'location_type_id' => $locationTypeID,
+			'weapon_type_id' => $weaponTypeID,
+			'expires' => $expires,
 			'bonus_accuracy' => $db->escapeBoolean($bonusAccuracy),
 			'bonus_damage' => $db->escapeBoolean($bonusDamage),
 		]);

--- a/src/lib/Smr/EnhancedWeaponEvent.php
+++ b/src/lib/Smr/EnhancedWeaponEvent.php
@@ -22,7 +22,12 @@ class EnhancedWeaponEvent {
 	public static function getShopEvents(int $gameID, int $sectorID, int $locationID): array {
 		$events = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM location_sells_special WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND location_type_id = ' . $db->escapeNumber($locationID) . ' AND game_id = ' . $db->escapeNumber($gameID) . ' AND expires > ' . $db->escapeNumber(Epoch::time()));
+		$dbResult = $db->read('SELECT * FROM location_sells_special WHERE sector_id = :sector_id AND location_type_id = :location_type_id AND game_id = :game_id AND expires > :now', [
+			'sector_id' => $db->escapeNumber($sectorID),
+			'location_type_id' => $db->escapeNumber($locationID),
+			'game_id' => $db->escapeNumber($gameID),
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$events[] = self::getEventFromDatabase($dbRecord);
 		}
@@ -38,11 +43,15 @@ class EnhancedWeaponEvent {
 	public static function getLatestEvent(int $gameID): self {
 		// First, remove any expired events from the database
 		$db = Database::getInstance();
-		$db->write('DELETE FROM location_sells_special WHERE expires < ' . $db->escapeNumber(Epoch::time()));
+		$db->write('DELETE FROM location_sells_special WHERE expires < :now', [
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 
 		// Next, check if an existing event can be advertised
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM location_sells_special WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY expires DESC LIMIT 1');
+		$dbResult = $db->read('SELECT * FROM location_sells_special WHERE game_id = :game_id ORDER BY expires DESC LIMIT 1', [
+			'game_id' => $db->escapeNumber($gameID),
+		]);
 		if ($dbResult->hasRecord()) {
 			$event = self::getEventFromDatabase($dbResult->record());
 			// Don't advertise if the event expires within one GRACE_PERIOD
@@ -66,7 +75,10 @@ class EnhancedWeaponEvent {
 		$weaponTypeID = array_rand(WeaponType::getAllSoldWeaponTypes($gameID));
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT location_type_id, sector_id FROM location JOIN location_sells_weapons USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND weapon_type_id = ' . $db->escapeNumber($weaponTypeID) . ' ORDER BY RAND() LIMIT 1');
+		$dbResult = $db->read('SELECT location_type_id, sector_id FROM location JOIN location_sells_weapons USING (location_type_id) WHERE game_id = :game_id AND weapon_type_id = :weapon_type_id ORDER BY RAND() LIMIT 1', [
+			'game_id' => $db->escapeNumber($gameID),
+			'weapon_type_id' => $db->escapeNumber($weaponTypeID),
+		]);
 		$dbRecord = $dbResult->record();
 		$locationTypeID = $dbRecord->getInt('location_type_id');
 		$sectorID = $dbRecord->getInt('sector_id');

--- a/src/lib/Smr/Force.php
+++ b/src/lib/Smr/Force.php
@@ -403,10 +403,10 @@ class Force {
 				$db->update(
 					'sector_has_forces',
 					[
-						'combat_drones' => $db->escapeNumber($this->combatDrones),
-						'scout_drones' => $db->escapeNumber($this->scoutDrones),
-						'mines' => $db->escapeNumber($this->mines),
-						'expire_time' => $db->escapeNumber($this->expire),
+						'combat_drones' => $this->combatDrones,
+						'scout_drones' => $this->scoutDrones,
+						'mines' => $this->mines,
+						'expire_time' => $this->expire,
 					],
 					$this->SQLID,
 				);
@@ -414,10 +414,10 @@ class Force {
 		} elseif ($this->exists()) {
 			$db->insert('sector_has_forces', [
 				...$this->SQLID,
-				'combat_drones' => $db->escapeNumber($this->combatDrones),
-				'scout_drones' => $db->escapeNumber($this->scoutDrones),
-				'mines' => $db->escapeNumber($this->mines),
-				'expire_time' => $db->escapeNumber($this->expire),
+				'combat_drones' => $this->combatDrones,
+				'scout_drones' => $this->scoutDrones,
+				'mines' => $this->mines,
+				'expire_time' => $this->expire,
 			]);
 			$this->isNew = false;
 		}
@@ -433,8 +433,8 @@ class Force {
 		$db->update(
 			'sector_has_forces',
 			[
-				'refresh_at' => $db->escapeNumber($refreshTime),
-				'refresher' => $db->escapeNumber($player->getAccountID()),
+				'refresh_at' => $refreshTime,
+				'refresher' => $player->getAccountID(),
 			],
 			$this->SQLID,
 		);

--- a/src/lib/Smr/Force.php
+++ b/src/lib/Smr/Force.php
@@ -400,13 +400,16 @@ class Force {
 				$db->delete('sector_has_forces', $this->SQLID);
 				$this->isNew = true;
 			} elseif ($this->hasChanged) {
-				$db->write('UPDATE sector_has_forces SET combat_drones = :combat_drones, scout_drones = :scout_drones, mines = :mines, expire_time = :expire_time WHERE ' . self::SQL, [
-					...$this->SQLID,
-					'combat_drones' => $db->escapeNumber($this->combatDrones),
-					'scout_drones' => $db->escapeNumber($this->scoutDrones),
-					'mines' => $db->escapeNumber($this->mines),
-					'expire_time' => $db->escapeNumber($this->expire),
-				]);
+				$db->update(
+					'sector_has_forces',
+					[
+						'combat_drones' => $db->escapeNumber($this->combatDrones),
+						'scout_drones' => $db->escapeNumber($this->scoutDrones),
+						'mines' => $db->escapeNumber($this->mines),
+						'expire_time' => $db->escapeNumber($this->expire),
+					],
+					$this->SQLID,
+				);
 			}
 		} elseif ($this->exists()) {
 			$db->insert('sector_has_forces', [
@@ -427,11 +430,14 @@ class Force {
 	 */
 	public function updateRefreshAll(AbstractPlayer $player, int $refreshTime): void {
 		$db = Database::getInstance();
-		$db->write('UPDATE sector_has_forces SET refresh_at = :refresh_at, refresher = :refresher WHERE ' . self::SQL, [
-			'refresh_at' => $db->escapeNumber($refreshTime),
-			'refresher' => $db->escapeNumber($player->getAccountID()),
-			...$this->SQLID,
-		]);
+		$db->update(
+			'sector_has_forces',
+			[
+				'refresh_at' => $db->escapeNumber($refreshTime),
+				'refresher' => $db->escapeNumber($player->getAccountID()),
+			],
+			$this->SQLID,
+		);
 	}
 
 	public function getExamineDropForcesHREF(): string {

--- a/src/lib/Smr/Force.php
+++ b/src/lib/Smr/Force.php
@@ -397,7 +397,7 @@ class Force {
 		$db = Database::getInstance();
 		if (!$this->isNew) {
 			if (!$this->exists()) {
-				$db->write('DELETE FROM sector_has_forces WHERE ' . self::SQL, $this->SQLID);
+				$db->delete('sector_has_forces', $this->SQLID);
 				$this->isNew = true;
 			} elseif ($this->hasChanged) {
 				$db->write('UPDATE sector_has_forces SET combat_drones = :combat_drones, scout_drones = :scout_drones, mines = :mines, expire_time = :expire_time WHERE ' . self::SQL, [

--- a/src/lib/Smr/Force.php
+++ b/src/lib/Smr/Force.php
@@ -32,7 +32,9 @@ class Force {
 	public const MAX_CDS = 50;
 	public const MAX_SDS = 5;
 
-	protected readonly string $SQL;
+	public const SQL = 'game_id = :game_id AND sector_id = :sector_id AND owner_id = :owner_id';
+	/** @var array{game_id: int, sector_id: int, owner_id: int} */
+	protected readonly array $SQLID;
 
 	protected int $combatDrones = 0;
 	protected int $scoutDrones = 0;
@@ -66,7 +68,10 @@ class Force {
 	 */
 	public static function getGalaxyForces(int $gameID, int $galaxyID, bool $forceUpdate = false): array {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT sector_has_forces.* FROM sector_has_forces LEFT JOIN sector USING(game_id, sector_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT sector_has_forces.* FROM sector_has_forces LEFT JOIN sector USING(game_id, sector_id) WHERE game_id = :game_id AND galaxy_id = :galaxy_id', [
+			'game_id' => $db->escapeNumber($gameID),
+			'galaxy_id' => $db->escapeNumber($galaxyID),
+		]);
 		$galaxyForces = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$sectorID = $dbRecord->getInt('sector_id');
@@ -85,7 +90,10 @@ class Force {
 		if ($forceUpdate || !isset(self::$CACHE_SECTOR_FORCES[$gameID][$sectorID])) {
 			self::tidyUpForces(Galaxy::getGalaxyContaining($gameID, $sectorID));
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM sector_has_forces WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID) . ' ORDER BY expire_time ASC');
+			$dbResult = $db->read('SELECT * FROM sector_has_forces WHERE sector_id = :sector_id AND game_id = :game_id ORDER BY expire_time ASC', [
+				'sector_id' => $db->escapeNumber($sectorID),
+				'game_id' => $db->escapeNumber($gameID),
+			]);
 			$forces = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$ownerID = $dbRecord->getInt('owner_id');
@@ -112,11 +120,24 @@ class Force {
 			$db->write('UPDATE sector_has_forces
 						SET refresher=0,
 							expire_time = (refresh_at + if(combat_drones+mines=0,
-															LEAST(' . $db->escapeNumber(self::LOWEST_MAX_EXPIRE_SCOUTS_ONLY) . ', scout_drones*' . $db->escapeNumber(self::TIME_PER_SCOUT_ONLY) . '),
-															LEAST(' . $db->escapeNumber($galaxyToTidy->getMaxForceTime()) . ', (combat_drones*' . $db->escapeNumber(self::TIME_PERCENT_PER_COMBAT) . '+scout_drones*' . $db->escapeNumber(self::TIME_PERCENT_PER_SCOUT) . '+mines*' . $db->escapeNumber(self::TIME_PERCENT_PER_MINE) . ')*' . $db->escapeNumber($galaxyToTidy->getMaxForceTime()) . ')
-														))
-						WHERE game_id = ' . $db->escapeNumber($galaxyToTidy->getGameID()) . ' AND sector_id >= ' . $db->escapeNumber($galaxyToTidy->getStartSector()) . ' AND sector_id <= ' . $db->escapeNumber($galaxyToTidy->getEndSector()) . ' AND refresher != 0 AND refresh_at <= ' . $db->escapeNumber(Epoch::time()));
-			$db->write('DELETE FROM sector_has_forces WHERE expire_time < ' . $db->escapeNumber(Epoch::time()));
+								LEAST(:scout_expire_lowest, scout_drones * :time_per_scout_only),
+								LEAST(:max_force_time, (combat_drones * :frac_per_cd + scout_drones * :frac_per_scout + mines * :frac_per_mine) * :max_force_time)
+							))
+						WHERE game_id = :game_id AND sector_id >= :start_sector AND sector_id <= :end_sector AND refresher != 0 AND refresh_at <= :now', [
+				'scout_expire_lowest' => $db->escapeNumber(self::LOWEST_MAX_EXPIRE_SCOUTS_ONLY),
+				'time_per_scout_only' => $db->escapeNumber(self::TIME_PER_SCOUT_ONLY),
+				'max_force_time' => $db->escapeNumber($galaxyToTidy->getMaxForceTime()),
+				'frac_per_cd' => $db->escapeNumber(self::TIME_PERCENT_PER_COMBAT),
+				'frac_per_scout' => $db->escapeNumber(self::TIME_PERCENT_PER_SCOUT),
+				'frac_per_mine' => $db->escapeNumber(self::TIME_PERCENT_PER_MINE),
+				'game_id' => $db->escapeNumber($galaxyToTidy->getGameID()),
+				'start_sector' => $db->escapeNumber($galaxyToTidy->getStartSector()),
+				'end_sector' => $db->escapeNumber($galaxyToTidy->getEndSector()),
+				'now' => $db->escapeNumber(Epoch::time()),
+			]);
+			$db->write('DELETE FROM sector_has_forces WHERE expire_time < :now', [
+				'now' => $db->escapeNumber(Epoch::time()),
+			]);
 		}
 	}
 
@@ -127,12 +148,14 @@ class Force {
 		DatabaseRecord $dbRecord = null
 	) {
 		$db = Database::getInstance();
-		$this->SQL = 'game_id = ' . $db->escapeNumber($gameID) . '
-		              AND sector_id = ' . $db->escapeNumber($sectorID) . '
-		              AND owner_id = ' . $db->escapeNumber($ownerID);
+		$this->SQLID = [
+			'game_id' => $db->escapeNumber($gameID),
+			'sector_id' => $db->escapeNumber($sectorID),
+			'owner_id' => $db->escapeNumber($ownerID),
+		];
 
 		if ($dbRecord === null) {
-			$dbResult = $db->read('SELECT * FROM sector_has_forces WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM sector_has_forces WHERE ' . self::SQL, $this->SQLID);
 			if ($dbResult->hasRecord()) {
 				$dbRecord = $dbResult->record();
 			}
@@ -374,16 +397,20 @@ class Force {
 		$db = Database::getInstance();
 		if (!$this->isNew) {
 			if (!$this->exists()) {
-				$db->write('DELETE FROM sector_has_forces WHERE ' . $this->SQL);
+				$db->write('DELETE FROM sector_has_forces WHERE ' . self::SQL, $this->SQLID);
 				$this->isNew = true;
 			} elseif ($this->hasChanged) {
-				$db->write('UPDATE sector_has_forces SET combat_drones = ' . $db->escapeNumber($this->combatDrones) . ', scout_drones = ' . $db->escapeNumber($this->scoutDrones) . ', mines = ' . $db->escapeNumber($this->mines) . ', expire_time = ' . $db->escapeNumber($this->expire) . ' WHERE ' . $this->SQL);
+				$db->write('UPDATE sector_has_forces SET combat_drones = :combat_drones, scout_drones = :scout_drones, mines = :mines, expire_time = :expire_time WHERE ' . self::SQL, [
+					...$this->SQLID,
+					'combat_drones' => $db->escapeNumber($this->combatDrones),
+					'scout_drones' => $db->escapeNumber($this->scoutDrones),
+					'mines' => $db->escapeNumber($this->mines),
+					'expire_time' => $db->escapeNumber($this->expire),
+				]);
 			}
 		} elseif ($this->exists()) {
 			$db->insert('sector_has_forces', [
-				'game_id' => $db->escapeNumber($this->gameID),
-				'sector_id' => $db->escapeNumber($this->sectorID),
-				'owner_id' => $db->escapeNumber($this->ownerID),
+				...$this->SQLID,
 				'combat_drones' => $db->escapeNumber($this->combatDrones),
 				'scout_drones' => $db->escapeNumber($this->scoutDrones),
 				'mines' => $db->escapeNumber($this->mines),
@@ -400,7 +427,11 @@ class Force {
 	 */
 	public function updateRefreshAll(AbstractPlayer $player, int $refreshTime): void {
 		$db = Database::getInstance();
-		$db->write('UPDATE sector_has_forces SET refresh_at=' . $db->escapeNumber($refreshTime) . ', refresher=' . $db->escapeNumber($player->getAccountID()) . ' WHERE ' . $this->SQL);
+		$db->write('UPDATE sector_has_forces SET refresh_at = :refresh_at, refresher = :refresher WHERE ' . self::SQL, [
+			'refresh_at' => $db->escapeNumber($refreshTime),
+			'refresher' => $db->escapeNumber($player->getAccountID()),
+			...$this->SQLID,
+		]);
 	}
 
 	public function getExamineDropForcesHREF(): string {

--- a/src/lib/Smr/Galaxy.php
+++ b/src/lib/Smr/Galaxy.php
@@ -122,19 +122,17 @@ class Galaxy {
 				'max_force_time' => $db->escapeNumber($this->getMaxForceTime()),
 			]);
 		} elseif ($this->hasChanged) {
-			$db->write('UPDATE game_galaxy SET galaxy_name = :galaxy_name,
-										width = :width,
-										height = :height,
-										galaxy_type = :galaxy_type,
-										max_force_time = :max_force_time
-									WHERE ' . self::SQL, [
-				...$this->SQLID,
-				'galaxy_name' => $db->escapeString($this->getName()),
-				'width' => $db->escapeNumber($this->getWidth()),
-				'height' => $db->escapeNumber($this->getHeight()),
-				'galaxy_type' => $db->escapeString($this->getGalaxyType()),
-				'max_force_time' => $db->escapeNumber($this->getMaxForceTime()),
-			]);
+			$db->update(
+				'game_galaxy',
+				[
+					'galaxy_name' => $db->escapeString($this->getName()),
+					'width' => $db->escapeNumber($this->getWidth()),
+					'height' => $db->escapeNumber($this->getHeight()),
+					'galaxy_type' => $db->escapeString($this->getGalaxyType()),
+					'max_force_time' => $db->escapeNumber($this->getMaxForceTime()),
+				],
+				$this->SQLID,
+			);
 		}
 		$this->isNew = false;
 		$this->hasChanged = false;

--- a/src/lib/Smr/Galaxy.php
+++ b/src/lib/Smr/Galaxy.php
@@ -115,21 +115,21 @@ class Galaxy {
 		if ($this->isNew) {
 			$db->insert('game_galaxy', [
 				...$this->SQLID,
-				'galaxy_name' => $db->escapeString($this->getName()),
-				'width' => $db->escapeNumber($this->getWidth()),
-				'height' => $db->escapeNumber($this->getHeight()),
-				'galaxy_type' => $db->escapeString($this->getGalaxyType()),
-				'max_force_time' => $db->escapeNumber($this->getMaxForceTime()),
+				'galaxy_name' => $this->getName(),
+				'width' => $this->getWidth(),
+				'height' => $this->getHeight(),
+				'galaxy_type' => $this->getGalaxyType(),
+				'max_force_time' => $this->getMaxForceTime(),
 			]);
 		} elseif ($this->hasChanged) {
 			$db->update(
 				'game_galaxy',
 				[
-					'galaxy_name' => $db->escapeString($this->getName()),
-					'width' => $db->escapeNumber($this->getWidth()),
-					'height' => $db->escapeNumber($this->getHeight()),
-					'galaxy_type' => $db->escapeString($this->getGalaxyType()),
-					'max_force_time' => $db->escapeNumber($this->getMaxForceTime()),
+					'galaxy_name' => $this->getName(),
+					'width' => $this->getWidth(),
+					'height' => $this->getHeight(),
+					'galaxy_type' => $this->getGalaxyType(),
+					'max_force_time' => $this->getMaxForceTime(),
 				],
 				$this->SQLID,
 			);

--- a/src/lib/Smr/Game.php
+++ b/src/lib/Smr/Game.php
@@ -91,7 +91,9 @@ class Game {
 	) {
 		$db = Database::getInstance();
 
-		$dbResult = $db->read('SELECT * FROM game WHERE game_id = ' . $db->escapeNumber($gameID));
+		$dbResult = $db->read('SELECT * FROM game WHERE game_id = :game_id', [
+			'game_id' => $db->escapeNumber($gameID),
+		]);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			$this->name = $dbRecord->getString('game_name');
@@ -140,23 +142,41 @@ class Game {
 				'starting_credits' => $db->escapeNumber($this->getStartingCredits()),
 			]);
 		} elseif ($this->hasChanged) {
-			$db->write('UPDATE game SET game_name = ' . $db->escapeString($this->getName()) .
-										', game_description = ' . $db->escapeString($this->getDescription()) .
-										', join_time = ' . $db->escapeNumber($this->getJoinTime()) .
-										', start_time = ' . $db->escapeNumber($this->getStartTime()) .
-										', end_time = ' . $db->escapeNumber($this->getEndTime()) .
-										', max_players = ' . $db->escapeNumber($this->getMaxPlayers()) .
-										', max_turns = ' . $db->escapeNumber($this->getMaxTurns()) .
-										', start_turns = ' . $db->escapeNumber($this->getStartTurnHours()) .
-										', game_type = ' . $db->escapeNumber($this->gameTypeID) .
-										', credits_needed = ' . $db->escapeNumber($this->getCreditsNeeded()) .
-										', game_speed = ' . $db->escapeNumber($this->getGameSpeed()) .
-										', enabled = ' . $db->escapeBoolean($this->isEnabled()) .
-										', ignore_stats = ' . $db->escapeBoolean($this->isIgnoreStats()) .
-										', alliance_max_players = ' . $db->escapeNumber($this->getAllianceMaxPlayers()) .
-										', alliance_max_vets = ' . $db->escapeNumber($this->getAllianceMaxVets()) .
-										', starting_credits = ' . $db->escapeNumber($this->getStartingCredits()) .
-									' WHERE game_id = ' . $db->escapeNumber($this->getGameID()));
+			$db->write('UPDATE game SET game_name = :game_name,
+										game_description = :game_description,
+										join_time = :join_time,
+										start_time = :start_time,
+										end_time = :end_time,
+										max_players = :max_players,
+										max_turns = :max_turns,
+										start_turns = :start_turns,
+										game_type = :game_type,
+										credits_needed = :credits_needed,
+										game_speed = :game_speed,
+										enabled = :enabled,
+										ignore_stats = :ignore_stats,
+										alliance_max_players = :alliance_max_players,
+										alliance_max_vets = :alliance_max_vets,
+										starting_credits = :starting_credits
+									WHERE game_id = :game_id', [
+				'game_id' => $db->escapeNumber($this->getGameID()),
+				'game_name' => $db->escapeString($this->getName()),
+				'game_description' => $db->escapeString($this->getDescription()),
+				'join_time' => $db->escapeNumber($this->getJoinTime()),
+				'start_time' => $db->escapeNumber($this->getStartTime()),
+				'end_time' => $db->escapeNumber($this->getEndTime()),
+				'max_players' => $db->escapeNumber($this->getMaxPlayers()),
+				'max_turns' => $db->escapeNumber($this->getMaxTurns()),
+				'start_turns' => $db->escapeNumber($this->getStartTurnHours()),
+				'game_type' => $db->escapeNumber($this->gameTypeID),
+				'credits_needed' => $db->escapeNumber($this->getCreditsNeeded()),
+				'game_speed' => $db->escapeNumber($this->getGameSpeed()),
+				'enabled' => $db->escapeBoolean($this->isEnabled()),
+				'ignore_stats' => $db->escapeBoolean($this->isIgnoreStats()),
+				'alliance_max_players' => $db->escapeNumber($this->getAllianceMaxPlayers()),
+				'alliance_max_vets' => $db->escapeNumber($this->getAllianceMaxVets()),
+				'starting_credits' => $db->escapeNumber($this->getStartingCredits()),
+			]);
 		}
 		$this->isNew = false;
 		$this->hasChanged = false;
@@ -383,7 +403,9 @@ class Game {
 	public function getTotalPlayers(): int {
 		if (!isset($this->totalPlayers)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT count(*) FROM player WHERE game_id = ' . $db->escapeNumber($this->getGameID()));
+			$dbResult = $db->read('SELECT count(*) FROM player WHERE game_id = :game_id', [
+				'game_id' => $db->escapeNumber($this->getGameID()),
+			]);
 			$this->totalPlayers = $dbResult->record()->getInt('count(*)');
 		}
 		return $this->totalPlayers;
@@ -457,10 +479,14 @@ class Game {
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT DISTINCT location_type_id
 				FROM location
-				WHERE location_type_id > ' . $db->escapeNumber(UNDERGROUND) . '
-					AND location_type_id < ' . $db->escapeNumber(FED) . '
-					AND game_id = ' . $db->escapeNumber($this->getGameID()) . '
-				ORDER BY location_type_id');
+				WHERE location_type_id > :location_type_id_ug
+					AND location_type_id < :location_type_id_fed
+					AND game_id = :game_id
+				ORDER BY location_type_id', [
+				'location_type_id_ug' => $db->escapeNumber(UNDERGROUND),
+				'location_type_id_fed' => $db->escapeNumber(FED),
+				'game_id' => $db->escapeNumber($this->getGameID()),
+			]);
 			$this->playableRaceIDs = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$this->playableRaceIDs[] = $dbRecord->getInt('location_type_id') - GOVERNMENT;

--- a/src/lib/Smr/Game.php
+++ b/src/lib/Smr/Game.php
@@ -142,41 +142,28 @@ class Game {
 				'starting_credits' => $db->escapeNumber($this->getStartingCredits()),
 			]);
 		} elseif ($this->hasChanged) {
-			$db->write('UPDATE game SET game_name = :game_name,
-										game_description = :game_description,
-										join_time = :join_time,
-										start_time = :start_time,
-										end_time = :end_time,
-										max_players = :max_players,
-										max_turns = :max_turns,
-										start_turns = :start_turns,
-										game_type = :game_type,
-										credits_needed = :credits_needed,
-										game_speed = :game_speed,
-										enabled = :enabled,
-										ignore_stats = :ignore_stats,
-										alliance_max_players = :alliance_max_players,
-										alliance_max_vets = :alliance_max_vets,
-										starting_credits = :starting_credits
-									WHERE game_id = :game_id', [
-				'game_id' => $db->escapeNumber($this->getGameID()),
-				'game_name' => $db->escapeString($this->getName()),
-				'game_description' => $db->escapeString($this->getDescription()),
-				'join_time' => $db->escapeNumber($this->getJoinTime()),
-				'start_time' => $db->escapeNumber($this->getStartTime()),
-				'end_time' => $db->escapeNumber($this->getEndTime()),
-				'max_players' => $db->escapeNumber($this->getMaxPlayers()),
-				'max_turns' => $db->escapeNumber($this->getMaxTurns()),
-				'start_turns' => $db->escapeNumber($this->getStartTurnHours()),
-				'game_type' => $db->escapeNumber($this->gameTypeID),
-				'credits_needed' => $db->escapeNumber($this->getCreditsNeeded()),
-				'game_speed' => $db->escapeNumber($this->getGameSpeed()),
-				'enabled' => $db->escapeBoolean($this->isEnabled()),
-				'ignore_stats' => $db->escapeBoolean($this->isIgnoreStats()),
-				'alliance_max_players' => $db->escapeNumber($this->getAllianceMaxPlayers()),
-				'alliance_max_vets' => $db->escapeNumber($this->getAllianceMaxVets()),
-				'starting_credits' => $db->escapeNumber($this->getStartingCredits()),
-			]);
+			$db->update(
+				'game',
+				[
+					'game_name' => $db->escapeString($this->getName()),
+					'game_description' => $db->escapeString($this->getDescription()),
+					'join_time' => $db->escapeNumber($this->getJoinTime()),
+					'start_time' => $db->escapeNumber($this->getStartTime()),
+					'end_time' => $db->escapeNumber($this->getEndTime()),
+					'max_players' => $db->escapeNumber($this->getMaxPlayers()),
+					'max_turns' => $db->escapeNumber($this->getMaxTurns()),
+					'start_turns' => $db->escapeNumber($this->getStartTurnHours()),
+					'game_type' => $db->escapeNumber($this->gameTypeID),
+					'credits_needed' => $db->escapeNumber($this->getCreditsNeeded()),
+					'game_speed' => $db->escapeNumber($this->getGameSpeed()),
+					'enabled' => $db->escapeBoolean($this->isEnabled()),
+					'ignore_stats' => $db->escapeBoolean($this->isIgnoreStats()),
+					'alliance_max_players' => $db->escapeNumber($this->getAllianceMaxPlayers()),
+					'alliance_max_vets' => $db->escapeNumber($this->getAllianceMaxVets()),
+					'starting_credits' => $db->escapeNumber($this->getStartingCredits()),
+				],
+				['game_id' => $db->escapeNumber($this->getGameID())],
+			);
 		}
 		$this->isNew = false;
 		$this->hasChanged = false;

--- a/src/lib/Smr/Game.php
+++ b/src/lib/Smr/Game.php
@@ -123,46 +123,46 @@ class Game {
 		$db = Database::getInstance();
 		if ($this->isNew) {
 			$db->insert('game', [
-				'game_id' => $db->escapeNumber($this->getGameID()),
-				'game_name' => $db->escapeString($this->getName()),
-				'game_description' => $db->escapeString($this->getDescription()),
-				'join_time' => $db->escapeNumber($this->getJoinTime()),
-				'start_time' => $db->escapeNumber($this->getStartTime()),
-				'end_time' => $db->escapeNumber($this->getEndTime()),
-				'max_players' => $db->escapeNumber($this->getMaxPlayers()),
-				'max_turns' => $db->escapeNumber($this->getMaxTurns()),
-				'start_turns' => $db->escapeNumber($this->getStartTurnHours()),
-				'game_type' => $db->escapeNumber($this->gameTypeID),
-				'credits_needed' => $db->escapeNumber($this->getCreditsNeeded()),
-				'game_speed' => $db->escapeNumber($this->getGameSpeed()),
+				'game_id' => $this->getGameID(),
+				'game_name' => $this->getName(),
+				'game_description' => $this->getDescription(),
+				'join_time' => $this->getJoinTime(),
+				'start_time' => $this->getStartTime(),
+				'end_time' => $this->getEndTime(),
+				'max_players' => $this->getMaxPlayers(),
+				'max_turns' => $this->getMaxTurns(),
+				'start_turns' => $this->getStartTurnHours(),
+				'game_type' => $this->gameTypeID,
+				'credits_needed' => $this->getCreditsNeeded(),
+				'game_speed' => $this->getGameSpeed(),
 				'enabled' => $db->escapeBoolean($this->isEnabled()),
 				'ignore_stats' => $db->escapeBoolean($this->isIgnoreStats()),
-				'alliance_max_players' => $db->escapeNumber($this->getAllianceMaxPlayers()),
-				'alliance_max_vets' => $db->escapeNumber($this->getAllianceMaxVets()),
-				'starting_credits' => $db->escapeNumber($this->getStartingCredits()),
+				'alliance_max_players' => $this->getAllianceMaxPlayers(),
+				'alliance_max_vets' => $this->getAllianceMaxVets(),
+				'starting_credits' => $this->getStartingCredits(),
 			]);
 		} elseif ($this->hasChanged) {
 			$db->update(
 				'game',
 				[
-					'game_name' => $db->escapeString($this->getName()),
-					'game_description' => $db->escapeString($this->getDescription()),
-					'join_time' => $db->escapeNumber($this->getJoinTime()),
-					'start_time' => $db->escapeNumber($this->getStartTime()),
-					'end_time' => $db->escapeNumber($this->getEndTime()),
-					'max_players' => $db->escapeNumber($this->getMaxPlayers()),
-					'max_turns' => $db->escapeNumber($this->getMaxTurns()),
-					'start_turns' => $db->escapeNumber($this->getStartTurnHours()),
-					'game_type' => $db->escapeNumber($this->gameTypeID),
-					'credits_needed' => $db->escapeNumber($this->getCreditsNeeded()),
-					'game_speed' => $db->escapeNumber($this->getGameSpeed()),
+					'game_name' => $this->getName(),
+					'game_description' => $this->getDescription(),
+					'join_time' => $this->getJoinTime(),
+					'start_time' => $this->getStartTime(),
+					'end_time' => $this->getEndTime(),
+					'max_players' => $this->getMaxPlayers(),
+					'max_turns' => $this->getMaxTurns(),
+					'start_turns' => $this->getStartTurnHours(),
+					'game_type' => $this->gameTypeID,
+					'credits_needed' => $this->getCreditsNeeded(),
+					'game_speed' => $this->getGameSpeed(),
 					'enabled' => $db->escapeBoolean($this->isEnabled()),
 					'ignore_stats' => $db->escapeBoolean($this->isIgnoreStats()),
-					'alliance_max_players' => $db->escapeNumber($this->getAllianceMaxPlayers()),
-					'alliance_max_vets' => $db->escapeNumber($this->getAllianceMaxVets()),
-					'starting_credits' => $db->escapeNumber($this->getStartingCredits()),
+					'alliance_max_players' => $this->getAllianceMaxPlayers(),
+					'alliance_max_vets' => $this->getAllianceMaxVets(),
+					'starting_credits' => $this->getStartingCredits(),
 				],
-				['game_id' => $db->escapeNumber($this->getGameID())],
+				['game_id' => $this->getGameID()],
 			);
 		}
 		$this->isNew = false;
@@ -445,10 +445,10 @@ class Game {
 					$amount = $relations;
 				}
 				$db->replace('race_has_relation', [
-					'game_id' => $db->escapeNumber($this->getGameID()),
-					'race_id_1' => $db->escapeNumber($raceID1),
-					'race_id_2' => $db->escapeNumber($raceID2),
-					'relation' => $db->escapeNumber($amount),
+					'game_id' => $this->getGameID(),
+					'race_id_1' => $raceID1,
+					'race_id_2' => $raceID2,
+					'relation' => $amount,
 				]);
 			}
 		}

--- a/src/lib/Smr/Globals.php
+++ b/src/lib/Smr/Globals.php
@@ -94,7 +94,9 @@ class Globals {
 	public static function getGalacticPostEditorIDs(int $gameID): array {
 		$editorIDs = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT account_id FROM galactic_post_writer WHERE position=\'editor\' AND game_id=' . $db->escapeNumber($gameID));
+		$dbResult = $db->read('SELECT account_id FROM galactic_post_writer WHERE position=\'editor\' AND game_id = :game_id', [
+			'game_id' => $db->escapeNumber($gameID),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$editorIDs[] = $dbRecord->getInt('account_id');
 		}
@@ -136,7 +138,10 @@ class Globals {
 				self::$RACE_RELATIONS[$gameID][$raceID][$otherRaceID] = 0;
 			}
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT race_id_2,relation FROM race_has_relation WHERE race_id_1=' . $db->escapeNumber($raceID) . ' AND game_id=' . $db->escapeNumber($gameID));
+			$dbResult = $db->read('SELECT race_id_2,relation FROM race_has_relation WHERE race_id_1 = :race_id_1 AND game_id = :game_id', [
+				'race_id_1' => $db->escapeNumber($raceID),
+				'game_id' => $db->escapeNumber($gameID),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				self::$RACE_RELATIONS[$gameID][$raceID][$dbRecord->getInt('race_id_2')] = $dbRecord->getInt('relation');
 			}

--- a/src/lib/Smr/HallOfFame.php
+++ b/src/lib/Smr/HallOfFame.php
@@ -113,9 +113,9 @@ class HallOfFame {
 				'account_id' => $db->escapeNumber($accountID),
 			]);
 		} elseif ($viewType == HOF_TYPE_USER_SCORE) {
-			$statements = Account::getUserScoreCaseStatement($db);
+			$statements = Account::getUserScoreCaseStatement();
 			$dbResult = $db->read('SELECT ' . $statements['CASE'] . ' amount FROM (SELECT type, SUM(amount) amount FROM player_hof WHERE type IN (:hof_types) AND account_id = :account_id' . $gameIDSql . ' GROUP BY account_id,type) x', [
-				'hof_types' => $statements['IN'],
+				'hof_types' => $db->escapeArray($statements['IN']),
 				'account_id' => $db->escapeNumber($accountID),
 			]);
 		} else {
@@ -138,9 +138,9 @@ class HallOfFame {
 				'amount' => $db->escapeNumber($realAmount),
 			]);
 		} elseif ($viewType == HOF_TYPE_USER_SCORE) {
-			$statements = Account::getUserScoreCaseStatement($db);
+			$statements = Account::getUserScoreCaseStatement();
 			$dbResult = $db->read('SELECT COUNT(account_id) `rank` FROM (SELECT account_id FROM player_hof WHERE type IN (:hof_types)' . $gameIDSql . ' GROUP BY account_id HAVING ' . $statements['CASE'] . ' > :amount) x', [
-				'hof_types' => $statements['IN'],
+				'hof_types' => $db->escapeArray($statements['IN']),
 				'amount' => $db->escapeNumber($realAmount),
 			]);
 		} else {

--- a/src/lib/Smr/Location.php
+++ b/src/lib/Smr/Location.php
@@ -142,7 +142,7 @@ class Location {
 
 	public static function removeSectorLocations(int $gameID, int $sectorID): void {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM location WHERE game_id = :game_id AND sector_id = :sector_id', [
+		$db->delete('location', [
 			'game_id' => $db->escapeNumber($gameID),
 			'sector_id' => $db->escapeNumber($sectorID),
 		]);
@@ -245,7 +245,7 @@ class Location {
 		if ($bool) {
 			$db->write('INSERT IGNORE INTO location_is_fed (location_type_id) values (:location_type_id)', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_fed WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('location_is_fed', $this->SQLID);
 		}
 		$this->fed = $bool;
 	}
@@ -267,7 +267,7 @@ class Location {
 		if ($bool) {
 			$db->insert('location_is_bank', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_bank WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('location_is_bank', $this->SQLID);
 		}
 		$this->bank = $bool;
 	}
@@ -289,7 +289,7 @@ class Location {
 		if ($bool) {
 			$db->write('INSERT IGNORE INTO location_is_bar (location_type_id) values (:location_type_id)', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_bar WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('location_is_bar', $this->SQLID);
 		}
 		$this->bar = $bool;
 	}
@@ -311,7 +311,7 @@ class Location {
 		if ($bool) {
 			$db->write('INSERT IGNORE INTO location_is_hq (location_type_id) values (:location_type_id)', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_hq WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('location_is_hq', $this->SQLID);
 		}
 		$this->HQ = $bool;
 	}
@@ -333,7 +333,7 @@ class Location {
 		if ($bool) {
 			$db->insert('location_is_ug', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_ug WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('location_is_ug', $this->SQLID);
 		}
 		$this->UG = $bool;
 	}
@@ -385,7 +385,7 @@ class Location {
 			return;
 		}
 		$db = Database::getInstance();
-		$db->write('DELETE FROM location_sells_hardware WHERE ' . self::SQL . ' AND hardware_type_id = :hardware_type_id', [
+		$db->delete('location_sells_hardware', [
 			...$this->SQLID,
 			'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
 		]);
@@ -444,7 +444,7 @@ class Location {
 			return;
 		}
 		$db = Database::getInstance();
-		$db->write('DELETE FROM location_sells_ships WHERE ' . self::SQL . ' AND ship_type_id = :ship_type_id', [
+		$db->delete('location_sells_ships', [
 			...$this->SQLID,
 			'ship_type_id' => $db->escapeNumber($shipTypeID),
 		]);
@@ -493,7 +493,7 @@ class Location {
 			return;
 		}
 		$db = Database::getInstance();
-		$db->write('DELETE FROM location_sells_weapons WHERE ' . self::SQL . ' AND weapon_type_id = :weapon_type_id', [
+		$db->delete('location_sells_weapons', [
 			...$this->SQLID,
 			'weapon_type_id' => $db->escapeNumber($weaponTypeID),
 		]);

--- a/src/lib/Smr/Location.php
+++ b/src/lib/Smr/Location.php
@@ -22,7 +22,9 @@ class Location {
 	/** @var array<int, array<int, array<int, self>>> */
 	protected static array $CACHE_SECTOR_LOCATIONS = [];
 
-	protected readonly string $SQL;
+	public const SQL = 'location_type_id = :location_type_id';
+	/** @var array{location_type_id: int} */
+	public readonly array $SQLID;
 
 	protected string $name;
 	protected ?string $processor;
@@ -69,7 +71,10 @@ class Location {
 	 */
 	public static function getGalaxyLocations(int $gameID, int $galaxyID, bool $forceUpdate = false): array {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT location_type.*, sector_id FROM location LEFT JOIN sector USING(game_id, sector_id) LEFT JOIN location_type USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND galaxy_id = ' . $db->escapeNumber($galaxyID));
+		$dbResult = $db->read('SELECT location_type.*, sector_id FROM location LEFT JOIN sector USING(game_id, sector_id) LEFT JOIN location_type USING (location_type_id) WHERE game_id = :game_id AND galaxy_id = :galaxy_id', [
+			'game_id' => $db->escapeNumber($gameID),
+			'galaxy_id' => $db->escapeNumber($galaxyID),
+		]);
 		$galaxyLocations = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$sectorID = $dbRecord->getInt('sector_id');
@@ -87,7 +92,10 @@ class Location {
 	public static function getSectorLocations(int $gameID, int $sectorID, bool $forceUpdate = false): array {
 		if ($forceUpdate || !isset(self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID])) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM location LEFT JOIN location_type USING (location_type_id) WHERE sector_id = ' . $db->escapeNumber($sectorID) . ' AND game_id=' . $db->escapeNumber($gameID));
+			$dbResult = $db->read('SELECT * FROM location LEFT JOIN location_type USING (location_type_id) WHERE sector_id = :sector_id AND game_id = :game_id', [
+				'sector_id' => $db->escapeNumber($sectorID),
+				'game_id' => $db->escapeNumber($gameID),
+			]);
 			$locations = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$locationTypeID = $dbRecord->getInt('location_type_id');
@@ -104,7 +112,7 @@ class Location {
 		$db->insert('location', [
 			'game_id' => $db->escapeNumber($gameID),
 			'sector_id' => $db->escapeNumber($sectorID),
-			'location_type_id' => $db->escapeNumber($location->getTypeID()),
+			...$location->SQLID,
 		]);
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID][$location->getTypeID()] = $location;
 	}
@@ -119,7 +127,12 @@ class Location {
 		self::getSectorLocations($gameID, $newSectorID);
 
 		$db = Database::getInstance();
-		$db->write('UPDATE location SET sector_id = ' . $db->escapeNumber($newSectorID) . ' WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND sector_id = ' . $db->escapeNumber($oldSectorID) . ' AND location_type_id = ' . $location->getTypeID());
+		$db->write('UPDATE location SET sector_id = :new_sector_id WHERE game_id = :game_id AND sector_id = :old_sector_id AND ' . self::SQL, [
+			'new_sector_id' => $db->escapeNumber($newSectorID),
+			'game_id' => $db->escapeNumber($gameID),
+			'old_sector_id' => $db->escapeNumber($oldSectorID),
+			...$location->SQLID,
+		]);
 		unset(self::$CACHE_SECTOR_LOCATIONS[$gameID][$oldSectorID][$location->getTypeID()]);
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$newSectorID][$location->getTypeID()] = $location;
 
@@ -129,7 +142,10 @@ class Location {
 
 	public static function removeSectorLocations(int $gameID, int $sectorID): void {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM location WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND sector_id = ' . $db->escapeNumber($sectorID));
+		$db->write('DELETE FROM location WHERE game_id = :game_id AND sector_id = :sector_id', [
+			'game_id' => $db->escapeNumber($gameID),
+			'sector_id' => $db->escapeNumber($sectorID),
+		]);
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] = [];
 	}
 
@@ -146,10 +162,10 @@ class Location {
 		DatabaseRecord $dbRecord = null
 	) {
 		$db = Database::getInstance();
-		$this->SQL = 'location_type_id = ' . $db->escapeNumber($typeID);
+		$this->SQLID = ['location_type_id' => $db->escapeNumber($typeID)];
 
 		if ($dbRecord === null) {
-			$dbResult = $db->read('SELECT * FROM location_type WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM location_type WHERE ' . self::SQL, $this->SQLID);
 			if ($dbResult->hasRecord()) {
 				$dbRecord = $dbResult->record();
 			}
@@ -194,7 +210,10 @@ class Location {
 		}
 		$this->name = $name;
 		$db = Database::getInstance();
-		$db->write('UPDATE location_type SET location_name=' . $db->escapeString($this->name) . ' WHERE ' . $this->SQL);
+		$db->write('UPDATE location_type SET location_name = :location_name WHERE ' . self::SQL, [
+			'location_name' => $db->escapeString($this->name),
+			...$this->SQLID,
+		]);
 	}
 
 	public function hasAction(): bool {
@@ -212,7 +231,7 @@ class Location {
 	public function isFed(): bool {
 		if (!isset($this->fed)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT 1 FROM location_is_fed WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT 1 FROM location_is_fed WHERE ' . self::SQL, $this->SQLID);
 			$this->fed = $dbResult->hasRecord();
 		}
 		return $this->fed;
@@ -224,9 +243,9 @@ class Location {
 		}
 		$db = Database::getInstance();
 		if ($bool) {
-			$db->write('INSERT IGNORE INTO location_is_fed (location_type_id) values (' . $db->escapeNumber($this->getTypeID()) . ')');
+			$db->write('INSERT IGNORE INTO location_is_fed (location_type_id) values (:location_type_id)', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_fed WHERE ' . $this->SQL);
+			$db->write('DELETE FROM location_is_fed WHERE ' . self::SQL, $this->SQLID);
 		}
 		$this->fed = $bool;
 	}
@@ -234,7 +253,7 @@ class Location {
 	public function isBank(): bool {
 		if (!isset($this->bank)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT 1 FROM location_is_bank WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT 1 FROM location_is_bank WHERE ' . self::SQL, $this->SQLID);
 			$this->bank = $dbResult->hasRecord();
 		}
 		return $this->bank;
@@ -246,11 +265,9 @@ class Location {
 		}
 		$db = Database::getInstance();
 		if ($bool) {
-			$db->insert('location_is_bank', [
-				'location_type_id' => $db->escapeNumber($this->getTypeID()),
-			]);
+			$db->insert('location_is_bank', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_bank WHERE ' . $this->SQL);
+			$db->write('DELETE FROM location_is_bank WHERE ' . self::SQL, $this->SQLID);
 		}
 		$this->bank = $bool;
 	}
@@ -258,7 +275,7 @@ class Location {
 	public function isBar(): bool {
 		if (!isset($this->bar)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT 1 FROM location_is_bar WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT 1 FROM location_is_bar WHERE ' . self::SQL, $this->SQLID);
 			$this->bar = $dbResult->hasRecord();
 		}
 		return $this->bar;
@@ -270,9 +287,9 @@ class Location {
 		}
 		$db = Database::getInstance();
 		if ($bool) {
-			$db->write('INSERT IGNORE INTO location_is_bar (location_type_id) values (' . $db->escapeNumber($this->getTypeID()) . ')');
+			$db->write('INSERT IGNORE INTO location_is_bar (location_type_id) values (:location_type_id)', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_bar WHERE ' . $this->SQL);
+			$db->write('DELETE FROM location_is_bar WHERE ' . self::SQL, $this->SQLID);
 		}
 		$this->bar = $bool;
 	}
@@ -280,7 +297,7 @@ class Location {
 	public function isHQ(): bool {
 		if (!isset($this->HQ)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT 1 FROM location_is_hq WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT 1 FROM location_is_hq WHERE ' . self::SQL, $this->SQLID);
 			$this->HQ = $dbResult->hasRecord();
 		}
 		return $this->HQ;
@@ -292,9 +309,9 @@ class Location {
 		}
 		$db = Database::getInstance();
 		if ($bool) {
-			$db->write('INSERT IGNORE INTO location_is_hq (location_type_id) values (' . $db->escapeNumber($this->getTypeID()) . ')');
+			$db->write('INSERT IGNORE INTO location_is_hq (location_type_id) values (:location_type_id)', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_hq WHERE ' . $this->SQL);
+			$db->write('DELETE FROM location_is_hq WHERE ' . self::SQL, $this->SQLID);
 		}
 		$this->HQ = $bool;
 	}
@@ -302,7 +319,7 @@ class Location {
 	public function isUG(): bool {
 		if (!isset($this->UG)) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT 1 FROM location_is_ug WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT 1 FROM location_is_ug WHERE ' . self::SQL, $this->SQLID);
 			$this->UG = $dbResult->hasRecord();
 		}
 		return $this->UG;
@@ -314,11 +331,9 @@ class Location {
 		}
 		$db = Database::getInstance();
 		if ($bool) {
-			$db->insert('location_is_ug', [
-				'location_type_id' => $db->escapeNumber($this->getTypeID()),
-			]);
+			$db->insert('location_is_ug', $this->SQLID);
 		} else {
-			$db->write('DELETE FROM location_is_ug WHERE ' . $this->SQL);
+			$db->write('DELETE FROM location_is_ug WHERE ' . self::SQL, $this->SQLID);
 		}
 		$this->UG = $bool;
 	}
@@ -330,7 +345,7 @@ class Location {
 		if (!isset($this->hardwareSold)) {
 			$this->hardwareSold = [];
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT hardware_type_id FROM location_sells_hardware WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT hardware_type_id FROM location_sells_hardware WHERE ' . self::SQL, $this->SQLID);
 			foreach ($dbResult->records() as $dbRecord) {
 				$hardwareTypeID = $dbRecord->getInt('hardware_type_id');
 				$this->hardwareSold[$hardwareTypeID] = HardwareType::get($hardwareTypeID);
@@ -352,12 +367,14 @@ class Location {
 			return;
 		}
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM hardware_type WHERE hardware_type_id = ' . $db->escapeNumber($hardwareTypeID));
+		$dbResult = $db->read('SELECT 1 FROM hardware_type WHERE hardware_type_id = :hardware_type_id', [
+			'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
+		]);
 		if (!$dbResult->hasRecord()) {
 			throw new Exception('Invalid hardware type id given');
 		}
 		$db->insert('location_sells_hardware', [
-			'location_type_id' => $db->escapeNumber($this->getTypeID()),
+			...$this->SQLID,
 			'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
 		]);
 		$this->hardwareSold[$hardwareTypeID] = HardwareType::get($hardwareTypeID);
@@ -368,7 +385,10 @@ class Location {
 			return;
 		}
 		$db = Database::getInstance();
-		$db->write('DELETE FROM location_sells_hardware WHERE ' . $this->SQL . ' AND hardware_type_id = ' . $db->escapeNumber($hardwareTypeID));
+		$db->write('DELETE FROM location_sells_hardware WHERE ' . self::SQL . ' AND hardware_type_id = :hardware_type_id', [
+			...$this->SQLID,
+			'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
+		]);
 		unset($this->hardwareSold[$hardwareTypeID]);
 	}
 
@@ -379,7 +399,7 @@ class Location {
 		if (!isset($this->shipsSold)) {
 			$this->shipsSold = [];
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM location_sells_ships JOIN ship_type USING (ship_type_id) WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM location_sells_ships JOIN ship_type USING (ship_type_id) WHERE ' . self::SQL, $this->SQLID);
 			foreach ($dbResult->records() as $dbRecord) {
 				$shipTypeID = $dbRecord->getInt('ship_type_id');
 				$this->shipsSold[$shipTypeID] = ShipType::get($shipTypeID, $dbRecord);
@@ -413,7 +433,7 @@ class Location {
 		$ship = ShipType::get($shipTypeID);
 		$db = Database::getInstance();
 		$db->insert('location_sells_ships', [
-			'location_type_id' => $db->escapeNumber($this->getTypeID()),
+			...$this->SQLID,
 			'ship_type_id' => $db->escapeNumber($shipTypeID),
 		]);
 		$this->shipsSold[$shipTypeID] = $ship;
@@ -424,7 +444,10 @@ class Location {
 			return;
 		}
 		$db = Database::getInstance();
-		$db->write('DELETE FROM location_sells_ships WHERE ' . $this->SQL . ' AND ship_type_id = ' . $db->escapeNumber($shipTypeID));
+		$db->write('DELETE FROM location_sells_ships WHERE ' . self::SQL . ' AND ship_type_id = :ship_type_id', [
+			...$this->SQLID,
+			'ship_type_id' => $db->escapeNumber($shipTypeID),
+		]);
 		unset($this->shipsSold[$shipTypeID]);
 	}
 
@@ -435,7 +458,7 @@ class Location {
 		if (!isset($this->weaponsSold)) {
 			$this->weaponsSold = [];
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) WHERE ' . $this->SQL);
+			$dbResult = $db->read('SELECT * FROM location_sells_weapons JOIN weapon_type USING (weapon_type_id) WHERE ' . self::SQL, $this->SQLID);
 			foreach ($dbResult->records() as $dbRecord) {
 				$weaponTypeID = $dbRecord->getInt('weapon_type_id');
 				$this->weaponsSold[$weaponTypeID] = Weapon::getWeapon($weaponTypeID, $dbRecord);
@@ -459,7 +482,7 @@ class Location {
 		$weapon = Weapon::getWeapon($weaponTypeID);
 		$db = Database::getInstance();
 		$db->insert('location_sells_weapons', [
-			'location_type_id' => $db->escapeNumber($this->getTypeID()),
+			...$this->SQLID,
 			'weapon_type_id' => $db->escapeNumber($weaponTypeID),
 		]);
 		$this->weaponsSold[$weaponTypeID] = $weapon;
@@ -470,7 +493,10 @@ class Location {
 			return;
 		}
 		$db = Database::getInstance();
-		$db->write('DELETE FROM location_sells_weapons WHERE ' . $this->SQL . ' AND weapon_type_id = ' . $db->escapeNumber($weaponTypeID));
+		$db->write('DELETE FROM location_sells_weapons WHERE ' . self::SQL . ' AND weapon_type_id = :weapon_type_id', [
+			...$this->SQLID,
+			'weapon_type_id' => $db->escapeNumber($weaponTypeID),
+		]);
 		unset($this->weaponsSold[$weaponTypeID]);
 	}
 

--- a/src/lib/Smr/Location.php
+++ b/src/lib/Smr/Location.php
@@ -110,8 +110,8 @@ class Location {
 		self::getSectorLocations($gameID, $sectorID); // make sure cache is populated
 		$db = Database::getInstance();
 		$db->insert('location', [
-			'game_id' => $db->escapeNumber($gameID),
-			'sector_id' => $db->escapeNumber($sectorID),
+			'game_id' => $gameID,
+			'sector_id' => $sectorID,
 			...$location->SQLID,
 		]);
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID][$location->getTypeID()] = $location;
@@ -129,10 +129,10 @@ class Location {
 		$db = Database::getInstance();
 		$db->update(
 			'location',
-			['sector_id' => $db->escapeNumber($newSectorID)],
+			['sector_id' => $newSectorID],
 			[
-				'game_id' => $db->escapeNumber($gameID),
-				'sector_id' => $db->escapeNumber($oldSectorID),
+				'game_id' => $gameID,
+				'sector_id' => $oldSectorID,
 				...$location->SQLID,
 			],
 		);
@@ -146,8 +146,8 @@ class Location {
 	public static function removeSectorLocations(int $gameID, int $sectorID): void {
 		$db = Database::getInstance();
 		$db->delete('location', [
-			'game_id' => $db->escapeNumber($gameID),
-			'sector_id' => $db->escapeNumber($sectorID),
+			'game_id' => $gameID,
+			'sector_id' => $sectorID,
 		]);
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] = [];
 	}
@@ -215,7 +215,7 @@ class Location {
 		$db = Database::getInstance();
 		$db->update(
 			'location_type',
-			['location_name' => $db->escapeString($this->name)],
+			['location_name' => $this->name],
 			$this->SQLID,
 		);
 	}
@@ -379,7 +379,7 @@ class Location {
 		}
 		$db->insert('location_sells_hardware', [
 			...$this->SQLID,
-			'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
+			'hardware_type_id' => $hardwareTypeID,
 		]);
 		$this->hardwareSold[$hardwareTypeID] = HardwareType::get($hardwareTypeID);
 	}
@@ -391,7 +391,7 @@ class Location {
 		$db = Database::getInstance();
 		$db->delete('location_sells_hardware', [
 			...$this->SQLID,
-			'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
+			'hardware_type_id' => $hardwareTypeID,
 		]);
 		unset($this->hardwareSold[$hardwareTypeID]);
 	}
@@ -438,7 +438,7 @@ class Location {
 		$db = Database::getInstance();
 		$db->insert('location_sells_ships', [
 			...$this->SQLID,
-			'ship_type_id' => $db->escapeNumber($shipTypeID),
+			'ship_type_id' => $shipTypeID,
 		]);
 		$this->shipsSold[$shipTypeID] = $ship;
 	}
@@ -450,7 +450,7 @@ class Location {
 		$db = Database::getInstance();
 		$db->delete('location_sells_ships', [
 			...$this->SQLID,
-			'ship_type_id' => $db->escapeNumber($shipTypeID),
+			'ship_type_id' => $shipTypeID,
 		]);
 		unset($this->shipsSold[$shipTypeID]);
 	}
@@ -487,7 +487,7 @@ class Location {
 		$db = Database::getInstance();
 		$db->insert('location_sells_weapons', [
 			...$this->SQLID,
-			'weapon_type_id' => $db->escapeNumber($weaponTypeID),
+			'weapon_type_id' => $weaponTypeID,
 		]);
 		$this->weaponsSold[$weaponTypeID] = $weapon;
 	}
@@ -499,7 +499,7 @@ class Location {
 		$db = Database::getInstance();
 		$db->delete('location_sells_weapons', [
 			...$this->SQLID,
-			'weapon_type_id' => $db->escapeNumber($weaponTypeID),
+			'weapon_type_id' => $weaponTypeID,
 		]);
 		unset($this->weaponsSold[$weaponTypeID]);
 	}

--- a/src/lib/Smr/Location.php
+++ b/src/lib/Smr/Location.php
@@ -127,12 +127,15 @@ class Location {
 		self::getSectorLocations($gameID, $newSectorID);
 
 		$db = Database::getInstance();
-		$db->write('UPDATE location SET sector_id = :new_sector_id WHERE game_id = :game_id AND sector_id = :old_sector_id AND ' . self::SQL, [
-			'new_sector_id' => $db->escapeNumber($newSectorID),
-			'game_id' => $db->escapeNumber($gameID),
-			'old_sector_id' => $db->escapeNumber($oldSectorID),
-			...$location->SQLID,
-		]);
+		$db->update(
+			'location',
+			['sector_id' => $db->escapeNumber($newSectorID)],
+			[
+				'game_id' => $db->escapeNumber($gameID),
+				'sector_id' => $db->escapeNumber($oldSectorID),
+				...$location->SQLID,
+			],
+		);
 		unset(self::$CACHE_SECTOR_LOCATIONS[$gameID][$oldSectorID][$location->getTypeID()]);
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$newSectorID][$location->getTypeID()] = $location;
 
@@ -210,10 +213,11 @@ class Location {
 		}
 		$this->name = $name;
 		$db = Database::getInstance();
-		$db->write('UPDATE location_type SET location_name = :location_name WHERE ' . self::SQL, [
-			'location_name' => $db->escapeString($this->name),
-			...$this->SQLID,
-		]);
+		$db->update(
+			'location_type',
+			['location_name' => $db->escapeString($this->name)],
+			$this->SQLID,
+		);
 	}
 
 	public function hasAction(): bool {

--- a/src/lib/Smr/Lotto.php
+++ b/src/lib/Smr/Lotto.php
@@ -42,13 +42,13 @@ class Lotto {
 
 		// Delete all tickets and re-insert the winning ticket
 		$db->delete('player_has_ticket', [
-			'game_id' => $db->escapeNumber($gameID),
+			'game_id' => $gameID,
 		]);
 		$db->insert('player_has_ticket', [
-			'game_id' => $db->escapeNumber($gameID),
-			'account_id' => $db->escapeNumber($winner_id),
+			'game_id' => $gameID,
+			'account_id' => $winner_id,
 			'time' => 0,
-			'prize' => $db->escapeNumber($lottoInfo['Prize']),
+			'prize' => $lottoInfo['Prize'],
 		]);
 		$db->unlock();
 
@@ -60,15 +60,15 @@ class Lotto {
 		// insert the news entry
 		$db->delete('news', [
 			'type' => 'lotto',
-			'game_id' => $db->escapeNumber($gameID),
+			'game_id' => $gameID,
 		]);
 		$db->insert('news', [
-			'game_id' => $db->escapeNumber($gameID),
-			'time' => $db->escapeNumber(Epoch::time()),
-			'news_message' => $db->escapeString($news_message),
-			'type' => $db->escapeString('lotto'),
-			'dead_id' => $db->escapeNumber($winner->getAccountID()),
-			'dead_alliance' => $db->escapeNumber($winner->getAllianceID()),
+			'game_id' => $gameID,
+			'time' => Epoch::time(),
+			'news_message' => $news_message,
+			'type' => 'lotto',
+			'dead_id' => $winner->getAccountID(),
+			'dead_alliance' => $winner->getAllianceID(),
 		]);
 	}
 

--- a/src/lib/Smr/Lotto.php
+++ b/src/lib/Smr/Lotto.php
@@ -76,19 +76,17 @@ class Lotto {
 	 * @return array{Prize: int, TimeRemaining: int}
 	 */
 	public static function getLottoInfo(int $gameID): array {
-		$amount = self::TICKET_COST; // pot starts with 1 ticket value
-		$firstBuy = Epoch::time();
-
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT count(*) as num, min(time) as time FROM player_has_ticket
 				WHERE game_id = :game_id AND time > 0', [
 			'game_id' => $db->escapeNumber($gameID),
 		]);
 		$dbRecord = $dbResult->record();
-		if ($dbRecord->getInt('num') > 0) {
-			$amount += $dbRecord->getInt('num') * IFloor(self::TICKET_COST * self::WIN_FRAC);
-			$firstBuy = $dbRecord->getInt('time');
-		}
+
+		// pot starts with 1 ticket value
+		$amount = self::TICKET_COST + $dbRecord->getInt('num') * IFloor(self::TICKET_COST * self::WIN_FRAC);
+		$firstBuy = $dbRecord->getNullableInt('time') ?? Epoch::time();
+
 		//find the time remaining in this jackpot. (which is 2 days from the first purchased ticket)
 		return ['Prize' => $amount, 'TimeRemaining' => $firstBuy + TIME_LOTTO - Epoch::time()];
 	}

--- a/src/lib/Smr/Lotto.php
+++ b/src/lib/Smr/Lotto.php
@@ -41,7 +41,7 @@ class Lotto {
 		$lottoInfo['Prize'] += $dbResult->record()->getInt('total_prize');
 
 		// Delete all tickets and re-insert the winning ticket
-		$db->write('DELETE FROM player_has_ticket WHERE game_id = :game_id', [
+		$db->delete('player_has_ticket', [
 			'game_id' => $db->escapeNumber($gameID),
 		]);
 		$db->insert('player_has_ticket', [
@@ -58,7 +58,8 @@ class Lotto {
 		$winner->increaseHOF(1, ['Bar', 'Lotto', 'Results', 'Wins'], HOF_PUBLIC);
 		$news_message = $winner->getBBLink() . ' has won the lotto! The jackpot was ' . number_format($lottoInfo['Prize']) . '. ' . $winner->getBBLink() . ' can report to any bar to claim their prize before the next drawing!';
 		// insert the news entry
-		$db->write('DELETE FROM news WHERE type = \'lotto\' AND game_id = :game_id', [
+		$db->delete('news', [
+			'type' => 'lotto',
 			'game_id' => $db->escapeNumber($gameID),
 		]);
 		$db->insert('news', [

--- a/src/lib/Smr/Menu.php
+++ b/src/lib/Smr/Menu.php
@@ -106,10 +106,14 @@ class Menu {
 		// Check if player has permissions through an alliance treaty
 		if (!$in_alliance) {
 			$dbResult = $db->read('SELECT mb_read, mod_read, planet_land FROM alliance_treaties
-							WHERE (alliance_id_1 = ' . $db->escapeNumber($alliance_id) . ' OR alliance_id_1 = ' . $db->escapeNumber($player->getAllianceID()) . ')
-							AND (alliance_id_2 = ' . $db->escapeNumber($alliance_id) . ' OR alliance_id_2 = ' . $db->escapeNumber($player->getAllianceID()) . ')
-							AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND (mb_read = 1 OR mod_read = 1 OR planet_land = 1) AND official = \'TRUE\'');
+							WHERE (alliance_id_1 = :alliance_id OR alliance_id_1 = :player_alliance_id)
+							AND (alliance_id_2 = :alliance_id OR alliance_id_2 = :player_alliance_id)
+							AND game_id = :game_id
+							AND (mb_read = 1 OR mod_read = 1 OR planet_land = 1) AND official = \'TRUE\'', [
+				'alliance_id' => $db->escapeNumber($alliance_id),
+				'player_alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 			if ($dbResult->hasRecord()) {
 				$dbRecord = $dbResult->record();
 				$canReadMb = $dbRecord->getBoolean('mb_read');
@@ -119,7 +123,11 @@ class Menu {
 		}
 
 		$role_id = $player->getAllianceRole($alliance_id);
-		$dbResult = $db->read('SELECT send_alliance_msg FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
+		$dbResult = $db->read('SELECT send_alliance_msg FROM alliance_has_roles WHERE alliance_id = :alliance_id AND game_id = :game_id AND role_id = :role_id', [
+			'alliance_id' => $db->escapeNumber($alliance_id),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'role_id' => $db->escapeNumber($role_id),
+		]);
 		if ($dbResult->hasRecord()) {
 			$send_alliance_msg = $dbResult->record()->getBoolean('send_alliance_msg');
 		} else {

--- a/src/lib/Smr/News.php
+++ b/src/lib/Smr/News.php
@@ -35,7 +35,10 @@ class News {
 
 	public static function doBreakingNewsAssign(int $gameID): void {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type = \'breaking\' AND time > ' . $db->escapeNumber(Epoch::time() - TIME_FOR_BREAKING_NEWS) . ' ORDER BY time DESC LIMIT 1');
+		$dbResult = $db->read('SELECT * FROM news WHERE game_id = :game_id AND type = \'breaking\' AND time > :breaking_news_time  ORDER BY time DESC LIMIT 1', [
+			'game_id' => $db->escapeNumber($gameID),
+			'breaking_news_time' => $db->escapeNumber(Epoch::time() - TIME_FOR_BREAKING_NEWS),
+		]);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			$template = Template::getInstance();
@@ -49,7 +52,9 @@ class News {
 	public static function doLottoNewsAssign(int $gameID): void {
 		Lotto::checkForLottoWinner($gameID);
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type = \'lotto\' ORDER BY time DESC LIMIT 1');
+		$dbResult = $db->read('SELECT * FROM news WHERE game_id = :game_id AND type = \'lotto\' ORDER BY time DESC LIMIT 1', [
+			'game_id' => $db->escapeNumber($gameID),
+		]);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			$template = Template::getInstance();

--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -134,7 +134,7 @@ class Planet {
 		$db->delete('planet_has_building', $SQLID);
 		$db->delete('planet_is_building', $SQLID);
 		//kick everyone from planet
-		$db->write('UPDATE player SET land_on_planet = \'FALSE\' WHERE ' . self::SQL, $SQLID);
+		$db->update('player', ['land_on_planet' => 'FALSE'], $SQLID);
 
 		unset(self::$CACHE_PLANETS[$gameID][$sectorID]);
 	}
@@ -757,10 +757,11 @@ class Planet {
 		}
 		$this->typeID = $num;
 		$db = Database::getInstance();
-		$db->write('UPDATE planet SET planet_type_id = :planet_type_id WHERE ' . self::SQL, [
-			'planet_type_id' => $db->escapeNumber($num),
-			...$this->SQLID,
-		]);
+		$db->update(
+			'planet',
+			['planet_type_id' => $db->escapeNumber($num)],
+			$this->SQLID,
+		);
 		$this->typeInfo = PlanetType::getTypeInfo($this->getTypeID());
 
 		//trim buildings first
@@ -822,22 +823,18 @@ class Planet {
 		}
 		$db = Database::getInstance();
 		if ($this->hasChanged) {
-			$db->write('UPDATE planet SET
-									owner_id = :owner_id,
-									password = :password,
-									planet_name = :planet_name,
-									shields = :shields,
-									armour = :armour,
-									drones = :drones
-								WHERE ' . self::SQL, [
-				'owner_id' => $db->escapeNumber($this->ownerID),
-				'password' => $db->escapeString($this->password),
-				'planet_name' => $db->escapeString($this->planetName),
-				'shields' => $db->escapeNumber($this->shields),
-				'armour' => $db->escapeNumber($this->armour),
-				'drones' => $db->escapeNumber($this->drones),
-				...$this->SQLID,
-			]);
+			$db->update(
+				'planet',
+				[
+					'owner_id' => $db->escapeNumber($this->ownerID),
+					'password' => $db->escapeString($this->password),
+					'planet_name' => $db->escapeString($this->planetName),
+					'shields' => $db->escapeNumber($this->shields),
+					'armour' => $db->escapeNumber($this->armour),
+					'drones' => $db->escapeNumber($this->drones),
+				],
+				$this->SQLID,
+			);
 			$this->hasChanged = false;
 		}
 
@@ -845,16 +842,15 @@ class Planet {
 		// at the planet list (i.e. you might not have sector lock and could
 		// cause a race condition with events happening in the planet sector).
 		if ($this->hasChangedFinancial) {
-			$db->write('UPDATE planet SET
-									credits = :credits,
-									bonds = :bonds,
-									maturity = :maturity
-								WHERE ' . self::SQL, [
-				'credits' => $db->escapeNumber($this->credits),
-				'bonds' => $db->escapeNumber($this->bonds),
-				'maturity' => $db->escapeNumber($this->maturity),
-				...$this->SQLID,
-			]);
+			$db->update(
+				'planet',
+				[
+					'credits' => $db->escapeNumber($this->credits),
+					'bonds' => $db->escapeNumber($this->bonds),
+					'maturity' => $db->escapeNumber($this->maturity),
+				],
+				$this->SQLID,
+			);
 			$this->hasChangedFinancial = false;
 		}
 
@@ -1387,7 +1383,7 @@ class Planet {
 
 		//kick everyone from planet
 		$db = Database::getInstance();
-		$db->write('UPDATE player SET land_on_planet = \'FALSE\' WHERE ' . self::SQL, $this->SQLID);
+		$db->update('player', ['land_on_planet' => 'FALSE'], $this->SQLID);
 		$this->removeOwner();
 		$this->removePassword();
 		return [];

--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -128,11 +128,11 @@ class Planet {
 			'game_id' => $db->escapeNumber($gameID),
 			'sector_id' => $db->escapeNumber($sectorID),
 		];
-		$db->write('DELETE FROM planet WHERE ' . self::SQL, $SQLID);
-		$db->write('DELETE FROM planet_has_weapon WHERE ' . self::SQL, $SQLID);
-		$db->write('DELETE FROM planet_has_cargo WHERE ' . self::SQL, $SQLID);
-		$db->write('DELETE FROM planet_has_building WHERE ' . self::SQL, $SQLID);
-		$db->write('DELETE FROM planet_is_building WHERE ' . self::SQL, $SQLID);
+		$db->delete('planet', $SQLID);
+		$db->delete('planet_has_weapon', $SQLID);
+		$db->delete('planet_has_cargo', $SQLID);
+		$db->delete('planet_has_building', $SQLID);
+		$db->delete('planet_is_building', $SQLID);
 		//kick everyone from planet
 		$db->write('UPDATE player SET land_on_planet = \'FALSE\' WHERE ' . self::SQL, $SQLID);
 
@@ -868,8 +868,7 @@ class Planet {
 						'amount' => $db->escapeNumber($amount),
 					]);
 				} else {
-					$db->write('DELETE FROM planet_has_cargo WHERE ' . self::SQL . '
-										AND good_id = :good_id', [
+					$db->delete('planet_has_cargo', [
 						...$this->SQLID,
 						'good_id' => $db->escapeNumber($id),
 					]);
@@ -888,7 +887,7 @@ class Planet {
 						'bonus_damage' => $db->escapeBoolean($this->mountedWeapons[$orderID]->hasBonusDamage()),
 					]);
 				} else {
-					$db->write('DELETE FROM planet_has_weapon WHERE ' . self::SQL . ' AND order_id = :order_id', [
+					$db->delete('planet_has_weapon', [
 						...$this->SQLID,
 						'order_id' => $db->escapeNumber($orderID),
 					]);
@@ -916,8 +915,7 @@ class Planet {
 						'amount' => $db->escapeNumber($this->getBuilding($id)),
 					]);
 				} else {
-					$db->write('DELETE FROM planet_has_building WHERE ' . self::SQL . '
-										AND construction_id = :construction_id', [
+					$db->delete('planet_has_building', [
 						...$this->SQLID,
 						'construction_id' => $db->escapeNumber($id),
 					]);
@@ -1378,7 +1376,7 @@ class Planet {
 			$currPlayer->increaseHOF($dbRecord->getFloat('level'), ['Combat', 'Planet', 'Levels'], HOF_PUBLIC);
 			$currPlayer->increaseHOF(1, ['Combat', 'Planet', 'Completed'], HOF_PUBLIC);
 		}
-		$db->write('DELETE FROM player_attacks_planet WHERE ' . self::SQL, $this->SQLID);
+		$db->delete('player_attacks_planet', $this->SQLID);
 	}
 
 	/**

--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -114,10 +114,10 @@ class Planet {
 		// insert planet into db
 		$db = Database::getInstance();
 		$db->insert('planet', [
-			'game_id' => $db->escapeNumber($gameID),
-			'sector_id' => $db->escapeNumber($sectorID),
-			'inhabitable_time' => $db->escapeNumber($inhabitableTime),
-			'planet_type_id' => $db->escapeNumber($typeID),
+			'game_id' => $gameID,
+			'sector_id' => $sectorID,
+			'inhabitable_time' => $inhabitableTime,
+			'planet_type_id' => $typeID,
 		]);
 		return self::getPlanet($gameID, $sectorID, true);
 	}
@@ -759,7 +759,7 @@ class Planet {
 		$db = Database::getInstance();
 		$db->update(
 			'planet',
-			['planet_type_id' => $db->escapeNumber($num)],
+			['planet_type_id' => $num],
 			$this->SQLID,
 		);
 		$this->typeInfo = PlanetType::getTypeInfo($this->getTypeID());
@@ -826,12 +826,12 @@ class Planet {
 			$db->update(
 				'planet',
 				[
-					'owner_id' => $db->escapeNumber($this->ownerID),
-					'password' => $db->escapeString($this->password),
-					'planet_name' => $db->escapeString($this->planetName),
-					'shields' => $db->escapeNumber($this->shields),
-					'armour' => $db->escapeNumber($this->armour),
-					'drones' => $db->escapeNumber($this->drones),
+					'owner_id' => $this->ownerID,
+					'password' => $this->password,
+					'planet_name' => $this->planetName,
+					'shields' => $this->shields,
+					'armour' => $this->armour,
+					'drones' => $this->drones,
 				],
 				$this->SQLID,
 			);
@@ -845,9 +845,9 @@ class Planet {
 			$db->update(
 				'planet',
 				[
-					'credits' => $db->escapeNumber($this->credits),
-					'bonds' => $db->escapeNumber($this->bonds),
-					'maturity' => $db->escapeNumber($this->maturity),
+					'credits' => $this->credits,
+					'bonds' => $this->bonds,
+					'maturity' => $this->maturity,
 				],
 				$this->SQLID,
 			);
@@ -860,13 +860,13 @@ class Planet {
 				if ($amount != 0) {
 					$db->replace('planet_has_cargo', [
 						...$this->SQLID,
-						'good_id' => $db->escapeNumber($id),
-						'amount' => $db->escapeNumber($amount),
+						'good_id' => $id,
+						'amount' => $amount,
 					]);
 				} else {
 					$db->delete('planet_has_cargo', [
 						...$this->SQLID,
-						'good_id' => $db->escapeNumber($id),
+						'good_id' => $id,
 					]);
 				}
 			}
@@ -877,15 +877,15 @@ class Planet {
 				if (isset($this->mountedWeapons[$orderID])) {
 					$db->replace('planet_has_weapon', [
 						...$this->SQLID,
-						'order_id' => $db->escapeNumber($orderID),
-						'weapon_type_id' => $db->escapeNumber($this->mountedWeapons[$orderID]->getWeaponTypeID()),
+						'order_id' => $orderID,
+						'weapon_type_id' => $this->mountedWeapons[$orderID]->getWeaponTypeID(),
 						'bonus_accuracy' => $db->escapeBoolean($this->mountedWeapons[$orderID]->hasBonusAccuracy()),
 						'bonus_damage' => $db->escapeBoolean($this->mountedWeapons[$orderID]->hasBonusDamage()),
 					]);
 				} else {
 					$db->delete('planet_has_weapon', [
 						...$this->SQLID,
-						'order_id' => $db->escapeNumber($orderID),
+						'order_id' => $orderID,
 					]);
 				}
 			}
@@ -907,13 +907,13 @@ class Planet {
 				if ($this->hasBuilding($id)) {
 					$db->replace('planet_has_building', [
 						...$this->SQLID,
-						'construction_id' => $db->escapeNumber($id),
-						'amount' => $db->escapeNumber($this->getBuilding($id)),
+						'construction_id' => $id,
+						'amount' => $this->getBuilding($id),
 					]);
 				} else {
 					$db->delete('planet_has_building', [
 						...$this->SQLID,
-						'construction_id' => $db->escapeNumber($id),
+						'construction_id' => $id,
 					]);
 				}
 				$this->hasChangedBuildings[$id] = false;
@@ -1019,11 +1019,11 @@ class Planet {
 		$timeComplete = Epoch::time() + $this->getConstructionTime($constructionID);
 		$db = Database::getInstance();
 		$insertID = $db->insert('planet_is_building', [
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'sector_id' => $db->escapeNumber($this->getSectorID()),
-			'construction_id' => $db->escapeNumber($constructionID),
-			'constructor_id' => $db->escapeNumber($constructor->getAccountID()),
-			'time_complete' => $db->escapeNumber($timeComplete),
+			'game_id' => $this->getGameID(),
+			'sector_id' => $this->getSectorID(),
+			'construction_id' => $constructionID,
+			'constructor_id' => $constructor->getAccountID(),
+			'time_complete' => $timeComplete,
 		]);
 
 		$this->currentlyBuilding[$insertID] = [
@@ -1131,11 +1131,11 @@ class Planet {
 		foreach ($attackers as $attacker) {
 			$attacker->increaseHOF(1, ['Combat', 'Planet', 'Number Of Attacks'], HOF_PUBLIC);
 			$db->replace('player_attacks_planet', [
-				'game_id' => $db->escapeNumber($this->getGameID()),
-				'account_id' => $db->escapeNumber($attacker->getAccountID()),
-				'sector_id' => $db->escapeNumber($this->getSectorID()),
-				'time' => $db->escapeNumber(Epoch::time()),
-				'level' => $db->escapeNumber($this->getLevel()),
+				'game_id' => $this->getGameID(),
+				'account_id' => $attacker->getAccountID(),
+				'sector_id' => $this->getSectorID(),
+				'time' => Epoch::time(),
+				'level' => $this->getLevel(),
 			]);
 		}
 
@@ -1156,14 +1156,14 @@ class Planet {
 				}
 				$text .= '.';
 				$db->insert('news', [
-					'game_id' => $db->escapeNumber($this->getGameID()),
-					'time' => $db->escapeNumber(Epoch::time()),
-					'news_message' => $db->escapeString($text),
-					'type' => $db->escapeString('breaking'),
-					'killer_id' => $db->escapeNumber($trigger->getAccountID()),
-					'killer_alliance' => $db->escapeNumber($trigger->getAllianceID()),
-					'dead_id' => $db->escapeNumber($owner->getAccountID()),
-					'dead_alliance' => $db->escapeNumber($owner->getAllianceID()),
+					'game_id' => $this->getGameID(),
+					'time' => Epoch::time(),
+					'news_message' => $text,
+					'type' => 'breaking',
+					'killer_id' => $trigger->getAccountID(),
+					'killer_alliance' => $trigger->getAllianceID(),
+					'dead_id' => $owner->getAccountID(),
+					'dead_alliance' => $owner->getAllianceID(),
 				]);
 			}
 		}

--- a/src/lib/Smr/Port.php
+++ b/src/lib/Smr/Port.php
@@ -681,11 +681,11 @@ class Port {
 		foreach ($attackers as $attacker) {
 			$attacker->increaseHOF(1, ['Combat', 'Port', 'Number Of Attacks'], HOF_PUBLIC);
 			$db->replace('player_attacks_port', [
-				'game_id' => $db->escapeNumber($this->getGameID()),
-				'account_id' => $db->escapeNumber($attacker->getAccountID()),
-				'sector_id' => $db->escapeNumber($this->getSectorID()),
-				'time' => $db->escapeNumber(Epoch::time()),
-				'level' => $db->escapeNumber($this->getLevel()),
+				'game_id' => $this->getGameID(),
+				'account_id' => $attacker->getAccountID(),
+				'sector_id' => $this->getSectorID(),
+				'time' => Epoch::time(),
+				'level' => $this->getLevel(),
 			]);
 		}
 		if (!$this->isUnderAttack()) {
@@ -714,12 +714,12 @@ class Port {
 			$newsMessage .= ' prior to the destruction of the port, or until federal forces arrive to defend the port.';
 
 			$db->insert('news', [
-				'game_id' => $db->escapeNumber($this->getGameID()),
-				'time' => $db->escapeNumber(Epoch::time()),
-				'news_message' => $db->escapeString($newsMessage),
-				'killer_id' => $db->escapeNumber($trigger->getAccountID()),
-				'killer_alliance' => $db->escapeNumber($trigger->getAllianceID()),
-				'dead_id' => $db->escapeNumber(ACCOUNT_ID_PORT),
+				'game_id' => $this->getGameID(),
+				'time' => Epoch::time(),
+				'news_message' => $newsMessage,
+				'killer_id' => $trigger->getAccountID(),
+				'killer_alliance' => $trigger->getAllianceID(),
+				'dead_id' => ACCOUNT_ID_PORT,
 			]);
 		}
 	}
@@ -1267,23 +1267,23 @@ class Port {
 			$this->updateSectorPlayersCache();
 			// route_cache tells NPC's where they can trade
 			$db->delete('route_cache', [
-				'game_id' => $db->escapeNumber($this->getGameID()),
+				'game_id' => $this->getGameID(),
 			]);
 		}
 
 		// If any fields in the `port` table have changed, update table
 		if ($this->hasChanged) {
 			$params = [
-				'experience' => $db->escapeNumber($this->getExperience()),
-				'shields' => $db->escapeNumber($this->getShields()),
-				'armour' => $db->escapeNumber($this->getArmour()),
-				'combat_drones' => $db->escapeNumber($this->getCDs()),
-				'level' => $db->escapeNumber($this->getLevel()),
-				'credits' => $db->escapeNumber($this->getCredits()),
-				'upgrade' => $db->escapeNumber($this->getUpgrade()),
-				'reinforce_time' => $db->escapeNumber($this->getReinforceTime()),
-				'attack_started' => $db->escapeNumber($this->getAttackStarted()),
-				'race_id' => $db->escapeNumber($this->getRaceID()),
+				'experience' => $this->getExperience(),
+				'shields' => $this->getShields(),
+				'armour' => $this->getArmour(),
+				'combat_drones' => $this->getCDs(),
+				'level' => $this->getLevel(),
+				'credits' => $this->getCredits(),
+				'upgrade' => $this->getUpgrade(),
+				'reinforce_time' => $this->getReinforceTime(),
+				'attack_started' => $this->getAttackStarted(),
+				'race_id' => $this->getRaceID(),
 			];
 			if ($this->isNew === false) {
 				$db->update('port', $params, $this->SQLID);
@@ -1304,12 +1304,12 @@ class Port {
 			$db->update(
 				'port_has_goods',
 				[
-					'amount' => $db->escapeNumber($amount),
-					'last_update' => $db->escapeNumber(Epoch::time()),
+					'amount' => $amount,
+					'last_update' => Epoch::time(),
 				],
 				[
 					...$this->SQLID,
-					'good_id' => $db->escapeNumber($goodID),
+					'good_id' => $goodID,
 				],
 			);
 			unset($this->goodAmountsChanged[$goodID]);
@@ -1321,16 +1321,16 @@ class Port {
 				// add the good
 				$db->replace('port_has_goods', [
 					...$this->SQLID,
-					'good_id' => $db->escapeNumber($goodID),
-					'transaction_type' => $db->escapeString($this->getGoodTransaction($goodID)->value),
-					'amount' => $db->escapeNumber($this->getGoodAmount($goodID)),
-					'last_update' => $db->escapeNumber(Epoch::time()),
+					'good_id' => $goodID,
+					'transaction_type' => $this->getGoodTransaction($goodID)->value,
+					'amount' => $this->getGoodAmount($goodID),
+					'last_update' => Epoch::time(),
 				]);
 			} else {
 				// remove the good
 				$db->delete('port_has_goods', [
 					...$this->SQLID,
-					'good_id' => $db->escapeNumber($goodID),
+					'good_id' => $goodID,
 				]);
 			}
 			unset($this->goodTransactionsChanged[$goodID]);
@@ -1515,12 +1515,12 @@ class Port {
 		}
 		$db = Database::getInstance();
 		$db->insert('news', [
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'time' => $db->escapeNumber(Epoch::time()),
-			'news_message' => $db->escapeString($news),
-			'killer_id' => $db->escapeNumber($killer->getAccountID()),
-			'killer_alliance' => $db->escapeNumber($killer->getAllianceID()),
-			'dead_id' => $db->escapeNumber(ACCOUNT_ID_PORT),
+			'game_id' => $this->getGameID(),
+			'time' => Epoch::time(),
+			'news_message' => $news,
+			'killer_id' => $killer->getAccountID(),
+			'killer_alliance' => $killer->getAllianceID(),
+			'dead_id' => ACCOUNT_ID_PORT,
 		]);
 
 		// Killer gets a relations change and a bounty if port is taken

--- a/src/lib/Smr/Port.php
+++ b/src/lib/Smr/Port.php
@@ -1274,7 +1274,6 @@ class Port {
 		// If any fields in the `port` table have changed, update table
 		if ($this->hasChanged) {
 			$params = [
-				...$this->SQLID,
 				'experience' => $db->escapeNumber($this->getExperience()),
 				'shields' => $db->escapeNumber($this->getShields()),
 				'armour' => $db->escapeNumber($this->getArmour()),
@@ -1287,19 +1286,9 @@ class Port {
 				'race_id' => $db->escapeNumber($this->getRaceID()),
 			];
 			if ($this->isNew === false) {
-				$db->write('UPDATE port SET experience = :experience,
-								shields = :shields,
-								armour = :armour,
-								combat_drones = :combat_drones,
-								level = :level,
-								credits = :credits,
-								upgrade = :upgrade,
-								reinforce_time = :reinforce_time,
-								attack_started = :attack_started,
-								race_id = :race_id
-								WHERE ' . self::SQL, $params);
+				$db->update('port', $params, $this->SQLID);
 			} else {
-				$db->insert('port', $params);
+				$db->insert('port', [...$params, ...$this->SQLID]);
 				$this->isNew = false;
 			}
 			$this->hasChanged = false;
@@ -1312,12 +1301,17 @@ class Port {
 				continue;
 			}
 			$amount = $this->getGoodAmount($goodID);
-			$db->write('UPDATE port_has_goods SET amount = :amount, last_update = :last_update WHERE ' . self::SQL . ' AND good_id = :good_id', [
-				...$this->SQLID,
-				'good_id' => $db->escapeNumber($goodID),
-				'amount' => $db->escapeNumber($amount),
-				'last_update' => $db->escapeNumber(Epoch::time()),
-			]);
+			$db->update(
+				'port_has_goods',
+				[
+					'amount' => $db->escapeNumber($amount),
+					'last_update' => $db->escapeNumber(Epoch::time()),
+				],
+				[
+					...$this->SQLID,
+					'good_id' => $db->escapeNumber($goodID),
+				],
+			);
 			unset($this->goodAmountsChanged[$goodID]);
 		}
 

--- a/src/lib/Smr/Port.php
+++ b/src/lib/Smr/Port.php
@@ -120,11 +120,11 @@ class Port {
 			'game_id' => $db->escapeNumber($gameID),
 			'sector_id' => $db->escapeNumber($sectorID),
 		];
-		$db->write('DELETE FROM port WHERE ' . self::SQL, $SQLID);
-		$db->write('DELETE FROM port_has_goods WHERE ' . self::SQL, $SQLID);
-		$db->write('DELETE FROM player_visited_port WHERE ' . self::SQL, $SQLID);
-		$db->write('DELETE FROM player_attacks_port WHERE ' . self::SQL, $SQLID);
-		$db->write('DELETE FROM port_info_cache WHERE ' . self::SQL, $SQLID);
+		$db->delete('port', $SQLID);
+		$db->delete('port_has_goods', $SQLID);
+		$db->delete('player_visited_port', $SQLID);
+		$db->delete('player_attacks_port', $SQLID);
+		$db->delete('port_info_cache', $SQLID);
 		unset(self::$CACHE_PORTS[$gameID][$sectorID]);
 	}
 
@@ -225,7 +225,7 @@ class Port {
 				$this->setCreditsToDefault();
 			}
 			$db = Database::getInstance();
-			$db->write('DELETE FROM player_attacks_port WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('player_attacks_port', $this->SQLID);
 		}
 	}
 
@@ -1266,7 +1266,7 @@ class Port {
 		if (!$this->cacheIsValid) {
 			$this->updateSectorPlayersCache();
 			// route_cache tells NPC's where they can trade
-			$db->write('DELETE FROM route_cache WHERE game_id = :game_id', [
+			$db->delete('route_cache', [
 				'game_id' => $db->escapeNumber($this->getGameID()),
 			]);
 		}
@@ -1334,7 +1334,7 @@ class Port {
 				]);
 			} else {
 				// remove the good
-				$db->write('DELETE FROM port_has_goods WHERE ' . self::SQL . ' AND good_id = :good_id', [
+				$db->delete('port_has_goods', [
 					...$this->SQLID,
 					'good_id' => $db->escapeNumber($goodID),
 				]);

--- a/src/lib/Smr/Sector.php
+++ b/src/lib/Smr/Sector.php
@@ -169,24 +169,24 @@ class Sector {
 		if ($this->isNew) {
 			$db->insert('sector', [
 				...$this->SQLID,
-				'galaxy_id' => $db->escapeNumber($this->getGalaxyID()),
-				'link_up' => $db->escapeNumber($this->getLinkUp()),
-				'link_down' => $db->escapeNumber($this->getLinkDown()),
-				'link_left' => $db->escapeNumber($this->getLinkLeft()),
-				'link_right' => $db->escapeNumber($this->getLinkRight()),
-				'warp' => $db->escapeNumber($this->getWarp()),
+				'galaxy_id' => $this->getGalaxyID(),
+				'link_up' => $this->getLinkUp(),
+				'link_down' => $this->getLinkDown(),
+				'link_left' => $this->getLinkLeft(),
+				'link_right' => $this->getLinkRight(),
+				'warp' => $this->getWarp(),
 			]);
 		} elseif ($this->hasChanged) {
 			$db->update(
 				'sector',
 				[
-					'battles' => $db->escapeNumber($this->getBattles()),
-					'galaxy_id' => $db->escapeNumber($this->getGalaxyID()),
-					'link_up' => $db->escapeNumber($this->getLinkUp()),
-					'link_right' => $db->escapeNumber($this->getLinkRight()),
-					'link_down' => $db->escapeNumber($this->getLinkDown()),
-					'link_left' => $db->escapeNumber($this->getLinkLeft()),
-					'warp' => $db->escapeNumber($this->getWarp()),
+					'battles' => $this->getBattles(),
+					'galaxy_id' => $this->getGalaxyID(),
+					'link_up' => $this->getLinkUp(),
+					'link_right' => $this->getLinkRight(),
+					'link_down' => $this->getLinkDown(),
+					'link_left' => $this->getLinkLeft(),
+					'warp' => $this->getWarp(),
 				],
 				$this->SQLID,
 			);
@@ -205,7 +205,7 @@ class Sector {
 			$db = Database::getInstance();
 			$db->delete('player_visited_sector', [
 				...$this->SQLID,
-				'account_id' => $db->escapeNumber($player->getAccountID()),
+				'account_id' => $player->getAccountID(),
 			]);
 		}
 		$this->visited[$player->getAccountID()] = true;
@@ -269,7 +269,7 @@ class Sector {
 			['refresher' => 0],
 			[
 				...$this->SQLID,
-				'refresher' => $db->escapeNumber($player->getAccountID()),
+				'refresher' => $player->getAccountID(),
 			],
 		);
 	}

--- a/src/lib/Smr/Sector.php
+++ b/src/lib/Smr/Sector.php
@@ -177,23 +177,19 @@ class Sector {
 				'warp' => $db->escapeNumber($this->getWarp()),
 			]);
 		} elseif ($this->hasChanged) {
-			$db->write('UPDATE sector SET battles = :battles,
-									galaxy_id = :galaxy_id,
-									link_up = :link_up,
-									link_right = :link_right,
-									link_down = :link_down,
-									link_left = :link_left,
-									warp = :warp
-								WHERE ' . self::SQL, [
-				'battles' => $db->escapeNumber($this->getBattles()),
-				'galaxy_id' => $db->escapeNumber($this->getGalaxyID()),
-				'link_up' => $db->escapeNumber($this->getLinkUp()),
-				'link_right' => $db->escapeNumber($this->getLinkRight()),
-				'link_down' => $db->escapeNumber($this->getLinkDown()),
-				'link_left' => $db->escapeNumber($this->getLinkLeft()),
-				'warp' => $db->escapeNumber($this->getWarp()),
-				...$this->SQLID,
-			]);
+			$db->update(
+				'sector',
+				[
+					'battles' => $db->escapeNumber($this->getBattles()),
+					'galaxy_id' => $db->escapeNumber($this->getGalaxyID()),
+					'link_up' => $db->escapeNumber($this->getLinkUp()),
+					'link_right' => $db->escapeNumber($this->getLinkRight()),
+					'link_down' => $db->escapeNumber($this->getLinkDown()),
+					'link_left' => $db->escapeNumber($this->getLinkLeft()),
+					'warp' => $db->escapeNumber($this->getWarp()),
+				],
+				$this->SQLID,
+			);
 		}
 		$this->isNew = false;
 		$this->hasChanged = false;
@@ -268,11 +264,14 @@ class Sector {
 			$force->ping($message, $player);
 		}
 		$db = Database::getInstance();
-		$db->write('UPDATE sector_has_forces SET refresher = 0 WHERE ' . self::SQL . '
-								AND refresher = :refresher', [
-			...$this->SQLID,
-			'refresher' => $db->escapeNumber($player->getAccountID()),
-		]);
+		$db->update(
+			'sector_has_forces',
+			['refresher' => 0],
+			[
+				...$this->SQLID,
+				'refresher' => $db->escapeNumber($player->getAccountID()),
+			],
+		);
 	}
 
 	public function diedHere(AbstractPlayer $player): void {

--- a/src/lib/Smr/Sector.php
+++ b/src/lib/Smr/Sector.php
@@ -207,8 +207,7 @@ class Sector {
 		//now delete the entry from visited
 		if (!$this->isVisited($player)) {
 			$db = Database::getInstance();
-			$db->write('DELETE FROM player_visited_sector WHERE ' . self::SQL . '
-								 AND account_id = :account_id', [
+			$db->delete('player_visited_sector', [
 				...$this->SQLID,
 				'account_id' => $db->escapeNumber($player->getAccountID()),
 			]);

--- a/src/lib/Smr/SectorLock.php
+++ b/src/lib/Smr/SectorLock.php
@@ -75,10 +75,10 @@ class SectorLock {
 		// Insert ourselves into the queue.
 		$db = Database::getInstance();
 		$this->lockID = $db->insert('locks_queue', [
-			'game_id' => $db->escapeNumber($gameID),
-			'account_id' => $db->escapeNumber($accountID),
-			'sector_id' => $db->escapeNumber($sectorID),
-			'timestamp' => $db->escapeNumber(Epoch::time()),
+			'game_id' => $gameID,
+			'account_id' => $accountID,
+			'sector_id' => $sectorID,
+			'timestamp' => Epoch::time(),
 		]);
 
 		// Return once we are next in the queue.

--- a/src/lib/Smr/SectorLock.php
+++ b/src/lib/Smr/SectorLock.php
@@ -88,20 +88,31 @@ class SectorLock {
 			}
 
 			$staleLockEpoch = Epoch::time() - self::LOCK_DURATION;
-			$query = 'SELECT COUNT(*) FROM locks_queue WHERE'
-				. ' sector_id=' . $db->escapeNumber($sectorID)
-				. ' AND game_id=' . $db->escapeNumber($gameID)
-				. ' AND timestamp > ' . $db->escapeNumber($staleLockEpoch);
+			$query = 'SELECT COUNT(*) FROM locks_queue WHERE
+				sector_id = :sector_id
+				AND game_id = :game_id
+				AND timestamp > :stale_time';
+			$sqlParams = [
+				'sector_id' => $db->escapeNumber($sectorID),
+				'game_id' => $db->escapeNumber($gameID),
+				'stale_time' => $db->escapeNumber($staleLockEpoch),
+			];
 
 			// If there is someone else before us in the queue we sleep for a while
-			$dbResult = $db->read($query . ' AND lock_id < ' . $db->escapeNumber($this->lockID));
+			$dbResult = $db->read($query . ' AND lock_id < :lock_id', [
+				...$sqlParams,
+				'lock_id' => $db->escapeNumber($this->lockID),
+			]);
 			$locksInQueue = $dbResult->record()->getInt('COUNT(*)');
 			if ($locksInQueue == 0) {
 				return true;
 			}
 
 			// We can only have one lock in the queue, anything more means someone is screwing around
-			$dbResult = $db->read($query . ' AND account_id=' . $db->escapeNumber($accountID));
+			$dbResult = $db->read($query . ' AND account_id = :account_id', [
+				...$sqlParams,
+				'account_id' => $db->escapeNumber($accountID),
+			]);
 			if ($dbResult->record()->getInt('COUNT(*)') > 1) {
 				$this->setFailed();
 				throw new UserError('Multiple actions cannot be performed at the same time!');
@@ -140,7 +151,10 @@ class SectorLock {
 		}
 		// Delete this lock (and any stale locks)
 		$db = Database::getInstance();
-		$db->write('DELETE from locks_queue WHERE lock_id=' . $db->escapeNumber($this->lockID) . ' OR timestamp<' . $db->escapeNumber(Epoch::time() - self::LOCK_DURATION));
+		$db->write('DELETE from locks_queue WHERE lock_id = :lock_id OR timestamp < :lock_time', [
+			'lock_id' => $db->escapeNumber($this->lockID),
+			'lock_time' => $db->escapeNumber(Epoch::time() - self::LOCK_DURATION),
+		]);
 
 		$this->lockID = null;
 		return true;

--- a/src/lib/Smr/Session.php
+++ b/src/lib/Smr/Session.php
@@ -109,9 +109,9 @@ class Session {
 			}
 			if (ENABLE_DEBUG) {
 				$db->insert('debug', [
-					'debug_type' => $db->escapeString('Delay: ' . $file),
-					'account_id' => $db->escapeNumber($this->accountID),
-					'value' => $db->escapeNumber($timeBetweenLoads),
+					'debug_type' => 'Delay: ' . $file,
+					'account_id' => $this->accountID,
+					'value' => $timeBetweenLoads,
 				]);
 			}
 		}
@@ -169,30 +169,30 @@ class Session {
 		$db = Database::getInstance();
 		if (!$this->generate) {
 			$data = [
-				'account_id' => $db->escapeNumber($this->accountID),
-				'game_id' => $db->escapeNumber($this->gameID),
+				'account_id' => $this->accountID,
+				'game_id' => $this->gameID,
 				'session_var' => $db->escapeObject($sessionVar, true),
-				'last_sn' => $db->escapeString($this->SN),
+				'last_sn' => $this->SN,
 			];
 			$conditions = [
-				'session_id' => $db->escapeString($this->sessionID),
+				'session_id' => $this->sessionID,
 			];
 			if ($this->ajax) {
-				$conditions['last_sn'] = $db->escapeString($this->lastSN);
+				$conditions['last_sn'] = $this->lastSN;
 			} else {
-				$data['last_accessed'] = $db->escapeNumber(Epoch::microtime());
+				$data['last_accessed'] = Epoch::microtime();
 			}
 			$db->update('active_session', $data, $conditions);
 		} else {
 			$db->delete('active_session', [
-				'account_id' => $db->escapeNumber($this->accountID),
-				'game_id' => $db->escapeNumber($this->gameID),
+				'account_id' => $this->accountID,
+				'game_id' => $this->gameID,
 			]);
 			$db->insert('active_session', [
-				'session_id' => $db->escapeString($this->sessionID),
-				'account_id' => $db->escapeNumber($this->accountID),
-				'game_id' => $db->escapeNumber($this->gameID),
-				'last_accessed' => $db->escapeNumber(Epoch::microtime()),
+				'session_id' => $this->sessionID,
+				'account_id' => $this->accountID,
+				'game_id' => $this->gameID,
+				'last_accessed' => Epoch::microtime(),
 				'session_var' => $db->escapeObject($sessionVar, true),
 			]);
 			$this->generate = false;
@@ -254,13 +254,13 @@ class Session {
 		$this->gameID = $gameID;
 		$db = Database::getInstance();
 		$db->delete('active_session', [
-			'account_id' => $db->escapeNumber($this->accountID),
-			'game_id' => $db->escapeNumber($this->gameID),
+			'account_id' => $this->accountID,
+			'game_id' => $this->gameID,
 		]);
 		$db->update(
 			'active_session',
-			['game_id' => $db->escapeNumber($this->gameID)],
-			['session_id' => $db->escapeString($this->sessionID)],
+			['game_id' => $this->gameID],
+			['session_id' => $this->sessionID],
 		);
 	}
 
@@ -281,7 +281,7 @@ class Session {
 	public function destroy(): void {
 		$db = Database::getInstance();
 		$db->delete('active_session', [
-			'session_id' => $db->escapeString($this->sessionID),
+			'session_id' => $this->sessionID,
 		]);
 		unset($this->sessionID);
 		unset($this->accountID);
@@ -389,7 +389,7 @@ class Session {
 		$db->update(
 			'active_session',
 			['ajax_returns' => $db->escapeObject($this->ajaxReturns, true)],
-			['session_id' => $db->escapeString($this->sessionID)],
+			['session_id' => $this->sessionID],
 		);
 	}
 

--- a/src/lib/Smr/Session.php
+++ b/src/lib/Smr/Session.php
@@ -180,7 +180,7 @@ class Session {
 				'ajax' => $db->escapeBoolean($this->ajax),
 			]);
 		} else {
-			$db->write('DELETE FROM active_session WHERE account_id = :account_id  AND game_id = :game_id', [
+			$db->delete('active_session', [
 				'account_id' => $db->escapeNumber($this->accountID),
 				'game_id' => $db->escapeNumber($this->gameID),
 			]);
@@ -249,7 +249,7 @@ class Session {
 		}
 		$this->gameID = $gameID;
 		$db = Database::getInstance();
-		$db->write('DELETE FROM active_session WHERE account_id = :account_id AND game_id = :game_id', [
+		$db->delete('active_session', [
 			'account_id' => $db->escapeNumber($this->accountID),
 			'game_id' => $db->escapeNumber($this->gameID),
 		]);
@@ -275,7 +275,7 @@ class Session {
 
 	public function destroy(): void {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM active_session WHERE session_id = :session_id', [
+		$db->delete('active_session', [
 			'session_id' => $db->escapeString($this->sessionID),
 		]);
 		unset($this->sessionID);

--- a/src/lib/Smr/Ship.php
+++ b/src/lib/Smr/Ship.php
@@ -131,13 +131,13 @@ class Ship extends AbstractShip {
 			if ($amount > 0) {
 				$db->replace('ship_has_cargo', [
 					...$this->SQLID,
-					'good_id' => $db->escapeNumber($id),
-					'amount' => $db->escapeNumber($amount),
+					'good_id' => $id,
+					'amount' => $amount,
 				]);
 			} else {
 				$db->delete('ship_has_cargo', [
 					...$this->SQLID,
-					'good_id' => $db->escapeNumber($id),
+					'good_id' => $id,
 				]);
 				// Unset now to omit displaying this good with 0 amount
 				// before the next page is loaded.
@@ -158,13 +158,13 @@ class Ship extends AbstractShip {
 			if ($amount > 0) {
 				$db->replace('ship_has_hardware', [
 					...$this->SQLID,
-					'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
-					'amount' => $db->escapeNumber($amount),
+					'hardware_type_id' => $hardwareTypeID,
+					'amount' => $amount,
 				]);
 			} else {
 				$db->delete('ship_has_hardware', [
 					...$this->SQLID,
-					'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
+					'hardware_type_id' => $hardwareTypeID,
 				]);
 			}
 		}
@@ -181,8 +181,8 @@ class Ship extends AbstractShip {
 		foreach ($this->weapons as $orderID => $weapon) {
 			$db->insert('ship_has_weapon', [
 				...$this->SQLID,
-				'order_id' => $db->escapeNumber($orderID),
-				'weapon_type_id' => $db->escapeNumber($weapon->getWeaponTypeID()),
+				'order_id' => $orderID,
+				'weapon_type_id' => $weapon->getWeaponTypeID(),
 				'bonus_accuracy' => $db->escapeBoolean($weapon->hasBonusAccuracy()),
 				'bonus_damage' => $db->escapeBoolean($weapon->hasBonusDamage()),
 			]);
@@ -240,9 +240,9 @@ class Ship extends AbstractShip {
 		} else {
 			$db->replace('ship_has_illusion', [
 				...$this->SQLID,
-				'ship_type_id' => $db->escapeNumber($this->illusionShip->shipTypeID),
-				'attack' => $db->escapeNumber($this->illusionShip->attackRating),
-				'defense' => $db->escapeNumber($this->illusionShip->defenseRating),
+				'ship_type_id' => $this->illusionShip->shipTypeID,
+				'attack' => $this->illusionShip->attackRating,
+				'defense' => $this->illusionShip->defenseRating,
 			]);
 		}
 		$this->hasChangedIllusion = false;

--- a/src/lib/Smr/Ship.php
+++ b/src/lib/Smr/Ship.php
@@ -13,7 +13,9 @@ class Ship extends AbstractShip {
 	/** @var array<int, array<int, self>> */
 	protected static array $CACHE_SHIPS = [];
 
-	protected readonly string $SQL;
+	public const SQL = 'account_id = :account_id AND game_id = :game_id';
+	/** @var array{account_id: int, game_id: int} */
+	public readonly array $SQLID;
 
 	public static function clearCache(): void {
 		self::$CACHE_SHIPS = [];
@@ -38,7 +40,10 @@ class Ship extends AbstractShip {
 	protected function __construct(AbstractPlayer $player) {
 		parent::__construct($player);
 		$db = Database::getInstance();
-		$this->SQL = 'account_id=' . $db->escapeNumber($this->getAccountID()) . ' AND game_id=' . $db->escapeNumber($this->getGameID());
+		$this->SQLID = [
+			'account_id' => $db->escapeNumber($this->getAccountID()),
+			'game_id' => $db->escapeNumber($this->getGameID()),
+		];
 
 		$this->loadHardware();
 		$this->loadWeapons();
@@ -64,8 +69,11 @@ class Ship extends AbstractShip {
 		// determine weapon
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM ship_has_weapon JOIN weapon_type USING (weapon_type_id)
-							WHERE ' . $this->SQL . '
-							ORDER BY order_id LIMIT ' . $db->escapeNumber($this->getHardpoints()));
+							WHERE ' . self::SQL . '
+							ORDER BY order_id LIMIT :limit', [
+			...$this->SQLID,
+			'limit' => $db->escapeNumber($this->getHardpoints()),
+		]);
 
 		$this->weapons = [];
 		// generate list of weapon names the user transports
@@ -88,7 +96,7 @@ class Ship extends AbstractShip {
 		$dbResult = $db->read('SELECT *
 							FROM ship_has_hardware
 							JOIN hardware_type USING(hardware_type_id)
-							WHERE ' . $this->SQL);
+							WHERE ' . self::SQL, $this->SQLID);
 
 		foreach ($dbResult->records() as $dbRecord) {
 			$hardwareTypeID = $dbRecord->getInt('hardware_type_id');
@@ -105,7 +113,7 @@ class Ship extends AbstractShip {
 
 		// get cargo from db
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM ship_has_cargo WHERE ' . $this->SQL);
+		$dbResult = $db->read('SELECT * FROM ship_has_cargo WHERE ' . self::SQL, $this->SQLID);
 		foreach ($dbResult->records() as $dbRecord) {
 			// adding cargo and amount to array
 			$this->cargo[$dbRecord->getInt('good_id')] = $dbRecord->getInt('amount');
@@ -122,13 +130,15 @@ class Ship extends AbstractShip {
 		foreach ($this->getCargo() as $id => $amount) {
 			if ($amount > 0) {
 				$db->replace('ship_has_cargo', [
-					'account_id' => $db->escapeNumber($this->getAccountID()),
-					'game_id' => $db->escapeNumber($this->getGameID()),
+					...$this->SQLID,
 					'good_id' => $db->escapeNumber($id),
 					'amount' => $db->escapeNumber($amount),
 				]);
 			} else {
-				$db->write('DELETE FROM ship_has_cargo WHERE ' . $this->SQL . ' AND good_id = ' . $db->escapeNumber($id));
+				$db->write('DELETE FROM ship_has_cargo WHERE ' . self::SQL . ' AND good_id = :good_id', [
+					...$this->SQLID,
+					'good_id' => $db->escapeNumber($id),
+				]);
 				// Unset now to omit displaying this good with 0 amount
 				// before the next page is loaded.
 				unset($this->cargo[$id]);
@@ -147,13 +157,15 @@ class Ship extends AbstractShip {
 			$amount = $this->getHardware($hardwareTypeID);
 			if ($amount > 0) {
 				$db->replace('ship_has_hardware', [
-					'account_id' => $db->escapeNumber($this->getAccountID()),
-					'game_id' => $db->escapeNumber($this->getGameID()),
+					...$this->SQLID,
 					'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
 					'amount' => $db->escapeNumber($amount),
 				]);
 			} else {
-				$db->write('DELETE FROM ship_has_hardware WHERE ' . $this->SQL . ' AND hardware_type_id = ' . $db->escapeNumber($hardwareTypeID));
+				$db->write('DELETE FROM ship_has_hardware WHERE ' . self::SQL . ' AND hardware_type_id = :hardware_type_id', [
+					...$this->SQLID,
+					'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
+				]);
 			}
 		}
 		$this->hasChangedHardware = [];
@@ -165,11 +177,10 @@ class Ship extends AbstractShip {
 		}
 		// write weapon info
 		$db = Database::getInstance();
-		$db->write('DELETE FROM ship_has_weapon WHERE ' . $this->SQL);
+		$db->write('DELETE FROM ship_has_weapon WHERE ' . self::SQL, $this->SQLID);
 		foreach ($this->weapons as $orderID => $weapon) {
 			$db->insert('ship_has_weapon', [
-				'account_id' => $db->escapeNumber($this->getAccountID()),
-				'game_id' => $db->escapeNumber($this->getGameID()),
+				...$this->SQLID,
 				'order_id' => $db->escapeNumber($orderID),
 				'weapon_type_id' => $db->escapeNumber($weapon->getWeaponTypeID()),
 				'bonus_accuracy' => $db->escapeBoolean($weapon->hasBonusAccuracy()),
@@ -185,7 +196,7 @@ class Ship extends AbstractShip {
 			return;
 		}
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM ship_is_cloaked WHERE ' . $this->SQL);
+		$dbResult = $db->read('SELECT 1 FROM ship_is_cloaked WHERE ' . self::SQL, $this->SQLID);
 		$this->isCloaked = $dbResult->hasRecord();
 	}
 
@@ -195,12 +206,9 @@ class Ship extends AbstractShip {
 		}
 		$db = Database::getInstance();
 		if ($this->isCloaked === false) {
-			$db->write('DELETE FROM ship_is_cloaked WHERE ' . $this->SQL);
+			$db->write('DELETE FROM ship_is_cloaked WHERE ' . self::SQL, $this->SQLID);
 		} else {
-			$db->insert('ship_is_cloaked', [
-				'account_id' => $db->escapeNumber($this->getAccountID()),
-				'game_id' => $db->escapeNumber($this->getGameID()),
-			]);
+			$db->insert('ship_is_cloaked', $this->SQLID);
 		}
 		$this->hasChangedCloak = false;
 	}
@@ -211,7 +219,7 @@ class Ship extends AbstractShip {
 			return;
 		}
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM ship_has_illusion WHERE ' . $this->SQL);
+		$dbResult = $db->read('SELECT * FROM ship_has_illusion WHERE ' . self::SQL, $this->SQLID);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			$this->illusionShip = new ShipIllusion(
@@ -228,11 +236,10 @@ class Ship extends AbstractShip {
 		}
 		$db = Database::getInstance();
 		if ($this->illusionShip === false) {
-			$db->write('DELETE FROM ship_has_illusion WHERE ' . $this->SQL);
+			$db->write('DELETE FROM ship_has_illusion WHERE ' . self::SQL, $this->SQLID);
 		} else {
 			$db->replace('ship_has_illusion', [
-				'account_id' => $db->escapeNumber($this->getAccountID()),
-				'game_id' => $db->escapeNumber($this->getGameID()),
+				...$this->SQLID,
 				'ship_type_id' => $db->escapeNumber($this->illusionShip->shipTypeID),
 				'attack' => $db->escapeNumber($this->illusionShip->attackRating),
 				'defense' => $db->escapeNumber($this->illusionShip->defenseRating),

--- a/src/lib/Smr/Ship.php
+++ b/src/lib/Smr/Ship.php
@@ -135,7 +135,7 @@ class Ship extends AbstractShip {
 					'amount' => $db->escapeNumber($amount),
 				]);
 			} else {
-				$db->write('DELETE FROM ship_has_cargo WHERE ' . self::SQL . ' AND good_id = :good_id', [
+				$db->delete('ship_has_cargo', [
 					...$this->SQLID,
 					'good_id' => $db->escapeNumber($id),
 				]);
@@ -162,7 +162,7 @@ class Ship extends AbstractShip {
 					'amount' => $db->escapeNumber($amount),
 				]);
 			} else {
-				$db->write('DELETE FROM ship_has_hardware WHERE ' . self::SQL . ' AND hardware_type_id = :hardware_type_id', [
+				$db->delete('ship_has_hardware', [
 					...$this->SQLID,
 					'hardware_type_id' => $db->escapeNumber($hardwareTypeID),
 				]);
@@ -177,7 +177,7 @@ class Ship extends AbstractShip {
 		}
 		// write weapon info
 		$db = Database::getInstance();
-		$db->write('DELETE FROM ship_has_weapon WHERE ' . self::SQL, $this->SQLID);
+		$db->delete('ship_has_weapon', $this->SQLID);
 		foreach ($this->weapons as $orderID => $weapon) {
 			$db->insert('ship_has_weapon', [
 				...$this->SQLID,
@@ -206,7 +206,7 @@ class Ship extends AbstractShip {
 		}
 		$db = Database::getInstance();
 		if ($this->isCloaked === false) {
-			$db->write('DELETE FROM ship_is_cloaked WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('ship_is_cloaked', $this->SQLID);
 		} else {
 			$db->insert('ship_is_cloaked', $this->SQLID);
 		}
@@ -236,7 +236,7 @@ class Ship extends AbstractShip {
 		}
 		$db = Database::getInstance();
 		if ($this->illusionShip === false) {
-			$db->write('DELETE FROM ship_has_illusion WHERE ' . self::SQL, $this->SQLID);
+			$db->delete('ship_has_illusion', $this->SQLID);
 		} else {
 			$db->replace('ship_has_illusion', [
 				...$this->SQLID,

--- a/src/lib/Smr/ShipType.php
+++ b/src/lib/Smr/ShipType.php
@@ -36,7 +36,9 @@ class ShipType {
 		if (!isset(self::$CACHE_SHIP_TYPES[$shipTypeID])) {
 			if ($dbRecord === null) {
 				$db = Database::getInstance();
-				$dbResult = $db->read('SELECT * FROM ship_type WHERE ship_type_id = ' . $db->escapeNumber($shipTypeID));
+				$dbResult = $db->read('SELECT * FROM ship_type WHERE ship_type_id = :ship_type_id', [
+					'ship_type_id' => $db->escapeNumber($shipTypeID),
+				]);
 				$dbRecord = $dbResult->record();
 			} elseif ($shipTypeID !== $dbRecord->getInt('ship_type_id')) {
 				throw new Exception('Database result mismatch');
@@ -88,8 +90,10 @@ class ShipType {
 
 		// get supported hardware from db
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT hardware_type_id, max_amount FROM ship_type_support_hardware ' .
-			'WHERE ship_type_id = ' . $db->escapeNumber($this->typeID) . ' ORDER BY hardware_type_id');
+		$dbResult = $db->read('SELECT hardware_type_id, max_amount FROM ship_type_support_hardware
+			WHERE ship_type_id = :ship_type_id ORDER BY hardware_type_id', [
+			'ship_type_id' => $db->escapeNumber($this->typeID),
+		]);
 
 		$maxHardware = [];
 		foreach ($dbResult->records() as $dbRecord2) {

--- a/src/lib/Smr/VoteLink.php
+++ b/src/lib/Smr/VoteLink.php
@@ -101,9 +101,9 @@ class VoteLink {
 
 			// Don't start the timeout until the vote actually goes through.
 			$db->replace('vote_links', [
-				'account_id' => $db->escapeNumber($this->accountID),
-				'link_id' => $db->escapeNumber($this->site->value),
-				'timeout' => $db->escapeNumber(0),
+				'account_id' => $this->accountID,
+				'link_id' => $this->site->value,
+				'timeout' => 0,
 				'turns_claimed' => $db->escapeBoolean(false),
 			]);
 		} finally {
@@ -125,8 +125,8 @@ class VoteLink {
 				'turns_claimed' => 'TRUE',
 			],
 			[
-				'account_id' => $db->escapeNumber($this->accountID),
-				'link_id' => $db->escapeNumber($this->site->value),
+				'account_id' => $this->accountID,
+				'link_id' => $this->site->value,
 				'timeout' => 0,
 				'turns_claimed' => 'FALSE',
 			],

--- a/src/lib/Smr/VoteLink.php
+++ b/src/lib/Smr/VoteLink.php
@@ -70,7 +70,9 @@ class VoteLink {
 		if ($forceUpdate || !isset(self::$CACHE_TIMEOUTS)) {
 			self::$CACHE_TIMEOUTS = []; // ensure this is set
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT link_id, timeout FROM vote_links WHERE account_id=' . $db->escapeNumber($this->accountID));
+			$dbResult = $db->read('SELECT link_id, timeout FROM vote_links WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($this->accountID),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				// 'timeout' is the last time the player claimed free turns (or 0, if unclaimed)
 				self::$CACHE_TIMEOUTS[$dbRecord->getInt('link_id')] = $dbRecord->getInt('timeout');
@@ -116,8 +118,12 @@ class VoteLink {
 	 */
 	public function setFreeTurnsAwarded(): bool {
 		$db = Database::getInstance();
-		$db->write('UPDATE vote_links SET timeout = ' . Epoch::time() . ', turns_claimed = ' . $db->escapeBoolean(true) . ' WHERE account_id = ' . $db->escapeNumber($this->accountID) . ' AND link_id = ' . $db->escapeNumber($this->site->value) . ' AND timeout = 0 AND turns_claimed = ' . $db->escapeBoolean(false));
-		return $db->getChangedRows() === 1;
+		$changedRows = $db->write('UPDATE vote_links SET timeout = :now, turns_claimed = \'TRUE\' WHERE account_id = :account_id AND link_id = :link_id AND timeout = 0 AND turns_claimed = \'FALSE\'', [
+			'now' => Epoch::time(),
+			'account_id' => $db->escapeNumber($this->accountID),
+			'link_id' => $db->escapeNumber($this->site->value),
+		]);
+		return $changedRows === 1;
 	}
 
 	/**

--- a/src/lib/Smr/VoteLink.php
+++ b/src/lib/Smr/VoteLink.php
@@ -118,11 +118,19 @@ class VoteLink {
 	 */
 	public function setFreeTurnsAwarded(): bool {
 		$db = Database::getInstance();
-		$changedRows = $db->write('UPDATE vote_links SET timeout = :now, turns_claimed = \'TRUE\' WHERE account_id = :account_id AND link_id = :link_id AND timeout = 0 AND turns_claimed = \'FALSE\'', [
-			'now' => Epoch::time(),
-			'account_id' => $db->escapeNumber($this->accountID),
-			'link_id' => $db->escapeNumber($this->site->value),
-		]);
+		$changedRows = $db->update(
+			'vote_links',
+			[
+				'timeout' => Epoch::time(),
+				'turns_claimed' => 'TRUE',
+			],
+			[
+				'account_id' => $db->escapeNumber($this->accountID),
+				'link_id' => $db->escapeNumber($this->site->value),
+				'timeout' => 0,
+				'turns_claimed' => 'FALSE',
+			],
+		);
 		return $changedRows === 1;
 	}
 

--- a/src/lib/Smr/WeaponType.php
+++ b/src/lib/Smr/WeaponType.php
@@ -26,7 +26,9 @@ class WeaponType {
 		if (!isset(self::$CACHE_WEAPON_TYPES[$weaponTypeID])) {
 			if ($dbRecord === null) {
 				$db = Database::getInstance();
-				$dbResult = $db->read('SELECT * FROM weapon_type WHERE weapon_type_id = ' . $db->escapeNumber($weaponTypeID));
+				$dbResult = $db->read('SELECT * FROM weapon_type WHERE weapon_type_id = :weapon_type_id', [
+					'weapon_type_id' => $db->escapeNumber($weaponTypeID),
+				]);
 				$dbRecord = $dbResult->record();
 			}
 			$weapon = new self($weaponTypeID, $dbRecord);
@@ -56,7 +58,9 @@ class WeaponType {
 	 */
 	public static function getAllSoldWeaponTypes(int $gameID): array {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT DISTINCT weapon_type.* FROM weapon_type JOIN location_sells_weapons USING (weapon_type_id) JOIN location USING (location_type_id) WHERE game_id = ' . $db->escapeNumber($gameID));
+		$dbResult = $db->read('SELECT DISTINCT weapon_type.* FROM weapon_type JOIN location_sells_weapons USING (weapon_type_id) JOIN location USING (location_type_id) WHERE game_id = :game_id', [
+			'game_id' => $db->escapeNumber($gameID),
+		]);
 		$weapons = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$weaponTypeID = $dbRecord->getInt('weapon_type_id');

--- a/src/lib/Smr/WeightedRandom.php
+++ b/src/lib/Smr/WeightedRandom.php
@@ -53,7 +53,12 @@ class WeightedRandom {
 		protected readonly int $typeID
 	) {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT weighting FROM weighted_random WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND account_id = ' . $db->escapeNumber($accountID) . ' AND type = ' . $db->escapeString($type) . ' AND type_id = ' . $db->escapeNumber($typeID));
+		$dbResult = $db->read('SELECT weighting FROM weighted_random WHERE game_id = :game_id AND account_id = :account_id AND type = :type AND type_id = :type_id', [
+			'game_id' => $db->escapeNumber($gameID),
+			'account_id' => $db->escapeNumber($accountID),
+			'type' => $db->escapeString($type),
+			'type_id' => $db->escapeNumber($typeID),
+		]);
 		if ($dbResult->hasRecord()) {
 			$this->weighting = $dbResult->record()->getInt('weighting');
 		} else {

--- a/src/lib/Smr/WeightedRandom.php
+++ b/src/lib/Smr/WeightedRandom.php
@@ -113,11 +113,11 @@ class WeightedRandom {
 		if ($this->hasChanged === true) {
 			$db = Database::getInstance();
 			$db->replace('weighted_random', [
-				'game_id' => $db->escapeNumber($this->getGameID()),
-				'account_id' => $db->escapeNumber($this->getAccountID()),
-				'type' => $db->escapeString($this->getType()),
-				'type_id' => $db->escapeNumber($this->getTypeID()),
-				'weighting' => $db->escapeNumber($this->getWeighting()),
+				'game_id' => $this->getGameID(),
+				'account_id' => $this->getAccountID(),
+				'type' => $this->getType(),
+				'type_id' => $this->getTypeID(),
+				'weighting' => $this->getWeighting(),
 			]);
 			$this->hasChanged = false;
 		}

--- a/src/lib/Smr/WeightedRandom.php
+++ b/src/lib/Smr/WeightedRandom.php
@@ -60,7 +60,7 @@ class WeightedRandom {
 			'type_id' => $db->escapeNumber($typeID),
 		]);
 		if ($dbResult->hasRecord()) {
-			$this->weighting = $dbResult->record()->getInt('weighting');
+			$this->weighting = $dbResult->record()->getFloat('weighting');
 		} else {
 			$this->weighting = 0;
 		}

--- a/src/pages/Account/AlbumDeleteProcessor.php
+++ b/src/pages/Account/AlbumDeleteProcessor.php
@@ -12,15 +12,11 @@ class AlbumDeleteProcessor extends AccountPageProcessor {
 	public function build(Account $account): never {
 		if (Request::getBool('action')) {
 			$db = Database::getInstance();
-			$db->write('DELETE
-						FROM album
-						WHERE account_id = :account_id', [
+			$db->delete('album', [
 				'account_id' => $db->escapeNumber($account->getAccountID()),
 			]);
 
-			$db->write('DELETE
-						FROM album_has_comments
-						WHERE album_id = :album_id', [
+			$db->delete('album_has_comments', [
 				'album_id' => $db->escapeNumber($account->getAccountID()),
 			]);
 		}

--- a/src/pages/Account/AlbumDeleteProcessor.php
+++ b/src/pages/Account/AlbumDeleteProcessor.php
@@ -13,11 +13,11 @@ class AlbumDeleteProcessor extends AccountPageProcessor {
 		if (Request::getBool('action')) {
 			$db = Database::getInstance();
 			$db->delete('album', [
-				'account_id' => $db->escapeNumber($account->getAccountID()),
+				'account_id' => $account->getAccountID(),
 			]);
 
 			$db->delete('album_has_comments', [
-				'album_id' => $db->escapeNumber($account->getAccountID()),
+				'album_id' => $account->getAccountID(),
 			]);
 		}
 

--- a/src/pages/Account/AlbumDeleteProcessor.php
+++ b/src/pages/Account/AlbumDeleteProcessor.php
@@ -14,11 +14,15 @@ class AlbumDeleteProcessor extends AccountPageProcessor {
 			$db = Database::getInstance();
 			$db->write('DELETE
 						FROM album
-						WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+						WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($account->getAccountID()),
+			]);
 
 			$db->write('DELETE
 						FROM album_has_comments
-						WHERE album_id = ' . $db->escapeNumber($account->getAccountID()));
+						WHERE album_id = :album_id', [
+				'album_id' => $db->escapeNumber($account->getAccountID()),
+			]);
 		}
 
 		$container = new AlbumEdit();

--- a/src/pages/Account/AlbumEdit.php
+++ b/src/pages/Account/AlbumEdit.php
@@ -22,7 +22,9 @@ class AlbumEdit extends AccountPage {
 		$template->assign('PageTopic', 'Edit Photo');
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+		$dbResult = $db->read('SELECT * FROM album WHERE account_id = :account_id', [
+			'account_id' => $db->escapeNumber($account->getAccountID()),
+		]);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			$day = $dbRecord->getInt('day');

--- a/src/pages/Account/AlbumEditProcessor.php
+++ b/src/pages/Account/AlbumEditProcessor.php
@@ -103,16 +103,16 @@ class AlbumEditProcessor extends AccountPageProcessor {
 				[
 					'approved' => 'TBC',
 					'disabled' => 'FALSE',
-					'location' => $db->escapeString($location),
-					'email' => $db->escapeString($email),
-					'website' => $db->escapeString($website),
-					'day' => $db->escapeNumber($day),
-					'month' => $db->escapeNumber($month),
-					'year' => $db->escapeNumber($year),
-					'other' => $db->escapeString($other),
-					'last_changed' => $db->escapeNumber(Epoch::time()),
+					'location' => $location,
+					'email' => $email,
+					'website' => $website,
+					'day' => $day,
+					'month' => $month,
+					'year' => $year,
+					'other' => $other,
+					'last_changed' => Epoch::time(),
 				],
-				['account_id' => $db->escapeNumber($account->getAccountID())],
+				['account_id' => $account->getAccountID()],
 			);
 		} else {
 			// if he didn't upload a picture before
@@ -125,17 +125,17 @@ class AlbumEditProcessor extends AccountPageProcessor {
 
 			// add album entry
 			$db->insert('album', [
-				'account_id' => $db->escapeNumber($account->getAccountID()),
-				'location' => $db->escapeString($location),
-				'email' => $db->escapeString($email),
-				'website' => $db->escapeString($website),
-				'day' => $db->escapeNumber($day),
-				'month' => $db->escapeNumber($month),
-				'year' => $db->escapeNumber($year),
-				'other' => $db->escapeString($other),
-				'created' => $db->escapeNumber(Epoch::time()),
-				'last_changed' => $db->escapeNumber(Epoch::time()),
-				'approved' => $db->escapeString('TBC'),
+				'account_id' => $account->getAccountID(),
+				'location' => $location,
+				'email' => $email,
+				'website' => $website,
+				'day' => $day,
+				'month' => $month,
+				'year' => $year,
+				'other' => $other,
+				'created' => Epoch::time(),
+				'last_changed' => Epoch::time(),
+				'approved' => 'TBC',
 			]);
 		}
 
@@ -149,11 +149,11 @@ class AlbumEditProcessor extends AccountPageProcessor {
 			$comment_id = $dbResult->record()->getInt('next_comment_id');
 
 			$db->insert('album_has_comments', [
-				'album_id' => $db->escapeNumber($account->getAccountID()),
-				'comment_id' => $db->escapeNumber($comment_id),
-				'time' => $db->escapeNumber(Epoch::time()),
+				'album_id' => $account->getAccountID(),
+				'comment_id' => $comment_id,
+				'time' => Epoch::time(),
 				'post_id' => 0,
-				'msg' => $db->escapeString($comment),
+				'msg' => $comment,
 			]);
 			$db->unlock();
 		}

--- a/src/pages/Account/AlbumEditProcessor.php
+++ b/src/pages/Account/AlbumEditProcessor.php
@@ -89,7 +89,9 @@ class AlbumEditProcessor extends AccountPageProcessor {
 
 		// check if we had a album entry so far
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM album WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+		$dbResult = $db->read('SELECT 1 FROM album WHERE account_id = :account_id', [
+			'account_id' => $db->escapeNumber($account->getAccountID()),
+		]);
 		if ($dbResult->hasRecord()) {
 			if (!$noPicture) {
 				$comment = '<span class="green">*** Picture changed</span>';
@@ -97,17 +99,27 @@ class AlbumEditProcessor extends AccountPageProcessor {
 
 			// change album entry
 			$db->write('UPDATE album
-						SET location = ' . $db->escapeString($location) . ',
-							email = ' . $db->escapeString($email) . ',
-							website= ' . $db->escapeString($website) . ',
-							day = ' . $db->escapeNumber($day) . ',
-							month = ' . $db->escapeNumber($month) . ',
-							year = ' . $db->escapeNumber($year) . ',
-							other = ' . $db->escapeString($other) . ',
-							last_changed = ' . $db->escapeNumber(Epoch::time()) . ',
+						SET location = :location,
+							email = :email,
+							website = :website,
+							day = :day,
+							month = :month,
+							year = :year,
+							other = :other,
+							last_changed = :last_changed,
 							approved = \'TBC\',
 							disabled = \'FALSE\'
-						WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+						WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($account->getAccountID()),
+				'location' => $db->escapeString($location),
+				'email' => $db->escapeString($email),
+				'website' => $db->escapeString($website),
+				'day' => $db->escapeNumber($day),
+				'month' => $db->escapeNumber($month),
+				'year' => $db->escapeNumber($year),
+				'other' => $db->escapeString($other),
+				'last_changed' => $db->escapeNumber(Epoch::time()),
+			]);
 		} else {
 			// if he didn't upload a picture before
 			// we kick him out here
@@ -137,7 +149,9 @@ class AlbumEditProcessor extends AccountPageProcessor {
 			// check if we have comments for this album already
 			$db->lockTable('album_has_comments');
 
-			$dbResult = $db->read('SELECT IFNULL(MAX(comment_id)+1, 0) AS next_comment_id FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($account->getAccountID()));
+			$dbResult = $db->read('SELECT IFNULL(MAX(comment_id)+1, 0) AS next_comment_id FROM album_has_comments WHERE album_id = :album_id', [
+				'album_id' => $db->escapeNumber($account->getAccountID()),
+			]);
 			$comment_id = $dbResult->record()->getInt('next_comment_id');
 
 			$db->insert('album_has_comments', [

--- a/src/pages/Account/AlbumEditProcessor.php
+++ b/src/pages/Account/AlbumEditProcessor.php
@@ -98,28 +98,22 @@ class AlbumEditProcessor extends AccountPageProcessor {
 			}
 
 			// change album entry
-			$db->write('UPDATE album
-						SET location = :location,
-							email = :email,
-							website = :website,
-							day = :day,
-							month = :month,
-							year = :year,
-							other = :other,
-							last_changed = :last_changed,
-							approved = \'TBC\',
-							disabled = \'FALSE\'
-						WHERE account_id = :account_id', [
-				'account_id' => $db->escapeNumber($account->getAccountID()),
-				'location' => $db->escapeString($location),
-				'email' => $db->escapeString($email),
-				'website' => $db->escapeString($website),
-				'day' => $db->escapeNumber($day),
-				'month' => $db->escapeNumber($month),
-				'year' => $db->escapeNumber($year),
-				'other' => $db->escapeString($other),
-				'last_changed' => $db->escapeNumber(Epoch::time()),
-			]);
+			$db->update(
+				'album',
+				[
+					'approved' => 'TBC',
+					'disabled' => 'FALSE',
+					'location' => $db->escapeString($location),
+					'email' => $db->escapeString($email),
+					'website' => $db->escapeString($website),
+					'day' => $db->escapeNumber($day),
+					'month' => $db->escapeNumber($month),
+					'year' => $db->escapeNumber($year),
+					'other' => $db->escapeString($other),
+					'last_changed' => $db->escapeNumber(Epoch::time()),
+				],
+				['account_id' => $db->escapeNumber($account->getAccountID())],
+			);
 		} else {
 			// if he didn't upload a picture before
 			// we kick him out here

--- a/src/pages/Account/ChangelogView.php
+++ b/src/pages/Account/ChangelogView.php
@@ -30,8 +30,10 @@ class ChangelogView extends AccountPage {
 
 		$dbResult = $db->read('SELECT *
 					FROM version
-					WHERE went_live > ' . $db->escapeNumber($this->lastLogin ?? 0) . '
-					ORDER BY version_id DESC');
+					WHERE went_live > :last_login
+					ORDER BY version_id DESC', [
+			'last_login' => $db->escapeNumber($this->lastLogin ?? 0),
+		]);
 
 		$versions = [];
 		foreach ($dbResult->records() as $dbRecord) {
@@ -48,8 +50,10 @@ class ChangelogView extends AccountPage {
 
 			$dbResult2 = $db->read('SELECT *
 						FROM changelog
-						WHERE version_id = ' . $db->escapeNumber($version_id) . '
-						ORDER BY changelog_id');
+						WHERE version_id = :version_id
+						ORDER BY changelog_id', [
+				'version_id' => $db->escapeNumber($version_id),
+			]);
 			$changes = [];
 			foreach ($dbResult2->records() as $dbRecord2) {
 				$changes[] = [

--- a/src/pages/Account/Donation.php
+++ b/src/pages/Account/Donation.php
@@ -18,7 +18,9 @@ class Donation extends AccountPage {
 	public function build(Account $account, Template $template): void {
 		$template->assign('PageTopic', 'Donations');
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT IFNULL(SUM(amount), 0) as total_donation FROM account_donated WHERE time > ' . $db->escapeNumber(Epoch::time()) . ' - (86400 * 90)');
+		$dbResult = $db->read('SELECT IFNULL(SUM(amount), 0) as total_donation FROM account_donated WHERE time > :hide_donation_time', [
+			'hide_donation_time' => $db->escapeNumber(Epoch::time() - (86400 * 90)), // 90 days
+		]);
 		$template->assign('TotalDonation', $dbResult->record()->getInt('total_donation'));
 	}
 

--- a/src/pages/Account/FeatureRequestCommentProcessor.php
+++ b/src/pages/Account/FeatureRequestCommentProcessor.php
@@ -24,11 +24,11 @@ class FeatureRequestCommentProcessor extends AccountPageProcessor {
 		// add this feature comment
 		$db = Database::getInstance();
 		$db->insert('feature_request_comments', [
-			'feature_request_id' => $db->escapeNumber($this->featureRequestID),
-			'poster_id' => $db->escapeNumber($account->getAccountID()),
-			'posting_time' => $db->escapeNumber(Epoch::time()),
+			'feature_request_id' => $this->featureRequestID,
+			'poster_id' => $account->getAccountID(),
+			'posting_time' => Epoch::time(),
 			'anonymous' => $db->escapeBoolean(Request::has('anon')),
-			'text' => $db->escapeString(word_filter($comment)),
+			'text' => word_filter($comment),
 		]);
 
 		$this->previousPage->go();

--- a/src/pages/Account/FeatureRequestComments.php
+++ b/src/pages/Account/FeatureRequestComments.php
@@ -34,8 +34,10 @@ class FeatureRequestComments extends AccountPage {
 		$dbResult = $db->read('SELECT *
 					FROM feature_request
 					JOIN feature_request_comments USING(feature_request_id)
-					WHERE feature_request_id = ' . $db->escapeNumber($this->featureRequestID) . '
-					ORDER BY comment_id ASC');
+					WHERE feature_request_id = :feature_request_id
+					ORDER BY comment_id ASC', [
+			'feature_request_id' => $db->escapeNumber($this->featureRequestID),
+		]);
 		if ($dbResult->hasRecord()) {
 			$featureModerator = $account->hasPermission(PERMISSION_MODERATE_FEATURE_REQUEST);
 			$template->assign('FeatureModerator', $featureModerator);

--- a/src/pages/Account/FeatureRequestProcessor.php
+++ b/src/pages/Account/FeatureRequestProcessor.php
@@ -23,18 +23,18 @@ class FeatureRequestProcessor extends AccountPageProcessor {
 		$db = Database::getInstance();
 		$featureRequestID = $db->insert('feature_request', []);
 		$db->insert('feature_request_comments', [
-			'feature_request_id' => $db->escapeNumber($featureRequestID),
-			'poster_id' => $db->escapeNumber($account->getAccountID()),
-			'posting_time' => $db->escapeNumber(Epoch::time()),
+			'feature_request_id' => $featureRequestID,
+			'poster_id' => $account->getAccountID(),
+			'posting_time' => Epoch::time(),
 			'anonymous' => $db->escapeBoolean(Request::has('anon')),
-			'text' => $db->escapeString(word_filter($feature)),
+			'text' => word_filter($feature),
 		]);
 
 		// vote for this feature
 		$db->insert('account_votes_for_feature', [
-			'account_id' => $db->escapeNumber($account->getAccountID()),
-			'feature_request_id' => $db->escapeNumber($featureRequestID),
-			'vote_type' => $db->escapeString('YES'),
+			'account_id' => $account->getAccountID(),
+			'feature_request_id' => $featureRequestID,
+			'vote_type' => 'YES',
 		]);
 
 		(new FeatureRequest())->go();

--- a/src/pages/Account/FeatureRequestVoteProcessor.php
+++ b/src/pages/Account/FeatureRequestVoteProcessor.php
@@ -25,17 +25,17 @@ class FeatureRequestVoteProcessor extends AccountPageProcessor {
 			if (Request::has('vote')) {
 				foreach (Request::getArray('vote') as $requestID => $vote) {
 					$db->replace('account_votes_for_feature', [
-						'account_id' => $db->escapeNumber($account->getAccountID()),
-						'feature_request_id' => $db->escapeNumber($requestID),
-						'vote_type' => $db->escapeString($vote),
+						'account_id' => $account->getAccountID(),
+						'feature_request_id' => $requestID,
+						'vote_type' => $vote,
 					]);
 				}
 			}
 			if (Request::has('favourite')) {
 				$db->replace('account_votes_for_feature', [
-					'account_id' => $db->escapeNumber($account->getAccountID()),
-					'feature_request_id' => $db->escapeNumber(Request::getInt('favourite')),
-					'vote_type' => $db->escapeString('FAVOURITE'),
+					'account_id' => $account->getAccountID(),
+					'feature_request_id' => Request::getInt('favourite'),
+					'vote_type' => 'FAVOURITE',
 				]);
 			}
 
@@ -80,11 +80,11 @@ class FeatureRequestVoteProcessor extends AccountPageProcessor {
 			]);
 			foreach ($setStatusIDs as $featureID) {
 				$db->insert('feature_request_comments', [
-					'feature_request_id' => $db->escapeNumber($featureID),
-					'poster_id' => $db->escapeNumber($account->getAccountID()),
-					'posting_time' => $db->escapeNumber(Epoch::time()),
+					'feature_request_id' => $featureID,
+					'poster_id' => $account->getAccountID(),
+					'posting_time' => Epoch::time(),
 					'anonymous' => $db->escapeBoolean(false),
-					'text' => $db->escapeString($status),
+					'text' => $status,
 				]);
 			}
 		}

--- a/src/pages/Account/GameJoin.php
+++ b/src/pages/Account/GameJoin.php
@@ -48,7 +48,10 @@ class GameJoin extends AccountPage {
 		$db = Database::getInstance();
 		foreach ($game->getPlayableRaceIDs() as $raceID) {
 			// get number of traders in game
-			$dbResult = $db->read('SELECT count(*) as number_of_race FROM player WHERE race_id = ' . $db->escapeNumber($raceID) . ' AND game_id = ' . $db->escapeNumber($this->gameID));
+			$dbResult = $db->read('SELECT count(*) as number_of_race FROM player WHERE race_id = :race_id AND game_id = :game_id', [
+				'race_id' => $db->escapeNumber($raceID),
+				'game_id' => $db->escapeNumber($this->gameID),
+			]);
 
 			$races[$raceID] = [
 				'Name' => Race::getName($raceID),

--- a/src/pages/Account/GameJoinProcessor.php
+++ b/src/pages/Account/GameJoinProcessor.php
@@ -67,8 +67,11 @@ class GameJoinProcessor extends AccountPageProcessor {
 		// all sectors are visited (the majority of the game), the table is empty.
 		$db = Database::getInstance();
 		$db->write('INSERT INTO player_visited_sector (account_id, game_id, sector_id)
-		            SELECT ' . $db->escapeNumber($account->getAccountID()) . ', game_id, sector_id
-		              FROM sector WHERE game_id = ' . $db->escapeNumber($gameID));
+		            SELECT :account_id, game_id, sector_id
+		              FROM sector WHERE game_id = :game_id', [
+			'account_id' => $db->escapeNumber($account->getAccountID()),
+			'game_id' => $db->escapeNumber($gameID),
+		]);
 
 		// Mark the player's start sector as visited
 		$player->getSector()->markVisited($player);

--- a/src/pages/Account/GameJoinProcessor.php
+++ b/src/pages/Account/GameJoinProcessor.php
@@ -96,11 +96,11 @@ class GameJoinProcessor extends AccountPageProcessor {
 		// Announce the player joining in the news
 		$news = '[player=' . $player->getPlayerID() . '] has joined the game!';
 		$db->insert('news', [
-			'time' => $db->escapeNumber(Epoch::time()),
-			'news_message' => $db->escapeString($news),
-			'game_id' => $db->escapeNumber($gameID),
-			'type' => $db->escapeString('admin'),
-			'killer_id' => $db->escapeNumber($player->getAccountID()),
+			'time' => Epoch::time(),
+			'news_message' => $news,
+			'game_id' => $gameID,
+			'type' => 'admin',
+			'killer_id' => $player->getAccountID(),
 		]);
 
 		// Send the player directly into the game

--- a/src/pages/Account/GameStats.php
+++ b/src/pages/Account/GameStats.php
@@ -29,7 +29,9 @@ class GameStats extends AccountPage {
 		$template->assign('PageTopic', 'Game Stats: ' . $statsGame->getName() . ' (' . $gameID . ')');
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT count(*) total_players, IFNULL(MAX(experience),0) max_exp, IFNULL(MAX(alignment),0) max_align, IFNULL(MIN(alignment),0) min_align, IFNULL(MAX(kills),0) max_kills FROM player WHERE game_id = ' . $gameID);
+		$dbResult = $db->read('SELECT count(*) total_players, IFNULL(MAX(experience),0) max_exp, IFNULL(MAX(alignment),0) max_align, IFNULL(MIN(alignment),0) min_align, IFNULL(MAX(kills),0) max_kills FROM player WHERE game_id = :game_id', [
+			'game_id' => $gameID,
+		]);
 		$dbRecord = $dbResult->record();
 		$template->assign('TotalPlayers', $dbRecord->getInt('total_players'));
 		$template->assign('HighestExp', $dbRecord->getInt('max_exp'));
@@ -37,7 +39,9 @@ class GameStats extends AccountPage {
 		$template->assign('LowestAlign', $dbRecord->getInt('min_align'));
 		$template->assign('HighestKills', $dbRecord->getInt('max_kills'));
 
-		$dbResult = $db->read('SELECT count(*) num_alliance FROM alliance WHERE game_id = ' . $gameID);
+		$dbResult = $db->read('SELECT count(*) num_alliance FROM alliance WHERE game_id = :game_id', [
+			'game_id' => $gameID,
+		]);
 		$template->assign('TotalAlliances', $dbResult->record()->getInt('num_alliance'));
 
 		// Get current account's player for this game (if any)

--- a/src/pages/Account/HallOfFameAll.php
+++ b/src/pages/Account/HallOfFameAll.php
@@ -68,10 +68,10 @@ class HallOfFameAll extends AccountPage {
 				$dbResult = $db->read('SELECT account_id, SUM(amount) as amount FROM account_donated
 							GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25');
 			} elseif ($viewType == HOF_TYPE_USER_SCORE) {
-				$statements = Account::getUserScoreCaseStatement($db);
+				$statements = Account::getUserScoreCaseStatement();
 				$query = 'SELECT account_id, ' . $statements['CASE'] . ' amount FROM (SELECT account_id, type, SUM(amount) amount FROM player_hof WHERE type IN (:hof_types)' . $gameIDSql . ' GROUP BY account_id,type) x GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25';
 				$dbResult = $db->read($query, [
-					'hof_types' => $statements['IN'],
+					'hof_types' => $db->escapeArray($statements['IN']),
 				]);
 			} else {
 				$dbResult = $db->read('SELECT account_id,SUM(amount) amount FROM player_hof WHERE type = :hof_type ' . $gameIDSql . ' GROUP BY account_id ORDER BY amount DESC, account_id ASC LIMIT 25', [

--- a/src/pages/Account/HistoryGames/AllianceDetail.php
+++ b/src/pages/Account/HistoryGames/AllianceDetail.php
@@ -29,14 +29,20 @@ class AllianceDetail extends HistoryPage {
 		$id = $this->allianceID;
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT alliance_name, leader_id FROM alliance WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($game_id));
+		$dbResult = $db->read('SELECT alliance_name, leader_id FROM alliance WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+			'alliance_id' => $db->escapeNumber($id),
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		$dbRecord = $dbResult->record();
 		$leaderID = $dbRecord->getInt('leader_id');
 		$template->assign('PageTopic', 'Alliance Roster: ' . htmlentities($dbRecord->getString('alliance_name')));
 
 		//get alliance members
 		$oldAccountID = $account->getOldAccountID($this->historyDatabase);
-		$dbResult = $db->read('SELECT * FROM player WHERE alliance_id = ' . $db->escapeNumber($id) . ' AND game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY experience DESC');
+		$dbResult = $db->read('SELECT * FROM player WHERE alliance_id = :alliance_id AND game_id = :game_id ORDER BY experience DESC', [
+			'alliance_id' => $db->escapeNumber($id),
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		$players = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$memberAccountID = $dbRecord->getInt('account_id');

--- a/src/pages/Account/HistoryGames/ExtendedStatsDetail.php
+++ b/src/pages/Account/HistoryGames/ExtendedStatsDetail.php
@@ -35,7 +35,9 @@ class ExtendedStatsDetail extends HistoryPage {
 				'Top Mined Sectors' => ['mines', 'Mines'],
 				'Most Dangerous Sectors' => ['kills', 'Kills'],
 			};
-			$dbResult = $db->read('SELECT ' . $sql . ' as val, sector_id FROM sector WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY val DESC LIMIT 25');
+			$dbResult = $db->read('SELECT ' . $sql . ' as val, sector_id FROM sector WHERE game_id = :game_id ORDER BY val DESC LIMIT 25', [
+				'game_id' => $db->escapeNumber($game_id),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$rankings[] = [
 					'bold' => '',
@@ -52,10 +54,15 @@ class ExtendedStatsDetail extends HistoryPage {
 				'Top Alliance Deaths' => ['deaths', 'Deaths'],
 			};
 			// Determine which alliance this account was in
-			$dbResult = $db->read('SELECT alliance_id FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND account_id = ' . $db->escapeNumber($oldAccountID));
+			$dbResult = $db->read('SELECT alliance_id FROM player WHERE game_id = :game_id AND account_id = :account_id', [
+				'game_id' => $db->escapeNumber($game_id),
+				'account_id' => $db->escapeNumber($oldAccountID),
+			]);
 			$oldAllianceID = $dbResult->hasRecord() ? $dbResult->record()->getInt('alliance_id') : 0;
 			// Get the top 25 alliance ordered by the requested stat
-			$dbResult = $db->read('SELECT alliance_name, alliance_id, ' . $sql . ' as val FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND alliance_id > 0 GROUP BY alliance_id ORDER BY val DESC, alliance_id LIMIT 25');
+			$dbResult = $db->read('SELECT alliance_name, alliance_id, ' . $sql . ' as val FROM alliance WHERE game_id = :game_id AND alliance_id > 0 GROUP BY alliance_id ORDER BY val DESC, alliance_id LIMIT 25', [
+				'game_id' => $db->escapeNumber($game_id),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$allianceID = $dbRecord->getInt('alliance_id');
 				$name = htmlentities($dbRecord->getString('alliance_name'));
@@ -70,7 +77,9 @@ class ExtendedStatsDetail extends HistoryPage {
 			}
 			$headers = ['Alliance', $header];
 		} elseif ($this->category == 'Top Planets') {
-			$dbResult = $db->read('SELECT sector_id, owner_id, IFNULL(player_name, \'Unclaimed\') as player_name, IFNULL(alliance_name, \'None\') as alliance_name, IFNULL(player.alliance_id, 0) as alliance_id, ROUND((turrets + hangers + generators) / 3, 2) as level FROM planet LEFT JOIN player ON planet.owner_id = player.account_id AND planet.game_id = player.game_id LEFT JOIN alliance ON player.alliance_id = alliance.alliance_id AND planet.game_id = alliance.game_id WHERE planet.game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY level DESC LIMIT 25');
+			$dbResult = $db->read('SELECT sector_id, owner_id, IFNULL(player_name, \'Unclaimed\') as player_name, IFNULL(alliance_name, \'None\') as alliance_name, IFNULL(player.alliance_id, 0) as alliance_id, ROUND((turrets + hangers + generators) / 3, 2) as level FROM planet LEFT JOIN player ON planet.owner_id = player.account_id AND planet.game_id = player.game_id LEFT JOIN alliance ON player.alliance_id = alliance.alliance_id AND planet.game_id = alliance.game_id WHERE planet.game_id = :game_id ORDER BY level DESC LIMIT 25', [
+				'game_id' => $db->escapeNumber($game_id),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$ownerID = $dbRecord->getInt('owner_id');
 				$allianceID = $dbRecord->getInt('alliance_id');

--- a/src/pages/Account/HistoryGames/GameNews.php
+++ b/src/pages/Account/HistoryGames/GameNews.php
@@ -23,7 +23,11 @@ class GameNews extends HistoryPage {
 		$template->assign('ShowHREF', $this->href());
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($this->historyGameID) . ' AND news_id >= ' . $db->escapeNumber($min) . ' AND news_id <= ' . $db->escapeNumber($max));
+		$dbResult = $db->read('SELECT * FROM news WHERE game_id = :game_id AND news_id >= :min_news_id AND news_id <= :max_news_id', [
+			'game_id' => $db->escapeNumber($this->historyGameID),
+			'min_news_id' => $db->escapeNumber($min),
+			'max_news_id' => $db->escapeNumber($max),
+		]);
 		$rows = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$rows[] = [

--- a/src/pages/Account/HistoryGames/HallOfFame.php
+++ b/src/pages/Account/HistoryGames/HallOfFame.php
@@ -46,7 +46,9 @@ class HallOfFame extends HistoryPage {
 
 			// Rankings display
 			$oldAccountId = $account->getOldAccountID($this->historyDatabase);
-			$dbResult = $db->read('SELECT * FROM player_has_stats JOIN player USING(account_id, game_id) WHERE game_id=' . $db->escapeNumber($this->historyGameID) . ' ORDER BY player_has_stats.' . $this->stat . ' DESC LIMIT 25');
+			$dbResult = $db->read('SELECT * FROM player_has_stats JOIN player USING(account_id, game_id) WHERE game_id = :game_id ORDER BY player_has_stats.' . $this->stat . ' DESC LIMIT 25', [
+				'game_id' => $db->escapeNumber($this->historyGameID),
+			]);
 			$rankings = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$rankings[] = [

--- a/src/pages/Account/HistoryGames/Summary.php
+++ b/src/pages/Account/HistoryGames/Summary.php
@@ -18,8 +18,10 @@ class Summary extends HistoryPage {
 		$this->addMenu($template);
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT start_date, type, end_date, game_name, speed, game_id ' .
-			'FROM game WHERE game_id = ' . $db->escapeNumber($game_id));
+		$dbResult = $db->read('SELECT start_date, type, end_date, game_name, speed, game_id
+			FROM game WHERE game_id = :game_id', [
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		$dbRecord = $dbResult->record();
 		$template->assign('GameName', $game_name);
 		$template->assign('Start', date($account->getDateFormat(), $dbRecord->getInt('start_date')));
@@ -27,7 +29,9 @@ class Summary extends HistoryPage {
 		$template->assign('Type', $dbRecord->getString('type'));
 		$template->assign('Speed', $dbRecord->getFloat('speed'));
 
-		$dbResult = $db->read('SELECT count(*) total_players, IFNULL(max(experience),0) max_exp, IFNULL(max(alignment),0) max_align, IFNULL(min(alignment),0) min_align, IFNULL(max(kills),0) max_kills FROM player WHERE game_id = ' . $db->escapeNumber($game_id));
+		$dbResult = $db->read('SELECT count(*) total_players, IFNULL(max(experience),0) max_exp, IFNULL(max(alignment),0) max_align, IFNULL(min(alignment),0) min_align, IFNULL(max(kills),0) max_kills FROM player WHERE game_id = :game_id', [
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		$dbRecord = $dbResult->record();
 		$template->assign('NumPlayers', $dbRecord->getInt('total_players'));
 		$template->assign('MaxExp', $dbRecord->getInt('max_exp'));
@@ -35,16 +39,23 @@ class Summary extends HistoryPage {
 		$template->assign('MinAlign', $dbRecord->getInt('min_align'));
 		$template->assign('MaxKills', $dbRecord->getInt('max_kills'));
 
-		$dbResult = $db->read('SELECT count(*) FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id));
+		$dbResult = $db->read('SELECT count(*) FROM alliance WHERE game_id = :game_id', [
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		$template->assign('NumAlliances', $dbResult->record()->getInt('count(*)'));
 
 		// Get linked player information, if available
 		$oldAccountID = $account->getOldAccountID($this->historyDatabase);
-		$dbResult = $db->read('SELECT alliance_id FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND account_id = ' . $db->escapeNumber($oldAccountID));
+		$dbResult = $db->read('SELECT alliance_id FROM player WHERE game_id = :game_id AND account_id = :account_id', [
+			'game_id' => $db->escapeNumber($game_id),
+			'account_id' => $db->escapeNumber($oldAccountID),
+		]);
 		$oldAllianceID = $dbResult->hasRecord() ? $dbResult->record()->getInt('alliance_id') : 0;
 
 		$playerExp = [];
-		$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY experience DESC LIMIT 10');
+		$dbResult = $db->read('SELECT * FROM player WHERE game_id = :game_id ORDER BY experience DESC LIMIT 10', [
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$playerExp[] = [
 				'bold' => $dbRecord->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
@@ -55,7 +66,9 @@ class Summary extends HistoryPage {
 		$template->assign('PlayerExp', $playerExp);
 
 		$playerKills = [];
-		$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY kills DESC LIMIT 10');
+		$dbResult = $db->read('SELECT * FROM player WHERE game_id = :game_id ORDER BY kills DESC LIMIT 10', [
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$playerKills[] = [
 				'bold' => $dbRecord->getInt('account_id') == $oldAccountID ? 'class="bold"' : '',
@@ -69,7 +82,9 @@ class Summary extends HistoryPage {
 		$allianceExp = [];
 		$dbResult = $db->read('SELECT SUM(experience) as exp, alliance_name, alliance_id
 					FROM player JOIN alliance USING (game_id, alliance_id)
-					WHERE game_id = ' . $db->escapeNumber($game_id) . ' GROUP BY alliance_id ORDER BY exp DESC LIMIT 10');
+					WHERE game_id = :game_id GROUP BY alliance_id ORDER BY exp DESC LIMIT 10', [
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$alliance = htmlentities($dbRecord->getString('alliance_name'));
 			$id = $dbRecord->getInt('alliance_id');
@@ -83,7 +98,9 @@ class Summary extends HistoryPage {
 		$template->assign('AllianceExp', $allianceExp);
 
 		$allianceKills = [];
-		$dbResult = $db->read('SELECT kills, alliance_name, alliance_id FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id) . ' ORDER BY kills DESC LIMIT 10');
+		$dbResult = $db->read('SELECT kills, alliance_name, alliance_id FROM alliance WHERE game_id = :game_id ORDER BY kills DESC LIMIT 10', [
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$alliance = htmlentities($dbRecord->getString('alliance_name'));
 			$id = $dbRecord->getInt('alliance_id');

--- a/src/pages/Account/LoginAnnouncements.php
+++ b/src/pages/Account/LoginAnnouncements.php
@@ -23,8 +23,10 @@ class LoginAnnouncements extends AccountPage {
 		if (!$this->viewAll) {
 			$dbResult = $db->read('SELECT time, msg
 						FROM announcement
-						WHERE time > ' . $db->escapeNumber($account->getLastLogin()) . '
-						ORDER BY time DESC');
+						WHERE time > :last_login
+						ORDER BY time DESC', [
+				'last_login' => $db->escapeNumber($account->getLastLogin()),
+			]);
 			$container = new LoginCheckChangelogProcessor();
 		} else {
 			$dbResult = $db->read('SELECT time, msg

--- a/src/pages/Account/LoginCheckAnnouncementsProcessor.php
+++ b/src/pages/Account/LoginCheckAnnouncementsProcessor.php
@@ -12,7 +12,9 @@ class LoginCheckAnnouncementsProcessor extends AccountPageProcessor {
 		$lastLogin = $account->getLastLogin();
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM announcement WHERE time >= ' . $db->escapeNumber($lastLogin) . ' LIMIT 1');
+		$dbResult = $db->read('SELECT 1 FROM announcement WHERE time >= :last_login LIMIT 1', [
+			'last_login' => $db->escapeNumber($lastLogin),
+		]);
 		// do we have announcements?
 		if ($dbResult->hasRecord()) {
 			(new LoginAnnouncements())->go();

--- a/src/pages/Account/LoginCheckChangelogProcessor.php
+++ b/src/pages/Account/LoginCheckChangelogProcessor.php
@@ -12,7 +12,9 @@ class LoginCheckChangelogProcessor extends AccountPageProcessor {
 		$lastLogin = $account->getLastLogin();
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM version WHERE went_live > ' . $db->escapeNumber($lastLogin) . ' LIMIT 1');
+		$dbResult = $db->read('SELECT 1 FROM version WHERE went_live > :last_login LIMIT 1', [
+			'last_login' => $db->escapeNumber($lastLogin),
+		]);
 		// do we have updates?
 		if ($dbResult->hasRecord()) {
 			(new ChangelogView($lastLogin))->go();

--- a/src/pages/Account/NewsReadAdvancedProcessor.php
+++ b/src/pages/Account/NewsReadAdvancedProcessor.php
@@ -20,7 +20,10 @@ class NewsReadAdvancedProcessor extends AccountPageProcessor {
 		$db = Database::getInstance();
 		if ($submit == 'Search For Player') {
 			$playerName = Request::get('playerName');
-			$dbResult = $db->read('SELECT account_id FROM player WHERE player_name LIKE ' . $db->escapeString('%' . $playerName . '%') . ' AND game_id = ' . $db->escapeNumber($this->gameID));
+			$dbResult = $db->read('SELECT account_id FROM player WHERE player_name LIKE :player_name_like AND game_id = :game_id', [
+				'player_name_like' => $db->escapeString('%' . $playerName . '%'),
+				'game_id' => $db->escapeNumber($this->gameID),
+			]);
 			$IDs = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$IDs[] = $dbRecord->getInt('account_id');
@@ -29,7 +32,11 @@ class NewsReadAdvancedProcessor extends AccountPageProcessor {
 		} elseif ($submit == 'Search For Players') {
 			$playerName1 = Request::get('player1');
 			$playerName2 = Request::get('player2');
-			$dbResult = $db->read('SELECT account_id FROM player WHERE (player_name LIKE ' . $db->escapeString('%' . $playerName1 . '%') . ' OR player_name LIKE ' . $db->escapeString('%' . $playerName2 . '%') . ') AND game_id = ' . $db->escapeNumber($this->gameID));
+			$dbResult = $db->read('SELECT account_id FROM player WHERE (player_name LIKE :player_name_like_1 OR player_name LIKE :player_name_like_2) AND game_id = :game_id', [
+				'player_name_like_1' => $db->escapeString('%' . $playerName1 . '%'),
+				'player_name_like_2' => $db->escapeString('%' . $playerName2 . '%'),
+				'game_id' => $db->escapeNumber($this->gameID),
+			]);
 			$IDs = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$IDs[] = $dbRecord->getInt('account_id');

--- a/src/pages/Account/NewsReadArchives.php
+++ b/src/pages/Account/NewsReadArchives.php
@@ -42,7 +42,11 @@ class NewsReadArchives extends AccountPage {
 		$template->assign('ViewNewsFormHref', (new self($this->gameID))->href());
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND type != \'lotto\' ORDER BY news_id DESC LIMIT ' . ($min_news - 1) . ', ' . ($max_news - $min_news + 1));
+		$dbResult = $db->read('SELECT * FROM news WHERE game_id = :game_id AND type != \'lotto\' ORDER BY news_id DESC LIMIT :limit_offset, :limit_count', [
+			'game_id' => $db->escapeNumber($gameID),
+			'limit_count' => $max_news - $min_news + 1,
+			'limit_offset' => $min_news - 1,
+		]);
 		$template->assign('NewsItems', News::getNewsItems($dbResult));
 	}
 

--- a/src/pages/Account/Preferences.php
+++ b/src/pages/Account/Preferences.php
@@ -31,7 +31,9 @@ class Preferences extends AccountPage {
 
 		$transferAccounts = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT account_id,hof_name FROM account WHERE validated = ' . $db->escapeBoolean(true) . ' ORDER BY hof_name');
+		$dbResult = $db->read('SELECT account_id,hof_name FROM account WHERE validated = :validated ORDER BY hof_name', [
+			'validated' => $db->escapeBoolean(true),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$transferAccounts[$dbRecord->getInt('account_id')] = htmlspecialchars($dbRecord->getString('hof_name'));
 		}

--- a/src/pages/Account/PreferencesProcessor.php
+++ b/src/pages/Account/PreferencesProcessor.php
@@ -127,7 +127,10 @@ class PreferencesProcessor extends AccountPageProcessor {
 			$timez = Request::getInt('timez');
 
 			$db = Database::getInstance();
-			$db->write('UPDATE account SET offset = ' . $db->escapeNumber($timez) . ' WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+			$db->write('UPDATE account SET offset = :offset WHERE account_id = :account_id', [
+				'offset' => $db->escapeNumber($timez),
+				'account_id' => $db->escapeNumber($account->getAccountID()),
+			]);
 			$message = '<span class="green">SUCCESS: </span>You have changed your time offset.';
 
 		} elseif ($action == 'Change Date Formats') {

--- a/src/pages/Account/PreferencesProcessor.php
+++ b/src/pages/Account/PreferencesProcessor.php
@@ -127,10 +127,11 @@ class PreferencesProcessor extends AccountPageProcessor {
 			$timez = Request::getInt('timez');
 
 			$db = Database::getInstance();
-			$db->write('UPDATE account SET offset = :offset WHERE account_id = :account_id', [
-				'offset' => $db->escapeNumber($timez),
-				'account_id' => $db->escapeNumber($account->getAccountID()),
-			]);
+			$db->update(
+				'account',
+				['offset' => $db->escapeNumber($timez)],
+				['account_id' => $db->escapeNumber($account->getAccountID())],
+			);
 			$message = '<span class="green">SUCCESS: </span>You have changed your time offset.';
 
 		} elseif ($action == 'Change Date Formats') {

--- a/src/pages/Account/PreferencesProcessor.php
+++ b/src/pages/Account/PreferencesProcessor.php
@@ -129,8 +129,8 @@ class PreferencesProcessor extends AccountPageProcessor {
 			$db = Database::getInstance();
 			$db->update(
 				'account',
-				['offset' => $db->escapeNumber($timez)],
-				['account_id' => $db->escapeNumber($account->getAccountID())],
+				['offset' => $timez],
+				['account_id' => $account->getAccountID()],
 			);
 			$message = '<span class="green">SUCCESS: </span>You have changed your time offset.';
 

--- a/src/pages/Account/ValidateProcessor.php
+++ b/src/pages/Account/ValidateProcessor.php
@@ -28,9 +28,8 @@ class ValidateProcessor extends AccountPageProcessor {
 
 			// delete the notification (when send)
 			$db = Database::getInstance();
-			$db->write('DELETE FROM notification
-						WHERE account_id = :account_id
-						AND notification_type = \'validation_code\'', [
+			$db->delete('notification', [
+				'notification_type' => 'validation_code',
 				'account_id' => $db->escapeNumber($account->getAccountID()),
 			]);
 		}

--- a/src/pages/Account/ValidateProcessor.php
+++ b/src/pages/Account/ValidateProcessor.php
@@ -29,8 +29,10 @@ class ValidateProcessor extends AccountPageProcessor {
 			// delete the notification (when send)
 			$db = Database::getInstance();
 			$db->write('DELETE FROM notification
-						WHERE account_id = ' . $db->escapeNumber($account->getAccountID()) . '
-						AND notification_type = \'validation_code\'');
+						WHERE account_id = :account_id
+						AND notification_type = \'validation_code\'', [
+				'account_id' => $db->escapeNumber($account->getAccountID()),
+			]);
 		}
 
 		$container = new LoginCheckAnnouncementsProcessor();

--- a/src/pages/Account/ValidateProcessor.php
+++ b/src/pages/Account/ValidateProcessor.php
@@ -30,7 +30,7 @@ class ValidateProcessor extends AccountPageProcessor {
 			$db = Database::getInstance();
 			$db->delete('notification', [
 				'notification_type' => 'validation_code',
-				'account_id' => $db->escapeNumber($account->getAccountID()),
+				'account_id' => $account->getAccountID(),
 			]);
 		}
 

--- a/src/pages/Account/Vote.php
+++ b/src/pages/Account/Vote.php
@@ -19,7 +19,9 @@ class Vote extends AccountPage {
 		$dbResult = $db->read('SELECT * FROM voting ORDER BY end DESC');
 		if ($dbResult->hasRecord()) {
 			$votedFor = [];
-			$dbResult2 = $db->read('SELECT * FROM voting_results WHERE account_id = ' . $db->escapeNumber($account->getAccountID()));
+			$dbResult2 = $db->read('SELECT * FROM voting_results WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($account->getAccountID()),
+			]);
 			foreach ($dbResult2->records() as $dbRecord2) {
 				$votedFor[$dbRecord2->getInt('vote_id')] = $dbRecord2->getInt('option_id');
 			}
@@ -38,7 +40,9 @@ class Vote extends AccountPage {
 				}
 
 				$voting[$voteID]['Options'] = [];
-				$dbResult2 = $db->read('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = ' . $db->escapeNumber($dbRecord->getInt('vote_id')) . ' GROUP BY option_id');
+				$dbResult2 = $db->read('SELECT option_id,text,count(account_id) FROM voting_options LEFT OUTER JOIN voting_results USING(vote_id,option_id) WHERE vote_id = :vote_id GROUP BY option_id', [
+					'vote_id' => $db->escapeNumber($dbRecord->getInt('vote_id')),
+				]);
 				foreach ($dbResult2->records() as $dbRecord2) {
 					$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['ID'] = $dbRecord2->getInt('option_id');
 					$voting[$voteID]['Options'][$dbRecord2->getInt('option_id')]['Text'] = $dbRecord2->getString('text');

--- a/src/pages/Account/VoteProcessor.php
+++ b/src/pages/Account/VoteProcessor.php
@@ -22,9 +22,9 @@ class VoteProcessor extends AccountPageProcessor {
 
 		$db = Database::getInstance();
 		$db->replace('voting_results', [
-			'account_id' => $db->escapeNumber($account->getAccountID()),
-			'vote_id' => $db->escapeNumber($this->voteID),
-			'option_id' => $db->escapeNumber(Request::getInt('vote')),
+			'account_id' => $account->getAccountID(),
+			'vote_id' => $this->voteID,
+			'option_id' => Request::getInt('vote'),
 		]);
 
 		$this->targetPage->go();

--- a/src/pages/Admin/AccountEdit.php
+++ b/src/pages/Admin/AccountEdit.php
@@ -32,7 +32,9 @@ class AccountEdit extends AccountPage {
 		$template->assign('ResetFormHREF', (new AccountEditSearch())->href());
 
 		$editingPlayers = [];
-		$dbResult = $db->read('SELECT * FROM player WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY game_id ASC');
+		$dbResult = $db->read('SELECT * FROM player WHERE account_id = :account_id ORDER BY game_id ASC', [
+			'account_id' => $db->escapeNumber($curr_account->getAccountID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$editingPlayers[] = Player::getPlayer($curr_account->getAccountID(), $dbRecord->getInt('game_id'), false, $dbRecord);
 		}
@@ -52,7 +54,9 @@ class AccountEdit extends AccountPage {
 		$template->assign('BanReasons', $banReasons);
 
 		$closingHistory = [];
-		$dbResult = $db->read('SELECT * FROM account_has_closing_history WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY time DESC');
+		$dbResult = $db->read('SELECT * FROM account_has_closing_history WHERE account_id = :account_id ORDER BY time DESC', [
+			'account_id' => $db->escapeNumber($curr_account->getAccountID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			// if an admin did it we get his/her name
 			$admin_id = $dbRecord->getInt('admin_id');
@@ -69,13 +73,17 @@ class AccountEdit extends AccountPage {
 		}
 		$template->assign('ClosingHistory', $closingHistory);
 
-		$dbResult = $db->read('SELECT * FROM account_exceptions WHERE account_id = ' . $curr_account->getAccountID());
+		$dbResult = $db->read('SELECT * FROM account_exceptions WHERE account_id = :account_id', [
+			'account_id' => $curr_account->getAccountID(),
+		]);
 		if ($dbResult->hasRecord()) {
 			$template->assign('Exception', $dbResult->record()->getString('reason'));
 		}
 
 		$recentIPs = [];
-		$dbResult = $db->read('SELECT ip, time, host FROM account_has_ip WHERE account_id = ' . $db->escapeNumber($curr_account->getAccountID()) . ' ORDER BY time DESC');
+		$dbResult = $db->read('SELECT ip, time, host FROM account_has_ip WHERE account_id = :account_id ORDER BY time DESC', [
+			'account_id' => $db->escapeNumber($curr_account->getAccountID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$recentIPs[] = [
 				'IP' => $dbRecord->getString('ip'),

--- a/src/pages/Admin/AccountEditProcessor.php
+++ b/src/pages/Admin/AccountEditProcessor.php
@@ -199,38 +199,42 @@ class AccountEditProcessor extends AccountPageProcessor {
 						continue;
 					}
 
-					$db->write('DELETE FROM alliance_thread
-								WHERE sender_id = :account_id AND game_id = :game_id', $sqlParams);
-					$db->write('DELETE FROM bounty WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM galactic_post_applications WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM galactic_post_article
-								WHERE writer_id = :account_id AND game_id = :game_id', $sqlParams);
-					$db->write('DELETE FROM galactic_post_writer WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM message WHERE ' . $sql, $sqlParams);
+					$db->delete('alliance_thread', [
+						'sender_id' => $db->escapeNumber($account_id),
+						'game_id' => $db->escapeNumber($game_id),
+					]);
+					$db->delete('bounty', $sqlParams);
+					$db->delete('galactic_post_applications', $sqlParams);
+					$db->delete('galactic_post_article', [
+						'writer_id' => $db->escapeNumber($account_id),
+						'game_id' => $db->escapeNumber($game_id),
+					]);
+					$db->delete('galactic_post_writer', $sqlParams);
+					$db->delete('message', $sqlParams);
 					$db->write('DELETE FROM message_notify
 								WHERE (from_id = :account_id OR to_id = :account_id) AND game_id = :game_id', $sqlParams);
 					$db->write('UPDATE planet SET owner_id=0,planet_name=\'\',password=\'\',shields=0,drones=0,credits=0,bonds=0
 								WHERE owner_id = :account_id AND game_id = :game_id', $sqlParams);
-					$db->write('DELETE FROM player_attacks_planet WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_attacks_port WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_has_alliance_role WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_has_drinks WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_has_relation WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_has_ticker WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_has_ticket WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_has_unread_messages WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_plotted_course WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_read_thread WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_visited_port WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_visited_sector WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_votes_pact WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player_votes_relation WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM ship_has_cargo WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM ship_has_hardware WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM ship_has_illusion WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM ship_has_weapon WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM ship_is_cloaked WHERE ' . $sql, $sqlParams);
-					$db->write('DELETE FROM player WHERE ' . $sql, $sqlParams);
+					$db->delete('player_attacks_planet', $sqlParams);
+					$db->delete('player_attacks_port', $sqlParams);
+					$db->delete('player_has_alliance_role', $sqlParams);
+					$db->delete('player_has_drinks', $sqlParams);
+					$db->delete('player_has_relation', $sqlParams);
+					$db->delete('player_has_ticker', $sqlParams);
+					$db->delete('player_has_ticket', $sqlParams);
+					$db->delete('player_has_unread_messages', $sqlParams);
+					$db->delete('player_plotted_course', $sqlParams);
+					$db->delete('player_read_thread', $sqlParams);
+					$db->delete('player_visited_port', $sqlParams);
+					$db->delete('player_visited_sector', $sqlParams);
+					$db->delete('player_votes_pact', $sqlParams);
+					$db->delete('player_votes_relation', $sqlParams);
+					$db->delete('ship_has_cargo', $sqlParams);
+					$db->delete('ship_has_hardware', $sqlParams);
+					$db->delete('ship_has_illusion', $sqlParams);
+					$db->delete('ship_has_weapon', $sqlParams);
+					$db->delete('ship_is_cloaked', $sqlParams);
+					$db->delete('player', $sqlParams);
 
 					$db->write('UPDATE active_session SET game_id=0 WHERE ' . $sql . ' LIMIT 1', $sqlParams);
 

--- a/src/pages/Admin/AccountEditProcessor.php
+++ b/src/pages/Admin/AccountEditProcessor.php
@@ -62,7 +62,9 @@ class AccountEditProcessor extends AccountPageProcessor {
 		if (Request::has('special_close')) {
 			$specialClose = Request::get('special_close');
 			// Make sure the special closing reason exists
-			$dbResult = $db->read('SELECT reason_id FROM closing_reason WHERE reason=' . $db->escapeString($specialClose));
+			$dbResult = $db->read('SELECT reason_id FROM closing_reason WHERE reason = :reason', [
+				'reason' => $db->escapeString($specialClose),
+			]);
 			if ($dbResult->hasRecord()) {
 				$reasonID = $dbResult->record()->getInt('reason_id');
 			} else {
@@ -121,7 +123,10 @@ class AccountEditProcessor extends AccountPageProcessor {
 		}
 
 		if ($veteran_status != $curr_account->isVeteranForced()) {
-			$db->write('UPDATE account SET veteran = ' . $db->escapeBoolean($veteran_status) . ' WHERE account_id = ' . $db->escapeNumber($account_id));
+			$db->write('UPDATE account SET veteran = :veteran WHERE account_id = :account_id', [
+				'veteran' => $db->escapeBoolean($veteran_status),
+				'account_id' => $db->escapeNumber($account_id),
+			]);
 			$actions[] = 'set the veteran status to ' . $db->escapeBoolean($veteran_status);
 		}
 
@@ -170,17 +175,24 @@ class AccountEditProcessor extends AccountPageProcessor {
 			foreach ($delete as $game_id => $value) {
 				if ($value == 'TRUE') {
 					// Check for bank transactions into the alliance account
-					$dbResult = $db->read('SELECT 1 FROM alliance_bank_transactions WHERE payee_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id) . ' LIMIT 1');
+					$dbResult = $db->read('SELECT 1 FROM alliance_bank_transactions WHERE payee_id = :payee_id AND game_id = :game_id LIMIT 1', [
+						'payee_id' => $db->escapeNumber($account_id),
+						'game_id' => $db->escapeNumber($game_id),
+					]);
 					if ($dbResult->hasRecord()) {
 						// Can't delete
 						$actions[] = 'player has made alliance transaction';
 						continue;
 					}
 
-					$sql = 'account_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id);
+					$sql = 'account_id = :account_id AND game_id = :game_id';
+					$sqlParams = [
+						'account_id' => $db->escapeNumber($account_id),
+						'game_id' => $db->escapeNumber($game_id),
+					];
 
 					// Check anon accounts for transactions
-					$dbResult = $db->read('SELECT 1 FROM anon_bank_transactions WHERE ' . $sql . ' LIMIT 1');
+					$dbResult = $db->read('SELECT 1 FROM anon_bank_transactions WHERE ' . $sql . ' LIMIT 1', $sqlParams);
 					if ($dbResult->hasRecord()) {
 						// Can't delete
 						$actions[] = 'player has made anonymous transaction';
@@ -188,39 +200,39 @@ class AccountEditProcessor extends AccountPageProcessor {
 					}
 
 					$db->write('DELETE FROM alliance_thread
-								WHERE sender_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id));
-					$db->write('DELETE FROM bounty WHERE ' . $sql);
-					$db->write('DELETE FROM galactic_post_applications WHERE ' . $sql);
+								WHERE sender_id = :account_id AND game_id = :game_id', $sqlParams);
+					$db->write('DELETE FROM bounty WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM galactic_post_applications WHERE ' . $sql, $sqlParams);
 					$db->write('DELETE FROM galactic_post_article
-								WHERE writer_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id));
-					$db->write('DELETE FROM galactic_post_writer WHERE ' . $sql);
-					$db->write('DELETE FROM message WHERE ' . $sql);
+								WHERE writer_id = :account_id AND game_id = :game_id', $sqlParams);
+					$db->write('DELETE FROM galactic_post_writer WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM message WHERE ' . $sql, $sqlParams);
 					$db->write('DELETE FROM message_notify
-								WHERE (from_id=' . $db->escapeNumber($account_id) . ' OR to_id=' . $db->escapeNumber($account_id) . ') AND game_id=' . $db->escapeNumber($game_id));
+								WHERE (from_id = :account_id OR to_id = :account_id) AND game_id = :game_id', $sqlParams);
 					$db->write('UPDATE planet SET owner_id=0,planet_name=\'\',password=\'\',shields=0,drones=0,credits=0,bonds=0
-								WHERE owner_id=' . $db->escapeNumber($account_id) . ' AND game_id=' . $db->escapeNumber($game_id));
-					$db->write('DELETE FROM player_attacks_planet WHERE ' . $sql);
-					$db->write('DELETE FROM player_attacks_port WHERE ' . $sql);
-					$db->write('DELETE FROM player_has_alliance_role WHERE ' . $sql);
-					$db->write('DELETE FROM player_has_drinks WHERE ' . $sql);
-					$db->write('DELETE FROM player_has_relation WHERE ' . $sql);
-					$db->write('DELETE FROM player_has_ticker WHERE ' . $sql);
-					$db->write('DELETE FROM player_has_ticket WHERE ' . $sql);
-					$db->write('DELETE FROM player_has_unread_messages WHERE ' . $sql);
-					$db->write('DELETE FROM player_plotted_course WHERE ' . $sql);
-					$db->write('DELETE FROM player_read_thread WHERE ' . $sql);
-					$db->write('DELETE FROM player_visited_port WHERE ' . $sql);
-					$db->write('DELETE FROM player_visited_sector WHERE ' . $sql);
-					$db->write('DELETE FROM player_votes_pact WHERE ' . $sql);
-					$db->write('DELETE FROM player_votes_relation WHERE ' . $sql);
-					$db->write('DELETE FROM ship_has_cargo WHERE ' . $sql);
-					$db->write('DELETE FROM ship_has_hardware WHERE ' . $sql);
-					$db->write('DELETE FROM ship_has_illusion WHERE ' . $sql);
-					$db->write('DELETE FROM ship_has_weapon WHERE ' . $sql);
-					$db->write('DELETE FROM ship_is_cloaked WHERE ' . $sql);
-					$db->write('DELETE FROM player WHERE ' . $sql);
+								WHERE owner_id = :account_id AND game_id = :game_id', $sqlParams);
+					$db->write('DELETE FROM player_attacks_planet WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_attacks_port WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_has_alliance_role WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_has_drinks WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_has_relation WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_has_ticker WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_has_ticket WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_has_unread_messages WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_plotted_course WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_read_thread WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_visited_port WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_visited_sector WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_votes_pact WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player_votes_relation WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM ship_has_cargo WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM ship_has_hardware WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM ship_has_illusion WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM ship_has_weapon WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM ship_is_cloaked WHERE ' . $sql, $sqlParams);
+					$db->write('DELETE FROM player WHERE ' . $sql, $sqlParams);
 
-					$db->write('UPDATE active_session SET game_id=0 WHERE ' . $sql . ' LIMIT 1');
+					$db->write('UPDATE active_session SET game_id=0 WHERE ' . $sql . ' LIMIT 1', $sqlParams);
 
 					$actions[] = 'deleted player from game ' . $game_id;
 				}

--- a/src/pages/Admin/AccountEditProcessor.php
+++ b/src/pages/Admin/AccountEditProcessor.php
@@ -123,10 +123,11 @@ class AccountEditProcessor extends AccountPageProcessor {
 		}
 
 		if ($veteran_status != $curr_account->isVeteranForced()) {
-			$db->write('UPDATE account SET veteran = :veteran WHERE account_id = :account_id', [
-				'veteran' => $db->escapeBoolean($veteran_status),
-				'account_id' => $db->escapeNumber($account_id),
-			]);
+			$db->update(
+				'account',
+				['veteran' => $db->escapeBoolean($veteran_status)],
+				['account_id' => $db->escapeNumber($account_id)],
+			);
 			$actions[] = 'set the veteran status to ' . $db->escapeBoolean($veteran_status);
 		}
 
@@ -213,8 +214,22 @@ class AccountEditProcessor extends AccountPageProcessor {
 					$db->delete('message', $sqlParams);
 					$db->write('DELETE FROM message_notify
 								WHERE (from_id = :account_id OR to_id = :account_id) AND game_id = :game_id', $sqlParams);
-					$db->write('UPDATE planet SET owner_id=0,planet_name=\'\',password=\'\',shields=0,drones=0,credits=0,bonds=0
-								WHERE owner_id = :account_id AND game_id = :game_id', $sqlParams);
+					$db->update(
+						'planet',
+						[
+							'owner_id' => 0,
+							'planet_name' => '',
+							'password' => '',
+							'shields' => 0,
+							'drones' => 0,
+							'credits' => 0,
+							'bonds' => 0,
+						],
+						[
+							'owner_id' => $db->escapeNumber($account_id),
+							'game_id' => $db->escapeNumber($game_id),
+						],
+					);
 					$db->delete('player_attacks_planet', $sqlParams);
 					$db->delete('player_attacks_port', $sqlParams);
 					$db->delete('player_has_alliance_role', $sqlParams);
@@ -236,7 +251,7 @@ class AccountEditProcessor extends AccountPageProcessor {
 					$db->delete('ship_is_cloaked', $sqlParams);
 					$db->delete('player', $sqlParams);
 
-					$db->write('UPDATE active_session SET game_id=0 WHERE ' . $sql . ' LIMIT 1', $sqlParams);
+					$db->update('active_session', ['game_id' => 0], $sqlParams);
 
 					$actions[] = 'deleted player from game ' . $game_id;
 				}

--- a/src/pages/Admin/AccountEditProcessor.php
+++ b/src/pages/Admin/AccountEditProcessor.php
@@ -41,9 +41,9 @@ class AccountEditProcessor extends AccountPageProcessor {
 		if (!empty($donation)) {
 			// add entry to account donated table
 			$db->insert('account_donated', [
-				'account_id' => $db->escapeNumber($account_id),
-				'time' => $db->escapeNumber(Epoch::time()),
-				'amount' => $db->escapeNumber($donation),
+				'account_id' => $account_id,
+				'time' => Epoch::time(),
+				'amount' => $donation,
 			]);
 
 			// add the credits to the players account - if requested
@@ -69,7 +69,7 @@ class AccountEditProcessor extends AccountPageProcessor {
 				$reasonID = $dbResult->record()->getInt('reason_id');
 			} else {
 				$reasonID = $db->insert('closing_reason', [
-					'reason' => $db->escapeString($specialClose),
+					'reason' => $specialClose,
 				]);
 			}
 
@@ -90,7 +90,7 @@ class AccountEditProcessor extends AccountPageProcessor {
 		} elseif ($points > 0) {
 			if ($choise == 'individual') {
 				$reason_id = $db->insert('closing_reason', [
-					'reason' => $db->escapeString($reason_msg),
+					'reason' => $reason_msg,
 				]);
 			} else {
 				$reason_id = $reason_pre_select;
@@ -126,7 +126,7 @@ class AccountEditProcessor extends AccountPageProcessor {
 			$db->update(
 				'account',
 				['veteran' => $db->escapeBoolean($veteran_status)],
-				['account_id' => $db->escapeNumber($account_id)],
+				['account_id' => $account_id],
 			);
 			$actions[] = 'set the veteran status to ' . $db->escapeBoolean($veteran_status);
 		}
@@ -138,8 +138,8 @@ class AccountEditProcessor extends AccountPageProcessor {
 
 		if ($except != '') {
 			$db->insert('account_exceptions', [
-				'account_id' => $db->escapeNumber($account_id),
-				'reason' => $db->escapeString($except),
+				'account_id' => $account_id,
+				'reason' => $except,
 			]);
 			$actions[] = 'added the exception ' . $except;
 		}
@@ -164,11 +164,11 @@ class AccountEditProcessor extends AccountPageProcessor {
 			$news = 'Please be advised that player ' . $editPlayer->getPlayerID() . ' has had their name changed to ' . $editPlayer->getBBLink();
 
 			$db->insert('news', [
-				'time' => $db->escapeNumber(Epoch::time()),
-				'news_message' => $db->escapeString($news),
-				'game_id' => $db->escapeNumber($game_id),
-				'type' => $db->escapeString('admin'),
-				'killer_id' => $db->escapeNumber($account_id),
+				'time' => Epoch::time(),
+				'news_message' => $news,
+				'game_id' => $game_id,
+				'type' => 'admin',
+				'killer_id' => $account_id,
 			]);
 		}
 
@@ -201,14 +201,14 @@ class AccountEditProcessor extends AccountPageProcessor {
 					}
 
 					$db->delete('alliance_thread', [
-						'sender_id' => $db->escapeNumber($account_id),
-						'game_id' => $db->escapeNumber($game_id),
+						'sender_id' => $account_id,
+						'game_id' => $game_id,
 					]);
 					$db->delete('bounty', $sqlParams);
 					$db->delete('galactic_post_applications', $sqlParams);
 					$db->delete('galactic_post_article', [
-						'writer_id' => $db->escapeNumber($account_id),
-						'game_id' => $db->escapeNumber($game_id),
+						'writer_id' => $account_id,
+						'game_id' => $game_id,
 					]);
 					$db->delete('galactic_post_writer', $sqlParams);
 					$db->delete('message', $sqlParams);
@@ -226,8 +226,8 @@ class AccountEditProcessor extends AccountPageProcessor {
 							'bonds' => 0,
 						],
 						[
-							'owner_id' => $db->escapeNumber($account_id),
-							'game_id' => $db->escapeNumber($game_id),
+							'owner_id' => $account_id,
+							'game_id' => $game_id,
 						],
 					);
 					$db->delete('player_attacks_planet', $sqlParams);

--- a/src/pages/Admin/AccountEditSearchProcessor.php
+++ b/src/pages/Admin/AccountEditSearchProcessor.php
@@ -17,15 +17,21 @@ class AccountEditSearchProcessor extends AccountPageProcessor {
 		$searchGameID = Request::getInt('game_id');
 
 		if (!empty($player_name)) {
-			$gameIDClause = $searchGameID != 0 ? ' AND game_id = ' . $db->escapeNumber($searchGameID) . ' ' : '';
+			$gameIDClause = 'AND (:game_id = 0 OR :game_id = game_id)';
 			$dbResult = $db->read('SELECT account_id FROM player
-							WHERE player_name = ' . $db->escapeString($player_name) . $gameIDClause . '
-							ORDER BY game_id DESC LIMIT 1');
+							WHERE player_name = :player_name ' . $gameIDClause . '
+							ORDER BY game_id DESC LIMIT 1', [
+				'player_name' => $db->escapeString($player_name),
+				'game_id' => $db->escapeNumber($searchGameID),
+			]);
 			if ($dbResult->hasRecord()) {
 				$account_id = $dbResult->record()->getInt('account_id');
 			} else {
 				$dbResult = $db->read('SELECT * FROM player
-								WHERE player_name LIKE ' . $db->escapeString($player_name . '%') . $gameIDClause . ' LIMIT 1');
+								WHERE player_name LIKE :player_name_like ' . $gameIDClause . ' LIMIT 1', [
+					'player_name_like' => $db->escapeString($player_name . '%'),
+					'game_id' => $db->escapeNumber($searchGameID),
+				]);
 				if ($dbResult->hasRecord()) {
 					$account_id = $dbResult->record()->getInt('account_id');
 				}
@@ -33,11 +39,17 @@ class AccountEditSearchProcessor extends AccountPageProcessor {
 		}
 
 		// get account from db
-		$dbResult = $db->read('SELECT account_id FROM account WHERE account_id = ' . $db->escapeNumber($account_id) . ' OR ' .
-											   'login LIKE ' . $db->escapeString(Request::get('login')) . ' OR ' .
-											   'email LIKE ' . $db->escapeString(Request::get('email')) . ' OR ' .
-											   'hof_name LIKE ' . $db->escapeString(Request::get('hofname')) . ' OR ' .
-											   'validation_code LIKE ' . $db->escapeString(Request::get('val_code')) . ' LIMIT 1');
+		$dbResult = $db->read('SELECT account_id FROM account WHERE account_id = :account_id OR
+								login LIKE :login_like OR
+								email LIKE :email_like OR
+								hof_name LIKE :hof_name_like OR
+								validation_code LIKE :validation_code_like LIMIT 1', [
+			'account_id' => $db->escapeNumber($account_id),
+			'login_like' => $db->escapeString(Request::get('login')),
+			'email_like' => $db->escapeString(Request::get('email')),
+			'hof_name_like' => $db->escapeString(Request::get('hofname')),
+			'validation_code_like' => $db->escapeString(Request::get('val_code')),
+		]);
 		if ($dbResult->hasRecord()) {
 			$container = new AccountEdit($dbResult->record()->getInt('account_id'));
 		} else {

--- a/src/pages/Admin/AdminMessageSend.php
+++ b/src/pages/Admin/AdminMessageSend.php
@@ -36,7 +36,9 @@ class AdminMessageSend extends AccountPage {
 			$game = Game::getGame($gameID);
 			$gamePlayers = [['AccountID' => 0, 'Name' => 'All Players (' . $game->getName() . ')']];
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT account_id,player_id,player_name FROM player WHERE game_id = ' . $db->escapeNumber($gameID) . ' ORDER BY player_name');
+			$dbResult = $db->read('SELECT account_id,player_id,player_name FROM player WHERE game_id = :game_id ORDER BY player_name', [
+				'game_id' => $db->escapeNumber($gameID),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$gamePlayers[] = [
 					'AccountID' => $dbRecord->getInt('account_id'),

--- a/src/pages/Admin/AdminMessageSendProcessor.php
+++ b/src/pages/Admin/AdminMessageSendProcessor.php
@@ -43,7 +43,9 @@ class AdminMessageSendProcessor extends AccountPageProcessor {
 			$account_id = Request::getInt('account_id');
 			if ($account_id == 0) {
 				// Send to all players in the requested game
-				$dbResult = $db->read('SELECT account_id FROM player WHERE game_id = ' . $db->escapeNumber($game_id));
+				$dbResult = $db->read('SELECT account_id FROM player WHERE game_id = :game_id', [
+					'game_id' => $db->escapeNumber($game_id),
+				]);
 				foreach ($dbResult->records() as $dbRecord) {
 					$receivers[] = [$game_id, $dbRecord->getInt('account_id')];
 				}
@@ -52,7 +54,9 @@ class AdminMessageSendProcessor extends AccountPageProcessor {
 			}
 		} else {
 			//send to all players in games that haven't ended yet
-			$dbResult = $db->read('SELECT game_id,account_id FROM player JOIN game USING(game_id) WHERE end_time > ' . $db->escapeNumber(Epoch::time()));
+			$dbResult = $db->read('SELECT game_id,account_id FROM player JOIN game USING(game_id) WHERE end_time > :now', [
+				'now' => $db->escapeNumber(Epoch::time()),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$receivers[] = [$dbRecord->getInt('game_id'), $dbRecord->getInt('account_id')];
 			}

--- a/src/pages/Admin/AdminMessageSendSelect.php
+++ b/src/pages/Admin/AdminMessageSendSelect.php
@@ -21,7 +21,9 @@ class AdminMessageSendSelect extends AccountPage {
 		// Get a list of all games that have not yet ended
 		$activeGames = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Epoch::time()) . ' ORDER BY end_time DESC');
+		$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > :now ORDER BY end_time DESC', [
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$activeGames[] = Game::getGame($dbRecord->getInt('game_id'));
 		}

--- a/src/pages/Admin/AdminPermissionManage.php
+++ b/src/pages/Admin/AdminPermissionManage.php
@@ -44,8 +44,10 @@ class AdminPermissionManage extends AccountPage {
 			$validatedAccounts = [];
 			$dbResult = $db->read('SELECT account_id, login
 						FROM account
-						WHERE validated = ' . $db->escapeBoolean(true) . '
-						ORDER BY login');
+						WHERE validated = :validated
+						ORDER BY login', [
+				'validated' => $db->escapeBoolean(true),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$accountID = $dbRecord->getInt('account_id');
 				if (!array_key_exists($accountID, $adminLinks)) {

--- a/src/pages/Admin/AdminPermissionManageProcessor.php
+++ b/src/pages/Admin/AdminPermissionManageProcessor.php
@@ -21,15 +21,15 @@ class AdminPermissionManageProcessor extends AccountPageProcessor {
 			// delete everything first
 			$db = Database::getInstance();
 			$db->delete('account_has_permission', [
-				'account_id' => $db->escapeNumber($this->adminAccountID),
+				'account_id' => $this->adminAccountID,
 			]);
 
 			// Grant permissions
 			$permissions = Request::getIntArray('permission_ids', []);
 			foreach ($permissions as $permission_id) {
 				$db->replace('account_has_permission', [
-					'account_id' => $db->escapeNumber($this->adminAccountID),
-					'permission_id' => $db->escapeNumber($permission_id),
+					'account_id' => $this->adminAccountID,
+					'permission_id' => $permission_id,
 				]);
 			}
 
@@ -38,8 +38,8 @@ class AdminPermissionManageProcessor extends AccountPageProcessor {
 				// This might overwrite an existing unrelated tag.
 				$tag = '<span class="blue">Admin</span>';
 				$db->replace('cpl_tag', [
-					'account_id' => $db->escapeNumber($this->adminAccountID),
-					'tag' => $db->escapeString($tag),
+					'account_id' => $this->adminAccountID,
+					'tag' => $tag,
 					'custom' => 0,
 				]);
 			} elseif ($hadAdminTag) {
@@ -47,7 +47,7 @@ class AdminPermissionManageProcessor extends AccountPageProcessor {
 				// otherwise we might accidentally delete an unrelated tag.
 				$db->delete('cpl_tag', [
 					'custom' => 0,
-					'account_id' => $db->escapeNumber($this->adminAccountID),
+					'account_id' => $this->adminAccountID,
 				]);
 			}
 		}

--- a/src/pages/Admin/AdminPermissionManageProcessor.php
+++ b/src/pages/Admin/AdminPermissionManageProcessor.php
@@ -20,9 +20,7 @@ class AdminPermissionManageProcessor extends AccountPageProcessor {
 
 			// delete everything first
 			$db = Database::getInstance();
-			$db->write('DELETE
-						FROM account_has_permission
-						WHERE account_id = :account_id', [
+			$db->delete('account_has_permission', [
 				'account_id' => $db->escapeNumber($this->adminAccountID),
 			]);
 
@@ -47,7 +45,8 @@ class AdminPermissionManageProcessor extends AccountPageProcessor {
 			} elseif ($hadAdminTag) {
 				// Only delete the tag if they previously had an admin tag;
 				// otherwise we might accidentally delete an unrelated tag.
-				$db->write('DELETE FROM cpl_tag WHERE custom=0 AND account_id = :account_id', [
+				$db->delete('cpl_tag', [
+					'custom' => 0,
 					'account_id' => $db->escapeNumber($this->adminAccountID),
 				]);
 			}

--- a/src/pages/Admin/AdminPermissionManageProcessor.php
+++ b/src/pages/Admin/AdminPermissionManageProcessor.php
@@ -22,7 +22,9 @@ class AdminPermissionManageProcessor extends AccountPageProcessor {
 			$db = Database::getInstance();
 			$db->write('DELETE
 						FROM account_has_permission
-						WHERE account_id = ' . $db->escapeNumber($this->adminAccountID));
+						WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($this->adminAccountID),
+			]);
 
 			// Grant permissions
 			$permissions = Request::getIntArray('permission_ids', []);
@@ -45,7 +47,9 @@ class AdminPermissionManageProcessor extends AccountPageProcessor {
 			} elseif ($hadAdminTag) {
 				// Only delete the tag if they previously had an admin tag;
 				// otherwise we might accidentally delete an unrelated tag.
-				$db->write('DELETE FROM cpl_tag WHERE custom=0 AND account_id=' . $db->escapeNumber($this->adminAccountID));
+				$db->write('DELETE FROM cpl_tag WHERE custom=0 AND account_id = :account_id', [
+					'account_id' => $db->escapeNumber($this->adminAccountID),
+				]);
 			}
 		}
 

--- a/src/pages/Admin/AlbumApproveProcessor.php
+++ b/src/pages/Admin/AlbumApproveProcessor.php
@@ -18,8 +18,11 @@ class AlbumApproveProcessor extends AccountPageProcessor {
 
 		$db = Database::getInstance();
 		$db->write('UPDATE album
-					SET approved = ' . $db->escapeString($approved) . '
-					WHERE account_id = ' . $db->escapeNumber($this->albumAccountID));
+					SET approved = :approved
+					WHERE account_id = :account_id', [
+			'approved' => $db->escapeString($approved),
+			'account_id' => $db->escapeNumber($this->albumAccountID),
+		]);
 
 		(new AlbumApprove())->go();
 	}

--- a/src/pages/Admin/AlbumApproveProcessor.php
+++ b/src/pages/Admin/AlbumApproveProcessor.php
@@ -17,12 +17,11 @@ class AlbumApproveProcessor extends AccountPageProcessor {
 		$approved = $this->approved ? 'YES' : 'NO';
 
 		$db = Database::getInstance();
-		$db->write('UPDATE album
-					SET approved = :approved
-					WHERE account_id = :account_id', [
-			'approved' => $db->escapeString($approved),
-			'account_id' => $db->escapeNumber($this->albumAccountID),
-		]);
+		$db->update(
+			'album',
+			['approved' => $db->escapeString($approved)],
+			['account_id' => $db->escapeNumber($this->albumAccountID)],
+		);
 
 		(new AlbumApprove())->go();
 	}

--- a/src/pages/Admin/AlbumApproveProcessor.php
+++ b/src/pages/Admin/AlbumApproveProcessor.php
@@ -19,8 +19,8 @@ class AlbumApproveProcessor extends AccountPageProcessor {
 		$db = Database::getInstance();
 		$db->update(
 			'album',
-			['approved' => $db->escapeString($approved)],
-			['account_id' => $db->escapeNumber($this->albumAccountID)],
+			['approved' => $approved],
+			['account_id' => $this->albumAccountID],
 		);
 
 		(new AlbumApprove())->go();

--- a/src/pages/Admin/AlbumModerate.php
+++ b/src/pages/Admin/AlbumModerate.php
@@ -27,7 +27,9 @@ class AlbumModerate extends AccountPage {
 
 		// check if the given account really has an entry
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM album WHERE account_id = ' . $db->escapeNumber($account_id) . ' AND Approved = \'YES\'');
+		$dbResult = $db->read('SELECT * FROM album WHERE account_id = :account_id AND Approved = \'YES\'', [
+			'account_id' => $db->escapeNumber($account_id),
+		]);
 		$dbRecord = $dbResult->record();
 
 		$disabled = $dbRecord->getBoolean('disabled');
@@ -89,7 +91,9 @@ class AlbumModerate extends AccountPage {
 
 		$dbResult = $db->read('SELECT *
 					FROM album_has_comments
-					WHERE album_id = ' . $db->escapeNumber($account_id));
+					WHERE album_id = :album_id', [
+			'album_id' => $db->escapeNumber($account_id),
+		]);
 		$comments = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$comments[] = [

--- a/src/pages/Admin/AlbumModerateProcessor.php
+++ b/src/pages/Admin/AlbumModerateProcessor.php
@@ -36,11 +36,11 @@ class AlbumModerateProcessor extends AccountPageProcessor {
 			$comment_id = $dbResult->record()->getInt('next_comment_id');
 
 			$db->insert('album_has_comments', [
-				'album_id' => $db->escapeNumber($account_id),
-				'comment_id' => $db->escapeNumber($comment_id),
-				'time' => $db->escapeNumber(Epoch::time()),
+				'album_id' => $account_id,
+				'comment_id' => $comment_id,
+				'time' => Epoch::time(),
 				'post_id' => 0,
-				'msg' => $db->escapeString('<span class="green">*** Picture disabled by an admin</span>'),
+				'msg' => '<span class="green">*** Picture disabled by an admin</span>',
 			]);
 			$db->unlock();
 

--- a/src/pages/Admin/AlbumModerateProcessor.php
+++ b/src/pages/Admin/AlbumModerateProcessor.php
@@ -24,10 +24,14 @@ class AlbumModerateProcessor extends AccountPageProcessor {
 		// check for each task
 		if ($this->task == 'reset_image') {
 			$email_txt = Request::get('email_txt');
-			$db->write('UPDATE album SET disabled = \'TRUE\' WHERE account_id = ' . $db->escapeNumber($account_id));
+			$db->write('UPDATE album SET disabled = \'TRUE\' WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($account_id),
+			]);
 
 			$db->lockTable('album_has_comments');
-			$dbResult = $db->read('SELECT IFNULL(MAX(comment_id)+1, 0) as next_comment_id FROM album_has_comments WHERE album_id = ' . $db->escapeNumber($account_id));
+			$dbResult = $db->read('SELECT IFNULL(MAX(comment_id)+1, 0) as next_comment_id FROM album_has_comments WHERE album_id = :album_id', [
+				'album_id' => $db->escapeNumber($account_id),
+			]);
 			$comment_id = $dbResult->record()->getInt('next_comment_id');
 
 			$db->insert('album_has_comments', [
@@ -51,22 +55,35 @@ class AlbumModerateProcessor extends AccountPageProcessor {
 			}
 
 		} elseif ($this->task == 'reset_location') {
-			$db->write('UPDATE album SET location = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
+			$db->write('UPDATE album SET location = \'\' WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($account_id),
+			]);
 		} elseif ($this->task == 'reset_email') {
-			$db->write('UPDATE album SET email = \'\' WHERE account_id =' . $db->escapeNumber($account_id));
+			$db->write('UPDATE album SET email = \'\' WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($account_id),
+			]);
 		} elseif ($this->task == 'reset_website') {
-			$db->write('UPDATE album SET website = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
+			$db->write('UPDATE album SET website = \'\' WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($account_id),
+			]);
 		} elseif ($this->task == 'reset_birthdate') {
-			$db->write('UPDATE album SET day = 0, month = 0, year = 0 WHERE account_id = ' . $db->escapeNumber($account_id));
+			$db->write('UPDATE album SET day = 0, month = 0, year = 0 WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($account_id),
+			]);
 		} elseif ($this->task == 'reset_other') {
-			$db->write('UPDATE album SET other = \'\' WHERE account_id = ' . $db->escapeNumber($account_id));
+			$db->write('UPDATE album SET other = \'\' WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($account_id),
+			]);
 		} elseif ($this->task == 'delete_comment') {
 			// we just ignore if nothing was set
 			if (Request::has('comment_ids')) {
 				$db->write('DELETE
 							FROM album_has_comments
-							WHERE album_id = ' . $db->escapeNumber($account_id) . ' AND
-								  comment_id IN (' . $db->escapeArray(Request::getIntArray('comment_ids')) . ')');
+							WHERE album_id = :album_id AND
+								  comment_id IN (:comment_ids)', [
+					'album_id' => $db->escapeNumber($account_id),
+					'comment_ids' => $db->escapeArray(Request::getIntArray('comment_ids')),
+				]);
 			}
 		} else {
 			create_error('No action chosen!');

--- a/src/pages/Admin/AlbumModerateProcessor.php
+++ b/src/pages/Admin/AlbumModerateProcessor.php
@@ -20,13 +20,14 @@ class AlbumModerateProcessor extends AccountPageProcessor {
 
 		// get account_id from session
 		$account_id = $this->albumAccountID;
+		$sqlCondition = [
+			'account_id' => $db->escapeNumber($account_id),
+		];
 
 		// check for each task
 		if ($this->task == 'reset_image') {
 			$email_txt = Request::get('email_txt');
-			$db->write('UPDATE album SET disabled = \'TRUE\' WHERE account_id = :account_id', [
-				'account_id' => $db->escapeNumber($account_id),
-			]);
+			$db->update('album', ['disabled' => 'TRUE'], $sqlCondition);
 
 			$db->lockTable('album_has_comments');
 			$dbResult = $db->read('SELECT IFNULL(MAX(comment_id)+1, 0) as next_comment_id FROM album_has_comments WHERE album_id = :album_id', [
@@ -55,25 +56,23 @@ class AlbumModerateProcessor extends AccountPageProcessor {
 			}
 
 		} elseif ($this->task == 'reset_location') {
-			$db->write('UPDATE album SET location = \'\' WHERE account_id = :account_id', [
-				'account_id' => $db->escapeNumber($account_id),
-			]);
+			$db->update('album', ['location' => ''], $sqlCondition);
 		} elseif ($this->task == 'reset_email') {
-			$db->write('UPDATE album SET email = \'\' WHERE account_id = :account_id', [
-				'account_id' => $db->escapeNumber($account_id),
-			]);
+			$db->update('album', ['email' => ''], $sqlCondition);
 		} elseif ($this->task == 'reset_website') {
-			$db->write('UPDATE album SET website = \'\' WHERE account_id = :account_id', [
-				'account_id' => $db->escapeNumber($account_id),
-			]);
+			$db->update('album', ['website' => ''], $sqlCondition);
 		} elseif ($this->task == 'reset_birthdate') {
-			$db->write('UPDATE album SET day = 0, month = 0, year = 0 WHERE account_id = :account_id', [
-				'account_id' => $db->escapeNumber($account_id),
-			]);
+			$db->update(
+				'album',
+				[
+					'day' => 0,
+					'month' => 0,
+					'year' => 0,
+				],
+				$sqlCondition,
+			);
 		} elseif ($this->task == 'reset_other') {
-			$db->write('UPDATE album SET other = \'\' WHERE account_id = :account_id', [
-				'account_id' => $db->escapeNumber($account_id),
-			]);
+			$db->update('album', ['other' => ''], $sqlCondition);
 		} elseif ($this->task == 'delete_comment') {
 			// we just ignore if nothing was set
 			if (Request::has('comment_ids')) {

--- a/src/pages/Admin/AnnouncementCreateProcessor.php
+++ b/src/pages/Admin/AnnouncementCreateProcessor.php
@@ -20,9 +20,9 @@ class AnnouncementCreateProcessor extends AccountPageProcessor {
 		// put the msg into the database
 		$db = Database::getInstance();
 		$db->insert('announcement', [
-			'time' => $db->escapeNumber(Epoch::time()),
-			'admin_id' => $db->escapeNumber($account->getAccountID()),
-			'msg' => $db->escapeString($message),
+			'time' => Epoch::time(),
+			'admin_id' => $account->getAccountID(),
+			'msg' => $message,
 		]);
 
 		(new AdminTools())->go();

--- a/src/pages/Admin/AnonBankView.php
+++ b/src/pages/Admin/AnonBankView.php
@@ -28,9 +28,12 @@ class AnonBankView extends AccountPage {
 		$dbResult = $db->read('SELECT *
 					FROM anon_bank_transactions
 					JOIN player USING(account_id, game_id)
-					WHERE anon_id = ' . $db->escapeNumber($anonID) . '
-						AND game_id = ' . $db->escapeNumber($gameID) . '
-					ORDER BY transaction_id');
+					WHERE anon_id = :anon_id
+						AND game_id = :game_id
+					ORDER BY transaction_id', [
+			'anon_id' => $db->escapeNumber($anonID),
+			'game_id' => $db->escapeNumber($gameID),
+		]);
 		$rows = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$rows[] = [

--- a/src/pages/Admin/Changelog.php
+++ b/src/pages/Admin/Changelog.php
@@ -55,8 +55,10 @@ class Changelog extends AccountPage {
 
 			$dbResult2 = $db->read('SELECT *
 						FROM changelog
-						WHERE version_id = ' . $db->escapeNumber($version_id) . '
-						ORDER BY changelog_id');
+						WHERE version_id = :version_id
+						ORDER BY changelog_id', [
+				'version_id' => $db->escapeNumber($version_id),
+			]);
 			$changes = [];
 			foreach ($dbResult2->records() as $dbRecord2) {
 				$changes[] = [

--- a/src/pages/Admin/ChangelogAddProcessor.php
+++ b/src/pages/Admin/ChangelogAddProcessor.php
@@ -38,11 +38,11 @@ class ChangelogAddProcessor extends AccountPageProcessor {
 		$changelog_id = $dbResult->record()->getInt('next_changelog_id');
 
 		$db->insert('changelog', [
-			'version_id' => $db->escapeNumber($this->versionID),
-			'changelog_id' => $db->escapeNumber($changelog_id),
-			'change_title' => $db->escapeString($change_title),
-			'change_message' => $db->escapeString($change_message),
-			'affected_db' => $db->escapeString($affected_db),
+			'version_id' => $this->versionID,
+			'changelog_id' => $changelog_id,
+			'change_title' => $change_title,
+			'change_message' => $change_message,
+			'affected_db' => $affected_db,
 		]);
 		$db->unlock();
 

--- a/src/pages/Admin/ChangelogAddProcessor.php
+++ b/src/pages/Admin/ChangelogAddProcessor.php
@@ -32,7 +32,9 @@ class ChangelogAddProcessor extends AccountPageProcessor {
 
 		$dbResult = $db->read('SELECT IFNULL(MAX(changelog_id)+1, 0) AS next_changelog_id
 					FROM changelog
-					WHERE version_id = ' . $db->escapeNumber($this->versionID));
+					WHERE version_id = :version_id', [
+			'version_id' => $db->escapeNumber($this->versionID),
+		]);
 		$changelog_id = $dbResult->record()->getInt('next_changelog_id');
 
 		$db->insert('changelog', [

--- a/src/pages/Admin/ChangelogSetLiveProcessor.php
+++ b/src/pages/Admin/ChangelogSetLiveProcessor.php
@@ -16,19 +16,29 @@ class ChangelogSetLiveProcessor extends AccountPageProcessor {
 	public function build(Account $account): never {
 		$db = Database::getInstance();
 		$db->write('UPDATE version
-					SET went_live = ' . $db->escapeNumber(Epoch::time()) . '
-					WHERE version_id = ' . $db->escapeNumber($this->versionID));
+					SET went_live = :now
+					WHERE version_id = :version_id', [
+			'now' => $db->escapeNumber(Epoch::time()),
+			'version_id' => $db->escapeNumber($this->versionID),
+		]);
 
 		// Initialize the next version (since the version set live is not always the
 		// last one, we INSERT IGNORE to skip this step in this case).
-		$dbResult = $db->read('SELECT * FROM version WHERE version_id = ' . $db->escapeNumber($this->versionID));
+		$dbResult = $db->read('SELECT * FROM version WHERE version_id = :version_id', [
+			'version_id' => $db->escapeNumber($this->versionID),
+		]);
 		$dbRecord = $dbResult->record();
 		$versionID = $dbRecord->getInt('version_id') + 1;
 		$major = $dbRecord->getInt('major_version');
 		$minor = $dbRecord->getInt('minor_version');
 		$patch = $dbRecord->getInt('patch_level') + 1;
 		$db->write('INSERT IGNORE INTO version (version_id, major_version, minor_version, patch_level, went_live) VALUES
-					(' . $db->escapeNumber($versionID) . ',' . $db->escapeNumber($major) . ',' . $db->escapeNumber($minor) . ',' . $db->escapeNumber($patch) . ',0);');
+					(:version_id, :major_version, :minor_version, :patch_level, 0)', [
+			'version_id' => $db->escapeNumber($versionID),
+			'major_version' => $db->escapeNumber($major),
+			'minor_version' => $db->escapeNumber($minor),
+			'patch_level' => $db->escapeNumber($patch),
+		]);
 
 		(new Changelog())->go();
 	}

--- a/src/pages/Admin/ChangelogSetLiveProcessor.php
+++ b/src/pages/Admin/ChangelogSetLiveProcessor.php
@@ -15,12 +15,11 @@ class ChangelogSetLiveProcessor extends AccountPageProcessor {
 
 	public function build(Account $account): never {
 		$db = Database::getInstance();
-		$db->write('UPDATE version
-					SET went_live = :now
-					WHERE version_id = :version_id', [
-			'now' => $db->escapeNumber(Epoch::time()),
-			'version_id' => $db->escapeNumber($this->versionID),
-		]);
+		$db->update(
+			'version',
+			['went_live' => $db->escapeNumber(Epoch::time())],
+			['version_id' => $db->escapeNumber($this->versionID)],
+		);
 
 		// Initialize the next version (since the version set live is not always the
 		// last one, we INSERT IGNORE to skip this step in this case).

--- a/src/pages/Admin/ChangelogSetLiveProcessor.php
+++ b/src/pages/Admin/ChangelogSetLiveProcessor.php
@@ -17,8 +17,8 @@ class ChangelogSetLiveProcessor extends AccountPageProcessor {
 		$db = Database::getInstance();
 		$db->update(
 			'version',
-			['went_live' => $db->escapeNumber(Epoch::time())],
-			['version_id' => $db->escapeNumber($this->versionID)],
+			['went_live' => Epoch::time()],
+			['version_id' => $this->versionID],
 		);
 
 		// Initialize the next version (since the version set live is not always the

--- a/src/pages/Admin/CheatingShipCheckProcessor.php
+++ b/src/pages/Admin/CheatingShipCheckProcessor.php
@@ -26,11 +26,11 @@ class CheatingShipCheckProcessor extends AccountPageProcessor {
 		$db = Database::getInstance();
 		$db->update(
 			'ship_has_hardware',
-			['amount' => $db->escapeNumber($max_amount)],
+			['amount' => $max_amount],
 			[
-				'game_id' => $db->escapeNumber($game_id),
-				'account_id' => $db->escapeNumber($account_id),
-				'hardware_type_id' => $db->escapeNumber($hardware_id),
+				'game_id' => $game_id,
+				'account_id' => $account_id,
+				'hardware_type_id' => $hardware_id,
 			],
 		);
 

--- a/src/pages/Admin/CheatingShipCheckProcessor.php
+++ b/src/pages/Admin/CheatingShipCheckProcessor.php
@@ -24,16 +24,15 @@ class CheatingShipCheckProcessor extends AccountPageProcessor {
 
 		//update it so they arent cheating
 		$db = Database::getInstance();
-		$db->write('UPDATE ship_has_hardware
-					SET amount = :amount
-					WHERE game_id = :game_id AND
-						account_id = :account_id AND
-						hardware_type_id = :hardware_type_id', [
-			'amount' => $db->escapeNumber($max_amount),
-			'game_id' => $db->escapeNumber($game_id),
-			'account_id' => $db->escapeNumber($account_id),
-			'hardware_type_id' => $db->escapeNumber($hardware_id),
-		]);
+		$db->update(
+			'ship_has_hardware',
+			['amount' => $db->escapeNumber($max_amount)],
+			[
+				'game_id' => $db->escapeNumber($game_id),
+				'account_id' => $db->escapeNumber($account_id),
+				'hardware_type_id' => $db->escapeNumber($hardware_id),
+			],
+		);
 
 		//now erdirect back to page
 		$container = new CheatingShipCheck();

--- a/src/pages/Admin/CheatingShipCheckProcessor.php
+++ b/src/pages/Admin/CheatingShipCheckProcessor.php
@@ -24,11 +24,16 @@ class CheatingShipCheckProcessor extends AccountPageProcessor {
 
 		//update it so they arent cheating
 		$db = Database::getInstance();
-		$db->write('UPDATE ship_has_hardware ' .
-				   'SET amount = ' . $db->escapeNumber($max_amount) . ' ' .
-				   'WHERE game_id = ' . $db->escapeNumber($game_id) . ' AND ' .
-						 'account_id = ' . $db->escapeNumber($account_id) . ' AND ' .
-						 'hardware_type_id = ' . $db->escapeNumber($hardware_id));
+		$db->write('UPDATE ship_has_hardware
+					SET amount = :amount
+					WHERE game_id = :game_id AND
+						account_id = :account_id AND
+						hardware_type_id = :hardware_type_id', [
+			'amount' => $db->escapeNumber($max_amount),
+			'game_id' => $db->escapeNumber($game_id),
+			'account_id' => $db->escapeNumber($account_id),
+			'hardware_type_id' => $db->escapeNumber($hardware_id),
+		]);
 
 		//now erdirect back to page
 		$container = new CheatingShipCheck();

--- a/src/pages/Admin/ComputerSharing.php
+++ b/src/pages/Admin/ComputerSharing.php
@@ -47,7 +47,10 @@ class ComputerSharing extends AccountPage {
 			}
 
 			if ($rows > 1) {
-				$dbResult2 = $db->read('SELECT login FROM account WHERE account_id =' . $db->escapeNumber($currTabAccId) . ' AND last_login > ' . $db->escapeNumber(Epoch::time() - $unusedAfter));
+				$dbResult2 = $db->read('SELECT login FROM account WHERE account_id = :account_id AND last_login > :unused_time', [
+					'account_id' => $db->escapeNumber($currTabAccId),
+					'unused_time' => $db->escapeNumber(Epoch::time() - $unusedAfter),
+				]);
 				if (!$dbResult2->hasRecord()) {
 					continue;
 				}
@@ -55,7 +58,10 @@ class ComputerSharing extends AccountPage {
 				$rows = [];
 				foreach ($accountIDs as $currLinkAccId) {
 					$currLinkAccId = (int)$currLinkAccId;
-					$dbResult2 = $db->read('SELECT account_id, login, email, validated, last_login, (SELECT ip FROM account_has_ip WHERE account_id = account.account_id GROUP BY ip ORDER BY COUNT(ip) DESC LIMIT 1) common_ip FROM account WHERE account_id = ' . $db->escapeNumber($currLinkAccId) . ' AND last_login > ' . $db->escapeNumber(Epoch::time() - $unusedAfter));
+					$dbResult2 = $db->read('SELECT account_id, login, email, validated, last_login, (SELECT ip FROM account_has_ip WHERE account_id = account.account_id GROUP BY ip ORDER BY COUNT(ip) DESC LIMIT 1) common_ip FROM account WHERE account_id = :account_id AND last_login > :unused_time', [
+						'account_id' => $db->escapeNumber($currLinkAccId),
+						'unused_time' => $db->escapeNumber(Epoch::time() - $unusedAfter),
+					]);
 					if (!$dbResult2->hasRecord()) {
 						continue;
 					}
@@ -68,7 +74,9 @@ class ComputerSharing extends AccountPage {
 					$common_ip = $dbRecord2->getString('common_ip');
 					$last_login = date($account->getDateTimeFormat(), $dbRecord2->getInt('last_login'));
 
-					$dbResult2 = $db->read('SELECT * FROM account_is_closed WHERE account_id = ' . $db->escapeNumber($currLinkAccId));
+					$dbResult2 = $db->read('SELECT * FROM account_is_closed WHERE account_id = :account_id', [
+						'account_id' => $db->escapeNumber($currLinkAccId),
+					]);
 					$isDisabled = $dbResult2->hasRecord();
 					if ($isDisabled) {
 						$suspicion = $dbResult2->record()->getString('suspicion');
@@ -76,7 +84,9 @@ class ComputerSharing extends AccountPage {
 						$suspicion = '';
 					}
 
-					$dbResult2 = $db->read('SELECT * FROM account_exceptions WHERE account_id = ' . $db->escapeNumber($currLinkAccId));
+					$dbResult2 = $db->read('SELECT * FROM account_exceptions WHERE account_id = :account_id', [
+						'account_id' => $db->escapeNumber($currLinkAccId),
+					]);
 					if ($dbResult2->hasRecord()) {
 						$exception = $dbResult2->record()->getString('reason');
 					} else {

--- a/src/pages/Admin/EnableGame.php
+++ b/src/pages/Admin/EnableGame.php
@@ -23,7 +23,9 @@ class EnableGame extends AccountPage {
 
 		// Get the list of disabled games
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT game_name, game_id FROM game WHERE enabled=' . $db->escapeBoolean(false));
+		$dbResult = $db->read('SELECT game_name, game_id FROM game WHERE enabled = :enabled', [
+			'enabled' => $db->escapeBoolean(false),
+		]);
 		$disabledGames = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$disabledGames[$dbRecord->getInt('game_id')] = $dbRecord->getString('game_name');

--- a/src/pages/Admin/FormOpenProcessor.php
+++ b/src/pages/Admin/FormOpenProcessor.php
@@ -15,7 +15,10 @@ class FormOpenProcessor extends AccountPageProcessor {
 
 	public function build(Account $account): never {
 		$db = Database::getInstance();
-		$db->write('UPDATE open_forms SET open = ' . $db->escapeBoolean(!$this->isOpen) . ' WHERE type=' . $db->escapeString($this->type));
+		$db->write('UPDATE open_forms SET open = :open WHERE type = :type', [
+			'open' => $db->escapeBoolean(!$this->isOpen),
+			'type' => $db->escapeString($this->type),
+		]);
 
 		(new FormOpen())->go();
 	}

--- a/src/pages/Admin/FormOpenProcessor.php
+++ b/src/pages/Admin/FormOpenProcessor.php
@@ -15,10 +15,11 @@ class FormOpenProcessor extends AccountPageProcessor {
 
 	public function build(Account $account): never {
 		$db = Database::getInstance();
-		$db->write('UPDATE open_forms SET open = :open WHERE type = :type', [
-			'open' => $db->escapeBoolean(!$this->isOpen),
-			'type' => $db->escapeString($this->type),
-		]);
+		$db->update(
+			'open_forms',
+			['open' => $db->escapeBoolean(!$this->isOpen)],
+			['type' => $db->escapeString($this->type)],
+		);
 
 		(new FormOpen())->go();
 	}

--- a/src/pages/Admin/FormOpenProcessor.php
+++ b/src/pages/Admin/FormOpenProcessor.php
@@ -18,7 +18,7 @@ class FormOpenProcessor extends AccountPageProcessor {
 		$db->update(
 			'open_forms',
 			['open' => $db->escapeBoolean(!$this->isOpen)],
-			['type' => $db->escapeString($this->type)],
+			['type' => $this->type],
 		);
 
 		(new FormOpen())->go();

--- a/src/pages/Admin/GameDeleteProcessor.php
+++ b/src/pages/Admin/GameDeleteProcessor.php
@@ -29,22 +29,30 @@ class GameDeleteProcessor extends AccountPageProcessor {
 
 		if ($delete) {
 			if ($save) {
-				$dbResult = $db->read('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($game_id));
+				$dbResult = $db->read('SELECT * FROM alliance WHERE game_id = :game_id', [
+					'game_id' => $db->escapeNumber($game_id),
+				]);
 
 				foreach ($dbResult->records() as $dbRecord) {
 					$id = $dbRecord->getInt('alliance_id');
 					//we need info for forces
 					//populate alliance list
 					$dbResult2 = $db->read('SELECT * FROM player
-								WHERE alliance_id = ' . $db->escapeNumber($id) . '
-									AND game_id = ' . $db->escapeNumber($game_id));
+								WHERE alliance_id = :alliance_id
+									AND game_id = :game_id', [
+						'alliance_id' => $db->escapeNumber($id),
+						'game_id' => $db->escapeNumber($game_id),
+					]);
 					$list = [0];
 					foreach ($dbResult2->records() as $dbRecord2) {
 						$list[] = $dbRecord2->getInt('account_id');
 					}
 					$dbResult2 = $db->read('SELECT sum(mines) as sum_m, sum(combat_drones) as cds, sum(scout_drones) as sds
 								FROM sector_has_forces
-								WHERE owner_id IN (' . $db->escapeArray($list) . ') AND game_id = ' . $db->escapeNumber($game_id));
+								WHERE owner_id IN (:owner_ids) AND game_id = :game_id', [
+						'owner_ids' => $db->escapeArray($list),
+						'game_id' => $db->escapeNumber($game_id),
+					]);
 					if ($dbResult2->hasRecord()) {
 						$dbRecord2 = $dbResult2->record();
 						$mines = $dbRecord2->getInt('sum_m');
@@ -81,7 +89,9 @@ class GameDeleteProcessor extends AccountPageProcessor {
 
 			if ($save) {
 
-				$dbResult = $db->read('SELECT * FROM alliance_vs_alliance WHERE game_id = ' . $db->escapeNumber($game_id));
+				$dbResult = $db->read('SELECT * FROM alliance_vs_alliance WHERE game_id = :game_id', [
+					'game_id' => $db->escapeNumber($game_id),
+				]);
 				foreach ($dbResult->records() as $dbRecord) {
 
 					$alliance_1 = $dbRecord->getInt('alliance_id_1');
@@ -120,7 +130,9 @@ class GameDeleteProcessor extends AccountPageProcessor {
 
 			if ($save) {
 
-				$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $game_id . ' AND type = \'regular\'');
+				$dbResult = $db->read('SELECT * FROM news WHERE game_id = :game_id AND type = \'regular\'', [
+					'game_id' => $game_id,
+				]);
 				$id = 1;
 
 				foreach ($dbResult->records() as $dbRecord) {
@@ -140,7 +152,9 @@ class GameDeleteProcessor extends AccountPageProcessor {
 
 			if ($save) {
 
-				$dbResult = $db->read('SELECT * FROM planet WHERE game_id = ' . $db->escapeNumber($game_id));
+				$dbResult = $db->read('SELECT * FROM planet WHERE game_id = :game_id', [
+					'game_id' => $db->escapeNumber($game_id),
+				]);
 
 				foreach ($dbResult->records() as $dbRecord) {
 
@@ -148,21 +162,30 @@ class GameDeleteProcessor extends AccountPageProcessor {
 					$sector = $dbRecord->getInt('sector_id');
 					$owner = $dbRecord->getInt('owner_id');
 
-					$dbResult2 = $db->read('SELECT * FROM planet_has_building WHERE game_id = ' . $game_id . ' AND sector_id = ' . $sector . ' AND construction_id = 1');
+					$dbResult2 = $db->read('SELECT * FROM planet_has_building WHERE game_id = :game_id AND sector_id = :sector_id AND construction_id = 1', [
+						'game_id' => $game_id,
+						'sector_id' => $sector,
+					]);
 					if ($dbResult2->hasRecord()) {
 						$gens = $dbResult2->record()->getInt('amount');
 					} else {
 						$gens = 0;
 					}
 
-					$dbResult2 = $db->read('SELECT * FROM planet_has_building WHERE game_id = ' . $game_id . ' AND sector_id = ' . $sector . ' AND construction_id = 2');
+					$dbResult2 = $db->read('SELECT * FROM planet_has_building WHERE game_id = :game_id AND sector_id = :sector_id AND construction_id = 2', [
+						'game_id' => $game_id,
+						'sector_id' => $sector,
+					]);
 					if ($dbResult2->hasRecord()) {
 						$hangs = $dbResult2->record()->getInt('amount');
 					} else {
 						$hangs = 0;
 					}
 
-					$dbResult2 = $db->read('SELECT * FROM planet_has_building WHERE game_id = ' . $game_id . ' AND sector_id = ' . $sector . ' AND construction_id = 3');
+					$dbResult2 = $db->read('SELECT * FROM planet_has_building WHERE game_id = :game_id AND sector_id = :sector_id AND construction_id = 3', [
+						'game_id' => $game_id,
+						'sector_id' => $sector,
+					]);
 					if ($dbResult2->hasRecord()) {
 						$turs = $dbResult2->record()->getInt('amount');
 					} else {
@@ -184,7 +207,9 @@ class GameDeleteProcessor extends AccountPageProcessor {
 
 			if ($save) {
 
-				$dbResult = $db->read('SELECT * FROM player WHERE game_id = ' . $game_id);
+				$dbResult = $db->read('SELECT * FROM player WHERE game_id = :game_id', [
+					'game_id' => $game_id,
+				]);
 
 				foreach ($dbResult->records() as $dbRecord) {
 
@@ -202,14 +227,20 @@ class GameDeleteProcessor extends AccountPageProcessor {
 
 					$amount = 0;
 					$smrCredits = 0;
-					$dbResult2 = $db->read('SELECT sum(amount) as bounty_am, sum(smr_credits) as bounty_cred FROM bounty WHERE game_id = ' . $game_id . ' AND account_id = ' . $acc_id . ' AND claimer_id = 0');
+					$dbResult2 = $db->read('SELECT sum(amount) as bounty_am, sum(smr_credits) as bounty_cred FROM bounty WHERE game_id = :game_id AND account_id = :account_id AND claimer_id = 0', [
+						'game_id' => $game_id,
+						'account_id' => $acc_id,
+					]);
 					if ($dbResult2->hasRecord()) {
 						$dbRecord2 = $dbResult2->record();
 						$amount = $dbRecord2->getInt('bounty_am');
 						$smrCredits = $dbRecord2->getInt('bounty_cred');
 					}
 
-					$dbResult2 = $db->read('SELECT * FROM ship_has_name WHERE game_id = ' . $game_id . ' AND account_id = ' . $acc_id);
+					$dbResult2 = $db->read('SELECT * FROM ship_has_name WHERE game_id = :game_id AND account_id = :account_id', [
+						'game_id' => $game_id,
+						'account_id' => $acc_id,
+					]);
 					if ($dbResult2->hasRecord()) {
 						$ship_name = $dbResult2->record()->getString('ship_name');
 					} else {
@@ -245,7 +276,9 @@ class GameDeleteProcessor extends AccountPageProcessor {
 
 			if ($save) {
 
-				$dbResult = $db->read('SELECT * FROM sector WHERE game_id = ' . $game_id);
+				$dbResult = $db->read('SELECT * FROM sector WHERE game_id = :game_id', [
+					'game_id' => $game_id,
+				]);
 
 				foreach ($dbResult->records() as $dbRecord) {
 
@@ -255,7 +288,10 @@ class GameDeleteProcessor extends AccountPageProcessor {
 					$gal_id = $dbRecord->getInt('galaxy_id');
 
 					$dbResult2 = $db->read('SELECT sum(mines) as sum_mines, sum(combat_drones) as cds, sum(scout_drones) as sds FROM sector_has_forces ' .
-								'WHERE sector_id = ' . $sector . ' AND game_id = ' . $game_id . ' GROUP BY sector_id');
+								'WHERE sector_id = :sector_id AND game_id = :game_id GROUP BY sector_id', [
+						'sector_id' => $sector,
+						'game_id' => $game_id,
+					]);
 					if ($dbResult2->hasRecord()) {
 
 						$dbRecord2 = $dbResult2->record();

--- a/src/pages/Admin/LogConsole.php
+++ b/src/pages/Admin/LogConsole.php
@@ -38,7 +38,9 @@ class LogConsole extends AccountPage {
 				'Notes' => '',
 			];
 
-			$dbResult2 = $db->read('SELECT notes FROM log_has_notes WHERE account_id = ' . $db->escapeNumber($accountID));
+			$dbResult2 = $db->read('SELECT notes FROM log_has_notes WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($accountID),
+			]);
 			if ($dbResult2->hasRecord()) {
 				$loggedAccounts[$accountID]['Notes'] = nl2br($dbResult2->record()->getString('notes'));
 			}

--- a/src/pages/Admin/LogConsoleAnonBank.php
+++ b/src/pages/Admin/LogConsoleAnonBank.php
@@ -24,8 +24,10 @@ class LogConsoleAnonBank extends AccountPage {
 		// get all anon bank transactions that are logged in an array
 		$dbResult = $db->read('SELECT * FROM anon_bank_transactions
 		            JOIN account USING(account_id)
-		            WHERE account_id IN (' . $db->escapeArray($log_account_ids) . ')
-		            ORDER BY game_id DESC, anon_id ASC');
+		            WHERE account_id IN (:account_ids)
+		            ORDER BY game_id DESC, anon_id ASC', [
+			'account_ids' => $db->escapeArray($log_account_ids),
+		]);
 		$anon_logs = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$transaction = strtolower($dbRecord->getString('transaction'));

--- a/src/pages/Admin/LogConsoleDetail.php
+++ b/src/pages/Admin/LogConsoleDetail.php
@@ -45,7 +45,9 @@ class LogConsoleDetail extends AccountPage {
 			// assign it a color
 			$color = $avail_colors[$i % count($avail_colors)];
 
-			$dbResult = $db->read('SELECT login FROM account WHERE account_id = ' . $db->escapeNumber($id));
+			$dbResult = $db->read('SELECT login FROM account WHERE account_id = :account_id', [
+				'account_id' => $db->escapeNumber($id),
+			]);
 			if ($dbResult->hasRecord()) {
 				$colors[$id] = [
 					'name' => $dbResult->record()->getString('login'),
@@ -84,7 +86,9 @@ class LogConsoleDetail extends AccountPage {
 
 		// get notes from db
 		$log_notes = [];
-		$dbResult = $db->read('SELECT * FROM log_has_notes WHERE account_id IN (' . $account_list . ')');
+		$dbResult = $db->read('SELECT * FROM log_has_notes WHERE account_id IN (:account_ids)', [
+			'account_ids' => $account_list,
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$log_notes[] = $dbRecord->getString('notes');
 		}
@@ -100,7 +104,10 @@ class LogConsoleDetail extends AccountPage {
 		// * L o g   T a b l e
 		// *********************************
 		$logs = [];
-		$dbResult = $db->read('SELECT * FROM account_has_logs WHERE account_id IN (' . $account_list . ') AND log_type_id IN (' . $db->escapeArray($log_type_id_list) . ') ORDER BY microtime DESC');
+		$dbResult = $db->read('SELECT * FROM account_has_logs WHERE account_id IN (:account_ids) AND log_type_id IN (:log_type_ids) ORDER BY microtime DESC', [
+			'account_ids' => $account_list,
+			'log_type_ids' => $db->escapeArray($log_type_id_list),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$account_id = $dbRecord->getInt('account_id');
 			$microtime = $dbRecord->getFloat('microtime');

--- a/src/pages/Admin/LogConsoleNotesProcessor.php
+++ b/src/pages/Admin/LogConsoleNotesProcessor.php
@@ -24,12 +24,12 @@ class LogConsoleNotesProcessor extends AccountPageProcessor {
 		foreach ($this->accountIDs as $account_id) {
 			if (empty(Request::get('notes'))) {
 				$db->delete('log_has_notes', [
-					'account_id' => $db->escapeNumber($account_id),
+					'account_id' => $account_id,
 				]);
 			} else {
 				$db->replace('log_has_notes', [
-					'account_id' => $db->escapeNumber($account_id),
-					'notes' => $db->escapeString(Request::get('notes')),
+					'account_id' => $account_id,
+					'notes' => Request::get('notes'),
 				]);
 			}
 		}

--- a/src/pages/Admin/LogConsoleNotesProcessor.php
+++ b/src/pages/Admin/LogConsoleNotesProcessor.php
@@ -23,7 +23,7 @@ class LogConsoleNotesProcessor extends AccountPageProcessor {
 
 		foreach ($this->accountIDs as $account_id) {
 			if (empty(Request::get('notes'))) {
-				$db->write('DELETE FROM log_has_notes WHERE account_id = :account_id', [
+				$db->delete('log_has_notes', [
 					'account_id' => $db->escapeNumber($account_id),
 				]);
 			} else {

--- a/src/pages/Admin/LogConsoleNotesProcessor.php
+++ b/src/pages/Admin/LogConsoleNotesProcessor.php
@@ -23,7 +23,9 @@ class LogConsoleNotesProcessor extends AccountPageProcessor {
 
 		foreach ($this->accountIDs as $account_id) {
 			if (empty(Request::get('notes'))) {
-				$db->write('DELETE FROM log_has_notes WHERE account_id = ' . $db->escapeNumber($account_id));
+				$db->write('DELETE FROM log_has_notes WHERE account_id = :account_id', [
+					'account_id' => $db->escapeNumber($account_id),
+				]);
 			} else {
 				$db->replace('log_has_notes', [
 					'account_id' => $db->escapeNumber($account_id),

--- a/src/pages/Admin/LogConsoleProcessor.php
+++ b/src/pages/Admin/LogConsoleProcessor.php
@@ -20,8 +20,12 @@ class LogConsoleProcessor extends AccountPageProcessor {
 		$action = Request::get('action');
 		if ($action == 'Delete') {
 			// get rid of all entries
-			$db->write('DELETE FROM account_has_logs WHERE account_id IN (' . $db->escapeArray($accountIDs) . ')');
-			$db->write('DELETE FROM log_has_notes WHERE account_id IN (' . $db->escapeArray($accountIDs) . ')');
+			$db->write('DELETE FROM account_has_logs WHERE account_id IN (:account_ids)', [
+				'account_ids' => $db->escapeArray($accountIDs),
+			]);
+			$db->write('DELETE FROM log_has_notes WHERE account_id IN (:account_ids)', [
+				'account_ids' => $db->escapeArray($accountIDs),
+			]);
 			$container = new LogConsole();
 		} else {
 			$logTypes = [];

--- a/src/pages/Admin/ManageDraftLeaders.php
+++ b/src/pages/Admin/ManageDraftLeaders.php
@@ -28,7 +28,10 @@ class ManageDraftLeaders extends AccountPage {
 		// Get the list of active Draft games ordered by reverse start date
 		$activeGames = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE game_type=' . $db->escapeNumber(Game::GAME_TYPE_DRAFT) . ' AND join_time < ' . $db->escapeNumber(Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Epoch::time()) . ' ORDER BY start_time DESC');
+		$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE game_type = :game_type AND join_time < :now AND end_time > :now ORDER BY start_time DESC', [
+			'game_type' => $db->escapeNumber(Game::GAME_TYPE_DRAFT),
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$activeGames[] = [
 				'game_name' => $dbRecord->getString('game_name'),
@@ -44,7 +47,9 @@ class ManageDraftLeaders extends AccountPage {
 
 			// Get the list of current draft leaders for the selected game
 			$currentLeaders = [];
-			$dbResult = $db->read('SELECT account_id, home_sector_id FROM draft_leaders WHERE game_id=' . $db->escapeNumber($selectedGameID));
+			$dbResult = $db->read('SELECT account_id, home_sector_id FROM draft_leaders WHERE game_id = :game_id', [
+				'game_id' => $db->escapeNumber($selectedGameID),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$homeSectorID = $dbRecord->getInt('home_sector_id');
 				$leader = Player::getPlayer($dbRecord->getInt('account_id'), $selectedGameID);

--- a/src/pages/Admin/ManageDraftLeadersProcessor.php
+++ b/src/pages/Admin/ManageDraftLeadersProcessor.php
@@ -35,7 +35,6 @@ class ManageDraftLeadersProcessor extends AccountPageProcessor {
 		}
 
 		$name = $selectedPlayer->getDisplayName();
-		$accountId = $selectedPlayer->getAccountID();
 		$game = $selectedPlayer->getGame()->getDisplayName();
 
 		$msg = null; // by default, clear any messages from prior processing
@@ -44,8 +43,7 @@ class ManageDraftLeadersProcessor extends AccountPageProcessor {
 				$msg = "<span class='red'>ERROR: </span>$name is already a draft leader in game $game!";
 			} else {
 				$db->insert('draft_leaders', [
-					'account_id' => $db->escapeNumber($accountId),
-					'game_id' => $db->escapeNumber($gameId),
+					...$selectedPlayer->SQLID,
 					'home_sector_id' => $db->escapeNumber($homeSectorID),
 				]);
 			}
@@ -53,7 +51,7 @@ class ManageDraftLeadersProcessor extends AccountPageProcessor {
 			if (!$selectedPlayer->isDraftLeader()) {
 				$msg = "<span class='red'>ERROR: </span>$name is not a draft leader in game $game!";
 			} else {
-				$db->write('DELETE FROM draft_leaders WHERE ' . $selectedPlayer->getSQL());
+				$db->write('DELETE FROM draft_leaders WHERE ' . Player::SQL, $selectedPlayer->SQLID);
 			}
 		} else {
 			$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";

--- a/src/pages/Admin/ManageDraftLeadersProcessor.php
+++ b/src/pages/Admin/ManageDraftLeadersProcessor.php
@@ -51,7 +51,7 @@ class ManageDraftLeadersProcessor extends AccountPageProcessor {
 			if (!$selectedPlayer->isDraftLeader()) {
 				$msg = "<span class='red'>ERROR: </span>$name is not a draft leader in game $game!";
 			} else {
-				$db->write('DELETE FROM draft_leaders WHERE ' . Player::SQL, $selectedPlayer->SQLID);
+				$db->delete('draft_leaders', $selectedPlayer->SQLID);
 			}
 		} else {
 			$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";

--- a/src/pages/Admin/ManageDraftLeadersProcessor.php
+++ b/src/pages/Admin/ManageDraftLeadersProcessor.php
@@ -44,7 +44,7 @@ class ManageDraftLeadersProcessor extends AccountPageProcessor {
 			} else {
 				$db->insert('draft_leaders', [
 					...$selectedPlayer->SQLID,
-					'home_sector_id' => $db->escapeNumber($homeSectorID),
+					'home_sector_id' => $homeSectorID,
 				]);
 			}
 		} elseif ($action == 'Remove') {

--- a/src/pages/Admin/ManagePostEditors.php
+++ b/src/pages/Admin/ManagePostEditors.php
@@ -28,7 +28,9 @@ class ManagePostEditors extends AccountPage {
 		// Get the list of active games ordered by reverse start date
 		$activeGames = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE join_time < ' . $db->escapeNumber(Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Epoch::time()) . ' ORDER BY start_time DESC');
+		$dbResult = $db->read('SELECT game_id, game_name FROM game WHERE join_time < :now AND end_time > :now ORDER BY start_time DESC', [
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$activeGames[] = [
 				'game_name' => $dbRecord->getString('game_name'),

--- a/src/pages/Admin/ManagePostEditorsProcessor.php
+++ b/src/pages/Admin/ManagePostEditorsProcessor.php
@@ -34,7 +34,6 @@ class ManagePostEditorsProcessor extends AccountPageProcessor {
 		}
 
 		$name = $selected_player->getDisplayName();
-		$account_id = $selected_player->getAccountID();
 		$game = $selected_player->getGame()->getDisplayName();
 
 		$msg = null; // by default, clear any messages from prior processing
@@ -42,16 +41,13 @@ class ManagePostEditorsProcessor extends AccountPageProcessor {
 			if ($selected_player->isGPEditor()) {
 				$msg = "<span class='red'>ERROR: </span>$name is already an editor in game $game!";
 			} else {
-				$db->insert('galactic_post_writer', [
-					'account_id' => $db->escapeNumber($account_id),
-					'game_id' => $db->escapeNumber($game_id),
-				]);
+				$db->insert('galactic_post_writer', $selected_player->SQLID);
 			}
 		} elseif ($action == 'Remove') {
 			if (!$selected_player->isGPEditor()) {
 				$msg = "<span class='red'>ERROR: </span>$name is not an editor in game $game!";
 			} else {
-				$db->write('DELETE FROM galactic_post_writer WHERE ' . $selected_player->getSQL());
+				$db->write('DELETE FROM galactic_post_writer WHERE ' . Player::SQL, $selected_player->SQLID);
 			}
 		} else {
 			$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";

--- a/src/pages/Admin/ManagePostEditorsProcessor.php
+++ b/src/pages/Admin/ManagePostEditorsProcessor.php
@@ -47,7 +47,7 @@ class ManagePostEditorsProcessor extends AccountPageProcessor {
 			if (!$selected_player->isGPEditor()) {
 				$msg = "<span class='red'>ERROR: </span>$name is not an editor in game $game!";
 			} else {
-				$db->write('DELETE FROM galactic_post_writer WHERE ' . Player::SQL, $selected_player->SQLID);
+				$db->delete('galactic_post_writer', $selected_player->SQLID);
 			}
 		} else {
 			$msg = "<span class='red'>ERROR: </span>Do not know action '$action'!";

--- a/src/pages/Admin/MessageBoxDeleteProcessor.php
+++ b/src/pages/Admin/MessageBoxDeleteProcessor.php
@@ -24,12 +24,12 @@ class MessageBoxDeleteProcessor extends AccountPageProcessor {
 
 			foreach (Request::getIntArray('message_id') as $id) {
 				$db->delete('message_boxes', [
-					'message_id' => $db->escapeNumber($id),
+					'message_id' => $id,
 				]);
 			}
 		} elseif ($action == 'All Messages') {
 			$db->delete('message_boxes', [
-				'box_type_id' => $db->escapeNumber($this->boxTypeID),
+				'box_type_id' => $this->boxTypeID,
 			]);
 		}
 

--- a/src/pages/Admin/MessageBoxDeleteProcessor.php
+++ b/src/pages/Admin/MessageBoxDeleteProcessor.php
@@ -23,10 +23,14 @@ class MessageBoxDeleteProcessor extends AccountPageProcessor {
 			}
 
 			foreach (Request::getIntArray('message_id') as $id) {
-				$db->write('DELETE FROM message_boxes WHERE message_id = ' . $db->escapeNumber($id));
+				$db->write('DELETE FROM message_boxes WHERE message_id = :message_id', [
+					'message_id' => $db->escapeNumber($id),
+				]);
 			}
 		} elseif ($action == 'All Messages') {
-			$db->write('DELETE FROM message_boxes WHERE box_type_id = ' . $db->escapeNumber($this->boxTypeID));
+			$db->write('DELETE FROM message_boxes WHERE box_type_id = :box_type_id', [
+				'box_type_id' => $db->escapeNumber($this->boxTypeID),
+			]);
 		}
 
 		(new MessageBoxView())->go();

--- a/src/pages/Admin/MessageBoxDeleteProcessor.php
+++ b/src/pages/Admin/MessageBoxDeleteProcessor.php
@@ -23,12 +23,12 @@ class MessageBoxDeleteProcessor extends AccountPageProcessor {
 			}
 
 			foreach (Request::getIntArray('message_id') as $id) {
-				$db->write('DELETE FROM message_boxes WHERE message_id = :message_id', [
+				$db->delete('message_boxes', [
 					'message_id' => $db->escapeNumber($id),
 				]);
 			}
 		} elseif ($action == 'All Messages') {
-			$db->write('DELETE FROM message_boxes WHERE box_type_id = :box_type_id', [
+			$db->delete('message_boxes', [
 				'box_type_id' => $db->escapeNumber($this->boxTypeID),
 			]);
 		}

--- a/src/pages/Admin/MessageBoxView.php
+++ b/src/pages/Admin/MessageBoxView.php
@@ -48,7 +48,9 @@ class MessageBoxView extends AccountPage {
 			$template->assign('PageTopic', 'Viewing ' . $boxName);
 
 			$template->assign('BackHREF', (new self())->href());
-			$dbResult = $db->read('SELECT * FROM message_boxes WHERE box_type_id=' . $db->escapeNumber($this->boxTypeID) . ' ORDER BY send_time DESC');
+			$dbResult = $db->read('SELECT * FROM message_boxes WHERE box_type_id = :box_type_id ORDER BY send_time DESC', [
+				'box_type_id' => $db->escapeNumber($this->boxTypeID),
+			]);
 			$messages = [];
 			if ($dbResult->hasRecord()) {
 				$container = new MessageBoxDeleteProcessor($this->boxTypeID);

--- a/src/pages/Admin/NpcManage.php
+++ b/src/pages/Admin/NpcManage.php
@@ -28,7 +28,10 @@ class NpcManage extends AccountPage {
 
 		$games = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > ' . $db->escapeNumber(Epoch::time()) . ' AND enabled = ' . $db->escapeBoolean(true) . ' ORDER BY game_id DESC');
+		$dbResult = $db->read('SELECT game_id FROM game WHERE end_time > :now AND enabled = :enabled ORDER BY game_id DESC', [
+			'now' => $db->escapeNumber(Epoch::time()),
+			'enabled' => $db->escapeBoolean(true),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$gameID = $dbRecord->getInt('game_id');
 			if (empty($selectedGameID)) {
@@ -75,7 +78,10 @@ class NpcManage extends AccountPage {
 		$template->assign('NextLogin', 'npc' . $nextNpcID);
 
 		// Get the existing NPC players for the selected game
-		$dbResult = $db->read('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($selectedGameID) . ' AND npc=' . $db->escapeBoolean(true));
+		$dbResult = $db->read('SELECT * FROM player WHERE game_id = :game_id AND npc = :npc', [
+			'game_id' => $db->escapeNumber($selectedGameID),
+			'npc' => $db->escapeBoolean(true),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$accountID = $dbRecord->getInt('account_id');
 			$npcs[$accountID]['player'] = Player::getPlayer($accountID, $selectedGameID, false, $dbRecord);

--- a/src/pages/Admin/NpcManageAddAccountProcessor.php
+++ b/src/pages/Admin/NpcManageAddAccountProcessor.php
@@ -23,9 +23,9 @@ class NpcManageAddAccountProcessor extends AccountPageProcessor {
 
 		$db = Database::getInstance();
 		$db->insert('npc_logins', [
-			'login' => $db->escapeString($login),
-			'player_name' => $db->escapeString(Request::get('default_player_name')),
-			'alliance_name' => $db->escapeString(Request::get('default_alliance')),
+			'login' => $login,
+			'player_name' => Request::get('default_player_name'),
+			'alliance_name' => Request::get('default_alliance'),
 		]);
 
 		$container = new NpcManage($this->selectedGameID);

--- a/src/pages/Admin/NpcManageProcessor.php
+++ b/src/pages/Admin/NpcManageProcessor.php
@@ -29,7 +29,7 @@ class NpcManageProcessor extends AccountPageProcessor {
 			$db->update(
 				'npc_logins',
 				['active' => $db->escapeBoolean($active)],
-				['login' => $db->escapeString($this->login)],
+				['login' => $this->login],
 			);
 		}
 

--- a/src/pages/Admin/NpcManageProcessor.php
+++ b/src/pages/Admin/NpcManageProcessor.php
@@ -26,7 +26,10 @@ class NpcManageProcessor extends AccountPageProcessor {
 		if (Request::has('active-submit')) {
 			// Toggle the activity of this NPC
 			$active = Request::has('active');
-			$db->write('UPDATE npc_logins SET active=' . $db->escapeBoolean($active) . ' WHERE login=' . $db->escapeString($this->login));
+			$db->write('UPDATE npc_logins SET active = :active WHERE login = :login', [
+				'active' => $db->escapeBoolean($active),
+				'login' => $db->escapeString($this->login),
+			]);
 		}
 
 		// Create a new NPC player in a selected game

--- a/src/pages/Admin/NpcManageProcessor.php
+++ b/src/pages/Admin/NpcManageProcessor.php
@@ -26,10 +26,11 @@ class NpcManageProcessor extends AccountPageProcessor {
 		if (Request::has('active-submit')) {
 			// Toggle the activity of this NPC
 			$active = Request::has('active');
-			$db->write('UPDATE npc_logins SET active = :active WHERE login = :login', [
-				'active' => $db->escapeBoolean($active),
-				'login' => $db->escapeString($this->login),
-			]);
+			$db->update(
+				'npc_logins',
+				['active' => $db->escapeBoolean($active)],
+				['login' => $db->escapeString($this->login)],
+			);
 		}
 
 		// Create a new NPC player in a selected game

--- a/src/pages/Admin/ReportedMessageDeleteProcessor.php
+++ b/src/pages/Admin/ReportedMessageDeleteProcessor.php
@@ -15,7 +15,9 @@ class ReportedMessageDeleteProcessor extends AccountPageProcessor {
 		}
 
 		$db = Database::getInstance();
-		$db->write('DELETE FROM message_notify WHERE notify_id IN (' . $db->escapeArray(Request::getIntArray('notify_id')) . ')');
+		$db->write('DELETE FROM message_notify WHERE notify_id IN (:notify_ids)', [
+			'notify_ids' => $db->escapeArray(Request::getIntArray('notify_id')),
+		]);
 
 		(new ReportedMessageView())->go();
 	}

--- a/src/pages/Admin/ServerStatusProcessor.php
+++ b/src/pages/Admin/ServerStatusProcessor.php
@@ -17,7 +17,7 @@ class ServerStatusProcessor extends AccountPageProcessor {
 		if ($action == 'Close') {
 			$reason = Request::get('close_reason');
 			$db->replace('game_disable', [
-				'reason' => $db->escapeString($reason),
+				'reason' => $reason,
 			]);
 			$db->write('DELETE FROM active_session;');
 			$msg = '<span class="green">SUCCESS: </span>You have closed the server. You will now be logged out!';

--- a/src/pages/Admin/UniGen/CreateGame.php
+++ b/src/pages/Admin/UniGen/CreateGame.php
@@ -54,7 +54,9 @@ class CreateGame extends AccountPage {
 		if ($canEditEnabledGames) {
 			$dbResult = $db->read('SELECT game_id FROM game ORDER BY game_id DESC');
 		} else {
-			$dbResult = $db->read('SELECT game_id FROM game WHERE enabled=' . $db->escapeBoolean(false) . ' ORDER BY game_id DESC');
+			$dbResult = $db->read('SELECT game_id FROM game WHERE enabled = :enabled ORDER BY game_id DESC', [
+				'enabled' => $db->escapeBoolean(false),
+			]);
 		}
 		foreach ($dbResult->records() as $dbRecord) {
 			$games[] = Game::getGame($dbRecord->getInt('game_id'));

--- a/src/pages/Admin/UniGen/CreateGameProcessor.php
+++ b/src/pages/Admin/UniGen/CreateGameProcessor.php
@@ -15,7 +15,9 @@ class CreateGameProcessor extends AccountPageProcessor {
 		$db = Database::getInstance();
 
 		//first create the game
-		$dbResult = $db->read('SELECT 1 FROM game WHERE game_name=' . $db->escapeString(Request::get('game_name')));
+		$dbResult = $db->read('SELECT 1 FROM game WHERE game_name = :game_name', [
+			'game_name' => $db->escapeString(Request::get('game_name')),
+		]);
 		if ($dbResult->hasRecord()) {
 			create_error('That game name is already taken.');
 		}

--- a/src/pages/Admin/UniGen/CreateWarps.php
+++ b/src/pages/Admin/UniGen/CreateWarps.php
@@ -42,7 +42,9 @@ class CreateWarps extends AccountPage {
 		}
 
 		//get totals
-		$dbResult = $db->read('SELECT sector_id, warp FROM sector WHERE warp != 0 AND game_id=' . $db->escapeNumber($this->gameID));
+		$dbResult = $db->read('SELECT sector_id, warp FROM sector WHERE warp != 0 AND game_id = :game_id', [
+			'game_id' => $db->escapeNumber($this->gameID),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$warp1 = Sector::getSector($this->gameID, $dbRecord->getInt('sector_id'));
 			$warp2 = Sector::getSector($this->gameID, $dbRecord->getInt('warp'));

--- a/src/pages/Admin/UniGen/EditGalaxiesProcessor.php
+++ b/src/pages/Admin/UniGen/EditGalaxiesProcessor.php
@@ -102,7 +102,7 @@ class EditGalaxiesProcessor extends AccountPageProcessor {
 						// Remove this sector and everything in it
 						$delSector = Sector::getSector($gameID, $oldID);
 						$delSector->removeAllFixtures();
-						$db->write('DELETE FROM sector WHERE ' . Sector::SQL, $delSector->SQLID);
+						$db->delete('sector', $delSector->SQLID);
 					}
 				}
 			}

--- a/src/pages/Admin/UniGen/EditGalaxiesProcessor.php
+++ b/src/pages/Admin/UniGen/EditGalaxiesProcessor.php
@@ -121,7 +121,7 @@ class EditGalaxiesProcessor extends AccountPageProcessor {
 		$db->update(
 			'sector',
 			['warp' => 0],
-			['game_id' => $db->escapeNumber($gameID)],
+			['game_id' => $gameID],
 		);
 
 		// Many sectors will have their IDs shifted up or down, so we need to modify

--- a/src/pages/Admin/VoteCreate.php
+++ b/src/pages/Admin/VoteCreate.php
@@ -26,7 +26,9 @@ class VoteCreate extends AccountPage {
 
 		$voting = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM voting WHERE end > ' . $db->escapeNumber(Epoch::time()));
+		$dbResult = $db->read('SELECT * FROM voting WHERE end > :now', [
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$voteID = $dbRecord->getInt('vote_id');
 			$voting[$voteID]['ID'] = $voteID;

--- a/src/pages/Admin/VoteCreateProcessor.php
+++ b/src/pages/Admin/VoteCreateProcessor.php
@@ -32,15 +32,15 @@ class VoteCreateProcessor extends AccountPageProcessor {
 			$question = Request::get('question');
 			$end = Epoch::time() + 86400 * Request::getInt('days');
 			$db->insert('voting', [
-				'question' => $db->escapeString($question),
-				'end' => $db->escapeNumber($end),
+				'question' => $question,
+				'end' => $end,
 			]);
 		} elseif ($action == 'Add Option') {
 			$option = Request::get('option');
 			$voteID = Request::getInt('vote');
 			$db->insert('voting_options', [
-				'vote_id' => $db->escapeNumber($voteID),
-				'text' => $db->escapeString($option),
+				'vote_id' => $voteID,
+				'text' => $option,
 			]);
 		}
 		(new VoteCreate())->go();

--- a/src/pages/Admin/WordFilterAddProcessor.php
+++ b/src/pages/Admin/WordFilterAddProcessor.php
@@ -14,7 +14,9 @@ class WordFilterAddProcessor extends AccountPageProcessor {
 		$word_replacement = strtoupper(Request::get('WordReplacement'));
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM word_filter WHERE word_value=' . $db->escapeString($word) . ' LIMIT 1');
+		$dbResult = $db->read('SELECT 1 FROM word_filter WHERE word_value = :word_value LIMIT 1', [
+			'word_value' => $db->escapeString($word),
+		]);
 		if ($dbResult->hasRecord()) {
 			$msg = '<span class="red bold">ERROR: </span>This word is already filtered!';
 		} else {

--- a/src/pages/Admin/WordFilterAddProcessor.php
+++ b/src/pages/Admin/WordFilterAddProcessor.php
@@ -21,8 +21,8 @@ class WordFilterAddProcessor extends AccountPageProcessor {
 			$msg = '<span class="red bold">ERROR: </span>This word is already filtered!';
 		} else {
 			$db->insert('word_filter', [
-				'word_value' => $db->escapeString($word),
-				'word_replacement' => $db->escapeString($word_replacement),
+				'word_value' => $word,
+				'word_replacement' => $word_replacement,
 			]);
 			$msg = '<span class="yellow">' . $word . '</span> will now be replaced with <span class="yellow">' . $word_replacement . '</span>.';
 		}

--- a/src/pages/Admin/WordFilterDeleteProcessor.php
+++ b/src/pages/Admin/WordFilterDeleteProcessor.php
@@ -12,7 +12,9 @@ class WordFilterDeleteProcessor extends AccountPageProcessor {
 	public function build(Account $account): never {
 		if (Request::has('word_ids')) {
 			$db = Database::getInstance();
-			$db->write('DELETE FROM word_filter WHERE word_id IN (' . $db->escapeArray(Request::getIntArray('word_ids')) . ')');
+			$db->write('DELETE FROM word_filter WHERE word_id IN (:word_ids)', [
+				'word_ids' => $db->escapeArray(Request::getIntArray('word_ids')),
+			]);
 		}
 
 		$container = new WordFilter();

--- a/src/pages/Player/AllianceDraftMember.php
+++ b/src/pages/Player/AllianceDraftMember.php
@@ -50,7 +50,11 @@ class AllianceDraftMember extends PlayerPage {
 
 		// Get a list of players still in the pick pool
 		$players = [];
-		$dbResult = $db->read('SELECT * FROM player WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_id=0 OR alliance_id=' . $db->escapeNumber($NHAID) . ') AND account_id NOT IN (SELECT account_id FROM draft_leaders WHERE draft_leaders.game_id=player.game_id) AND account_id NOT IN (SELECT picked_account_id FROM draft_history WHERE draft_history.game_id=player.game_id) AND account_id != ' . $db->escapeNumber(ACCOUNT_ID_NHL) . ';');
+		$dbResult = $db->read('SELECT * FROM player WHERE game_id = :game_id AND (alliance_id=0 OR alliance_id = :nha_alliance_id) AND account_id NOT IN (SELECT account_id FROM draft_leaders WHERE draft_leaders.game_id=player.game_id) AND account_id NOT IN (SELECT picked_account_id FROM draft_history WHERE draft_history.game_id=player.game_id) AND account_id != :nhl_account_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'nha_alliance_id' => $db->escapeNumber($NHAID),
+			'nhl_account_id' => $db->escapeNumber(ACCOUNT_ID_NHL),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$pickPlayer = Player::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), false, $dbRecord);
 			$players[] = [
@@ -63,7 +67,9 @@ class AllianceDraftMember extends PlayerPage {
 
 		// Get the draft history
 		$history = [];
-		$dbResult = $db->read('SELECT * FROM draft_history WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' ORDER BY draft_id');
+		$dbResult = $db->read('SELECT * FROM draft_history WHERE game_id = :game_id ORDER BY draft_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$leader = Player::getPlayer($dbRecord->getInt('leader_account_id'), $player->getGameID());
 			$pickedPlayer = Player::getPlayer($dbRecord->getInt('picked_account_id'), $player->getGameID());

--- a/src/pages/Player/AllianceDraftMemberProcessor.php
+++ b/src/pages/Player/AllianceDraftMemberProcessor.php
@@ -59,10 +59,10 @@ class AllianceDraftMemberProcessor extends PlayerPageProcessor {
 		// Update the draft history
 		$db = Database::getInstance();
 		$db->insert('draft_history', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'leader_account_id' => $db->escapeNumber($player->getAccountID()),
-			'picked_account_id' => $db->escapeNumber($pickedPlayer->getAccountID()),
-			'time' => $db->escapeNumber(Epoch::time()),
+			'game_id' => $player->getGameID(),
+			'leader_account_id' => $player->getAccountID(),
+			'picked_account_id' => $pickedPlayer->getAccountID(),
+			'time' => Epoch::time(),
 		]);
 
 		(new AllianceDraftMember())->go();

--- a/src/pages/Player/AllianceExemptAuthorize.php
+++ b/src/pages/Player/AllianceExemptAuthorize.php
@@ -23,8 +23,11 @@ class AllianceExemptAuthorize extends PlayerPage {
 		$db = Database::getInstance();
 		$db->write('UPDATE alliance_bank_transactions SET request_exempt = 0 WHERE exempt = 1');
 
-		$dbResult = $db->read('SELECT * FROM alliance_bank_transactions WHERE request_exempt = 1 ' .
-					'AND alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND exempt = 0');
+		$dbResult = $db->read('SELECT * FROM alliance_bank_transactions WHERE request_exempt = 1
+					AND alliance_id = :alliance_id AND game_id = :game_id AND exempt = 0', [
+			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+			'game_id' => $db->escapeNumber($alliance->getGameID()),
+		]);
 		$transactions = [];
 		if ($dbResult->hasRecord()) {
 			$container = new AllianceBankExemptProcessor();

--- a/src/pages/Player/AllianceExemptAuthorize.php
+++ b/src/pages/Player/AllianceExemptAuthorize.php
@@ -21,7 +21,11 @@ class AllianceExemptAuthorize extends PlayerPage {
 
 		//get rid of already approved entries
 		$db = Database::getInstance();
-		$db->write('UPDATE alliance_bank_transactions SET request_exempt = 0 WHERE exempt = 1');
+		$db->update(
+			'alliance_bank_transactions',
+			['request_exempt' => 0],
+			['exempt' => 1],
+		);
 
 		$dbResult = $db->read('SELECT * FROM alliance_bank_transactions WHERE request_exempt = 1
 					AND alliance_id = :alliance_id AND game_id = :game_id AND exempt = 0', [

--- a/src/pages/Player/AllianceForces.php
+++ b/src/pages/Player/AllianceForces.php
@@ -37,9 +37,13 @@ class AllianceForces extends PlayerPage {
 			IFNULL(sum(combat_drones), 0) as tot_cds,
 			IFNULL(sum(scout_drones), 0) as tot_sds
 		FROM sector_has_forces JOIN player ON player.game_id=sector_has_forces.game_id AND sector_has_forces.owner_id=player.account_id
-		WHERE player.game_id=' . $db->escapeNumber($alliance->getGameID()) . '
-			AND player.alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
-			AND expire_time >= ' . $db->escapeNumber(Epoch::time()));
+		WHERE player.game_id = :game_id
+			AND player.alliance_id = :alliance_id
+			AND expire_time >= :now', [
+			'game_id' => $db->escapeNumber($alliance->getGameID()),
+			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 		$dbRecord = $dbResult->record();
 
 		// Get total number of forces
@@ -62,10 +66,14 @@ class AllianceForces extends PlayerPage {
 		SELECT sector_has_forces.*
 		FROM player
 		JOIN sector_has_forces ON player.game_id = sector_has_forces.game_id AND player.account_id = sector_has_forces.owner_id
-		WHERE player.game_id=' . $db->escapeNumber($alliance->getGameID()) . '
-		AND player.alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
-		AND expire_time >= ' . $db->escapeNumber(Epoch::time()) . '
-		ORDER BY sector_id ASC');
+		WHERE player.game_id = :game_id
+		AND player.alliance_id = :alliance_id
+		AND expire_time >= :now
+		ORDER BY sector_id ASC', [
+			'game_id' => $db->escapeNumber($alliance->getGameID()),
+			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 
 		$forces = [];
 		foreach ($dbResult->records() as $dbRecord) {

--- a/src/pages/Player/AllianceGovernance.php
+++ b/src/pages/Player/AllianceGovernance.php
@@ -28,7 +28,11 @@ class AllianceGovernance extends PlayerPage {
 		$role_id = $player->getAllianceRole($alliance->getAllianceID());
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
+		$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = :alliance_id AND game_id = :game_id AND role_id = :role_id', [
+			'alliance_id' => $db->escapeNumber($alliance_id),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'role_id' => $db->escapeNumber($role_id),
+		]);
 		if ($dbResult->hasRecord()) {
 			$dbRecord = $dbResult->record();
 			$change_mod = $dbRecord->getBoolean('change_mod');

--- a/src/pages/Player/AllianceGovernanceProcessor.php
+++ b/src/pages/Player/AllianceGovernanceProcessor.php
@@ -59,7 +59,11 @@ class AllianceGovernanceProcessor extends PlayerPageProcessor {
 			} else {
 				// no duplicates in a given game
 				$db = Database::getInstance();
-				$dbResult = $db->read('SELECT 1 FROM alliance WHERE discord_channel =' . $db->escapeString($discordChannel) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($alliance->getAllianceID()) . ' LIMIT 1');
+				$dbResult = $db->read('SELECT 1 FROM alliance WHERE discord_channel = :discord_channel AND game_id = :game_id AND alliance_id != :alliance_id LIMIT 1', [
+					'discord_channel' => $db->escapeString($discordChannel),
+					'game_id' => $db->escapeNumber($alliance->getGameID()),
+					'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+				]);
 				if ($dbResult->hasRecord()) {
 					create_error('Another alliance is already using that Discord Channel ID!');
 				}

--- a/src/pages/Player/AllianceInvitePlayer.php
+++ b/src/pages/Player/AllianceInvitePlayer.php
@@ -43,10 +43,14 @@ class AllianceInvitePlayer extends PlayerPage {
 		if ($alliance->getNumMembers() < $game->getAllianceMaxPlayers()) {
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT * FROM player
-			            WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-			              AND alliance_id != ' . $db->escapeNumber($alliance->getAllianceID()) . '
-			              AND npc = ' . $db->escapeBoolean(false) . '
-			            ORDER BY player_id DESC');
+			            WHERE game_id = :game_id
+			              AND alliance_id != :alliance_id
+			              AND npc = :npc
+			            ORDER BY player_id DESC', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+				'npc' => $db->escapeBoolean(false),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$invitePlayer = Player::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), false, $dbRecord);
 				if (array_key_exists($invitePlayer->getAccountID(), $pendingInvites)) {

--- a/src/pages/Player/AllianceInvitePlayerProcessor.php
+++ b/src/pages/Player/AllianceInvitePlayerProcessor.php
@@ -22,8 +22,11 @@ class AllianceInvitePlayerProcessor extends PlayerPageProcessor {
 		// If sender is mail banned or blacklisted by receiver, omit the custom message
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT 1 FROM message_blacklist
-		            WHERE account_id=' . $db->escapeNumber($receiverID) . '
-		              AND blacklisted_id=' . $db->escapeNumber($player->getAccountID()));
+		            WHERE account_id = :account_id
+		              AND blacklisted_id = :blacklisted_id', [
+			'account_id' => $db->escapeNumber($receiverID),
+			'blacklisted_id' => $db->escapeNumber($player->getAccountID()),
+		]);
 		if ($dbResult->hasRecord() || $account->isMailBanned()) {
 			$addMessage = '';
 		}

--- a/src/pages/Player/AllianceLeadershipProcessor.php
+++ b/src/pages/Player/AllianceLeadershipProcessor.php
@@ -17,18 +17,23 @@ class AllianceLeadershipProcessor extends PlayerPageProcessor {
 		$alliance->update();
 
 		$db = Database::getInstance();
-		$query = 'UPDATE player_has_alliance_role SET role_id = :role_id WHERE ' . AbstractPlayer::SQL . ' AND alliance_id = :alliance_id';
-		$db->write($query, [
-			...$player->SQLID,
-			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-			'role_id' => $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER),
-		]);
-		$db->write($query, [
-			'account_id' => $db->escapeNumber($leader_id),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-			'role_id' => $db->escapeNumber(ALLIANCE_ROLE_LEADER),
-		]);
+		$db->update(
+			'player_has_alliance_role',
+			['role_id' => $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER)],
+			[
+				...$player->SQLID,
+				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			],
+		);
+		$db->update(
+			'player_has_alliance_role',
+			['role_id' => $db->escapeNumber(ALLIANCE_ROLE_LEADER)],
+			[
+				'account_id' => $db->escapeNumber($leader_id),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			],
+		);
 
 		// Notify the new leader
 		$playerMessage = 'You are now the leader of ' . $alliance->getAllianceBBLink() . '!';

--- a/src/pages/Player/AllianceLeadershipProcessor.php
+++ b/src/pages/Player/AllianceLeadershipProcessor.php
@@ -17,8 +17,18 @@ class AllianceLeadershipProcessor extends PlayerPageProcessor {
 		$alliance->update();
 
 		$db = Database::getInstance();
-		$db->write('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER) . ' WHERE ' . $player->getSQL() . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
-		$db->write('UPDATE player_has_alliance_role SET role_id = ' . $db->escapeNumber(ALLIANCE_ROLE_LEADER) . ' WHERE account_id = ' . $db->escapeNumber($leader_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id=' . $db->escapeNumber($player->getAllianceID()));
+		$query = 'UPDATE player_has_alliance_role SET role_id = :role_id WHERE ' . AbstractPlayer::SQL . ' AND alliance_id = :alliance_id';
+		$db->write($query, [
+			...$player->SQLID,
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			'role_id' => $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER),
+		]);
+		$db->write($query, [
+			'account_id' => $db->escapeNumber($leader_id),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			'role_id' => $db->escapeNumber(ALLIANCE_ROLE_LEADER),
+		]);
 
 		// Notify the new leader
 		$playerMessage = 'You are now the leader of ' . $alliance->getAllianceBBLink() . '!';

--- a/src/pages/Player/AllianceLeadershipProcessor.php
+++ b/src/pages/Player/AllianceLeadershipProcessor.php
@@ -19,19 +19,19 @@ class AllianceLeadershipProcessor extends PlayerPageProcessor {
 		$db = Database::getInstance();
 		$db->update(
 			'player_has_alliance_role',
-			['role_id' => $db->escapeNumber(ALLIANCE_ROLE_NEW_MEMBER)],
+			['role_id' => ALLIANCE_ROLE_NEW_MEMBER],
 			[
 				...$player->SQLID,
-				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'alliance_id' => $player->getAllianceID(),
 			],
 		);
 		$db->update(
 			'player_has_alliance_role',
-			['role_id' => $db->escapeNumber(ALLIANCE_ROLE_LEADER)],
+			['role_id' => ALLIANCE_ROLE_LEADER],
 			[
-				'account_id' => $db->escapeNumber($leader_id),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'account_id' => $leader_id,
+				'game_id' => $player->getGameID(),
+				'alliance_id' => $player->getAllianceID(),
 			],
 		);
 

--- a/src/pages/Player/AllianceLeaveProcessor.php
+++ b/src/pages/Player/AllianceLeaveProcessor.php
@@ -20,21 +20,17 @@ class AllianceLeaveProcessor extends PlayerPageProcessor {
 		if ($alliance->getNumMembers() == 1 && !$alliance->isNHA()) {
 			// Retain the alliance, but delete some auxilliary info
 			$db = Database::getInstance();
-			$db->write('DELETE FROM alliance_bank_transactions
-			            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-			            AND game_id = ' . $db->escapeNumber($player->getGameID()));
-			$db->write('DELETE FROM alliance_thread
-			            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-			            AND game_id = ' . $db->escapeNumber($player->getGameID()));
-			$db->write('DELETE FROM alliance_thread_topic
-			            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-			            AND game_id = ' . $db->escapeNumber($player->getGameID()));
-			$db->write('DELETE FROM alliance_has_roles
-			            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-			            AND game_id = ' . $db->escapeNumber($player->getGameID()));
+			$sql = 'alliance_id = :alliance_id AND game_id = :game_id';
+			$sqlParams = [
+				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			];
+			$db->write('DELETE FROM alliance_bank_transactions WHERE ' . $sql, $sqlParams);
+			$db->write('DELETE FROM alliance_thread WHERE ' . $sql, $sqlParams);
+			$db->write('DELETE FROM alliance_thread_topic WHERE ' . $sql, $sqlParams);
+			$db->write('DELETE FROM alliance_has_roles WHERE ' . $sql, $sqlParams);
 			$db->write('UPDATE alliance SET leader_id = 0, discord_channel = NULL
-			            WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-			            AND game_id = ' . $db->escapeNumber($player->getGameID()));
+			            WHERE ' . $sql, $sqlParams);
 		}
 
 		// now leave the alliance

--- a/src/pages/Player/AllianceLeaveProcessor.php
+++ b/src/pages/Player/AllianceLeaveProcessor.php
@@ -20,7 +20,6 @@ class AllianceLeaveProcessor extends PlayerPageProcessor {
 		if ($alliance->getNumMembers() == 1 && !$alliance->isNHA()) {
 			// Retain the alliance, but delete some auxilliary info
 			$db = Database::getInstance();
-			$sql = 'alliance_id = :alliance_id AND game_id = :game_id';
 			$sqlParams = [
 				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
 				'game_id' => $db->escapeNumber($player->getGameID()),
@@ -29,8 +28,14 @@ class AllianceLeaveProcessor extends PlayerPageProcessor {
 			$db->delete('alliance_thread', $sqlParams);
 			$db->delete('alliance_thread_topic', $sqlParams);
 			$db->delete('alliance_has_roles', $sqlParams);
-			$db->write('UPDATE alliance SET leader_id = 0, discord_channel = NULL
-			            WHERE ' . $sql, $sqlParams);
+			$db->update(
+				'alliance',
+				[
+					'leader_id' => 0,
+					'discord_channel' => null,
+				],
+				$sqlParams,
+			);
 		}
 
 		// now leave the alliance

--- a/src/pages/Player/AllianceLeaveProcessor.php
+++ b/src/pages/Player/AllianceLeaveProcessor.php
@@ -25,10 +25,10 @@ class AllianceLeaveProcessor extends PlayerPageProcessor {
 				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
 				'game_id' => $db->escapeNumber($player->getGameID()),
 			];
-			$db->write('DELETE FROM alliance_bank_transactions WHERE ' . $sql, $sqlParams);
-			$db->write('DELETE FROM alliance_thread WHERE ' . $sql, $sqlParams);
-			$db->write('DELETE FROM alliance_thread_topic WHERE ' . $sql, $sqlParams);
-			$db->write('DELETE FROM alliance_has_roles WHERE ' . $sql, $sqlParams);
+			$db->delete('alliance_bank_transactions', $sqlParams);
+			$db->delete('alliance_thread', $sqlParams);
+			$db->delete('alliance_thread_topic', $sqlParams);
+			$db->delete('alliance_has_roles', $sqlParams);
 			$db->write('UPDATE alliance SET leader_id = 0, discord_channel = NULL
 			            WHERE ' . $sql, $sqlParams);
 		}

--- a/src/pages/Player/AllianceList.php
+++ b/src/pages/Player/AllianceList.php
@@ -35,9 +35,11 @@ class AllianceList extends PlayerPage {
 		FROM player
 		JOIN alliance USING (game_id, alliance_id)
 		WHERE leader_id > 0
-		AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+		AND game_id = :game_id
 		GROUP BY alliance_id
-		ORDER BY alliance_name ASC');
+		ORDER BY alliance_name ASC', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 
 		$alliances = [];
 		foreach ($dbResult->records() as $dbRecord) {

--- a/src/pages/Player/AllianceMessageBoardAddProcessor.php
+++ b/src/pages/Player/AllianceMessageBoardAddProcessor.php
@@ -97,30 +97,30 @@ class AllianceMessageBoardAddProcessor extends PlayerPageProcessor {
 			}
 
 			$db->insert('alliance_thread_topic', [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'alliance_id' => $db->escapeNumber($alliance_id),
-				'thread_id' => $db->escapeNumber($thread_id),
-				'topic' => $db->escapeString($topic),
+				'game_id' => $player->getGameID(),
+				'alliance_id' => $alliance_id,
+				'thread_id' => $thread_id,
+				'topic' => $topic,
 				'alliance_only' => $db->escapeBoolean($allEyesOnly),
 			]);
 		}
 
 		// and the body
 		$db->insert('alliance_thread', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'alliance_id' => $db->escapeNumber($alliance_id),
-			'thread_id' => $db->escapeNumber($thread_id),
-			'reply_id' => $db->escapeNumber($reply_id),
-			'text' => $db->escapeString($body),
-			'sender_id' => $db->escapeNumber($player->getAccountID()),
-			'time' => $db->escapeNumber(Epoch::time()),
+			'game_id' => $player->getGameID(),
+			'alliance_id' => $alliance_id,
+			'thread_id' => $thread_id,
+			'reply_id' => $reply_id,
+			'text' => $body,
+			'sender_id' => $player->getAccountID(),
+			'time' => Epoch::time(),
 		]);
 		$db->replace('player_read_thread', [
-			'account_id' => $db->escapeNumber($player->getAccountID()),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'alliance_id' => $db->escapeNumber($alliance_id),
-			'thread_id' => $db->escapeNumber($thread_id),
-			'time' => $db->escapeNumber(Epoch::time() + 2),
+			'account_id' => $player->getAccountID(),
+			'game_id' => $player->getGameID(),
+			'alliance_id' => $alliance_id,
+			'thread_id' => $thread_id,
+			'time' => Epoch::time() + 2,
 		]);
 
 		$this->lastPage->go();

--- a/src/pages/Player/AllianceMessageBoardAddProcessor.php
+++ b/src/pages/Player/AllianceMessageBoardAddProcessor.php
@@ -52,8 +52,11 @@ class AllianceMessageBoardAddProcessor extends PlayerPageProcessor {
 		if ($this->threadID === null) {
 			// get one
 			$dbResult = $db->read('SELECT IFNULL(max(thread_id)+1, 0) AS next_thread_id FROM alliance_thread
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND alliance_id = ' . $db->escapeNumber($alliance_id));
+						WHERE game_id = :game_id
+						AND alliance_id = :alliance_id', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $db->escapeNumber($alliance_id),
+			]);
 			$thread_id = $dbResult->record()->getInt('next_thread_id');
 		} else {
 			$thread_id = $this->threadID;
@@ -61,9 +64,13 @@ class AllianceMessageBoardAddProcessor extends PlayerPageProcessor {
 
 		// now get the next reply id
 		$dbResult = $db->read('SELECT IFNULL(max(reply_id)+1, 0) AS next_reply_id FROM alliance_thread
-					WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
-					AND thread_id = ' . $db->escapeNumber($thread_id));
+					WHERE game_id = :game_id
+					AND alliance_id = :alliance_id
+					AND thread_id = :thread_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'alliance_id' => $db->escapeNumber($alliance_id),
+			'thread_id' => $db->escapeNumber($thread_id),
+		]);
 		$reply_id = $dbResult->record()->getInt('next_reply_id');
 
 		// only add the topic if it's the first reply
@@ -78,9 +85,13 @@ class AllianceMessageBoardAddProcessor extends PlayerPageProcessor {
 
 			// test if this topic already exists
 			$dbResult = $db->read('SELECT 1 FROM alliance_thread_topic
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
-						AND topic = ' . $db->escapeString($topic));
+						WHERE game_id = :game_id
+						AND alliance_id = :alliance_id
+						AND topic = :topic', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $db->escapeNumber($alliance_id),
+				'topic' => $db->escapeString($topic),
+			]);
 			if ($dbResult->hasRecord()) {
 				create_error('This topic exists already!');
 			}

--- a/src/pages/Player/AllianceMessageBoardDeleteReplyProcessor.php
+++ b/src/pages/Player/AllianceMessageBoardDeleteReplyProcessor.php
@@ -18,10 +18,10 @@ class AllianceMessageBoardDeleteReplyProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 		$db->delete('alliance_thread', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'alliance_id' => $db->escapeNumber($this->allianceID),
-			'thread_id' => $db->escapeNumber($this->threadID),
-			'reply_id' => $db->escapeNumber($this->replyID),
+			'game_id' => $player->getGameID(),
+			'alliance_id' => $this->allianceID,
+			'thread_id' => $this->threadID,
+			'reply_id' => $this->replyID,
 		]);
 		$this->lastPage->go();
 	}

--- a/src/pages/Player/AllianceMessageBoardDeleteReplyProcessor.php
+++ b/src/pages/Player/AllianceMessageBoardDeleteReplyProcessor.php
@@ -18,10 +18,15 @@ class AllianceMessageBoardDeleteReplyProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 		$db->write('DELETE FROM alliance_thread
-					WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND alliance_id = ' . $db->escapeNumber($this->allianceID) . '
-					AND thread_id = ' . $db->escapeNumber($this->threadID) . '
-					AND reply_id = ' . $db->escapeNumber($this->replyID));
+					WHERE game_id = :game_id
+					AND alliance_id = :alliance_id
+					AND thread_id = :thread_id
+					AND reply_id = :reply_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'alliance_id' => $db->escapeNumber($this->allianceID),
+			'thread_id' => $db->escapeNumber($this->threadID),
+			'reply_id' => $db->escapeNumber($this->replyID),
+		]);
 		$this->lastPage->go();
 	}
 

--- a/src/pages/Player/AllianceMessageBoardDeleteReplyProcessor.php
+++ b/src/pages/Player/AllianceMessageBoardDeleteReplyProcessor.php
@@ -17,11 +17,7 @@ class AllianceMessageBoardDeleteReplyProcessor extends PlayerPageProcessor {
 
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM alliance_thread
-					WHERE game_id = :game_id
-					AND alliance_id = :alliance_id
-					AND thread_id = :thread_id
-					AND reply_id = :reply_id', [
+		$db->delete('alliance_thread', [
 			'game_id' => $db->escapeNumber($player->getGameID()),
 			'alliance_id' => $db->escapeNumber($this->allianceID),
 			'thread_id' => $db->escapeNumber($this->threadID),

--- a/src/pages/Player/AllianceMessageBoardDeleteThreadProcessor.php
+++ b/src/pages/Player/AllianceMessageBoardDeleteThreadProcessor.php
@@ -20,9 +20,9 @@ class AllianceMessageBoardDeleteThreadProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 		$sqlParams = [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'alliance_id' => $db->escapeNumber($this->allianceID),
-			'thread_id' => $db->escapeNumber($this->threadID),
+			'game_id' => $player->getGameID(),
+			'alliance_id' => $this->allianceID,
+			'thread_id' => $this->threadID,
 		];
 		$db->delete('alliance_thread', $sqlParams);
 		$db->delete('alliance_thread_topic', $sqlParams);

--- a/src/pages/Player/AllianceMessageBoardDeleteThreadProcessor.php
+++ b/src/pages/Player/AllianceMessageBoardDeleteThreadProcessor.php
@@ -19,16 +19,13 @@ class AllianceMessageBoardDeleteThreadProcessor extends PlayerPageProcessor {
 
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
-		$sql = 'WHERE game_id = :game_id
-				AND alliance_id = :alliance_id
-				AND thread_id = :thread_id';
 		$sqlParams = [
 			'game_id' => $db->escapeNumber($player->getGameID()),
 			'alliance_id' => $db->escapeNumber($this->allianceID),
 			'thread_id' => $db->escapeNumber($this->threadID),
 		];
-		$db->write('DELETE FROM alliance_thread ' . $sql, $sqlParams);
-		$db->write('DELETE FROM alliance_thread_topic ' . $sql, $sqlParams);
+		$db->delete('alliance_thread', $sqlParams);
+		$db->delete('alliance_thread_topic', $sqlParams);
 		$this->lastPage->go();
 	}
 

--- a/src/pages/Player/AllianceMessageBoardDeleteThreadProcessor.php
+++ b/src/pages/Player/AllianceMessageBoardDeleteThreadProcessor.php
@@ -19,14 +19,16 @@ class AllianceMessageBoardDeleteThreadProcessor extends PlayerPageProcessor {
 
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM alliance_thread
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND alliance_id = ' . $db->escapeNumber($this->allianceID) . '
-						AND thread_id = ' . $db->escapeNumber($this->threadID));
-		$db->write('DELETE FROM alliance_thread_topic
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND alliance_id = ' . $db->escapeNumber($this->allianceID) . '
-						AND thread_id = ' . $db->escapeNumber($this->threadID));
+		$sql = 'WHERE game_id = :game_id
+				AND alliance_id = :alliance_id
+				AND thread_id = :thread_id';
+		$sqlParams = [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'alliance_id' => $db->escapeNumber($this->allianceID),
+			'thread_id' => $db->escapeNumber($this->threadID),
+		];
+		$db->write('DELETE FROM alliance_thread ' . $sql, $sqlParams);
+		$db->write('DELETE FROM alliance_thread_topic ' . $sql, $sqlParams);
 		$this->lastPage->go();
 	}
 

--- a/src/pages/Player/AllianceMessageBoardView.php
+++ b/src/pages/Player/AllianceMessageBoardView.php
@@ -46,9 +46,9 @@ class AllianceMessageBoardView extends PlayerPage {
 		$db = Database::getInstance();
 		$db->replace('player_read_thread', [
 			...$player->SQLID,
-			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
-			'thread_id' => $db->escapeNumber($thread_id),
-			'time' => $db->escapeNumber(Epoch::time() + 2),
+			'alliance_id' => $alliance->getAllianceID(),
+			'thread_id' => $thread_id,
+			'time' => Epoch::time() + 2,
 		]);
 
 		$mbWrite = true;

--- a/src/pages/Player/AllianceOpResponseProcessor.php
+++ b/src/pages/Player/AllianceOpResponseProcessor.php
@@ -18,10 +18,10 @@ class AllianceOpResponseProcessor extends PlayerPageProcessor {
 
 		$db = Database::getInstance();
 		$db->replace('alliance_has_op_response', [
-			'alliance_id' => $db->escapeNumber($this->allianceID),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'account_id' => $db->escapeNumber($player->getAccountID()),
-			'response' => $db->escapeString($response),
+			'alliance_id' => $this->allianceID,
+			'game_id' => $player->getGameID(),
+			'account_id' => $player->getAccountID(),
+			'response' => $response,
 		]);
 
 		(new AllianceMotd($this->allianceID))->go();

--- a/src/pages/Player/AllianceOptions.php
+++ b/src/pages/Player/AllianceOptions.php
@@ -53,7 +53,11 @@ class AllianceOptions extends PlayerPage {
 		$role_id = $player->getAllianceRole($alliance->getAllianceID());
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
+		$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = :alliance_id AND game_id = :game_id AND role_id = :role_id', [
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'role_id' => $db->escapeNumber($role_id),
+		]);
 		$dbRecord = $dbResult->record();
 
 		if ($dbRecord->getBoolean('change_pass')) {

--- a/src/pages/Player/AllianceRoles.php
+++ b/src/pages/Player/AllianceRoles.php
@@ -24,10 +24,13 @@ class AllianceRoles extends PlayerPage {
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT *
 		FROM alliance_has_roles
-		WHERE game_id=' . $db->escapeNumber($alliance->getGameID()) . '
-		AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
+		WHERE game_id = :game_id
+		AND alliance_id = :alliance_id
 		ORDER BY role_id
-		');
+		', [
+			'game_id' => $db->escapeNumber($alliance->getGameID()),
+			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+		]);
 		$allianceRoles = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$roleID = $dbRecord->getInt('role_id');

--- a/src/pages/Player/AllianceRolesProcessor.php
+++ b/src/pages/Player/AllianceRolesProcessor.php
@@ -58,8 +58,11 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 			// get last id (always has one, since some roles are auto-bestowed)
 			$dbResult = $db->read('SELECT MAX(role_id)
 						FROM alliance_has_roles
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND alliance_id = ' . $db->escapeNumber($alliance_id));
+						WHERE game_id = :game_id
+							AND alliance_id = :alliance_id', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $db->escapeNumber($alliance_id),
+			]);
 			$role_id = $dbResult->record()->getInt('MAX(role_id)') + 1;
 
 			$db->insert('alliance_has_roles', [
@@ -90,29 +93,49 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 					create_error('You cannot delete the new member role.');
 				}
 				$db->write('DELETE FROM alliance_has_roles
-							WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
-							AND role_id = ' . $db->escapeNumber($this->roleID));
+							WHERE game_id = :game_id
+							AND alliance_id = :alliance_id
+							AND role_id = :role_id', [
+					'game_id' => $db->escapeNumber($player->getGameID()),
+					'alliance_id' => $db->escapeNumber($alliance_id),
+					'role_id' => $db->escapeNumber($this->roleID),
+				]);
 			} else {
 				// otherwise we update it
 				$db->write('UPDATE alliance_has_roles
-							SET role = ' . $db->escapeString($roleName) . ',
-							with_per_day = ' . $db->escapeNumber($withPerDay) . ',
-							positive_balance = ' . $db->escapeBoolean($positiveBalance) . ',
-							remove_member = ' . $db->escapeBoolean($removeMember) . ',
-							change_pass = ' . $db->escapeBoolean($changePass) . ',
-							change_mod = ' . $db->escapeBoolean($changeMOD) . ',
-							change_roles = ' . $db->escapeBoolean($changeRoles) . ',
-							planet_access = ' . $db->escapeBoolean($planetAccess) . ',
-							exempt_with = ' . $db->escapeBoolean($exemptWith) . ',
-							mb_messages = ' . $db->escapeBoolean($mbMessages) . ',
-							send_alliance_msg = ' . $db->escapeBoolean($sendAllMsg) . ',
-							op_leader = ' . $db->escapeBoolean($opLeader) . ',
-							view_bonds = ' . $db->escapeBoolean($viewBonds) . '
-							WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-								AND alliance_id = ' . $db->escapeNumber($alliance_id) . '
-								AND role_id = ' . $db->escapeNumber($this->roleID));
-
+							SET role = :role,
+							with_per_day = :with_per_day,
+							positive_balance = :positive_balance,
+							remove_member = :remove_member,
+							change_pass = :change_pass,
+							change_mod = :change_mod,
+							change_roles = :change_roles,
+							planet_access = :planet_access,
+							exempt_with = :exempt_with,
+							mb_messages = :mb_messages,
+							send_alliance_msg = :send_alliance_msg,
+							op_leader = :op_leader,
+							view_bonds = :view_bonds
+							WHERE game_id = :game_id
+								AND alliance_id = :alliance_id
+								AND role_id = :role_id', [
+					'alliance_id' => $db->escapeNumber($alliance_id),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+					'role_id' => $db->escapeNumber($this->roleID),
+					'role' => $db->escapeString($roleName),
+					'with_per_day' => $db->escapeNumber($withPerDay),
+					'positive_balance' => $db->escapeBoolean($positiveBalance),
+					'remove_member' => $db->escapeBoolean($removeMember),
+					'change_pass' => $db->escapeBoolean($changePass),
+					'change_mod' => $db->escapeBoolean($changeMOD),
+					'change_roles' => $db->escapeBoolean($changeRoles),
+					'planet_access' => $db->escapeBoolean($planetAccess),
+					'exempt_with' => $db->escapeBoolean($exemptWith),
+					'mb_messages' => $db->escapeBoolean($mbMessages),
+					'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
+					'op_leader' => $db->escapeBoolean($opLeader),
+					'view_bonds' => $db->escapeBoolean($viewBonds),
+				]);
 			}
 
 		}

--- a/src/pages/Player/AllianceRolesProcessor.php
+++ b/src/pages/Player/AllianceRolesProcessor.php
@@ -55,15 +55,15 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 
 			$db->lockTable('alliance_has_roles');
 
-			// get last id (always has one, since some roles are auto-bestowed)
-			$dbResult = $db->read('SELECT MAX(role_id)
+			// get last id
+			$dbResult = $db->read('SELECT IFNULL(MAX(role_id), 0) as max_role_id
 						FROM alliance_has_roles
 						WHERE game_id = :game_id
 							AND alliance_id = :alliance_id', [
 				'game_id' => $db->escapeNumber($player->getGameID()),
 				'alliance_id' => $db->escapeNumber($alliance_id),
 			]);
-			$role_id = $dbResult->record()->getInt('MAX(role_id)') + 1;
+			$role_id = $dbResult->record()->getInt('max_role_id') + 1;
 
 			$db->insert('alliance_has_roles', [
 				'alliance_id' => $alliance_id,

--- a/src/pages/Player/AllianceRolesProcessor.php
+++ b/src/pages/Player/AllianceRolesProcessor.php
@@ -92,10 +92,7 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 				} elseif ($this->roleID === ALLIANCE_ROLE_NEW_MEMBER) {
 					create_error('You cannot delete the new member role.');
 				}
-				$db->write('DELETE FROM alliance_has_roles
-							WHERE game_id = :game_id
-							AND alliance_id = :alliance_id
-							AND role_id = :role_id', [
+				$db->delete('alliance_has_roles', [
 					'game_id' => $db->escapeNumber($player->getGameID()),
 					'alliance_id' => $db->escapeNumber($alliance_id),
 					'role_id' => $db->escapeNumber($this->roleID),

--- a/src/pages/Player/AllianceRolesProcessor.php
+++ b/src/pages/Player/AllianceRolesProcessor.php
@@ -66,11 +66,11 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 			$role_id = $dbResult->record()->getInt('MAX(role_id)') + 1;
 
 			$db->insert('alliance_has_roles', [
-				'alliance_id' => $db->escapeNumber($alliance_id),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'role_id' => $db->escapeNumber($role_id),
-				'role' => $db->escapeString($roleName),
-				'with_per_day' => $db->escapeNumber($withPerDay),
+				'alliance_id' => $alliance_id,
+				'game_id' => $player->getGameID(),
+				'role_id' => $role_id,
+				'role' => $roleName,
+				'with_per_day' => $withPerDay,
 				'positive_balance' => $db->escapeBoolean($positiveBalance),
 				'remove_member' => $db->escapeBoolean($removeMember),
 				'change_pass' => $db->escapeBoolean($changePass),
@@ -93,17 +93,17 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 					create_error('You cannot delete the new member role.');
 				}
 				$db->delete('alliance_has_roles', [
-					'game_id' => $db->escapeNumber($player->getGameID()),
-					'alliance_id' => $db->escapeNumber($alliance_id),
-					'role_id' => $db->escapeNumber($this->roleID),
+					'game_id' => $player->getGameID(),
+					'alliance_id' => $alliance_id,
+					'role_id' => $this->roleID,
 				]);
 			} else {
 				// otherwise we update it
 				$db->update(
 					'alliance_has_roles',
 					[
-						'role' => $db->escapeString($roleName),
-						'with_per_day' => $db->escapeNumber($withPerDay),
+						'role' => $roleName,
+						'with_per_day' => $withPerDay,
 						'positive_balance' => $db->escapeBoolean($positiveBalance),
 						'remove_member' => $db->escapeBoolean($removeMember),
 						'change_pass' => $db->escapeBoolean($changePass),
@@ -117,9 +117,9 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 						'view_bonds' => $db->escapeBoolean($viewBonds),
 					],
 					[
-						'alliance_id' => $db->escapeNumber($alliance_id),
-						'game_id' => $db->escapeNumber($player->getGameID()),
-						'role_id' => $db->escapeNumber($this->roleID),
+						'alliance_id' => $alliance_id,
+						'game_id' => $player->getGameID(),
+						'role_id' => $this->roleID,
 					],
 				);
 			}

--- a/src/pages/Player/AllianceRolesProcessor.php
+++ b/src/pages/Player/AllianceRolesProcessor.php
@@ -99,40 +99,29 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 				]);
 			} else {
 				// otherwise we update it
-				$db->write('UPDATE alliance_has_roles
-							SET role = :role,
-							with_per_day = :with_per_day,
-							positive_balance = :positive_balance,
-							remove_member = :remove_member,
-							change_pass = :change_pass,
-							change_mod = :change_mod,
-							change_roles = :change_roles,
-							planet_access = :planet_access,
-							exempt_with = :exempt_with,
-							mb_messages = :mb_messages,
-							send_alliance_msg = :send_alliance_msg,
-							op_leader = :op_leader,
-							view_bonds = :view_bonds
-							WHERE game_id = :game_id
-								AND alliance_id = :alliance_id
-								AND role_id = :role_id', [
-					'alliance_id' => $db->escapeNumber($alliance_id),
-					'game_id' => $db->escapeNumber($player->getGameID()),
-					'role_id' => $db->escapeNumber($this->roleID),
-					'role' => $db->escapeString($roleName),
-					'with_per_day' => $db->escapeNumber($withPerDay),
-					'positive_balance' => $db->escapeBoolean($positiveBalance),
-					'remove_member' => $db->escapeBoolean($removeMember),
-					'change_pass' => $db->escapeBoolean($changePass),
-					'change_mod' => $db->escapeBoolean($changeMOD),
-					'change_roles' => $db->escapeBoolean($changeRoles),
-					'planet_access' => $db->escapeBoolean($planetAccess),
-					'exempt_with' => $db->escapeBoolean($exemptWith),
-					'mb_messages' => $db->escapeBoolean($mbMessages),
-					'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
-					'op_leader' => $db->escapeBoolean($opLeader),
-					'view_bonds' => $db->escapeBoolean($viewBonds),
-				]);
+				$db->update(
+					'alliance_has_roles',
+					[
+						'role' => $db->escapeString($roleName),
+						'with_per_day' => $db->escapeNumber($withPerDay),
+						'positive_balance' => $db->escapeBoolean($positiveBalance),
+						'remove_member' => $db->escapeBoolean($removeMember),
+						'change_pass' => $db->escapeBoolean($changePass),
+						'change_mod' => $db->escapeBoolean($changeMOD),
+						'change_roles' => $db->escapeBoolean($changeRoles),
+						'planet_access' => $db->escapeBoolean($planetAccess),
+						'exempt_with' => $db->escapeBoolean($exemptWith),
+						'mb_messages' => $db->escapeBoolean($mbMessages),
+						'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
+						'op_leader' => $db->escapeBoolean($opLeader),
+						'view_bonds' => $db->escapeBoolean($viewBonds),
+					],
+					[
+						'alliance_id' => $db->escapeNumber($alliance_id),
+						'game_id' => $db->escapeNumber($player->getGameID()),
+						'role_id' => $db->escapeNumber($this->roleID),
+					],
+				);
 			}
 
 		}

--- a/src/pages/Player/AllianceRolesSaveProcessor.php
+++ b/src/pages/Player/AllianceRolesSaveProcessor.php
@@ -17,10 +17,10 @@ class AllianceRolesSaveProcessor extends PlayerPageProcessor {
 		foreach (Request::getIntArray('role', []) as $accountID => $roleID) {
 			$db = Database::getInstance();
 			$db->replace('player_has_alliance_role', [
-				'account_id' => $db->escapeNumber($accountID),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'role_id' => $db->escapeNumber($roleID),
-				'alliance_id' => $db->escapeNumber($this->allianceID),
+				'account_id' => $accountID,
+				'game_id' => $player->getGameID(),
+				'role_id' => $roleID,
+				'alliance_id' => $this->allianceID,
 			]);
 		}
 

--- a/src/pages/Player/AllianceRoster.php
+++ b/src/pages/Player/AllianceRoster.php
@@ -40,9 +40,12 @@ class AllianceRoster extends PlayerPage {
 			// get all roles from db for faster access later
 			$dbResult = $db->read('SELECT role_id, role
 						FROM alliance_has_roles
-						WHERE game_id=' . $db->escapeNumber($alliance->getGameID()) . '
-						AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
-						ORDER BY role_id');
+						WHERE game_id = :game_id
+						AND alliance_id = :alliance_id
+						ORDER BY role_id', [
+				'game_id' => $db->escapeNumber($alliance->getGameID()),
+				'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$roles[$dbRecord->getInt('role_id')] = $dbRecord->getString('role');
 			}
@@ -56,9 +59,12 @@ class AllianceRoster extends PlayerPage {
 			SUM(experience) AS alliance_xp,
 			FLOOR(AVG(experience)) AS alliance_avg
 			FROM player
-			WHERE alliance_id=' . $db->escapeNumber($alliance->getAllianceID()) . '
-			AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
-			GROUP BY alliance_id');
+			WHERE alliance_id = :alliance_id
+			AND game_id = :game_id
+			GROUP BY alliance_id', [
+			'game_id' => $db->escapeNumber($alliance->getGameID()),
+			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+		]);
 		$dbRecord = $dbResult->record();
 
 		$template->assign('AllianceExp', $dbRecord->getInt('alliance_xp'));
@@ -69,8 +75,12 @@ class AllianceRoster extends PlayerPage {
 			$template->assign('EditAllianceDescriptionHREF', $container->href());
 		}
 
-		$dbResult = $db->read('SELECT 1 FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
-					AND role_id = ' . $db->escapeNumber($player->getAllianceRole()) . ' AND change_roles = \'TRUE\'');
+		$dbResult = $db->read('SELECT 1 FROM alliance_has_roles WHERE alliance_id = :alliance_id AND game_id = :game_id
+					AND role_id = :role_id AND change_roles = \'TRUE\'', [
+			'game_id' => $db->escapeNumber($alliance->getGameID()),
+			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+			'role_id' => $db->escapeNumber($player->getAllianceRole()),
+		]);
 		$allowed = $dbResult->hasRecord();
 		$template->assign('CanChangeRoles', $allowed);
 

--- a/src/pages/Player/AllianceSetOp.php
+++ b/src/pages/Player/AllianceSetOp.php
@@ -31,7 +31,10 @@ class AllianceSetOp extends PlayerPage {
 
 		// get the op from db
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND  game_id=' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 
 		if ($dbResult->hasRecord()) {
 			// An op is already scheduled, so get the time

--- a/src/pages/Player/AllianceSetOpProcessor.php
+++ b/src/pages/Player/AllianceSetOpProcessor.php
@@ -19,11 +19,11 @@ class AllianceSetOpProcessor extends PlayerPageProcessor {
 
 		if ($this->cancel) {
 			// just get rid of op
-			$db->write('DELETE FROM alliance_has_op WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+			$db->delete('alliance_has_op', [
 				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
 				'game_id' => $db->escapeNumber($player->getGameID()),
 			]);
-			$db->write('DELETE FROM alliance_has_op_response WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+			$db->delete('alliance_has_op_response', [
 				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
 				'game_id' => $db->escapeNumber($player->getGameID()),
 			]);

--- a/src/pages/Player/AllianceSetOpProcessor.php
+++ b/src/pages/Player/AllianceSetOpProcessor.php
@@ -19,11 +19,21 @@ class AllianceSetOpProcessor extends PlayerPageProcessor {
 
 		if ($this->cancel) {
 			// just get rid of op
-			$db->write('DELETE FROM alliance_has_op WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
-			$db->write('DELETE FROM alliance_has_op_response WHERE alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id=' . $db->escapeNumber($player->getGameID()));
+			$db->write('DELETE FROM alliance_has_op WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
+			$db->write('DELETE FROM alliance_has_op_response WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 
 			// Delete the announcement from alliance members message boxes
-			$db->write('DELETE FROM message WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND sender_id=' . $db->escapeNumber(ACCOUNT_ID_OP_ANNOUNCE) . ' AND account_id IN (' . $db->escapeArray($player->getAlliance()->getMemberIDs()) . ')');
+			$db->write('DELETE FROM message WHERE game_id = :game_id AND sender_id = :sender_id AND account_id IN (:account_ids)', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'sender_id' => $db->escapeNumber(ACCOUNT_ID_OP_ANNOUNCE),
+				'account_ids' => $db->escapeArray($player->getAlliance()->getMemberIDs()),
+			]);
 
 			// NOTE: for simplicity we don't touch `player_has_unread_messages` here,
 			// so they may get an errant alliance message icon if logged in.

--- a/src/pages/Player/AllianceSetOpProcessor.php
+++ b/src/pages/Player/AllianceSetOpProcessor.php
@@ -20,12 +20,12 @@ class AllianceSetOpProcessor extends PlayerPageProcessor {
 		if ($this->cancel) {
 			// just get rid of op
 			$db->delete('alliance_has_op', [
-				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $player->getAllianceID(),
+				'game_id' => $player->getGameID(),
 			]);
 			$db->delete('alliance_has_op_response', [
-				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $player->getAllianceID(),
+				'game_id' => $player->getGameID(),
 			]);
 
 			// Delete the announcement from alliance members message boxes
@@ -51,9 +51,9 @@ class AllianceSetOpProcessor extends PlayerPageProcessor {
 
 			// add op to db
 			$db->insert('alliance_has_op', [
-				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'time' => $db->escapeNumber($time),
+				'alliance_id' => $player->getAllianceID(),
+				'game_id' => $player->getGameID(),
+				'time' => $time,
 			]);
 
 			// Send an alliance message that expires at the time of the op.

--- a/src/pages/Player/AllianceTreaties.php
+++ b/src/pages/Player/AllianceTreaties.php
@@ -26,7 +26,10 @@ class AllianceTreaties extends PlayerPage {
 
 		$alliances = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id != ' . $db->escapeNumber($player->getAllianceID()) . ' ORDER BY alliance_name');
+		$dbResult = $db->read('SELECT * FROM alliance WHERE game_id = :game_id AND alliance_id != :alliance_id ORDER BY alliance_name', [
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$allianceID = $dbRecord->getInt('alliance_id');
 			$alliance = Alliance::getAlliance($allianceID, $player->getGameID(), false, $dbRecord);
@@ -37,7 +40,10 @@ class AllianceTreaties extends PlayerPage {
 		$template->assign('Message', $this->message);
 
 		$offers = [];
-		$dbResult = $db->read('SELECT * FROM alliance_treaties WHERE alliance_id_2 = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND official = \'FALSE\'');
+		$dbResult = $db->read('SELECT * FROM alliance_treaties WHERE alliance_id_2 = :alliance_id AND game_id = :game_id AND official = \'FALSE\'', [
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$offerTerms = [];
 			foreach (array_keys(Treaty::TYPES) as $term) {

--- a/src/pages/Player/AllianceTreatiesConfirm.php
+++ b/src/pages/Player/AllianceTreatiesConfirm.php
@@ -20,7 +20,11 @@ class AllianceTreatiesConfirm extends PlayerPage {
 		$alliance_id_2 = Request::getInt('proposedAlliance');
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM alliance_treaties WHERE (alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_1 = ' . $alliance_id_2 . ') AND (alliance_id_2 = ' . $db->escapeNumber($alliance_id_1) . ' OR alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT 1 FROM alliance_treaties WHERE (alliance_id_1 = :alliance_id_1 OR alliance_id_1 = :alliance_id_2) AND (alliance_id_2 = :alliance_id_1 OR alliance_id_2 = :alliance_id_2) AND game_id = :game_id', [
+			'alliance_id_1' => $db->escapeNumber($alliance_id_1),
+			'alliance_id_2' => $db->escapeNumber($alliance_id_2),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		if ($dbResult->hasRecord()) {
 			$message = '<span class="red bold">ERROR:</span> There is already an outstanding treaty with that alliance.';
 			$container = new AllianceTreaties($message);

--- a/src/pages/Player/AllianceTreatiesConfirmProcessor.php
+++ b/src/pages/Player/AllianceTreatiesConfirmProcessor.php
@@ -27,9 +27,9 @@ class AllianceTreatiesConfirmProcessor extends PlayerPageProcessor {
 
 		$db = Database::getInstance();
 		$db->insert('alliance_treaties', [
-			'alliance_id_1' => $db->escapeNumber($alliance_id_1),
-			'alliance_id_2' => $db->escapeNumber($alliance_id_2),
-			'game_id' => $db->escapeNumber($player->getGameID()),
+			'alliance_id_1' => $alliance_id_1,
+			'alliance_id_2' => $alliance_id_2,
+			'game_id' => $player->getGameID(),
 			'trader_assist' => $db->escapeBoolean($this->terms['trader_assist']),
 			'trader_defend' => $db->escapeBoolean($this->terms['trader_defend']),
 			'trader_nap' => $db->escapeBoolean($this->terms['trader_nap']),

--- a/src/pages/Player/AllianceTreatiesProcessor.php
+++ b/src/pages/Player/AllianceTreatiesProcessor.php
@@ -25,11 +25,15 @@ class AllianceTreatiesProcessor extends PlayerPageProcessor {
 
 		$db = Database::getInstance();
 		if ($this->accept) {
-			$db->write('UPDATE alliance_treaties SET official = \'TRUE\' WHERE alliance_id_1 = :alliance_id_1 AND alliance_id_2 = :alliance_id_2 AND game_id = :game_id', [
-				'alliance_id_1' => $db->escapeNumber($alliance_id_1),
-				'alliance_id_2' => $db->escapeNumber($alliance_id_2),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-			]);
+			$db->update(
+				'alliance_treaties',
+				['official' => 'TRUE'],
+				[
+					'alliance_id_1' => $db->escapeNumber($alliance_id_1),
+					'alliance_id_2' => $db->escapeNumber($alliance_id_2),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+				],
+			);
 
 			if ($this->allianceBankAccess) {
 				//make an AA role for both alliances, use treaty_created column

--- a/src/pages/Player/AllianceTreatiesProcessor.php
+++ b/src/pages/Player/AllianceTreatiesProcessor.php
@@ -43,14 +43,14 @@ class AllianceTreatiesProcessor extends PlayerPageProcessor {
 				];
 				foreach ($pairs as $alliance_id_A => $alliance_id_B) {
 					// get last id
-					$dbResult = $db->read('SELECT MAX(role_id)
+					$dbResult = $db->read('SELECT IFNULL(MAX(role_id), 0) as max_role_id
 								FROM alliance_has_roles
 								WHERE game_id = :game_id
 									AND alliance_id = :alliance_id', [
 						'game_id' => $db->escapeNumber($player->getGameID()),
 						'alliance_id' => $db->escapeNumber($alliance_id_A),
 					]);
-					$role_id = $dbResult->record()->getInt('MAX(role_id)') + 1;
+					$role_id = $dbResult->record()->getInt('max_role_id') + 1;
 
 					$allianceName = Alliance::getAlliance($alliance_id_B, $player->getGameID())->getAllianceName();
 					$db->insert('alliance_has_roles', [

--- a/src/pages/Player/AllianceTreatiesProcessor.php
+++ b/src/pages/Player/AllianceTreatiesProcessor.php
@@ -25,7 +25,11 @@ class AllianceTreatiesProcessor extends PlayerPageProcessor {
 
 		$db = Database::getInstance();
 		if ($this->accept) {
-			$db->write('UPDATE alliance_treaties SET official = \'TRUE\' WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+			$db->write('UPDATE alliance_treaties SET official = \'TRUE\' WHERE alliance_id_1 = :alliance_id_1 AND alliance_id_2 = :alliance_id_2 AND game_id = :game_id', [
+				'alliance_id_1' => $db->escapeNumber($alliance_id_1),
+				'alliance_id_2' => $db->escapeNumber($alliance_id_2),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 
 			if ($this->allianceBankAccess) {
 				//make an AA role for both alliances, use treaty_created column
@@ -37,8 +41,11 @@ class AllianceTreatiesProcessor extends PlayerPageProcessor {
 					// get last id
 					$dbResult = $db->read('SELECT MAX(role_id)
 								FROM alliance_has_roles
-								WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-									AND alliance_id = ' . $db->escapeNumber($alliance_id_A));
+								WHERE game_id = :game_id
+									AND alliance_id = :alliance_id', [
+						'game_id' => $db->escapeNumber($player->getGameID()),
+						'alliance_id' => $db->escapeNumber($alliance_id_A),
+					]);
 					$role_id = $dbResult->record()->getInt('MAX(role_id)') + 1;
 
 					$allianceName = Alliance::getAlliance($alliance_id_B, $player->getGameID())->getAllianceName();
@@ -52,7 +59,11 @@ class AllianceTreatiesProcessor extends PlayerPageProcessor {
 				}
 			}
 		} else {
-			$db->write('DELETE FROM alliance_treaties WHERE alliance_id_1 = ' . $db->escapeNumber($alliance_id_1) . ' AND alliance_id_2 = ' . $db->escapeNumber($alliance_id_2) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+			$db->write('DELETE FROM alliance_treaties WHERE alliance_id_1 = :alliance_id_1 AND alliance_id_2 = :alliance_id_2 AND game_id = :game_id', [
+				'alliance_id_1' => $db->escapeNumber($alliance_id_1),
+				'alliance_id_2' => $db->escapeNumber($alliance_id_2),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 		}
 
 		$container = new AllianceTreaties();

--- a/src/pages/Player/AllianceTreatiesProcessor.php
+++ b/src/pages/Player/AllianceTreatiesProcessor.php
@@ -59,7 +59,7 @@ class AllianceTreatiesProcessor extends PlayerPageProcessor {
 				}
 			}
 		} else {
-			$db->write('DELETE FROM alliance_treaties WHERE alliance_id_1 = :alliance_id_1 AND alliance_id_2 = :alliance_id_2 AND game_id = :game_id', [
+			$db->delete('alliance_treaties', [
 				'alliance_id_1' => $db->escapeNumber($alliance_id_1),
 				'alliance_id_2' => $db->escapeNumber($alliance_id_2),
 				'game_id' => $db->escapeNumber($player->getGameID()),

--- a/src/pages/Player/AllianceTreatiesProcessor.php
+++ b/src/pages/Player/AllianceTreatiesProcessor.php
@@ -58,7 +58,7 @@ class AllianceTreatiesProcessor extends PlayerPageProcessor {
 						'game_id' => $player->getGameID(),
 						'role_id' => $role_id,
 						'role' => $allianceName,
-						'treaty_created' => 1,
+						'treaty_created' => $db->escapeBoolean(true),
 					]);
 				}
 			}

--- a/src/pages/Player/AllianceTreatiesProcessor.php
+++ b/src/pages/Player/AllianceTreatiesProcessor.php
@@ -29,9 +29,9 @@ class AllianceTreatiesProcessor extends PlayerPageProcessor {
 				'alliance_treaties',
 				['official' => 'TRUE'],
 				[
-					'alliance_id_1' => $db->escapeNumber($alliance_id_1),
-					'alliance_id_2' => $db->escapeNumber($alliance_id_2),
-					'game_id' => $db->escapeNumber($player->getGameID()),
+					'alliance_id_1' => $alliance_id_1,
+					'alliance_id_2' => $alliance_id_2,
+					'game_id' => $player->getGameID(),
 				],
 			);
 
@@ -54,19 +54,19 @@ class AllianceTreatiesProcessor extends PlayerPageProcessor {
 
 					$allianceName = Alliance::getAlliance($alliance_id_B, $player->getGameID())->getAllianceName();
 					$db->insert('alliance_has_roles', [
-						'alliance_id' => $db->escapeNumber($alliance_id_A),
-						'game_id' => $db->escapeNumber($player->getGameID()),
-						'role_id' => $db->escapeNumber($role_id),
-						'role' => $db->escapeString($allianceName),
+						'alliance_id' => $alliance_id_A,
+						'game_id' => $player->getGameID(),
+						'role_id' => $role_id,
+						'role' => $allianceName,
 						'treaty_created' => 1,
 					]);
 				}
 			}
 		} else {
 			$db->delete('alliance_treaties', [
-				'alliance_id_1' => $db->escapeNumber($alliance_id_1),
-				'alliance_id_2' => $db->escapeNumber($alliance_id_2),
-				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id_1' => $alliance_id_1,
+				'alliance_id_2' => $alliance_id_2,
+				'game_id' => $player->getGameID(),
 			]);
 		}
 

--- a/src/pages/Player/AttackForcesProcessor.php
+++ b/src/pages/Player/AttackForcesProcessor.php
@@ -111,14 +111,14 @@ class AttackForcesProcessor extends PlayerPageProcessor {
 		// Add this log to the `combat_logs` database table
 		$db = Database::getInstance();
 		$logId = $db->insert('combat_logs', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'type' => $db->escapeString('FORCE'),
-			'sector_id' => $db->escapeNumber($forces->getSectorID()),
-			'timestamp' => $db->escapeNumber(Epoch::time()),
-			'attacker_id' => $db->escapeNumber($player->getAccountID()),
-			'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
-			'defender_id' => $db->escapeNumber($forceOwner->getAccountID()),
-			'defender_alliance_id' => $db->escapeNumber($forceOwner->getAllianceID()),
+			'game_id' => $player->getGameID(),
+			'type' => 'FORCE',
+			'sector_id' => $forces->getSectorID(),
+			'timestamp' => Epoch::time(),
+			'attacker_id' => $player->getAccountID(),
+			'attacker_alliance_id' => $player->getAllianceID(),
+			'defender_id' => $forceOwner->getAccountID(),
+			'defender_alliance_id' => $forceOwner->getAllianceID(),
 			'result' => $db->escapeObject($results, true),
 		]);
 

--- a/src/pages/Player/AttackPlanetProcessor.php
+++ b/src/pages/Player/AttackPlanetProcessor.php
@@ -103,7 +103,10 @@ class AttackPlanetProcessor extends PlayerPageProcessor {
 		]);
 
 		if ($planet->isDestroyed()) {
-			$db->write('UPDATE player SET land_on_planet = \'FALSE\' WHERE sector_id = ' . $db->escapeNumber($planet->getSectorID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+			$db->write('UPDATE player SET land_on_planet = \'FALSE\' WHERE sector_id = :sector_id AND game_id = :game_id', [
+				'sector_id' => $db->escapeNumber($planet->getSectorID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 			$planet->removeOwner();
 			$planet->removePassword();
 

--- a/src/pages/Player/AttackPlanetProcessor.php
+++ b/src/pages/Player/AttackPlanetProcessor.php
@@ -103,10 +103,14 @@ class AttackPlanetProcessor extends PlayerPageProcessor {
 		]);
 
 		if ($planet->isDestroyed()) {
-			$db->write('UPDATE player SET land_on_planet = \'FALSE\' WHERE sector_id = :sector_id AND game_id = :game_id', [
-				'sector_id' => $db->escapeNumber($planet->getSectorID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-			]);
+			$db->update(
+				'player',
+				['land_on_planet' => 'FALSE'],
+				[
+					'sector_id' => $db->escapeNumber($planet->getSectorID()),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+				],
+			);
 			$planet->removeOwner();
 			$planet->removePassword();
 

--- a/src/pages/Player/AttackPlanetProcessor.php
+++ b/src/pages/Player/AttackPlanetProcessor.php
@@ -91,14 +91,14 @@ class AttackPlanetProcessor extends PlayerPageProcessor {
 		// Add this log to the `combat_logs` database table
 		$db = Database::getInstance();
 		$logId = $db->insert('combat_logs', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'type' => $db->escapeString('PLANET'),
-			'sector_id' => $db->escapeNumber($planet->getSectorID()),
-			'timestamp' => $db->escapeNumber(Epoch::time()),
-			'attacker_id' => $db->escapeNumber($player->getAccountID()),
-			'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
-			'defender_id' => $db->escapeNumber($planetOwner->getAccountID()),
-			'defender_alliance_id' => $db->escapeNumber($planetOwner->getAllianceID()),
+			'game_id' => $player->getGameID(),
+			'type' => 'PLANET',
+			'sector_id' => $planet->getSectorID(),
+			'timestamp' => Epoch::time(),
+			'attacker_id' => $player->getAccountID(),
+			'attacker_alliance_id' => $player->getAllianceID(),
+			'defender_id' => $planetOwner->getAccountID(),
+			'defender_alliance_id' => $planetOwner->getAllianceID(),
 			'result' => $db->escapeObject($results, true),
 		]);
 
@@ -107,8 +107,8 @@ class AttackPlanetProcessor extends PlayerPageProcessor {
 				'player',
 				['land_on_planet' => 'FALSE'],
 				[
-					'sector_id' => $db->escapeNumber($planet->getSectorID()),
-					'game_id' => $db->escapeNumber($player->getGameID()),
+					'sector_id' => $planet->getSectorID(),
+					'game_id' => $player->getGameID(),
 				],
 			);
 			$planet->removeOwner();
@@ -133,9 +133,9 @@ class AttackPlanetProcessor extends PlayerPageProcessor {
 		foreach ($attackers as $attacker) {
 			if (!$player->equals($attacker)) {
 				$db->replace('sector_message', [
-					'account_id' => $db->escapeNumber($attacker->getAccountID()),
-					'game_id' => $db->escapeNumber($attacker->getGameID()),
-					'message' => $db->escapeString('[ATTACK_RESULTS]' . $logId),
+					'account_id' => $attacker->getAccountID(),
+					'game_id' => $attacker->getGameID(),
+					'message' => '[ATTACK_RESULTS]' . $logId,
 				]);
 			}
 		}

--- a/src/pages/Player/AttackPlayerProcessor.php
+++ b/src/pages/Player/AttackPlayerProcessor.php
@@ -100,14 +100,14 @@ class AttackPlayerProcessor extends PlayerPageProcessor {
 
 		$db = Database::getInstance();
 		$logId = $db->insert('combat_logs', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'type' => $db->escapeString('PLAYER'),
-			'sector_id' => $db->escapeNumber($sector->getSectorID()),
-			'timestamp' => $db->escapeNumber(Epoch::time()),
-			'attacker_id' => $db->escapeNumber($player->getAccountID()),
-			'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
-			'defender_id' => $db->escapeNumber($this->targetAccountID),
-			'defender_alliance_id' => $db->escapeNumber($targetPlayer->getAllianceID()),
+			'game_id' => $player->getGameID(),
+			'type' => 'PLAYER',
+			'sector_id' => $sector->getSectorID(),
+			'timestamp' => Epoch::time(),
+			'attacker_id' => $player->getAccountID(),
+			'attacker_alliance_id' => $player->getAllianceID(),
+			'defender_id' => $this->targetAccountID,
+			'defender_alliance_id' => $targetPlayer->getAllianceID(),
 			'result' => $db->escapeObject($results, true),
 		]);
 
@@ -116,9 +116,9 @@ class AttackPlayerProcessor extends PlayerPageProcessor {
 			foreach ($teamPlayers as $teamPlayer) {
 				if (!$player->equals($teamPlayer)) {
 					$db->replace('sector_message', [
-						'account_id' => $db->escapeNumber($teamPlayer->getAccountID()),
-						'game_id' => $db->escapeNumber($teamPlayer->getGameID()),
-						'message' => $db->escapeString('[ATTACK_RESULTS]' . $logId),
+						'account_id' => $teamPlayer->getAccountID(),
+						'game_id' => $teamPlayer->getGameID(),
+						'message' => '[ATTACK_RESULTS]' . $logId,
 					]);
 				}
 			}

--- a/src/pages/Player/AttackPortProcessor.php
+++ b/src/pages/Player/AttackPortProcessor.php
@@ -86,14 +86,14 @@ class AttackPortProcessor extends PlayerPageProcessor {
 
 		$db = Database::getInstance();
 		$logId = $db->insert('combat_logs', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'type' => $db->escapeString('PORT'),
-			'sector_id' => $db->escapeNumber($port->getSectorID()),
-			'timestamp' => $db->escapeNumber(Epoch::time()),
-			'attacker_id' => $db->escapeNumber($player->getAccountID()),
-			'attacker_alliance_id' => $db->escapeNumber($player->getAllianceID()),
-			'defender_id' => $db->escapeNumber(ACCOUNT_ID_PORT),
-			'defender_alliance_id' => $db->escapeNumber(PORT_ALLIANCE_ID),
+			'game_id' => $player->getGameID(),
+			'type' => 'PORT',
+			'sector_id' => $port->getSectorID(),
+			'timestamp' => Epoch::time(),
+			'attacker_id' => $player->getAccountID(),
+			'attacker_alliance_id' => $player->getAllianceID(),
+			'defender_id' => ACCOUNT_ID_PORT,
+			'defender_alliance_id' => PORT_ALLIANCE_ID,
 			'result' => $db->escapeObject($results, true),
 		]);
 
@@ -101,9 +101,9 @@ class AttackPortProcessor extends PlayerPageProcessor {
 		foreach ($attackers as $attacker) {
 			if (!$player->equals($attacker)) {
 				$db->replace('sector_message', [
-					'account_id' => $db->escapeNumber($attacker->getAccountID()),
-					'game_id' => $db->escapeNumber($attacker->getGameID()),
-					'message' => $db->escapeString($sectorMessage),
+					'account_id' => $attacker->getAccountID(),
+					'game_id' => $attacker->getGameID(),
+					'message' => $sectorMessage,
 				]);
 			}
 		}

--- a/src/pages/Player/Bank/AllianceBank.php
+++ b/src/pages/Player/Bank/AllianceBank.php
@@ -36,9 +36,12 @@ class AllianceBank extends PlayerPage {
 		Menu::bank();
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM alliance_treaties WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND (alliance_id_1 = ' . $db->escapeNumber($player->getAllianceID()) . ' OR alliance_id_2 = ' . $db->escapeNumber($player->getAllianceID()) . ')
-					AND aa_access = 1 AND official = \'TRUE\'');
+		$dbResult = $db->read('SELECT * FROM alliance_treaties WHERE game_id = :game_id
+					AND (alliance_id_1 = :alliance_id OR alliance_id_2 = :alliance_id)
+					AND aa_access = 1 AND official = \'TRUE\'', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		]);
 		$alliedAllianceBanks = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$alliedAllianceBanks[$dbRecord->getInt('alliance_id_2')] = Alliance::getAlliance($dbRecord->getInt('alliance_id_2'), $alliance->getGameID());
@@ -47,21 +50,29 @@ class AllianceBank extends PlayerPage {
 		$template->assign('AlliedAllianceBanks', $alliedAllianceBanks);
 
 		$dbResult = $db->read('SELECT transaction, sum(amount) as total FROM alliance_bank_transactions
-					WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . '
-					GROUP BY transaction');
+					WHERE alliance_id = :alliance_id AND game_id = :game_id AND payee_id = :payee_id
+					GROUP BY transaction', [
+			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+			'game_id' => $db->escapeNumber($alliance->getGameID()),
+			'payee_id' => $db->escapeNumber($player->getAccountID()),
+		]);
 		$playerTrans = ['Deposit' => 0, 'Payment' => 0];
 		foreach ($dbResult->records() as $dbRecord) {
 			$playerTrans[$dbRecord->getString('transaction')] = $dbRecord->getInt('total');
 		}
 
+		$query = 'SELECT * FROM alliance_has_roles WHERE alliance_id = :alliance_id AND game_id = :game_id AND ';
+		$sqlParams = [
+			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+			'game_id' => $db->escapeNumber($alliance->getGameID()),
+		];
 		if ($alliance->getAllianceID() == $player->getAllianceID()) {
-			$role_id = $player->getAllianceRole($alliance->getAllianceID());
-			$query = 'role_id = ' . $db->escapeNumber($role_id);
+			$sqlParams['role_id'] = $player->getAllianceRole($alliance->getAllianceID());
+			$dbResult = $db->read($query . 'role_id = :role_id', $sqlParams);
 		} else {
-			$query = 'role = ' . $db->escapeString($player->getAlliance()->getAllianceName());
+			$sqlParams['role'] = $db->escapeString($player->getAlliance()->getAllianceName());
+			$dbResult = $db->read($query . 'role = :role', $sqlParams);
 		}
-
-		$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . ' AND ' . $query);
 		$dbRecord = $dbResult->record();
 		$template->assign('CanExempt', $dbRecord->getBoolean('exempt_with'));
 		$withdrawalPerDay = $dbRecord->getInt('with_per_day');
@@ -71,8 +82,15 @@ class AllianceBank extends PlayerPage {
 		} elseif ($withdrawalPerDay == ALLIANCE_BANK_UNLIMITED) {
 			$template->assign('UnlimitedWithdrawal', true);
 		} else {
-			$dbResult = $db->read('SELECT IFNULL(sum(amount), 0) as total FROM alliance_bank_transactions WHERE alliance_id = ' . $db->escapeNumber($alliance->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($alliance->getGameID()) . '
-						AND payee_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND transaction = \'Payment\' AND exempt = 0 AND time > ' . $db->escapeNumber(Epoch::time() - 86400));
+			$dbResult = $db->read('SELECT IFNULL(sum(amount), 0) as total FROM alliance_bank_transactions
+						WHERE alliance_id = :alliance_id AND game_id = :game_id
+						AND payee_id = :payee_id AND transaction = \'Payment\' AND exempt = 0
+						AND time > :one_day_ago', [
+				'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+				'game_id' => $db->escapeNumber($alliance->getGameID()),
+				'payee_id' => $db->escapeNumber($player->getAccountID()),
+				'one_day_ago' => $db->escapeNumber(Epoch::time() - 86400),
+			]);
 			$totalWithdrawn = $dbResult->record()->getInt('total');
 			$template->assign('WithdrawalPerDay', $withdrawalPerDay);
 			$template->assign('RemainingWithdrawal', $withdrawalPerDay - $totalWithdrawn);
@@ -84,8 +102,11 @@ class AllianceBank extends PlayerPage {
 
 		if ($maxValue <= 0) {
 			$dbResult = $db->read('SELECT IFNULL(MAX(transaction_id), 0) as max_transaction_id FROM alliance_bank_transactions
-						WHERE game_id=' . $db->escapeNumber($alliance->getGameID()) . '
-						AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID()));
+						WHERE game_id = :game_id
+						AND alliance_id = :alliance_id', [
+				'game_id' => $db->escapeNumber($alliance->getGameID()),
+				'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+			]);
 			$maxValue = $dbResult->record()->getInt('max_transaction_id');
 		}
 
@@ -95,14 +116,18 @@ class AllianceBank extends PlayerPage {
 
 		$query = 'SELECT time, transaction_id, transaction, amount, exempt, reason, payee_id
 			FROM alliance_bank_transactions
-			WHERE game_id=' . $db->escapeNumber($alliance->getGameID()) . '
-			AND alliance_id=' . $db->escapeNumber($alliance->getAllianceID());
-
-		$query .= ' AND transaction_id>=' . $db->escapeNumber($minValue) . '
-					AND transaction_id<=' . $db->escapeNumber($maxValue) . '
-					ORDER BY time LIMIT ' . (1 + $maxValue - $minValue);
-
-		$dbResult = $db->read($query);
+			WHERE game_id = :game_id
+			AND alliance_id = :alliance_id
+			AND transaction_id >= :min_transaction_id
+			AND transaction_id <= :max_transaction_id
+			ORDER BY time LIMIT :limit';
+		$dbResult = $db->read($query, [
+			'game_id' => $db->escapeNumber($alliance->getGameID()),
+			'alliance_id' => $db->escapeNumber($alliance->getAllianceID()),
+			'min_transaction_id' => $db->escapeNumber($minValue),
+			'max_transaction_id' => $db->escapeNumber($maxValue),
+			'limit' => 1 + $maxValue - $minValue,
+		]);
 
 		// only if we have at least one result
 		if ($dbResult->hasRecord()) {

--- a/src/pages/Player/Bank/AllianceBankExemptProcessor.php
+++ b/src/pages/Player/Bank/AllianceBankExemptProcessor.php
@@ -20,14 +20,23 @@ class AllianceBankExemptProcessor extends PlayerPageProcessor {
 
 		//only if we are coming from the bank screen do we unexempt selection first
 		if ($this->minTransactionID !== null && $this->maxTransactionID !== null) {
-			$db->write('UPDATE alliance_bank_transactions SET exempt = 0 WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-						AND transaction_id BETWEEN ' . $db->escapeNumber($this->minTransactionID) . ' AND ' . $db->escapeNumber($this->maxTransactionID));
+			$db->write('UPDATE alliance_bank_transactions SET exempt = 0 WHERE game_id = :game_id AND alliance_id = :alliance_id
+						AND transaction_id BETWEEN :transaction_id_min AND :transaction_id_max', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'transaction_id_min' => $db->escapeNumber($this->minTransactionID),
+				'transaction_id_max' => $db->escapeNumber($this->maxTransactionID),
+			]);
 		}
 
 		if (Request::has('exempt')) {
 			$trans_ids = array_keys(Request::getArray('exempt'));
-			$db->write('UPDATE alliance_bank_transactions SET exempt = 1, request_exempt = 0 WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-						AND transaction_id IN (' . $db->escapeArray($trans_ids) . ')');
+			$db->write('UPDATE alliance_bank_transactions SET exempt = 1, request_exempt = 0 WHERE game_id = :game_id AND alliance_id = :alliance_id
+						AND transaction_id IN (:transaction_ids)', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'transaction_ids' => $db->escapeArray($trans_ids),
+			]);
 		}
 
 		if ($this->minTransactionID !== null) {

--- a/src/pages/Player/Bank/AllianceBankProcessor.php
+++ b/src/pages/Player/Bank/AllianceBankProcessor.php
@@ -119,15 +119,15 @@ class AllianceBankProcessor extends PlayerPageProcessor {
 		// save log
 		$requestExempt = Request::has('requestExempt') ? 1 : 0;
 		$db->insert('alliance_bank_transactions', [
-			'alliance_id' => $db->escapeNumber($alliance_id),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'transaction_id' => $db->escapeNumber($next_id),
-			'time' => $db->escapeNumber(Epoch::time()),
-			'payee_id' => $db->escapeNumber($player->getAccountID()),
-			'reason' => $db->escapeString($message),
-			'transaction' => $db->escapeString($action),
-			'amount' => $db->escapeNumber($amount),
-			'request_exempt' => $db->escapeNumber($requestExempt),
+			'alliance_id' => $alliance_id,
+			'game_id' => $player->getGameID(),
+			'transaction_id' => $next_id,
+			'time' => Epoch::time(),
+			'payee_id' => $player->getAccountID(),
+			'reason' => $message,
+			'transaction' => $action,
+			'amount' => $amount,
+			'request_exempt' => $requestExempt,
 		]);
 
 		// update player credits

--- a/src/pages/Player/Bank/AllianceBankReport.php
+++ b/src/pages/Player/Bank/AllianceBankReport.php
@@ -25,7 +25,10 @@ class AllianceBankReport extends PlayerPage {
 
 		//get all transactions
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM alliance_bank_transactions WHERE alliance_id = ' . $db->escapeNumber($alliance_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT * FROM alliance_bank_transactions WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+			'alliance_id' => $db->escapeNumber($alliance_id),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		if (!$dbResult->hasRecord()) {
 			create_error('Your alliance has no recorded transactions.');
 		}
@@ -47,7 +50,10 @@ class AllianceBankReport extends PlayerPage {
 			$totals[$accId] = $transArray[self::DEPOSIT] - $transArray[self::WITHDRAW];
 		}
 		arsort($totals, SORT_NUMERIC);
-		$dbResult = $db->read('SELECT * FROM player WHERE account_id IN (' . $db->escapeArray($playerIDs) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY player_name');
+		$dbResult = $db->read('SELECT * FROM player WHERE account_id IN (:account_ids) AND game_id = :game_id ORDER BY player_name', [
+			'account_ids' => $db->escapeArray($playerIDs),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$players = [0 => 'Alliance Funds'];
 		foreach ($dbResult->records() as $dbRecord) {
 			$players[$dbRecord->getInt('account_id')] = htmlentities($dbRecord->getString('player_name'));

--- a/src/pages/Player/Bank/AllianceBankReportProcessor.php
+++ b/src/pages/Player/Bank/AllianceBankReportProcessor.php
@@ -32,20 +32,20 @@ class AllianceBankReportProcessor extends PlayerPageProcessor {
 			$db->update(
 				'alliance_thread',
 				[
-					'time' => $db->escapeNumber(Epoch::time()),
-					'text' => $db->escapeString($text),
+					'time' => Epoch::time(),
+					'text' => $text,
 				],
 				[
-					'thread_id' => $db->escapeNumber($thread_id),
-					'alliance_id' => $db->escapeNumber($alliance_id),
-					'game_id' => $db->escapeNumber($player->getGameID()),
+					'thread_id' => $thread_id,
+					'alliance_id' => $alliance_id,
+					'game_id' => $player->getGameID(),
 					'reply_id' => 1,
 				],
 			);
 			$db->delete('player_read_thread', [
-				'thread_id' => $db->escapeNumber($thread_id),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'alliance_id' => $db->escapeNumber($alliance_id),
+				'thread_id' => $thread_id,
+				'game_id' => $player->getGameID(),
+				'alliance_id' => $alliance_id,
 			]);
 		} else {
 			// There is no "Bank Statement" thread yet
@@ -55,19 +55,19 @@ class AllianceBankReportProcessor extends PlayerPageProcessor {
 			]);
 			$thread_id = $dbResult->record()->getInt('next_id');
 			$db->insert('alliance_thread_topic', [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'alliance_id' => $db->escapeNumber($alliance_id),
-				'thread_id' => $db->escapeNumber($thread_id),
-				'topic' => $db->escapeString('Bank Statement'),
+				'game_id' => $player->getGameID(),
+				'alliance_id' => $alliance_id,
+				'thread_id' => $thread_id,
+				'topic' => 'Bank Statement',
 			]);
 			$db->insert('alliance_thread', [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'alliance_id' => $db->escapeNumber($alliance_id),
-				'thread_id' => $db->escapeNumber($thread_id),
+				'game_id' => $player->getGameID(),
+				'alliance_id' => $alliance_id,
+				'thread_id' => $thread_id,
 				'reply_id' => 1,
-				'text' => $db->escapeString($text),
-				'sender_id' => $db->escapeNumber(ACCOUNT_ID_BANK_REPORTER),
-				'time' => $db->escapeNumber(Epoch::time()),
+				'text' => $text,
+				'sender_id' => ACCOUNT_ID_BANK_REPORTER,
+				'time' => Epoch::time(),
 			]);
 		}
 

--- a/src/pages/Player/Bank/AllianceBankReportProcessor.php
+++ b/src/pages/Player/Bank/AllianceBankReportProcessor.php
@@ -36,7 +36,7 @@ class AllianceBankReportProcessor extends PlayerPageProcessor {
 				'alliance_id' => $db->escapeNumber($alliance_id),
 				'game_id' => $db->escapeNumber($player->getGameID()),
 			]);
-			$db->write('DELETE FROM player_read_thread WHERE thread_id = :thread_id AND game_id = :game_id AND alliance_id = :alliance_id', [
+			$db->delete('player_read_thread', [
 				'thread_id' => $db->escapeNumber($thread_id),
 				'game_id' => $db->escapeNumber($player->getGameID()),
 				'alliance_id' => $db->escapeNumber($alliance_id),

--- a/src/pages/Player/Bank/AllianceBankReportProcessor.php
+++ b/src/pages/Player/Bank/AllianceBankReportProcessor.php
@@ -29,13 +29,19 @@ class AllianceBankReportProcessor extends PlayerPageProcessor {
 		if ($dbResult->hasRecord()) {
 			// Update the existing "Bank Statement" thread
 			$thread_id = $dbResult->record()->getInt('thread_id');
-			$db->write('UPDATE alliance_thread SET time = :now, text = :text WHERE thread_id = :thread_id AND alliance_id = :alliance_id AND game_id = :game_id AND reply_id = 1', [
-				'now' => $db->escapeNumber(Epoch::time()),
-				'text' => $db->escapeString($text),
-				'thread_id' => $db->escapeNumber($thread_id),
-				'alliance_id' => $db->escapeNumber($alliance_id),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-			]);
+			$db->update(
+				'alliance_thread',
+				[
+					'time' => $db->escapeNumber(Epoch::time()),
+					'text' => $db->escapeString($text),
+				],
+				[
+					'thread_id' => $db->escapeNumber($thread_id),
+					'alliance_id' => $db->escapeNumber($alliance_id),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+					'reply_id' => 1,
+				],
+			);
 			$db->delete('player_read_thread', [
 				'thread_id' => $db->escapeNumber($thread_id),
 				'game_id' => $db->escapeNumber($player->getGameID()),

--- a/src/pages/Player/Bank/AnonBank.php
+++ b/src/pages/Player/Bank/AnonBank.php
@@ -34,8 +34,11 @@ class AnonBank extends PlayerPage {
 
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM anon_bank
-					WHERE owner_id=' . $db->escapeNumber($player->getAccountID()) . '
-					AND game_id=' . $db->escapeNumber($player->getGameID()));
+					WHERE owner_id = :owner_id
+					AND game_id = :game_id', [
+			'owner_id' => $db->escapeNumber($player->getAccountID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 
 		$ownedAnon = [];
 		foreach ($dbResult->records() as $dbRecord) {
@@ -45,8 +48,11 @@ class AnonBank extends PlayerPage {
 			$anon['amount'] = $dbRecord->getInt('amount');
 
 			$dbResult2 = $db->read('SELECT MAX(time) FROM anon_bank_transactions
-						WHERE game_id=' . $db->escapeNumber($player->getGameID()) . '
-						AND anon_id=' . $db->escapeNumber($dbRecord->getInt('anon_id')) . ' GROUP BY anon_id');
+						WHERE game_id = :game_id
+						AND anon_id = :anon_id GROUP BY anon_id', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'anon_id' => $db->escapeNumber($dbRecord->getInt('anon_id')),
+			]);
 			if ($dbResult2->hasRecord()) {
 				$anon['last_transaction'] = date($account->getDateTimeFormat(), $dbResult2->record()->getInt('MAX(time)'));
 			} else {

--- a/src/pages/Player/Bank/AnonBank.php
+++ b/src/pages/Player/Bank/AnonBank.php
@@ -49,12 +49,13 @@ class AnonBank extends PlayerPage {
 
 			$dbResult2 = $db->read('SELECT MAX(time) FROM anon_bank_transactions
 						WHERE game_id = :game_id
-						AND anon_id = :anon_id GROUP BY anon_id', [
+						AND anon_id = :anon_id', [
 				'game_id' => $db->escapeNumber($player->getGameID()),
 				'anon_id' => $db->escapeNumber($dbRecord->getInt('anon_id')),
 			]);
-			if ($dbResult2->hasRecord()) {
-				$anon['last_transaction'] = date($account->getDateTimeFormat(), $dbResult2->record()->getInt('MAX(time)'));
+			$lastTransactionTime = $dbResult2->record()->getNullableInt('MAX(time)');
+			if ($lastTransactionTime !== null) {
+				$anon['last_transaction'] = date($account->getDateTimeFormat(), $lastTransactionTime);
 			} else {
 				$anon['last_transaction'] = 'No transactions';
 			}

--- a/src/pages/Player/Bank/AnonBankCreateProcessor.php
+++ b/src/pages/Player/Bank/AnonBankCreateProcessor.php
@@ -17,7 +17,9 @@ class AnonBankCreateProcessor extends PlayerPageProcessor {
 		}
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT IFNULL(MAX(anon_id), 0) as max_id FROM anon_bank WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT IFNULL(MAX(anon_id), 0) as max_id FROM anon_bank WHERE game_id = :game_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$nextID = $dbResult->record()->getInt('max_id') + 1;
 
 		$db->insert('anon_bank', [

--- a/src/pages/Player/Bank/AnonBankCreateProcessor.php
+++ b/src/pages/Player/Bank/AnonBankCreateProcessor.php
@@ -23,10 +23,10 @@ class AnonBankCreateProcessor extends PlayerPageProcessor {
 		$nextID = $dbResult->record()->getInt('max_id') + 1;
 
 		$db->insert('anon_bank', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'anon_id' => $db->escapeNumber($nextID),
-			'owner_id' => $db->escapeNumber($player->getAccountID()),
-			'password' => $db->escapeString($password),
+			'game_id' => $player->getGameID(),
+			'anon_id' => $nextID,
+			'owner_id' => $player->getAccountID(),
+			'password' => $password,
 			'amount' => 0,
 		]);
 

--- a/src/pages/Player/Bank/AnonBankDetailProcessor.php
+++ b/src/pages/Player/Bank/AnonBankDetailProcessor.php
@@ -70,13 +70,13 @@ class AnonBankDetailProcessor extends PlayerPageProcessor {
 
 		// Log the bank transaction
 		$db->insert('anon_bank_transactions', [
-			'account_id' => $db->escapeNumber($player->getAccountID()),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'anon_id' => $db->escapeNumber($account_num),
-			'transaction_id' => $db->escapeNumber($trans_id),
-			'transaction' => $db->escapeString($action),
-			'amount' => $db->escapeNumber($amount),
-			'time' => $db->escapeNumber(Epoch::time()),
+			'account_id' => $player->getAccountID(),
+			'game_id' => $player->getGameID(),
+			'anon_id' => $account_num,
+			'transaction_id' => $trans_id,
+			'transaction' => $action,
+			'amount' => $amount,
+			'time' => Epoch::time(),
 		]);
 
 		// Log the player action

--- a/src/pages/Player/Bank/AnonBankProcessor.php
+++ b/src/pages/Player/Bank/AnonBankProcessor.php
@@ -15,8 +15,11 @@ class AnonBankProcessor extends PlayerPageProcessor {
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT password
 			FROM anon_bank
-			WHERE anon_id=' . $db->escapeNumber($account_num) . '
-			AND game_id=' . $db->escapeNumber($player->getGameID()));
+			WHERE anon_id = :anon_id
+			AND game_id = :game_id', [
+			'anon_id' => $db->escapeNumber($account_num),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		if (!$dbResult->hasRecord()) {
 			create_error('This anonymous account does not exist!');
 		}

--- a/src/pages/Player/Bar/BarMain.php
+++ b/src/pages/Player/Bar/BarMain.php
@@ -34,7 +34,7 @@ class BarMain extends PlayerPage {
 		$winningTicket = false;
 		//check for winner
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT prize FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
+		$dbResult = $db->read('SELECT prize FROM player_has_ticket WHERE ' . AbstractPlayer::SQL . ' AND time = 0', $player->SQLID);
 		if ($dbResult->hasRecord()) {
 			$winningTicket = $dbResult->record()->getInt('prize');
 

--- a/src/pages/Player/Bar/BuyDrinkProcessor.php
+++ b/src/pages/Player/Bar/BuyDrinkProcessor.php
@@ -95,7 +95,7 @@ class BuyDrinkProcessor extends PlayerPageProcessor {
 			$player->increaseHOF(1, ['Bar', 'Robbed', 'Number Of Times'], HOF_PUBLIC);
 			$player->increaseHOF($lostCredits, ['Bar', 'Robbed', 'Money Lost'], HOF_PUBLIC);
 
-			$db->write('DELETE FROM player_has_drinks WHERE ' . AbstractPlayer::SQL, $player->SQLID);
+			$db->delete('player_has_drinks', $player->SQLID);
 
 		}
 		$player->increaseHOF(1, ['Bar', 'Drinks', 'Total'], HOF_PUBLIC);

--- a/src/pages/Player/Bar/BuyDrinkProcessor.php
+++ b/src/pages/Player/Bar/BuyDrinkProcessor.php
@@ -56,10 +56,10 @@ class BuyDrinkProcessor extends PlayerPageProcessor {
 
 			$curr_drink_id++;
 			$db->insert('player_has_drinks', [
-				'account_id' => $db->escapeNumber($player->getAccountID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'drink_id' => $db->escapeNumber($curr_drink_id),
-				'time' => $db->escapeNumber(Epoch::time()),
+				'account_id' => $player->getAccountID(),
+				'game_id' => $player->getGameID(),
+				'drink_id' => $curr_drink_id,
+				'time' => Epoch::time(),
 			]);
 
 			if (!BarDrink::isSpecial($drinkName)) {

--- a/src/pages/Player/Bar/BuyGalaxyMapProcessor.php
+++ b/src/pages/Player/Bar/BuyGalaxyMapProcessor.php
@@ -38,7 +38,12 @@ class BuyGalaxyMapProcessor extends PlayerPageProcessor {
 
 		// Have they already got this map? (Are there any unexplored sectors?
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND ' . $player->getSQL() . ' LIMIT 1');
+		$params = [
+			'low' => $db->escapeNumber($low),
+			'high' => $db->escapeNumber($high),
+			...$player->SQLID,
+		];
+		$dbResult = $db->read('SELECT 1 FROM player_visited_sector WHERE sector_id >= :low AND sector_id <= :high AND ' . AbstractPlayer::SQL . ' LIMIT 1', $params);
 		if (!$dbResult->hasRecord()) {
 			create_error('You already have maps of this galaxy!');
 		}
@@ -49,7 +54,7 @@ class BuyGalaxyMapProcessor extends PlayerPageProcessor {
 		//now give maps
 
 		// delete all entries from the player_visited_sector/port table
-		$db->write('DELETE FROM player_visited_sector WHERE sector_id >= ' . $db->escapeNumber($low) . ' AND sector_id <= ' . $db->escapeNumber($high) . ' AND ' . $player->getSQL());
+		$db->write('DELETE FROM player_visited_sector WHERE sector_id >= :low AND sector_id <= :high AND ' . AbstractPlayer::SQL, $params);
 		//start section
 
 		// add port infos

--- a/src/pages/Player/Bar/BuyTickerProcessor.php
+++ b/src/pages/Player/Bar/BuyTickerProcessor.php
@@ -30,10 +30,10 @@ class BuyTickerProcessor extends PlayerPageProcessor {
 
 		$db = Database::getInstance();
 		$db->replace('player_has_ticker', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'account_id' => $db->escapeNumber($player->getAccountID()),
-			'type' => $db->escapeString($type),
-			'expires' => $db->escapeNumber($expires),
+			'game_id' => $player->getGameID(),
+			'account_id' => $player->getAccountID(),
+			'type' => $type,
+			'expires' => $expires,
 		]);
 
 		//take credits

--- a/src/pages/Player/Bar/LottoBuyTicketProcessor.php
+++ b/src/pages/Player/Bar/LottoBuyTicketProcessor.php
@@ -35,9 +35,9 @@ class LottoBuyTicketProcessor extends PlayerPageProcessor {
 		}
 
 		$db->insert('player_has_ticket', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'account_id' => $db->escapeNumber($player->getAccountID()),
-			'time' => $db->escapeNumber($time),
+			'game_id' => $player->getGameID(),
+			'account_id' => $player->getAccountID(),
+			'time' => $time,
 		]);
 		$player->decreaseCredits(Lotto::TICKET_COST);
 		$player->increaseHOF(Lotto::TICKET_COST, ['Bar', 'Lotto', 'Money', 'Spent'], HOF_PUBLIC);

--- a/src/pages/Player/Bar/LottoBuyTicketProcessor.php
+++ b/src/pages/Player/Bar/LottoBuyTicketProcessor.php
@@ -24,8 +24,10 @@ class LottoBuyTicketProcessor extends PlayerPageProcessor {
 		$time = Epoch::time();
 		while (true) {
 			//avoid double entries (since table is unique on game,account,time)
-			$dbResult = $db->read('SELECT 1 FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND account_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND time = ' . $db->escapeNumber($time));
+			$dbResult = $db->read('SELECT 1 FROM player_has_ticket WHERE ' . AbstractPlayer::SQL . ' AND time = :time', [
+				...$player->SQLID,
+				'time' => $db->escapeNumber($time),
+			]);
 			if (!$dbResult->hasRecord()) {
 				break;
 			}
@@ -40,7 +42,7 @@ class LottoBuyTicketProcessor extends PlayerPageProcessor {
 		$player->decreaseCredits(Lotto::TICKET_COST);
 		$player->increaseHOF(Lotto::TICKET_COST, ['Bar', 'Lotto', 'Money', 'Spent'], HOF_PUBLIC);
 		$player->increaseHOF(1, ['Bar', 'Lotto', 'Tickets Bought'], HOF_PUBLIC);
-		$dbResult = $db->read('SELECT count(*) as num FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0 GROUP BY account_id');
+		$dbResult = $db->read('SELECT count(*) as num FROM player_has_ticket WHERE ' . AbstractPlayer::SQL . ' AND time > 0 GROUP BY account_id', $player->SQLID);
 		$num = $dbResult->record()->getInt('num');
 		$message = ('<div class="center">Thanks for your purchase and good luck!  You currently');
 		$message .= (' own ' . pluralise($num, 'ticket') . '!</div><br />');

--- a/src/pages/Player/Bar/LottoClaimProcessor.php
+++ b/src/pages/Player/Bar/LottoClaimProcessor.php
@@ -32,12 +32,12 @@ class LottoClaimProcessor extends PlayerPageProcessor {
 			$message .= '<div class="center">You have claimed <span class="red">$' . number_format($prize) . '</span>!<br /></div><br />';
 			$db->delete('player_has_ticket', [
 				...$player->SQLID,
-				'prize' => $db->escapeNumber($prize),
+				'prize' => $prize,
 				'time' => 0,
 			]);
 			$db->delete('news', [
 				'type' => 'lotto',
-				'game_id' => $db->escapeNumber($player->getGameID()),
+				'game_id' => $player->getGameID(),
 			]);
 		}
 		//offer another drink and such

--- a/src/pages/Player/Bar/LottoClaimProcessor.php
+++ b/src/pages/Player/Bar/LottoClaimProcessor.php
@@ -30,11 +30,13 @@ class LottoClaimProcessor extends PlayerPageProcessor {
 			$player->increaseHOF($prize, ['Bar', 'Lotto', 'Money', 'Claimed'], HOF_PUBLIC);
 			$player->increaseHOF(1, ['Bar', 'Lotto', 'Results', 'Claims'], HOF_PUBLIC);
 			$message .= '<div class="center">You have claimed <span class="red">$' . number_format($prize) . '</span>!<br /></div><br />';
-			$db->write('DELETE FROM player_has_ticket WHERE ' . AbstractPlayer::SQL . ' AND prize = :prize AND time = 0', [
+			$db->delete('player_has_ticket', [
 				...$player->SQLID,
 				'prize' => $db->escapeNumber($prize),
+				'time' => 0,
 			]);
-			$db->write('DELETE FROM news WHERE type = \'lotto\' AND game_id = :game_id', [
+			$db->delete('news', [
+				'type' => 'lotto',
 				'game_id' => $db->escapeNumber($player->getGameID()),
 			]);
 		}

--- a/src/pages/Player/Bar/TalkToBartender.php
+++ b/src/pages/Player/Bar/TalkToBartender.php
@@ -24,7 +24,9 @@ class TalkToBartender extends PlayerPage {
 		// We save the displayed message in session since it is randomized
 		if ($this->message === null) {
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT message FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY rand() LIMIT 1');
+			$dbResult = $db->read('SELECT message FROM bar_tender WHERE game_id = :game_id ORDER BY rand() LIMIT 1', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 			if ($dbResult->hasRecord()) {
 				$message = 'I heard... ' . htmlentities(word_filter($dbResult->record()->getString('message'))) . '<br /><br />Got anything else to tell me?';
 			} else {

--- a/src/pages/Player/Bar/TalkToBartenderProcessor.php
+++ b/src/pages/Player/Bar/TalkToBartenderProcessor.php
@@ -24,7 +24,9 @@ class TalkToBartenderProcessor extends PlayerPageProcessor {
 			$gossip = Request::get('gossip_tell');
 			if (!empty($gossip)) {
 				$db = Database::getInstance();
-				$dbResult = $db->read('SELECT IFNULL(MAX(message_id)+1, 0) AS next_message_id FROM bar_tender WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
+				$dbResult = $db->read('SELECT IFNULL(MAX(message_id)+1, 0) AS next_message_id FROM bar_tender WHERE game_id = :game_id', [
+					'game_id' => $db->escapeNumber($player->getGameID()),
+				]);
 				$messageID = $dbResult->record()->getInt('next_message_id');
 
 				$db->insert('bar_tender', [

--- a/src/pages/Player/Bar/TalkToBartenderProcessor.php
+++ b/src/pages/Player/Bar/TalkToBartenderProcessor.php
@@ -30,9 +30,9 @@ class TalkToBartenderProcessor extends PlayerPageProcessor {
 				$messageID = $dbResult->record()->getInt('next_message_id');
 
 				$db->insert('bar_tender', [
-					'game_id' => $db->escapeNumber($player->getGameID()),
-					'message_id' => $db->escapeNumber($messageID),
-					'message' => $db->escapeString($gossip),
+					'game_id' => $player->getGameID(),
+					'message_id' => $messageID,
+					'message' => $gossip,
 				]);
 				$player->sendMessageToBox(BOX_BARTENDER, $gossip);
 

--- a/src/pages/Player/BetaFunctions/RevealMapProcessor.php
+++ b/src/pages/Player/BetaFunctions/RevealMapProcessor.php
@@ -13,10 +13,12 @@ class RevealMapProcessor extends BetaFunctionsPageProcessor {
 		$game_id = $player->getGameID();
 		// delete all entries from the player_visited_sector/port table
 		$db = Database::getInstance();
-		$db->write('DELETE FROM player_visited_sector WHERE ' . $player->getSQL());
+		$db->write('DELETE FROM player_visited_sector WHERE ' . AbstractPlayer::SQL, $player->SQLID);
 
 		// add port infos
-		$dbResult = $db->read('SELECT * FROM port WHERE game_id = ' . $db->escapeNumber($game_id));
+		$dbResult = $db->read('SELECT * FROM port WHERE game_id = :game_id', [
+			'game_id' => $db->escapeNumber($game_id),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$port = Port::getPort($game_id, $dbRecord->getInt('sector_id'), false, $dbRecord);
 			$port->addCachePort($account_id);

--- a/src/pages/Player/BetaFunctions/RevealMapProcessor.php
+++ b/src/pages/Player/BetaFunctions/RevealMapProcessor.php
@@ -13,7 +13,7 @@ class RevealMapProcessor extends BetaFunctionsPageProcessor {
 		$game_id = $player->getGameID();
 		// delete all entries from the player_visited_sector/port table
 		$db = Database::getInstance();
-		$db->write('DELETE FROM player_visited_sector WHERE ' . AbstractPlayer::SQL, $player->SQLID);
+		$db->delete('player_visited_sector', $player->SQLID);
 
 		// add port infos
 		$dbResult = $db->read('SELECT * FROM port WHERE game_id = :game_id', [

--- a/src/pages/Player/BetaFunctions/SetPoliticalRelationsProcessor.php
+++ b/src/pages/Player/BetaFunctions/SetPoliticalRelationsProcessor.php
@@ -15,8 +15,19 @@ class SetPoliticalRelationsProcessor extends BetaFunctionsPageProcessor {
 			create_error('You cannot change race relations with your own race.');
 		}
 		$db = Database::getInstance();
-		$db->write('UPDATE race_has_relation SET relation = ' . $db->escapeNumber($amount) . ' WHERE race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . ' AND race_id_2 = ' . $db->escapeNumber($race) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
-		$db->write('UPDATE race_has_relation SET relation = ' . $db->escapeNumber($amount) . ' WHERE race_id_1 = ' . $db->escapeNumber($race) . ' AND race_id_2 = ' . $db->escapeNumber($player->getRaceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$query = 'UPDATE race_has_relation SET relation = :relation WHERE race_id_1 = :race_id_1 AND race_id_2 = :race_id_2 AND game_id = :game_id';
+		$db->write($query, [
+			'relation' => $db->escapeNumber($amount),
+			'race_id_1' => $db->escapeNumber($player->getRaceID()),
+			'race_id_2' => $db->escapeNumber($race),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
+		$db->write($query, [
+			'relation' => $db->escapeNumber($amount),
+			'race_id_1' => $db->escapeNumber($race),
+			'race_id_2' => $db->escapeNumber($player->getRaceID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 	}
 
 }

--- a/src/pages/Player/BetaFunctions/SetPoliticalRelationsProcessor.php
+++ b/src/pages/Player/BetaFunctions/SetPoliticalRelationsProcessor.php
@@ -15,19 +15,24 @@ class SetPoliticalRelationsProcessor extends BetaFunctionsPageProcessor {
 			create_error('You cannot change race relations with your own race.');
 		}
 		$db = Database::getInstance();
-		$query = 'UPDATE race_has_relation SET relation = :relation WHERE race_id_1 = :race_id_1 AND race_id_2 = :race_id_2 AND game_id = :game_id';
-		$db->write($query, [
-			'relation' => $db->escapeNumber($amount),
-			'race_id_1' => $db->escapeNumber($player->getRaceID()),
-			'race_id_2' => $db->escapeNumber($race),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-		]);
-		$db->write($query, [
-			'relation' => $db->escapeNumber($amount),
-			'race_id_1' => $db->escapeNumber($race),
-			'race_id_2' => $db->escapeNumber($player->getRaceID()),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-		]);
+		$db->update(
+			'race_has_relation',
+			['relation' => $db->escapeNumber($amount)],
+			[
+				'race_id_1' => $db->escapeNumber($player->getRaceID()),
+				'race_id_2' => $db->escapeNumber($race),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			],
+		);
+		$db->update(
+			'race_has_relation',
+			['relation' => $db->escapeNumber($amount)],
+			[
+				'race_id_1' => $db->escapeNumber($race),
+				'race_id_2' => $db->escapeNumber($player->getRaceID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			],
+		);
 	}
 
 }

--- a/src/pages/Player/BetaFunctions/SetPoliticalRelationsProcessor.php
+++ b/src/pages/Player/BetaFunctions/SetPoliticalRelationsProcessor.php
@@ -17,20 +17,20 @@ class SetPoliticalRelationsProcessor extends BetaFunctionsPageProcessor {
 		$db = Database::getInstance();
 		$db->update(
 			'race_has_relation',
-			['relation' => $db->escapeNumber($amount)],
+			['relation' => $amount],
 			[
-				'race_id_1' => $db->escapeNumber($player->getRaceID()),
-				'race_id_2' => $db->escapeNumber($race),
-				'game_id' => $db->escapeNumber($player->getGameID()),
+				'race_id_1' => $player->getRaceID(),
+				'race_id_2' => $race,
+				'game_id' => $player->getGameID(),
 			],
 		);
 		$db->update(
 			'race_has_relation',
-			['relation' => $db->escapeNumber($amount)],
+			['relation' => $amount],
 			[
-				'race_id_1' => $db->escapeNumber($race),
-				'race_id_2' => $db->escapeNumber($player->getRaceID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
+				'race_id_1' => $race,
+				'race_id_2' => $player->getRaceID(),
+				'game_id' => $player->getGameID(),
 			],
 		);
 	}

--- a/src/pages/Player/ChatSharing.php
+++ b/src/pages/Player/ChatSharing.php
@@ -25,7 +25,10 @@ class ChatSharing extends PlayerPage {
 
 		$shareFrom = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($player->getGameID()) . ')');
+		$dbResult = $db->read('SELECT * FROM account_shares_info WHERE to_account_id = :to_account_id AND (game_id=0 OR game_id = :game_id)', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'to_account_id' => $db->escapeNumber($player->getAccountID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$fromAccountId = $dbRecord->getInt('from_account_id');
 			$gameId = $dbRecord->getInt('game_id');
@@ -46,7 +49,10 @@ class ChatSharing extends PlayerPage {
 		}
 
 		$shareTo = [];
-		$dbResult = $db->read('SELECT * FROM account_shares_info WHERE from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND (game_id=0 OR game_id=' . $db->escapeNumber($player->getGameID()) . ')');
+		$dbResult = $db->read('SELECT * FROM account_shares_info WHERE from_account_id = :from_account_id AND (game_id=0 OR game_id = :game_id)', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'from_account_id' => $db->escapeNumber($player->getAccountID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$gameId = $dbRecord->getInt('game_id');
 			$toAccountId = $dbRecord->getInt('to_account_id');

--- a/src/pages/Player/ChatSharingProcessor.php
+++ b/src/pages/Player/ChatSharingProcessor.php
@@ -52,7 +52,7 @@ class ChatSharingProcessor extends PlayerPageProcessor {
 
 		// Process removing a "share to" account
 		if (Request::has('remove_share_to')) {
-			$db->write('DELETE FROM account_shares_info WHERE to_account_id = :to_account_id AND from_account_id = :from_account_id AND game_id = :game_id', [
+			$db->delete('account_shares_info', [
 				'to_account_id' => $db->escapeNumber(Request::getInt('remove_share_to')),
 				'from_account_id' => $db->escapeNumber($player->getAccountID()),
 				'game_id' => $db->escapeNumber(Request::getInt('game_id')),
@@ -61,7 +61,7 @@ class ChatSharingProcessor extends PlayerPageProcessor {
 
 		// Process removing a "share from" account
 		if (Request::has('remove_share_from')) {
-			$db->write('DELETE FROM account_shares_info WHERE to_account_id = :to_account_id AND from_account_id = :from_account_id AND game_id = :game_id', [
+			$db->delete('account_shares_info', [
 				'to_account_id' => $db->escapeNumber($player->getAccountID()),
 				'from_account_id' => $db->escapeNumber(Request::getInt('remove_share_from')),
 				'game_id' => $db->escapeNumber(Request::getInt('game_id')),

--- a/src/pages/Player/ChatSharingProcessor.php
+++ b/src/pages/Player/ChatSharingProcessor.php
@@ -44,27 +44,27 @@ class ChatSharingProcessor extends PlayerPageProcessor {
 
 			$gameId = Request::has('all_games') ? 0 : $player->getGameID();
 			$db->insert('account_shares_info', [
-				'to_account_id' => $db->escapeNumber($accountId),
-				'from_account_id' => $db->escapeNumber($player->getAccountID()),
-				'game_id' => $db->escapeNumber($gameId),
+				'to_account_id' => $accountId,
+				'from_account_id' => $player->getAccountID(),
+				'game_id' => $gameId,
 			]);
 		}
 
 		// Process removing a "share to" account
 		if (Request::has('remove_share_to')) {
 			$db->delete('account_shares_info', [
-				'to_account_id' => $db->escapeNumber(Request::getInt('remove_share_to')),
-				'from_account_id' => $db->escapeNumber($player->getAccountID()),
-				'game_id' => $db->escapeNumber(Request::getInt('game_id')),
+				'to_account_id' => Request::getInt('remove_share_to'),
+				'from_account_id' => $player->getAccountID(),
+				'game_id' => Request::getInt('game_id'),
 			]);
 		}
 
 		// Process removing a "share from" account
 		if (Request::has('remove_share_from')) {
 			$db->delete('account_shares_info', [
-				'to_account_id' => $db->escapeNumber($player->getAccountID()),
-				'from_account_id' => $db->escapeNumber(Request::getInt('remove_share_from')),
-				'game_id' => $db->escapeNumber(Request::getInt('game_id')),
+				'to_account_id' => $player->getAccountID(),
+				'from_account_id' => Request::getInt('remove_share_from'),
+				'game_id' => Request::getInt('game_id'),
 			]);
 		}
 

--- a/src/pages/Player/ChatSharingProcessor.php
+++ b/src/pages/Player/ChatSharingProcessor.php
@@ -52,12 +52,20 @@ class ChatSharingProcessor extends PlayerPageProcessor {
 
 		// Process removing a "share to" account
 		if (Request::has('remove_share_to')) {
-			$db->write('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber(Request::getInt('remove_share_to')) . ' AND from_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND game_id=' . $db->escapeNumber(Request::getInt('game_id')));
+			$db->write('DELETE FROM account_shares_info WHERE to_account_id = :to_account_id AND from_account_id = :from_account_id AND game_id = :game_id', [
+				'to_account_id' => $db->escapeNumber(Request::getInt('remove_share_to')),
+				'from_account_id' => $db->escapeNumber($player->getAccountID()),
+				'game_id' => $db->escapeNumber(Request::getInt('game_id')),
+			]);
 		}
 
 		// Process removing a "share from" account
 		if (Request::has('remove_share_from')) {
-			$db->write('DELETE FROM account_shares_info WHERE to_account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND from_account_id=' . $db->escapeNumber(Request::getInt('remove_share_from')) . ' AND game_id=' . $db->escapeNumber(Request::getInt('game_id')));
+			$db->write('DELETE FROM account_shares_info WHERE to_account_id = :to_account_id AND from_account_id = :from_account_id AND game_id = :game_id', [
+				'to_account_id' => $db->escapeNumber($player->getAccountID()),
+				'from_account_id' => $db->escapeNumber(Request::getInt('remove_share_from')),
+				'game_id' => $db->escapeNumber(Request::getInt('game_id')),
+			]);
 		}
 
 		(new ChatSharing())->go();

--- a/src/pages/Player/Chess/MatchList.php
+++ b/src/pages/Player/Chess/MatchList.php
@@ -28,7 +28,12 @@ class MatchList extends PlayerPage {
 
 		$players = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) WHERE npc = ' . $db->escapeBoolean(false) . ' AND validated = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
+		$dbResult = $db->read('SELECT player_id, player.player_name FROM player JOIN account USING(account_id) WHERE npc = :npc AND validated = :validated AND game_id = :game_id AND account_id NOT IN (:account_ids) ORDER BY player_name', [
+			'npc' => $db->escapeBoolean(false),
+			'validated' => $db->escapeBoolean(true),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'account_ids' => $db->escapeArray(array_keys($playersChallenged)),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$players[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getString('player_name'));
 		}
@@ -36,7 +41,11 @@ class MatchList extends PlayerPage {
 
 		if (ENABLE_NPCS_CHESS) {
 			$npcs = [];
-			$dbResult = $db->read('SELECT player_id, player.player_name FROM player WHERE npc = ' . $db->escapeBoolean(true) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id NOT IN (' . $db->escapeArray(array_keys($playersChallenged)) . ') ORDER BY player_name');
+			$dbResult = $db->read('SELECT player_id, player.player_name FROM player WHERE npc = :npc AND game_id = :game_id AND account_id NOT IN (:account_ids) ORDER BY player_name', [
+				'npc' => $db->escapeBoolean(true),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'account_ids' => $db->escapeArray(array_keys($playersChallenged)),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$npcs[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getString('player_name'));
 			}

--- a/src/pages/Player/CombatLogViewer.php
+++ b/src/pages/Player/CombatLogViewer.php
@@ -27,7 +27,9 @@ class CombatLogViewer extends PlayerPage {
 		// Set properties for the current display page
 		$display_id = $this->logIDs[$this->currentLog];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT timestamp,sector_id,result,type FROM combat_logs WHERE log_id=' . $db->escapeNumber($display_id) . ' LIMIT 1');
+		$dbResult = $db->read('SELECT timestamp,sector_id,result,type FROM combat_logs WHERE log_id = :log_id LIMIT 1', [
+			'log_id' => $db->escapeNumber($display_id),
+		]);
 
 		$dbRecord = $dbResult->record();
 		$template->assign('CombatLogSector', $dbRecord->getInt('sector_id'));

--- a/src/pages/Player/CombatLogViewerVerifyProcessor.php
+++ b/src/pages/Player/CombatLogViewerVerifyProcessor.php
@@ -19,13 +19,19 @@ class CombatLogViewerVerifyProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 
-		$query = 'SELECT 1 FROM combat_logs WHERE log_id=' . $db->escapeNumber($this->logID) . ' AND game_id=' . $db->escapeNumber($player->getGameID()) . ' AND ';
+		$query = 'SELECT 1 FROM combat_logs WHERE log_id = :log_id AND game_id = :game_id AND ';
+		$params = [
+			'log_id' => $db->escapeNumber($this->logID),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		];
 		if ($player->hasAlliance()) {
-			$query .= '(attacker_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' OR defender_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ')';
+			$query .= '(attacker_alliance_id = :alliance_id OR defender_alliance_id = :alliance_id)';
+			$params['alliance_id'] = $db->escapeNumber($player->getAllianceID());
 		} else {
-			$query .= '(attacker_id=' . $db->escapeNumber($player->getAccountID()) . ' OR defender_id=' . $db->escapeNumber($player->getAccountID()) . ')';
+			$query .= '(attacker_id = :account_id OR defender_id = :account_id)';
+			$params['account_id'] = $db->escapeNumber($player->getAccountID());
 		}
-		$dbResult = $db->read($query . ' LIMIT 1');
+		$dbResult = $db->read($query . ' LIMIT 1', $params);
 
 		// Error if qualifications are not met
 		if (!$dbResult->hasRecord()) {

--- a/src/pages/Player/Council/Embassy.php
+++ b/src/pages/Player/Council/Embassy.php
@@ -33,9 +33,13 @@ class Embassy extends PlayerPage {
 				continue;
 			}
 			$dbResult = $db->read('SELECT 1 FROM race_has_voting
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . '
-						AND race_id_2 = ' . $db->escapeNumber($raceID));
+						WHERE game_id = :game_id
+						AND race_id_1 = :race_id_1
+						AND race_id_2 = :race_id_2', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'race_id_1' => $db->escapeNumber($player->getRaceID()),
+				'race_id_2' => $db->escapeNumber($raceID),
+			]);
 			if ($dbResult->hasRecord()) {
 				continue;
 			}

--- a/src/pages/Player/Council/EmbassyProcessor.php
+++ b/src/pages/Player/Council/EmbassyProcessor.php
@@ -27,15 +27,22 @@ class EmbassyProcessor extends PlayerPageProcessor {
 
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT count(*) FROM race_has_voting
-					WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()));
+					WHERE game_id = :game_id
+					AND race_id_1 = :race_id_1', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'race_id_1' => $db->escapeNumber($player->getRaceID()),
+		]);
 		if ($dbResult->record()->getInt('count(*)') > 2) {
 			create_error('You can\'t initiate more than 3 votes at a time!');
 		}
 
 		if ($type == 'PEACE') {
 			$dbResult = $db->read('SELECT 1 FROM race_has_voting
-						WHERE race_id_1=' . $db->escapeNumber($race_id) . ' AND race_id_2=' . $db->escapeNumber($player->getRaceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+						WHERE race_id_1 = :race_id_1 AND race_id_2 = :race_id_2 AND game_id = :game_id', [
+				'race_id_1' => $db->escapeNumber($race_id),
+				'race_id_2' => $db->escapeNumber($player->getRaceID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 			if ($dbResult->hasRecord()) {
 				create_error('You cannot start a vote with that race.');
 			}

--- a/src/pages/Player/Council/EmbassyProcessor.php
+++ b/src/pages/Player/Council/EmbassyProcessor.php
@@ -50,21 +50,21 @@ class EmbassyProcessor extends PlayerPageProcessor {
 
 		// Create the vote for the player's race
 		$db->replace('race_has_voting', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'race_id_1' => $db->escapeNumber($player->getRaceID()),
-			'race_id_2' => $db->escapeNumber($race_id),
-			'type' => $db->escapeString($type),
-			'end_time' => $db->escapeNumber($time),
+			'game_id' => $player->getGameID(),
+			'race_id_1' => $player->getRaceID(),
+			'race_id_2' => $race_id,
+			'type' => $type,
+			'end_time' => $time,
 		]);
 
 		// If voting for peace, the other race also has to vote
 		if ($type == 'PEACE') {
 			$db->replace('race_has_voting', [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'race_id_1' => $db->escapeNumber($race_id),
-				'race_id_2' => $db->escapeNumber($player->getRaceID()),
-				'type' => $db->escapeString($type),
-				'end_time' => $db->escapeNumber($time),
+				'game_id' => $player->getGameID(),
+				'race_id_1' => $race_id,
+				'race_id_2' => $player->getRaceID(),
+				'type' => $type,
+				'end_time' => $time,
 			]);
 		}
 

--- a/src/pages/Player/Council/VotingCenter.php
+++ b/src/pages/Player/Council/VotingCenter.php
@@ -29,8 +29,11 @@ class VotingCenter extends PlayerPage {
 		// determine for what we voted
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM player_votes_relation
-					WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-						AND game_id = ' . $db->escapeNumber($player->getGameID()));
+					WHERE account_id = :account_id
+						AND game_id = :game_id', [
+			'account_id' => $db->escapeNumber($player->getAccountID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$votedForRace = null;
 		$votedFor = null;
 		if ($dbResult->hasRecord()) {
@@ -57,9 +60,13 @@ class VotingCenter extends PlayerPage {
 
 		$voteTreaties = [];
 		$dbResult = $db->read('SELECT * FROM race_has_voting
-					WHERE ' . $db->escapeNumber(Epoch::time()) . ' < end_time
-					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()));
+					WHERE :now < end_time
+					AND game_id = :game_id
+					AND race_id_1 = :race_id_1', [
+			'now' => $db->escapeNumber(Epoch::time()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'race_id_1' => $db->escapeNumber($player->getRaceID()),
+		]);
 
 		foreach ($dbResult->records() as $dbRecord) {
 			$otherRaceID = $dbRecord->getInt('race_id_2');
@@ -67,25 +74,38 @@ class VotingCenter extends PlayerPage {
 
 			// get 'yes' votes
 			$dbResult2 = $db->read('SELECT count(*) FROM player_votes_pact
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . '
-							AND race_id_2 = ' . $db->escapeNumber($otherRaceID) . '
-							AND vote = \'YES\'');
+						WHERE game_id = :game_id
+							AND race_id_1 = :race_id_1
+							AND race_id_2 = :race_id_2
+							AND vote = \'YES\'', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'race_id_1' => $db->escapeNumber($player->getRaceID()),
+				'race_id_2' => $db->escapeNumber($otherRaceID),
+			]);
 			$yesVotes = $dbResult2->record()->getInt('count(*)');
 
 			// get 'no' votes
 			$dbResult2 = $db->read('SELECT count(*) FROM player_votes_pact
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . '
-							AND race_id_2 = ' . $db->escapeNumber($otherRaceID) . '
-							AND vote = \'NO\'');
+						WHERE game_id = :game_id
+							AND race_id_1 = :race_id_1
+							AND race_id_2 = :race_id_2
+							AND vote = \'NO\'', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'race_id_1' => $db->escapeNumber($player->getRaceID()),
+				'race_id_2' => $db->escapeNumber($otherRaceID),
+			]);
 			$noVotes = $dbResult2->record()->getInt('count(*)');
 
 			$dbResult2 = $db->read('SELECT vote FROM player_votes_pact
-						WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-							AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . '
-							AND race_id_2 = ' . $db->escapeNumber($otherRaceID));
+						WHERE account_id = :account_id
+							AND game_id = :game_id
+							AND race_id_1 = :race_id_1
+							AND race_id_2 = :race_id_2', [
+				'account_id' => $db->escapeNumber($player->getAccountID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'race_id_1' => $db->escapeNumber($player->getRaceID()),
+				'race_id_2' => $db->escapeNumber($otherRaceID),
+			]);
 			$votedFor = '';
 			if ($dbResult2->hasRecord()) {
 				$votedFor = $dbResult2->record()->getString('vote'); // this should be a boolean

--- a/src/pages/Player/Council/VotingCenterProcessor.php
+++ b/src/pages/Player/Council/VotingCenterProcessor.php
@@ -55,22 +55,15 @@ class VotingCenterProcessor extends PlayerPageProcessor {
 				'race_id_1' => $db->escapeNumber($player->getRaceID()),
 				'race_id_2' => $db->escapeNumber($race_id),
 			];
-			$db->write('DELETE FROM race_has_voting
-					WHERE game_id = :game_id
-						AND race_id_1 = :race_id_1
-						AND race_id_2 = :race_id_2', $sqlParams);
-			$db->write('DELETE FROM player_votes_pact
-					WHERE game_id = :game_id
-						AND race_id_1 = :race_id_1
-						AND race_id_2 = :race_id_2', $sqlParams);
-			$db->write('DELETE FROM race_has_voting
-					WHERE game_id = :game_id
-						AND race_id_1 = :race_id_2
-						AND race_id_2 = :race_id_1', $sqlParams);
-			$db->write('DELETE FROM player_votes_pact
-					WHERE game_id = :game_id
-						AND race_id_1 = :race_id_2
-						AND race_id_2 = :race_id_1', $sqlParams);
+			$db->delete('race_has_voting', $sqlParams);
+			$db->delete('player_votes_pact', $sqlParams);
+			$sqlParams2 = [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'race_id_1' => $db->escapeNumber($race_id),
+				'race_id_2' => $db->escapeNumber($player->getRaceID()),
+			];
+			$db->delete('race_has_voting', $sqlParams2);
+			$db->delete('player_votes_pact', $sqlParams2);
 		}
 
 		(new VotingCenter())->go();

--- a/src/pages/Player/Council/VotingCenterProcessor.php
+++ b/src/pages/Player/Council/VotingCenterProcessor.php
@@ -33,34 +33,34 @@ class VotingCenterProcessor extends PlayerPageProcessor {
 
 		if ($action == 'INC' || $action == 'DEC') {
 			$db->replace('player_votes_relation', [
-				'account_id' => $db->escapeNumber($player->getAccountID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'race_id_1' => $db->escapeNumber($player->getRaceID()),
-				'race_id_2' => $db->escapeNumber($race_id),
-				'action' => $db->escapeString($action),
-				'time' => $db->escapeNumber(Epoch::time()),
+				'account_id' => $player->getAccountID(),
+				'game_id' => $player->getGameID(),
+				'race_id_1' => $player->getRaceID(),
+				'race_id_2' => $race_id,
+				'action' => $action,
+				'time' => Epoch::time(),
 			]);
 		} elseif ($action == 'YES' || $action == 'NO') {
 			$db->replace('player_votes_pact', [
-				'account_id' => $db->escapeNumber($player->getAccountID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'race_id_1' => $db->escapeNumber($player->getRaceID()),
-				'race_id_2' => $db->escapeNumber($race_id),
-				'vote' => $db->escapeString($action),
+				'account_id' => $player->getAccountID(),
+				'game_id' => $player->getGameID(),
+				'race_id_1' => $player->getRaceID(),
+				'race_id_2' => $race_id,
+				'vote' => $action,
 			]);
 		} elseif ($action == 'VETO') {
 			// try to cancel both votings
 			$sqlParams = [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'race_id_1' => $db->escapeNumber($player->getRaceID()),
-				'race_id_2' => $db->escapeNumber($race_id),
+				'game_id' => $player->getGameID(),
+				'race_id_1' => $player->getRaceID(),
+				'race_id_2' => $race_id,
 			];
 			$db->delete('race_has_voting', $sqlParams);
 			$db->delete('player_votes_pact', $sqlParams);
 			$sqlParams2 = [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'race_id_1' => $db->escapeNumber($race_id),
-				'race_id_2' => $db->escapeNumber($player->getRaceID()),
+				'game_id' => $player->getGameID(),
+				'race_id_1' => $race_id,
+				'race_id_2' => $player->getRaceID(),
 			];
 			$db->delete('race_has_voting', $sqlParams2);
 			$db->delete('player_votes_pact', $sqlParams2);

--- a/src/pages/Player/Council/VotingCenterProcessor.php
+++ b/src/pages/Player/Council/VotingCenterProcessor.php
@@ -50,22 +50,27 @@ class VotingCenterProcessor extends PlayerPageProcessor {
 			]);
 		} elseif ($action == 'VETO') {
 			// try to cancel both votings
-			$db->write('DELETE FROM race_has_voting ' .
-					'WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . '
-						AND race_id_2 = ' . $db->escapeNumber($race_id));
-			$db->write('DELETE FROM player_votes_pact ' .
-					'WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND race_id_1 = ' . $db->escapeNumber($player->getRaceID()) . '
-						AND race_id_2 = ' . $db->escapeNumber($race_id));
-			$db->write('DELETE FROM race_has_voting ' .
-					'WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND race_id_1 = ' . $db->escapeNumber($race_id) . '
-						AND race_id_2 = ' . $db->escapeNumber($player->getRaceID()));
-			$db->write('DELETE FROM player_votes_pact ' .
-					'WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND race_id_1 = ' . $db->escapeNumber($race_id) . '
-						AND race_id_2 = ' . $db->escapeNumber($player->getRaceID()));
+			$sqlParams = [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'race_id_1' => $db->escapeNumber($player->getRaceID()),
+				'race_id_2' => $db->escapeNumber($race_id),
+			];
+			$db->write('DELETE FROM race_has_voting
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_1
+						AND race_id_2 = :race_id_2', $sqlParams);
+			$db->write('DELETE FROM player_votes_pact
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_1
+						AND race_id_2 = :race_id_2', $sqlParams);
+			$db->write('DELETE FROM race_has_voting
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_2
+						AND race_id_2 = :race_id_1', $sqlParams);
+			$db->write('DELETE FROM player_votes_pact
+					WHERE game_id = :game_id
+						AND race_id_1 = :race_id_2
+						AND race_id_2 = :race_id_1', $sqlParams);
 		}
 
 		(new VotingCenter())->go();

--- a/src/pages/Player/CurrentSector.php
+++ b/src/pages/Player/CurrentSector.php
@@ -133,7 +133,7 @@ class CurrentSector extends PlayerPage {
 		$dbResult = $db->read('SELECT * FROM sector_message WHERE ' . AbstractPlayer::SQL, $player->SQLID);
 		if ($dbResult->hasRecord()) {
 			$this->attackMessage = $dbResult->record()->getString('message');
-			$db->write('DELETE FROM sector_message WHERE ' . AbstractPlayer::SQL, $player->SQLID);
+			$db->delete('sector_message', $player->SQLID);
 		}
 
 		if ($this->attackMessage !== null) {

--- a/src/pages/Player/ExaminePlanet.php
+++ b/src/pages/Player/ExaminePlanet.php
@@ -33,11 +33,16 @@ class ExaminePlanet extends PlayerPage {
 			$dbResult = $db->read('
 				SELECT 1
 				FROM alliance_treaties
-				WHERE (alliance_id_1 = ' . $db->escapeNumber($ownerAllianceID) . ' OR alliance_id_1 = ' . $db->escapeNumber($player->getAllianceID()) . ')
-				AND (alliance_id_2 = ' . $db->escapeNumber($ownerAllianceID) . ' OR alliance_id_2 = ' . $db->escapeNumber($player->getAllianceID()) . ')
-				AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+				WHERE (alliance_id_1 = :owner_alliance_id OR alliance_id_1 = :player_alliance_id)
+				AND (alliance_id_2 = :owner_alliance_id OR alliance_id_2 = :player_alliance_id)
+				AND game_id = :game_id
 				AND planet_land = 1
-				AND official = ' . $db->escapeBoolean(true));
+				AND official = :official', [
+				'owner_alliance_id' => $db->escapeNumber($ownerAllianceID),
+				'player_alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'official' => $db->escapeBoolean(true),
+			]);
 			$planetLand = $dbResult->hasRecord();
 		}
 		$template->assign('PlanetLand', $planetLand);

--- a/src/pages/Player/ForcesList.php
+++ b/src/pages/Player/ForcesList.php
@@ -22,10 +22,14 @@ class ForcesList extends PlayerPage {
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT *
 					FROM sector_has_forces
-					WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . '
-					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND expire_time >= ' . $db->escapeNumber(Epoch::time()) . '
-					ORDER BY sector_id ASC');
+					WHERE owner_id = :owner_id
+					AND game_id = :game_id
+					AND expire_time >= :now
+					ORDER BY sector_id ASC', [
+			'owner_id' => $db->escapeNumber($player->getAccountID()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 
 		$forces = [];
 		foreach ($dbResult->records() as $dbRecord) {

--- a/src/pages/Player/GalacticPost/ArticleAddToNewsProcessor.php
+++ b/src/pages/Player/GalacticPost/ArticleAddToNewsProcessor.php
@@ -15,7 +15,10 @@ class ArticleAddToNewsProcessor extends PlayerPageProcessor {
 
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT text FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($this->articleID));
+		$dbResult = $db->read('SELECT text FROM galactic_post_article WHERE game_id = :game_id AND article_id = :article_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'article_id' => $db->escapeNumber($this->articleID),
+		]);
 		$dbRecord = $dbResult->record();
 		$newsMessage = $dbRecord->getString('text');
 

--- a/src/pages/Player/GalacticPost/ArticleAddToNewsProcessor.php
+++ b/src/pages/Player/GalacticPost/ArticleAddToNewsProcessor.php
@@ -23,10 +23,10 @@ class ArticleAddToNewsProcessor extends PlayerPageProcessor {
 		$newsMessage = $dbRecord->getString('text');
 
 		$db->insert('news', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'time' => $db->escapeNumber(Epoch::time()),
-			'news_message' => $db->escapeString($newsMessage),
-			'type' => $db->escapeString('breaking'),
+			'game_id' => $player->getGameID(),
+			'time' => Epoch::time(),
+			'news_message' => $newsMessage,
+			'type' => 'breaking',
 		]);
 
 		$container = new ArticleView($this->articleID, addedToNews: true);

--- a/src/pages/Player/GalacticPost/ArticleAddToPaperProcessor.php
+++ b/src/pages/Player/GalacticPost/ArticleAddToPaperProcessor.php
@@ -16,7 +16,10 @@ class ArticleAddToPaperProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		//limit 4 per paper...make sure we arent over that
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($this->paperID));
+		$dbResult = $db->read('SELECT 1 FROM galactic_post_paper_content WHERE game_id = :game_id AND paper_id = :paper_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'paper_id' => $db->escapeNumber($this->paperID),
+		]);
 		if ($dbResult->getNumRecords() >= 8) {
 			create_error('You can only have 8 articles per paper.');
 		}

--- a/src/pages/Player/GalacticPost/ArticleAddToPaperProcessor.php
+++ b/src/pages/Player/GalacticPost/ArticleAddToPaperProcessor.php
@@ -24,9 +24,9 @@ class ArticleAddToPaperProcessor extends PlayerPageProcessor {
 			create_error('You can only have 8 articles per paper.');
 		}
 		$db->insert('galactic_post_paper_content', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'paper_id' => $db->escapeNumber($this->paperID),
-			'article_id' => $db->escapeNumber($this->articleID),
+			'game_id' => $player->getGameID(),
+			'paper_id' => $this->paperID,
+			'article_id' => $this->articleID,
 		]);
 		//we now have that article in the paper
 		$container = new ArticleView();

--- a/src/pages/Player/GalacticPost/ArticleDeleteConfirm.php
+++ b/src/pages/Player/GalacticPost/ArticleDeleteConfirm.php
@@ -19,7 +19,10 @@ class ArticleDeleteConfirm extends PlayerPage {
 		$db = Database::getInstance();
 
 		$template->assign('PageTopic', 'Delete Article - Confirm');
-		$dbResult = $db->read('SELECT title FROM galactic_post_article WHERE article_id = ' . $db->escapeNumber($this->articleID) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT title FROM galactic_post_article WHERE article_id = :article_id AND game_id = :game_id', [
+			'article_id' => $db->escapeNumber($this->articleID),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$template->assign('ArticleTitle', $dbResult->record()->getString('title'));
 
 		$container = new ArticleDeleteProcessor($this->articleID);

--- a/src/pages/Player/GalacticPost/ArticleDeleteProcessor.php
+++ b/src/pages/Player/GalacticPost/ArticleDeleteProcessor.php
@@ -17,8 +17,8 @@ class ArticleDeleteProcessor extends PlayerPageProcessor {
 		$db = Database::getInstance();
 		if (Request::getBool('action')) {
 			$db->delete('galactic_post_article', [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'article_id' => $db->escapeNumber($this->articleID),
+				'game_id' => $player->getGameID(),
+				'article_id' => $this->articleID,
 			]);
 		}
 

--- a/src/pages/Player/GalacticPost/ArticleDeleteProcessor.php
+++ b/src/pages/Player/GalacticPost/ArticleDeleteProcessor.php
@@ -16,7 +16,7 @@ class ArticleDeleteProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 		if (Request::getBool('action')) {
-			$db->write('DELETE FROM galactic_post_article WHERE game_id = :game_id AND article_id = :article_id', [
+			$db->delete('galactic_post_article', [
 				'game_id' => $db->escapeNumber($player->getGameID()),
 				'article_id' => $db->escapeNumber($this->articleID),
 			]);

--- a/src/pages/Player/GalacticPost/ArticleDeleteProcessor.php
+++ b/src/pages/Player/GalacticPost/ArticleDeleteProcessor.php
@@ -16,7 +16,10 @@ class ArticleDeleteProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 		if (Request::getBool('action')) {
-			$db->write('DELETE FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($this->articleID));
+			$db->write('DELETE FROM galactic_post_article WHERE game_id = :game_id AND article_id = :article_id', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'article_id' => $db->escapeNumber($this->articleID),
+			]);
 		}
 
 		$container = new ArticleView();

--- a/src/pages/Player/GalacticPost/ArticleView.php
+++ b/src/pages/Player/GalacticPost/ArticleView.php
@@ -26,7 +26,9 @@ class ArticleView extends PlayerPage {
 
 		// Get the articles that are not already in a paper
 		$articles = [];
-		$dbResult = $db->read('SELECT * FROM galactic_post_article WHERE article_id NOT IN (SELECT article_id FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ') AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT * FROM galactic_post_article WHERE article_id NOT IN (SELECT article_id FROM galactic_post_paper_content WHERE game_id = :game_id) AND game_id = :game_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$title = $dbRecord->getString('title');
 			$writer = Player::getPlayer($dbRecord->getInt('writer_id'), $player->getGameID());
@@ -41,7 +43,10 @@ class ArticleView extends PlayerPage {
 
 		// Details about a selected article
 		if ($this->articleID !== null) {
-			$dbResult = $db->read('SELECT * FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($this->articleID));
+			$dbResult = $db->read('SELECT * FROM galactic_post_article WHERE game_id = :game_id AND article_id = :article_id', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'article_id' => $db->escapeNumber($this->articleID),
+			]);
 			$dbRecord = $dbResult->record();
 
 			$container = new ArticleWrite($this->articleID);
@@ -59,7 +64,9 @@ class ArticleView extends PlayerPage {
 			$template->assign('SelectedArticle', $selectedArticle);
 
 			$papers = [];
-			$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
+			$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = :game_id', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$container = new ArticleAddToPaperProcessor($dbRecord->getInt('paper_id'), $this->articleID);
 				$papers[] = [

--- a/src/pages/Player/GalacticPost/ArticleWrite.php
+++ b/src/pages/Player/GalacticPost/ArticleWrite.php
@@ -28,7 +28,10 @@ class ArticleWrite extends PlayerPage {
 			$template->assign('PageTopic', 'Editing An Article');
 			if ($this->previewText === null) {
 				$db = Database::getInstance();
-				$dbResult = $db->read('SELECT title, text FROM galactic_post_article WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($this->articleID));
+				$dbResult = $db->read('SELECT title, text FROM galactic_post_article WHERE game_id = :game_id AND article_id = :article_id', [
+					'game_id' => $db->escapeNumber($player->getGameID()),
+					'article_id' => $db->escapeNumber($this->articleID),
+				]);
 				if ($dbResult->hasRecord()) {
 					$dbRecord = $dbResult->record();
 					$title = $dbRecord->getString('title');

--- a/src/pages/Player/GalacticPost/ArticleWriteProcessor.php
+++ b/src/pages/Player/GalacticPost/ArticleWriteProcessor.php
@@ -33,13 +33,18 @@ class ArticleWriteProcessor extends PlayerPageProcessor {
 		$db = Database::getInstance();
 		if ($this->articleID !== null) {
 			// Editing an article
-			$db->write('UPDATE galactic_post_article SET last_modified = :now, text = :text, title = :title WHERE game_id = :game_id AND article_id = :article_id', [
-				'now' => $db->escapeNumber(Epoch::time()),
-				'text' => $db->escapeString($message),
-				'title' => $db->escapeString($title),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'article_id' => $db->escapeNumber($this->articleID),
-			]);
+			$db->update(
+				'galactic_post_article',
+				[
+					'last_modified' => $db->escapeNumber(Epoch::time()),
+					'text' => $db->escapeString($message),
+					'title' => $db->escapeString($title),
+				],
+				[
+					'game_id' => $db->escapeNumber($player->getGameID()),
+					'article_id' => $db->escapeNumber($this->articleID),
+				],
+			);
 			(new ArticleView($this->articleID))->go();
 		} else {
 			// Adding a new article
@@ -63,10 +68,11 @@ class ArticleWriteProcessor extends PlayerPageProcessor {
 				'text' => $db->escapeString($message),
 				'last_modified' => $db->escapeNumber(Epoch::time()),
 			]);
-			$db->write('UPDATE galactic_post_writer SET last_wrote = :now WHERE account_id = :account_id', [
-				'now' => $db->escapeNumber(Epoch::time()),
-				'account_id' => $db->escapeNumber($player->getAccountID()),
-			]);
+			$db->update(
+				'galactic_post_writer',
+				['last_wrote' => $db->escapeNumber(Epoch::time())],
+				['account_id' => $db->escapeNumber($player->getAccountID())],
+			);
 			$msg = '<span class="green">SUCCESS</span>: Your article has been submitted.';
 			$container = new CurrentSector(message: $msg);
 			$container->go();

--- a/src/pages/Player/GalacticPost/ArticleWriteProcessor.php
+++ b/src/pages/Player/GalacticPost/ArticleWriteProcessor.php
@@ -36,13 +36,13 @@ class ArticleWriteProcessor extends PlayerPageProcessor {
 			$db->update(
 				'galactic_post_article',
 				[
-					'last_modified' => $db->escapeNumber(Epoch::time()),
-					'text' => $db->escapeString($message),
-					'title' => $db->escapeString($title),
+					'last_modified' => Epoch::time(),
+					'text' => $message,
+					'title' => $title,
 				],
 				[
-					'game_id' => $db->escapeNumber($player->getGameID()),
-					'article_id' => $db->escapeNumber($this->articleID),
+					'game_id' => $player->getGameID(),
+					'article_id' => $this->articleID,
 				],
 			);
 			(new ArticleView($this->articleID))->go();
@@ -61,17 +61,17 @@ class ArticleWriteProcessor extends PlayerPageProcessor {
 			$num = $dbResult->record()->getInt('next_article_id');
 
 			$db->insert('galactic_post_article', [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'article_id' => $db->escapeNumber($num),
-				'writer_id' => $db->escapeNumber($player->getAccountID()),
-				'title' => $db->escapeString($title),
-				'text' => $db->escapeString($message),
-				'last_modified' => $db->escapeNumber(Epoch::time()),
+				'game_id' => $player->getGameID(),
+				'article_id' => $num,
+				'writer_id' => $player->getAccountID(),
+				'title' => $title,
+				'text' => $message,
+				'last_modified' => Epoch::time(),
 			]);
 			$db->update(
 				'galactic_post_writer',
-				['last_wrote' => $db->escapeNumber(Epoch::time())],
-				['account_id' => $db->escapeNumber($player->getAccountID())],
+				['last_wrote' => Epoch::time()],
+				['account_id' => $player->getAccountID()],
 			);
 			$msg = '<span class="green">SUCCESS</span>: Your article has been submitted.';
 			$container = new CurrentSector(message: $msg);

--- a/src/pages/Player/GalacticPost/CurrentEditionProcessor.php
+++ b/src/pages/Player/GalacticPost/CurrentEditionProcessor.php
@@ -13,7 +13,9 @@ class CurrentEditionProcessor extends PlayerPageProcessor {
 
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY online_since DESC LIMIT 1');
+		$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = :game_id ORDER BY online_since DESC LIMIT 1', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		if ($dbResult->hasRecord()) {
 			$paper_id = $dbResult->record()->getInt('paper_id');
 		} else {

--- a/src/pages/Player/GalacticPost/EditionRead.php
+++ b/src/pages/Player/GalacticPost/EditionRead.php
@@ -31,12 +31,18 @@ class EditionRead extends PlayerPage {
 			}
 
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($this->gameID) . ' AND paper_id = ' . $this->paperID);
+			$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE game_id = :game_id AND paper_id = :paper_id', [
+				'game_id' => $db->escapeNumber($this->gameID),
+				'paper_id' => $this->paperID,
+			]);
 			$paper_name = bbifyMessage($dbResult->record()->getString('title'), $this->gameID);
 			$template->assign('PageTopic', 'Reading <i>Galactic Post</i> Edition : ' . $paper_name);
 
 			//now get the articles in this paper.
-			$dbResult = $db->read('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING(game_id, article_id) WHERE paper_id = ' . $db->escapeNumber($this->paperID) . ' AND game_id = ' . $db->escapeNumber($this->gameID));
+			$dbResult = $db->read('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING(game_id, article_id) WHERE paper_id = :paper_id AND game_id = :game_id', [
+				'paper_id' => $db->escapeNumber($this->paperID),
+				'game_id' => $db->escapeNumber($this->gameID),
+			]);
 
 			$articles = [];
 			foreach ($dbResult->records() as $dbRecord) {

--- a/src/pages/Player/GalacticPost/EditorOptions.php
+++ b/src/pages/Player/GalacticPost/EditorOptions.php
@@ -29,13 +29,18 @@ class EditorOptions extends PlayerPage {
 		$container = new PaperMake();
 		$template->assign('MakePaperHREF', $container->href());
 
-		$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = :game_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$papers = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$paper_id = $dbRecord->getInt('paper_id');
 			$published = $dbRecord->getNullableInt('online_since') !== null;
 
-			$dbResult2 = $db->read('SELECT count(*) FROM galactic_post_paper_content WHERE paper_id = ' . $db->escapeNumber($paper_id) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+			$dbResult2 = $db->read('SELECT count(*) FROM galactic_post_paper_content WHERE paper_id = :paper_id AND game_id = :game_id', [
+				'paper_id' => $db->escapeNumber($paper_id),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 			$numArticles = $dbResult2->record()->getInt('count(*)');
 			$hasEnoughArticles = $numArticles > 2 && $numArticles < 9;
 

--- a/src/pages/Player/GalacticPost/PaperDeleteConfirm.php
+++ b/src/pages/Player/GalacticPost/PaperDeleteConfirm.php
@@ -19,11 +19,17 @@ class PaperDeleteConfirm extends PlayerPage {
 		$db = Database::getInstance();
 
 		$template->assign('PageTopic', 'Delete Paper - Confirm');
-		$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($this->paperID));
+		$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE game_id = :game_id AND paper_id = :paper_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'paper_id' => $db->escapeNumber($this->paperID),
+		]);
 		$template->assign('PaperTitle', $dbResult->record()->getString('title'));
 
 		$articles = [];
-		$dbResult = $db->read('SELECT title FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($this->paperID));
+		$dbResult = $db->read('SELECT title FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE game_id = :game_id AND paper_id = :paper_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'paper_id' => $db->escapeNumber($this->paperID),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$articles[] = bbifyMessage($dbRecord->getString('title'));
 		}

--- a/src/pages/Player/GalacticPost/PaperDeleteProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperDeleteProcessor.php
@@ -17,18 +17,26 @@ class PaperDeleteProcessor extends PlayerPageProcessor {
 		$db = Database::getInstance();
 		// Should we delete this paper?
 		if (Request::getBool('action')) {
+			$sql = 'game_id = :game_id AND paper_id = :paper_id';
+			$sqlParams = [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'paper_id' => $db->escapeNumber($this->paperID),
+			];
 
 			// Should the articles associated with the paper be deleted as well?
 			if (Request::getBool('delete_articles')) {
-				$dbResult = $db->read('SELECT * FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($this->paperID));
+				$dbResult = $db->read('SELECT * FROM galactic_post_paper_content WHERE ' . $sql, $sqlParams);
 				foreach ($dbResult->records() as $dbRecord) {
-					$db->write('DELETE FROM galactic_post_article WHERE article_id = ' . $db->escapeNumber($dbRecord->getInt('article_id')) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+					$db->write('DELETE FROM galactic_post_article WHERE article_id = :article_id AND game_id = :game_id', [
+						'article_id' => $db->escapeNumber($dbRecord->getInt('article_id')),
+						'game_id' => $db->escapeNumber($player->getGameID()),
+					]);
 				}
 			}
 
 			// Delete the paper and the article associations
-			$db->write('DELETE FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($this->paperID));
-			$db->write('DELETE FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($this->paperID));
+			$db->write('DELETE FROM galactic_post_paper WHERE ' . $sql, $sqlParams);
+			$db->write('DELETE FROM galactic_post_paper_content WHERE ' . $sql, $sqlParams);
 		}
 
 		$container = new EditorOptions();

--- a/src/pages/Player/GalacticPost/PaperDeleteProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperDeleteProcessor.php
@@ -27,7 +27,7 @@ class PaperDeleteProcessor extends PlayerPageProcessor {
 			if (Request::getBool('delete_articles')) {
 				$dbResult = $db->read('SELECT * FROM galactic_post_paper_content WHERE ' . $sql, $sqlParams);
 				foreach ($dbResult->records() as $dbRecord) {
-					$db->write('DELETE FROM galactic_post_article WHERE article_id = :article_id AND game_id = :game_id', [
+					$db->delete('galactic_post_article', [
 						'article_id' => $db->escapeNumber($dbRecord->getInt('article_id')),
 						'game_id' => $db->escapeNumber($player->getGameID()),
 					]);
@@ -35,8 +35,8 @@ class PaperDeleteProcessor extends PlayerPageProcessor {
 			}
 
 			// Delete the paper and the article associations
-			$db->write('DELETE FROM galactic_post_paper WHERE ' . $sql, $sqlParams);
-			$db->write('DELETE FROM galactic_post_paper_content WHERE ' . $sql, $sqlParams);
+			$db->delete('galactic_post_paper', $sqlParams);
+			$db->delete('galactic_post_paper_content', $sqlParams);
 		}
 
 		$container = new EditorOptions();

--- a/src/pages/Player/GalacticPost/PaperEdit.php
+++ b/src/pages/Player/GalacticPost/PaperEdit.php
@@ -21,10 +21,16 @@ class PaperEdit extends PlayerPage {
 		Menu::galacticPost();
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE paper_id = ' . $db->escapeNumber($this->paperID) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT title FROM galactic_post_paper WHERE paper_id = :paper_id AND game_id = :game_id', [
+			'paper_id' => $db->escapeNumber($this->paperID),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$template->assign('PaperTitle', bbifyMessage($dbResult->record()->getString('title')));
 
-		$dbResult = $db->read('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE paper_id = ' . $db->escapeNumber($this->paperID) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING (game_id, article_id) WHERE paper_id = :paper_id AND game_id = :game_id', [
+			'paper_id' => $db->escapeNumber($this->paperID),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 
 		$articles = [];
 		foreach ($dbResult->records() as $dbRecord) {

--- a/src/pages/Player/GalacticPost/PaperEditProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperEditProcessor.php
@@ -16,9 +16,9 @@ class PaperEditProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 		$db->delete('galactic_post_paper_content', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'article_id' => $db->escapeNumber($this->articleID),
-			'paper_id' => $db->escapeNumber($this->paperID),
+			'game_id' => $player->getGameID(),
+			'article_id' => $this->articleID,
+			'paper_id' => $this->paperID,
 		]);
 
 		$container = new PaperEdit($this->paperID);

--- a/src/pages/Player/GalacticPost/PaperEditProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperEditProcessor.php
@@ -15,7 +15,7 @@ class PaperEditProcessor extends PlayerPageProcessor {
 
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM galactic_post_paper_content WHERE game_id = :game_id AND article_id = :article_id AND paper_id = :paper_id', [
+		$db->delete('galactic_post_paper_content', [
 			'game_id' => $db->escapeNumber($player->getGameID()),
 			'article_id' => $db->escapeNumber($this->articleID),
 			'paper_id' => $db->escapeNumber($this->paperID),

--- a/src/pages/Player/GalacticPost/PaperEditProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperEditProcessor.php
@@ -15,7 +15,11 @@ class PaperEditProcessor extends PlayerPageProcessor {
 
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
-		$db->write('DELETE FROM galactic_post_paper_content WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND article_id = ' . $db->escapeNumber($this->articleID) . ' AND paper_id = ' . $db->escapeNumber($this->paperID));
+		$db->write('DELETE FROM galactic_post_paper_content WHERE game_id = :game_id AND article_id = :article_id AND paper_id = :paper_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'article_id' => $db->escapeNumber($this->articleID),
+			'paper_id' => $db->escapeNumber($this->paperID),
+		]);
 
 		$container = new PaperEdit($this->paperID);
 		$container->go();

--- a/src/pages/Player/GalacticPost/PaperMakeProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperMakeProcessor.php
@@ -11,7 +11,9 @@ class PaperMakeProcessor extends PlayerPageProcessor {
 
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY paper_id DESC');
+		$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE game_id = :game_id ORDER BY paper_id DESC', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		if ($dbResult->hasRecord()) {
 			$num = $dbResult->record()->getInt('paper_id') + 1;
 		} else {

--- a/src/pages/Player/GalacticPost/PaperMakeProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperMakeProcessor.php
@@ -21,9 +21,9 @@ class PaperMakeProcessor extends PlayerPageProcessor {
 		}
 		$title = Request::get('title');
 		$db->insert('galactic_post_paper', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'paper_id' => $db->escapeNumber($num),
-			'title' => $db->escapeString($title),
+			'game_id' => $player->getGameID(),
+			'paper_id' => $num,
+			'title' => $title,
 		]);
 		//send em back
 		$container = new ArticleView();

--- a/src/pages/Player/GalacticPost/PaperPublishProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperPublishProcessor.php
@@ -16,13 +16,20 @@ class PaperPublishProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		// Make sure this paper hasn't been published before
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($this->paperID));
+		$dbResult = $db->read('SELECT 1 FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = :game_id AND paper_id = :paper_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'paper_id' => $db->escapeNumber($this->paperID),
+		]);
 		if ($dbResult->hasRecord()) {
 			create_error('Cannot publish a paper that has previously been published!');
 		}
 
 		// Update the online_since column
-		$db->write('UPDATE galactic_post_paper SET online_since=' . $db->escapeNumber(Epoch::time()) . ' WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND paper_id = ' . $db->escapeNumber($this->paperID));
+		$db->write('UPDATE galactic_post_paper SET online_since = :now WHERE game_id = :game_id AND paper_id = :paper_id', [
+			'now' => $db->escapeNumber(Epoch::time()),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'paper_id' => $db->escapeNumber($this->paperID),
+		]);
 
 		//all done lets send back to the main GP page.
 		$container = new EditorOptions();

--- a/src/pages/Player/GalacticPost/PaperPublishProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperPublishProcessor.php
@@ -27,10 +27,10 @@ class PaperPublishProcessor extends PlayerPageProcessor {
 		// Update the online_since column
 		$db->update(
 			'galactic_post_paper',
-			['online_since' => $db->escapeNumber(Epoch::time())],
+			['online_since' => Epoch::time()],
 			[
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'paper_id' => $db->escapeNumber($this->paperID),
+				'game_id' => $player->getGameID(),
+				'paper_id' => $this->paperID,
 			],
 		);
 

--- a/src/pages/Player/GalacticPost/PaperPublishProcessor.php
+++ b/src/pages/Player/GalacticPost/PaperPublishProcessor.php
@@ -25,11 +25,14 @@ class PaperPublishProcessor extends PlayerPageProcessor {
 		}
 
 		// Update the online_since column
-		$db->write('UPDATE galactic_post_paper SET online_since = :now WHERE game_id = :game_id AND paper_id = :paper_id', [
-			'now' => $db->escapeNumber(Epoch::time()),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'paper_id' => $db->escapeNumber($this->paperID),
-		]);
+		$db->update(
+			'galactic_post_paper',
+			['online_since' => $db->escapeNumber(Epoch::time())],
+			[
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'paper_id' => $db->escapeNumber($this->paperID),
+			],
+		);
 
 		//all done lets send back to the main GP page.
 		$container = new EditorOptions();

--- a/src/pages/Player/GalacticPost/PastEditionSelect.php
+++ b/src/pages/Player/GalacticPost/PastEditionSelect.php
@@ -29,7 +29,9 @@ class PastEditionSelect extends PlayerPage {
 		// Get the list of games with published papers
 		// Add the current game to this list no matter what
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT game_name, game_id FROM game WHERE game_id IN (SELECT DISTINCT game_id FROM galactic_post_paper WHERE online_since IS NOT NULL) OR game_id=' . $db->escapeNumber($player->getGameID()) . ' ORDER BY game_id DESC');
+		$dbResult = $db->read('SELECT game_name, game_id FROM game WHERE game_id IN (SELECT DISTINCT game_id FROM galactic_post_paper WHERE online_since IS NOT NULL) OR game_id = :game_id ORDER BY game_id DESC', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$publishedGames = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$publishedGames[] = [
@@ -40,7 +42,9 @@ class PastEditionSelect extends PlayerPage {
 		$template->assign('PublishedGames', $publishedGames);
 
 		// Get the list of published papers for the selected game
-		$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id=' . $db->escapeNumber($this->gameID));
+		$dbResult = $db->read('SELECT * FROM galactic_post_paper WHERE online_since IS NOT NULL AND game_id = :game_id', [
+			'game_id' => $db->escapeNumber($this->gameID),
+		]);
 		$pastEditions = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$container = new EditionRead($this->gameID, $dbRecord->getInt('paper_id'), true);

--- a/src/pages/Player/Headquarters/BountyPlace.php
+++ b/src/pages/Player/Headquarters/BountyPlace.php
@@ -26,7 +26,10 @@ class BountyPlace extends PlayerPage {
 
 		$bountyPlayers = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT player_id, player_name FROM player JOIN account USING(account_id) WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND account_id != ' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY player_name');
+		$dbResult = $db->read('SELECT player_id, player_name FROM player JOIN account USING(account_id) WHERE game_id = :game_id AND account_id != :account_id ORDER BY player_name', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'account_id' => $db->escapeNumber($player->getAccountID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$bountyPlayers[$dbRecord->getInt('player_id')] = htmlentities($dbRecord->getString('player_name'));
 		}

--- a/src/pages/Player/ListPlanetFinancial.php
+++ b/src/pages/Player/ListPlanetFinancial.php
@@ -32,10 +32,14 @@ class ListPlanetFinancial extends PlayerPage {
 			$dbResult = $db->read('
 				SELECT 1
 				FROM alliance_has_roles
-				WHERE alliance_id = ' . $db->escapeNumber($this->allianceID) . '
-				AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-				AND role_id = ' . $db->escapeNumber($role_id) . '
-				AND view_bonds = 1');
+				WHERE alliance_id = :alliance_id
+				AND game_id = :game_id
+				AND role_id = :role_id
+				AND view_bonds = 1', [
+				'alliance_id' => $db->escapeNumber($this->allianceID),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'role_id' => $db->escapeNumber($role_id),
+			]);
 			$viewBonds = $dbResult->hasRecord();
 		}
 		$template->assign('CanViewBonds', $viewBonds);

--- a/src/pages/Player/MessageBlacklist.php
+++ b/src/pages/Player/MessageBlacklist.php
@@ -26,7 +26,9 @@ class MessageBlacklist extends PlayerPage {
 		}
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT p.player_name, p.game_id, b.entry_id FROM player p JOIN message_blacklist b ON p.account_id = b.blacklisted_id AND b.game_id = p.game_id WHERE b.account_id=' . $db->escapeNumber($player->getAccountID()) . ' ORDER BY p.game_id, p.player_name');
+		$dbResult = $db->read('SELECT p.player_name, p.game_id, b.entry_id FROM player p JOIN message_blacklist b ON p.account_id = b.blacklisted_id AND b.game_id = p.game_id WHERE b.account_id = :account_id ORDER BY p.game_id, p.player_name', [
+			'account_id' => $db->escapeNumber($player->getAccountID()),
+		]);
 
 		$blacklist = [];
 		foreach ($dbResult->records() as $dbRecord) {

--- a/src/pages/Player/MessageBlacklistAddProcessor.php
+++ b/src/pages/Player/MessageBlacklistAddProcessor.php
@@ -28,18 +28,18 @@ class MessageBlacklistAddProcessor extends PlayerPageProcessor {
 		}
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT 1 FROM message_blacklist WHERE ' . $player->getSQL() . ' AND blacklisted_id=' . $db->escapeNumber($blacklisted->getAccountID()) . ' LIMIT 1');
+		$params = [
+			...$player->SQLID,
+			'blacklisted_id' => $db->escapeNumber($blacklisted->getAccountID()),
+		];
+		$dbResult = $db->read('SELECT 1 FROM message_blacklist WHERE ' . AbstractPlayer::SQL . ' AND blacklisted_id = :blacklisted_id LIMIT 1', $params);
 
 		if ($dbResult->hasRecord()) {
 			$container = new MessageBlacklist('<span class="red bold">ERROR: </span>Player is already blacklisted.');
 			$container->go();
 		}
 
-		$db->insert('message_blacklist', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'account_id' => $db->escapeNumber($player->getAccountID()),
-			'blacklisted_id' => $db->escapeNumber($blacklisted->getAccountID()),
-		]);
+		$db->insert('message_blacklist', $params);
 
 		$container = new MessageBlacklist($blacklisted->getDisplayName() . ' has been added to your blacklist.');
 		$container->go();

--- a/src/pages/Player/MessageBlacklistDeleteProcessor.php
+++ b/src/pages/Player/MessageBlacklistDeleteProcessor.php
@@ -17,7 +17,10 @@ class MessageBlacklistDeleteProcessor extends PlayerPageProcessor {
 		}
 
 		$db = Database::getInstance();
-		$db->write('DELETE FROM message_blacklist WHERE account_id=' . $db->escapeNumber($player->getAccountID()) . ' AND entry_id IN (' . $db->escapeArray($entry_ids) . ')');
+		$db->write('DELETE FROM message_blacklist WHERE account_id = :account_id AND entry_id IN (:entry_ids)', [
+			'account_id' => $db->escapeNumber($player->getAccountID()),
+			'entry_ids' => $db->escapeArray($entry_ids),
+		]);
 		$container = new MessageBlacklist();
 		$container->go();
 	}

--- a/src/pages/Player/MessageBox.php
+++ b/src/pages/Player/MessageBox.php
@@ -33,27 +33,43 @@ class MessageBox extends PlayerPage {
 				$messageBox['HasUnread'] = false;
 			} else {
 				$dbResult = $db->read('SELECT 1 FROM message
-						WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-							AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND message_type_id = ' . $db->escapeNumber($message_type_id) . '
-							AND msg_read = ' . $db->escapeBoolean(false) . '
-							AND receiver_delete = ' . $db->escapeBoolean(false) . ' LIMIT 1');
+						WHERE account_id = :account_id
+							AND game_id = :game_id
+							AND message_type_id = :message_type_id
+							AND msg_read = :msg_read
+							AND receiver_delete = :receiver_delete LIMIT 1', [
+					'account_id' => $db->escapeNumber($player->getAccountID()),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+					'message_type_id' => $db->escapeNumber($message_type_id),
+					'msg_read' => $db->escapeBoolean(false),
+					'receiver_delete' => $db->escapeBoolean(false),
+				]);
 				$messageBox['HasUnread'] = $dbResult->hasRecord();
 			}
 
 			// get number of msges
 			if ($message_type_id == MSG_SENT) {
 				$dbResult = $db->read('SELECT count(message_id) as message_count FROM message
-						WHERE sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
-							AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND message_type_id = ' . $db->escapeNumber(MSG_PLAYER) . '
-							AND sender_delete = ' . $db->escapeBoolean(false));
+						WHERE sender_id = :sender_id
+							AND game_id = :game_id
+							AND message_type_id = :message_type_id
+							AND sender_delete = :sender_delete', [
+					'sender_id' => $db->escapeNumber($player->getAccountID()),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+					'message_type_id' => $db->escapeNumber(MSG_PLAYER),
+					'sender_delete' => $db->escapeBoolean(false),
+				]);
 			} else {
 				$dbResult = $db->read('SELECT count(message_id) as message_count FROM message
-						WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-							AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND message_type_id = ' . $db->escapeNumber($message_type_id) . '
-							AND receiver_delete = ' . $db->escapeBoolean(false));
+						WHERE account_id = :account_id
+							AND game_id = :game_id
+							AND message_type_id = :message_type_id
+							AND receiver_delete = :receiver_delete', [
+					'account_id' => $db->escapeNumber($player->getAccountID()),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+					'message_type_id' => $db->escapeNumber($message_type_id),
+					'receiver_delete' => $db->escapeBoolean(false),
+				]);
 			}
 			$messageBox['MessageCount'] = $dbResult->record()->getInt('message_count');
 

--- a/src/pages/Player/MessageBoxDeleteProcessor.php
+++ b/src/pages/Player/MessageBoxDeleteProcessor.php
@@ -20,8 +20,8 @@ class MessageBoxDeleteProcessor extends PlayerPageProcessor {
 				'message',
 				['sender_delete' => $db->escapeBoolean(true)],
 				[
-					'sender_id' => $db->escapeNumber($player->getAccountID()),
-					'game_id' => $db->escapeNumber($player->getGameID()),
+					'sender_id' => $player->getAccountID(),
+					'game_id' => $player->getGameID(),
 				],
 			);
 		} else {
@@ -29,9 +29,9 @@ class MessageBoxDeleteProcessor extends PlayerPageProcessor {
 				'message',
 				['receiver_delete' => $db->escapeBoolean(true)],
 				[
-					'account_id' => $db->escapeNumber($player->getAccountID()),
-					'game_id' => $db->escapeNumber($player->getGameID()),
-					'message_type_id' => $db->escapeNumber($this->folderID),
+					'account_id' => $player->getAccountID(),
+					'game_id' => $player->getGameID(),
+					'message_type_id' => $this->folderID,
 					'msg_read' => $db->escapeBoolean(true),
 				],
 			);

--- a/src/pages/Player/MessageBoxDeleteProcessor.php
+++ b/src/pages/Player/MessageBoxDeleteProcessor.php
@@ -16,25 +16,25 @@ class MessageBoxDeleteProcessor extends PlayerPageProcessor {
 		$db = Database::getInstance();
 
 		if ($this->folderID == MSG_SENT) {
-			$db->write('UPDATE message SET sender_delete = :sender_delete
-						WHERE sender_id = :sender_id
-							AND game_id = :game_id', [
-				'sender_delete' => $db->escapeBoolean(true),
-				'sender_id' => $db->escapeNumber($player->getAccountID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-			]);
+			$db->update(
+				'message',
+				['sender_delete' => $db->escapeBoolean(true)],
+				[
+					'sender_id' => $db->escapeNumber($player->getAccountID()),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+				],
+			);
 		} else {
-			$db->write('UPDATE message SET receiver_delete = :receiver_delete
-						WHERE account_id = :account_id
-							AND game_id = :game_id
-							AND message_type_id = :message_type_id
-							AND msg_read = :msg_read', [
-				'receiver_delete' => $db->escapeBoolean(true),
-				'account_id' => $db->escapeNumber($player->getAccountID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'message_type_id' => $db->escapeNumber($this->folderID),
-				'msg_read' => $db->escapeBoolean(true),
-			]);
+			$db->update(
+				'message',
+				['receiver_delete' => $db->escapeBoolean(true)],
+				[
+					'account_id' => $db->escapeNumber($player->getAccountID()),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+					'message_type_id' => $db->escapeNumber($this->folderID),
+					'msg_read' => $db->escapeBoolean(true),
+				],
+			);
 		}
 
 		(new MessageBox())->go();

--- a/src/pages/Player/MessageBoxDeleteProcessor.php
+++ b/src/pages/Player/MessageBoxDeleteProcessor.php
@@ -16,15 +16,25 @@ class MessageBoxDeleteProcessor extends PlayerPageProcessor {
 		$db = Database::getInstance();
 
 		if ($this->folderID == MSG_SENT) {
-			$db->write('UPDATE message SET sender_delete = ' . $db->escapeBoolean(true) . '
-						WHERE sender_id = ' . $db->escapeNumber($player->getAccountID()) . '
-							AND game_id = ' . $db->escapeNumber($player->getGameID()));
+			$db->write('UPDATE message SET sender_delete = :sender_delete
+						WHERE sender_id = :sender_id
+							AND game_id = :game_id', [
+				'sender_delete' => $db->escapeBoolean(true),
+				'sender_id' => $db->escapeNumber($player->getAccountID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 		} else {
-			$db->write('UPDATE message SET receiver_delete = ' . $db->escapeBoolean(true) . '
-						WHERE account_id = ' . $db->escapeNumber($player->getAccountID()) . '
-							AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND message_type_id = ' . $db->escapeNumber($this->folderID) . '
-							AND msg_read = ' . $db->escapeBoolean(true));
+			$db->write('UPDATE message SET receiver_delete = :receiver_delete
+						WHERE account_id = :account_id
+							AND game_id = :game_id
+							AND message_type_id = :message_type_id
+							AND msg_read = :msg_read', [
+				'receiver_delete' => $db->escapeBoolean(true),
+				'account_id' => $db->escapeNumber($player->getAccountID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'message_type_id' => $db->escapeNumber($this->folderID),
+				'msg_read' => $db->escapeBoolean(true),
+			]);
 		}
 
 		(new MessageBox())->go();

--- a/src/pages/Player/MessageReportConfirm.php
+++ b/src/pages/Player/MessageReportConfirm.php
@@ -22,7 +22,9 @@ class MessageReportConfirm extends PlayerPage {
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT message_text
 					FROM message
-					WHERE message_id = ' . $db->escapeNumber($this->messageID));
+					WHERE message_id = :message_id', [
+			'message_id' => $db->escapeNumber($this->messageID),
+		]);
 		if (!$dbResult->hasRecord()) {
 			create_error('Could not find the message you selected!');
 		}

--- a/src/pages/Player/MessageReportProcessor.php
+++ b/src/pages/Player/MessageReportProcessor.php
@@ -30,7 +30,7 @@ class MessageReportProcessor extends PlayerPageProcessor {
 		$notify_id = $dbResult->record()->getInt('next_notify_id');
 
 		// get message form db
-		$dbResult = $db->read('SELECT account_id, sender_id, message_text
+		$dbResult = $db->read('SELECT account_id, sender_id, message_text, send_time
 					FROM message
 					WHERE message_id = :message_id AND receiver_delete = \'FALSE\'', [
 			'message_id' => $this->messageID,

--- a/src/pages/Player/MessageReportProcessor.php
+++ b/src/pages/Player/MessageReportProcessor.php
@@ -24,13 +24,17 @@ class MessageReportProcessor extends PlayerPageProcessor {
 
 		// get next id
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT IFNULL(max(notify_id)+1, 0) as next_notify_id FROM message_notify WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY notify_id DESC');
+		$dbResult = $db->read('SELECT IFNULL(max(notify_id)+1, 0) as next_notify_id FROM message_notify WHERE game_id = :game_id ORDER BY notify_id DESC', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$notify_id = $dbResult->record()->getInt('next_notify_id');
 
 		// get message form db
 		$dbResult = $db->read('SELECT account_id, sender_id, message_text
 					FROM message
-					WHERE message_id = ' . $this->messageID . ' AND receiver_delete = \'FALSE\'');
+					WHERE message_id = :message_id AND receiver_delete = \'FALSE\'', [
+			'message_id' => $this->messageID,
+		]);
 		if (!$dbResult->hasRecord()) {
 			create_error('Could not find the message you selected!');
 		}

--- a/src/pages/Player/MessageReportProcessor.php
+++ b/src/pages/Player/MessageReportProcessor.php
@@ -42,13 +42,13 @@ class MessageReportProcessor extends PlayerPageProcessor {
 
 		// insert
 		$db->insert('message_notify', [
-			'notify_id' => $db->escapeNumber($notify_id),
-			'game_id' => $db->escapeNumber($player->getGameID()),
+			'notify_id' => $notify_id,
+			'game_id' => $player->getGameID(),
 			'from_id' => $dbRecord->getInt('sender_id'),
 			'to_id' => $dbRecord->getInt('account_id'),
-			'text' => $db->escapeString($dbRecord->getString('message_text')),
-			'sent_time' => $db->escapeNumber($dbRecord->getInt('send_time')),
-			'notify_time' => $db->escapeNumber(Epoch::time()),
+			'text' => $dbRecord->getString('message_text'),
+			'sent_time' => $dbRecord->getInt('send_time'),
+			'notify_time' => Epoch::time(),
 		]);
 
 		$container->go();

--- a/src/pages/Player/MessageSendProcessor.php
+++ b/src/pages/Player/MessageSendProcessor.php
@@ -33,9 +33,13 @@ class MessageSendProcessor extends PlayerPageProcessor {
 		if ($this->allianceID !== null) {
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT account_id FROM player
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND alliance_id = ' . $this->allianceID . '
-						AND account_id != ' . $db->escapeNumber($player->getAccountID())); //No limit in case they are over limit - ie NHA
+						WHERE game_id = :game_id
+						AND alliance_id = :alliance_id
+						AND account_id != :account_id', [ //No limit in case they are over limit - ie NHA
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'alliance_id' => $this->allianceID,
+				'account_id' => $db->escapeNumber($player->getAccountID()),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$player->sendMessage($dbRecord->getInt('account_id'), MSG_ALLIANCE, $message, false);
 			}

--- a/src/pages/Player/NewsReadCurrent.php
+++ b/src/pages/Player/NewsReadCurrent.php
@@ -34,7 +34,10 @@ class NewsReadCurrent extends PlayerPage {
 		}
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM news WHERE game_id = ' . $db->escapeNumber($gameID) . ' AND time > ' . $db->escapeNumber($this->lastNewsUpdate) . ' AND type != \'lotto\' ORDER BY news_id DESC');
+		$dbResult = $db->read('SELECT * FROM news WHERE game_id = :game_id AND time > :last_news_update AND type != \'lotto\' ORDER BY news_id DESC', [
+			'game_id' => $db->escapeNumber($gameID),
+			'last_news_update' => $db->escapeNumber($this->lastNewsUpdate),
+		]);
 		$template->assign('NewsItems', News::getNewsItems($dbResult));
 
 		$player->updateLastNewsUpdate();

--- a/src/pages/Player/Planet/LandProcessor.php
+++ b/src/pages/Player/Planet/LandProcessor.php
@@ -32,7 +32,11 @@ class LandProcessor extends PlayerPageProcessor {
 		if ($player->hasAlliance()) {
 			$role_id = $player->getAllianceRole();
 			$db = Database::getInstance();
-			$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND role_id = ' . $db->escapeNumber($role_id));
+			$dbResult = $db->read('SELECT * FROM alliance_has_roles WHERE alliance_id = :alliance_id AND game_id = :game_id AND role_id = :role_id', [
+				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'role_id' => $db->escapeNumber($role_id),
+			]);
 			if (!$dbResult->record()->getBoolean('planet_access')) {
 				if ($planet->hasOwner() && $planet->getOwnerID() != $player->getAccountID()) {
 					create_error('Your alliance doesn\'t allow you to dock at their planet.');

--- a/src/pages/Player/Planet/OwnershipProcessor.php
+++ b/src/pages/Player/Planet/OwnershipProcessor.php
@@ -31,8 +31,8 @@ class OwnershipProcessor extends PlayerPageProcessor {
 					'password' => null,
 				],
 				[
-					'owner_id' => $db->escapeNumber($player->getAccountID()),
-					'game_id' => $db->escapeNumber($player->getGameID()),
+					'owner_id' => $player->getAccountID(),
+					'game_id' => $player->getGameID(),
 				],
 			);
 

--- a/src/pages/Player/Planet/OwnershipProcessor.php
+++ b/src/pages/Player/Planet/OwnershipProcessor.php
@@ -28,7 +28,7 @@ class OwnershipProcessor extends PlayerPageProcessor {
 				'planet',
 				[
 					'owner_id' => 0,
-					'password' => null,
+					'password' => '',
 				],
 				[
 					'owner_id' => $player->getAccountID(),

--- a/src/pages/Player/Planet/OwnershipProcessor.php
+++ b/src/pages/Player/Planet/OwnershipProcessor.php
@@ -24,12 +24,17 @@ class OwnershipProcessor extends PlayerPageProcessor {
 
 			// delete all previous ownerships
 			$db = Database::getInstance();
-			$db->write('UPDATE planet SET owner_id = 0, password = NULL
-						WHERE owner_id = :owner_id
-						AND game_id = :game_id', [
-				'owner_id' => $db->escapeNumber($player->getAccountID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-			]);
+			$db->update(
+				'planet',
+				[
+					'owner_id' => 0,
+					'password' => null,
+				],
+				[
+					'owner_id' => $db->escapeNumber($player->getAccountID()),
+					'game_id' => $db->escapeNumber($player->getGameID()),
+				],
+			);
 
 			// set ownership
 			$planet->setOwnerID($player->getAccountID());

--- a/src/pages/Player/Planet/OwnershipProcessor.php
+++ b/src/pages/Player/Planet/OwnershipProcessor.php
@@ -25,8 +25,11 @@ class OwnershipProcessor extends PlayerPageProcessor {
 			// delete all previous ownerships
 			$db = Database::getInstance();
 			$db->write('UPDATE planet SET owner_id = 0, password = NULL
-						WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . '
-						AND game_id = ' . $db->escapeNumber($player->getGameID()));
+						WHERE owner_id = :owner_id
+						AND game_id = :game_id', [
+				'owner_id' => $db->escapeNumber($player->getAccountID()),
+				'game_id' => $db->escapeNumber($player->getGameID()),
+			]);
 
 			// set ownership
 			$planet->setOwnerID($player->getAccountID());

--- a/src/pages/Player/PreferencesProcessor.php
+++ b/src/pages/Player/PreferencesProcessor.php
@@ -72,7 +72,7 @@ class PreferencesProcessor extends PlayerPageProcessor {
 			$player->setRaceChanged(true);
 
 			// Reset relations
-			$db->write('DELETE FROM player_has_relation WHERE ' . $player->getSQL());
+			$db->write('DELETE FROM player_has_relation WHERE ' . AbstractPlayer::SQL, $player->SQLID);
 			$player->giveStartingRelations();
 
 			// Move them to their new race HQ and reset sector lock

--- a/src/pages/Player/PreferencesProcessor.php
+++ b/src/pages/Player/PreferencesProcessor.php
@@ -72,7 +72,7 @@ class PreferencesProcessor extends PlayerPageProcessor {
 			$player->setRaceChanged(true);
 
 			// Reset relations
-			$db->write('DELETE FROM player_has_relation WHERE ' . AbstractPlayer::SQL, $player->SQLID);
+			$db->delete('player_has_relation', $player->SQLID);
 			$player->giveStartingRelations();
 
 			// Move them to their new race HQ and reset sector lock

--- a/src/pages/Player/PreferencesProcessor.php
+++ b/src/pages/Player/PreferencesProcessor.php
@@ -41,11 +41,11 @@ class PreferencesProcessor extends PlayerPageProcessor {
 
 			$news = 'Please be advised that ' . $old_name . ' has changed their name to ' . $player->getBBLink();
 			$db->insert('news', [
-				'time' => $db->escapeNumber(Epoch::time()),
-				'news_message' => $db->escapeString($news),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'type' => $db->escapeString('admin'),
-				'killer_id' => $db->escapeNumber($player->getAccountID()),
+				'time' => Epoch::time(),
+				'news_message' => $news,
+				'game_id' => $player->getGameID(),
+				'type' => 'admin',
+				'killer_id' => $player->getAccountID(),
 			]);
 			$message = '<span class="green">SUCCESS: </span>You have changed your player name.';
 
@@ -85,11 +85,11 @@ class PreferencesProcessor extends PlayerPageProcessor {
 
 			$news = 'Please be advised that ' . $player->getBBLink() . ' has changed their race from [race=' . $oldRaceID . '] to [race=' . $player->getRaceID() . ']';
 			$db->insert('news', [
-				'time' => $db->escapeNumber(Epoch::time()),
-				'news_message' => $db->escapeString($news),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'type' => $db->escapeString('admin'),
-				'killer_id' => $db->escapeNumber($player->getAccountID()),
+				'time' => Epoch::time(),
+				'news_message' => $news,
+				'game_id' => $player->getGameID(),
+				'type' => 'admin',
+				'killer_id' => $player->getAccountID(),
 			]);
 			$message = '<span class="green">SUCCESS: </span>You have changed your player race.';
 		} else {

--- a/src/pages/Player/Rankings/AllianceVsAlliance.php
+++ b/src/pages/Player/Rankings/AllianceVsAlliance.php
@@ -39,7 +39,9 @@ class AllianceVsAlliance extends PlayerPage {
 
 		// Get list of alliances that have kills or deaths
 		$activeAlliances = [];
-		$dbResult = $db->read('SELECT * FROM alliance WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND (alliance_deaths > 0 OR alliance_kills > 0) ORDER BY alliance_kills DESC, alliance_name');
+		$dbResult = $db->read('SELECT * FROM alliance WHERE game_id = :game_id AND (alliance_deaths > 0 OR alliance_kills > 0) ORDER BY alliance_kills DESC, alliance_name', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$allianceID = $dbRecord->getInt('alliance_id');
 			$activeAlliances[$allianceID] = Alliance::getAlliance($allianceID, $player->getGameID(), false, $dbRecord);
@@ -93,9 +95,13 @@ class AllianceVsAlliance extends PlayerPage {
 					}
 				} else {
 					$dbResult = $db->read('SELECT kills FROM alliance_vs_alliance
-								WHERE alliance_id_2 = ' . $db->escapeNumber($curr_id) . '
-									AND alliance_id_1 = ' . $db->escapeNumber($id) . '
-									AND game_id = ' . $db->escapeNumber($player->getGameID()));
+								WHERE alliance_id_2 = :alliance_id_2
+									AND alliance_id_1 = :alliance_id_1
+									AND game_id = :game_id', [
+						'alliance_id_1' => $db->escapeNumber($id),
+						'alliance_id_2' => $db->escapeNumber($curr_id),
+						'game_id' => $db->escapeNumber($player->getGameID()),
+					]);
 					$value = $dbResult->hasRecord() ? $dbResult->record()->getInt('kills') : 0;
 					if ($showRed && $showBold) {
 						$style = 'class="bold red"';
@@ -120,8 +126,11 @@ class AllianceVsAlliance extends PlayerPage {
 
 		$kills = [];
 		$dbResult = $db->read('SELECT * FROM alliance_vs_alliance
-					WHERE alliance_id_1 = ' . $db->escapeNumber($this->detailsAllianceID) . '
-						AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC');
+					WHERE alliance_id_1 = :alliance_id_1
+						AND game_id = :game_id ORDER BY kills DESC', [
+			'alliance_id_1' => $db->escapeNumber($this->detailsAllianceID),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$id = $dbRecord->getInt('alliance_id_2');
 			$alliance_name = match (true) {
@@ -142,8 +151,11 @@ class AllianceVsAlliance extends PlayerPage {
 
 		$deaths = [];
 		$dbResult = $db->read('SELECT * FROM alliance_vs_alliance
-					WHERE alliance_id_2 = ' . $db->escapeNumber($this->detailsAllianceID) . '
-						AND game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY kills DESC');
+					WHERE alliance_id_2 = :alliance_id_2
+						AND game_id = :game_id ORDER BY kills DESC', [
+			'alliance_id_2' => $db->escapeNumber($this->detailsAllianceID),
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$id = $dbRecord->getInt('alliance_id_1');
 			$alliance_name = match (true) {

--- a/src/pages/Player/Rankings/SectorKills.php
+++ b/src/pages/Player/Rankings/SectorKills.php
@@ -23,7 +23,9 @@ class SectorKills extends PlayerPage {
 		Menu::rankings(3, 0);
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT sector_id, battles as amount FROM sector WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' ORDER BY battles DESC, sector_id');
+		$dbResult = $db->read('SELECT sector_id, battles as amount FROM sector WHERE game_id = :game_id ORDER BY battles DESC, sector_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$rankedStats = [];
 		foreach ($dbResult->records() as $dbRecord) {
 			$rankedStats[$dbRecord->getInt('sector_id')] = $dbRecord;

--- a/src/pages/Player/SearchForTraderResult.php
+++ b/src/pages/Player/SearchForTraderResult.php
@@ -53,10 +53,14 @@ class SearchForTraderResult extends PlayerPage {
 
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT * FROM player
-						WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-							AND player_name LIKE ' . $db->escapeString('%' . $player_name . '%') . '
-							AND player_name != ' . $db->escapeString($player_name) . '
-						ORDER BY player_name LIMIT 5');
+						WHERE game_id = :game_id
+							AND player_name LIKE :player_name_like
+							AND player_name != :player_name
+						ORDER BY player_name LIMIT 5', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'player_name_like' => $db->escapeString('%' . $player_name . '%'),
+				'player_name' => $db->escapeString($player_name),
+			]);
 			$similarPlayers = [];
 			foreach ($dbResult->records() as $dbRecord) {
 				$similarPlayers[] = Player::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), false, $dbRecord);

--- a/src/pages/Player/TraderNoteAddProcessor.php
+++ b/src/pages/Player/TraderNoteAddProcessor.php
@@ -18,8 +18,8 @@ class TraderNoteAddProcessor extends PlayerPageProcessor {
 
 		$db = Database::getInstance();
 		$db->insert('player_has_notes', [
-			'account_id' => $db->escapeNumber($player->getAccountID()),
-			'game_id' => $db->escapeNumber($player->getGameID()),
+			'account_id' => $player->getAccountID(),
+			'game_id' => $player->getGameID(),
 			'note' => $db->escapeObject($note, true),
 		]);
 

--- a/src/pages/Player/TraderNoteDeleteProcessor.php
+++ b/src/pages/Player/TraderNoteDeleteProcessor.php
@@ -13,9 +13,13 @@ class TraderNoteDeleteProcessor extends PlayerPageProcessor {
 		$note_ids = Request::getIntArray('note_id', []);
 		if (!empty($note_ids)) {
 			$db = Database::getInstance();
-			$db->write('DELETE FROM player_has_notes WHERE game_id=' . $db->escapeNumber($player->getGameID()) . '
-							AND account_id=' . $db->escapeNumber($player->getAccountID()) . '
-							AND note_id IN (' . $db->escapeArray($note_ids) . ')');
+			$db->write('DELETE FROM player_has_notes WHERE game_id = :game_id
+							AND account_id = :account_id
+							AND note_id IN (:note_ids)', [
+				'game_id' => $db->escapeNumber($player->getGameID()),
+				'account_id' => $db->escapeNumber($player->getAccountID()),
+				'note_ids' => $db->escapeArray($note_ids),
+			]);
 		}
 
 		(new TraderStatus())->go();

--- a/src/pages/Player/TraderSavings.php
+++ b/src/pages/Player/TraderSavings.php
@@ -23,7 +23,7 @@ class TraderSavings extends PlayerPage {
 
 		$anonAccounts = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM anon_bank WHERE owner_id = ' . $db->escapeNumber($player->getAccountID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		$dbResult = $db->read('SELECT * FROM anon_bank WHERE owner_id = :account_id AND game_id = :game_id', $player->SQLID);
 		foreach ($dbResult->records() as $dbRecord) {
 			$anonAccounts[] = [
 				'ID' => $dbRecord->getInt('anon_id'),
@@ -36,12 +36,14 @@ class TraderSavings extends PlayerPage {
 		$template->assign('LottoInfo', Lotto::getLottoInfo($player->getGameID()));
 
 		// Number of active lotto tickets this player has
-		$dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time > 0');
+		$dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE ' . AbstractPlayer::SQL . ' AND time > 0', $player->SQLID);
 		$tickets = $dbResult->record()->getInt('count(*)');
 		$template->assign('LottoTickets', $tickets);
 
 		// Number of active lotto tickets all players have
-		$dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . ' AND time > 0');
+		$dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE game_id = :game_id AND time > 0', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		]);
 		$tickets_tot = $dbResult->record()->getInt('count(*)');
 		if ($tickets == 0) {
 			$win_chance = 0;
@@ -51,7 +53,7 @@ class TraderSavings extends PlayerPage {
 		$template->assign('LottoWinChance', $win_chance);
 
 		// Number of winning lotto tickets this player has to claim
-		$dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE ' . $player->getSQL() . ' AND time = 0');
+		$dbResult = $db->read('SELECT count(*) FROM player_has_ticket WHERE ' . AbstractPlayer::SQL . ' AND time = 0', $player->SQLID);
 		$template->assign('WinningTickets', $dbResult->record()->getInt('count(*)'));
 	}
 

--- a/src/pages/Player/TraderStatus.php
+++ b/src/pages/Player/TraderStatus.php
@@ -71,7 +71,7 @@ class TraderStatus extends PlayerPage {
 
 		$notes = [];
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM player_has_notes WHERE ' . $player->getSQL() . ' ORDER BY note_id DESC');
+		$dbResult = $db->read('SELECT * FROM player_has_notes WHERE ' . AbstractPlayer::SQL . ' ORDER BY note_id DESC', $player->SQLID);
 		foreach ($dbResult->records() as $dbRecord) {
 			$note = $dbRecord->getObject('note', true);
 			$notes[$dbRecord->getInt('note_id')] = htmlentities($note);

--- a/src/tools/chat_helpers/channel_msg_money.php
+++ b/src/tools/chat_helpers/channel_msg_money.php
@@ -20,7 +20,10 @@ function shared_channel_msg_money(AbstractPlayer $player): array {
 
 	// get money on ships and personal bank accounts
 	$db = Database::getInstance();
-	$dbResult = $db->read('SELECT sum(credits) as total_onship, sum(bank) as total_onbank FROM player WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID());
+	$dbResult = $db->read('SELECT sum(credits) as total_onship, sum(bank) as total_onbank FROM player WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+		'alliance_id' => $player->getAllianceID(),
+		'game_id' => $player->getGameID(),
+	]);
 
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
@@ -29,7 +32,10 @@ function shared_channel_msg_money(AbstractPlayer $player): array {
 	}
 
 	// get money on planets
-	$dbResult = $db->read('SELECT SUM(credits) AS total_credits, SUM(bonds) AS total_bonds FROM planet WHERE game_id = ' . $player->getGameID() . ' AND owner_id IN (SELECT account_id FROM player WHERE alliance_id = ' . $player->getAllianceID() . ' AND game_id = ' . $player->getGameID() . ')');
+	$dbResult = $db->read('SELECT SUM(credits) AS total_credits, SUM(bonds) AS total_bonds FROM planet WHERE game_id = :game_id AND owner_id IN (SELECT account_id FROM player WHERE alliance_id = :alliance_id AND game_id = :game_id)', [
+		'alliance_id' => $player->getAllianceID(),
+		'game_id' => $player->getGameID(),
+	]);
 	if ($dbResult->hasRecord()) {
 		$dbRecord = $dbResult->record();
 		$result[] = 'There is a total of ' . number_format($dbRecord->getInt('total_credits')) . ' credits on the planets';

--- a/src/tools/chat_helpers/channel_msg_money.php
+++ b/src/tools/chat_helpers/channel_msg_money.php
@@ -20,27 +20,23 @@ function shared_channel_msg_money(AbstractPlayer $player): array {
 
 	// get money on ships and personal bank accounts
 	$db = Database::getInstance();
-	$dbResult = $db->read('SELECT sum(credits) as total_onship, sum(bank) as total_onbank FROM player WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+	$dbResult = $db->read('SELECT IFNULL(SUM(credits), 0) as total_onship, IFNULL(SUM(bank), 0) as total_onbank FROM player WHERE alliance_id = :alliance_id AND game_id = :game_id', [
 		'alliance_id' => $player->getAllianceID(),
 		'game_id' => $player->getGameID(),
 	]);
 
-	if ($dbResult->hasRecord()) {
-		$dbRecord = $dbResult->record();
-		$result[] = 'Alliance members carry a total of ' . number_format($dbRecord->getInt('total_onship')) . ' credits with them';
-		$result[] = 'and keep a total of ' . number_format($dbRecord->getInt('total_onbank')) . ' credits in their personal bank accounts.';
-	}
+	$dbRecord = $dbResult->record();
+	$result[] = 'Alliance members carry a total of ' . number_format($dbRecord->getInt('total_onship')) . ' credits with them';
+	$result[] = 'and keep a total of ' . number_format($dbRecord->getInt('total_onbank')) . ' credits in their personal bank accounts.';
 
 	// get money on planets
-	$dbResult = $db->read('SELECT SUM(credits) AS total_credits, SUM(bonds) AS total_bonds FROM planet WHERE game_id = :game_id AND owner_id IN (SELECT account_id FROM player WHERE alliance_id = :alliance_id AND game_id = :game_id)', [
+	$dbResult = $db->read('SELECT IFNULL(SUM(credits), 0) AS total_credits, IFNULL(SUM(bonds), 0) AS total_bonds FROM planet WHERE game_id = :game_id AND owner_id IN (SELECT account_id FROM player WHERE alliance_id = :alliance_id AND game_id = :game_id)', [
 		'alliance_id' => $player->getAllianceID(),
 		'game_id' => $player->getGameID(),
 	]);
-	if ($dbResult->hasRecord()) {
-		$dbRecord = $dbResult->record();
-		$result[] = 'There is a total of ' . number_format($dbRecord->getInt('total_credits')) . ' credits on the planets';
-		$result[] = 'and ' . number_format($dbRecord->getInt('total_bonds')) . ' credits in bonds.';
-	}
+	$dbRecord = $dbResult->record();
+	$result[] = 'There is a total of ' . number_format($dbRecord->getInt('total_credits')) . ' credits on the planets';
+	$result[] = 'and ' . number_format($dbRecord->getInt('total_bonds')) . ' credits in bonds.';
 
 	return $result;
 }

--- a/src/tools/chat_helpers/channel_msg_op_info.php
+++ b/src/tools/chat_helpers/channel_msg_op_info.php
@@ -9,7 +9,10 @@ use Smr\Database;
 function shared_channel_msg_op_info(AbstractPlayer $player): array {
 	// get the op from db
 	$db = Database::getInstance();
-	$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND game_id = ' . $db->escapeNumber($player->getGameID()));
+	$dbResult = $db->read('SELECT time FROM alliance_has_op WHERE alliance_id = :alliance_id AND game_id = :game_id', [
+		'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+	]);
 	if (!$dbResult->hasRecord()) {
 		return ['Your leader has not scheduled an operation.'];
 	}
@@ -24,7 +27,10 @@ function shared_channel_msg_op_info(AbstractPlayer $player): array {
 	$getOpInfoMessage = function(AbstractPlayer $player) use ($opTime): string {
 		// have we signed up?
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT response FROM alliance_has_op_response WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . ' AND ' . $player->getSQL());
+		$dbResult = $db->read('SELECT response FROM alliance_has_op_response WHERE alliance_id = :alliance_id AND ' . AbstractPlayer::SQL, [
+			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			...$player->SQLID,
+		]);
 		if ($dbResult->hasRecord()) {
 			$msg = $player->getPlayerName() . ' is on the ' . $dbResult->record()->getString('response') . ' list.';
 		} else {

--- a/src/tools/chat_helpers/channel_msg_op_list.php
+++ b/src/tools/chat_helpers/channel_msg_op_list.php
@@ -12,8 +12,11 @@ function shared_channel_msg_op_list(AbstractPlayer $player): array {
 	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT 1
 				FROM alliance_has_op
-				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-					AND game_id = ' . $db->escapeNumber($player->getGameID()));
+				WHERE alliance_id = :alliance_id
+					AND game_id = :game_id', [
+		'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+	]);
 	if (!$dbResult->hasRecord()) {
 		return ['Your leader has not scheduled an op.'];
 	}
@@ -25,8 +28,11 @@ function shared_channel_msg_op_list(AbstractPlayer $player): array {
 	];
 	$dbResult = $db->read('SELECT account_id, response
 				FROM alliance_has_op_response
-				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-					AND game_id = ' . $db->escapeNumber($player->getGameID()));
+				WHERE alliance_id = :alliance_id
+					AND game_id = :game_id', [
+		'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+	]);
 	foreach ($dbResult->records() as $dbRecord) {
 		$respondingPlayer = Player::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), true);
 		// check that the player is still in this alliance

--- a/src/tools/chat_helpers/channel_msg_op_turns.php
+++ b/src/tools/chat_helpers/channel_msg_op_turns.php
@@ -12,8 +12,11 @@ function shared_channel_msg_op_turns(AbstractPlayer $player): array {
 	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT 1
 				FROM alliance_has_op
-				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-					AND game_id = ' . $db->escapeNumber($player->getGameID()));
+				WHERE alliance_id = :alliance_id
+					AND game_id = :game_id', [
+		'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+	]);
 	if (!$dbResult->hasRecord()) {
 		return ['There is no op scheduled.'];
 	}
@@ -21,9 +24,12 @@ function shared_channel_msg_op_turns(AbstractPlayer $player): array {
 	$oppers = [];
 	$dbResult = $db->read('SELECT account_id
 				FROM alliance_has_op_response
-				WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-					AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND response = \'YES\'');
+				WHERE alliance_id = :alliance_id
+					AND game_id = :game_id
+					AND response = \'YES\'', [
+		'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+	]);
 	foreach ($dbResult->records() as $dbRecord) {
 		$attendeePlayer = Player::getPlayer($dbRecord->getInt('account_id'), $player->getGameID(), true);
 		// check that the player is still in this alliance

--- a/src/tools/chat_helpers/channel_msg_seed.php
+++ b/src/tools/chat_helpers/channel_msg_seed.php
@@ -8,14 +8,18 @@ function get_seed_message(AbstractPlayer $player): string {
 	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT sector_id
 		FROM alliance_has_seedlist
-		WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-			AND game_id = ' . $db->escapeNumber($player->getGameID()) . '
+		WHERE alliance_id = :alliance_id
+			AND game_id = :game_id
 			AND sector_id NOT IN (
 				SELECT sector_id
 				FROM sector_has_forces
-				WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-					AND owner_id = ' . $db->escapeNumber($player->getAccountID()) . '
-			)');
+				WHERE game_id = :game_id
+					AND owner_id = :owner_id
+			)', [
+		'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'owner_id' => $db->escapeNumber($player->getAccountID()),
+	]);
 
 	$missingSeeds = [];
 	foreach ($dbResult->records() as $dbRecord) {
@@ -36,8 +40,11 @@ function shared_channel_msg_seed(AbstractPlayer $player): array {
 	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT count(*)
 		FROM alliance_has_seedlist
-		WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-			AND game_id = ' . $db->escapeNumber($player->getGameID()));
+		WHERE alliance_id = :alliance_id
+			AND game_id = :game_id', [
+		'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+	]);
 	$numSectors = $dbResult->record()->getInt('count(*)');
 
 	if ($numSectors == 0) {

--- a/src/tools/chat_helpers/channel_msg_seedlist.php
+++ b/src/tools/chat_helpers/channel_msg_seedlist.php
@@ -85,9 +85,9 @@ function shared_channel_msg_seedlist_add(AbstractPlayer $player, ?array $sectors
 
 		// add sector to db (and the current seedlist)
 		$db->insert('alliance_has_seedlist', [
-			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'sector_id' => $db->escapeNumber($sector),
+			'alliance_id' => $player->getAllianceID(),
+			'game_id' => $player->getGameID(),
+			'sector_id' => $sector,
 		]);
 		$currentSeedlist[] = $sector;
 	}

--- a/src/tools/chat_helpers/channel_msg_seedlist.php
+++ b/src/tools/chat_helpers/channel_msg_seedlist.php
@@ -10,8 +10,11 @@ function get_seedlist(AbstractPlayer $player): array {
 	// Return the seedlist
 	$db = Database::getInstance();
 	$dbResult = $db->read('SELECT sector_id FROM alliance_has_seedlist
-						WHERE alliance_id = ' . $db->escapeNumber($player->getAllianceID()) . '
-							AND game_id = ' . $db->escapeNumber($player->getGameID()));
+						WHERE alliance_id = :alliance_id
+							AND game_id = :game_id', [
+		'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+		'game_id' => $db->escapeNumber($player->getGameID()),
+	]);
 	$seedlist = [];
 	foreach ($dbResult->records() as $dbRecord) {
 		$seedlist[] = $dbRecord->getInt('sector_id');
@@ -64,8 +67,11 @@ function shared_channel_msg_seedlist_add(AbstractPlayer $player, ?array $sectors
 		// check if the sector is a part of the game
 		$dbResult = $db->read('SELECT 1
 					FROM sector
-					WHERE game_id = ' . $db->escapeNumber($player->getGameID()) . '
-						AND  sector_id = ' . $db->escapeNumber($sector));
+					WHERE game_id = :game_id
+						AND sector_id = :sector_id', [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+			'sector_id' => $db->escapeNumber($sector),
+		]);
 		if (!$dbResult->hasRecord()) {
 			$result[] = "WARNING: The sector '$sector' does not exist in the current game.";
 			continue;
@@ -122,9 +128,13 @@ function shared_channel_msg_seedlist_del(AbstractPlayer $player, ?array $sectors
 	// remove sectors from the db
 	$db = Database::getInstance();
 	$db->write('DELETE FROM alliance_has_seedlist
-				WHERE alliance_id = ' . $player->getAllianceID() . '
-					AND game_id = ' . $player->getGameID() . '
-					AND sector_id IN (' . $db->escapeArray($sectors) . ')');
+				WHERE alliance_id = :alliance_id
+					AND game_id = :game_id
+					AND sector_id IN (:sector_ids)', [
+		'alliance_id' => $player->getAllianceID(),
+		'game_id' => $player->getGameID(),
+		'sector_ids' => $db->escapeArray($sectors),
+	]);
 
 	return ['The following sectors have been removed from the seedlist: ' . implode(' ', $sectors)];
 }

--- a/src/tools/irc/channel.php
+++ b/src/tools/irc/channel.php
@@ -41,25 +41,25 @@ function channel_join($fp, string $rdata): bool {
 			$db->update(
 				'irc_seen',
 				[
-					'signed_on' => $db->escapeNumber(time()),
+					'signed_on' => time(),
 					'signed_off' => 0,
-					'user' => $db->escapeString($user),
-					'host' => $db->escapeString($host),
+					'user' => $user,
+					'host' => $host,
 					'seen_count' => 0,
 					'seen_by' => null,
 					'registered' => null,
 				],
-				['seen_id' => $db->escapeNumber($seen_id)],
+				['seen_id' => $seen_id],
 			);
 
 		} else {
 			// new nick?
 			$db->insert('irc_seen', [
-				'nick' => $db->escapeString($nick),
-				'user' => $db->escapeString($user),
-				'host' => $db->escapeString($host),
-				'channel' => $db->escapeString($channel),
-				'signed_on' => $db->escapeNumber(time()),
+				'nick' => $nick,
+				'user' => $user,
+				'host' => $host,
+				'channel' => $channel,
+				'signed_on' => time(),
 			]);
 
 			if ($nick != IRC_BOT_NICK) {

--- a/src/tools/irc/channel.php
+++ b/src/tools/irc/channel.php
@@ -38,20 +38,19 @@ function channel_join($fp, string $rdata): bool {
 				fwrite($fp, 'PRIVMSG ' . $channel . ' :Welcome back ' . $nick . '. While being away ' . $seen_by . ' was looking for you.' . EOL);
 			}
 
-			$db->write('UPDATE irc_seen
-						SET signed_on = :now,
-							signed_off = 0,
-							user = :user,
-							host = :host,
-							seen_count = 0,
-							seen_by = NULL,
-							registered = NULL
-						WHERE seen_id = :seen_id', [
-				'now' => $db->escapeNumber(time()),
-				'user' => $db->escapeString($user),
-				'host' => $db->escapeString($host),
-				'seen_id' => $db->escapeNumber($seen_id),
-			]);
+			$db->update(
+				'irc_seen',
+				[
+					'signed_on' => $db->escapeNumber(time()),
+					'signed_off' => 0,
+					'user' => $db->escapeString($user),
+					'host' => $db->escapeString($host),
+					'seen_count' => 0,
+					'seen_by' => null,
+					'registered' => null,
+				],
+				['seen_id' => $db->escapeNumber($seen_id)],
+			);
 
 		} else {
 			// new nick?
@@ -106,10 +105,11 @@ function channel_part($fp, string $rdata): bool {
 
 			$seen_id = $dbResult->record()->getInt('seen_id');
 
-			$db->write('UPDATE irc_seen SET signed_off = :now WHERE seen_id = :seen_id', [
-				'now' => time(),
-				'seen_id' => $seen_id,
-			]);
+			$db->update(
+				'irc_seen',
+				['signed_off' => time()],
+				['seen_id' => $seen_id],
+			);
 
 		} else {
 			// we don't know this one, but who cares? he just left anyway...

--- a/src/tools/irc/channel_msg_op.php
+++ b/src/tools/irc/channel_msg_op.php
@@ -135,9 +135,9 @@ function channel_msg_op_set($fp, Message $msg, AbstractPlayer $player): bool {
 
 		// add op to db
 		$db->insert('alliance_has_op', [
-			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'time' => $db->escapeNumber($op_time),
+			'alliance_id' => $player->getAllianceID(),
+			'game_id' => $player->getGameID(),
+			'time' => $op_time,
 		]);
 
 		fwrite($fp, 'PRIVMSG ' . $channel . ' :The OP has been scheduled.' . EOL);
@@ -202,10 +202,10 @@ function channel_msg_op_response($fp, Message $msg, AbstractPlayer $player): boo
 		}
 
 		$db->replace('alliance_has_op_response', [
-			'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-			'game_id' => $db->escapeNumber($player->getGameID()),
-			'account_id' => $db->escapeNumber($player->getAccountID()),
-			'response' => $db->escapeString($response),
+			'alliance_id' => $player->getAllianceID(),
+			'game_id' => $player->getGameID(),
+			'account_id' => $player->getAccountID(),
+			'response' => $response,
 		]);
 
 		fwrite($fp, 'PRIVMSG ' . $channel . ' :' . $nick . ', you have been added to the ' . $response . ' list.' . EOL);

--- a/src/tools/irc/channel_msg_op.php
+++ b/src/tools/irc/channel_msg_op.php
@@ -85,10 +85,8 @@ function channel_msg_op_cancel($fp, Message $msg, AbstractPlayer $player): bool 
 		}
 
 		// just get rid of op
-		$db->write('DELETE FROM alliance_has_op
-					WHERE ' . Alliance::SQL, $alliance->SQLID);
-		$db->write('DELETE FROM alliance_has_op_response
-					WHERE ' . Alliance::SQL, $alliance->SQLID);
+		$db->delete('alliance_has_op', $alliance->SQLID);
+		$db->delete('alliance_has_op_response', $alliance->SQLID);
 
 		fwrite($fp, 'PRIVMSG ' . $channel . ' :The OP has been canceled.' . EOL);
 		return true;

--- a/src/tools/irc/irc.php
+++ b/src/tools/irc/irc.php
@@ -32,7 +32,9 @@ while (true) {
 	// delete all seen stats that appear to be on (we do not want to take
 	// something for granted that happend while we were away)
 	$db = Database::getInstance();
-	$db->write('DELETE from irc_seen WHERE signed_off = 0');
+	$db->delete('irc_seen', [
+		'signed_off' => 0,
+	]);
 
 	// Reset last ping each time we try connecting.
 	$last_ping = time();

--- a/src/tools/irc/irc.php
+++ b/src/tools/irc/irc.php
@@ -70,8 +70,10 @@ while (true) {
 			$dbResult = $db->read('SELECT channel
 						FROM irc_alliance_has_channel
 						JOIN game USING (game_id)
-						WHERE join_time < ' . time() . '
-							AND end_time > ' . time());
+						WHERE join_time < :now
+							AND end_time > :now', [
+				'now' => time(),
+			]);
 			foreach ($dbResult->records() as $dbRecord) {
 				$joinChannels[] = $dbRecord->getString('channel');
 			}

--- a/src/tools/irc/notice.php
+++ b/src/tools/irc/notice.php
@@ -26,8 +26,8 @@ function notice_nickserv_registered_user($fp, string $rdata): bool {
 
 			$db->update(
 				'irc_seen',
-				['registered_nick' => $db->escapeString($registeredNick)],
-				['seen_id' => $db->escapeNumber($seen_id)],
+				['registered_nick' => $registeredNick],
+				['seen_id' => $seen_id],
 			);
 		}
 

--- a/src/tools/irc/notice.php
+++ b/src/tools/irc/notice.php
@@ -24,12 +24,11 @@ function notice_nickserv_registered_user($fp, string $rdata): bool {
 		foreach ($dbResult->records() as $dbRecord) {
 			$seen_id = $dbRecord->getInt('seen_id');
 
-			$db->write('UPDATE irc_seen SET
-						registered_nick = :registered_nick
-						WHERE seen_id = :seen_id', [
-				'registered_nick' => $db->escapeString($registeredNick),
-				'seen_id' => $db->escapeNumber($seen_id),
-			]);
+			$db->update(
+				'irc_seen',
+				['registered_nick' => $db->escapeString($registeredNick)],
+				['seen_id' => $db->escapeNumber($seen_id)],
+			);
 		}
 
 		foreach (CallbackEvent::getAll() as $event) {

--- a/src/tools/irc/notice.php
+++ b/src/tools/irc/notice.php
@@ -18,13 +18,18 @@ function notice_nickserv_registered_user($fp, string $rdata): bool {
 
 		$db = Database::getInstance();
 
-		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick));
+		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = :nick', [
+			'nick' => $db->escapeString($nick),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$seen_id = $dbRecord->getInt('seen_id');
 
 			$db->write('UPDATE irc_seen SET
-						registered_nick = ' . $db->escapeString($registeredNick) . '
-						WHERE seen_id = ' . $seen_id);
+						registered_nick = :registered_nick
+						WHERE seen_id = :seen_id', [
+				'registered_nick' => $db->escapeString($registeredNick),
+				'seen_id' => $db->escapeNumber($seen_id),
+			]);
 		}
 
 		foreach (CallbackEvent::getAll() as $event) {

--- a/src/tools/irc/server.php
+++ b/src/tools/irc/server.php
@@ -167,21 +167,21 @@ function server_msg_352($fp, string $rdata): bool {
 				[
 					'signed_on' => time(),
 					'signed_off' => 0,
-					'user' => $db->escapeString($user),
-					'host' => $db->escapeString($host),
+					'user' => $user,
+					'host' => $host,
 					'registered' => null,
 				],
-				['seen_id' => $db->escapeNumber($seen_id)],
+				['seen_id' => $seen_id],
 			);
 
 		} else {
 			// new nick?
 			$db->insert('irc_seen', [
-				'nick' => $db->escapeString($nick),
-				'user' => $db->escapeString($user),
-				'host' => $db->escapeString($host),
-				'channel' => $db->escapeString($channel),
-				'signed_on' => $db->escapeNumber(time()),
+				'nick' => $nick,
+				'user' => $user,
+				'host' => $host,
+				'channel' => $channel,
+				'signed_on' => time(),
 			]);
 		}
 

--- a/src/tools/irc/server.php
+++ b/src/tools/irc/server.php
@@ -53,11 +53,11 @@ function server_msg_307($fp, string $rdata): bool {
 		foreach ($dbResult->records() as $dbRecord) {
 			$seen_id = $dbRecord->getInt('seen_id');
 
-			$db->write('UPDATE irc_seen SET ' .
-						'registered = 1 ' .
-						'WHERE seen_id = :seen_id', [
-				'seen_id' => $seen_id,
-			]);
+			$db->update(
+				'irc_seen',
+				['registered' => 1],
+				['seen_id' => $seen_id],
+			);
 		}
 
 		return true;
@@ -89,11 +89,11 @@ function server_msg_318($fp, string $rdata): bool {
 		foreach ($dbResult->records() as $dbRecord) {
 			$seen_id = $dbRecord->getInt('seen_id');
 
-			$db->write('UPDATE irc_seen SET ' .
-						'registered = 0 ' .
-						'WHERE seen_id = :seen_id', [
-				'seen_id' => $seen_id,
-			]);
+			$db->update(
+				'irc_seen',
+				['registered' => 0],
+				['seen_id' => $seen_id],
+			);
 		}
 
 		foreach (CallbackEvent::getAll() as $event) {
@@ -162,18 +162,17 @@ function server_msg_352($fp, string $rdata): bool {
 			// exiting nick?
 			$seen_id = $dbResult->record()->getInt('seen_id');
 
-			$db->write('UPDATE irc_seen SET
-					signed_on = :now,
-					signed_off = 0,
-					user = :user,
-					host = :host,
-					registered = NULL
-					WHERE seen_id = :seen_id', [
-				'now' => time(),
-				'user' => $db->escapeString($user),
-				'host' => $db->escapeString($host),
-				'seen_id' => $db->escapeNumber($seen_id),
-			]);
+			$db->update(
+				'irc_seen',
+				[
+					'signed_on' => time(),
+					'signed_off' => 0,
+					'user' => $db->escapeString($user),
+					'host' => $db->escapeString($host),
+					'registered' => null,
+				],
+				['seen_id' => $db->escapeNumber($seen_id)],
+			);
 
 		} else {
 			// new nick?
@@ -217,12 +216,11 @@ function server_msg_401($fp, string $rdata): bool {
 			$seen_id = $dbResult->record()->getInt('seen_id');
 
 			// maybe he left without us noticing, so we fix this now
-			$db->write('UPDATE irc_seen SET
-					signed_off = :now
-					WHERE seen_id = :seen_id', [
-				'now' => time(),
-				'seen_id' => $seen_id,
-			]);
+			$db->update(
+				'irc_seen',
+				['signed_off' => time()],
+				['seen_id' => $seen_id],
+			);
 		}
 
 		return true;

--- a/src/tools/irc/server.php
+++ b/src/tools/irc/server.php
@@ -47,13 +47,17 @@ function server_msg_307($fp, string $rdata): bool {
 		echo_r('[SERVER_307] ' . $server . ' said that ' . $nick . ' is registered');
 
 		$db = Database::getInstance();
-		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick));
+		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = :nick', [
+			'nick' => $db->escapeString($nick),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$seen_id = $dbRecord->getInt('seen_id');
 
 			$db->write('UPDATE irc_seen SET ' .
 						'registered = 1 ' .
-						'WHERE seen_id = ' . $seen_id);
+						'WHERE seen_id = :seen_id', [
+				'seen_id' => $seen_id,
+			]);
 		}
 
 		return true;
@@ -79,13 +83,17 @@ function server_msg_318($fp, string $rdata): bool {
 
 		$db = Database::getInstance();
 
-		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND registered IS NULL');
+		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = :nick AND registered IS NULL', [
+			'nick' => $db->escapeString($nick),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$seen_id = $dbRecord->getInt('seen_id');
 
 			$db->write('UPDATE irc_seen SET ' .
 						'registered = 0 ' .
-						'WHERE seen_id = ' . $seen_id);
+						'WHERE seen_id = :seen_id', [
+				'seen_id' => $seen_id,
+			]);
 		}
 
 		foreach (CallbackEvent::getAll() as $event) {
@@ -96,7 +104,10 @@ function server_msg_318($fp, string $rdata): bool {
 				CallbackEvent::remove($event);
 
 				// so we should do a callback but need to check first if the guy has registered
-				$dbResult = $db->read('SELECT 1 FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND registered = 1 AND channel = ' . $db->escapeString($event->channel));
+				$dbResult = $db->read('SELECT 1 FROM irc_seen WHERE nick = :nick AND registered = 1 AND channel = :channel', [
+					'nick' => $db->escapeString($nick),
+					'channel' => $db->escapeString($event->channel),
+				]);
 				if ($dbResult->hasRecord()) {
 					//Forward to a NICKSERV INFO call.
 					fwrite($fp, 'NICKSERV INFO ' . $nick . EOL);
@@ -142,19 +153,27 @@ function server_msg_352($fp, string $rdata): bool {
 		$db = Database::getInstance();
 
 		// check if we have seen this user before
-		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND channel = ' . $db->escapeString($channel));
+		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = :nick AND channel = :channel', [
+			'nick' => $db->escapeString($nick),
+			'channel' => $db->escapeString($channel),
+		]);
 
 		if ($dbResult->hasRecord()) {
 			// exiting nick?
 			$seen_id = $dbResult->record()->getInt('seen_id');
 
-			$db->write('UPDATE irc_seen SET ' .
-					   'signed_on = ' . time() . ', ' .
-					   'signed_off = 0, ' .
-					   'user = ' . $db->escapeString($user) . ', ' .
-					   'host = ' . $db->escapeString($host) . ', ' .
-					   'registered = NULL ' .
-					   'WHERE seen_id = ' . $seen_id);
+			$db->write('UPDATE irc_seen SET
+					signed_on = :now,
+					signed_off = 0,
+					user = :user,
+					host = :host,
+					registered = NULL
+					WHERE seen_id = :seen_id', [
+				'now' => time(),
+				'user' => $db->escapeString($user),
+				'host' => $db->escapeString($host),
+				'seen_id' => $db->escapeNumber($seen_id),
+			]);
 
 		} else {
 			// new nick?
@@ -191,14 +210,19 @@ function server_msg_401($fp, string $rdata): bool {
 		$db = Database::getInstance();
 
 		// get the user in question
-		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = ' . $db->escapeString($nick) . ' AND signed_off = 0');
+		$dbResult = $db->read('SELECT * FROM irc_seen WHERE nick = :nick AND signed_off = 0', [
+			'nick' => $db->escapeString($nick),
+		]);
 		if ($dbResult->hasRecord()) {
 			$seen_id = $dbResult->record()->getInt('seen_id');
 
 			// maybe he left without us noticing, so we fix this now
-			$db->write('UPDATE irc_seen SET ' .
-					   'signed_off = ' . time() .
-					   ' WHERE seen_id = ' . $seen_id);
+			$db->write('UPDATE irc_seen SET
+					signed_off = :now
+					WHERE seen_id = :seen_id', [
+				'now' => time(),
+				'seen_id' => $seen_id,
+			]);
 		}
 
 		return true;

--- a/src/tools/irc/user.php
+++ b/src/tools/irc/user.php
@@ -26,10 +26,11 @@ function user_quit(string $rdata): bool {
 
 			$seen_id = $dbRecord->getInt('seen_id');
 
-			$db->write('UPDATE irc_seen SET signed_off = :now WHERE seen_id = :seen_id', [
-				'now' => time(),
-				'seen_id' => $seen_id,
-			]);
+			$db->update(
+				'irc_seen',
+				['signed_off' => time()],
+				['seen_id' => $seen_id],
+			);
 
 		}
 
@@ -71,10 +72,11 @@ function user_nick(string $rdata): bool {
 			// remember channels where this nick was active
 			$channel_list[] = $dbRecord->getString('channel');
 
-			$db->write('UPDATE irc_seen SET signed_off = :now WHERE seen_id = :seen_id', [
-				'now' => time(),
-				'seen_id' => $seen_id,
-			]);
+			$db->update(
+				'irc_seen',
+				['signed_off' => time()],
+				['seen_id' => $seen_id],
+			);
 
 		}
 
@@ -91,18 +93,17 @@ function user_nick(string $rdata): bool {
 				// exiting nick?
 				$seen_id = $dbResult->record()->getInt('seen_id');
 
-				$db->write('UPDATE irc_seen SET
-						signed_on = :now,
-						signed_off = 0,
-						user = :user,
-						host = :host,
-						registered = NULL
-						WHERE seen_id = :seen_id', [
-					'now' => time(),
-					'user' => $db->escapeString($user),
-					'host' => $db->escapeString($host),
-					'seen_id' => $db->escapeNumber($seen_id),
-				]);
+				$db->update(
+					'irc_seen',
+					[
+						'signed_on' => time(),
+						'signed_off' => 0,
+						'user' => $db->escapeString($user),
+						'host' => $db->escapeString($host),
+						'registered' => null,
+					],
+					['seen_id' => $db->escapeNumber($seen_id)],
+				);
 
 			} else {
 				// new nick?

--- a/src/tools/irc/user.php
+++ b/src/tools/irc/user.php
@@ -98,21 +98,21 @@ function user_nick(string $rdata): bool {
 					[
 						'signed_on' => time(),
 						'signed_off' => 0,
-						'user' => $db->escapeString($user),
-						'host' => $db->escapeString($host),
+						'user' => $user,
+						'host' => $host,
 						'registered' => null,
 					],
-					['seen_id' => $db->escapeNumber($seen_id)],
+					['seen_id' => $seen_id],
 				);
 
 			} else {
 				// new nick?
 				$db->insert('irc_seen', [
-					'nick' => $db->escapeString($new_nick),
-					'user' => $db->escapeString($user),
-					'host' => $db->escapeString($host),
-					'channel' => $db->escapeString($channel),
-					'signed_on' => $db->escapeNumber(time()),
+					'nick' => $new_nick,
+					'user' => $user,
+					'host' => $host,
+					'channel' => $channel,
+					'signed_on' => time(),
 				]);
 			}
 

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -13,9 +13,9 @@ function debug(string $message, mixed $debugObject = null): void {
 		'script_id' => defined('SCRIPT_ID') ? SCRIPT_ID : 0,
 		'npc_id' => 0,
 		'time' => 'NOW()',
-		'message' => $db->escapeString($message),
-		'debug_info' => $db->escapeString(var_export($debugObject, true)),
-		'var' => $db->escapeString(''),
+		'message' => $message,
+		'debug_info' => var_export($debugObject, true),
+		'var' => '',
 	]);
 
 	// On the first call to debug, we need to update the script_id retroactively

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -21,9 +21,11 @@ function debug(string $message, mixed $debugObject = null): void {
 	// On the first call to debug, we need to update the script_id retroactively
 	if (!defined('SCRIPT_ID')) {
 		define('SCRIPT_ID', $logID);
-		$db->write('UPDATE npc_logs SET script_id = :script_id WHERE log_id = :script_id', [
-			'script_id' => SCRIPT_ID,
-		]);
+		$db->update(
+			'npc_logs',
+			['script_id' => SCRIPT_ID],
+			['log_id' => SCRIPT_ID],
+		);
 	}
 }
 

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -21,7 +21,9 @@ function debug(string $message, mixed $debugObject = null): void {
 	// On the first call to debug, we need to update the script_id retroactively
 	if (!defined('SCRIPT_ID')) {
 		define('SCRIPT_ID', $logID);
-		$db->write('UPDATE npc_logs SET script_id=' . SCRIPT_ID . ' WHERE log_id=' . SCRIPT_ID);
+		$db->write('UPDATE npc_logs SET script_id = :script_id WHERE log_id = :script_id', [
+			'script_id' => SCRIPT_ID,
+		]);
 	}
 }
 

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -200,7 +200,9 @@ function debug(string $message, mixed $debugObject = null): void {
 		// On the first call to debug, we need to update the script_id retroactively
 		if (!defined('SCRIPT_ID')) {
 			define('SCRIPT_ID', $logID);
-			$db->write('UPDATE npc_logs SET script_id=' . SCRIPT_ID . ' WHERE log_id=' . SCRIPT_ID);
+			$db->write('UPDATE npc_logs SET script_id = :script_id WHERE log_id = :script_id', [
+				'script_id' => SCRIPT_ID,
+			]);
 		}
 	}
 }
@@ -252,8 +254,11 @@ function releaseNPC(): void {
 	}
 	$login = $session->getAccount()->getLogin();
 	$db = Database::getInstance();
-	$db->write('UPDATE npc_logins SET working=' . $db->escapeBoolean(false) . ' WHERE login=' . $db->escapeString($login));
-	if ($db->getChangedRows() > 0) {
+	$changedRows = $db->write('UPDATE npc_logins SET working = :working WHERE login = :login', [
+		'working' => $db->escapeBoolean(false),
+		'login' => $db->escapeString($login),
+	]);
+	if ($changedRows > 0) {
 		debug('Released NPC: ' . $login);
 	} else {
 		debug('Failed to release NPC: ' . $login);
@@ -290,7 +295,9 @@ function changeNPCLogin(): void {
 		}
 
 		// Make sure to select NPCs from active games only
-		$dbResult = $db->read('SELECT account_id, game_id FROM player JOIN account USING(account_id) JOIN npc_logins USING(login) JOIN game USING(game_id) WHERE active=\'TRUE\' AND working=\'FALSE\' AND start_time < ' . $db->escapeNumber(Epoch::time()) . ' AND end_time > ' . $db->escapeNumber(Epoch::time()) . ' ORDER BY last_turn_update ASC');
+		$dbResult = $db->read('SELECT account_id, game_id FROM player JOIN account USING(account_id) JOIN npc_logins USING(login) JOIN game USING(game_id) WHERE active=\'TRUE\' AND working=\'FALSE\' AND start_time < :now AND end_time > :now ORDER BY last_turn_update ASC', [
+			'now' => $db->escapeNumber(Epoch::time()),
+		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$availableNpcs[] = [
 				'account_id' => $dbRecord->getInt('account_id'),
@@ -312,7 +319,10 @@ function changeNPCLogin(): void {
 	$session->setAccount($account);
 	$session->updateGame($npc['game_id']);
 
-	$db->write('UPDATE npc_logins SET working=' . $db->escapeBoolean(true) . ' WHERE login=' . $db->escapeString($account->getLogin()));
+	$db->write('UPDATE npc_logins SET working = :working WHERE login = :login', [
+		'working' => $db->escapeBoolean(true),
+		'login' => $db->escapeString($account->getLogin()),
+	]);
 	debug('Chosen NPC: login = ' . $account->getLogin() . ', game = ' . $session->getGameID() . ', player = ' . $session->getPlayer()->getPlayerName());
 }
 
@@ -516,7 +526,16 @@ function findRoutes(AbstractPlayer $player): array {
 	$maxDistance = 15;
 
 	$db = Database::getInstance();
-	$dbResult = $db->read('SELECT routes FROM route_cache WHERE game_id=' . $db->escapeNumber($player->getGameID()) . ' AND max_ports=' . $db->escapeNumber($maxNumberOfPorts) . ' AND goods_allowed=' . $db->escapeObject($tradeGoods) . ' AND races_allowed=' . $db->escapeObject($tradeRaces) . ' AND start_sector_id=' . $db->escapeNumber($startSectorID) . ' AND end_sector_id=' . $db->escapeNumber($endSectorID) . ' AND routes_for_port=' . $db->escapeNumber($routesForPort) . ' AND max_distance=' . $db->escapeNumber($maxDistance));
+	$dbResult = $db->read('SELECT routes FROM route_cache WHERE game_id = :game_id AND max_ports = :max_ports AND goods_allowed = :goods_allowed AND races_allowed = :races_allowed AND start_sector_id = :start_sector_id AND end_sector_id = :end_sector_id AND routes_for_port = :routes_for_port AND max_distance = :max_distance', [
+		'game_id' => $db->escapeNumber($player->getGameID()),
+		'max_ports' => $db->escapeNumber($maxNumberOfPorts),
+		'goods_allowed' => $db->escapeObject($tradeGoods),
+		'races_allowed' => $db->escapeObject($tradeRaces),
+		'start_sector_id' => $db->escapeNumber($startSectorID),
+		'end_sector_id' => $db->escapeNumber($endSectorID),
+		'routes_for_port' => $db->escapeNumber($routesForPort),
+		'max_distance' => $db->escapeNumber($maxDistance),
+	]);
 	if ($dbResult->hasRecord()) {
 		$routes = $dbResult->record()->getObject('routes', true);
 		debug('Using Cached Routes: #' . count($routes));

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -200,9 +200,11 @@ function debug(string $message, mixed $debugObject = null): void {
 		// On the first call to debug, we need to update the script_id retroactively
 		if (!defined('SCRIPT_ID')) {
 			define('SCRIPT_ID', $logID);
-			$db->write('UPDATE npc_logs SET script_id = :script_id WHERE log_id = :script_id', [
-				'script_id' => SCRIPT_ID,
-			]);
+			$db->update(
+				'npc_logs',
+				['script_id' => SCRIPT_ID],
+				['log_id' => SCRIPT_ID],
+			);
 		}
 	}
 }
@@ -254,10 +256,11 @@ function releaseNPC(): void {
 	}
 	$login = $session->getAccount()->getLogin();
 	$db = Database::getInstance();
-	$changedRows = $db->write('UPDATE npc_logins SET working = :working WHERE login = :login', [
-		'working' => $db->escapeBoolean(false),
-		'login' => $db->escapeString($login),
-	]);
+	$changedRows = $db->update(
+		'npc_logins',
+		['working' => $db->escapeBoolean(false)],
+		['login' => $db->escapeString($login)],
+	);
 	if ($changedRows > 0) {
 		debug('Released NPC: ' . $login);
 	} else {
@@ -319,10 +322,11 @@ function changeNPCLogin(): void {
 	$session->setAccount($account);
 	$session->updateGame($npc['game_id']);
 
-	$db->write('UPDATE npc_logins SET working = :working WHERE login = :login', [
-		'working' => $db->escapeBoolean(true),
-		'login' => $db->escapeString($account->getLogin()),
-	]);
+	$db->update(
+		'npc_logins',
+		['working' => $db->escapeBoolean(true)],
+		['login' => $db->escapeString($account->getLogin())],
+	);
 	debug('Chosen NPC: login = ' . $account->getLogin() . ', game = ' . $session->getGameID() . ', player = ' . $session->getPlayer()->getPlayerName());
 }
 

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -190,11 +190,11 @@ function debug(string $message, mixed $debugObject = null): void {
 		$db = Database::getInstance();
 		$logID = $db->insert('npc_logs', [
 			'script_id' => defined('SCRIPT_ID') ? SCRIPT_ID : 0,
-			'npc_id' => $db->escapeNumber($accountID),
+			'npc_id' => $accountID,
 			'time' => 'NOW()',
-			'message' => $db->escapeString($message),
-			'debug_info' => $db->escapeString(var_export($debugObject, true)),
-			'var' => $db->escapeString(var_export($var, true)),
+			'message' => $message,
+			'debug_info' => var_export($debugObject, true),
+			'var' => var_export($var, true),
 		]);
 
 		// On the first call to debug, we need to update the script_id retroactively
@@ -259,7 +259,7 @@ function releaseNPC(): void {
 	$changedRows = $db->update(
 		'npc_logins',
 		['working' => $db->escapeBoolean(false)],
-		['login' => $db->escapeString($login)],
+		['login' => $login],
 	);
 	if ($changedRows > 0) {
 		debug('Released NPC: ' . $login);
@@ -325,7 +325,7 @@ function changeNPCLogin(): void {
 	$db->update(
 		'npc_logins',
 		['working' => $db->escapeBoolean(true)],
-		['login' => $db->escapeString($account->getLogin())],
+		['login' => $account->getLogin()],
 	);
 	debug('Chosen NPC: login = ' . $account->getLogin() . ', game = ' . $session->getGameID() . ', player = ' . $session->getPlayer()->getPlayerName());
 }
@@ -572,14 +572,14 @@ function findRoutes(AbstractPlayer $player): array {
 	}
 
 	$db->insert('route_cache', [
-		'game_id' => $db->escapeNumber($player->getGameID()),
-		'max_ports' => $db->escapeNumber($maxNumberOfPorts),
+		'game_id' => $player->getGameID(),
+		'max_ports' => $maxNumberOfPorts,
 		'goods_allowed' => $db->escapeObject($tradeGoods),
 		'races_allowed' => $db->escapeObject($tradeRaces),
-		'start_sector_id' => $db->escapeNumber($startSectorID),
-		'end_sector_id' => $db->escapeNumber($endSectorID),
-		'routes_for_port' => $db->escapeNumber($routesForPort),
-		'max_distance' => $db->escapeNumber($maxDistance),
+		'start_sector_id' => $startSectorID,
+		'end_sector_id' => $endSectorID,
+		'routes_for_port' => $routesForPort,
+		'max_distance' => $maxDistance,
 		'routes' => $db->escapeObject($routesMerged, true),
 	]);
 	debug('Found Routes: #' . count($routesMerged));

--- a/src/tools/reserializeCombatLogs.php
+++ b/src/tools/reserializeCombatLogs.php
@@ -8,8 +8,9 @@ $db = Database::getInstance();
 
 $dbResult = $db->read('SELECT result,log_id FROM combat_logs');
 foreach ($dbResult->records() as $dbRecord) {
-	$db->write('UPDATE combat_logs SET result = :result WHERE log_id = :log_id', [
-		'result' => $db->escapeObject($dbRecord->getObject('result', true), true),
-		'log_id' => $dbRecord->getInt('log_id'),
-	]);
+	$db->update(
+		'combat_logs',
+		['result' => $db->escapeObject($dbRecord->getObject('result', true), true)],
+		['log_id' => $dbRecord->getInt('log_id')],
+	);
 }

--- a/src/tools/reserializeCombatLogs.php
+++ b/src/tools/reserializeCombatLogs.php
@@ -8,5 +8,8 @@ $db = Database::getInstance();
 
 $dbResult = $db->read('SELECT result,log_id FROM combat_logs');
 foreach ($dbResult->records() as $dbRecord) {
-	$db->write('UPDATE combat_logs SET result=' . $db->escapeObject($dbRecord->getObject('result', true), true) . ' WHERE log_id=' . $dbRecord->getInt('log_id'));
+	$db->write('UPDATE combat_logs SET result = :result WHERE log_id = :log_id', [
+		'result' => $db->escapeObject($dbRecord->getObject('result', true), true),
+		'log_id' => $dbRecord->getInt('log_id'),
+	]);
 }

--- a/test/SmrTest/TestUtils.php
+++ b/test/SmrTest/TestUtils.php
@@ -30,7 +30,7 @@ class TestUtils {
 
 	/**
 	 * Construct an instance of a class with a protected constructor for test
-	 * purposes. Note that this function should only beused as a last resort!
+	 * purposes. Note that this function should only be used as a last resort!
 	 * Its use indicates that the input class is a candidate for refactoring.
 	 *
 	 * @template T of object

--- a/test/SmrTest/lib/BountyTest.php
+++ b/test/SmrTest/lib/BountyTest.php
@@ -7,7 +7,11 @@ use Smr\AbstractPlayer;
 use Smr\Bounty;
 use Smr\BountyType;
 use Smr\Database;
+use Smr\DatabaseRecord;
+use Smr\Player;
+use Smr\ScoutMessageGroupType;
 use SmrTest\BaseIntegrationSpec;
+use SmrTest\TestUtils;
 
 #[CoversClass(Bounty::class)]
 class BountyTest extends BaseIntegrationSpec {
@@ -88,9 +92,17 @@ class BountyTest extends BaseIntegrationSpec {
 		$bounty1->update();
 		$bounty2->update();
 
+		// Stub player (can't use default mock for enums)
+		$dbRecord = $this->createStub(DatabaseRecord::class);
+		$dbRecord->method('getStringEnum')->willReturn(ScoutMessageGroupType::Auto);
+		$player1 = TestUtils::constructPrivateClass(
+			name: Player::class,
+			gameID: 42,
+			accountID: 1,
+			dbRecord: $dbRecord,
+		);
+
 		// We should only get $bounty1 if we get bounties on player 1
-		$player1 = $this->createStub(AbstractPlayer::class);
-		$player1->method('getSQL')->willReturn('account_id=1 AND game_id=42');
 		$bounties = Bounty::getPlacedOnPlayer($player1);
 		self::assertEquals([7 => $bounty1], $bounties);
 	}

--- a/test/SmrTest/lib/DatabaseInsertTest.php
+++ b/test/SmrTest/lib/DatabaseInsertTest.php
@@ -43,7 +43,9 @@ class DatabaseInsertTest extends TestCase {
 		$logID = $db->insert('test2', [
 			'var' => $db->escapeString('foo'),
 		]);
-		$result = $db->read('SELECT * FROM test2 WHERE id = ' . $logID);
+		$result = $db->read('SELECT * FROM test2 WHERE id = :id', [
+			'id' => $logID,
+		]);
 		$record = $result->record();
 		self::assertSame('foo', $record->getString('var'));
 	}
@@ -67,7 +69,9 @@ class DatabaseInsertTest extends TestCase {
 		self::assertSame(2, $logID);
 
 		// Non-empty fields are successfully recovered
-		$result = $db->read('SELECT * FROM test2 WHERE id = ' . $logID);
+		$result = $db->read('SELECT * FROM test2 WHERE id = :id', [
+			'id' => $logID,
+		]);
 		$record = $result->record();
 		self::assertSame('foo', $record->getString('var'));
 	}

--- a/test/SmrTest/lib/DatabaseInsertTest.php
+++ b/test/SmrTest/lib/DatabaseInsertTest.php
@@ -41,7 +41,7 @@ class DatabaseInsertTest extends TestCase {
 
 		// Non-empty fields are successfully recovered
 		$logID = $db->insert('test2', [
-			'var' => $db->escapeString('foo'),
+			'var' => 'foo',
 		]);
 		$result = $db->read('SELECT * FROM test2 WHERE id = :id', [
 			'id' => $logID,
@@ -64,7 +64,7 @@ class DatabaseInsertTest extends TestCase {
 		// Replacing an existing row returns that row as the insert ID
 		$logID = $db->replace('test2', [
 			'id' => 2,
-			'var' => $db->escapeString('foo'),
+			'var' => 'foo',
 		]);
 		self::assertSame(2, $logID);
 

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -2,12 +2,12 @@
 
 namespace SmrTest\lib;
 
-use Error;
-use mysqli;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\DriverException;
+use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 use Smr\Container\DiContainer;
 use Smr\Database;
 use Smr\DatabaseProperties;
@@ -19,18 +19,18 @@ use Smr\DatabaseProperties;
 class DatabaseIntegrationTest extends TestCase {
 
 	protected function setUp(): void {
-		// Start each test with a fresh container (and mysqli connection).
+		// Start each test with a fresh container (and connection).
 		// This ensures the independence of each test.
 		DiContainer::initialize(false);
 	}
 
-	public function test_mysqli_factory(): void {
+	public function test_connectionFactory(): void {
 		// Given database properties are retrieved from the container
 		$dbProperties = DiContainer::get(DatabaseProperties::class);
-		// When using the factory to retrieve a mysqli instance
-		$mysql = Database::mysqliFactory($dbProperties);
-		// Then the connection is successful
-		self::assertNotNull($mysql->server_info);
+		// When using the factory to retrieve a connection instance
+		$conn = Database::connectionFactory($dbProperties);
+		// The the connection is successful
+		self::assertSame($dbProperties->database, $conn->getDatabase());
 	}
 
 	public function test__construct_happy_path(): void {
@@ -47,22 +47,24 @@ class DatabaseIntegrationTest extends TestCase {
 	}
 
 	public function test_resetInstance_returns_new_instance(): void {
-		// Given an original mysql instance
-		$originalMysql = DiContainer::get(mysqli::class);
+		// Given an original connection instance
+		$original = DiContainer::get(Connection::class);
 		// And resetInstance is called
 		Database::resetInstance();
 		// And Database is usable again after reconnecting
 		Database::getInstance()->read('SELECT 1');
-		// Then new mysqli instance is not the same as the original instance
-		self::assertNotSame($originalMysql, DiContainer::get(mysqli::class));
+		// Then new instance is not the same as the original instance
+		self::assertNotSame($original, DiContainer::get(Connection::class));
 	}
 
 	public function test_resetInstance_closes_connection(): void {
+		$conn = DiContainer::get(Connection::class);
 		$db = Database::getInstance();
+		$db->read('SELECT 1'); // initialize the connection
+		self::assertTrue($conn->isConnected());
+
 		Database::resetInstance();
-		$this->expectException(Error::class);
-		$this->expectExceptionMessage('mysqli object is already closed');
-		$db->read('SELECT 1');
+		self::assertFalse($conn->isConnected());
 	}
 
 	public function test_getDbBytes(): void {
@@ -78,34 +80,34 @@ class DatabaseIntegrationTest extends TestCase {
 	public function test_escapeBoolean(): void {
 		$db = Database::getInstance();
 		// Test both boolean values
-		self::assertSame("'TRUE'", $db->escapeBoolean(true));
-		self::assertSame("'FALSE'", $db->escapeBoolean(false));
+		self::assertSame('TRUE', $db->escapeBoolean(true));
+		self::assertSame('FALSE', $db->escapeBoolean(false));
 	}
 
 	public function test_escapeString(): void {
 		$db = Database::getInstance();
 		// Test the empty string
-		self::assertSame("''", $db->escapeString(''));
+		self::assertSame('', $db->escapeString(''));
 		// Test a normal string
-		self::assertSame("'bla'", $db->escapeString('bla'));
+		self::assertSame('bla', $db->escapeString('bla'));
 	}
 
 	public function test_escapeNullableString(): void {
 		$db = Database::getInstance();
 		// Test the empty string
-		self::assertSame('NULL', $db->escapeNullableString(''));
+		self::assertNull($db->escapeNullableString(''));
 		// Test null
-		self::assertSame('NULL', $db->escapeNullableString(null));
+		self::assertNull($db->escapeNullableString(null));
 		// Test a normal string
-		self::assertSame("'bla'", $db->escapeString('bla'));
+		self::assertSame('bla', $db->escapeString('bla'));
 	}
 
 	public function test_escapeArray(): void {
 		$db = Database::getInstance();
 		// Test a string array
-		self::assertSame("'a','b','c'", $db->escapeArray(['a', 'b', 'c']));
+		self::assertSame(['a', 'b', 'c'], $db->escapeArray(['a', 'b', 'c']));
 		// Test an int array
-		self::assertSame('1,2,3', $db->escapeArray([1, 2, 3]));
+		self::assertSame([1, 2, 3], $db->escapeArray([1, 2, 3]));
 	}
 
 	public function test_escapeNumber(): void {
@@ -120,21 +122,21 @@ class DatabaseIntegrationTest extends TestCase {
 	public function test_escapeObject(): void {
 		$db = Database::getInstance();
 		// Test empty array
-		self::assertSame("'a:0:{}'", $db->escapeObject([]));
+		self::assertSame('a:0:{}', $db->escapeObject([]));
 		// Test empty string
-		self::assertSame('\'s:0:\"\";\'', $db->escapeObject(''));
+		self::assertSame('s:0:"";', $db->escapeObject(''));
 	}
 
 	public function test_escapeNullableObject(): void {
 		$db = Database::getInstance();
 		// Test null
-		self::assertSame('NULL', $db->escapeNullableObject(null));
+		self::assertNull($db->escapeNullableObject(null));
 	}
 
 	public function test_write_throws_on_wrong_query_type(): void {
 		// Queries that return a result should not use the 'write' method
 		$db = Database::getInstance();
-		$this->expectException(RuntimeException::class);
+		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Wrong query type');
 		$db->write('SELECT 1');
 	}
@@ -142,11 +144,11 @@ class DatabaseIntegrationTest extends TestCase {
 	public function test_lockTable_throws_if_read_other_table(): void {
 		$db = Database::getInstance();
 		$db->lockTable('player');
-		$this->expectException(RuntimeException::class);
+		$this->expectException(DriverException::class);
 		$this->expectExceptionMessage("Table 'account' was not locked with LOCK TABLES");
 		try {
 			$db->read('SELECT 1 FROM account LIMIT 1');
-		} catch (RuntimeException $err) {
+		} catch (Exception $err) {
 			// Avoid leaving database in a locked state
 			$db->unlock();
 			throw $err;
@@ -186,7 +188,7 @@ class DatabaseIntegrationTest extends TestCase {
 	#[TestWith([[1, 2, 3], 'escapeNullableObject', 'getNullableObject'])]
 	public function test_inversion_of_escape_and_get(mixed $value, string $escaper, string $getter, array $args = []): void {
 		$db = Database::getInstance();
-		$result = $db->read('SELECT ' . $db->$escaper($value, ...$args) . ' AS val');
+		$result = $db->read('SELECT ? AS val', [$db->$escaper($value, ...$args)]);
 		self::assertSame($value, $result->record()->$getter('val', ...$args));
 	}
 

--- a/test/SmrTest/lib/DatabaseResultTest.php
+++ b/test/SmrTest/lib/DatabaseResultTest.php
@@ -34,7 +34,7 @@ class DatabaseResultTest extends TestCase {
 	}
 
 	public function test_record_one_row(): void {
-		self::assertSame([1 => '1'], $this->runQuery(1)->record()->getRow());
+		self::assertSame([1 => 1], $this->runQuery(1)->record()->getRow());
 	}
 
 	public function test_record_too_many_rows(): void {
@@ -81,7 +81,7 @@ class DatabaseResultTest extends TestCase {
 		$result = $this->runQuery(3);
 		foreach ($result->records() as $index => $record) {
 			$row = $index + 1;
-			self::assertSame([1 => (string)$row], $record->getRow());
+			self::assertSame([1 => $row], $record->getRow());
 			$numRecords++;
 		}
 		self::assertSame(3, $numRecords);

--- a/test/SmrTest/lib/EnhancedWeaponEventTest.php
+++ b/test/SmrTest/lib/EnhancedWeaponEventTest.php
@@ -5,10 +5,12 @@ namespace SmrTest\lib;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClassConstant;
 use Smr\Container\DiContainer;
+use Smr\DatabaseRecord;
 use Smr\EnhancedWeaponEvent;
 use Smr\Epoch;
 use Smr\Location;
 use SmrTest\BaseIntegrationSpec;
+use SmrTest\TestUtils;
 
 #[CoversClass(EnhancedWeaponEvent::class)]
 class EnhancedWeaponEventTest extends BaseIntegrationSpec {
@@ -32,8 +34,12 @@ class EnhancedWeaponEventTest extends BaseIntegrationSpec {
 
 		// We need to insert at least one location into the database, since
 		// the class doesn't have a very modular design.
-		$location = $this->createPartialMock(Location::class, ['getTypeID']);
-		$location->method('getTypeID')->willReturn($locTypePPL);
+		$location = TestUtils::constructPrivateClass(
+			name: Location::class,
+			gameID: $gameID,
+			typeID: $locTypePPL,
+			dbRecord: $this->createStub(DatabaseRecord::class),
+		);
 		Location::addSectorLocation($gameID, $sectorID, $location);
 
 		// Set an initial t=0


### PR DESCRIPTION
Instead of manually escaping variables inline in SQL statements, we now
use prepared statements. These automatically take care of escaping, and
are generally considered a best practice. It's easier to read as well,
since we have a structured array of parameters instead of a long string
concatenation. This also enables SQL static analysis using phpstan-dba.

We switch the database access layer from MySQLi to Doctrine/DBAL with
PDO as the underlying driver.

See commit messages for details.