### PR TITLE
Fix traefik ACME certificate in live

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,8 @@ services:
             - frontend
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock:ro
-            - ./traefik:/etc/traefik:ro
+            # Mount read+write for writing acme.json file in live
+            - ./traefik:/etc/traefik:rw
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.traefik.rule=PathPrefix(`/api`) || PathPrefix(`/dashboard`)"

--- a/traefik/traefik-live.toml
+++ b/traefik/traefik-live.toml
@@ -25,7 +25,7 @@
 [api]
 
 [certificatesResolvers.myresolver.acme]
-  email = "mrspock@smrealms.de,daniel.hemberger@gmail.com"
+  email = "daniel.hemberger@gmail.com"
   storage = "/etc/traefik/acme.json"
   caServer = "https://acme-v02.api.letsencrypt.org/directory"
   [certificatesResolvers.myresolver.acme.tlsChallenge]


### PR DESCRIPTION
* Contrary to smrealms/dockerize@24c8e5a, we are not allowed to have multiple email addresses for a single ACME resolver (even though Let's Encrypt seems to allow comma-delimited email registration). I'm not sure how this ever worked, but it creates a very clear error in traefik now: "Error validating contact(s) :: unable to parse email address".

* Mount the traefik subdirectory as read+write in the traefik service so that the `acme.json` file can be written. This recovers the dockerize repo behavior and fixes a "read-only file system" error.