### PR TITLE
Deduplicate damage taken display construction

### DIFF
--- a/src/lib/Smr/Force.php
+++ b/src/lib/Smr/Force.php
@@ -555,18 +555,18 @@ class Force {
 			}
 		}
 		return [
-						'KillingShot' => !$alreadyDead && !$this->exists(),
-						'TargetAlreadyDead' => $alreadyDead,
-						'Mines' => $minesDamage,
-						'NumMines' => $numMines,
-						'HasMines' => $this->hasMines(),
-						'CDs' => $cdDamage,
-						'NumCDs' => $numCDs,
-						'HasCDs' => $this->hasCDs(),
-						'SDs' => $sdDamage,
-						'NumSDs' => $numSDs,
-						'HasSDs' => $this->hasSDs(),
-						'TotalDamage' => $minesDamage + $cdDamage + $sdDamage,
+			'KillingShot' => !$alreadyDead && !$this->exists(),
+			'TargetAlreadyDead' => $alreadyDead,
+			'Mines' => $minesDamage,
+			'NumMines' => $numMines,
+			'HasMines' => $this->hasMines(),
+			'CDs' => $cdDamage,
+			'NumCDs' => $numCDs,
+			'HasCDs' => $this->hasCDs(),
+			'SDs' => $sdDamage,
+			'NumSDs' => $numSDs,
+			'HasSDs' => $this->hasSDs(),
+			'TotalDamage' => $minesDamage + $cdDamage + $sdDamage,
 		];
 	}
 

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -140,13 +140,41 @@ class Template {
 		return preg_match('/<input (?![^>]*(submit|hidden|image))/i', $html) !== 0;
 	}
 
-	protected function doDamageTypeReductionDisplay(int &$damageTypes): void {
-		if ($damageTypes === 3) {
-			echo ', ';
-		} elseif ($damageTypes === 2) {
-			echo ' and ';
+	/**
+	 * @param ForceTakenDamageData $damageTaken
+	 */
+	public function displayForceTakenDamage(array $damageTaken, int $kamikaze = 0): string {
+		$items = [
+			[$damageTaken['NumMines'] - $kamikaze, 'red', 'mine', ''],
+			[$damageTaken['NumCDs'], 'red', 'combat drone', ''],
+			[$damageTaken['NumSDs'], 'red', 'scout drone', ''],
+		];
+		return $this->displayDamage($items);
+	}
+
+	/**
+	 * @param TakenDamageData $damageTaken
+	 */
+	public function displayTakenDamage(array $damageTaken): string {
+		$items = [
+			[$damageTaken['Shield'], 'shields', 'shield', ''],
+			[$damageTaken['NumCDs'], 'cds', 'combat drone', ''],
+			[$damageTaken['Armour'], 'red', 'plate', ' of armour'],
+		];
+		return $this->displayDamage($items);
+	}
+
+	/**
+	 * @param array<array{int, string, string, string}> $damageTypes
+	 */
+	private function displayDamage(array $damageTypes): string {
+		$strings = [];
+		foreach ($damageTypes as [$damage, $class, $name, $suffix]) {
+			if ($damage > 0) {
+				$strings[] = '<span class="' . $class . '">' . number_format($damage) . '</span> ' . pluralise($damage, $name, false) . $suffix;
+			}
 		}
-		$damageTypes--;
+		return format_list($strings);
 	}
 
 	protected function doAn(string $wordAfter): string {

--- a/src/templates/Default/engine/Default/includes/ForceTraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/ForceTraderTeamCombatResults.inc.php
@@ -36,23 +36,7 @@ foreach ($AllTraderResults as $TraderResults) {
 						?> but it cannot do any damage<?php
 					}
 				} else {
-					?> destroying <?php
-					$DamageTypes = 0;
-					if ($ActualDamage['NumMines'] > 0) { $DamageTypes += 1; }
-					if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-					if ($ActualDamage['NumSDs'] > 0) { $DamageTypes += 1; }
-
-					if ($ActualDamage['NumMines'] > 0) {
-						?><span class="red"><?php echo number_format($ActualDamage['NumMines']) ?></span> mines<?php
-						$this->doDamageTypeReductionDisplay($DamageTypes);
-					}
-					if ($ActualDamage['NumCDs'] > 0) {
-						?><span class="red"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-						$this->doDamageTypeReductionDisplay($DamageTypes);
-					}
-					if ($ActualDamage['NumSDs'] > 0) {
-						?><span class="red"><?php echo number_format($ActualDamage['NumSDs']) ?></span> scout drones<?php
-					}
+					?> destroying <?php echo $this->displayForceTakenDamage($ActualDamage);
 				}
 			} ?>.
 			<br />
@@ -97,17 +81,7 @@ foreach ($AllTraderResults as $TraderResults) {
 								?> whilst the others destroy <?php
 							}
 						}
