### PR TITLE
UniGen: add ability to insert new galaxy

### DIFF
--- a/src/lib/Smr/Galaxy.php
+++ b/src/lib/Smr/Galaxy.php
@@ -202,8 +202,11 @@ class Galaxy {
 			$this->startSector = 1;
 			if ($this->galaxyID !== 1) {
 				$galaxies = self::getGameGalaxies($this->gameID);
-				for ($i = 1; $i < $this->galaxyID; $i++) {
-					$this->startSector += $galaxies[$i]->getSize();
+				foreach ($galaxies as $galaxyId => $galaxy) {
+					if ($galaxyId >= $this->galaxyID) {
+						break;
+					}
+					$this->startSector += $galaxy->getSize();
 				}
 			}
 		}
@@ -387,6 +390,9 @@ class Galaxy {
 	 * Returns the sector connectivity of the galaxy as a percent.
 	 */
 	public function getConnectivity(): float {
+		if ($this->getSize() === 0) {
+			return 0;
+		}
 		$totalLinks = 0;
 		foreach ($this->getSectors() as $galSector) {
 			$totalLinks += $galSector->getNumberOfLinks();

--- a/src/pages/Admin/UniGen/EditGalaxies.php
+++ b/src/pages/Admin/UniGen/EditGalaxies.php
@@ -13,7 +13,7 @@ class EditGalaxies extends AccountPage {
 
 	public function __construct(
 		private readonly int $gameID,
-		private readonly int $galaxyID,
+		private readonly int $galaxyID, // for back button only
 	) {}
 
 	public function build(Account $account, Template $template): void {
@@ -42,6 +42,10 @@ class EditGalaxies extends AccountPage {
 
 		$container = new EditGalaxy($this->gameID, $this->galaxyID);
 		$template->assign('BackHREF', $container->href());
+
+		$container = new EditGalaxiesAddProcessor($this->gameID, $this->galaxyID);
+		$template->assign('AddHREF', $container->href());
+		$template->assign('MaxAddId', $game->getNumberOfGalaxies() + 1);
 	}
 
 }

--- a/src/pages/Admin/UniGen/EditGalaxiesAddProcessor.php
+++ b/src/pages/Admin/UniGen/EditGalaxiesAddProcessor.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Pages\Admin\UniGen;
+
+use Exception;
+use Smr\Account;
+use Smr\Database;
+use Smr\Galaxy;
+use Smr\Game;
+use Smr\Page\AccountPageProcessor;
+use Smr\Request;
+use Smr\Sector;
+
+class EditGalaxiesAddProcessor extends AccountPageProcessor {
+
+	public function __construct(
+		private readonly int $gameID,
+		private readonly int $galaxyID, // for back button only
+	) {}
+
+	public function build(Account $account): never {
+		$db = Database::getInstance();
+
+		$insertGalaxyId = Request::getInt('insert_galaxy_id');
+
+		$game = Game::getGame($this->gameID);
+		if ($game->isEnabled()) {
+			throw new Exception('Unexpected galaxy insertion in an enabled game!');
+		}
+		if ($insertGalaxyId > $game->getNumberOfGalaxies() + 1) {
+			throw new Exception('Cannot insert galaxy ID: ' . $insertGalaxyId);
+		}
+
+		// Make room for the new galaxy, working in reverse galaxy ID order
+		$galaxies = $game->getGalaxies();
+		krsort($galaxies);
+		foreach ($galaxies as $galaxyId => $galaxy) {
+			if ($galaxyId >= $insertGalaxyId) {
+				// Increment the galaxy ID
+				$newGalaxyId = $galaxyId + 1;
+				$data = ['galaxy_id' => $db->escapeNumber($newGalaxyId)];
+				$db->update('game_galaxy', $data, $galaxy->SQLID);
+
+				// Modify the associated sectors
+				$sectors = $galaxy->getSectors();
+				foreach ($sectors as $sector) {
+					$sector->setGalaxyID($newGalaxyId);
+				}
+			}
+		}
+
+		// Add a new empty galaxy
+		$galaxy = Galaxy::createGalaxy($this->gameID, $insertGalaxyId);
+		$galaxy->setName('NEW GALAXY');
+		$galaxy->setWidth(0);
+		$galaxy->setHeight(0);
+		$galaxy->setGalaxyType(Galaxy::TYPE_NEUTRAL);
+		$galaxy->setMaxForceTime(0);
+		$galaxy->save();
+
+		Sector::saveSectors();
+		Sector::clearCache();
+		Galaxy::clearCache();
+
+		$container = new EditGalaxies($this->gameID, $this->galaxyID);
+		$container->go();
+	}
+
+}

--- a/src/pages/Admin/UniGen/EditGalaxiesProcessor.php
+++ b/src/pages/Admin/UniGen/EditGalaxiesProcessor.php
@@ -18,7 +18,7 @@ class EditGalaxiesProcessor extends AccountPageProcessor {
 
 	public function __construct(
 		private readonly int $gameID,
-		private readonly int $galaxyID,
+		private readonly int $galaxyID, // for back button only
 	) {}
 
 	public function build(Account $account): never {
@@ -61,6 +61,8 @@ class EditGalaxiesProcessor extends AccountPageProcessor {
 			$message = '<span class="green">SUCCESS: </span>Edited galaxies (sizes unchanged).';
 			$container = new EditGalaxy($this->gameID, $this->galaxyID, $message);
 			$container->go();
+		} elseif ($game->isEnabled()) {
+			throw new Exception('Unexpected galaxy size changes in an enabled game!');
 		}
 
 		// *** BEGIN GALAXY DIMENSION MODIFICATION! ***

--- a/src/templates/Default/engine/Default/admin/unigen/galaxies_edit.php
+++ b/src/templates/Default/engine/Default/admin/unigen/galaxies_edit.php
@@ -1,12 +1,34 @@
 <?php declare(strict_types=1);
 
+/**
+ * @var string $AddHREF
+ * @var string $BackHREF
+ * @var bool $GameEnabled
+ * @var int $MaxAddId
+ */
+
 ?>
-<p><span class="red bold">WARNING: </span>You cannot modify galaxy sizes in
-games that have already been enabled! Ports, planets, and locations in
-sectors that are removed will also be removed!
-<br />
 
 <?php $this->includeTemplate('admin/unigen/GalaxyDetails.inc.php'); ?>
+
+<?php
+if ($GameEnabled) { ?>
+	<p>
+		<span class="bold">NOTE: </span>Galaxy sizes cannot be changed because
+		this game has already been enabled.
+	</p><?php
+} else { ?>
+	<p>
+		<span class="red bold">WARNING: </span>If you modify galaxy sizes,
+		any ports, planets, and locations in sectors that are removed will also
+		be removed! Relative locations may also shift.
+	</p>
+	<br />
+
+	<form method=POST action="<?php echo $AddHREF; ?>">
+		Add new galaxy ID: <input required name="insert_galaxy_id" type="number" min="1" max="<?php echo $MaxAddId; ?>" /> <input type="submit" value="Insert" />
+	</form><?php
+} ?>
 
 <br />
 <a href="<?php echo $BackHREF; ?>">&lt;&lt; Back</a>


### PR DESCRIPTION
When designing games, it can be helpful to be able to add a new galaxy. In the past, we would have to create an entirely new game. This feature is only available for games that are not yet enabled.

It was easiest to create an empty dummy galaxy that could then be modified using the existing EditGalaxiesProcessor subsequently. I had considered creating a javascript interface where you specify all desired changes client-side before any submissions, but that was harder to code both for the display and the processing. Maybe something for the future.

* Galaxy::getConnectivity now handles 0-size galaxies, since that's the default for newly inserted galaxies.

* Galaxy::getStartSector no longer assumes that we have all the galaxy IDs starting from 1. This *should* be true, but I ran into this issue during development due to an improperly added galaxy, and the new implementation handles this case and is also just safer in general.

* Tweaked the warning on the "Edit Galaxies" page so that it makes more sense when you can/can't change galaxy sizes (i.e. when the game isn't/is enabled respectively).

![image](https://github.com/user-attachments/assets/0f19eebe-f099-424c-9dfb-15273e582f83)
