### PR TITLE
Fix Dockerfile check from GitHub Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine as builder
+FROM node:alpine AS builder
 
 WORKDIR /smr/
 

--- a/api-docs/Dockerfile
+++ b/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3.8-cli-alpine as builder
+FROM php:8.3.8-cli-alpine AS builder
 
 RUN curl -L -O https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.5.0/phpDocumentor.phar
 RUN chmod +x phpDocumentor.phar


### PR DESCRIPTION
> The 'as' keyword should match the case of the 'from' keyword
> FromAsCasing: 'as' and 'FROM' keywords' casing do not match
> More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/