### PR TITLE
Fix format_time pluralization

### DIFF
--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -341,7 +341,7 @@ function word_filter(string $string): string {
 // choose correct pluralization based on amount
 function pluralise(int|float $amount, string $word, bool $includeAmount = true): string {
 	$result = $word;
-	if ($amount !== 1) {
+	if ((float)$amount !== 1.) {
 		$result .= 's';
 	}
 	if ($includeAmount) {

--- a/test/SmrTest/lib/functions/FormatTimeTest.php
+++ b/test/SmrTest/lib/functions/FormatTimeTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\functions;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+#[CoversFunction('format_time')]
+class FormatTimeTest extends TestCase {
+
+	#[TestWith([-60, '1 minute ago', '1m ago'])]
+	#[TestWith([0, 'now', 'now'])]
+	#[TestWith([59, 'less than 1 minute', '&lt;1m'])]
+	#[TestWith([60, '1 minute', '1m'])]
+	#[TestWith([120, '2 minutes', '2m'])]
+	#[TestWith([1092131, '1 week, 5 days, 15 hours and 23 minutes', '1w, 5d, 15h and 23m'])]
+	public function test_format_time(int $seconds, string $expectedLong, string $expectedShort): void {
+		self::assertSame($expectedLong, format_time($seconds));
+		self::assertSame($expectedShort, format_time($seconds, short: true));
+	}
+
+}

--- a/test/SmrTest/lib/functions/PluraliseTest.php
+++ b/test/SmrTest/lib/functions/PluraliseTest.php
@@ -12,6 +12,7 @@ class PluraliseTest extends TestCase {
 	#[TestWith([3, true, '3 tests'])]
 	#[TestWith([1, true, '1 test'])]
 	#[TestWith([0, true, '0 tests'])]
+	#[TestWith([1.0, true, '1 test'])]
 	#[TestWith([0.5, true, '0.5 tests'])]
 	#[TestWith([3, false, 'tests'])]
 	#[TestWith([1, false, 'test'])]


### PR DESCRIPTION
The `pluralise` function was not returning the correct pluralization for identically 1 float values. Since ceil/floor return a float, this was causing `format_time` to return strings like "1 minutes" instead of "1 minute".

This is fixed by casting the value to a float in the comparison to 1 in `pluralise`.