### PR TITLE
Upgrade to PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,8 +82,8 @@
 		"fig-r/psr2r-sniffer": "2.1.0",
 		"overtrue/phplint": "9.3.1",
 		"phpstan/phpstan": "1.11.8",
-		"phpunit/phpunit": "10.5.24",
-		"phpunit/php-code-coverage": "10.1.14",
+		"phpunit/phpunit": "11.2.6",
+		"phpunit/php-code-coverage": "11.0.5",
 		"rector/rector": "0.15.13",
 		"squizlabs/php_codesniffer": "3.10.1"
 	}

--- a/test/SmrTest/Container/ResettableContainerTraitTest.php
+++ b/test/SmrTest/Container/ResettableContainerTraitTest.php
@@ -2,12 +2,12 @@
 
 namespace SmrTest\Container;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\ResettableContainer;
 use Smr\Container\ResettableContainerTrait;
 
-#[CoversClass(ResettableContainerTrait::class)]
+#[CoversTrait(ResettableContainerTrait::class)]
 class ResettableContainerTraitTest extends TestCase {
 
 	public function test_not_initialized_by_definition(): void {

--- a/test/SmrTest/lib/Routes/RouteGeneratorTest.php
+++ b/test/SmrTest/lib/Routes/RouteGeneratorTest.php
@@ -32,7 +32,7 @@ class RouteGeneratorTest extends TestCase {
 		foreach ($goods as $goodID => [$_, $distance]) {
 			$getGoodDistanceMap[] = [$goodID, $distance];
 		}
-		$port->method('getGoodDistance')->will(self::returnValueMap($getGoodDistanceMap));
+		$port->method('getGoodDistance')->willReturnMap($getGoodDistanceMap);
 
 		// We could call `setRaceID` instead, but `raceID` is not initialized
 		$port->method('getRaceID')->willReturn($raceID);


### PR DESCRIPTION
Address deprecation warnings:

> Targeting a trait such as Smr\Container\ResettableContainerTrait with #[CoversClass] is deprecated, please refactor your test to use #[CoversTrait] instead.

> returnValueMap() is deprecated and will be removed in PHPUnit 12. Use $double->willReturnMap() instead of $double->will($this->returnValueMap())