### PR TITLE
Force: move expire limit from setExpire to updateExpire

### DIFF
--- a/src/lib/Smr/Force.php
+++ b/src/lib/Smr/Force.php
@@ -304,9 +304,6 @@ class Force {
 		if ($time === $this->getExpire()) {
 			return;
 		}
-		if ($time > Epoch::time() + $this->getMaxExpireTime()) {
-			$time = Epoch::time() + $this->getMaxExpireTime();
-		}
 		$this->hasChanged = true;
 		$this->expire = $time;
 		if (!$this->isNew) {
@@ -316,11 +313,13 @@ class Force {
 
 	public function updateExpire(): void {
 		// Changed (26/10/05) - scout drones count * 2
-		if ($this->getCDs() === 0 && $this->getMines() === 0 && $this->getSDs() > 0) {
+		if (!$this->hasCDs() && !$this->hasMines() && $this->hasSDs()) {
 			$time = self::TIME_PER_SCOUT_ONLY * $this->getSDs();
 		} else {
 			$time = ($this->getCDs() * self::TIME_PERCENT_PER_COMBAT + $this->getSDs() * self::TIME_PERCENT_PER_SCOUT + $this->getMines() * self::TIME_PERCENT_PER_MINE) * $this->getMaxGalaxyExpireTime();
 		}
+		// Limit to max expire time
+		$time = min($time, $this->getMaxExpireTime());
 		$this->setExpire(Epoch::time() + IFloor($time));
 	}
 

--- a/test/SmrTest/lib/ForceTest.php
+++ b/test/SmrTest/lib/ForceTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Smr\AbstractShip;
+use Smr\Epoch;
 use Smr\Force;
 use Smr\Galaxy;
 use SmrTest\TestUtils;
@@ -330,6 +331,54 @@ class ForceTest extends TestCase {
 			[0, 0, 1, $below, $below],
 			[0, 1, 1, $below, $below],
 			[0, 0, 0, $below, 0],
+		];
+	}
+
+	#[DataProvider('dataProvider_updateExpire')]
+	public function test_updateExpire(int $sds, int $cds, int $mines, int $galMaxForceTime, int $expectedExpire): void {
+		// Stub the galaxy that this force is inside
+		$galaxy = $this->createStub(Galaxy::class);
+		$galaxy->method('getMaxForceTime')->willReturn($galMaxForceTime);
+
+		// Partially mock the force so we can use the galaxy stub
+		$force = $this->createPartialMock($this->force::class, ['getGalaxy']);
+		$force
+			->expects(self::atMost(2))
+			->method('getGalaxy')
+			->willReturn($galaxy)
+			->seal();
+
+		// Set the number of forces, and check result
+		$force->setSDs($sds);
+		$force->setCDs($cds);
+		$force->setMines($mines);
+		$force->updateExpire();
+		self::assertSame($expectedExpire, $force->getExpire() - Epoch::time());
+	}
+
+	/**
+	 * @return array<array<int>>
+	 */
+	public static function dataProvider_updateExpire(): array {
+		$day = 86400;
+		// sds, cds, mines, galaxy max expire time, expected expire time
+		return [
+			[0, 0, 0, $day, 0],
+			// Scouts independent of gal max expire time
+			[1, 0, 0, 0, 1 * $day],
+			[5, 0, 0, 0, 5 * $day],
+			// Non-scout-only goes up to gal max expire time
+			[5, 50, 50, 7 * $day, 7 * $day],
+			// Individual cd/mine add 1/50th
+			[0, 1, 0, 50 * $day, $day],
+			[0, 0, 1, 50 * $day, $day],
+			[0, 49, 0, 50 * $day, 49 * $day],
+			[0, 0, 49, 50 * $day, 49 * $day],
+			[0, 50, 0, $day, $day],
+			[0, 0, 50, $day, $day],
+			[1, 1, 1, 50 * $day, 3 * $day],
+			[0, 25, 24, 50 * $day, 49 * $day],
+			[0, 25, 25, 50 * $day, 50 * $day],
 		];
 	}
 


### PR DESCRIPTION
When we want to explicitly set a force expire time (e.g. non-expiring NPC forces), we don't want to be implicitly limited to the max expire time in the galaxy. Since all non-NPC player-related expire times are set with `updateExpire` (or `tidyUpForces`), we can safely move the implicit limit out of `setExpire`, so that it is a pure setter function without gameplay restrictions.