### PR TITLE
Use native discord time formatting in op messages

### DIFF
--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -812,6 +812,14 @@ function format_time(int $seconds, bool $short = false): string {
 	return $result;
 }
 
+/**
+ * Convert a time epoch to a special relative time display on Discord
+ */
+function format_time_discord(int $epoch): string {
+	// R = relative format (gives full local date and time on hover)
+	return '<t:' . $epoch . ':R>';
+}
+
 function number_colour_format(float $number, bool $justSign = false): string {
 	$formatted = '<span';
 	if ($number > 0) {

--- a/src/lib/Smr/Discord/Commands/Op.php
+++ b/src/lib/Smr/Discord/Commands/Op.php
@@ -18,7 +18,7 @@ class Op extends DatabaseCommand {
 
 	public function databaseResponse(string ...$args): array {
 		// print info about the next op
-		return shared_channel_msg_op_info($this->player);
+		return shared_channel_msg_op_info($this->player, discord: true);
 	}
 
 }

--- a/src/tools/chat_helpers/channel_msg_op_info.php
+++ b/src/tools/chat_helpers/channel_msg_op_info.php
@@ -6,7 +6,7 @@ use Smr\Player;
 /**
  * @return array<string>
  */
-function shared_channel_msg_op_info(Player $player): array {
+function shared_channel_msg_op_info(Player $player, bool $discord = false): array {
 	// get the op from db
 	$db = Database::getInstance();
 	$dbResult = $db->select('alliance_has_op', $player->getAlliance()->SQLID, ['time']);
@@ -17,7 +17,12 @@ function shared_channel_msg_op_info(Player $player): array {
 	// check if the op has already started
 	$opTime = $dbResult->record()->getInt('time');
 	if ($opTime < time()) {
-		return ['The op started ' . format_time(time() - $opTime, true) . ' ago!'];
+		if ($discord) {
+			$when = format_time_discord($opTime);
+		} else {
+			$when = format_time(time() - $opTime, true) . ' ago';
+		}
+		return ['The op started ' . $when . '!'];
 	}
 
 	// function to return op info message for each player
@@ -57,7 +62,12 @@ function shared_channel_msg_op_info(Player $player): array {
 	$result = array_map($getOpInfoMessage, $player->getSharingPlayers(true));
 
 	// Prepend the time left until the op
-	array_unshift($result, 'The next scheduled op is ' . in_time_or_now($opTime - time(), true) . '.');
+	if ($discord) {
+		$when = format_time_discord($opTime);
+	} else {
+		$when = in_time_or_now($opTime - time(), true);
+	}
+	array_unshift($result, 'The next scheduled op is ' . $when . '.');
 
 	return $result;
 }


### PR DESCRIPTION
Discord can display times relative to the user's local time, which may be useful for preventing confusion about op times.