### PR TITLE
Feat: NPC traders for hire

### DIFF
--- a/db/patches/V1_6_69_06__remove_player_joined_alliance.sql
+++ b/db/patches/V1_6_69_06__remove_player_joined_alliance.sql
@@ -1,0 +1,2 @@
+-- No longer tracking player newbie status when joining alliances
+DROP TABLE `player_joined_alliance`;

--- a/db/patches/V1_6_69_07__alliance_bank_transactions.sql
+++ b/db/patches/V1_6_69_07__alliance_bank_transactions.sql
@@ -1,0 +1,28 @@
+-- Create a copy of `alliance_bank_transactions`
+CREATE TABLE `alliance_bank_transactions2` LIKE `alliance_bank_transactions`;
+
+-- Restructure copy so that it has an auto-increment column
+ALTER TABLE `alliance_bank_transactions2`
+  ENGINE = InnoDB,
+  DROP PRIMARY KEY,
+  MODIFY `transaction_id` int unsigned NOT NULL AUTO_INCREMENT,
+  ADD PRIMARY KEY (`transaction_id`),
+  ADD KEY `alliance` (`game_id`, `alliance_id`);
+
+-- Copy data into the new table
+INSERT INTO `alliance_bank_transactions2` (
+  `alliance_id`, `game_id`, `time`, `payee_id`, `reason`, `transaction`,
+  `amount`, `exempt`, `request_exempt`
+)
+SELECT
+  `alliance_id`, `game_id`, `time`, `payee_id`, `reason`, `transaction`,
+  `amount`, `exempt`, `request_exempt`
+FROM `alliance_bank_transactions`
+ORDER BY
+  `game_id`,
+  `alliance_id`,
+  `transaction_id`;
+
+-- Replace the original table with the new table
+DROP TABLE `alliance_bank_transactions`;
+RENAME TABLE `alliance_bank_transactions2` TO `alliance_bank_transactions`;

--- a/db/patches/V1_6_69_08__alliance_manage_npcs.sql
+++ b/db/patches/V1_6_69_08__alliance_manage_npcs.sql
@@ -1,0 +1,3 @@
+-- Add alliance role permission to manage hired NPCs
+ALTER TABLE `alliance_has_roles`
+	ADD COLUMN `manage_npcs` enum('TRUE','FALSE') NOT NULL DEFAULT 'FALSE';

--- a/src/config.php
+++ b/src/config.php
@@ -469,7 +469,11 @@ const ALLIANCE_BANK_UNLIMITED = -1;
 
 const UNI_GEN_LOCATION_SLOTS = 9;
 
+/*
+ * Reserved alliance names
+ */
 const NHA_ALLIANCE_NAME = 'Newbie Help Alliance';
+const NPC_FOR_HIRE_ALLIANCE_NAME = 'The Freelancers';
 
 const CLOSE_ACCOUNT_BY_REQUEST_REASON = 'User Request';
 const CLOSE_ACCOUNT_INVALID_EMAIL_REASON = 'Invalid email';

--- a/src/lib/Default/nha.inc.php
+++ b/src/lib/Default/nha.inc.php
@@ -3,6 +3,7 @@
 use Smr\Alliance;
 use Smr\Database;
 use Smr\Epoch;
