### PR TITLE
Add docker-compose ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,12 @@ updates:
   schedule:
     interval: daily
   rebase-strategy: disabled
+
+- package-ecosystem: docker-compose
+  directories:
+    - "/"
+    - "/test"
+    - "/live"
+  schedule:
+    interval: daily
+  rebase-strategy: disabled


### PR DESCRIPTION
This is necessary for updating packages like traefik, mysql, etc.