### PR TITLE
NpcActor: launch from planet before moving

### DIFF
--- a/src/tools/npc/NpcActor.php
+++ b/src/tools/npc/NpcActor.php
@@ -58,6 +58,9 @@ class NpcActor {
 		// Upgrade ship if possible, reset hardware to max, etc.
 		setupShip($player);
 
+		// Launch from planet, if necessary
+		$player->setLandedOnPlanet(false);
+
 		// Update database (not essential to have a lock here)
 		$player->update();
 


### PR DESCRIPTION
If we don't launch, then the NPC would be automatically landed in any sector with a planet. This was an oversight when adding NPC planets, and fixing it improves consistency with normal players.