+use Smr\Player;
 
 /**
  * Create the Newbie Help Alliance and populate its Message Board
@@ -17,7 +18,9 @@ function createNHA(int $gameID): void {
 	$alliance->setDiscordServer(DISCORD_SERVER_ID);
 	$alliance->update();
 
-	$allianceID = $alliance->getAllianceID();
+	$nhl = Player::createPlayer(ACCOUNT_ID_NHL, $gameID, 'Newbie Help Leader', RACE_HUMAN, false);
+	$nhl->joinAlliance($alliance->getAllianceID(), log: false);
+	$nhl->update();
 
 	// NHA default topics
 	$threads = [
@@ -29,7 +32,7 @@ function createNHA(int $gameID): void {
 	4) Talk to other players ingame or in IRC chat.<br />
 	5) Stay in the racial galaxies as much as possible.<br />
 	6) Learn to use Merchant\'s Guide to the Universe.<br />
-	7) Contact Newbie Help Leader for help, advice or with any questions you have.<br />
+	7) Contact ' . $nhl->getBBLink() . ' for help, advice or with any questions you have.<br />
 	<br />
 	8) Most of all - have fun out there!',
 
@@ -41,9 +44,9 @@ function createNHA(int $gameID): void {
 	<br />
 	3) Maps. A short time into every game, this alliance will usually have full maps of the game universe. However, keep in mind that maps will change slightly during the course of a game as ports get upgraded and busted down.<br />
 	<br />
-	4) If you stay in NHA, stay active, try to learn, and keep in touch with the Newbie Help Leader then this alliance can be a stepping stone to the more established alliances. Every game I get alliance leaders asking me to recommend newbies who are active and have potential.<br />
+	4) If you stay in NHA, stay active, try to learn, and keep in touch with ' . $nhl->getBBLink() . ', then this alliance can be a stepping stone to the more established alliances. Every game I get alliance leaders asking me to recommend newbies who are active and have potential.<br />
 	<br />
-	5) Newbie Help Leader will work with each of you individually on specific questions and game goals if you want. If resources allow it (I am dependent on my own trading income for cash) I try to reward players for achieving the game goals they work towards. I also try to make sure that members have at least a mid-level tradeship after they have been killed, although I try to make sure that they have learned from their mistakes before buying replacement ships (to be fair to the rest of the players in the game, you can no longer get cash or new ships after reaching fledgling status, although you are welcome to stay in the alliance as long as you like).',
+	5) ' . $nhl->getBBLink() . ' will work with each of you individually on specific questions and game goals if you want. If resources allow it (I am dependent on my own trading income for cash) I try to reward players for achieving the game goals they work towards. I also try to make sure that members have at least a mid-level tradeship after they have been killed, although I try to make sure that they have learned from their mistakes before buying replacement ships (to be fair to the rest of the players in the game, you can no longer get cash or new ships after reaching fledgling status, although you are welcome to stay in the alliance as long as you like).',
 
 		'Turns' => 'Many of the basic actions performed in SMR cost turns, the most common examples being moving, trading &amp; attacking. One of the keys to success in the game is good turn management, no matter what you are busing the turns to accomplish. If you are a trader, you want to get as much cash and xp as possible per turn used. If you are a hunter, you want to spend as many turns as possible efficiently locating targets and getting kills, and as few as possible chasing traders around without getting the final trigger shot off. In an alliance, you will often be expected to save turns for op\'s, where it is often crucial to have plenty of alliance members show up with plenty of turns.<br />
 	<br />
@@ -221,14 +224,12 @@ function createNHA(int $gameID): void {
 	$threadID = 1;
 	foreach ($threads as $topic => $text) {
 		$db->replace('alliance_thread_topic', [
-			'game_id' => $gameID,
-			'alliance_id' => $allianceID,
+			...$alliance->SQLID,
 			'thread_id' => $threadID,
 			'topic' => $topic,
 		]);
 		$db->replace('alliance_thread', [
-			'game_id' => $gameID,
-			'alliance_id' => $allianceID,
+			...$alliance->SQLID,
 			'thread_id' => $threadID,
 			'reply_id' => 1,
 			'text' => $text,

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -1556,16 +1556,6 @@ abstract class AbstractPlayer {
 	public function joinAlliance(int $allianceID, bool $log = true): void {
 		$this->setAllianceID($allianceID);
 
-		$status = $this->hasNewbieStatus() ? 'NEWBIE' : 'VETERAN';
-		$db = Database::getInstance();
-		$db->write('INSERT IGNORE INTO player_joined_alliance (account_id,game_id,alliance_id,status)
-			VALUES (:account_id, :game_id, :alliance_id, :status)', [
-			'account_id' => $db->escapeNumber($this->getAccountID()),
-			'game_id' => $db->escapeNumber($this->getGameID()),
-			'alliance_id' => $db->escapeNumber($allianceID),
-			'status' => $db->escapeString($status),
-		]);
-
 		$alliance = $this->getAlliance();
 
 		if (!$this->isAllianceLeader()) {

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -656,6 +656,21 @@ abstract class AbstractPlayer {
 	}
 
 	/**
+	 * Is this an NPC that has been hired by a player alliance?
+	 */
+	public function isHiredNPC(): bool {
+		// Currently determined by whether or not alliance leader is an NPC.
+		// This should really be tracked in the database directly instead.
+		if ($this->isNPC() && $this->hasAlliance()) {
+			$alliance = $this->getAlliance();
+			if ($alliance->hasLeader() && !$alliance->getLeader()->isNPC()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Does the player have Newbie status?
 	 */
 	public function hasNewbieStatus(): bool {
@@ -1523,7 +1538,7 @@ abstract class AbstractPlayer {
 
 	public function leaveAlliance(?self $kickedBy = null): void {
 		$alliance = $this->getAlliance();
-		if ($kickedBy !== null) {
+		if ($kickedBy !== null && !$kickedBy->equals($this)) {
 			$kickedBy->sendMessage($this->getAccountID(), MSG_PLAYER, 'You were kicked out of the alliance!', false);
 			$this->log(LOG_TYPE_ALLIANCE, 'was kicked from alliance ' . $alliance->getAllianceName() . ' by ' . $kickedBy->getAccount()->getLogin() . ' (' . $kickedBy->getPlayerName() . ')');
 			$kickedBy->log(LOG_TYPE_ALLIANCE, 'kicked ' . $this->getAccount()->getLogin() . ' (' . $this->getPlayerName() . ') from alliance ' . $alliance->getAllianceName());
@@ -1537,7 +1552,7 @@ abstract class AbstractPlayer {
 		}
 
 		// Don't have a delay for switching alliance after leaving NHA, or for disbanding an alliance.
-		if (!$this->isAllianceLeader() && !$alliance->isNHA()) {
+		if (!$this->isAllianceLeader() && !$alliance->isNHA() && !$alliance->isNpcForHire()) {
 			$this->setAllianceJoinable(Epoch::time() + self::TIME_FOR_ALLIANCE_SWITCH);
 			$alliance->getLeader()->setAllianceJoinable(Epoch::time() + self::TIME_FOR_ALLIANCE_SWITCH); //We set the joinable time for leader here, that way a single player alliance won't cause a player to wait before switching.
 		}
@@ -1559,7 +1574,9 @@ abstract class AbstractPlayer {
 		$alliance = $this->getAlliance();
 
 		if (!$this->isAllianceLeader()) {
-			$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I joined your alliance!', false);
+			if ($alliance->getLeaderID() !== 0) {
+				$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I joined your alliance!', false);
+			}
 			$roleID = ALLIANCE_ROLE_NEW_MEMBER;
 		} else {
 			$roleID = ALLIANCE_ROLE_LEADER;

--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -1531,7 +1531,7 @@ abstract class AbstractPlayer {
 			$this->log(LOG_TYPE_ALLIANCE, 'disbanded alliance ' . $alliance->getAllianceName());
 		} else {
 			$this->log(LOG_TYPE_ALLIANCE, 'left alliance: ' . $alliance->getAllianceName());
-			if ($alliance->getLeaderID() !== 0 && $alliance->getLeaderID() !== ACCOUNT_ID_NHL) {
+			if ($alliance->getLeaderID() !== 0) {
 				$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I left your alliance!', false);
 			}
 		}
@@ -1553,7 +1553,7 @@ abstract class AbstractPlayer {
 	/**
 	 * Join an alliance (used for both Leader and New Member roles)
 	 */
-	public function joinAlliance(int $allianceID): void {
+	public function joinAlliance(int $allianceID, bool $log = true): void {
 		$this->setAllianceID($allianceID);
 
 		$status = $this->hasNewbieStatus() ? 'NEWBIE' : 'VETERAN';
@@ -1569,15 +1569,7 @@ abstract class AbstractPlayer {
 		$alliance = $this->getAlliance();
 
 		if (!$this->isAllianceLeader()) {
-			// Do not throw an exception if the NHL account doesn't exist.
-			try {
-				$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I joined your alliance!', false);
-			} catch (AccountNotFound $e) {
-				if ($alliance->getLeaderID() !== ACCOUNT_ID_NHL) {
-					throw $e;
-				}
-			}
-
+			$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I joined your alliance!', false);
 			$roleID = ALLIANCE_ROLE_NEW_MEMBER;
 		} else {
 			$roleID = ALLIANCE_ROLE_LEADER;
@@ -1589,7 +1581,9 @@ abstract class AbstractPlayer {
 			'alliance_id' => $this->getAllianceID(),
 		]);
 
-		$this->log(LOG_TYPE_ALLIANCE, 'joined alliance: ' . $alliance->getAllianceName());
+		if ($log) {
+			$this->log(LOG_TYPE_ALLIANCE, 'joined alliance: ' . $alliance->getAllianceName());
+		}
 	}
 
 	public function getAllianceJoinable(): int {

--- a/src/lib/Smr/Alliance.php
+++ b/src/lib/Smr/Alliance.php
@@ -129,7 +129,7 @@ class Alliance {
 	 * Create an alliance and return the new object.
 	 * Starts alliance with "closed" recruitment (for safety).
 	 */
-	public static function createAlliance(int $gameID, string $name, bool $allowNHA = false): self {
+	public static function createAlliance(int $gameID, string $name, bool $allowReserved = false): self {
 		$db = Database::getInstance();
 		$db->lockTable('alliance');
 		try {
@@ -141,7 +141,11 @@ class Alliance {
 				// alliance with this name does not yet exist
 			}
 
-			if (!$allowNHA && trim($name) === NHA_ALLIANCE_NAME) {
+			$reserved = [
+				NHA_ALLIANCE_NAME,
+				NPC_FOR_HIRE_ALLIANCE_NAME,
+			];
+			if (!$allowReserved && in_array(trim($name), $reserved, true)) {
 				throw new UserError('That alliance name is reserved.');
 			}
 
@@ -172,6 +176,13 @@ class Alliance {
 	 */
 	public function isNHA(): bool {
 		return $this->allianceName === NHA_ALLIANCE_NAME;
+	}
+
+	/**
+	 * Returns true if the alliance is the NPC-For-Hire alliance.
+	 */
+	public function isNpcForHire(): bool {
+		return $this->allianceName === NPC_FOR_HIRE_ALLIANCE_NAME;
 	}
 
 	public function getAllianceID(): int {
@@ -530,6 +541,16 @@ class Alliance {
 	}
 
 	/**
+	 * @return array<int, Player>
+	 */
+	public function getNpcs(): array {
+		return array_filter(
+			$this->getMembers(includeNpc: true),
+			fn($player) => $player->isNPC(),
+		);
+	}
+
+	/**
 	 * @return array<int>
 	 */
 	public function getActiveIDs(): array {
@@ -613,10 +634,10 @@ class Alliance {
 		$sendAllMsg = true;
 		$opLeader = true;
 		$viewBonds = true;
+		$manageNpcs = true;
 		$db = Database::getInstance();
 		$db->insert('alliance_has_roles', [
-			'alliance_id' => $this->getAllianceID(),
-			'game_id' => $this->getGameID(),
+			...$this->SQLID,
 			'role_id' => ALLIANCE_ROLE_LEADER,
 			'role' => 'Leader',
 			'with_per_day' => $withPerDay,
@@ -630,6 +651,7 @@ class Alliance {
 			'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
 			'op_leader' => $db->escapeBoolean($opLeader),
 			'view_bonds' => $db->escapeBoolean($viewBonds),
+			'manage_npcs' => $db->escapeBoolean($manageNpcs),
 		]);
 
 		// Create new member role
@@ -649,6 +671,7 @@ class Alliance {
 				$sendAllMsg = false;
 				$opLeader = false;
 				$viewBonds = false;
+				$manageNpcs = false;
 				break;
 			case 'basic':
 				$withPerDay = ALLIANCE_BANK_UNLIMITED;
@@ -662,11 +685,11 @@ class Alliance {
 				$sendAllMsg = false;
 				$opLeader = false;
 				$viewBonds = false;
+				$manageNpcs = true;
 				break;
 		}
 		$db->insert('alliance_has_roles', [
-			'alliance_id' => $this->getAllianceID(),
-			'game_id' => $this->getGameID(),
+			...$this->SQLID,
 			'role_id' => ALLIANCE_ROLE_NEW_MEMBER,
 			'role' => 'New Member',
 			'with_per_day' => $withPerDay,
@@ -680,6 +703,7 @@ class Alliance {
 			'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
 			'op_leader' => $db->escapeBoolean($opLeader),
 			'view_bonds' => $db->escapeBoolean($viewBonds),
+			'manage_npcs' => $db->escapeBoolean($manageNpcs),
 		]);
 	}
 

--- a/src/lib/Smr/Alliance.php
+++ b/src/lib/Smr/Alliance.php
@@ -31,8 +31,6 @@ class Alliance {
 	protected int $flagshipID;
 
 	/** @var array<int> */
-	protected array $memberList;
-	/** @var array<int> */
 	protected array $seedlist;
 
 	// Recruit type constants
@@ -463,39 +461,28 @@ class Alliance {
 		if ($player->getAllianceJoinable() > Epoch::time()) {
 			return 'You cannot join another alliance for ' . format_time($player->getAllianceJoinable() - Epoch::time()) . '.';
 		}
-		if ($this->getNumMembers() < $this->getGame()->getAllianceMaxPlayers()) {
-			if ($player->hasNewbieStatus()) {
-				return false;
-			}
-			$maxVets = $this->getGame()->getAllianceMaxVets();
-			if ($this->getNumMembers() < $maxVets) {
-				return false;
-			}
-			$db = Database::getInstance();
-			$dbResult = $db->select(
-				'player_joined_alliance',
-				['account_id' => $player->getAccountID(), ...$this->SQLID],
-				['status'],
-			);
-			if ($dbResult->hasRecord()) {
-				if ($dbResult->record()->getString('status') === 'NEWBIE') {
-					return false;
-				}
-			}
-			$dbResult = $db->read('SELECT COUNT(*) AS num_orig_vets
-							FROM player_joined_alliance
-							JOIN player USING (account_id, alliance_id, game_id)
-							WHERE ' . self::SQL . ' AND status=\'VETERAN\'', $this->SQLID);
-			if (!$dbResult->hasRecord() || $dbResult->record()->getInt('num_orig_vets') < $maxVets) {
-				return false;
-			}
+		if (!$this->hasRoomForPlayer($player)) {
+			return 'There is not currently enough room for you in this alliance.';
 		}
-		return 'There is not currently enough room for you in this alliance.';
+		return false; // player is allowed to join alliance
 	}
 
+	public function hasRoomForPlayer(?AbstractPlayer $player = null): bool {
+		if ($this->getNumMembers() >= $this->getGame()->getAllianceMaxPlayers()) {
+			return false;
+		}
+		if ($player === null || $player->hasNewbieStatus()) {
+			return true;
+		}
+		return $this->getNumVeterans() < $this->getGame()->getAllianceMaxVets();
+	}
+
+	/**
+	 * Number of members who are currently non-Newbie status (excluding NPCs)
+	 */
 	public function getNumVeterans(): int {
 		$numVeterans = 0;
-		foreach ($this->getMembers() as $player) {
+		foreach ($this->getMembers(includeNpc: false) as $player) {
 			if (!$player->hasNewbieStatus()) {
 				$numVeterans++;
 			}
@@ -504,7 +491,7 @@ class Alliance {
 	}
 
 	public function getNumMembers(): int {
-		return count($this->getMemberIDs());
+		return count($this->getMembers(includeNpc: true));
 	}
 
 	public function update(): void {
@@ -534,25 +521,12 @@ class Alliance {
 	 *
 	 * @return array<int, Player>
 	 */
-	public function getMembers(): array {
-		return Player::getAlliancePlayers($this->getGameID(), $this->getAllianceID());
-	}
-
-	/**
-	 * @return array<int>
-	 */
-	public function getMemberIDs(): array {
-		if (!isset($this->memberList)) {
-			$db = Database::getInstance();
-			$dbResult = $db->select('player', $this->SQLID, ['account_id']);
-
-			//we have the list of players put them in an array now
-			$this->memberList = [];
-			foreach ($dbResult->records() as $dbRecord) {
-				$this->memberList[] = $dbRecord->getInt('account_id');
-			}
+	public function getMembers(bool $includeNpc): array {
+		$members = Player::getAlliancePlayers($this->getGameID(), $this->getAllianceID());
+		if (!$includeNpc) {
+			$members = array_filter($members, fn($player) => !$player->isNPC());
 		}
-		return $this->memberList;
+		return $members;
 	}
 
 	/**

--- a/src/lib/Smr/Menu.php
+++ b/src/lib/Smr/Menu.php
@@ -24,6 +24,7 @@ use Smr\Pages\Player\GalacticPost\PastEditionSelect;
 use Smr\Pages\Player\Headquarters\BountyClaimProcessor;
 use Smr\Pages\Player\Headquarters\BountyPlace;
 use Smr\Pages\Player\Headquarters\Government;
+use Smr\Pages\Player\Headquarters\HireTrader;
 use Smr\Pages\Player\Headquarters\MilitaryPaymentClaimProcessor;
 use Smr\Pages\Player\Headquarters\Underground;
 use Smr\Pages\Player\NewsReadCurrent;
@@ -67,6 +68,9 @@ class Menu {
 			$links[] = [BountyClaimProcessor::class, 'Claim Bounty'];
 			$links[] = [BountyPlace::class, 'Place Bounty'];
 		}
+
+		// Show to everybody, even if they don't have hiring permission yet
+		$links[] = [HireTrader::class, 'Hire Trader'];
 
 		$menuItems = [];
 		foreach ($links as [$class, $text]) {

--- a/src/pages/Account/GameJoinProcessor.php
+++ b/src/pages/Account/GameJoinProcessor.php
@@ -76,8 +76,8 @@ class GameJoinProcessor extends AccountPageProcessor {
 		// Mark the player's start sector as visited
 		$player->getSector()->markVisited($player);
 
-		if ($isNewbie || $account->getAccountID() === ACCOUNT_ID_NHL) {
-			// If player is a newb (or NHL), set alliance to be Newbie Help Allaince
+		if ($isNewbie) {
+			// If player is a newb, set alliance to be Newbie Help Allaince
 			$NHA = Alliance::getAllianceByName(NHA_ALLIANCE_NAME, $gameID);
 			$player->joinAlliance($NHA->getAllianceID());
 

--- a/src/pages/Account/PreviousGameAllianceDetail.php
+++ b/src/pages/Account/PreviousGameAllianceDetail.php
@@ -31,7 +31,7 @@ class PreviousGameAllianceDetail extends AccountPage {
 		$template->assign('BackHREF', $container->href());
 
 		$players = [];
-		foreach ($alliance->getMembers() as $player) {
+		foreach ($alliance->getMembers(includeNpc: false) as $player) {
 			$players[] = [
 				'leader' => $player->isAllianceLeader() ? '*' : '',
 				'bold' => $player->getAccountID() === $account->getAccountID() ? 'class="bold"' : '',

--- a/src/pages/Admin/NpcManage.php
+++ b/src/pages/Admin/NpcManage.php
@@ -64,6 +64,7 @@ class NpcManage extends AccountPage {
 				'active' => $dbRecord->getBoolean('active'),
 				'working' => $dbRecord->getBoolean('working'),
 				'href' => $container->href(),
+				'disable_active_toggle' => false,
 			];
 		}
 
@@ -78,7 +79,11 @@ class NpcManage extends AccountPage {
 		]);
 		foreach ($dbResult->records() as $dbRecord) {
 			$accountID = $dbRecord->getInt('account_id');
-			$npcs[$accountID]['player'] = Player::getPlayer($accountID, $selectedGameID, false, $dbRecord);
+			$npc = Player::getPlayer($accountID, $selectedGameID, false, $dbRecord);
+			$npcs[$accountID]['player'] = $npc;
+			if (($npc->hasAlliance() && $npc->getAlliance()->isNpcForHire()) || $npc->isHiredNPC()) {
+				$npcs[$accountID]['disable_active_toggle'] = true;
+			}
 		}
 
 		$template->assign('Npcs', $npcs);

--- a/src/pages/Admin/NpcManageProcessor.php
+++ b/src/pages/Admin/NpcManageProcessor.php
@@ -52,11 +52,25 @@ class NpcManageProcessor extends AccountPageProcessor {
 			$npcPlayer->setAlignment(rand(-300, 300));
 
 			$allianceName = Request::get('player_alliance');
+			if ($allianceName === NPC_FOR_HIRE_ALLIANCE_NAME) {
+				// For-hire NPCs must start out deactivated
+				$db->update(
+					'npc_logins',
+					['active' => $db->escapeBoolean(false)],
+					['login' => $this->login],
+				);
+				$allowReserved = true;
+				$allianceDescription = 'Traders for hire.';
+			} else {
+				$allowReserved = false;
+				$allianceDescription = '';
+			}
 			try {
 				$alliance = Alliance::getAllianceByName($allianceName, $gameID);
 			} catch (AllianceNotFound) {
-				$alliance = Alliance::createAlliance($gameID, $allianceName);
+				$alliance = Alliance::createAlliance($gameID, $allianceName, $allowReserved);
 				$alliance->setLeaderID($npcPlayer->getAccountID());
+				$alliance->setAllianceDescription($allianceDescription);
 				$alliance->update();
 				$alliance->createDefaultRoles();
 			}

--- a/src/pages/Player/AllianceExemptAuthorize.php
+++ b/src/pages/Player/AllianceExemptAuthorize.php
@@ -35,7 +35,7 @@ class AllianceExemptAuthorize extends PlayerPage {
 		]);
 		$transactions = [];
 		if ($dbResult->hasRecord()) {
-			$container = new AllianceBankExemptProcessor();
+			$container = new AllianceBankExemptProcessor($this);
 			$template->assign('ExemptHREF', $container->href());
 
 			foreach ($dbResult->records() as $dbRecord) {

--- a/src/pages/Player/AllianceExemptAuthorize.php
+++ b/src/pages/Player/AllianceExemptAuthorize.php
@@ -7,6 +7,7 @@ use Smr\Database;
 use Smr\Menu;
 use Smr\Page\PlayerPage;
 use Smr\Pages\Player\Bank\AllianceBankExemptProcessor;
+use Smr\Player;
 use Smr\Template;
 
 class AllianceExemptAuthorize extends PlayerPage {
@@ -37,11 +38,11 @@ class AllianceExemptAuthorize extends PlayerPage {
 			$container = new AllianceBankExemptProcessor();
 			$template->assign('ExemptHREF', $container->href());
 
-			$players = $alliance->getMembers();
 			foreach ($dbResult->records() as $dbRecord) {
+				$recPlayer = Player::getPlayer($dbRecord->getInt('payee_id'), $player->getGameID());
 				$transactions[] = [
 					'type' => $dbRecord->getString('transaction') === 'Payment' ? 'Withdraw' : 'Deposit',
-					'player' => $players[$dbRecord->getInt('payee_id')]->getDisplayName(),
+					'player' => $recPlayer->getDisplayName(),
 					'reason' => $dbRecord->getString('reason'),
 					'amount' => number_format($dbRecord->getInt('amount')),
 					'transactionID' => $dbRecord->getInt('transaction_id'),

--- a/src/pages/Player/AllianceInvitePlayer.php
+++ b/src/pages/Player/AllianceInvitePlayer.php
@@ -40,7 +40,7 @@ class AllianceInvitePlayer extends PlayerPage {
 		// Get list of players eligible to join this alliance.
 		// List those who joined the game most recently first.
 		$invitePlayers = [];
-		if ($alliance->getNumMembers() < $game->getAllianceMaxPlayers()) {
+		if ($alliance->hasRoomForPlayer()) {
 			$db = Database::getInstance();
 			$dbResult = $db->read('SELECT * FROM player
 			            WHERE game_id = :game_id
@@ -57,7 +57,7 @@ class AllianceInvitePlayer extends PlayerPage {
 					// Don't display players we've already invited
 					continue;
 				}
-				if ($alliance->getNumVeterans() < $game->getAllianceMaxVets() || $invitePlayer->hasNewbieStatus()) {
+				if ($alliance->hasRoomForPlayer($invitePlayer)) {
 					$invitePlayers[] = $invitePlayer;
 				}
 			}

--- a/src/pages/Player/AllianceLeadership.php
+++ b/src/pages/Player/AllianceLeadership.php
@@ -20,7 +20,7 @@ class AllianceLeadership extends PlayerPage {
 		$container = new AllianceLeadershipProcessor();
 		$template->assign('HandoverHREF', $container->href());
 
-		$template->assign('AlliancePlayers', $alliance->getMembers());
+		$template->assign('AlliancePlayers', $alliance->getMembers(includeNpc: false));
 	}
 
 }

--- a/src/pages/Player/AllianceLeaveProcessor.php
+++ b/src/pages/Player/AllianceLeaveProcessor.php
@@ -24,14 +24,9 @@ class AllianceLeaveProcessor extends PlayerPageProcessor {
 			$db->delete('alliance_thread', $alliance->SQLID);
 			$db->delete('alliance_thread_topic', $alliance->SQLID);
 			$db->delete('alliance_has_roles', $alliance->SQLID);
-			$db->update(
-				'alliance',
-				[
-					'leader_id' => 0,
-					'discord_channel' => null,
-				],
-				$alliance->SQLID,
-			);
+			$alliance->setLeaderID(0);
+			$alliance->setDiscordChannel(null);
+			$alliance->update();
 		}
 
 		// now leave the alliance

--- a/src/pages/Player/AllianceLeaveProcessor.php
+++ b/src/pages/Player/AllianceLeaveProcessor.php
@@ -20,21 +20,17 @@ class AllianceLeaveProcessor extends PlayerPageProcessor {
 		if ($alliance->getNumMembers() === 1 && !$alliance->isNHA()) {
 			// Retain the alliance, but delete some auxilliary info
 			$db = Database::getInstance();
-			$sqlParams = [
-				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-				'game_id' => $db->escapeNumber($player->getGameID()),
-			];
-			$db->delete('alliance_bank_transactions', $sqlParams);
-			$db->delete('alliance_thread', $sqlParams);
-			$db->delete('alliance_thread_topic', $sqlParams);
-			$db->delete('alliance_has_roles', $sqlParams);
+			$db->delete('alliance_bank_transactions', $alliance->SQLID);
+			$db->delete('alliance_thread', $alliance->SQLID);
+			$db->delete('alliance_thread_topic', $alliance->SQLID);
+			$db->delete('alliance_has_roles', $alliance->SQLID);
 			$db->update(
 				'alliance',
 				[
 					'leader_id' => 0,
 					'discord_channel' => null,
 				],
-				$sqlParams,
+				$alliance->SQLID,
 			);
 		}
 

--- a/src/pages/Player/AllianceManageNpcs.php
+++ b/src/pages/Player/AllianceManageNpcs.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Pages\Player;
+
+use Smr\AbstractPlayer;
+use Smr\Menu;
+use Smr\Page\PlayerPage;
+use Smr\Template;
+
+class AllianceManageNpcs extends PlayerPage {
+
+	public string $file = 'alliance_manage_npcs.php';
+
+	public function build(AbstractPlayer $player, Template $template): void {
+		$alliance = $player->getAlliance();
+
+		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		Menu::alliance($alliance->getAllianceID());
+
+		$npcs = [];
+		foreach ($alliance->getNpcs() as $npc) {
+			$npcs[] = [
+				'player' => $npc,
+				'dismissHref' => (new AllianceManageNpcsDismissProcessor($npc->getAccountID()))->href(),
+			];
+		}
+		$template->assign('Npcs', $npcs);
+	}
+
+}

--- a/src/pages/Player/AllianceManageNpcsDismissProcessor.php
+++ b/src/pages/Player/AllianceManageNpcsDismissProcessor.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Pages\Player;
+
+use Smr\AbstractPlayer;
+use Smr\Alliance;
+use Smr\Database;
+use Smr\Page\PlayerPageProcessor;
+use Smr\Player;
+
+class AllianceManageNpcsDismissProcessor extends PlayerPageProcessor {
+
+	public function __construct(
+		private readonly int $npcAccountID,
+	) {}
+
+	public function build(AbstractPlayer $player): never {
+		$npc = Player::getPlayer($this->npcAccountID, $player->getGameID());
+		if (!$npc->sameAlliance($player)) {
+			create_error('You cannot dismiss an NPC that is not in your alliance!');
+		}
+
+		// Dismissing an NPC while working could lead to abuse, so forbid it.
+		$db = Database::getInstance();
+		$dbResult = $db->select(
+			'npc_logins',
+			['login' => $npc->getAccount()->getLogin()],
+		);
+		if ($dbResult->record()->getBoolean('working')) {
+			create_error('You cannot dismiss an NPC while it is on the job! Wait for it to finish working.');
+		}
+
+		self::dismissNpc($npc, $player);
+
+		(new AllianceManageNpcs())->go();
+	}
+
+	public static function dismissNpc(AbstractPlayer $npc, AbstractPlayer $kickedBy): void {
+		// Return to NPC-For-Hire alliance and deactive.
+		$npc->leaveAlliance($kickedBy);
+		$npcAlliance = Alliance::getAllianceByName(NPC_FOR_HIRE_ALLIANCE_NAME, $npc->getGameID());
+		$npc->joinAlliance($npcAlliance->getAllianceID());
+		$npc->update();
+		if (!$npcAlliance->hasLeader()) {
+			$npcAlliance->setLeaderID($npc->getAccountID());
+			$npcAlliance->update();
+		}
+		$db = Database::getInstance();
+		$db->update(
+			'npc_logins',
+			['active' => $db->escapeBoolean(false)],
+			['login' => $npc->getAccount()->getLogin()],
+		);
+	}
+
+}

--- a/src/pages/Player/AllianceOptions.php
+++ b/src/pages/Player/AllianceOptions.php
@@ -35,7 +35,7 @@ class AllianceOptions extends PlayerPage {
 			];
 		}
 
-		if (!$isDraftGame) {
+		if (!$isDraftGame && !$alliance->isNHA()) {
 			// Players can choose to leave their alliance (except in Draft games)
 			$container = new AllianceLeaveConfirm();
 			$links[] = [
@@ -59,28 +59,28 @@ class AllianceOptions extends PlayerPage {
 		]);
 		$dbRecord = $dbResult->record();
 
-		if ($dbRecord->getBoolean('change_pass')) {
+		if ($dbRecord->getBoolean('change_pass') && !$alliance->isNHA()) {
 			$container = new AllianceInvitePlayer();
 			$links[] = [
 				'link' => create_link($container, 'Invite Player'),
 				'text' => 'Invite a player to the alliance.',
 			];
 		}
-		if ($dbRecord->getBoolean('remove_member')) {
+		if ($dbRecord->getBoolean('remove_member') && !$alliance->isNHA()) {
 			$container = new AllianceRemoveMember();
 			$links[] = [
 				'link' => create_link($container, 'Remove Member'),
 				'text' => 'Remove a trader from alliance roster.',
 			];
 		}
-		if ($player->isAllianceLeader()) {
+		if ($player->isAllianceLeader() && !$alliance->isNHA()) {
 			$container = new AllianceLeadership();
 			$links[] = [
 				'link' => create_link($container, 'Handover Leadership'),
 				'text' => 'Hand over leadership of the alliance to an alliance mate.',
 			];
 		}
-		if ($dbRecord->getBoolean('change_pass') || $dbRecord->getBoolean('change_mod')) {
+		if (($dbRecord->getBoolean('change_pass') || $dbRecord->getBoolean('change_mod')) && !$alliance->isNHA()) {
 			$container = new AllianceGovernance($alliance->getAllianceID());
 			$links[] = [
 				'link' => create_link($container, 'Govern Alliance'),

--- a/src/pages/Player/AllianceOptions.php
+++ b/src/pages/Player/AllianceOptions.php
@@ -115,6 +115,13 @@ class AllianceOptions extends PlayerPage {
 				'text' => 'Schedule and manage the next alliance operation and designate an alliance flagship.',
 			];
 		}
+		if ($dbRecord->getBoolean('manage_npcs')) {
+			$container = new AllianceManageNpcs();
+			$links[] = [
+				'link' => create_link($container, 'Manage NPCs'),
+				'text' => 'Make changes to hired NPC traders.',
+			];
+		}
 
 		$template->assign('Links', $links);
 	}

--- a/src/pages/Player/AllianceRemoveMember.php
+++ b/src/pages/Player/AllianceRemoveMember.php
@@ -26,7 +26,7 @@ class AllianceRemoveMember extends PlayerPage {
 		$template->assign('BanishHREF', $container->href());
 
 		// Get alliance members sorted by most active first
-		$alliancePlayers = $alliance->getMembers();
+		$alliancePlayers = $alliance->getMembers(includeNpc: false);
 		uasort($alliancePlayers, fn($a, $b) => $b->getLastCPLAction() <=> $a->getLastCPLAction());
 
 		$members = [];

--- a/src/pages/Player/AllianceRoles.php
+++ b/src/pages/Player/AllianceRoles.php
@@ -45,6 +45,7 @@ class AllianceRoles extends PlayerPage {
 				$allianceRoles[$roleID]['SendAllianceMessage'] = $dbRecord->getBoolean('send_alliance_msg');
 				$allianceRoles[$roleID]['OpLeader'] = $dbRecord->getBoolean('op_leader');
 				$allianceRoles[$roleID]['ViewBondsInPlanetList'] = $dbRecord->getBoolean('view_bonds');
+				$allianceRoles[$roleID]['ManageNpcs'] = $dbRecord->getBoolean('manage_npcs');
 			} else {
 				$container = new self($roleID);
 			}
@@ -71,6 +72,7 @@ class AllianceRoles extends PlayerPage {
 			'SendAllianceMessage' => false,
 			'OpLeader' => false,
 			'ViewBondsInPlanetList' => false,
+			'ManageNpcs' => true,
 		]);
 	}
 

--- a/src/pages/Player/AllianceRolesProcessor.php
+++ b/src/pages/Player/AllianceRolesProcessor.php
@@ -4,6 +4,7 @@ namespace Smr\Pages\Player;
 
 use Exception;
 use Smr\AbstractPlayer;
+use Smr\Alliance;
 use Smr\Database;
 use Smr\Page\PlayerPageProcessor;
 use Smr\Request;
@@ -17,7 +18,7 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 
-		$alliance_id = $player->getAllianceID();
+		$alliance = $player->getAlliance();
 
 		// Checkbox inputs only post if they are checked
 		$unlimited = Request::has('unlimited');
@@ -32,6 +33,7 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 		$sendAllMsg = Request::has('sendAllMsg');
 		$viewBonds = Request::has('viewBonds');
 		$opLeader = Request::has('opLeader');
+		$manageNpcs = Request::has('manageNpcs');
 
 		if ($unlimited) {
 			$withPerDay = ALLIANCE_BANK_UNLIMITED;
@@ -56,18 +58,16 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 			$db->lockTable('alliance_has_roles');
 			try {
 				// get last id
-				$dbResult = $db->read('SELECT IFNULL(MAX(role_id), 0) as max_role_id
+				$dbResult = $db->read(
+					'SELECT IFNULL(MAX(role_id), 0) as max_role_id
 						FROM alliance_has_roles
-						WHERE game_id = :game_id
-							AND alliance_id = :alliance_id', [
-					'game_id' => $db->escapeNumber($player->getGameID()),
-					'alliance_id' => $db->escapeNumber($alliance_id),
-				]);
+						WHERE ' . Alliance::SQL,
+					$alliance->SQLID,
+				);
 				$role_id = $dbResult->record()->getInt('max_role_id') + 1;
 
 				$db->insert('alliance_has_roles', [
-					'alliance_id' => $alliance_id,
-					'game_id' => $player->getGameID(),
+					...$alliance->SQLID,
 					'role_id' => $role_id,
 					'role' => $roleName,
 					'with_per_day' => $withPerDay,
@@ -82,6 +82,7 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 					'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
 					'op_leader' => $db->escapeBoolean($opLeader),
 					'view_bonds' => $db->escapeBoolean($viewBonds),
+					'manage_npcs' => $db->escapeBoolean($manageNpcs),
 				]);
 			} finally {
 				$db->unlock();
@@ -95,8 +96,7 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 					create_error('You cannot delete the new member role.');
 				}
 				$db->delete('alliance_has_roles', [
-					'game_id' => $player->getGameID(),
-					'alliance_id' => $alliance_id,
+					...$alliance->SQLID,
 					'role_id' => $this->roleID,
 				]);
 			} else {
@@ -117,10 +117,10 @@ class AllianceRolesProcessor extends PlayerPageProcessor {
 						'send_alliance_msg' => $db->escapeBoolean($sendAllMsg),
 						'op_leader' => $db->escapeBoolean($opLeader),
 						'view_bonds' => $db->escapeBoolean($viewBonds),
+						'manage_npcs' => $db->escapeBoolean($manageNpcs),
 					],
 					[
-						'alliance_id' => $alliance_id,
-						'game_id' => $player->getGameID(),
+						...$alliance->SQLID,
 						'role_id' => $this->roleID,
 					],
 				);

--- a/src/pages/Player/AllianceRoster.php
+++ b/src/pages/Player/AllianceRoster.php
@@ -76,7 +76,7 @@ class AllianceRoster extends PlayerPage {
 		$allowed = $dbResult->hasRecord();
 		$template->assign('CanChangeRoles', $allowed);
 
-		$alliancePlayers = $alliance->getMembers();
+		$alliancePlayers = $alliance->getMembers(includeNpc: true);
 		$template->assign('AlliancePlayers', $alliancePlayers);
 
 		if ($alliance->getAllianceID() === $player->getAllianceID()) {

--- a/src/pages/Player/AllianceSetOp.php
+++ b/src/pages/Player/AllianceSetOp.php
@@ -47,7 +47,7 @@ class AllianceSetOp extends PlayerPage {
 
 		// Stuff for designating a flagship
 		$template->assign('FlagshipID', $alliance->getFlagshipID());
-		$template->assign('AlliancePlayers', $alliance->getMembers());
+		$template->assign('AlliancePlayers', $alliance->getMembers(includeNpc: false));
 
 		$container = new AllianceSetFlagshipProcessor();
 		$template->assign('FlagshipHREF', $container->href());

--- a/src/pages/Player/AllianceSetOpProcessor.php
+++ b/src/pages/Player/AllianceSetOpProcessor.php
@@ -16,23 +16,19 @@ class AllianceSetOpProcessor extends PlayerPageProcessor {
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 		$account = $player->getAccount();
+		$alliance = $player->getAlliance();
+		$memberIDs = array_keys($alliance->getMembers(includeNpc: false));
 
 		if ($this->cancel) {
 			// just get rid of op
-			$db->delete('alliance_has_op', [
-				'alliance_id' => $player->getAllianceID(),
-				'game_id' => $player->getGameID(),
-			]);
-			$db->delete('alliance_has_op_response', [
-				'alliance_id' => $player->getAllianceID(),
-				'game_id' => $player->getGameID(),
-			]);
+			$db->delete('alliance_has_op', $alliance->SQLID);
+			$db->delete('alliance_has_op_response', $alliance->SQLID);
 
 			// Delete the announcement from alliance members message boxes
 			$db->write('DELETE FROM message WHERE game_id = :game_id AND sender_id = :sender_id AND account_id IN (:account_ids)', [
 				'game_id' => $db->escapeNumber($player->getGameID()),
 				'sender_id' => $db->escapeNumber(ACCOUNT_ID_OP_ANNOUNCE),
-				'account_ids' => $db->escapeArray($player->getAlliance()->getMemberIDs()),
+				'account_ids' => $db->escapeArray($memberIDs),
 			]);
 
 			// NOTE: for simplicity we don't touch `player_has_unread_messages` here,
@@ -51,15 +47,14 @@ class AllianceSetOpProcessor extends PlayerPageProcessor {
 
 			// add op to db
 			$db->insert('alliance_has_op', [
-				'alliance_id' => $player->getAllianceID(),
-				'game_id' => $player->getGameID(),
+				...$alliance->SQLID,
 				'time' => $time,
 			]);
 
 			// Send an alliance message that expires at the time of the op.
 			// Since the message is procedural, don't exclude this player.
 			$message = $player->getBBLink() . ' has scheduled an operation for ' . date($account->getDateTimeFormat(), $time) . '. Navigate to your Alliance console to respond!';
-			foreach ($player->getAlliance()->getMemberIDs() as $memberAccountID) {
+			foreach ($memberIDs as $memberAccountID) {
 				$player->sendMessageFromOpAnnounce($memberAccountID, $message, $time);
 			}
 		}

--- a/src/pages/Player/AllianceShareMapsProcessor.php
+++ b/src/pages/Player/AllianceShareMapsProcessor.php
@@ -11,7 +11,8 @@ class AllianceShareMapsProcessor extends PlayerPageProcessor {
 
 	public function build(AbstractPlayer $player): never {
 		// get a list of alliance member (remove current player)
-		$memberIDs = $player->getAlliance()->getMemberIDs();
+		$alliance = $player->getAlliance();
+		$memberIDs = array_keys($alliance->getMembers(includeNpc: false));
 		$alliance_ids = array_diff($memberIDs, [$player->getAccountID()]);
 
 		// end here if we are alone in the alliance

--- a/src/pages/Player/AttackPlanetProcessor.php
+++ b/src/pages/Player/AttackPlanetProcessor.php
@@ -125,8 +125,8 @@ class AttackPlanetProcessor extends PlayerPageProcessor {
 
 		// Send notification to planet owners
 		if ($planetOwner->hasAlliance()) {
-			foreach ($planetOwner->getAlliance()->getMemberIDs() as $allyAccountID) {
-				Player::sendMessageFromPlanet($planet->getGameID(), $allyAccountID, $planetAttackMessage);
+			foreach ($planetOwner->getAlliance()->getMembers(includeNpc: false) as $allyPlayer) {
+				Player::sendMessageFromPlanet($planet->getGameID(), $allyPlayer->getAccountID(), $planetAttackMessage);
 			}
 		} else {
 			Player::sendMessageFromPlanet($planet->getGameID(), $planetOwner->getAccountID(), $planetAttackMessage);

--- a/src/pages/Player/Bank/AllianceBank.php
+++ b/src/pages/Player/Bank/AllianceBank.php
@@ -94,32 +94,31 @@ class AllianceBank extends PlayerPage {
 		$maxValue = $session->getRequestVarInt('maxValue', 0);
 		$minValue = $session->getRequestVarInt('minValue', 0);
 
+		// By default, display the last 5 records
 		if ($maxValue <= 0) {
-			$dbResult = $db->read('SELECT IFNULL(MAX(transaction_id), 0) as max_transaction_id FROM alliance_bank_transactions WHERE ' . Alliance::SQL, $alliance->SQLID);
-			$maxValue = $dbResult->record()->getInt('max_transaction_id');
+			$maxValue = $db->count('alliance_bank_transactions', $alliance->SQLID);
 		}
 
 		if ($minValue <= 0 || $minValue > $maxValue) {
-			$minValue = max(1, $maxValue - 5);
+			$minValue = max(1, $maxValue - 4);
 		}
 
-		$query = 'SELECT time, transaction_id, transaction, amount, exempt, reason, payee_id
+		$query = 'SELECT *
 			FROM alliance_bank_transactions
 			WHERE ' . Alliance::SQL . '
-			AND transaction_id >= :min_transaction_id
-			AND transaction_id <= :max_transaction_id
-			ORDER BY time LIMIT :limit';
+			LIMIT :limit_offset, :limit_count';
 		$dbResult = $db->read($query, [
 			...$alliance->SQLID,
-			'min_transaction_id' => $db->escapeNumber($minValue),
-			'max_transaction_id' => $db->escapeNumber($maxValue),
-			'limit' => 1 + $maxValue - $minValue,
+			'limit_offset' => $minValue - 1,
+			'limit_count' => $maxValue - $minValue + 1,
 		]);
 
 		$bankTransactions = [];
-		foreach ($dbResult->records() as $dbRecord) {
+		$transactionIDs = [];
+		foreach ($dbResult->records() as $i => $dbRecord) {
+			$index = $i + $minValue;
 			$trans = $dbRecord->getString('transaction');
-			$bankTransactions[$dbRecord->getInt('transaction_id')] = [
+			$bankTransactions[$index] = [
 				'Time' => $dbRecord->getInt('time'),
 				'Player' => Player::getPlayer($dbRecord->getInt('payee_id'), $player->getGameID()),
 				'Reason' => $dbRecord->getString('reason'),
@@ -128,6 +127,7 @@ class AllianceBank extends PlayerPage {
 				'Deposit' => $trans === 'Deposit' ? number_format($dbRecord->getInt('amount')) : '',
 				'Exempt' => $dbRecord->getInt('exempt') === 1,
 			];
+			$transactionIDs[] = $dbRecord->getInt('transaction_id');
 		}
 		$template->assign('BankTransactions', $bankTransactions);
 
@@ -138,7 +138,7 @@ class AllianceBank extends PlayerPage {
 			$container = new self($allianceID);
 			$template->assign('FilterTransactionsFormHREF', $container->href());
 
-			$container = new AllianceBankExemptProcessor($minValue, $maxValue);
+			$container = new AllianceBankExemptProcessor($this, $transactionIDs);
 			$template->assign('ExemptTransactionsFormHREF', $container->href());
 
 			$template->assign('EndingBalance', number_format($alliance->getBank()));

--- a/src/pages/Player/Bank/AllianceBankExemptProcessor.php
+++ b/src/pages/Player/Bank/AllianceBankExemptProcessor.php
@@ -4,47 +4,40 @@ namespace Smr\Pages\Player\Bank;
 
 use Smr\AbstractPlayer;
 use Smr\Database;
+use Smr\Page\Page;
 use Smr\Page\PlayerPageProcessor;
-use Smr\Pages\Player\AllianceExemptAuthorize;
 use Smr\Request;
 
 class AllianceBankExemptProcessor extends PlayerPageProcessor {
 
+	/**
+	 * @param list<int> $displayedTransactionIDs
+	 */
 	public function __construct(
-		private readonly ?int $minTransactionID = null,
-		private readonly ?int $maxTransactionID = null,
+		private readonly Page $forwardTo,
+		private readonly array $displayedTransactionIDs = [],
 	) {}
 
 	public function build(AbstractPlayer $player): never {
 		$db = Database::getInstance();
 
-		//only if we are coming from the bank screen do we unexempt selection first
-		if ($this->minTransactionID !== null && $this->maxTransactionID !== null) {
-			$db->write('UPDATE alliance_bank_transactions SET exempt = 0 WHERE game_id = :game_id AND alliance_id = :alliance_id
-						AND transaction_id BETWEEN :transaction_id_min AND :transaction_id_max', [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
-				'transaction_id_min' => $db->escapeNumber($this->minTransactionID),
-				'transaction_id_max' => $db->escapeNumber($this->maxTransactionID),
+		// Unexempt all displayed transactions first, then exempt selected below.
+		if (count($this->displayedTransactionIDs) > 0) {
+			$db->write('UPDATE alliance_bank_transactions SET exempt = 0 WHERE
+						transaction_id IN (:transaction_ids)', [
+				'transaction_ids' => $db->escapeArray($this->displayedTransactionIDs),
 			]);
 		}
 
 		if (Request::has('exempt')) {
 			$trans_ids = array_keys(Request::getArray('exempt'));
-			$db->write('UPDATE alliance_bank_transactions SET exempt = 1, request_exempt = 0 WHERE game_id = :game_id AND alliance_id = :alliance_id
-						AND transaction_id IN (:transaction_ids)', [
-				'game_id' => $db->escapeNumber($player->getGameID()),
-				'alliance_id' => $db->escapeNumber($player->getAllianceID()),
+			$db->write('UPDATE alliance_bank_transactions SET exempt = 1, request_exempt = 0 WHERE
+						transaction_id IN (:transaction_ids)', [
 				'transaction_ids' => $db->escapeArray($trans_ids),
 			]);
 		}
 
-		if ($this->minTransactionID !== null) {
-			$container = new AllianceBank($player->getAllianceID());
-		} else {
-			$container = new AllianceExemptAuthorize();
-		}
-		$container->go();
+		$this->forwardTo->go();
 	}
 
 }

--- a/src/pages/Player/Bank/AllianceBankProcessor.php
+++ b/src/pages/Player/Bank/AllianceBankProcessor.php
@@ -100,17 +100,10 @@ class AllianceBankProcessor extends PlayerPageProcessor {
 		// log action
 		$player->log(LOG_TYPE_BANK, $action . ' ' . $amount . ' credits for alliance account of ' . $alliance->getAllianceName());
 
-		// get next transaction id
-		$dbResult = $db->read('SELECT IFNULL(MAX(transaction_id), 0) as max_id FROM alliance_bank_transactions
-					WHERE ' . Alliance::SQL, $alliance->SQLID);
-		$next_id = $dbResult->record()->getInt('max_id') + 1;
-
-		// save log
+		// save transaction
 		$requestExempt = Request::has('requestExempt') ? 1 : 0;
 		$db->insert('alliance_bank_transactions', [
-			'alliance_id' => $alliance_id,
-			'game_id' => $player->getGameID(),
-			'transaction_id' => $next_id,
+			...$alliance->SQLID,
 			'time' => Epoch::time(),
 			'payee_id' => $player->getAccountID(),
 			'reason' => $message,

--- a/src/pages/Player/Bank/AllianceBankProcessor.php
+++ b/src/pages/Player/Bank/AllianceBankProcessor.php
@@ -16,10 +16,6 @@ class AllianceBankProcessor extends PlayerPageProcessor {
 	) {}
 
 	public function build(AbstractPlayer $player): never {
-		$db = Database::getInstance();
-
-		$alliance_id = $this->allianceID;
-
 		$amount = Request::getInt('amount');
 
 		// no negative amounts are allowed
@@ -31,8 +27,38 @@ class AllianceBankProcessor extends PlayerPageProcessor {
 			$message = 'No reason specified';
 		}
 
-		$alliance = Alliance::getAlliance($alliance_id, $player->getGameID());
+		$alliance = Alliance::getAlliance($this->allianceID, $player->getGameID());
+
 		$action = Request::get('action');
+		if ($action !== 'Deposit') {
+			$action = 'Payment';
+		}
+
+		self::doTransaction(
+			action: $action,
+			alliance: $alliance,
+			player: $player,
+			message: $message,
+			amount: $amount,
+			requestExempt: Request::has('requestExempt'),
+		);
+
+		$container = new AllianceBank($this->allianceID);
+		$container->go();
+	}
+
+	/**
+	 * @param 'Deposit'|'Payment' $action
+	 */
+	public static function doTransaction(
+		string $action,
+		Alliance $alliance,
+		AbstractPlayer $player,
+		string $message,
+		int $amount,
+		bool $requestExempt = false,
+	): void {
+		$db = Database::getInstance();
 		if ($action === 'Deposit') {
 			if ($player->getCredits() < $amount) {
 				create_error('You don\'t own that much money!');
@@ -51,8 +77,8 @@ class AllianceBankProcessor extends PlayerPageProcessor {
 			}
 
 			$table = 'alliance_has_roles';
-			if ($alliance_id === $player->getAllianceID()) {
-				$roleID = $player->getAllianceRole($alliance_id);
+			if ($alliance->getAllianceID() === $player->getAllianceID()) {
+				$roleID = $player->getAllianceRole($alliance->getAllianceID());
 				$dbResult = $db->select($table, [...$alliance->SQLID, 'role_id' => $roleID]);
 			} else {
 				// Alliance treaties create new roles with alliance names
@@ -101,7 +127,6 @@ class AllianceBankProcessor extends PlayerPageProcessor {
 		$player->log(LOG_TYPE_BANK, $action . ' ' . $amount . ' credits for alliance account of ' . $alliance->getAllianceName());
 
 		// save transaction
-		$requestExempt = Request::has('requestExempt') ? 1 : 0;
 		$db->insert('alliance_bank_transactions', [
 			...$alliance->SQLID,
 			'time' => Epoch::time(),
@@ -109,17 +134,11 @@ class AllianceBankProcessor extends PlayerPageProcessor {
 			'reason' => $message,
 			'transaction' => $action,
 			'amount' => $amount,
-			'request_exempt' => $requestExempt,
+			'request_exempt' => $requestExempt ? 1 : 0,
 		]);
-
-		// update player credits
-		$player->update();
 
 		// save money for alliance
 		$alliance->update();
-
-		$container = new AllianceBank($alliance_id);
-		$container->go();
 	}
 
 }

--- a/src/pages/Player/Headquarters/HireTrader.php
+++ b/src/pages/Player/Headquarters/HireTrader.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Pages\Player\Headquarters;
+
+use Smr\AbstractPlayer;
+use Smr\Alliance;
+use Smr\Database;
+use Smr\Exceptions\AllianceNotFound;
+use Smr\Menu;
+use Smr\Page\PlayerPage;
+use Smr\Template;
+
+class HireTrader extends PlayerPage {
+
+	public string $file = 'hire_trader.php';
+
+	public const int BASE_HIRE_COST = 150_000;
+	public const int MAX_NPCS_PER_ALLIANCE = 3;
+
+	public function __construct(
+		private readonly int $locationID,
+	) {}
+
+	public function build(AbstractPlayer $player, Template $template): void {
+		$template->assign('PageTopic', 'Hire Trader');
+
+		Menu::headquarters($this->locationID);
+
+		$npcs = [];
+		try {
+			$alliance = Alliance::getAllianceByName(NPC_FOR_HIRE_ALLIANCE_NAME, $player->getGameID());
+			foreach ($alliance->getMembers(includeNpc: true) as $npc) {
+				$hireCost = self::BASE_HIRE_COST + 10 * $npc->getExperience();
+				$container = new HireTraderProcessor(
+					locationID: $this->locationID,
+					npcAccountID: $npc->getAccountID(),
+					hireCost: $hireCost,
+				);
+				$npcs[] = [
+					'player' => $npc,
+					'hireCost' => $hireCost,
+					'hireHref' => $container->href(),
+				];
+			}
+		} catch (AllianceNotFound) {
+			// No NPCs because alliance has not been created yet
+		}
+		$template->assign('Npcs', $npcs);
+
+		$disableReason = null;
+		if (!$player->hasAlliance()) {
+			$disableReason = 'You must be in an alliance to hire traders.';
+		} else {
+			$alliance = $player->getAlliance();
+			$db = Database::getInstance();
+			$dbResult = $db->select('alliance_has_roles', [
+				...$alliance->SQLID,
+				'role_id' => $player->getAllianceRole(),
+			]);
+			if (!$dbResult->record()->getBoolean('manage_npcs')) {
+				$disableReason = 'You are not authorized to hire traders on behalf of your alliance.';
+			} elseif (count($alliance->getNpcs()) >= self::MAX_NPCS_PER_ALLIANCE) {
+				$disableReason = 'You have reached the maximum number of hires for your alliance.';
+			} elseif (!$alliance->hasRoomForPlayer()) {
+				$disableReason = 'You do not have enough room in your alliance to hire traders.';
+			} elseif (count($npcs) === 0) {
+				$disableReason = 'There are no traders available for hire at this time.';
+			}
+		}
+		$template->assign('DisableReason', $disableReason);
+	}
+
+}

--- a/src/pages/Player/Headquarters/HireTraderProcessor.php
+++ b/src/pages/Player/Headquarters/HireTraderProcessor.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Pages\Player\Headquarters;
+
+use Smr\AbstractPlayer;
+use Smr\Database;
+use Smr\Page\PlayerPageProcessor;
+
+class HireTraderProcessor extends PlayerPageProcessor {
+
+	public function __construct(
+		private readonly int $locationID,
+		private readonly int $npcAccountID,
+		private readonly int $hireCost,
+	) {}
+
+	public function build(AbstractPlayer $player): never {
+		// Pay the hiring fee
+		if ($player->getCredits() < $this->hireCost) {
+			create_error('You do not have enough credits to hire this trader!');
+		}
+		$player->decreaseCredits($this->hireCost);
+
+		// Leave NPC alliance and join player's alliance (this should be locked)
+		$npc = AbstractPlayer::getPlayer($this->npcAccountID, $player->getGameID());
+		$npcAlliance = $npc->getAlliance();
+		if ($npcAlliance->getNumMembers() === 1) {
+			$npcAlliance->setLeaderID(0);
+			$npcAlliance->update();
+		}
+		$npc->leaveAlliance();
+		$npc->joinAlliance($player->getAllianceID());
+
+		// Enable NPC
+		$db = Database::getInstance();
+		$db->update(
+			'npc_logins',
+			['active' => $db->escapeBoolean(true)],
+			['login' => $npc->getAccount()->getLogin()],
+		);
+
+		(new HireTrader($this->locationID))->go();
+	}
+
+}

--- a/src/templates/Default/engine/Default/admin/npc_manage.php
+++ b/src/templates/Default/engine/Default/admin/npc_manage.php
@@ -19,6 +19,7 @@ use Smr\Race;
 <?php
 if ($SelectedGameID !== 0) { ?>
 	<br />
+	<div><b>Note: </b>For-hire NPCs use alliance name: <?php echo NPC_FOR_HIRE_ALLIANCE_NAME; ?></div>
 	<table class="standard">
 		<tr>
 			<th>Login</th>
@@ -33,7 +34,7 @@ if ($SelectedGameID !== 0) { ?>
 				<td><?php echo $npc['login']; ?></td>
 				<td class="center">
 					<form method="POST" action="<?php echo $npc['href']; ?>">
-						<input name="active" type="checkbox" <?php if ($npc['active']) { ?>checked<?php } ?> onclick="this.form.submit()" />
+						<input name="active" type="checkbox" <?php if ($npc['active']) { ?>checked<?php } ?> onclick="this.form.submit()" <?php if ($npc['disable_active_toggle']) { ?>disabled<?php } ?> />
 						<input type="hidden" name="active-submit" />
 					</form>
 				</td><?php

--- a/src/templates/Default/engine/Default/alliance_manage_npcs.php
+++ b/src/templates/Default/engine/Default/alliance_manage_npcs.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+/**
+ * @var list<array{player: Smr\Player, dismissHref: string}> $Npcs
+ */
+
+if (count($Npcs) > 0) { ?>
+	<table class="standard center">
+		<tr>
+			<th>Trader</th>
+			<th></th>
+		</tr><?php
+		foreach ($Npcs as $npc) { ?>
+			<tr>
+				<td><?php echo $npc['player']->getDisplayName(); ?></td>
+				<td>
+					<div class="buttonA">
+						<a class="buttonA" href="<?php echo $npc['dismissHref']; ?>">Dismiss</a>
+					</div>
+				</td>
+			</tr><?php
+		} ?>
+	</table><?php
+} else { ?>
+	<div>Your alliance does not have any hired NPCs at this time.</div><?php
+}

--- a/src/templates/Default/engine/Default/hire_trader.php
+++ b/src/templates/Default/engine/Default/hire_trader.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+/**
+ * @var list<array{player: Smr\Player, hireCost: int, hireHref: string}> $Npcs
+ * @var ?string $DisableReason
+ * @var Smr\Player $ThisPlayer
+ */
+
+if ($DisableReason !== null) { ?>
+	<div><?php echo $DisableReason; ?></div><?php
+}
+
+if (count($Npcs) > 0) { ?>
+	<table class="standard center">
+		<tr>
+			<th>Trader</th>
+			<th>Race</th>
+			<th>Cost</th>
+			<th></th>
+		</tr><?php
+		foreach ($Npcs as $npc) { ?>
+			<tr>
+				<td><?php echo $npc['player']->getLinkedDisplayName(true); ?></td>
+				<td><?php echo $npc['player']->getColouredRaceName($ThisPlayer->getRaceID()); ?></td>
+				<td><?php echo number_format($npc['hireCost']); ?></td>
+				<td>
+					<?php if ($DisableReason !== null) { ?>
+						<div class="buttonA">
+							<a class="buttonA" href="<?php echo $npc['hireHref']; ?>">Hire</a>
+						</div><?php
+					} ?>
+				</td>
+			</tr><?php
+		} ?>
+	</table><?php
+}

--- a/src/templates/Default/engine/Default/includes/AllianceRole.inc.php
+++ b/src/templates/Default/engine/Default/includes/AllianceRole.inc.php
@@ -62,6 +62,10 @@
 				<tr>
 					<td>View Bonds In Planet List</td>
 					<td><input type="checkbox" name="viewBonds"<?php if ($Role['ViewBondsInPlanetList']) { ?> checked="checked"<?php } ?>></td>
+				</tr>
+				<tr>
+					<td>Manage NPCs</td>
+					<td><input type="checkbox" name="manageNpcs"<?php if ($Role['ManageNpcs']) { ?> checked="checked"<?php } ?>></td>
 				</tr><?php
 			}
 		} ?>

--- a/src/tools/npc/NpcActor.php
+++ b/src/tools/npc/NpcActor.php
@@ -8,6 +8,8 @@ use Smr\Npc\Exceptions\FinalAction;
 use Smr\Npc\Exceptions\ForwardAction;
 use Smr\Npc\Exceptions\TradeRouteDrained;
 use Smr\Page\PlayerPageProcessor;
+use Smr\Pages\Player\AllianceManageNpcsDismissProcessor;
+use Smr\Pages\Player\Bank\AllianceBankProcessor;
 use Smr\Routes\RouteIterator;
 use Smr\Sector;
 use Smr\TransactionType;
@@ -18,6 +20,8 @@ class NpcActor {
 	private array $allTradeRoutes;
 	private ?RouteIterator $tradeRoute = null;
 	private int $actions = 0;
+	private readonly int $startingCredits;
+	private readonly bool $hired;
 
 	public function __construct(
 		private readonly int $gameID,
@@ -51,6 +55,9 @@ class NpcActor {
 
 		// Update database (not essential to have a lock here)
 		$player->update();
+
+		$this->startingCredits = $player->getCredits();
+		$this->hired = $player->isHiredNPC();
 	}
 
 	private function refreshPlayer(): AbstractPlayer {
@@ -68,6 +75,20 @@ class NpcActor {
 			$player->getShip()->setCDs(0);
 			$player->getShip()->removeAllWeapons();
 			$player->getShip()->update();
+		}
+
+		if ($this->hired) {
+			// Give half earned profits to employer
+			$credits = IFloor(max(0, $player->getCredits() - $this->startingCredits) / 2);
+			debug('Giving ' . $credits . ' credits to alliance');
+			AllianceBankProcessor::doTransaction(
+				action: 'Deposit',
+				alliance: $player->getAlliance(),
+				player: $player,
+				message: 'Profits from trading',
+				amount: $credits,
+			);
+			$player->update();
 		}
 	}
 
@@ -89,8 +110,16 @@ class NpcActor {
 
 		if ($player->isDead()) {
 			debug('Some evil person killed us, let\'s move on now.');
+
 			$player->setDead(false); // see death_processing.php
 			$player->setNewbieWarning(false); // undo Player::killPlayer setting this to true
+
+			if ($this->hired) {
+				// Hired traders quit their job after getting podded
+				AllianceManageNpcsDismissProcessor::dismissNpc($player, $player);
+				throw new FinalAction();
+			}
+
 			checkStartConditions($player);
 
 			global $previousContainer;

--- a/test/SmrTest/lib/AllianceIntegrationTest.php
+++ b/test/SmrTest/lib/AllianceIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace SmrTest\lib;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use Smr\Alliance;
 use Smr\Exceptions\AllianceNotFound;
 use Smr\Exceptions\UserError;
@@ -80,10 +81,12 @@ class AllianceIntegrationTest extends BaseIntegrationSpec {
 		Alliance::createAlliance(1, $name);
 	}
 
-	public function test_createAlliance_with_NHA_name(): void {
+	#[TestWith([NHA_ALLIANCE_NAME])]
+	#[TestWith([NPC_FOR_HIRE_ALLIANCE_NAME])]
+	public function test_createAlliance_with_reserved_name(string $name): void {
 		$this->expectException(UserError::class);
 		$this->expectExceptionMessage('That alliance name is reserved.');
-		Alliance::createAlliance(1, NHA_ALLIANCE_NAME);
+		Alliance::createAlliance(1, $name);
 	}
 
 	public function test_createAlliance_increment_allianceID(): void {
@@ -100,6 +103,16 @@ class AllianceIntegrationTest extends BaseIntegrationSpec {
 		// Create an alliance that is the NHA
 		$alliance = Alliance::createAlliance(1, NHA_ALLIANCE_NAME, true);
 		self::assertTrue($alliance->isNHA());
+	}
+
+	public function test_isNpcForHire(): void {
+		// Create an alliance that is not NPC-For-Hire
+		$alliance = Alliance::createAlliance(1, 'The Expensivelancers', true);
+		self::assertFalse($alliance->isNpcForHire());
+
+		// Create an alliance that is the NPC-For-Hire
+		$alliance = Alliance::createAlliance(1, NPC_FOR_HIRE_ALLIANCE_NAME, true);
+		self::assertTrue($alliance->isNpcForHire());
 	}
 
 }

--- a/test/SmrTest/lib/CreateNHATest.php
+++ b/test/SmrTest/lib/CreateNHATest.php
@@ -4,6 +4,8 @@ namespace SmrTest\lib;
 
 use PHPUnit\Framework\Attributes\CoversFunction;
 use Smr\Alliance;
+use Smr\Game;
+use Smr\Player;
 use SmrTest\BaseIntegrationSpec;
 
 require_once(LIB . 'Default/nha.inc.php');
@@ -17,12 +19,18 @@ class CreateNHATest extends BaseIntegrationSpec {
 			'alliance_has_roles',
 			'alliance_thread',
 			'alliance_thread_topic',
+			'player',
+			'player_has_alliance_role',
 		];
 	}
 
 	public function test_createNHA(): void {
-		// Create the NHA
+		// Set up a fake game (needed for Player::getHome)
 		$gameID = 1;
+		$game = Game::createGame($gameID);
+		$game->setGameTypeID(Game::GAME_TYPE_DEFAULT);
+
+		// Create the NHA
 		createNHA($gameID);
 
 		// Reload NHA and make sure relevant properties are set
@@ -33,6 +41,11 @@ class CreateNHATest extends BaseIntegrationSpec {
 		self::assertSame('Alliance message board includes tips and FAQs.', $alliance->getMotD());
 		self::assertSame('Newbie Help Alliance', $alliance->getDescription());
 		self::assertFalse($alliance->isRecruiting());
+
+		// Reload NHL and make sure it's set
+		$nhl = Player::getPlayer(ACCOUNT_ID_NHL, $gameID, true);
+		self::assertSame('Newbie Help Leader', $nhl->getPlayerName());
+		self::assertSame($alliance->getAllianceID(), $nhl->getAllianceID());
 	}
 
 }

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -153,7 +153,7 @@ class DatabaseIntegrationTest extends TestCase {
 		// added that modify the base table size. If that becomes too onerous,
 		// we can do a fuzzier comparison. Until then, this is a useful check
 		// that the test database is properly reset between invocations.
-		self::assertSame($bytes, 728580);
+		self::assertSame($bytes, 727556);
 	}
 
 	public function test_escapeBoolean(): void {

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -153,7 +153,7 @@ class DatabaseIntegrationTest extends TestCase {
 		// added that modify the base table size. If that becomes too onerous,
 		// we can do a fuzzier comparison. Until then, this is a useful check
 		// that the test database is properly reset between invocations.
-		self::assertSame($bytes, 727556);
+		self::assertSame($bytes, 759300);
 	}
 
 	public function test_escapeBoolean(): void {


### PR DESCRIPTION
NPC traders may now be hired from any HQ/UG. Only 3 hires allowed per
alliance currently. Permission to hire/fire NPCs is set in alliance
roles, and defaults to being allowed (so more people can try it out).

* Special reserved alliance name for NPCs-for-hire. NPCs will be in
  this alliance whenever they are not hired.
* NPCs in this alliance won't be active until hired, at which point
  they join the hiring alliance.
* NPCs count toward the non-vet alliance cap.
* NPCs only leave the alliance when they are podded, but may need to
  implement some additional limits in the future (e.g. profit limit).
* New alliance role for managing NPCs currently only affects hiring
  or firing NPCs, but may be expanded in the future to influence their
  behavior (e.g. when they trade, which routes, etc.).
* Hiring cost and profits paid to the hiring alliance will be tweaked
  as needed for game balance.

Related fixes to NHA and database race conditions.