### PR TITLE
api-docs: update phpDocumentor from 3.5.3 to 3.7.1

### DIFF
--- a/.github/actions/api-docs/Dockerfile
+++ b/.github/actions/api-docs/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.3.8-cli-alpine
 
-RUN curl -L -O https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.5.3/phpDocumentor.phar
+RUN curl -L -O https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.7.1/phpDocumentor.phar
 RUN chmod +x phpDocumentor.phar
 RUN mv phpDocumentor.phar /usr/local/bin/phpdoc
 

--- a/api-docs/Dockerfile
+++ b/api-docs/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.3.8-cli-alpine AS builder
 
-RUN curl -L -O https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.5.3/phpDocumentor.phar
+RUN curl -L -O https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.7.1/phpDocumentor.phar
 RUN chmod +x phpDocumentor.phar
 RUN mv phpDocumentor.phar /usr/local/bin/phpdoc
 


### PR DESCRIPTION
This adds support for PHP 8.3 and 8.4.