### PR TITLE
Fix php 8.4 deprecation in nbbc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
 	"name": "smr/smr",
 	"description": "SMR",
 	"license": "AGPL-3.0",
+	"repositories": [
+		{
+			"type": "github",
+			"url": "https://github.com/hemberger/nbbc"
+		}
+	],
 	"require": {
 		"abraham/twitteroauth": "7.0.0",
 		"doctrine/dbal": "4.2.3",
@@ -15,7 +21,7 @@
 		"php-di/php-di": "7.0.10",
 		"phpmailer/phpmailer": "6.10.0",
 		"team-reflex/discord-php": "10.5.0",
-		"vanilla/nbbc": "2.6.0"
+		"vanilla/nbbc": "dev-php-8.4-deprecation#79c7e0457c"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -213,7 +213,7 @@ function bbify(string $message, ?int $gameID = null, bool $noLinks = false): str
 
 		$smrRule = [
 				'mode' => BBCode::BBCODE_MODE_CALLBACK,
-				'method' => 'smrBBCode',
+				'method' => smrBBCode(...),
 				'class' => 'link',
 				'allow_in' => ['listitem', 'block', 'columns', 'inline'],
 				'end_tag' => BBCode::BBCODE_PROHIBIT,

--- a/test/SmrTest/lib/functions/BbifyTest.php
+++ b/test/SmrTest/lib/functions/BbifyTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\functions;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+#[CoversFunction('bbify')]
+#[CoversFunction('smrBBCode')]
+class BbifyTest extends TestCase {
+
+	public function test_verbatim(): void {
+		$result = bbify('[verbatim]Hello[/verbatim]', gameID: 0, noLinks: true);
+		$expect = '<tt>Hello</tt>';
+		self::assertSame($expect, $result);
+	}
+
+	#[TestWith([true, '<span style="color:#ffff00">Creonti</span>'])]
+	#[TestWith([false, '<a href="/loader.php?sn=icmlzw"><span style="color:#ffff00">Creonti</span></a>'])]
+	public function test_race(bool $noLinks, string $expect): void {
+		srand(321); // set rand seed for session href generation
+		$result = bbify('[race=3]', gameID: 0, noLinks: $noLinks);
+		self::assertSame($expect, $result);
+	}
+
+}


### PR DESCRIPTION
The vanilla/nbbc code has a deprecation warning that will be fixed with the following PR:

https://github.com/vanilla/nbbc/pull/39

While we wait for that to be merged, install from the PR branch to avoid the deprecation warning.

Added a test of the `bbify` function, since there was previously no test code exercising nbbc. Also pass the `smrBBCode` function as a first- class callable when creating BBCode rules.