### PR TITLE
resend_password_processing.php: do not throw on no email

### DIFF
--- a/src/htdocs/resend_password_processing.php
+++ b/src/htdocs/resend_password_processing.php
@@ -7,7 +7,7 @@ use Smr\Request;
 try {
 	require_once('../bootstrap.php');
 
-	$email = Request::get('email');
+	$email = Request::get('email', ''); // default prevents crawler bug report spam
 	if ($email === '') {
 		create_error('You must specify an e-mail address!');
 	}


### PR DESCRIPTION
When the `email` request field doesn't exist, an error is thrown and it sends a bug report email. Even though the actual page has an HTML5 form property that prevents submitting an empty email, it appears that crawlers are submitting this page without the `email` field.

We can prevent this bug report email if we default `email` to an empty string, so that the user gets an error message response. This is not ideal, because it means that if the form breaks (e.g. field is changed without updating the processor), we won't get bug emails, but I think this is necessary to avoid the sheer volume of crawler bug emails.