-						if ($ActualDamage['NumMines'] > $WeaponDamage['Kamikaze']) {
-							?><span class="red"><?php echo number_format($ActualDamage['NumMines']) ?></span> mines<?php
-							$this->doDamageTypeReductionDisplay($DamageTypes);
-						}
-						if ($ActualDamage['NumCDs'] > 0) {
-							?><span class="red"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-							$this->doDamageTypeReductionDisplay($DamageTypes);
-						}
-						if ($ActualDamage['NumSDs'] > 0) {
-							?><span class="red"><?php echo number_format($ActualDamage['NumSDs']) ?></span> scout drones<?php
-						}
+						echo $this->displayForceTakenDamage($ActualDamage, $WeaponDamage['Kamikaze']);
 					}
 				}
 			}?>.

--- a/src/templates/Default/engine/Default/includes/ForcesCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/ForcesCombatResults.inc.php
@@ -42,23 +42,7 @@ foreach ($CombatForces as $ForceType => $ForceResults) {
 				?> but it cannot do any damage<?php
 			}
 		} else {
-			?> destroying <?php
-		}
-		$DamageTypes = 0;
-		if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-		if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-		if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
-
-		if ($ActualDamage['Shield'] > 0) {
-			?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
-			$this->doDamageTypeReductionDisplay($DamageTypes);
-		}
-		if ($ActualDamage['NumCDs'] > 0) {
-			?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']) ?></span> drones<?php
-			$this->doDamageTypeReductionDisplay($DamageTypes);
-		}
-		if ($ActualDamage['Armour'] > 0) {
-			?><span class="red"><?php echo number_format($ActualDamage['Armour']) ?></span> plates of armour<?php
+			?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 		}
 	} ?>.
 	<br /><?php

--- a/src/templates/Default/engine/Default/includes/PlanetCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/PlanetCombatResults.inc.php
@@ -49,23 +49,7 @@ if (isset($PlanetCombatResults['Weapons'])) {
 					?> but it cannot do any damage<?php
 				}
 			} else {
-				?> destroying <?php
-				$DamageTypes = 0;
-				if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-				if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-				if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
-
-				if ($ActualDamage['Shield'] > 0) {
-					?><span class="shields"><?php echo number_format($ActualDamage['Shield']); ?></span> shields<?php
-					$this->doDamageTypeReductionDisplay($DamageTypes);
-				}
-				if ($ActualDamage['NumCDs'] > 0) {
-					?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']); ?></span> combat drones<?php
-					$this->doDamageTypeReductionDisplay($DamageTypes);
-				}
-				if ($ActualDamage['Armour'] > 0) {
-					?><span class="red"><?php echo number_format($ActualDamage['Armour']); ?></span> plates of armour<?php
-				}
+				?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 			}
 		} ?>.
 		<br /><?php
