### PR TITLE
Fix NPC error when plotting to current sector

### DIFF
--- a/src/tools/npc/npc.php
+++ b/src/tools/npc/npc.php
@@ -412,6 +412,10 @@ function dumpCargo(Player $player): PlayerPageProcessor {
 }
 
 function plotToSector(Player $player, int $sectorID): PlayerPageProcessor {
+	if ($player->getSectorID() === $sectorID) {
+		debug('Already in sector ' . $sectorID);
+		throw new ForwardAction();
+	}
 	return new PlotCourseConventionalProcessor(from: $player->getSectorID(), to: $sectorID);
 }
 


### PR DESCRIPTION
If an NPC plots to its current sector for any reason (e.g. it triggered low turns and is already in its safe location), it will now gracefully continue to its next action instead of aborting.