### PR TITLE
Container template methods

### DIFF
--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -1796,7 +1796,7 @@ abstract class AbstractPlayer {
 
 			if ($dbResult->hasRecord()) {
 				// get the course back
-				$this->plottedCourse = $dbResult->record()->getObject('course');
+				$this->plottedCourse = $dbResult->record()->getClass('course', Path::class);
 			} else {
 				$this->plottedCourse = false;
 			}

--- a/src/lib/Smr/Container/DiContainer.php
+++ b/src/lib/Smr/Container/DiContainer.php
@@ -4,6 +4,7 @@ namespace Smr\Container;
 
 use DI\ContainerBuilder;
 use Doctrine\DBAL\Connection;
+use Exception;
 use Smr\Database;
 use Smr\DatabaseProperties;
 use Smr\Epoch;
@@ -73,23 +74,41 @@ class DiContainer {
 
 	/**
 	 * Retrieve the managed instance of $className, or construct a new instance with all dependencies.
-	 * @param string $className The name of the class to retrieve from the container.
+	 *
+	 * @template T of object
+	 * @param class-string<T> $className The name of the class to retrieve from the container.
+	 *
 	 * @throws \DI\DependencyException
 	 * @throws \DI\NotFoundException
+	 *
+	 * @return T
 	 */
-	public static function get(string $className): mixed {
-		return self::getContainer()->get($className);
+	public static function getClass(string $className): mixed {
+		$class = self::getContainer()->get($className);
+		if (!($class instanceof $className)) {
+			throw new Exception('Expected instance of ' . $className . ' from container, got ' . gettype($class));
+		}
+		return $class;
 	}
 
 	/**
 	 * Construct a fresh instance of $className. Dependencies will be retrieved from the container if they
 	 * are already managed, and created themselves if they are not.
-	 * @param string $className The name of the class to construct.
+	 *
+	 * @template T of object
+	 * @param class-string<T> $className The name of the class to construct.
+	 *
 	 * @throws \DI\DependencyException
 	 * @throws \DI\NotFoundException
+	 *
+	 * @return T
 	 */
-	public static function make(string $className): mixed {
-		return self::getContainer()->make($className);
+	public static function makeClass(string $className): mixed {
+		$class = self::getContainer()->make($className);
+		if (!($class instanceof $className)) {
+			throw new Exception('Expected instance of ' . $className . ' from container, got ' . gettype($class));
+		}
+		return $class;
 	}
 
 	/**

--- a/src/lib/Smr/Database.php
+++ b/src/lib/Smr/Database.php
@@ -21,7 +21,7 @@ class Database {
 	 * This is the intended way to construct this class.
 	 */
 	public static function getInstance(): self {
-		return DiContainer::get(self::class);
+		return DiContainer::getClass(self::class);
 	}
 
 	/**

--- a/src/lib/Smr/DatabaseRecord.php
+++ b/src/lib/Smr/DatabaseRecord.php
@@ -69,6 +69,19 @@ class DatabaseRecord {
 	}
 
 	/**
+	 * @template T of object
+	 * @param class-string<T> $class
+	 * @return T
+	 */
+	public function getClass(string $name, string $class, bool $compressed = false): mixed {
+		$object = $this->getObject($name, $compressed);
+		if (!($object instanceof $class)) {
+			throw new Exception('Value ' . var_export($object, true) . ' is not of type ' . $class);
+		}
+		return $object;
+	}
+
+	/**
 	 * @template T of BackedEnum
 	 * @param class-string<T> $enum
 	 * @return T

--- a/src/lib/Smr/DummyShip.php
+++ b/src/lib/Smr/DummyShip.php
@@ -36,7 +36,7 @@ class DummyShip extends AbstractShip {
 				'dummy_name' => $db->escapeString($dummyName),
 			]);
 			if ($dbResult->hasRecord()) {
-				$ship = $dbResult->record()->getObject('info');
+				$ship = $dbResult->record()->getClass('info', self::class);
 			} else {
 				$player = new DummyPlayer($dummyName);
 				$ship = new self($player);

--- a/src/lib/Smr/Epoch.php
+++ b/src/lib/Smr/Epoch.php
@@ -39,7 +39,7 @@ class Epoch {
 	 * and this will be the time associated with the page request.
 	 */
 	private static function getInstance(): self {
-		return DiContainer::get(self::class);
+		return DiContainer::getClass(self::class);
 	}
 
 	/**
@@ -66,7 +66,7 @@ class Epoch {
 	 * only be used by the CLI programs that run continuously.
 	 */
 	public static function update(): void {
-		if (DiContainer::get('NPC_SCRIPT') === false) {
+		if (DiContainer::getContainer()->get('NPC_SCRIPT') === false) {
 			throw new Exception('Only call this function from CLI programs!');
 		}
 		DiContainer::getContainer()->set(self::class, new self());

--- a/src/lib/Smr/Port.php
+++ b/src/lib/Smr/Port.php
@@ -1219,7 +1219,7 @@ class Port {
 
 			if ($dbResult->hasRecord()) {
 				$dbRecord = $dbResult->record();
-				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID] = $dbRecord->getObject('port_info', true);
+				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID] = $dbRecord->getClass('port_info', self::class, true);
 				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID]->setCachedTime($dbRecord->getInt('visited'));
 			} else {
 				self::$CACHE_CACHED_PORTS[$gameID][$sectorID][$accountID] = false;

--- a/src/lib/Smr/SectorLock.php
+++ b/src/lib/Smr/SectorLock.php
@@ -172,7 +172,7 @@ class SectorLock {
 	 * The first time this is called, it will populate the DI container.
 	 */
 	public static function getInstance(): self {
-		return DiContainer::get(self::class);
+		return DiContainer::getClass(self::class);
 	}
 
 	/**
@@ -183,7 +183,7 @@ class SectorLock {
 	 * only be used by the CLI programs that run continuously.
 	 */
 	public static function resetInstance(): void {
-		if (DiContainer::get('NPC_SCRIPT') === false) {
+		if (DiContainer::getContainer()->get('NPC_SCRIPT') === false) {
 			throw new Exception('Only call this function from CLI programs!');
 		}
 		// Release before resetting

--- a/src/lib/Smr/Session.php
+++ b/src/lib/Smr/Session.php
@@ -58,7 +58,7 @@ class Session {
 	 * This is the intended way to construct this class.
 	 */
 	public static function getInstance(): self {
-		return DiContainer::get(self::class);
+		return DiContainer::getClass(self::class);
 	}
 
 	/**

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -31,7 +31,7 @@ class Template {
 	 * This is the intended way to construct this class.
 	 */
 	public static function getInstance(): self {
-		return DiContainer::get(self::class);
+		return DiContainer::getClass(self::class);
 	}
 
 	public function hasTemplateVar(string $var): bool {

--- a/test/SmrTest/BaseIntegrationSpec.php
+++ b/test/SmrTest/BaseIntegrationSpec.php
@@ -30,7 +30,7 @@ abstract class BaseIntegrationSpec extends TestCase {
 	#[BeforeClass]
 	final public static function initializeTableRowCounts(): void {
 		if (!isset(self::$conn)) {
-			self::$conn = DiContainer::make(Connection::class);
+			self::$conn = DiContainer::makeClass(Connection::class);
 			self::$checksums = self::getChecksums();
 		}
 	}

--- a/test/SmrTest/Container/DiContainerTest.php
+++ b/test/SmrTest/Container/DiContainerTest.php
@@ -2,8 +2,12 @@
 
 namespace SmrTest\Container;
 
+use ArrayObject;
+use DI\Definition\StringDefinition;
+use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
 use Smr\DatabaseProperties;
@@ -33,30 +37,43 @@ class DiContainerTest extends TestCase {
 		self::assertFileDoesNotExist(self::PHPDI_COMPILED_CONTAINER_FILE);
 	}
 
-	public function test_container_get_and_make(): void {
+	public function test_getClass_and_makeClass(): void {
 		// Start with a fresh container
 		DiContainer::initialize(false);
 
 		// The first get should construct a new object
 		$class = DatabaseProperties::class;
-		$instance1 = DiContainer::get($class);
+		$instance1 = DiContainer::getClass($class);
 		self::assertInstanceOf($class, $instance1);
 
 		// Getting the same class should now give the exact same object
-		$instance2 = DiContainer::get($class);
+		$instance2 = DiContainer::getClass($class);
 		self::assertSame($instance1, $instance2);
 
 		// Using make should construct a new object
-		$instance3 = DiContainer::make($class);
+		$instance3 = DiContainer::makeClass($class);
 		self::assertNotSame($instance1, $instance3);
 		self::assertEquals($instance1, $instance3);
+	}
+
+	#[TestWith(['makeClass'])]
+	#[TestWith(['getClass'])]
+	public function test_getClass_makeClass_error(string $method): void {
+		// Set class name entry in container to something other than the
+		// instance of the class to verify that we check the type.
+		$class = ArrayObject::class;
+		DiContainer::initialize(false);
+		DiContainer::getContainer()->set($class, new StringDefinition('foo'));
+		$this->expectExceptionMessage('Expected instance of ' . $class . ' from container, got string');
+		$this->expectException(Exception::class);
+		DiContainer::$method($class);
 	}
 
 	public function test_factory_DatabaseName(): void {
 		// Start with a fresh container
 		DiContainer::initialize(false);
 		// Then make sure the 'DatabaseName' is as expected
-		$dbName = DiContainer::get('DatabaseName');
+		$dbName = DiContainer::getContainer()->get('DatabaseName');
 		self::assertSame($dbName, 'smr_live_test');
 	}
 
@@ -77,7 +94,7 @@ class DiContainerTest extends TestCase {
 		self::assertFalse(DiContainer::initialized($entry));
 
 		// Only once the entry is requested should it be initialized.
-		DiContainer::get($entry);
+		DiContainer::getContainer()->get($entry);
 		self::assertTrue(DiContainer::initialized($entry));
 	}
 

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -26,7 +26,7 @@ class DatabaseIntegrationTest extends TestCase {
 
 	public function test_connectionFactory(): void {
 		// Given database properties are retrieved from the container
-		$dbProperties = DiContainer::get(DatabaseProperties::class);
+		$dbProperties = DiContainer::getClass(DatabaseProperties::class);
 		// When using the factory to retrieve a connection instance
 		$conn = Database::connectionFactory($dbProperties);
 		// The the connection is successful
@@ -34,8 +34,8 @@ class DatabaseIntegrationTest extends TestCase {
 	}
 
 	public function test__construct_happy_path(): void {
-		$db = DiContainer::get(Database::class);
-		self::assertNotNull($db);
+		$db = DiContainer::getClass(Database::class);
+		self::assertInstanceOf(Database::class, $db);
 	}
 
 	public function test_getInstance_always_returns_same_instance(): void {
@@ -48,17 +48,17 @@ class DatabaseIntegrationTest extends TestCase {
 
 	public function test_resetInstance_returns_new_instance(): void {
 		// Given an original connection instance
-		$original = DiContainer::get(Connection::class);
+		$original = DiContainer::getClass(Connection::class);
 		// And resetInstance is called
 		Database::resetInstance();
 		// And Database is usable again after reconnecting
 		Database::getInstance()->read('SELECT 1');
 		// Then new instance is not the same as the original instance
-		self::assertNotSame($original, DiContainer::get(Connection::class));
+		self::assertNotSame($original, DiContainer::getClass(Connection::class));
 	}
 
 	public function test_resetInstance_closes_connection(): void {
-		$conn = DiContainer::get(Connection::class);
+		$conn = DiContainer::getClass(Connection::class);
 		$db = Database::getInstance();
 		$db->read('SELECT 1'); // initialize the connection
 		self::assertTrue($conn->isConnected());

--- a/test/SmrTest/lib/SectorLockTest.php
+++ b/test/SmrTest/lib/SectorLockTest.php
@@ -80,7 +80,7 @@ class SectorLockTest extends BaseIntegrationSpec {
 		// Given that we acquire a lock
 		$lock1->acquire(1, 1, 1);
 		// And we use a new SectorLock instance to simulate a separate request
-		$lock2 = DiContainer::make(SectorLock::class);
+		$lock2 = DiContainer::makeClass(SectorLock::class);
 		// Then if that instance tries to acquire a lock (even for the same
 		// sector) before the other instance releases, we throw a UserError.
 		$this->expectException(UserError::class);

--- a/test/SmrTest/lib/SessionIntegrationTest.php
+++ b/test/SmrTest/lib/SessionIntegrationTest.php
@@ -67,7 +67,7 @@ class SessionIntegrationTest extends BaseIntegrationSpec {
 		// Now create a new Session with a specific 'sn' parameter set.
 		$sn = 'some_sn';
 		$_REQUEST['sn'] = $sn;
-		$session = DiContainer::make(Session::class);
+		$session = DiContainer::makeClass(Session::class);
 		self::assertSame($sn, $session->getSN());
 	}
 
@@ -78,14 +78,14 @@ class SessionIntegrationTest extends BaseIntegrationSpec {
 		// Create a Session with a specific ID
 		$sessionID = md5('hello');
 		$_COOKIE['session_id'] = $sessionID;
-		$session = DiContainer::make(Session::class);
+		$session = DiContainer::makeClass(Session::class);
 		self::assertSame($sessionID, $session->getSessionID());
 
 		// If we try to use a session ID with fewer than 32 chars,
 		// we get a random ID instead
 		$sessionID = 'hello';
 		$_COOKIE['session_id'] = $sessionID;
-		$session = DiContainer::make(Session::class);
+		$session = DiContainer::makeClass(Session::class);
 		self::assertNotEquals($sessionID, $session->getSessionID());
 	}
 
@@ -95,9 +95,9 @@ class SessionIntegrationTest extends BaseIntegrationSpec {
 
 		// Test other values in $_REQUEST
 		$_REQUEST['ajax'] = 1;
-		self::assertTrue(DiContainer::make(Session::class)->ajax);
+		self::assertTrue(DiContainer::makeClass(Session::class)->ajax);
 		$_REQUEST['ajax'] = 'anything other than 1';
-		self::assertFalse(DiContainer::make(Session::class)->ajax);
+		self::assertFalse(DiContainer::makeClass(Session::class)->ajax);
 	}
 
 	public function test_getCurrentVar_throws(): void {
@@ -119,7 +119,7 @@ class SessionIntegrationTest extends BaseIntegrationSpec {
 		// Create a new Session, requesting the SN we just made
 		$_REQUEST['sn'] = $sn;
 		$_COOKIE['session_id'] = $this->session->getSessionID();
-		$session = DiContainer::make(Session::class);
+		$session = DiContainer::makeClass(Session::class);
 
 		// Now we should be able to find this sn in the var
 		self::assertTrue($session->hasCurrentVar());
@@ -143,16 +143,16 @@ class SessionIntegrationTest extends BaseIntegrationSpec {
 		// with this SN.
 		$session->update();
 		$_REQUEST['ajax'] = 1; // simulate AJAX refresh
-		$session = DiContainer::make(Session::class);
+		$session = DiContainer::makeClass(Session::class);
 		self::assertEquals($var2, $session->getCurrentVar());
 		$_REQUEST['ajax'] = 0; // simulate F5 refresh
-		$session = DiContainer::make(Session::class);
+		$session = DiContainer::makeClass(Session::class);
 		self::assertEquals($var2, $session->getCurrentVar());
 
 		// If we destroy the Session, then the current var should no longer
 		// be accessible to a new Session.
 		$session->destroy();
-		$session = DiContainer::make(Session::class);
+		$session = DiContainer::makeClass(Session::class);
 		self::assertFalse($session->hasCurrentVar());
 	}
 


### PR DESCRIPTION
Use the `@template` syntax to reduce how often we return `mixed` types from container querying methods.

This impacts the following classes:
* DatabaseRecord
* DiContainer