### PR TITLE
AbstractShip: match assertions in moveWeapons{Up,Down}

### DIFF
--- a/src/lib/Smr/AbstractShip.php
+++ b/src/lib/Smr/AbstractShip.php
@@ -199,6 +199,9 @@ class AbstractShip {
 	}
 
 	public function moveWeaponDown(int $orderID): void {
+		if (count($this->weapons) === 0) {
+			throw new Exception('This method cannot be used when there are no weapons');
+		}
 		$replacement = $orderID + 1;
 		if ($replacement >= count($this->weapons)) {
 			// Shift everything down by one and put the selected weapon at the top


### PR DESCRIPTION
Neither of these methods work if there are no Weapons.

Also add unit tests for these methods.