### PR TITLE
Gameplay: allow NHA members to land on planets with newbie turns

### DIFF
--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -1030,7 +1030,7 @@ class Planet {
 
 		// Consume the required resources
 		$constructor->decreaseCredits($this->getStructureTypes($constructionID)->creditCost());
-		$constructor->takeTurns(TURNS_TO_BUILD);
+		$constructor->takeTurns(TURNS_TO_BUILD, TURNS_TO_BUILD);
 		foreach ($this->getStructureTypes($constructionID)->goods() as $goodID => $amount) {
 			$this->decreaseStockpile($goodID, $amount);
 		}

--- a/src/pages/Player/Planet/LandProcessor.php
+++ b/src/pages/Player/Planet/LandProcessor.php
@@ -19,8 +19,9 @@ class LandProcessor extends PlayerPageProcessor {
 			create_error('You don\'t have enough turns to land on planet.');
 		}
 
-		if ($player->hasNewbieTurns()) {
-			create_error('You cannot land on a planet whilst under newbie protection.');
+		// Only allow landing in newbie turns if in the NHA
+		if ($player->hasNewbieTurns() && !($player->hasAlliance() && $player->getAlliance()->isNHA())) {
+			create_error('You cannot land on this planet whilst under newbie protection.');
 		}
 
 		//check to make sure the planet isn't full!
@@ -44,7 +45,7 @@ class LandProcessor extends PlayerPageProcessor {
 			}
 		}
 		$player->setLandedOnPlanet(true);
-		$player->takeTurns(TURNS_TO_LAND);
+		$player->takeTurns(TURNS_TO_LAND, TURNS_TO_LAND);
 		$player->log(LOG_TYPE_MOVEMENT, 'Player lands at planet');
 		(new Main())->go();
 	}


### PR DESCRIPTION
Newbie Help Alliance players should get to experience planet gameplay without needing to make themselves vulnerable by dropping their newbie turns in order to land.

As a consequence, newbie turns will be consumed for landing and building for consistency.