### PR TITLE
Fix alliance BBLinks for disbanded alliances

### DIFF
--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -28,7 +28,6 @@ use Smr\Pages\Account\Preferences;
 use Smr\Pages\Admin\AdminTools;
 use Smr\Pages\Player\AllianceInviteAcceptProcessor;
 use Smr\Pages\Player\AllianceMotd;
-use Smr\Pages\Player\AllianceRoster;
 use Smr\Pages\Player\CargoDump;
 use Smr\Pages\Player\CombatLogList;
 use Smr\Pages\Player\CombatLogViewerVerifyProcessor;

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -83,6 +83,7 @@ function linkCombatLog(int $logID): string {
 function smrBBCode(BBCode $bbParser, int $action, string $tagName, string $default, array $tagParams, string $tagContent): bool|string {
 	global $overrideGameID, $disableBBLinks;
 	$session = Session::getInstance();
+	$linked = $disableBBLinks === false && $session->hasGame() && $overrideGameID === $session->getGameID();
 	try {
 		switch ($tagName) {
 			case 'combatlog':
@@ -99,7 +100,7 @@ function smrBBCode(BBCode $bbParser, int $action, string $tagName, string $defau
 				$playerID = (int)$default;
 				$bbPlayer = Player::getPlayerByPlayerID($playerID, $overrideGameID);
 				$showAlliance = isset($tagParams['showalliance']) ? parseBoolean($tagParams['showalliance']) : false;
-				if ($disableBBLinks === false && $overrideGameID === $session->getGameID()) {
+				if ($linked) {
 					return $bbPlayer->getLinkedDisplayName($showAlliance);
 				}
 				return $bbPlayer->getDisplayName($showAlliance);
@@ -110,15 +111,11 @@ function smrBBCode(BBCode $bbParser, int $action, string $tagName, string $defau
 				}
 				$allianceID = (int)$default;
 				$alliance = Alliance::getAlliance($allianceID, $overrideGameID);
-				if ($disableBBLinks === false && $overrideGameID === $session->getGameID()) {
-					if ($session->hasGame() && $alliance->getAllianceID() === $session->getPlayer()->getAllianceID()) {
-						$container = new AllianceMotd($alliance->getAllianceID());
-					} else {
-						$container = new AllianceRoster($alliance->getAllianceID());
-					}
+				if ($linked && $alliance->getAllianceID() === $session->getPlayer()->getAllianceID()) {
+					$container = new AllianceMotd($alliance->getAllianceID());
 					return create_link($container, $alliance->getAllianceDisplayName());
 				}
-				return $alliance->getAllianceDisplayName();
+				return $alliance->getAllianceDisplayName($linked);
 
 			case 'race':
 				$raceNameID = $default;

--- a/src/lib/Smr/Player.php
+++ b/src/lib/Smr/Player.php
@@ -1382,7 +1382,7 @@ class Player {
 	}
 
 	public function getLinkedDisplayName(bool $includeAlliance = true): string {
-		$return = '<a href="' . $this->getTraderSearchHREF() . '">' . $this->getDisplayName() . '</a>';
+		$return = create_link($this->getTraderSearchHREF(), $this->getDisplayName());
 		if ($includeAlliance) {
 			$return .= ' (' . $this->getAllianceDisplayName(true) . ')';
 		}


### PR DESCRIPTION
Use the Alliance::getAllianceDisplayName method to get the link instead of directly creating an AllianceRoster link, since the former properly handles disbanded alliances. Thanks to StupidNewbie for reporting this bug.

Also fixed player BBLinks so that they are only linked if the session has a game. Previously, they could be linked if both the session and the overrideGameID were 0.