### PR TITLE
composer.json: fix nbbc repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"license": "AGPL-3.0",
 	"repositories": [
 		{
-			"type": "github",
+			"type": "vcs",
 			"url": "https://github.com/hemberger/nbbc"
 		}
 	],


### PR DESCRIPTION
Replace "github" with "vcs". I'm not sure why the former doesn't work, but it seems to give intermittent git/authentication errors that I wouldn't expect for a simple https download. If I still wanted to use "github", I think I would need to specify `"no-api": true`, otherwise the GitHub API would be used, maybe?

See https://getcomposer.org/doc/05-repositories.md#git-alternatives.