### PR TITLE
AllianceLeadership: don't display current leader

### DIFF
--- a/src/pages/Player/AllianceLeadership.php
+++ b/src/pages/Player/AllianceLeadership.php
@@ -20,7 +20,9 @@ class AllianceLeadership extends PlayerPage {
 		$container = new AllianceLeadershipProcessor();
 		$template->assign('HandoverHREF', $container->href());
 
-		$template->assign('AlliancePlayers', $alliance->getMembers(includeNpc: false));
+		$members = $alliance->getMembers(includeNpc: false);
+		unset($members[$alliance->getLeaderID()]); // don't show current leader
+		$template->assign('AlliancePlayers', $members);
 	}
 
 }


### PR DESCRIPTION
Handing over leadership to the current leader doesn't make sense, so don't even display it as an option. Now only non-leader players will be listed in the dropdown.