### PR TITLE
EditGalaxy: fix recenter link

### DIFF
--- a/src/pages/Admin/UniGen/EditGalaxy.php
+++ b/src/pages/Admin/UniGen/EditGalaxy.php
@@ -98,7 +98,8 @@ class EditGalaxy extends AccountPage {
 		$container = new self($this->canEdit, $this->gameID);
 		$template->assign('JumpGalaxyHREF', $container->href());
 
-		$template->assign('RecenterHREF', new self($this->canEdit, $this->gameID)->href());
+		$container = new self($this->canEdit, $this->gameID, $this->galaxyID);
+		$template->assign('RecenterHREF', $container->href());
 
 		$container = new CreateGame();
 		$template->assign('BackButtonHREF', $container->href());


### PR DESCRIPTION
We were not passing along the galaxyID to the next container, and so it would default to galaxyID=1 and try to start that galaxy at the recenter sectorID (which usually was not in that galaxy).