### PR TITLE
NPC: fix database insertion error with cloak ships

### DIFF
--- a/src/lib/Smr/AbstractShip.php
+++ b/src/lib/Smr/AbstractShip.php
@@ -314,22 +314,23 @@ class AbstractShip {
 	}
 
 	public function decloak(): void {
-		if ($this->isCloaked === false) {
-			return;
-		}
-		$this->isCloaked = false;
-		$this->hasChangedCloak = true;
+		$this->setCloak(false);
 	}
 
 	public function enableCloak(): void {
 		if ($this->hasCloak() === false) {
 			throw new Exception('Ship does not have the supported hardware!');
 		}
-		if ($this->isCloaked === true) {
+		$this->setCloak(true);
+	}
+
+	protected function setCloak(bool $isCloaked): void {
+		if ($this->isCloaked == $isCloaked) {
 			return;
 		}
-		$this->isCloaked = true;
-		$this->hasChangedCloak = true;
+		$this->isCloaked = $isCloaked;
+		// Toggle rather than set true because we insert to db on update.
+		$this->hasChangedCloak = !$this->hasChangedCloak;
 	}
 
 	public function hasIllusion(): bool {

--- a/src/lib/Smr/AbstractShip.php
+++ b/src/lib/Smr/AbstractShip.php
@@ -325,7 +325,7 @@ class AbstractShip {
 	}
 
 	protected function setCloak(bool $isCloaked): void {
-		if ($this->isCloaked == $isCloaked) {
+		if ($this->isCloaked === $isCloaked) {
 			return;
 		}
 		$this->isCloaked = $isCloaked;

--- a/test/SmrTest/lib/ShipIntegrationTest.php
+++ b/test/SmrTest/lib/ShipIntegrationTest.php
@@ -178,6 +178,29 @@ class ShipIntegrationTest extends BaseIntegrationSpec {
 		self::assertEquals($original, $ship);
 	}
 
+	/**
+	 * Check that if cloak is enabled, we can disable and then re-enable
+	 * without breaking update.
+	 */
+	public function test_updateCloak_idempotency(): void {
+		$original = Ship::getShip($this->player);
+		$original->setHardwareToMax();
+
+		// Enable cloak
+		$original->enableCloak();
+		$original->update();
+
+		// Now disable and re-enable before updating again
+		$original->decloak();
+		$original->enableCloak();
+		$original->update();
+
+		// Check that the reloaded ship is equal to the original
+		$ship = Ship::getShip($this->player, true);
+		self::assertNotSame($original, $ship);
+		self::assertEquals($original, $ship);
+	}
+
 	public function test_updateIllusion(): void {
 		$original = Ship::getShip($this->player);
 		$original->setHardwareToMax();


### PR DESCRIPTION
In the NPC code, if we upgraded to a ship with cloak from another ship with cloak, it would decloak (due to changing ships) and then recloak (due to setting up the new ship) all before updating the database. However, since `Ship::updateCloak` does an `insert` instead of a `replace`, we would get a duplicate entry error as the ship was still cloaked as of the previous database update, and so the state has not actually changed.

To fix this, we toggle the `hasChangedCloak` state whenever we enable or disable cloak, rather than forcing it to true. Now if you cloak and then decloak (or vice versa), `hasChangedCloak` is set to false.

An alternative solution would be to `replace` into the database, as a way to prevent duplicate entries, but this feels more like it hides the error rather than fixing it. It also involves more database queries.

Note that this only affects NPCs because we only ever change the cloak state once before updating in normal player requests.