@@ -82,10 +66,6 @@ if (isset($PlanetCombatResults['Drones'])) {
 	$ActualDamage = $Drones['ActualDamage'];
 	$WeaponDamage = $Drones['WeaponDamage'];
 	$TargetPlayer = $Drones['Target'];
-	$DamageTypes = 0;
-	if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-	if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-	if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
 
 	echo $CombatPlanet->getCombatName();
 	if (!isset($WeaponDamage['Launched'])) {
@@ -109,18 +89,7 @@ if (isset($PlanetCombatResults['Drones'])) {
 					?> but they cannot do any damage<?php
 				}
 			} else {
-				?> destroying <?php
-				if ($ActualDamage['Shield'] > 0) {
-					?><span class="shields"><?php echo number_format($ActualDamage['Shield']); ?></span> shields<?php
-					$this->doDamageTypeReductionDisplay($DamageTypes);
-				}
-				if ($ActualDamage['NumCDs'] > 0) {
-					?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']); ?></span> combat drones<?php
-					$this->doDamageTypeReductionDisplay($DamageTypes);
-				}
-				if ($ActualDamage['Armour'] > 0) {
-					?><span class="red"><?php echo number_format($ActualDamage['Armour']); ?></span> plates of armour<?php
-				}
+				?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 			}
 		}
 	} ?>.

--- a/src/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/PlanetTraderTeamCombatResults.inc.php
@@ -55,23 +55,7 @@ foreach ($AllTraderResults as $TraderResults) {
 						?> but it cannot do any damage<?php
 					}
 				} else {
-					?> destroying <?php
-					$DamageTypes = 0;
-					if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-					if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-					if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
-
-					if ($ActualDamage['Shield'] > 0) {
-						?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
-						$this->doDamageTypeReductionDisplay($DamageTypes);
-					}
-					if ($ActualDamage['NumCDs'] > 0) {
-						?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-						$this->doDamageTypeReductionDisplay($DamageTypes);
-					}
-					if ($ActualDamage['Armour'] > 0) {
-						?><span class="red"><?php echo number_format($ActualDamage['Armour']) ?></span> plates of armour<?php
-					}
+					?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 				}
 			} ?>.
 			<br /><?php
@@ -87,10 +71,6 @@ foreach ($AllTraderResults as $TraderResults) {
 			$ActualDamage = $Drones['ActualDamage'];
 			$WeaponDamage = $Drones['WeaponDamage'];
 			$TargetPlanet = $Drones['Target'];
-			$DamageTypes = 0;
-			if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-			if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-			if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
 
 			echo $ShootingPlayer->getDisplayName();
 			if (!isset($WeaponDamage['Launched'])) {
@@ -119,18 +99,7 @@ foreach ($AllTraderResults as $TraderResults) {
 							?> but they cannot do any damage<?php
 						}
 					} else {
-						?> destroying <?php
-						if ($ActualDamage['Shield'] > 0) {
-							?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
-							$this->doDamageTypeReductionDisplay($DamageTypes);
-						}
-						if ($ActualDamage['NumCDs'] > 0) {
-							?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-							$this->doDamageTypeReductionDisplay($DamageTypes);
-						}
-						if ($ActualDamage['Armour'] > 0) {
-							?><span class="red"><?php echo number_format($ActualDamage['Armour']) ?></span> plates of armour<?php
-						}
+						?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 					}
 				}
 			} ?>.

--- a/src/templates/Default/engine/Default/includes/PortCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/PortCombatResults.inc.php
@@ -49,23 +49,7 @@ if (isset($PortCombatResults['Weapons'])) {
 					?> but it cannot do any damage<?php
 				}
 			} else {
-				?> destroying <?php
-				$DamageTypes = 0;
-				if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-				if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-				if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
-
-				if ($ActualDamage['Shield'] > 0) {
-					?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
-					$this->doDamageTypeReductionDisplay($DamageTypes);
-				}
-				if ($ActualDamage['NumCDs'] > 0) {
-					?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-					$this->doDamageTypeReductionDisplay($DamageTypes);
-				}
-				if ($ActualDamage['Armour'] > 0) {
-					?><span class="red"><?php echo number_format($ActualDamage['Armour']) ?></span> plates of armour<?php
-				}
+				?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 			}
 		} ?>.
 		<br /><?php
