### PR TITLE
Fix implicitly nullable function arguments

### DIFF
--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -192,7 +192,7 @@ function inify(string $text): string {
 	return str_replace(',', '', html_entity_decode($text));
 }
 
-function bbify(string $message, int $gameID = null, bool $noLinks = false): string {
+function bbify(string $message, ?int $gameID = null, bool $noLinks = false): string {
 	static $bbParser;
 	if (!isset($bbParser)) {
 		$bbParser = new BBCode();
@@ -281,7 +281,7 @@ function handleUserError(string $message): never {
 	$container->go();
 }
 
-function create_link(Page|string $container, string $text, string $class = null): string {
+function create_link(Page|string $container, string $text, ?string $class = null): string {
 	return '<a' . ($class === null ? '' : ' class="' . $class . '"') . ' href="' . (is_string($container) ? $container : $container->href()) . '">' . $text . '</a>';
 }
 
@@ -289,7 +289,7 @@ function create_submit_link(Page $container, string $text): string {
 	return '<a href="' . $container->href() . '" class="submitStyle">' . $text . '</a>';
 }
 
-function get_colored_text_range(float $value, int $maxValue, string $text = null, int $minValue = 0): string {
+function get_colored_text_range(float $value, int $maxValue, ?string $text = null, int $minValue = 0): string {
 	if ($text === null) {
 		$text = number_format($value);
 	}
@@ -317,7 +317,7 @@ function get_colored_text_range(float $value, int $maxValue, string $text = null
 	return '<span style="color:#' . $colour . '">' . $text . '</span>';
 }
 
-function get_colored_text(float $value, string $text = null): string {
+function get_colored_text(float $value, ?string $text = null): string {
 	return get_colored_text_range($value, 300, $text, -300);
 }
 

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -245,7 +245,7 @@ abstract class AbstractPlayer {
 		return self::$CACHE_ALLIANCE_PLAYERS[$gameID][$allianceID];
 	}
 
-	public static function getPlayer(int $accountID, int $gameID, bool $forceUpdate = false, DatabaseRecord $dbRecord = null): Player {
+	public static function getPlayer(int $accountID, int $gameID, bool $forceUpdate = false, ?DatabaseRecord $dbRecord = null): Player {
 		if ($forceUpdate || !isset(self::$CACHE_PLAYERS[$gameID][$accountID])) {
 			self::$CACHE_PLAYERS[$gameID][$accountID] = new Player($gameID, $accountID, $dbRecord);
 		}
@@ -281,7 +281,7 @@ abstract class AbstractPlayer {
 	protected function __construct(
 		protected readonly int $gameID,
 		protected readonly int $accountID,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$db = Database::getInstance();
 		$this->SQLID = [
@@ -834,7 +834,7 @@ abstract class AbstractPlayer {
 	/**
 	 * @return ($canBeIgnored is true ? int|false : int) Message ID
 	 */
-	public function sendMessage(int $receiverID, int $messageTypeID, string $message, bool $canBeIgnored = true, bool $unread = true, int $expires = null, bool $senderDelete = false): int|false {
+	public function sendMessage(int $receiverID, int $messageTypeID, string $message, bool $canBeIgnored = true, bool $unread = true, ?int $expires = null, bool $senderDelete = false): int|false {
 		//get expire time
 		if ($canBeIgnored) {
 			if ($this->getAccount()->isMailBanned()) {
@@ -878,7 +878,7 @@ abstract class AbstractPlayer {
 		return self::doMessageSending($this->getAccountID(), $receiverID, $this->getGameID(), $messageTypeID, $message, $expires, $senderDelete, $unread);
 	}
 
-	public function sendMessageFromOpAnnounce(int $receiverID, string $message, int $expires = null): void {
+	public function sendMessageFromOpAnnounce(int $receiverID, string $message, ?int $expires = null): void {
 		// get expire time if not set
 		if ($expires === null) {
 			$expires = Epoch::time() + 86400 * 14;
@@ -910,7 +910,7 @@ abstract class AbstractPlayer {
 		self::doMessageSending(ACCOUNT_ID_FED_CLERK, $receiverID, $gameID, MSG_PLAYER, $message, $expires);
 	}
 
-	public static function sendMessageFromAdmin(int $gameID, int $receiverID, string $message, int $expires = null): void {
+	public static function sendMessageFromAdmin(int $gameID, int $receiverID, string $message, ?int $expires = null): void {
 		//get expire time
 		if ($expires === null) {
 			$expires = Epoch::time() + 86400 * 365;
@@ -919,7 +919,7 @@ abstract class AbstractPlayer {
 		self::doMessageSending(ACCOUNT_ID_ADMIN, $receiverID, $gameID, MSG_ADMIN, $message, $expires);
 	}
 
-	public static function sendMessageFromAllianceAmbassador(int $gameID, int $receiverID, string $message, int $expires = null): void {
+	public static function sendMessageFromAllianceAmbassador(int $gameID, int $receiverID, string $message, ?int $expires = null): void {
 		//get expire time
 		if ($expires === null) {
 			$expires = Epoch::time() + 86400 * 31;
@@ -928,7 +928,7 @@ abstract class AbstractPlayer {
 		self::doMessageSending(ACCOUNT_ID_ALLIANCE_AMBASSADOR, $receiverID, $gameID, MSG_ALLIANCE, $message, $expires);
 	}
 
-	public function sendMessageFromCasino(string $message, int $expires = null): void {
+	public function sendMessageFromCasino(string $message, ?int $expires = null): void {
 		//get expire time
 		if ($expires === null) {
 			$expires = Epoch::time() + 86400 * 7;
@@ -937,7 +937,7 @@ abstract class AbstractPlayer {
 		self::doMessageSending(ACCOUNT_ID_CASINO, $this->getAccountID(), $this->getGameID(), MSG_CASINO, $message, $expires);
 	}
 
-	public static function sendMessageFromRace(int $raceID, int $gameID, int $receiverID, string $message, int $expires = null): void {
+	public static function sendMessageFromRace(int $raceID, int $gameID, int $receiverID, string $message, ?int $expires = null): void {
 		//get expire time
 		if ($expires === null) {
 			$expires = Epoch::time() + 86400 * 5;
@@ -1433,7 +1433,7 @@ abstract class AbstractPlayer {
 		return !$this->isRaceChanged() && (Epoch::time() - $this->getGame()->getStartTime() < TIME_FOR_RACE_CHANGE);
 	}
 
-	public static function getColouredRaceNameOrDefault(int $otherRaceID, self $player = null, bool $linked = false): string {
+	public static function getColouredRaceNameOrDefault(int $otherRaceID, ?self $player = null, bool $linked = false): string {
 		$relations = 0;
 		if ($player !== null) {
 			$relations = $player->getRelation($otherRaceID);
@@ -1491,7 +1491,7 @@ abstract class AbstractPlayer {
 		return $this->getAlliance()->getAllianceDisplayName($linked, $includeAllianceID);
 	}
 
-	public function getAllianceRole(int $allianceID = null): int {
+	public function getAllianceRole(?int $allianceID = null): int {
 		if ($allianceID === null) {
 			$allianceID = $this->getAllianceID();
 		}
@@ -1512,7 +1512,7 @@ abstract class AbstractPlayer {
 		return $this->allianceRoles[$allianceID];
 	}
 
-	public function leaveAlliance(self $kickedBy = null): void {
+	public function leaveAlliance(?self $kickedBy = null): void {
 		$alliance = $this->getAlliance();
 		if ($kickedBy !== null) {
 			$kickedBy->sendMessage($this->getAccountID(), MSG_PLAYER, 'You were kicked out of the alliance!', false);

--- a/src/lib/Smr/AbstractShip.php
+++ b/src/lib/Smr/AbstractShip.php
@@ -468,7 +468,7 @@ class AbstractShip {
 	/**
 	 * @return ($hardwareTypeID is null ? array<int, int> : int)
 	 */
-	public function getHardware(int $hardwareTypeID = null): array|int {
+	public function getHardware(?int $hardwareTypeID = null): array|int {
 		if ($hardwareTypeID === null) {
 			return $this->hardware;
 		}
@@ -646,14 +646,14 @@ class AbstractShip {
 	/**
 	 * @return ($goodID is null ? array<int, int> : int)
 	 */
-	public function getCargo(int $goodID = null): int|array {
+	public function getCargo(?int $goodID = null): int|array {
 		if ($goodID === null) {
 			return $this->cargo;
 		}
 		return $this->cargo[$goodID] ?? 0;
 	}
 
-	public function hasCargo(int $goodID = null): bool {
+	public function hasCargo(?int $goodID = null): bool {
 		if ($goodID === null) {
 			return $this->getUsedHolds() > 0;
 		}

--- a/src/lib/Smr/Account.php
+++ b/src/lib/Smr/Account.php
@@ -509,7 +509,7 @@ class Account {
 	/**
 	 * @return array<array{Stat: array<string>, Score: float}>
 	 */
-	public function getIndividualScores(Player $player = null): array {
+	public function getIndividualScores(?Player $player = null): array {
 		$gameID = 0;
 		if ($player !== null) {
 			$gameID = $player->getGameID();
@@ -767,7 +767,7 @@ class Account {
 	/**
 	 * Perform basic sanity checks on the usability of an email address.
 	 */
-	public static function checkEmail(string $email, self $owner = null): void {
+	public static function checkEmail(string $email, ?self $owner = null): void {
 		if ($email === '') {
 			throw new UserError('Email address is missing!');
 		}
@@ -1143,7 +1143,7 @@ class Account {
 	/**
 	 * @return ($hotkeyType is null ? array<string, array<string>> : array<string>)
 	 */
-	public function getHotkeys(string $hotkeyType = null): array {
+	public function getHotkeys(?string $hotkeyType = null): array {
 		if ($hotkeyType !== null) {
 			return $this->hotkeys[$hotkeyType] ?? [];
 		}
@@ -1245,7 +1245,7 @@ class Account {
 		return $this->permissions;
 	}
 
-	public function hasPermission(int $permissionID = null): bool {
+	public function hasPermission(?int $permissionID = null): bool {
 		$permissions = $this->getPermissions();
 		if ($permissionID === null) {
 			return count($permissions) > 0;
@@ -1414,7 +1414,7 @@ class Account {
 		}
 	}
 
-	public function unbanAccount(self $admin = null, string $currException = null): void {
+	public function unbanAccount(?self $admin = null, ?string $currException = null): void {
 		$adminID = 0;
 		if ($admin !== null) {
 			$adminID = $admin->getAccountID();

--- a/src/lib/Smr/Album.php
+++ b/src/lib/Smr/Album.php
@@ -67,7 +67,7 @@ readonly class Album {
 
 	public function __construct(
 		public int $accountID,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$db = Database::getInstance();
 		if ($dbRecord === null) {

--- a/src/lib/Smr/Alliance.php
+++ b/src/lib/Smr/Alliance.php
@@ -48,7 +48,7 @@ class Alliance {
 		self::$CACHE_ALLIANCES = [];
 	}
 
-	public static function getAlliance(int $allianceID, int $gameID, bool $forceUpdate = false, DatabaseRecord $dbRecord = null): self {
+	public static function getAlliance(int $allianceID, int $gameID, bool $forceUpdate = false, ?DatabaseRecord $dbRecord = null): self {
 		if ($forceUpdate || !isset(self::$CACHE_ALLIANCES[$gameID][$allianceID])) {
 			self::$CACHE_ALLIANCES[$gameID][$allianceID] = new self($allianceID, $gameID, $dbRecord);
 		}
@@ -96,7 +96,7 @@ class Alliance {
 	protected function __construct(
 		protected readonly int $allianceID,
 		protected readonly int $gameID,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$db = Database::getInstance();
 		$this->SQLID = [
@@ -412,7 +412,7 @@ class Alliance {
 		return htmlentities($this->description);
 	}
 
-	public function setAllianceDescription(string $description, AbstractPlayer $player = null): void {
+	public function setAllianceDescription(string $description, ?AbstractPlayer $player = null): void {
 		$description = word_filter($description);
 		if ($description === $this->description) {
 			return;

--- a/src/lib/Smr/Combat/Weapon/Weapon.php
+++ b/src/lib/Smr/Combat/Weapon/Weapon.php
@@ -32,13 +32,13 @@ class Weapon extends AbstractWeapon {
 	protected bool $bonusDamage = false; // default
 	protected bool $damageRollover = false; // fixed for all Weapons
 
-	public static function getWeapon(int $weaponTypeID, DatabaseRecord $dbRecord = null): self {
+	public static function getWeapon(int $weaponTypeID, ?DatabaseRecord $dbRecord = null): self {
 		return new self($weaponTypeID, $dbRecord);
 	}
 
 	protected function __construct(
 		protected readonly int $weaponTypeID,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$this->weaponType = WeaponType::getWeaponType($weaponTypeID, $dbRecord);
 		$this->raceID = $this->weaponType->getRaceID();

--- a/src/lib/Smr/Force.php
+++ b/src/lib/Smr/Force.php
@@ -104,7 +104,7 @@ class Force {
 		return self::$CACHE_SECTOR_FORCES[$gameID][$sectorID];
 	}
 
-	public static function getForce(int $gameID, int $sectorID, int $ownerID, bool $forceUpdate = false, DatabaseRecord $dbRecord = null): self {
+	public static function getForce(int $gameID, int $sectorID, int $ownerID, bool $forceUpdate = false, ?DatabaseRecord $dbRecord = null): self {
 		if ($forceUpdate || !isset(self::$CACHE_FORCES[$gameID][$sectorID][$ownerID])) {
 			self::tidyUpForces(Galaxy::getGalaxyContaining($gameID, $sectorID));
 			$p = new self($gameID, $sectorID, $ownerID, $dbRecord);
@@ -145,7 +145,7 @@ class Force {
 		protected readonly int $gameID,
 		protected readonly int $sectorID,
 		protected readonly int $ownerID,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$db = Database::getInstance();
 		$this->SQLID = [

--- a/src/lib/Smr/Galaxy.php
+++ b/src/lib/Smr/Galaxy.php
@@ -55,7 +55,7 @@ class Galaxy {
 		return self::$CACHE_GAME_GALAXIES[$gameID];
 	}
 
-	public static function getGalaxy(int $gameID, int $galaxyID, bool $forceUpdate = false, DatabaseRecord $dbRecord = null): self {
+	public static function getGalaxy(int $gameID, int $galaxyID, bool $forceUpdate = false, ?DatabaseRecord $dbRecord = null): self {
 		if ($forceUpdate || !isset(self::$CACHE_GALAXIES[$gameID][$galaxyID])) {
 			$g = new self($gameID, $galaxyID, false, $dbRecord);
 			self::$CACHE_GALAXIES[$gameID][$galaxyID] = $g;
@@ -83,7 +83,7 @@ class Galaxy {
 		protected readonly int $gameID,
 		protected readonly int $galaxyID,
 		bool $create = false,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$db = Database::getInstance();
 		$this->SQLID = [
@@ -270,7 +270,7 @@ class Galaxy {
 	 *
 	 * @return array<int, array<int, Sector>>
 	 */
-	public function getMapSectors(int $centerSectorID = null, int $dist = null): array {
+	public function getMapSectors(?int $centerSectorID = null, ?int $dist = null): array {
 		if ($centerSectorID === null) {
 			$topLeft = Sector::getSector($this->getGameID(), $this->getStartSector());
 		} else {

--- a/src/lib/Smr/Globals.php
+++ b/src/lib/Smr/Globals.php
@@ -206,14 +206,14 @@ class Globals {
 		return self::$AVAILABLE_LINKS['Scan' . $player->getSector()->getSectorDirection($toSector)] = $container->href();
 	}
 
-	public static function getPlotCourseHREF(int $fromSector = null, int $toSector = null): string {
+	public static function getPlotCourseHREF(?int $fromSector = null, ?int $toSector = null): string {
 		if ($fromSector === null && $toSector === null) {
 			return self::$AVAILABLE_LINKS['PlotCourse'] = (new PlotCourse())->href();
 		}
 		return (new PlotCourseConventionalProcessor(from: $fromSector, to: $toSector))->href();
 	}
 
-	public static function getAllianceHREF(int $allianceID = null): string {
+	public static function getAllianceHREF(?int $allianceID = null): string {
 		if ($allianceID > 0) {
 			return self::getAllianceMotdHREF($allianceID);
 		}
@@ -225,7 +225,7 @@ class Globals {
 		return $container->href();
 	}
 
-	public static function getAllianceRosterHREF(int $allianceID = null): string {
+	public static function getAllianceRosterHREF(?int $allianceID = null): string {
 		return (new AllianceRoster($allianceID))->href();
 	}
 

--- a/src/lib/Smr/Location.php
+++ b/src/lib/Smr/Location.php
@@ -152,7 +152,7 @@ class Location {
 		self::$CACHE_SECTOR_LOCATIONS[$gameID][$sectorID] = [];
 	}
 
-	public static function getLocation(int $gameID, int $locationTypeID, bool $forceUpdate = false, DatabaseRecord $dbRecord = null): self {
+	public static function getLocation(int $gameID, int $locationTypeID, bool $forceUpdate = false, ?DatabaseRecord $dbRecord = null): self {
 		if ($forceUpdate || !isset(self::$CACHE_LOCATIONS[$locationTypeID])) {
 			self::$CACHE_LOCATIONS[$locationTypeID] = new self($gameID, $locationTypeID, $dbRecord);
 		}
@@ -162,7 +162,7 @@ class Location {
 	protected function __construct(
 		protected readonly int $gameID, // use 0 to be independent of game
 		protected readonly int $typeID,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$db = Database::getInstance();
 		$this->SQLID = ['location_type_id' => $db->escapeNumber($typeID)];
@@ -358,7 +358,7 @@ class Location {
 		return $this->hardwareSold;
 	}
 
-	public function isHardwareSold(int $hardwareTypeID = null): bool {
+	public function isHardwareSold(?int $hardwareTypeID = null): bool {
 		$hardware = $this->getHardwareSold();
 		if ($hardwareTypeID === null) {
 			return count($hardware) !== 0;
@@ -422,7 +422,7 @@ class Location {
 		return $this->shipsSold;
 	}
 
-	public function isShipSold(int $shipTypeID = null): bool {
+	public function isShipSold(?int $shipTypeID = null): bool {
 		$ships = $this->getShipsSold();
 		if ($shipTypeID === null) {
 			return count($ships) !== 0;
@@ -471,7 +471,7 @@ class Location {
 		return $this->weaponsSold;
 	}
 
-	public function isWeaponSold(int $weaponTypeID = null): bool {
+	public function isWeaponSold(?int $weaponTypeID = null): bool {
 		$weapons = $this->getWeaponsSold();
 		if ($weaponTypeID === null) {
 			return count($weapons) !== 0;
@@ -547,7 +547,7 @@ class Location {
 		return $this->getTypeID() === $otherLocation->getTypeID();
 	}
 
-	public function hasX(mixed $x, AbstractPlayer $player = null): bool {
+	public function hasX(mixed $x, ?AbstractPlayer $player = null): bool {
 		if ($x instanceof WeaponType) {
 			return $this->isWeaponSold($x->getWeaponTypeID());
 		}

--- a/src/lib/Smr/Messages.php
+++ b/src/lib/Smr/Messages.php
@@ -12,7 +12,7 @@ class Messages {
 	/**
 	 * @return ($typeID is null ? array<int, string> : string)
 	 */
-	public static function getMessageTypeNames(int $typeID = null): array|string {
+	public static function getMessageTypeNames(?int $typeID = null): array|string {
 		$typeNames = [
 			MSG_PLAYER => 'Player Messages',
 			MSG_PLANET => 'Planet Messages',
@@ -55,7 +55,7 @@ class Messages {
 		];
 	}
 
-	public static function getMessagePlayer(int $accountID, int $gameID, int $messageType = null): string|Player {
+	public static function getMessagePlayer(int $accountID, int $gameID, ?int $messageType = null): string|Player {
 		if ($accountID === ACCOUNT_ID_PORT) {
 			$return = '<span class="yellow">Port Defenses</span>';
 		} elseif ($accountID === ACCOUNT_ID_ADMIN) {

--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -94,14 +94,14 @@ class Planet {
 		return $galaxyPlanets;
 	}
 
-	public static function getPlanet(int $gameID, int $sectorID, bool $forceUpdate = false, DatabaseRecord $dbRecord = null): self {
+	public static function getPlanet(int $gameID, int $sectorID, bool $forceUpdate = false, ?DatabaseRecord $dbRecord = null): self {
 		if ($forceUpdate || !isset(self::$CACHE_PLANETS[$gameID][$sectorID])) {
 			self::$CACHE_PLANETS[$gameID][$sectorID] = new self($gameID, $sectorID, $dbRecord);
 		}
 		return self::$CACHE_PLANETS[$gameID][$sectorID];
 	}
 
-	public static function createPlanet(int $gameID, int $sectorID, int $typeID = 1, int $inhabitableTime = null): self {
+	public static function createPlanet(int $gameID, int $sectorID, int $typeID = 1, ?int $inhabitableTime = null): self {
 		if (self::getPlanet($gameID, $sectorID)->exists()) {
 			throw new Exception('Planet already exists in sector ' . $sectorID . ' game ' . $gameID);
 		}
@@ -142,7 +142,7 @@ class Planet {
 	protected function __construct(
 		protected readonly int $gameID,
 		protected readonly int $sectorID,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$db = Database::getInstance();
 		$this->SQLID = [
@@ -582,7 +582,7 @@ class Planet {
 	/**
 	 * @return ($goodID is null ? array<int, int> : int)
 	 */
-	public function getStockpile(int $goodID = null): int|array {
+	public function getStockpile(?int $goodID = null): int|array {
 		if (!isset($this->stockpile)) {
 			// initialize cargo array
 			$this->stockpile = [];
@@ -603,7 +603,7 @@ class Planet {
 		return 0;
 	}
 
-	public function hasStockpile(int $goodID = null): bool {
+	public function hasStockpile(?int $goodID = null): bool {
 		if ($goodID === null) {
 			$stockpile = $this->getStockpile();
 			return count($stockpile) > 0 && max($stockpile) > 0;
@@ -736,7 +736,7 @@ class Planet {
 	/**
 	 * @return ($buildingTypeID is null ? array<int, int> : int)
 	 */
-	public function getMaxBuildings(int $buildingTypeID = null): int|array {
+	public function getMaxBuildings(?int $buildingTypeID = null): int|array {
 		if ($buildingTypeID === null) {
 			$maxBuildings = [];
 			foreach ($this->getStructureTypes() as $ID => $type) {
@@ -801,7 +801,7 @@ class Planet {
 	/**
 	 * @return ($structureID is null ? array<int, PlanetStructureType> : PlanetStructureType)
 	 */
-	public function getStructureTypes(int $structureID = null): PlanetStructureType|array {
+	public function getStructureTypes(?int $structureID = null): PlanetStructureType|array {
 		return $this->typeInfo->structureTypes($structureID);
 	}
 

--- a/src/lib/Smr/PlanetTypes/PlanetType.php
+++ b/src/lib/Smr/PlanetTypes/PlanetType.php
@@ -66,7 +66,7 @@ abstract class PlanetType {
 	 *
 	 * @return \Smr\PlanetStructureType|array<int, PlanetStructureType>
 	 */
-	public function structureTypes(int $structureID = null): PlanetStructureType|array {
+	public function structureTypes(?int $structureID = null): PlanetStructureType|array {
 		if (!isset($this->structures)) {
 			foreach ($this->getStructureData() as $ID => $Info) {
 				$this->structures[$ID] = new PlanetStructureType($ID, $Info);

--- a/src/lib/Smr/Plotter.php
+++ b/src/lib/Smr/Plotter.php
@@ -7,7 +7,7 @@ use Smr\Exceptions\PathNotFound;
 
 class Plotter {
 
-	public static function getX(PlotGroup $xType, int|string $X, int $gameID, AbstractPlayer $player = null): mixed {
+	public static function getX(PlotGroup $xType, int|string $X, int $gameID, ?AbstractPlayer $player = null): mixed {
 		// Special case for Location categories (i.e. Bar, HQ, SafeFed)
 		if (!is_numeric($X)) {
 			if ($xType !== PlotGroup::Locations) {
@@ -51,7 +51,7 @@ class Plotter {
 	 *
 	 * @throws \Smr\Exceptions\PathNotFound
 	 */
-	public static function findReversiblePathToX(mixed $x, Sector $sector, AbstractPlayer $needsToHaveBeenExploredBy = null, AbstractPlayer $player = null): Path {
+	public static function findReversiblePathToX(mixed $x, Sector $sector, ?AbstractPlayer $needsToHaveBeenExploredBy = null, ?AbstractPlayer $player = null): Path {
 		if ($x instanceof Sector) {
 
 			// To ensure reversibility, always plot lowest to highest.
@@ -99,7 +99,7 @@ class Plotter {
 	 * @throws \Smr\Exceptions\PathNotFound
 	 * @return ($useFirst is true ? Path : array<int, Path>)
 	 */
-	public static function findDistanceToX(mixed $x, Sector $sector, bool $useFirst, AbstractPlayer $needsToHaveBeenExploredBy = null, AbstractPlayer $player = null, int $distanceLimit = 10000, int $lowLimit = 0, int $highLimit = 100000): array|Path {
+	public static function findDistanceToX(mixed $x, Sector $sector, bool $useFirst, ?AbstractPlayer $needsToHaveBeenExploredBy = null, ?AbstractPlayer $player = null, int $distanceLimit = 10000, int $lowLimit = 0, int $highLimit = 100000): array|Path {
 		$warpAddIndex = TURNS_WARP_SECTOR_EQUIVALENCE - 1;
 
 		$checkSector = $sector;

--- a/src/lib/Smr/Port.php
+++ b/src/lib/Smr/Port.php
@@ -106,7 +106,7 @@ class Port {
 		return $galaxyPorts;
 	}
 
-	public static function getPort(int $gameID, int $sectorID, bool $forceUpdate = false, DatabaseRecord $dbRecord = null): self {
+	public static function getPort(int $gameID, int $sectorID, bool $forceUpdate = false, ?DatabaseRecord $dbRecord = null): self {
 		if ($forceUpdate || !isset(self::$CACHE_PORTS[$gameID][$sectorID])) {
 			self::$CACHE_PORTS[$gameID][$sectorID] = new self($gameID, $sectorID, $dbRecord);
 		}
@@ -150,7 +150,7 @@ class Port {
 	protected function __construct(
 		protected readonly int $gameID,
 		protected readonly int $sectorID,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$this->cachedTime = Epoch::time();
 		$db = Database::getInstance();
@@ -272,7 +272,7 @@ class Port {
 	 * @param array<int> $goodIDs
 	 * @return array<int, TradeGood>
 	 */
-	private function getVisibleGoods(array $goodIDs, AbstractPlayer $player = null): array {
+	private function getVisibleGoods(array $goodIDs, ?AbstractPlayer $player = null): array {
 		$visibleGoods = [];
 		foreach ($goodIDs as $goodID) {
 			$good = TradeGood::get($goodID);
@@ -288,7 +288,7 @@ class Port {
 	 *
 	 * @return array<int, TradeGood>
 	 */
-	public function getVisibleGoodsSold(AbstractPlayer $player = null): array {
+	public function getVisibleGoodsSold(?AbstractPlayer $player = null): array {
 		return $this->getVisibleGoods($this->getSellGoodIDs(), $player);
 	}
 
@@ -297,7 +297,7 @@ class Port {
 	 *
 	 * @return array<int, TradeGood>
 	 */
-	public function getVisibleGoodsBought(AbstractPlayer $player = null): array {
+	public function getVisibleGoodsBought(?AbstractPlayer $player = null): array {
 		return $this->getVisibleGoods($this->getBuyGoodIDs(), $player);
 	}
 
@@ -482,7 +482,7 @@ class Port {
 	 * If no level specified, will use the current port level.
 	 * This is useful for determining what trade goods to add/remove.
 	 */
-	protected function getGoodClassAtLevel(int $level = null): int {
+	protected function getGoodClassAtLevel(?int $level = null): int {
 		if ($level === null) {
 			$level = $this->getLevel();
 		}

--- a/src/lib/Smr/Request.php
+++ b/src/lib/Smr/Request.php
@@ -22,7 +22,7 @@ class Request {
 	/**
 	 * Returns index value as a boolean for boolean-like inputs.
 	 */
-	public static function getBool(string $index, bool $default = null): bool {
+	public static function getBool(string $index, ?bool $default = null): bool {
 		if (self::has($index)) {
 			$bool = filter_var($_REQUEST[$index], FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
 			if ($bool === null) {
@@ -39,7 +39,7 @@ class Request {
 	/**
 	 * Returns index value as an integer.
 	 */
-	public static function getInt(string $index, int $default = null): int {
+	public static function getInt(string $index, ?int $default = null): int {
 		if (self::has($index)) {
 			return (int)$_REQUEST[$index];
 		}
@@ -52,7 +52,7 @@ class Request {
 	/**
 	 * Returns index value as a float.
 	 */
-	public static function getFloat(string $index, float $default = null): float {
+	public static function getFloat(string $index, ?float $default = null): float {
 		if (self::has($index)) {
 			return (float)$_REQUEST[$index];
 		}
@@ -68,7 +68,7 @@ class Request {
 	 * @param ?array<int, string> $default
 	 * @return array<int, string>
 	 */
-	public static function getArray(string $index, array $default = null): array {
+	public static function getArray(string $index, ?array $default = null): array {
 		if (self::has($index)) {
 			foreach ($_REQUEST[$index] as $key => $value) {
 				// String keys are legal HTML, but we do not allow them
@@ -91,7 +91,7 @@ class Request {
 	 * @param ?array<int, int> $default
 	 * @return array<int, int>
 	 */
-	public static function getIntArray(string $index, array $default = null): array {
+	public static function getIntArray(string $index, ?array $default = null): array {
 		if (self::has($index)) {
 			$result = [];
 			foreach ($_REQUEST[$index] as $key => $value) {
@@ -112,7 +112,7 @@ class Request {
 	/**
 	 * Returns index value as a (trimmed) string.
 	 */
-	public static function get(string $index, string $default = null): string {
+	public static function get(string $index, ?string $default = null): string {
 		if (self::has($index)) {
 			return trim($_REQUEST[$index]);
 		}
@@ -129,14 +129,14 @@ class Request {
 	 *
 	 * Note that this does not save the result in $var (see Smr\Session).
 	 */
-	public static function getVar(string $index, string $default = null): string {
+	public static function getVar(string $index, ?string $default = null): string {
 		return self::getVarX($index, $default, self::get(...));
 	}
 
 	/**
 	 * Like getVar, but returns an int instead of a string.
 	 */
-	public static function getVarInt(string $index, int $default = null): int {
+	public static function getVarInt(string $index, ?int $default = null): int {
 		return self::getVarX($index, $default, self::getInt(...));
 	}
 
@@ -146,7 +146,7 @@ class Request {
 	 * @param ?array<int, int> $default
 	 * @return array<int, int>
 	 */
-	public static function getVarIntArray(string $index, array $default = null): array {
+	public static function getVarIntArray(string $index, ?array $default = null): array {
 		return self::getVarX($index, $default, self::getIntArray(...));
 	}
 

--- a/src/lib/Smr/Sector.php
+++ b/src/lib/Smr/Sector.php
@@ -94,7 +94,7 @@ class Sector {
 		return self::$CACHE_LOCATION_SECTORS[$gameID][$locationTypeID];
 	}
 
-	public static function getSector(int $gameID, int $sectorID, bool $forceUpdate = false, DatabaseRecord $dbRecord = null): self {
+	public static function getSector(int $gameID, int $sectorID, bool $forceUpdate = false, ?DatabaseRecord $dbRecord = null): self {
 		if (!isset(self::$CACHE_SECTORS[$gameID][$sectorID]) || $forceUpdate) {
 			self::$CACHE_SECTORS[$gameID][$sectorID] = new self($gameID, $sectorID, false, $dbRecord);
 		}
@@ -127,7 +127,7 @@ class Sector {
 		protected readonly int $gameID,
 		protected readonly int $sectorID,
 		bool $create = false,
-		DatabaseRecord $dbRecord = null,
+		?DatabaseRecord $dbRecord = null,
 	) {
 		$db = Database::getInstance();
 		$this->SQLID = [
@@ -603,7 +603,7 @@ class Sector {
 	/**
 	 * @phpstan-assert-if-true =AbstractPlayer $player
 	 */
-	public function hasCachedPort(AbstractPlayer $player = null): bool {
+	public function hasCachedPort(?AbstractPlayer $player = null): bool {
 		if ($player === null) {
 			return false;
 		}
@@ -630,7 +630,7 @@ class Sector {
 		return $hasAction;
 	}
 
-	public function hasLocation(int $locationTypeID = null): bool {
+	public function hasLocation(?int $locationTypeID = null): bool {
 		$locations = $this->getLocations();
 		if (count($locations) === 0) {
 			return false;
@@ -736,7 +736,7 @@ class Sector {
 		return count($this->getForces()) > 0;
 	}
 
-	public function hasEnemyForces(AbstractPlayer $player = null): bool {
+	public function hasEnemyForces(?AbstractPlayer $player = null): bool {
 		if ($player === null || !$this->hasForces()) {
 			return false;
 		}
@@ -776,7 +776,7 @@ class Sector {
 	/**
 	 * @phpstan-assert-if-true =AbstractPlayer $player
 	 */
-	public function hasFriendlyForces(AbstractPlayer $player = null): bool {
+	public function hasFriendlyForces(?AbstractPlayer $player = null): bool {
 		if ($player === null || !$this->hasForces()) {
 			return false;
 		}
@@ -832,7 +832,7 @@ class Sector {
 		return count($this->getOtherTraders($player)) > 0;
 	}
 
-	public function hasEnemyTraders(AbstractPlayer $player = null): bool {
+	public function hasEnemyTraders(?AbstractPlayer $player = null): bool {
 		if ($player === null || !$this->hasOtherTraders($player)) {
 			return false;
 		}
@@ -847,7 +847,7 @@ class Sector {
 		return false;
 	}
 
-	public function hasFriendlyTraders(AbstractPlayer $player = null): bool {
+	public function hasFriendlyTraders(?AbstractPlayer $player = null): bool {
 		if ($player === null || !$this->hasOtherTraders($player)) {
 			return false;
 		}
@@ -863,7 +863,7 @@ class Sector {
 	/**
 	 * Is the $player's alliance flagship in this sector?
 	 */
-	public function hasAllianceFlagship(AbstractPlayer $player = null): bool {
+	public function hasAllianceFlagship(?AbstractPlayer $player = null): bool {
 		if ($player === null || !$player->hasAlliance() || !$player->getAlliance()->hasFlagship()) {
 			return false;
 		}
@@ -876,7 +876,7 @@ class Sector {
 		return false;
 	}
 
-	public function hasProtectedTraders(AbstractPlayer $player = null): bool {
+	public function hasProtectedTraders(?AbstractPlayer $player = null): bool {
 		if ($player === null || !$this->hasOtherTraders($player)) {
 			return false;
 		}
@@ -1028,7 +1028,7 @@ class Sector {
 		return $otherSector->getGameID() === $this->getGameID() && $this->isLinked($otherSector->getSectorID());
 	}
 
-	public function isVisited(AbstractPlayer $player = null): bool {
+	public function isVisited(?AbstractPlayer $player = null): bool {
 		if ($player === null) {
 			return true;
 		}
@@ -1059,7 +1059,7 @@ class Sector {
 		return Globals::getSectorScanHREF($player, $this->getSectorID());
 	}
 
-	public function hasX(mixed $x, AbstractPlayer $player = null): bool {
+	public function hasX(mixed $x, ?AbstractPlayer $player = null): bool {
 		if ($x instanceof Sector) {
 			return $this->equals($x);
 		}

--- a/src/lib/Smr/Session.php
+++ b/src/lib/Smr/Session.php
@@ -313,13 +313,13 @@ class Session {
 	 * This is the recommended way to get $_REQUEST data for display pages.
 	 * For processing pages, see the Request class.
 	 */
-	public function getRequestVar(string $varName, string $default = null): string {
+	public function getRequestVar(string $varName, ?string $default = null): string {
 		$result = Request::getVar($varName, $default);
 		$this->requestData[$varName] = $result;
 		return $result;
 	}
 
-	public function getRequestVarInt(string $varName, int $default = null): int {
+	public function getRequestVarInt(string $varName, ?int $default = null): int {
 		$result = Request::getVarInt($varName, $default);
 		$this->requestData[$varName] = $result;
 		return $result;
@@ -329,7 +329,7 @@ class Session {
 	 * @param ?array<int, int> $default
 	 * @return array<int, int>
 	 */
-	public function getRequestVarIntArray(string $varName, array $default = null): array {
+	public function getRequestVarIntArray(string $varName, ?array $default = null): array {
 		$result = Request::getVarIntArray($varName, $default);
 		$this->requestData[$varName] = $result;
 		return $result;

--- a/src/lib/Smr/ShipType.php
+++ b/src/lib/Smr/ShipType.php
@@ -32,7 +32,7 @@ class ShipType {
 		self::$CACHE_SHIP_TYPES = [];
 	}
 
-	public static function get(int $shipTypeID, DatabaseRecord $dbRecord = null): self {
+	public static function get(int $shipTypeID, ?DatabaseRecord $dbRecord = null): self {
 		if (!isset(self::$CACHE_SHIP_TYPES[$shipTypeID])) {
 			if ($dbRecord === null) {
 				$db = Database::getInstance();

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -116,9 +116,9 @@ class Template {
 	}
 
 	/**
-	 * @param array<string, mixed> $assignVars
+	 * @param ?array<string, mixed> $assignVars
 	 */
-	protected function includeTemplate(string $templateName, array $assignVars = null): void {
+	protected function includeTemplate(string $templateName, ?array $assignVars = null): void {
 		if ($this->nestedIncludes > 15) {
 			throw new Exception('Nested more than 15 template includes, is something wrong?');
 		}

--- a/src/lib/Smr/WeaponType.php
+++ b/src/lib/Smr/WeaponType.php
@@ -22,7 +22,7 @@ class WeaponType {
 	protected readonly int $powerLevel;
 	protected readonly BuyerRestriction $buyerRestriction;
 
-	public static function getWeaponType(int $weaponTypeID, DatabaseRecord $dbRecord = null): self {
+	public static function getWeaponType(int $weaponTypeID, ?DatabaseRecord $dbRecord = null): self {
 		if (!isset(self::$CACHE_WEAPON_TYPES[$weaponTypeID])) {
 			if ($dbRecord === null) {
 				$db = Database::getInstance();


### PR DESCRIPTION
In PHP 8.4, making function arguments implicitly nullable via a null default value is deprecated. The specified type must be explicitly nullable.

No functionality changes.