### PR TITLE
Fix NHA members being unable to leave alliance

### DIFF
--- a/src/lib/Smr/Account.php
+++ b/src/lib/Smr/Account.php
@@ -463,6 +463,13 @@ class Account {
 		return $this->npc;
 	}
 
+	/**
+	 * Is account designated as the Newbie Help Leader?
+	 */
+	public function isNHL(): bool {
+		return $this->accountID === ACCOUNT_ID_NHL;
+	}
+
 	protected function getHOFData(): void {
 		if (!isset($this->HOF)) {
 			//Get Player HOF

--- a/src/pages/Account/FeatureRequestVoteProcessor.php
+++ b/src/pages/Account/FeatureRequestVoteProcessor.php
@@ -19,7 +19,7 @@ class FeatureRequestVoteProcessor extends AccountPageProcessor {
 
 		$action = Request::get('action');
 		if ($action === 'Vote') {
-			if ($account->getAccountID() === ACCOUNT_ID_NHL) {
+			if ($account->isNHL()) {
 				create_error('This account is not allowed to cast a vote!');
 			}
 			if (Request::has('vote')) {

--- a/src/pages/Account/VoteProcessor.php
+++ b/src/pages/Account/VoteProcessor.php
@@ -16,7 +16,7 @@ class VoteProcessor extends AccountPageProcessor {
 	) {}
 
 	public function build(Account $account): never {
-		if ($account->getAccountID() === ACCOUNT_ID_NHL) {
+		if ($account->isNHL()) {
 			create_error('This account is not allowed to cast a vote!');
 		}
 

--- a/src/pages/Player/AllianceOptions.php
+++ b/src/pages/Player/AllianceOptions.php
@@ -35,7 +35,7 @@ class AllianceOptions extends PlayerPage {
 			];
 		}
 
-		if (!$isDraftGame && !$alliance->isNHA()) {
+		if (!$isDraftGame && !$player->getAccount()->isNHL()) {
 			// Players can choose to leave their alliance (except in Draft games)
 			$container = new AllianceLeaveConfirm();
 			$links[] = [


### PR DESCRIPTION
Introduced in 653f3cb39, this bug prevented all NHA members from leaving alliance instead of just the NHL.

Add convenience method Account::isNHL to simplify the check.