### PR TITLE
Give mysql service more time to pass healthcheck

### DIFF
--- a/abstract-services.yml
+++ b/abstract-services.yml
@@ -98,7 +98,9 @@ services:
         healthcheck:
             test: mysql -e 'SHOW DATABASES'
             interval: 5s
-            timeout: 20s
+            timeout: 5s
+            retries: 10
+            start_period: 30s
 
     flyway-base:
         image: flyway/flyway:10.14.0-alpine


### PR DESCRIPTION
In CI, we sometimes fail to start the mysql service in the allotted time. During the `start_period`, the test will be performed every 5s (by default) but won't count toward the number of retries. Then we'll try every 5s 10 times for a total of 30 + 50 = 80s. Timeout is decreased to 5s because the command should return almost immediately once mysql is ready for connections.

Note that this was likely failing because the first mysql run requires additional setup. If we continue to see failures, then there is likely some other issue at play.