@@ -105,23 +89,7 @@ if (isset($PortCombatResults['Drones'])) {
 					?> but they cannot do any damage<?php
 				}
 			} else {
-				?> destroying <?php
-				$DamageTypes = 0;
-				if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-				if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-				if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
-
-				if ($ActualDamage['Shield'] > 0) {
-					?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
-					$this->doDamageTypeReductionDisplay($DamageTypes);
-				}
-				if ($ActualDamage['NumCDs'] > 0) {
-					?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-					$this->doDamageTypeReductionDisplay($DamageTypes);
-				}
-				if ($ActualDamage['Armour'] > 0) {
-					?><span class="red"><?php echo number_format($ActualDamage['Armour']) ?></span> plates of armour<?php
-				}
+				?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 			}
 		}
 	} ?>.

--- a/src/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/PortTraderTeamCombatResults.inc.php
@@ -53,23 +53,7 @@ foreach ($AllTraderResults as $TraderResults) {
 						?> but it cannot do any damage<?php
 					}
 				} else {
-					?> destroying <?php
-					$DamageTypes = 0;
-					if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-					if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-					if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
-
-					if ($ActualDamage['Shield'] > 0) {
-						?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
-						$this->doDamageTypeReductionDisplay($DamageTypes);
-					}
-					if ($ActualDamage['NumCDs'] > 0) {
-						?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-						$this->doDamageTypeReductionDisplay($DamageTypes);
-					}
-					if ($ActualDamage['Armour'] > 0) {
-						?><span class="red"><?php echo number_format($ActualDamage['Armour']) ?></span> plates of armour<?php
-					}
+					?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 				}
 			} ?>.
 			<br /><?php
@@ -114,23 +98,7 @@ foreach ($AllTraderResults as $TraderResults) {
 							?> but they cannot do any damage<?php
 						}
 					} else {
-						?> destroying <?php
-						$DamageTypes = 0;
-						if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-						if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-						if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
-
-						if ($ActualDamage['Shield'] > 0) {
-							?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
-							$this->doDamageTypeReductionDisplay($DamageTypes);
-						}
-						if ($ActualDamage['NumCDs'] > 0) {
-							?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-							$this->doDamageTypeReductionDisplay($DamageTypes);
-						}
-						if ($ActualDamage['Armour'] > 0) {
-							?><span class="red"><?php echo number_format($ActualDamage['Armour']) ?></span> plates of armour<?php
-						}
+						?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 					}
 				}
 			} ?>.

--- a/src/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc.php
+++ b/src/templates/Default/engine/Default/includes/TraderTeamCombatResults.inc.php
@@ -58,23 +58,7 @@ foreach ($CombatTeamResults as $TraderResults) {
 						?> but it cannot do any damage<?php
 					}
 				} else {
-					?> destroying <?php
-					$DamageTypes = 0;
-					if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-					if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-					if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
-
-					if ($ActualDamage['Shield'] > 0) {
-						?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
-						$this->doDamageTypeReductionDisplay($DamageTypes);
-					}
-					if ($ActualDamage['NumCDs'] > 0) {
-						?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-						$this->doDamageTypeReductionDisplay($DamageTypes);
-					}
-					if ($ActualDamage['Armour'] > 0) {
-						?><span class="red"><?php echo number_format($ActualDamage['Armour']) ?></span> plates of armour<?php
-					}
+					?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 				}
 			} ?>.
 			<br /><?php
@@ -90,10 +74,6 @@ foreach ($CombatTeamResults as $TraderResults) {
 			$ActualDamage = $Drones['ActualDamage'];
 			$WeaponDamage = $Drones['WeaponDamage'];
 			$TargetPlayer = $Drones['Target'];
-			$DamageTypes = 0;
-			if ($ActualDamage['Shield'] > 0) { $DamageTypes += 1; }
-			if ($ActualDamage['NumCDs'] > 0) { $DamageTypes += 1; }
-			if ($ActualDamage['Armour'] > 0) { $DamageTypes += 1; }
 
 			echo $ShootingPlayer->getDisplayName();
 			if (!isset($WeaponDamage['Launched'])) {
@@ -122,18 +102,7 @@ foreach ($CombatTeamResults as $TraderResults) {
 							?> but they cannot do any damage<?php
 						}
 					} else {
-						?> destroying <?php
-						if ($ActualDamage['Shield'] > 0) {
-							?><span class="shields"><?php echo number_format($ActualDamage['Shield']) ?></span> shields<?php
-							$this->doDamageTypeReductionDisplay($DamageTypes);
-						}
-						if ($ActualDamage['NumCDs'] > 0) {
-							?><span class="cds"><?php echo number_format($ActualDamage['NumCDs']) ?></span> combat drones<?php
-							$this->doDamageTypeReductionDisplay($DamageTypes);
-						}
-						if ($ActualDamage['Armour'] > 0) {
-							?><span class="red"><?php echo number_format($ActualDamage['Armour']) ?></span> plates of armour<?php
-						}
+						?> destroying <?php echo $this->displayTakenDamage($ActualDamage);
 					}
 				}
 			} ?>.

