### PR TITLE
Update codecov-action from v3 to v4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,9 +66,12 @@ jobs:
         run: composer phpunit
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: test/coverage/clover.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
 
   phpstan:
     name: PHPStan


### PR DESCRIPTION
We need to specify the token due to rate limiting of their global upload token.

We also want the workflow to fail if we can't upload the coverage report for any reason. Otherwise, it is too easy to overlook the absence of coverage data.