### PR TITLE
.my.cnf.sample: switch back to root user

### DIFF
--- a/.my.cnf.sample
+++ b/.my.cnf.sample
@@ -1,5 +1,5 @@
 # Allow passwordless login to mysql via commandline
 [client]
 host=localhost
-user=smr
+user=root
 password=smr


### PR DESCRIPTION
While this expands the permissions of commandline mysql access, using the non-root user was problematic in the live configuration because we modify the password on redeploy, which means we're not able to complete the password change without doing so as the root user.

Then we also run into issues where if the container is already running, the `.my.cnf` file won't be updated properly because it's file-mounted (and the container will continue to see the old inode).

Therefore, it's simpler to use the root user for commandline access.