### PR TITLE
alliance_set_op.php: add another date format example

### DIFF
--- a/src/templates/Default/engine/Default/alliance_set_op.php
+++ b/src/templates/Default/engine/Default/alliance_set_op.php
@@ -32,7 +32,7 @@ if (isset($OpDate)) { ?>
 	<div class="buttonA"><a class="buttonA" href="<?php echo $OpProcessingHREF; ?>">Cancel</a></div>
 	<?php
 } else { ?>
-	<p>Schedule the next alliance operation:<br><small>Enter the date in server time (example: Dec 12 18:30)</small></p>
+	<p>Schedule the next alliance operation:<br><small>Enter the date in server time (example: Dec 12 18:30) or a specified timezone (example: Next monday 7 pm EST)</small></p>
 	<form method="POST" action="<?php echo $OpProcessingHREF; ?>">
 		<input type="text" name="date" required />
 		<?php echo create_submit_display('Confirm'); ?>


### PR DESCRIPTION
Give an example using a specified timezone (and also relative dates and AM/PM). Any format supported by `strtotime` works:

https://www.php.net/manual/en/datetime.formats.php