### PR TITLE
Alliance: database race condition safety

### DIFF
--- a/src/lib/Smr/AbstractPlayer.php
+++ b/src/lib/Smr/AbstractPlayer.php
@@ -2233,12 +2233,7 @@ abstract class AbstractPlayer {
 
 		// if we are in an alliance we increase their deaths
 		if ($this->hasAlliance()) {
-			$db = Database::getInstance();
-			$db->write('UPDATE alliance SET alliance_deaths = alliance_deaths + 1
-							WHERE game_id = :game_id AND alliance_id = :alliance_id', [
-				'game_id' => $db->escapeNumber($this->getGameID()),
-				'alliance_id' => $db->escapeNumber($this->getAllianceID()),
-			]);
+			$this->getAlliance()->incrementDeaths();
 		}
 
 		// record death stat
@@ -2402,10 +2397,7 @@ abstract class AbstractPlayer {
 			$killer->increaseHOF(1, ['Killing', 'Kills'], HOF_PUBLIC);
 
 			if ($killer->hasAlliance()) {
-				$db->write('UPDATE alliance SET alliance_kills=alliance_kills+1 WHERE alliance_id = :alliance_id AND game_id = :game_id', [
-					'alliance_id' => $db->escapeNumber($killer->getAllianceID()),
-					'game_id' => $db->escapeNumber($killer->getGameID()),
-				]);
+				$killer->getAlliance()->incrementKills();
 			}
 
 			// alliance vs. alliance stats

--- a/src/lib/Smr/Alliance.php
+++ b/src/lib/Smr/Alliance.php
@@ -320,17 +320,27 @@ class Alliance {
 	public function increaseBank(int $credits): int {
 		$newTotal = min($this->bank + $credits, MAX_MONEY);
 		$actualAdded = $newTotal - $this->bank;
-		$this->setBank($newTotal);
+		$this->updateBank($actualAdded);
 		return $actualAdded;
 	}
 
 	public function decreaseBank(int $credits): void {
-		$newTotal = $this->bank - $credits;
-		$this->setBank($newTotal);
+		if ($credits > $this->bank) {
+			throw new Exception('Do not allow negative credits');
+		}
+		$this->updateBank(-$credits);
 	}
 
-	public function setBank(int $credits): void {
-		$this->bank = $credits;
+	private function updateBank(int $creditChange): void {
+		// Write immediately to avoid race conditions
+		$db = Database::getInstance();
+		$db->write('UPDATE alliance
+			SET alliance_account = alliance_account + :credit_change
+			WHERE ' . self::SQL, [
+			...$this->SQLID,
+			'credit_change' => $creditChange,
+		]);
+		$this->bank += $creditChange;
 	}
 
 	/**
@@ -405,8 +415,28 @@ class Alliance {
 		return $this->kills;
 	}
 
+	public function incrementKills(): void {
+		// Write immediately to avoid race conditions
+		$db = Database::getInstance();
+		$db->write(
+			'UPDATE alliance SET alliance_kills = alliance_kills + 1 WHERE ' . self::SQL,
+			$this->SQLID,
+		);
+		$this->kills++;
+	}
+
 	public function getDeaths(): int {
 		return $this->deaths;
+	}
+
+	public function incrementDeaths(): void {
+		// Write immediately to avoid race conditions
+		$db = Database::getInstance();
+		$db->write(
+			'UPDATE alliance SET alliance_deaths = alliance_deaths + 1 WHERE ' . self::SQL,
+			$this->SQLID,
+		);
+		$this->deaths++;
 	}
 
 	/**
@@ -506,18 +536,17 @@ class Alliance {
 	}
 
 	public function update(): void {
+		// We do not update kills, deaths, and alliance_account here
+		// because they are updated separately for race condition safety.
 		$db = Database::getInstance();
 		$db->update(
 			'alliance',
 			[
 				'alliance_password' => $this->password,
 				'recruiting' => $db->escapeBoolean($this->recruiting),
-				'alliance_account' => $this->bank,
 				'alliance_description' => $this->description,
 				'`mod`' => $this->motd,
 				'img_src' => $this->imgSrc,
-				'alliance_kills' => $this->kills,
-				'alliance_deaths' => $this->deaths,
 				'discord_server' => $this->discordServer,
 				'discord_channel' => $this->discordChannel,
 				'flagship_id' => $this->flagshipID,

--- a/src/pages/Player/Bank/AllianceBankProcessor.php
+++ b/src/pages/Player/Bank/AllianceBankProcessor.php
@@ -136,9 +136,6 @@ class AllianceBankProcessor extends PlayerPageProcessor {
 			'amount' => $amount,
 			'request_exempt' => $requestExempt ? 1 : 0,
 		]);
-
-		// save money for alliance
-		$alliance->update();
 	}
 
 }

--- a/test/SmrTest/lib/AllianceIntegrationTest.php
+++ b/test/SmrTest/lib/AllianceIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace SmrTest\lib;
 
+use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use Smr\Alliance;
@@ -113,6 +114,58 @@ class AllianceIntegrationTest extends BaseIntegrationSpec {
 		// Create an alliance that is the NPC-For-Hire
 		$alliance = Alliance::createAlliance(1, NPC_FOR_HIRE_ALLIANCE_NAME, true);
 		self::assertTrue($alliance->isNpcForHire());
+	}
+
+	public function test_incrementKills(): void {
+		$alliance = Alliance::createAlliance(1, 'test');
+		self::assertSame(0, $alliance->getKills());
+		$alliance->incrementKills();
+		self::assertSame(1, $alliance->getKills());
+		// Force update to check database
+		$alliance = Alliance::getAlliance($alliance->getAllianceID(), 1, forceUpdate: true);
+		self::assertSame(1, $alliance->getKills());
+	}
+
+	public function test_incrementDeaths(): void {
+		$alliance = Alliance::createAlliance(1, 'test');
+		self::assertSame(0, $alliance->getDeaths());
+		$alliance->incrementDeaths();
+		self::assertSame(1, $alliance->getDeaths());
+		// Force update to check database
+		$alliance = Alliance::getAlliance($alliance->getAllianceID(), 1, forceUpdate: true);
+		self::assertSame(1, $alliance->getDeaths());
+	}
+
+	public function test_decreaseBank_underflow(): void {
+		$alliance = Alliance::createAlliance(1, 'test');
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Do not allow negative credits');
+		$alliance->decreaseBank(1);
+	}
+
+	public function test_increaseBank_decreaseBank(): void {
+		$alliance = Alliance::createAlliance(1, 'test');
+		self::assertSame(0, $alliance->getBank());
+
+		// Test adding money
+		$added = $alliance->increaseBank(300);
+		self::assertSame(300, $added);
+		self::assertSame(300, $alliance->getBank());
+		// Force update to check database
+		$alliance = Alliance::getAlliance($alliance->getAllianceID(), 1, forceUpdate: true);
+		self::assertSame(300, $alliance->getBank());
+
+		// Test removing money
+		$alliance->decreaseBank(200);
+		self::assertSame(100, $alliance->getBank());
+		// Force update to check database
+		$alliance = Alliance::getAlliance($alliance->getAllianceID(), 1, forceUpdate: true);
+		self::assertSame(100, $alliance->getBank());
+
+		// Test adding money over the limit
+		$added = $alliance->increaseBank(MAX_MONEY);
+		self::assertSame(MAX_MONEY - 100, $added);
+		self::assertSame(MAX_MONEY, $alliance->getBank());
 	}
 
 }


### PR DESCRIPTION
All Alliance properties are at risk of race conditions because they can be updated from any sector (and thus the SectorLock does not protect them).

This is especially dangerous for gameplay-related fields, since they affect fairness and stats (and can theoretically be abused). Not so for the alliance management properties, for which a race condition would be only an annoyance.

To fix this issue, we update bank/kills/deaths immediately, and we let the database determine the final value by only providing the delta. There is still an edge case with `increaseBank` when hitting MAX_MONEY, but this is rare and will trigger a SQL error (overflow) rather than inconsistent bank amount updates.

Eventually this should be fixed more cleanly with transactions and row-level locking, but we are nowhere near that yet.