--- a/test/SmrTest/lib/TemplateTest.php
+++ b/test/SmrTest/lib/TemplateTest.php
@@ -5,6 +5,7 @@ namespace SmrTest\lib;
 use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
 use Smr\Template;
@@ -49,6 +50,48 @@ class TemplateTest extends TestCase {
 		self::assertSame('a', $method->invoke($template, 'house'));
 		self::assertSame('an', $method->invoke($template, 'Egg'));
 		self::assertSame('an', $method->invoke($template, 'apple'));
+	}
+
+	#[TestWith([3, 1, 1, '<span class="red">1</span> mine, <span class="red">1</span> combat drone and <span class="red">1</span> scout drone'])]
+	#[TestWith([4, 0, 2, '<span class="red">2</span> mines and <span class="red">2</span> scout drones'])]
+	#[TestWith([0, 2, 0, '<span class="red">2</span> combat drones'])]
+	public function test_displayForceTakenDamage(int $mines, int $cds, int $sds, string $expected): void {
+		$template = Template::getInstance();
+		$damageTaken = [
+			'KillingShot' => false, // unused
+			'TargetAlreadyDead' => false, // unused
+			'Mines' => 0, // unused
+			'NumMines' => $mines,
+			'HasMines' => false, // unused
+			'CDs' => 0, // unused
+			'NumCDs' => $cds,
+			'HasCDs' => false, // unused
+			'SDs' => 0, // unused
+			'NumSDs' => $sds,
+			'HasSDs' => false, // unused
+			'TotalDamage' => 0, // unused
+		];
+		$result = $template->displayForceTakenDamage($damageTaken, kamikaze: 2);
+		self::assertSame($expected, $result);
+	}
+
+	#[TestWith([1, 1, 1, '<span class="shields">1</span> shield, <span class="cds">1</span> combat drone and <span class="red">1</span> plate of armour'])]
+	#[TestWith([2, 0, 2, '<span class="shields">2</span> shields and <span class="red">2</span> plates of armour'])]
+	#[TestWith([0, 2, 0, '<span class="cds">2</span> combat drones'])]
+	public function test_displayTakenDamage(int $shields, int $cds, int $armour, string $expected): void {
+		$template = Template::getInstance();
+		$damageTaken = [
+			'KillingShot' => false, // unused
+			'TargetAlreadyDead' => false, // unused
+			'Shield' => $shields,
+			'CDs' => 0, // unused
+			'NumCDs' => $cds,
+			'HasCDs' => false, // unused
+			'Armour' => $armour,
+			'TotalDamage' => 0, // unused
+		];
+		$result = $template->displayTakenDamage($damageTaken);
+		self::assertSame($expected, $result);
 	}
 
 	#[DataProvider('checkDisableAJAX_provider')]


### PR DESCRIPTION
The combat templates were all duplicating the exact logic for building the damage taken display HTML. We refactor this logic into the Template methods `display{Force}TakenDamage`.

Also fix the messages so that they are properly pluralized.

Note that the kamikaze effect is handled slightly differently. Now, if there is a kamikaze, it subtracts that from the number of mines that were destroyed by non-kamikaze. Previously, it only printed the mine damage if it was greater than kamikaze, but then displayed the total number of mines lost. I think the new logic is more correct, but from a practical perspective they are identical, because combat drones do not currently do both kamikaze and normal damage to mines.