### PR TITLE
game_play.php: add note when there are no games

### DIFF
--- a/src/templates/Default/engine/Default/game_play.php
+++ b/src/templates/Default/engine/Default/game_play.php
@@ -85,6 +85,9 @@ You are ranked as <?php echo $this->doAn($UserRankName); ?> <a style="font-size:
 		</table><?php
 	} else {
 		?><p>You have joined all open games.</p><?php
+		if (!isset($Games['Play'])) { ?>
+			<p>A new game will be starting shortly. More information is available on the Discord server at <a href="<?php echo DISCORD_URL; ?>" target="discord"><?php echo DISCORD_URL; ?></a>. Thank you for your patience!<?php
+		}
 	} ?>
 </div>
 


### PR DESCRIPTION
In case the current game ends without one prepared to replace it, we want some way to direct players to get information about when the next game will start.

To achieve this, we add a note to the "Play Game" page if there is no active games and no games to join, with a link to the Discord server to get more information.

![image](https://github.com/smrealms/smr/assets/846186/c81f9ff1-1b12-43b8-8b8c-3529d5c0324e)
