### PR TITLE
Add configuration for CC addresses in Contact Form

### DIFF
--- a/config/config.specific.sample.php
+++ b/config/config.specific.sample.php
@@ -31,6 +31,9 @@ const SMTP_HOSTNAME = 'smtp';
 // E-mail addresses to receive bug reports
 const BUG_REPORT_TO_ADDRESSES = [];
 
+// E-mail addresses to CC on contact form submissions
+const CONTACT_FORM_CC_ADDRESSES = [];
+
 //const HISTORY_DATABASES = [
 //	'smr_classic_history' => 'old_account_id',
 //	'smr_12_history' => 'old_account_id2',

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,6 +24,7 @@ parameters:
 
     dynamicConstantNames:
         - BUG_REPORT_TO_ADDRESSES
+        - CONTACT_FORM_CC_ADDRESSES
         - ENABLE_BETA
         - ENABLE_DEBUG
         - ENABLE_LIBXML_ERRORS
@@ -92,6 +93,11 @@ parameters:
             paths:
                 - src/bootstrap.php
                 - src/pages/Account/BugReportProcessor.php
+        -
+            # https://github.com/phpstan/phpstan/issues/7520
+            message: '#Empty array passed to foreach.#'
+            path: src/pages/Account/ContactFormProcessor.php
+            count: 1
         -
             # https://github.com/thephpleague/oauth2-client/issues/897
             message: '#Parameter \#1 \$token of method .*::getResourceOwner\(\) expects .*AccessToken, .*AccessTokenInterface given.#'

--- a/src/pages/Account/ContactFormProcessor.php
+++ b/src/pages/Account/ContactFormProcessor.php
@@ -22,6 +22,9 @@ class ContactFormProcessor extends AccountPageProcessor {
 			'Account ID:' . EOL . '-----------' . EOL . $account->getAccountID() . EOL . EOL .
 			'Message:' . EOL . '------------' . EOL . $msg;
 		$mail->addAddress($receiver);
+		foreach (CONTACT_FORM_CC_ADDRESSES as $ccAddress) {
+			$mail->addCC($ccAddress);
+		}
 		$mail->send();
 
 		$message = 'Your message has been successfully submitted!';


### PR DESCRIPTION
This is a necessity in part because the `@smrealms.de` mailbox is overwhelmed with spam. But even if it weren't, this would allow for more prompt responses to submissions (e.g. CC'ing a personal email address that is monitored much more frequently than the official mailbox).