### PR TITLE
api-docs: fix phpDocumentor version in Dockerfile

### DIFF
--- a/.github/actions/api-docs/Dockerfile
+++ b/.github/actions/api-docs/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.3.8-cli-alpine
 
-RUN curl -L -O https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.4.1/phpDocumentor.phar
+RUN curl -L -O https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.5.3/phpDocumentor.phar
 RUN chmod +x phpDocumentor.phar
 RUN mv phpDocumentor.phar /usr/local/bin/phpdoc
 


### PR DESCRIPTION
This version update should have taken place in #1968.