### PR TITLE
UniGen: add ability to delete galaxies

### DIFF
--- a/src/lib/Smr/Galaxy.php
+++ b/src/lib/Smr/Galaxy.php
@@ -274,6 +274,10 @@ class Galaxy {
 	 * @return array<int, array<int, Sector>>
 	 */
 	public function getMapSectors(?int $centerSectorID = null, ?int $dist = null): array {
+		if ($this->getSize() === 0) {
+			return [];
+		}
+
 		if ($centerSectorID === null) {
 			$topLeft = Sector::getSector($this->getGameID(), $this->getStartSector());
 		} else {

--- a/src/pages/Admin/UniGen/EditGalaxies.php
+++ b/src/pages/Admin/UniGen/EditGalaxies.php
@@ -29,13 +29,19 @@ class EditGalaxies extends AccountPage {
 		$template->assign('Submit', $submit);
 
 		$galaxies = [];
-		foreach ($game->getGalaxies() as $galaxy) {
-			$galaxies[$galaxy->getGalaxyID()] = [
+		foreach ($game->getGalaxies() as $galaxyId => $galaxy) {
+			$container = new EditGalaxiesDelProcessor(
+				gameId: $this->gameID,
+				galaxyId: $this->galaxyID,
+				deleteGalaxyId: $galaxyId,
+			);
+			$galaxies[$galaxyId] = [
 				'Name' => $galaxy->getDisplayName(),
 				'Width' => $galaxy->getWidth(),
 				'Height' => $galaxy->getHeight(),
 				'Type' => $galaxy->getGalaxyType(),
 				'ForceMaxHours' => $galaxy->getMaxForceTime() / 3600,
+				'DelHREF' => $container->href(),
 			];
 		}
 		$template->assign('Galaxies', $galaxies);

--- a/src/pages/Admin/UniGen/EditGalaxiesAddProcessor.php
+++ b/src/pages/Admin/UniGen/EditGalaxiesAddProcessor.php
@@ -48,6 +48,10 @@ class EditGalaxiesAddProcessor extends AccountPageProcessor {
 				}
 			}
 		}
+		// Save modified sectors, then reset cache since primary IDs changed
+		Sector::saveSectors();
+		Sector::clearCache();
+		Galaxy::clearCache();
 
 		// Add a new empty galaxy
 		$galaxy = Galaxy::createGalaxy($this->gameID, $insertGalaxyId);
@@ -58,11 +62,12 @@ class EditGalaxiesAddProcessor extends AccountPageProcessor {
 		$galaxy->setMaxForceTime(0);
 		$galaxy->save();
 
-		Sector::saveSectors();
-		Sector::clearCache();
-		Galaxy::clearCache();
-
-		$container = new EditGalaxies($this->gameID, $this->galaxyID);
+		// Adjust the galaxy the back button returns to
+		$backGalaxyId = $this->galaxyID;
+		if ($backGalaxyId >= $insertGalaxyId) {
+			$backGalaxyId += 1;
+		}
+		$container = new EditGalaxies($this->gameID, $backGalaxyId);
 		$container->go();
 	}
 

--- a/src/pages/Admin/UniGen/EditGalaxiesDelProcessor.php
+++ b/src/pages/Admin/UniGen/EditGalaxiesDelProcessor.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Pages\Admin\UniGen;
+
+use Exception;
+use Smr\Account;
+use Smr\Database;
+use Smr\Galaxy;
+use Smr\Game;
+use Smr\Page\AccountPageProcessor;
+use Smr\Sector;
+
+class EditGalaxiesDelProcessor extends AccountPageProcessor {
+
+	public function __construct(
+		private readonly int $gameId,
+		private readonly int $galaxyId, // for back button only
+		private readonly int $deleteGalaxyId,
+	) {}
+
+	public function build(Account $account): never {
+		$db = Database::getInstance();
+
+		$game = Game::getGame($this->gameId);
+		if ($game->isEnabled()) {
+			throw new Exception('Unexpected galaxy deletion in an enabled game!');
+		}
+
+		$galaxies = $game->getGalaxies(); // efficient cache population
+		$galaxy = $galaxies[$this->deleteGalaxyId];
+
+		// Start by shrinking the galaxy down to 0 size to handle all sectors
+		$newSizes = [$this->deleteGalaxyId => ['Width' => 0, 'Height' => 0]];
+		EditGalaxiesProcessor::resizeGalaxies($this->gameId, $newSizes);
+
+		// Delete the selected galaxy
+		$db->delete('game_galaxy', $galaxy->SQLID);
+		unset($galaxies[$this->deleteGalaxyId]);
+
+		// Re-index remaining galaxies
+		foreach ($galaxies as $galaxyId => $galaxy) {
+			if ($galaxyId > $this->deleteGalaxyId) {
+				// Decrement the ID for the galaxies above the deleted galaxy
+				$newGalaxyId = $galaxyId - 1;
+				$data = ['galaxy_id' => $db->escapeNumber($newGalaxyId)];
+				$db->update('game_galaxy', $data, $galaxy->SQLID);
+
+				// Modify the associated sectors
+				$sectors = $galaxy->getSectors();
+				foreach ($sectors as $sector) {
+					$sector->setGalaxyID($newGalaxyId);
+				}
+			}
+		}
+
+		Sector::saveSectors();
+		Sector::clearCache();
+		Galaxy::clearCache();
+
+		// Adjust the galaxy the back button returns to
+		$backGalaxyId = $this->galaxyId;
+		if ($backGalaxyId >= $this->deleteGalaxyId) {
+			$backGalaxyId -= 1;
+		}
+		$container = new EditGalaxies($this->gameId, $backGalaxyId);
+		$container->go();
+	}
+
+}

--- a/src/pages/Admin/UniGen/EditGalaxy.php
+++ b/src/pages/Admin/UniGen/EditGalaxy.php
@@ -70,7 +70,7 @@ class EditGalaxy extends AccountPage {
 		}
 		$template->assign('NextGalaxy', $nextGalaxy);
 
-		$template->assign('GameName', Game::getGame($this->gameID)->getName());
+		$template->assign('GameName', Game::getGame($this->gameID)->getDisplayName());
 		$template->assign('Galaxy', $galaxy);
 		$template->assign('Galaxies', $galaxies);
 		$template->assign('MapSectors', $mapSectors);

--- a/src/templates/Default/engine/Default/admin/unigen/GalaxyDetails.inc.php
+++ b/src/templates/Default/engine/Default/admin/unigen/GalaxyDetails.inc.php
@@ -2,6 +2,12 @@
 
 use Smr\Galaxy;
 
+/**
+ * @var array<int, array{Name: string, Width: int, Height: int, Type: Galaxy::TYPE_*, ForceMaxHours: float, DelHREF?: string}> $Galaxies
+ * @var bool $GameEnabled
+ * @var array{value: string, href: string} $Submit
+ */
+
 ?>
 <form method="POST" action="<?php echo $Submit['href']; ?>">
 	<table class="standard">
@@ -30,7 +36,14 @@ use Smr\Galaxy;
 					} ?>
 					</select>
 				</td>
-				<td class="center"><input required size="3" type="text" value="<?php echo $gal['ForceMaxHours']; ?>" name="forces<?php echo $i; ?>"></td>
+				<td class="center"><input required size="3" type="text" value="<?php echo $gal['ForceMaxHours']; ?>" name="forces<?php echo $i; ?>"></td><?php
+				if (!$GameEnabled && isset($gal['DelHREF'])) { ?>
+					<td>
+						<a href="<?php echo $gal['DelHREF']; ?>">
+							<img class="bottom" src="images/silk/cross.png" width="16" height="16" alt="Delete" title="Delete Galaxy <?php echo $i; ?>" />
+						</a>
+					</td><?php
+				} ?>
 			</tr><?php
 		} ?>
 		<tr><td class="center" colspan="6"><input type="submit" value="<?php echo $Submit['value']; ?>" name="submit"></td>


### PR DESCRIPTION
Implemented by reusing the galaxy resizing (setting the size to 0) from EditGalaxiesProcessor (with only a slight reorganization, no real logic changes) to handle the sector bookkeeping, and then deleting the galaxy.

Related fixes:

* Add early return in Galaxy::getMapSectors, which otherwise will throw if the size is 0 and it is the last galaxy ID (since the start sector it thinks it has won't exist).

* Fix the ordering of clearing the Galaxy cache and adding a new galaxy, since `Galaxy::createGalaxy` returns the cached galaxy if a galaxy with the same ID already exists. This fixes #2081, which only worked when the galaxy didn't exist.

* Fix the galaxyID for the back button when adding a new galaxy (and use the same kind of logic for deleting a galaxy) so that we return to the galaxy we were originally editing, or at least a valid galaxy if it no longer exists.

![image](https://github.com/user-attachments/assets/3e018f94-f4c2-4463-837e-655bd97bd024)
