### PR TITLE
Enable strict SQL mode

### DIFF
--- a/db/patches/V1_6_68_11__strict_sql.sql
+++ b/db/patches/V1_6_68_11__strict_sql.sql
@@ -1,0 +1,2 @@
+-- Make changes needed to enable strict SQL mode
+ALTER TABLE `player` DROP COLUMN `attack_warning`;

--- a/db/patches/V1_6_68_11__strict_sql.sql
+++ b/db/patches/V1_6_68_11__strict_sql.sql
@@ -9,3 +9,7 @@ UPDATE `account` SET `password_reset` = NULL WHERE `password_reset` = '';
 ALTER TABLE `account` MODIFY `mail_banned` int unsigned NOT NULL DEFAULT 0;
 
 ALTER TABLE `alliance` MODIFY `img_src` varchar(255) NOT NULL DEFAULT '';
+
+ALTER TABLE `planet` MODIFY `password` varchar(32) NOT NULL DEFAULT '';
+
+ALTER TABLE `planet` DROP COLUMN `last_updated`;

--- a/db/patches/V1_6_68_11__strict_sql.sql
+++ b/db/patches/V1_6_68_11__strict_sql.sql
@@ -2,3 +2,6 @@
 ALTER TABLE `player` DROP COLUMN `attack_warning`;
 
 ALTER TABLE `player` MODIFY `last_port` int unsigned NOT NULL DEFAULT 0;
+
+ALTER TABLE `account` MODIFY `password_reset` char(32) DEFAULT NULL;
+UPDATE `account` SET `password_reset` = NULL WHERE `password_reset` = '';

--- a/db/patches/V1_6_68_11__strict_sql.sql
+++ b/db/patches/V1_6_68_11__strict_sql.sql
@@ -7,3 +7,5 @@ ALTER TABLE `account` MODIFY `password_reset` char(32) DEFAULT NULL;
 UPDATE `account` SET `password_reset` = NULL WHERE `password_reset` = '';
 
 ALTER TABLE `account` MODIFY `mail_banned` int unsigned NOT NULL DEFAULT 0;
+
+ALTER TABLE `alliance` MODIFY `img_src` varchar(255) NOT NULL DEFAULT '';

--- a/db/patches/V1_6_68_11__strict_sql.sql
+++ b/db/patches/V1_6_68_11__strict_sql.sql
@@ -5,3 +5,5 @@ ALTER TABLE `player` MODIFY `last_port` int unsigned NOT NULL DEFAULT 0;
 
 ALTER TABLE `account` MODIFY `password_reset` char(32) DEFAULT NULL;
 UPDATE `account` SET `password_reset` = NULL WHERE `password_reset` = '';
+
+ALTER TABLE `account` MODIFY `mail_banned` int unsigned NOT NULL DEFAULT 0;

--- a/db/patches/V1_6_68_11__strict_sql.sql
+++ b/db/patches/V1_6_68_11__strict_sql.sql
@@ -1,2 +1,4 @@
 -- Make changes needed to enable strict SQL mode
 ALTER TABLE `player` DROP COLUMN `attack_warning`;
+
+ALTER TABLE `player` MODIFY `last_port` int unsigned NOT NULL DEFAULT 0;

--- a/db/patches/V1_6_68_12__hof_signed_double.sql
+++ b/db/patches/V1_6_68_12__hof_signed_double.sql
@@ -1,0 +1,2 @@
+-- Remove unsigned attribute from `player_hof.amount`
+ALTER TABLE `player_hof` MODIFY `amount` double NOT NULL;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,10 +88,7 @@ x-mysql-common: &mysql-common
     secrets:
         - mysql-password
         - mysql-root-password
