### PR TITLE
ajax.js: remove deprecated onunload event listener

### DIFF
--- a/src/htdocs/js/ajax.js
+++ b/src/htdocs/js/ajax.js
@@ -89,7 +89,6 @@ var exec = function(s) {
 		// Similarly, we only need event listeners when refresh is enabled.
 		window.onfocus = scheduleRefresh;
 		window.onblur = cancelRefresh;
-		window.onunload = cancelRefresh;
 
 		if(!_refreshSpeed) {
 			return;


### PR DESCRIPTION
https://chromestatus.com/feature/5579556305502208