### PR TITLE
Update to PHPStan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,10 +81,10 @@
 	"require-dev": {
 		"fig-r/psr2r-sniffer": "2.1.1",
 		"overtrue/phplint": "9.5.5",
-		"phpstan/phpstan": "1.12.5",
+		"phpstan/phpstan": "2.0.3",
 		"phpunit/phpunit": "11.5.0",
 		"phpunit/php-code-coverage": "11.0.8",
-		"rector/rector": "0.15.13",
+		"rector/rector": "2.0.0",
 		"squizlabs/php_codesniffer": "3.11.2"
 	}
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,9 +10,6 @@ parameters:
     # Stricter analysis
     polluteScopeWithLoopInitialAssignments: false
     polluteScopeWithAlwaysIterableForeach: false
-    checkAlwaysTrueCheckTypeFunctionCall: true
-    checkAlwaysTrueInstanceof: true
-    checkAlwaysTrueStrictComparison: true
     checkExplicitMixedMissingReturn: true
     checkFunctionNameCase: true
     checkInternalClassCaseSensitivity: true

--- a/src/lib/Default/alliance_pick.inc.php
+++ b/src/lib/Default/alliance_pick.inc.php
@@ -36,6 +36,10 @@ function get_draft_teams(int $gameId): array {
 		}
 	}
 
+	if (count($teams) === 0) {
+		throw new Exception('No draft leaders have been selected yet.');
+	}
+
 	// Determine the smallest team alliance size.
 	$minSize = min(array_map(fn(array $i): int => $i['Size'], $teams));
 

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -2051,6 +2051,9 @@ abstract class AbstractPlayer {
 		return $this->bounties;
 	}
 
+	/**
+	 * @phpstan-assert-if-false array{} $this->getBounties()
+	 */
 	public function hasBounties(): bool {
 		return count($this->getBounties()) > 0;
 	}

--- a/src/lib/Smr/Chess/Board.php
+++ b/src/lib/Smr/Chess/Board.php
@@ -11,7 +11,7 @@ class Board {
 
 	/** @var array<value-of<Colour>, array<Castling>> */
 	private array $canCastle;
-	/** @var array{X: int, Y: int}> */
+	/** @var array{X: int, Y: int} */
 	private array $enPassantPawn;
 	/** @var array<int, array<int, ?ChessPiece>> */
 	private array $board;
@@ -190,7 +190,7 @@ class Board {
 	}
 
 	/**
-	 * @return array{'X': int, 'Y': int}
+	 * @return array{X: int, Y: int}
 	 */
 	public function getEnPassantPawn(): array {
 		return $this->enPassantPawn;

--- a/src/lib/Smr/Chess/ChessPiece.php
+++ b/src/lib/Smr/Chess/ChessPiece.php
@@ -43,7 +43,7 @@ class ChessPiece {
 	}
 
 	/**
-	 * @return array<array{int, int}>>
+	 * @return array<array{int, int}>
 	 */
 	public function getPossibleMoves(Board $board, bool $attackingCheck = false): array {
 		$moves = [];
@@ -139,7 +139,7 @@ class ChessPiece {
 	}
 
 	/**
-	 * @param array{int, int} $moves
+	 * @param list<array{int, int}> $moves
 	 */
 	private function addMove(int $toX, int $toY, Board $board, array &$moves, bool $attackingCheck = true): bool {
 		if ($board->isValidCoord($toX, $toY)) {

--- a/src/lib/Smr/Globals.php
+++ b/src/lib/Smr/Globals.php
@@ -320,7 +320,7 @@ class Globals {
 	}
 
 	/**
-	 * @return array<string, int>
+	 * @return array{text: int, html: int, logo: int}
 	 */
 	public static function getBuyShipNameCosts(): array {
 		return [

--- a/src/lib/Smr/Port.php
+++ b/src/lib/Smr/Port.php
@@ -1331,7 +1331,7 @@ class Port {
 	}
 
 	/**
-	 * @param array<AbstractPlayer> $targetPlayers
+	 * @param non-empty-array<int, AbstractPlayer> $targetPlayers
 	 * @return PortCombatResults
 	 */
 	public function shootPlayers(array $targetPlayers): array {

--- a/src/lib/Smr/Routes/Route.php
+++ b/src/lib/Smr/Routes/Route.php
@@ -30,7 +30,7 @@ abstract class Route {
 	/**
 	 * Recurse through the Route tree to get an ordered list.
 	 *
-	 * @return array<OneWayRoute>
+	 * @return non-empty-list<OneWayRoute>
 	 */
 	abstract public function getOneWayRoutes(): array;
 

--- a/src/lib/Smr/Routes/RouteIterator.php
+++ b/src/lib/Smr/Routes/RouteIterator.php
@@ -11,6 +11,7 @@ use Smr\TransactionType;
  */
 class RouteIterator {
 
+	/** @var InfiniteIterator<int, OneWayRoute, ArrayIterator<int, OneWayRoute>> */
 	private InfiniteIterator $routeIterator;
 
 	private TransactionType $transaction = TransactionType::Buy;

--- a/test/SmrTest/lib/BarDrinkTest.php
+++ b/test/SmrTest/lib/BarDrinkTest.php
@@ -46,7 +46,7 @@ class BarDrinkTest extends TestCase {
 	public function test_getSpecialMessage(): void {
 		// every special drink has a special message
 		foreach (BarDrink::getSpecial() as $drink) {
-			self::assertIsString(BarDrink::getSpecialMessage($drink));
+			self::assertNotEmpty(BarDrink::getSpecialMessage($drink));
 		}
 	}
 


### PR DESCRIPTION
* Update rector to 2.0 as well due to its PHPStan dependency.
* Remove some `checkAlwaysTrue*` options that are now true by default.
* Fix errors reported by PHPStan 2.0 (some typos, wrong types, and wide types).