### PR TITLE
NPC: handle hired NPC being podded while offline

### DIFF
--- a/src/tools/npc/NpcActor.php
+++ b/src/tools/npc/NpcActor.php
@@ -86,8 +86,8 @@ class NpcActor {
 		return Player::getPlayer($this->accountID, $this->gameID, true);
 	}
 
-	public function getNumActions(): int {
-		return $this->actions;
+	public function hasTakenActions(): bool {
+		return $this->actions > 0;
 	}
 
 	public function shutdown(): void {
@@ -131,10 +131,6 @@ class NpcActor {
 			throw new FinalAction();
 		}
 
-		// Start the action sequence
-		$this->actions++;
-		debug('Action #' . $this->actions);
-
 		//We have to reload player on each loop
 		$player = $this->refreshPlayer();
 		$player->updateTurns();
@@ -145,8 +141,9 @@ class NpcActor {
 			$player->setDead(false); // see death_processing.php
 			$player->setNewbieWarning(false); // undo Player::killPlayer setting this to true
 
-			if ($this->hired) {
-				// Hired traders quit their job after getting podded
+			// Hired traders quit their job after getting podded while acting.
+			// If no action yet, don't dismiss since this might be a new employer.
+			if ($this->hired && $this->hasTakenActions()) {
 				AllianceManageNpcsDismissProcessor::dismissNpc($player, $player);
 				throw new FinalAction();
 			}
@@ -158,6 +155,10 @@ class NpcActor {
 			setupShip($player); // reship before continuing
 			$this->changeRoute(avoidPreviousPorts: true);
 		}
+
+		// Start the action sequence
+		$this->actions++;
+		debug('Action #' . $this->actions);
 
 		if ($this->isReturningToSafety) {
 			// Returning to safety is our highest priority action

--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -187,7 +187,7 @@ function npcDriver(): bool {
 		} catch (FinalAction) {
 			$actor->shutdown();
 			// switch to a new NPC if we haven't taken any actions yet
-			return $actor->getNumActions() > 0;
+			return $actor->hasTakenActions();
 		} finally {
 			// Save any changes that we made during this action
 			saveAllAndReleaseLock(updateSession: false);


### PR DESCRIPTION
It should not currently be possible for an NPC to get podded while offline, but this can happen sometimes (unexpected bugs, max actions, etc.). When it does, it will process its death the next time it is selected, and if it is in the "hired" state, it will leave the alliance and stop. However, if the original employer fired the NPC between when it was podded and the next time it acted, then that death processing would occur the *next* time it was hired, potentially with a new alliance, which it would then immediately leave.

To fix this, we now skip leaving the alliance if it's the NPC has yet to take an action. Since offline podding is more likely to be due to a bug or a server issue, it seems fair to not have the NPC leave its alliance.

We will need to revisit this design if/once we allow hired NPCs to land on planets, in which case we *should* leave the alliance if podded offline while on a planet. We will probably need to add NPC handling to death processing in the killer's session, or have additional tracking data in the database to know which alliance it was hired by when it was killed.