-    # The mysql:5.7+ docker default sql mode uses STRICT_TRANS_TABLES,
-    # which is incompatible with the way the SMR database is used.
-    # Therefore, we override CMD to omit this sql mode.
-    command: [ "mysqld", "--sql-mode=NO_ENGINE_SUBSTITUTION",
+    command: [ "mysqld",
                "--character-set-server=utf8",
                "--collation-server=utf8_general_ci" ]
     healthcheck:

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -2155,9 +2155,7 @@ abstract class AbstractPlayer {
 			// Don't store HOF for NPCs.
 			return;
 		}
-		if ($amount < 0) {
-			throw new Exception('Cannot set negative HOF stats');
-		}
+
 		if ($this->getHOF($typeList) === $amount) {
 			return;
 		}

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -81,7 +81,6 @@ abstract class AbstractPlayer {
 	protected array $tickers;
 	protected int $lastTurnUpdate;
 	protected int $lastNewsUpdate;
-	protected string $attackColour;
 	protected int $allianceJoinable;
 	protected int $lastPort;
 	protected int $bank;
@@ -308,7 +307,6 @@ abstract class AbstractPlayer {
 		$this->lastTurnUpdate = $dbRecord->getInt('last_turn_update');
 		$this->newbieTurns = $dbRecord->getInt('newbie_turns');
 		$this->lastNewsUpdate = $dbRecord->getInt('last_news_update');
-		$this->attackColour = $dbRecord->getString('attack_warning');
 		$this->dead = $dbRecord->getBoolean('dead');
 		$this->npc = $dbRecord->getBoolean('npc');
 		$this->newbieStatus = $dbRecord->getBoolean('newbie_status');
@@ -445,18 +443,6 @@ abstract class AbstractPlayer {
 			throw new Exception('Trying to decrease negative zoom.');
 		}
 		$this->setZoom($this->getZoom() - $zoom);
-	}
-
-	public function getAttackColour(): string {
-		return $this->attackColour;
-	}
-
-	public function setAttackColour(string $colour): void {
-		if ($this->attackColour === $colour) {
-			return;
-		}
-		$this->attackColour = $colour;
-		$this->hasChanged = true;
 	}
 
 	public function isIgnoreGlobals(): bool {
@@ -3216,7 +3202,6 @@ abstract class AbstractPlayer {
 					'last_turn_update' => $this->lastTurnUpdate,
 					'newbie_turns' => $this->newbieTurns,
 					'last_news_update' => $this->lastNewsUpdate,
-					'attack_warning' => $this->attackColour,
 					'dead' => $db->escapeBoolean($this->dead),
 					'newbie_status' => $db->escapeBoolean($this->newbieStatus),
 					'land_on_planet' => $db->escapeBoolean($this->landedOnPlanet),

--- a/src/lib/Smr/Account.php
+++ b/src/lib/Smr/Account.php
@@ -60,7 +60,7 @@ class Account {
 	protected int $offset;
 	protected bool $images;
 	protected int $fontSize;
-	protected string $passwordReset;
+	protected ?string $passwordReset;
 	protected int $points;
 	protected bool $useAJAX;
 	protected int $mailBanned;
@@ -259,7 +259,7 @@ class Account {
 			$this->images = $dbRecord->getBoolean('images');
 			$this->fontSize = $dbRecord->getInt('fontsize');
 
-			$this->passwordReset = $dbRecord->getString('password_reset');
+			$this->passwordReset = $dbRecord->getNullableString('password_reset');
 			$this->useAJAX = $dbRecord->getBoolean('use_ajax');
 			$this->mailBanned = $dbRecord->getInt('mail_banned');
 
@@ -1066,6 +1066,9 @@ class Account {
 	}
 
 	public function getPasswordReset(): string {
+		if ($this->passwordReset === null) {
+			throw new Exception('You must call generatePasswordReset() first');
+		}
 		return $this->passwordReset;
 	}
 

--- a/src/lib/Smr/Alliance.php
+++ b/src/lib/Smr/Alliance.php
@@ -160,6 +160,7 @@ class Alliance {
 				'alliance_name' => $name,
 				'alliance_password' => '',
 				'recruiting' => $db->escapeBoolean(false),
+				'`mod`' => '', // text columns can't have default values
 			]);
 		} finally {
 			$db->unlock();

--- a/src/lib/Smr/Session.php
+++ b/src/lib/Smr/Session.php
@@ -167,13 +167,13 @@ class Session {
 	public function update(): void {
 		$sessionVar = [$this->links, $this->currentPage, $this->requestData];
 		$db = Database::getInstance();
+		$data = [
+			'account_id' => $this->accountID,
+			'game_id' => $this->gameID,
+			'session_var' => $db->escapeObject($sessionVar, true),
+			'last_sn' => $this->SN,
+		];
 		if (!$this->generate) {
-			$data = [
-				'account_id' => $this->accountID,
-				'game_id' => $this->gameID,
-				'session_var' => $db->escapeObject($sessionVar, true),
-				'last_sn' => $this->SN,
-			];
 			$conditions = [
 				'session_id' => $this->sessionID,
 			];
@@ -189,11 +189,9 @@ class Session {
 				'game_id' => $this->gameID,
 			]);
 			$db->insert('active_session', [
+				...$data,
 				'session_id' => $this->sessionID,
-				'account_id' => $this->accountID,
-				'game_id' => $this->gameID,
 				'last_accessed' => Epoch::microtime(),
-				'session_var' => $db->escapeObject($sessionVar, true),
 			]);
 			$this->generate = false;
 		}

--- a/src/pages/Admin/IpViewResults.php
+++ b/src/pages/Admin/IpViewResults.php
@@ -42,7 +42,7 @@ class IpViewResults extends AccountPage {
 			//=========================================================
 
 			//we are listing ALL IPs
-			$dbResult = $db->read('SELECT * FROM account_has_ip GROUP BY ip, account_id ORDER BY ip');
+			$dbResult = $db->read('SELECT ip, account_id, host FROM account_has_ip GROUP BY ip, account_id, host ORDER BY ip');
 			$ip_array = [];
 			//make sure we have enough but not too mant to reduce lag
 			foreach ($dbResult->records() as $dbRecord) {
@@ -218,7 +218,7 @@ class IpViewResults extends AccountPage {
 				//=========================================================
 				// Wildcard IP search
 				//=========================================================
-				$dbResult = $db->read('SELECT * FROM account_has_ip WHERE ip LIKE :ip_like GROUP BY account_id, ip ORDER BY time DESC, ip', [
+				$dbResult = $db->read('SELECT ip, account_id, host, MAX(time) as time FROM account_has_ip WHERE ip LIKE :ip_like GROUP BY account_id, ip, host ORDER BY time DESC, ip', [
 					'ip_like' => $db->escapeString($variable),
 				]);
 				$summary = 'Listing all IPs LIKE ' . $variable;
@@ -227,7 +227,7 @@ class IpViewResults extends AccountPage {
 				//=========================================================
 				// Wildcard host search
 				//=========================================================
-				$dbResult = $db->read('SELECT * FROM account_has_ip WHERE host LIKE :host_like GROUP BY account_id, ip ORDER BY time, ip', [
+				$dbResult = $db->read('SELECT ip, account_id, host, MAX(time) as time FROM account_has_ip WHERE host LIKE :host_like GROUP BY account_id, ip, host ORDER BY time, ip', [
 					'host_like' => $db->escapeString($variable),
 				]);
 				$summary = 'Listing all hosts LIKE ' . $variable;

--- a/src/pages/Player/AllianceMessageBoard.php
+++ b/src/pages/Player/AllianceMessageBoard.php
@@ -74,7 +74,7 @@ class AllianceMessageBoard extends PlayerPage {
 				)
 			SELECT alliance_only, topic, thread_id, MAX(time) as sendtime, COUNT(reply_id) as num_replies, author_account_id
 			FROM t2
-			GROUP BY thread_id ORDER BY sendtime DESC
+			GROUP BY thread_id, author_account_id ORDER BY sendtime DESC
 		', [
 			'in_alliance' => $db->escapeBoolean($in_alliance),
 			'game_id' => $db->escapeNumber($alliance->getGameID()),


### PR DESCRIPTION
This helps to ensure that all queries behave in the expected way, and
respect the table/column definitions. For example, in non-strict mode,
if a column without a default value is omitted, MySQL will guess what
the default value should be and use that.