### PR TITLE
dependabot.yml: use directories and groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,28 +9,18 @@ updates:
   rebase-strategy: disabled
 
 - package-ecosystem: docker
-  directory: "/.github/actions/api-docs"
+  directories:
+    - "/"
+    - "/.github/actions/api-docs"
+    - "/api-docs"
+    - "/db"
   schedule:
     interval: daily
   rebase-strategy: disabled
-
-- package-ecosystem: docker
-  directory: "/api-docs"
-  schedule:
-    interval: daily
-  rebase-strategy: disabled
-
-- package-ecosystem: docker
-  directory: "/db"
-  schedule:
-    interval: daily
-  rebase-strategy: disabled
-
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-  rebase-strategy: disabled
+  groups:
+    php-updates:
+      patterns:
+        - "php"
 
 - package-ecosystem: composer
   directory: "/"


### PR DESCRIPTION
The use of `directories` instead of `directory` allows consolidating updates within the same package ecosystem. We had 4 docker entries with the same settings, which is now collapsed into a single entry.

The use of `groups` with the "php" pattern should allow all PHP version updates to occur in a single dependabot PR. This ensures consistency across the repo.