### PR TITLE
Chess: fix checkmate and add draw

### DIFF
--- a/src/lib/Smr/Chess/Board.php
+++ b/src/lib/Smr/Chess/Board.php
@@ -209,6 +209,16 @@ class Board {
 		return false;
 	}
 
+	public function isCheckmated(Colour $colour): bool {
+		foreach ($this->getPieces($colour) as $piece) {
+			// If any piece can make a legal move, it's not checkmate
+			if (count($piece->getPossibleMoves($this)) > 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	/**
 	 * Change the position of a piece on the board
 	 */

--- a/src/lib/Smr/Chess/Board.php
+++ b/src/lib/Smr/Chess/Board.php
@@ -37,11 +37,28 @@ class Board {
 		$this->board = $board;
 
 		// Initialize metadata (castling/en passant)
-		$this->canCastle = [
-			Colour::White->value => Castling::cases(),
-			Colour::Black->value => Castling::cases(),
-		];
-		$this->enPassantPawn = ['X' => -1, 'Y' => -1];
+		foreach (Colour::cases() as $colour) {
+			$this->setCastling($colour, Castling::cases());
+		}
+		$this->setEnPassantPawn();
+	}
+
+	/**
+	 * @param array<Castling> $castling Set allowed castling operations
+	 */
+	public function setCastling(Colour $colour, array $castling): void {
+		$this->canCastle[$colour->value] = $castling;
+	}
+
+	/**
+	 * @param ?array{X: int, Y: int} $enPassantPawn Set (or reset) en passant pawn
+	 */
+	public function setEnPassantPawn(?array $enPassantPawn = null): void {
+		if ($enPassantPawn === null) {
+			$this->enPassantPawn = ['X' => -1, 'Y' => -1];
+		} else {
+			$this->enPassantPawn = $enPassantPawn;
+		}
 	}
 
 	public function deepCopy(): self {
@@ -210,13 +227,35 @@ class Board {
 	}
 
 	public function isCheckmated(Colour $colour): bool {
-		foreach ($this->getPieces($colour) as $piece) {
-			// If any piece can make a legal move, it's not checkmate
-			if (count($piece->getPossibleMoves($this)) > 0) {
+		// Checkmate only if there are no legal moves and King is in check
+		return !$this->hasLegalMoves($colour) && $this->isChecked($colour);
+	}
+
+	public function isDraw(Colour $colour): bool {
+		if (!$this->hasLegalMoves($colour) && !$this->isChecked($colour)) {
+			// Draw by stalemate
+			return true;
+		}
+		// Draw by insufficient material
+		// (Consider only the case where Kings remain, others too complex)
+		foreach ($this->getPieces() as $piece) {
+			if ($piece->pieceID !== ChessPiece::KING) {
 				return false;
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Can $colour make any legal moves in the current position?
+	 */
+	private function hasLegalMoves(Colour $colour): bool {
+		foreach ($this->getPieces($colour) as $piece) {
+			if (count($piece->getPossibleMoves($this)) > 0) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -228,8 +267,25 @@ class Board {
 		$piece->y = $y;
 	}
 
+	/**
+	 * Remove the piece, if any, from this square
+	 */
 	public function clearSquare(int $x, int $y): void {
 		$this->board[$y][$x] = null;
+	}
+
+	/**
+	 * Remove all pieces from the board
+	 */
+	public function clear(): void {
+		foreach ($this->board as $y => $row) {
+			foreach (array_keys($row) as $x) {
+				$this->board[$y][$x] = null;
+			}
+		}
+		$this->setEnPassantPawn();
+		$this->setCastling(Colour::White, []);
+		$this->setCastling(Colour::Black, []);
 	}
 
 	/**

--- a/src/lib/Smr/Chess/ChessGame.php
+++ b/src/lib/Smr/Chess/ChessGame.php
@@ -261,25 +261,6 @@ class ChessGame {
 			. ($enPassant ? ' e.p.' : '');
 	}
 
-	public function isCheckmated(Colour $colour): bool {
-		$king = null;
-		foreach ($this->board->getPieces($colour) as $piece) {
-			if ($piece->pieceID === ChessPiece::KING) {
-				$king = $piece;
-				break;
-			}
-		}
-		if ($king === null) {
-			throw new Exception('Could not find the king: game id = ' . $this->chessGameID);
-		}
-		if (!$this->board->isChecked($colour)) {
-			return false;
-		}
-		$moves = $king->getPossibleMoves($this->board);
-		// If there are no moves the King can make, they are checkmated.
-		return count($moves) === 0;
-	}
-
 	/**
 	 * @return array{Type: Castling, X: int, ToX: int}|false
 	 */
@@ -359,7 +340,7 @@ class ChessGame {
 		if ($this->board->isChecked($p->colour->opposite())) {
 			$checking = 'CHECK';
 		}
-		if ($this->isCheckmated($p->colour->opposite())) {
+		if ($this->board->isCheckmated($p->colour->opposite())) {
 			$checking = 'MATE';
 		}
 

--- a/src/pages/Player/Chess/MatchPlay.php
+++ b/src/pages/Player/Chess/MatchPlay.php
@@ -30,6 +30,7 @@ class MatchPlay extends PlayerPage {
 		$template->assign('Board', $board);
 
 		// Check if there is a winner
+		$template->assign('Ended', $chessGame->hasEnded());
 		if ($chessGame->hasWinner()) {
 			$winningPlayer = Player::getPlayer($chessGame->getWinner(), $player->getGameID());
 			$template->assign('Winner', $winningPlayer->getLinkedDisplayName(false));

--- a/src/templates/Default/engine/Default/chess_play.php
+++ b/src/templates/Default/engine/Default/chess_play.php
@@ -9,12 +9,17 @@
  * @var array<string> $FileCoords
  * @var string $MoveMessage
  * @var string $ChessMoveHREF
+ * @var bool $Ended
+ * @var ?string $Winner
  */
 
 ?>
 <p><span id="chess_status">
-	<?php if (isset($Winner)) { ?>
-		The game has ended. <?php echo $Winner; ?> has won!<?php
+	<?php if ($Ended) { ?>
+		The game has ended.<?php
+		if (isset($Winner)) { ?>
+			<?php echo $Winner; ?> has won!<?php
+		}
 	} else { ?>
 		It is currently <?php echo $ChessGame->getCurrentTurnPlayer()->getLinkedDisplayName(false); ?>'s turn.<?php
 	} ?>

--- a/test/SmrTest/lib/Chess/BoardTest.php
+++ b/test/SmrTest/lib/Chess/BoardTest.php
@@ -166,6 +166,7 @@ class BoardTest extends TestCase {
 		$board->movePiece(3, 6, 3, 5); // d6
 		$board->movePiece(5, 0, 1, 4); // Bb5+
 		self::assertTrue($board->isChecked(Colour::Black));
+		self::assertFalse($board->isCheckmated(Colour::Black));
 		self::assertFalse($board->isChecked(Colour::White));
 
 		// Blocking the check results in no longer being checked
@@ -173,6 +174,24 @@ class BoardTest extends TestCase {
 		foreach (Colour::cases() as $colour) {
 			self::assertFalse($board->isChecked($colour));
 		}
+	}
+
+	public function test_isCheckmated(): void {
+		// Not in checkmate by default
+		$board = new Board();
+		foreach (Colour::cases() as $colour) {
+			self::assertFalse($board->isCheckmated($colour));
+		}
+
+		// Scholar's Mate against Black
+		$board->movePiece(4, 1, 4, 3); // e4
+		$board->movePiece(4, 6, 4, 4); // e5
+		$board->movePiece(5, 0, 2, 3); // Bc4
+		$board->movePiece(1, 7, 2, 5); // Nc6
+		$board->movePiece(3, 0, 7, 4); // Qh5
+		$board->movePiece(6, 7, 5, 5); // Nf6
+		$board->movePiece(7, 4, 5, 6); // Qxf7++
+		self::assertTrue($board->isCheckmated(Colour::Black));
 	}
 
 	public function test_setSquare(): void {
@@ -300,6 +319,20 @@ class BoardTest extends TestCase {
 		// Make sure pieces are in the right spot
 		$expectedQueen = new ChessPiece(Colour::White, ChessPiece::QUEEN, 0, 7);
 		self::assertEquals($expectedQueen, $board->getPiece(0, 7));
+	}
+
+	public function test_movePiece_invalid_to_coord(): void {
+		$board = new Board();
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Invalid from coordinates, x=0, y=8');
+		$board->movePiece(0, 8, 0, 7);
+	}
+
+	public function test_movePiece_invalid_from_coord(): void {
+		$board = new Board();
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Invalid to coordinates, x=0, y=8');
+		$board->movePiece(0, 7, 0, 8);
 	}
 
 }


### PR DESCRIPTION
* Checkmate no longer incorrectly happens when there are valid moves to block check.
* Two simple draw conditions are now checked to properly end the game in a draw:
  1. Insufficient material (just two kings)
  2. Stalemate