### PR TITLE
Fix amazon/aws-cli error

### DIFF
--- a/live/docker-compose.override.yml
+++ b/live/docker-compose.override.yml
@@ -23,7 +23,8 @@ services:
             - "traefik.http.middlewares.traefik-auth.basicauth.users=traefik:$$apr1$$N1XTczE5$$5GvS93f.oSRstkxmjw9JD0"
 
     backup-s3:
-        image: amazon/aws-cli:2.34.18
+        # Note: from 2.27.51 onward, requires x86-64-v2, which we don't have
+        image: amazon/aws-cli:2.27.50
         networks:
             - backend
         environment:


### PR DESCRIPTION
The amazon/aws-cli image requires x86-64-v2 as of 2.27.51, which the live VM server does not currently support. Therefore we need to pin to an older version of this image.

Fixes the error:

> Fatal glibc error: CPU does not support x86-64-v2