### PR TITLE
AllianceLeaveProcessor: fix disbanding alliance

### DIFF
--- a/src/lib/Smr/Player.php
+++ b/src/lib/Smr/Player.php
@@ -1546,7 +1546,7 @@ class Player {
 			$this->log(LOG_TYPE_ALLIANCE, 'disbanded alliance ' . $alliance->getAllianceName());
 		} else {
 			$this->log(LOG_TYPE_ALLIANCE, 'left alliance: ' . $alliance->getAllianceName());
-			if ($alliance->getLeaderID() !== 0) {
+			if ($alliance->hasLeader()) {
 				$this->sendMessage($alliance->getLeaderID(), MSG_PLAYER, 'I left your alliance!', false);
 			}
 		}

--- a/src/pages/Player/AllianceLeaveProcessor.php
+++ b/src/pages/Player/AllianceLeaveProcessor.php
@@ -15,9 +15,12 @@ class AllianceLeaveProcessor extends PlayerPageProcessor {
 			create_error('You are the leader! You must hand over leadership first!');
 		}
 
-		// will this alliance be empty if we leave? (means one member right now)
+		// now leave the alliance
+		$player->leaveAlliance();
+
+		// Disband this alliance if it is now empty.
 		// Don't delete the Newbie Help Alliance!
-		if ($alliance->getNumMembers() === 1 && !$alliance->isNHA()) {
+		if ($alliance->getNumMembers() === 0 && !$alliance->isNHA()) {
 			// Retain the alliance, but delete some auxilliary info
 			$db = Database::getInstance();
 			$db->delete('alliance_bank_transactions', $alliance->SQLID);
@@ -28,9 +31,6 @@ class AllianceLeaveProcessor extends PlayerPageProcessor {
 			$alliance->setDiscordChannel(null);
 			$alliance->update();
 		}
-
-		// now leave the alliance
-		$player->leaveAlliance();
 
 		$container = new CurrentSector();
 		$container->go();


### PR DESCRIPTION
Prior to 51b218582, we were directly unsetting the `alliance.leader_id` in the database, which allowed us to call Player::leaveAlliance (which queries the alliance leader player) *after* removing the leader, because the leader was still present in the actual Alliance object.

When we switched to unsetting the leader using Alliance::setLeaderID, we needed to also switch the order of leaving/disbanding so that disbanding happens after the last player has left.

Thanks to RR for uncovering this bug.