### PR TITLE
NPC: fix two issues relating to illegal goods

### DIFF
--- a/src/lib/Smr/AbstractShip.php
+++ b/src/lib/Smr/AbstractShip.php
@@ -1045,4 +1045,8 @@ class AbstractShip {
 		throw new Exception('Can only call update on Ship objects');
 	}
 
+	public function updateCargo(): void {
+		throw new Exception('Can only call updateCargo on Ship objects');
+	}
+
 }

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -433,12 +433,7 @@ function plotToSafety(Player $player): PlayerPageProcessor {
 		}
 	}
 
-	// Always drop illegal goods before heading to fed space
-	if ($player->getShip()->hasIllegalGoods()) {
-		debug('Dumping illegal goods');
-		return dumpCargo($player);
-	}
-
+	$ship = $player->getShip();
 	$fedLocID = $player->getRaceID() + LOCATION_GROUP_RACIAL_BEACONS;
 	try {
 		$needToMove = plotToNearest($player, Location::getLocation($player->getGameID(), $fedLocID));
@@ -448,8 +443,24 @@ function plotToSafety(Player $player): PlayerPageProcessor {
 	}
 	if ($needToMove === false) {
 		debug('Plotted to fed whilst in fed, switch NPC and wait for turns');
+		// In the rare case where we are already in fed and have illegal goods,
+		// just remove the cargo since traditional dumping is not allowed here.
+		if ($ship->hasIllegalGoods()) {
+			debug('Dumping illegal goods (forced)');
+			$ship->removeAllCargo();
+			$ship->updateCargo();
+		}
 		throw new FinalAction();
 	}
+
+	// Always drop illegal goods before heading to fed space.
+	// This must be done *after* setting the plotted course and relies on the
+	// course plotting being done directly rather than through a Processor.
+	if ($ship->hasIllegalGoods()) {
+		debug('Dumping illegal goods');
+		return dumpCargo($player);
+	}
+
 	throw new ForwardAction();
 }
 


### PR DESCRIPTION
1. If the NPC plots to safety while already in Fed, it won't be able to dump cargo via the normal Processor page. In the past, I think we considered this a lucky treat for anyone who came across the NPC, but now with hired NPCs we want to avoid that. To avoid an excessively complex procedure, just delete the goods (rather than plot out of Fed, dump, plot back to Fed).

2. On the return to safety, `dumpCargo` was preempting setting the plotted course to Fed, and so the NPC would finish whatever plot it had previously set, and then stop in open space. To fix this, we set the course first, and then dump cargo if necessary. This is a bit fragile because it relies on exactly how the course is set in this case (directly rather than through a Processor page), but it should work for now. Note that we only call Ship::updateCargo instead of the full Ship::update in case the NPC is under attack, so that we don't collide with Player/Ship updates from that external action.