### PR TITLE
Ship: call decloak and disableIllusion in setTypeID

### DIFF
--- a/src/lib/Smr/AbstractShip.php
+++ b/src/lib/Smr/AbstractShip.php
@@ -394,6 +394,10 @@ class AbstractShip {
 	 * Switch to a new ship, updating player turns accordingly.
 	 */
 	public function setTypeID(int $shipTypeID): void {
+		// Remove any hardware-related settings before we change ship type
+		$this->decloak();
+		$this->disableIllusion();
+
 		$oldSpeed = $this->shipType->getSpeed();
 		$this->getPlayer()->setShipTypeID($shipTypeID);
 		$this->regenerateShipType();

--- a/src/lib/Smr/Ship.php
+++ b/src/lib/Smr/Ship.php
@@ -58,7 +58,7 @@ class Ship extends AbstractShip {
 		$this->updateCargo();
 		$this->updateCloak();
 		$this->updateIllusion();
-		// note: Ship::setTypeID updates the Player only
+		// note: Ship::setTypeID modifies the Player
 		$this->getPlayer()->update();
 	}
 

--- a/src/pages/Player/BetaFunctions/SetShipProcessor.php
+++ b/src/pages/Player/BetaFunctions/SetShipProcessor.php
@@ -12,8 +12,6 @@ class SetShipProcessor extends BetaFunctionsPageProcessor {
 		$shipTypeID = Request::getInt('ship_type_id');
 		if ($shipTypeID <= 75 && $shipTypeID !== 68) {
 			// assign the new ship
-			$ship->decloak();
-			$ship->disableIllusion();
 			$ship->setTypeID($shipTypeID);
 			$ship->setHardwareToMax();
 		}

--- a/src/pages/Player/ShopShipProcessor.php
+++ b/src/pages/Player/ShopShipProcessor.php
@@ -47,8 +47,6 @@ class ShopShipProcessor extends PlayerPageProcessor {
 		}
 
 		// assign the new ship
-		$ship->decloak();
-		$ship->disableIllusion();
 		$ship->setTypeID($shipTypeID);
 
 		$player->log(LOG_TYPE_HARDWARE, 'Buys a ' . $newShipType->getName() . ' for ' . $cost . ' credits');


### PR DESCRIPTION
This fixes an issue with NPCs, where we called setTypeID without first removing cloak/illusion settings. All other callers did this, but now the logic is secured in the function itself.

What would happen is that the NPC would get a ship with cloak and then enable cloak, then switch to a ship without cloak, and then back to a ship with cloak. Because we weren't calling `decloak`, it had retained the original `ship_is_cloaked` setting. But since we don't call `loadCloak` again after switching ships, the `isCloaked` attribute is set to false, and so it tries to insert a duplicate entry into the `ship_is_cloaked` table, causing an error. The reason it doesn't get deleted when in the ship without cloak is due to the optimization in `loadCloak` where we don't even check the `ship_is_cloaked` table if the ship isn't capable of cloaking.

We could have changed `updateCloak` to replace into `ship_is_cloaked`, rather than inserting (which would override the previous entry), but it is preferable to try to fix the inconsistency at its root cause.