### PR TITLE
Handle overflow in anon bank deposits

### DIFF
--- a/src/pages/Player/Bank/AnonBankDetailProcessor.php
+++ b/src/pages/Player/Bank/AnonBankDetailProcessor.php
@@ -49,7 +49,7 @@ class AnonBankDetailProcessor extends PlayerPageProcessor {
 				create_error('You don\'t own that much money!');
 			}
 			$amount = min($amount, MAX_MONEY - $anonAmount); // handle overflow
-			if ($amount == 0) {
+			if ($amount === 0) {
 				create_error('This account has reached the maximum credit limit!');
 			}
 


### PR DESCRIPTION
When depositing into an anon account, the database would overflow if the amount in the account would exceed MAX_MONEY. Now, the deposit will be adjusted so that it doesn't exceed MAX_MONEY, and if the account is already at MAX_MONEY, it will emit a comprehensible error.