### PR TITLE
Refactor SocialLogin classes

### DIFF
--- a/src/htdocs/login_social_create.php
+++ b/src/htdocs/login_social_create.php
@@ -10,21 +10,21 @@ try {
 	if (session_status() === PHP_SESSION_NONE) {
 		session_start();
 	}
-	if (!isset($_SESSION['socialLogin'])) {
+	if (!isset($_SESSION['socialId'])) {
 		$msg = 'Authentication data not found!';
 		header('Location: /login.php?msg=' . rawurlencode(htmlspecialchars($msg, ENT_QUOTES)));
 		exit;
 	}
-	$socialLogin = $_SESSION['socialLogin'];
+	/** @var Smr\SocialLogin\SocialIdentity $socialId */
+	$socialId = $_SESSION['socialId'];
 
 	$template = Template::getInstance();
-	$template->assign('SocialLogin', $socialLogin);
 
 	// Pre-populate the login field if an account with this email exists.
 	// (Also disable creating a new account because they would just get
 	// an "Email already registered" error anyway.)
 	try {
-		$account = Account::getAccountByEmail($socialLogin->getEmail());
+		$account = Account::getAccountByEmail($socialId->email);
 		$template->assign('MatchingLogin', $account->getLogin());
 	} catch (AccountNotFound) {
 		// Proceed without matching account

--- a/src/lib/Smr/SocialLogin/SocialIdentity.php
+++ b/src/lib/Smr/SocialLogin/SocialIdentity.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Smr\SocialLogin;
+
+use Smr\Exceptions\UserError;
+
+class SocialIdentity {
+
+	public readonly string $type;
+	/** @var non-empty-string */
+	public readonly string $id;
+	/** @var non-empty-string */
+	public readonly string $email;
+
+	public function __construct(?string $id, ?string $email, string $type) {
+		if ($id === null || $id === '') {
+			throw new UserError('Failed to retrieve your ' . $type . ' ID!');
+		}
+		if ($email === null || $email === '') {
+			throw new UserError('An email address is required, but was not found!');
+		}
+		$this->id = $id;
+		$this->email = $email;
+		$this->type = $type;
+	}
+
+}

--- a/src/lib/Smr/SocialLogin/SocialLogin.php
+++ b/src/lib/Smr/SocialLogin/SocialLogin.php
@@ -10,10 +10,6 @@ use Smr\Exceptions\SocialLoginInvalidType;
  */
 abstract class SocialLogin {
 
-	private ?string $userID = null;
-	private ?string $email = null;
-	protected ?string $errorMessage = null;
-
 	/**
 	 * Provides the canonical name of the platform to use in string comparison.
 	 */
@@ -41,14 +37,6 @@ abstract class SocialLogin {
 	}
 
 	/**
-	 * After a successful authentication, set credentials.
-	 */
-	protected function setCredentials(?string $userID, ?string $email): void {
-		$this->userID = $userID;
-		$this->email = $email;
-	}
-
-	/**
 	 * Returns the URL that the social platform will redirect to
 	 * after authentication.
 	 */
@@ -64,31 +52,6 @@ abstract class SocialLogin {
 	/**
 	 * Authenticates with the social platform.
 	 */
-	abstract public function login(): self;
-
-	/**
-	 * Returns true if the authentication was successful.
-	 *
-	 * @phpstan-assert-if-true non-empty-string $this->getUserID()
-	 * @phpstan-assert-if-true non-empty-string $this->getEmail()
-	 */
-	public function isValid(): bool {
-		return !empty($this->userID) && !empty($this->email);
-	}
-
-	public function getUserID(): ?string {
-		return $this->userID;
-	}
-
-	public function getEmail(): ?string {
-		return $this->email;
-	}
-
-	/**
-	 * Returns the authentication error message, if one has been set.
-	 */
-	public function getErrorMessage(): ?string {
-		return $this->errorMessage;
-	}
+	abstract public function login(): SocialIdentity;
 
 }

--- a/src/templates/Default/login/login_social_create.php
+++ b/src/templates/Default/login/login_social_create.php
@@ -3,10 +3,6 @@
 use Smr\Epoch;
 use Smr\Request;
 
-/**
- * @var Smr\SocialLogin\SocialLogin $SocialLogin
- */
-
 ?>
 <div class="centered" style="width: 630px;">
 	<h1>Link To Existing Login</h1>
@@ -62,13 +58,7 @@ use Smr\Request;
 				<tr>
 					<td width="27%">Verify Password (Optional):</td>
 					<td width="73%"><input type="password" name="pass_verify" size="20" maxlength="32" class="InputFields"></td>
-				</tr><?php
-				if (empty($SocialLogin->getEmail())) { ?>
-					<tr>
-						<td width="27%">Email:</td>
-						<td width="73%"><input type="email" name="email" size="20" maxlength="32" class="InputFields"></td>
-					</tr><?php
-				} ?>
+				</tr>
 				<tr>
 					<td width="27%">Local Time:</td>
 					<td width="73%">

--- a/test/SmrTest/lib/SocialLogin/SocialIdentityTest.php
+++ b/test/SmrTest/lib/SocialLogin/SocialIdentityTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\SocialLogin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Smr\Exceptions\UserError;
+use Smr\SocialLogin\SocialIdentity;
+
+#[CoversClass(SocialIdentity::class)]
+class SocialIdentityTest extends TestCase {
+
+	public function test_happy_path(): void {
+		$id = new SocialIdentity('foo', 'bar', 'baz');
+		self::assertSame('foo', $id->id);
+		self::assertSame('bar', $id->email);
+		self::assertSame('baz', $id->type);
+	}
+
+	#[TestWith(['', null])]
+	public function test_invalid_id(?string $id): void {
+		$this->expectException(UserError::class);
+		$this->expectExceptionMessage('Failed to retrieve your bar ID!');
+		new SocialIdentity($id, 'foo', 'bar');
+	}
+
+	#[TestWith(['', null])]
+	public function test_invalid_email(?string $email): void {
+		$this->expectException(UserError::class);
+		$this->expectExceptionMessage('An email address is required, but was not found!');
+		new SocialIdentity('foo', $email, 'bar');
+	}
+
+}


### PR DESCRIPTION
Separate the concepts of the social login machinery from the storage of social identity.

The new `SocialIdentity` class will be the output of social login, and will not be allowed to exist in an invalid state.

Also disallow social registration without an email. Previously we allowed manually specifying an email in this case, but I think we should insist that the email is provided by the social platform.