### PR TITLE
NPC: fix abandoning trade route when selling goods

### DIFF
--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -388,7 +388,7 @@ function tradeGoods(int $goodID, Player $player, Port $port): PlayerPageProcesso
 
 	$idealPrice = $port->getIdealPrice($goodID, $transaction, $amount, $relations);
 	$offeredPrice = $port->getOfferPrice($idealPrice, $relations, $transaction);
-	if ($player->getCredits() < $offeredPrice) {
+	if ($transaction === TransactionType::Buy && $player->getCredits() < $offeredPrice) {
 		throw new AbandonTradeRoute('Goods cost ' . $offeredPrice . ', but player has ' . $player->getCredits());
 	}
 


### PR DESCRIPTION
The insufficient funds check was incorrectly being applied to selling, resulting in NPCs abandoning routes where they would have earned more credits than they had.