### PR TITLE
BetaFunctions: better handling of invalid input

### DIFF
--- a/src/pages/Player/BetaFunctions/SetHardwareProcessor.php
+++ b/src/pages/Player/BetaFunctions/SetHardwareProcessor.php
@@ -10,7 +10,8 @@ class SetHardwareProcessor extends BetaFunctionsPageProcessor {
 	public function buildBetaFunctionsProcessor(Player $player): void {
 		$ship = $player->getShip();
 		$type_hard = Request::getInt('type_hard');
-		$amount_hard = Request::getInt('amount_hard');
+		$max_hard = $ship->getType()->getMaxHardware($type_hard);
+		$amount_hard = min(Request::getInt('amount_hard'), $max_hard);
 		$ship->setHardware($type_hard, $amount_hard);
 	}
 


### PR DESCRIPTION
If the input hardware amount is too large, it will silently clamp to the maximum value allowed for the ship. This is easier than adding HTML5 validation since the maximum value is so variable.