### PR TITLE
docker-compose.yml: remove secrets mode attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ x-smr-base: &smr-base
         MYSQL_PASSWORD_FILE: /run/secrets/mysql-password
     secrets:
         - source: mysql-password
-          mode: 0444
 
 # Web configuration for `smr` (production) and `smr-dev` (testing).
 x-smr-web: &smr-web


### PR DESCRIPTION
Fixes the following warning:

> WARN[0000] secrets `uid`, `gid` and `mode` are not supported, they will be ignored

See https://github.com/docker/compose/issues/9648.

By inspection of the secrets file, the uid/gid is root and the mode is 0444. This seems fine for the current state of the container, but we can't change it if needed without further docker-compose development.