### PR TITLE
AdminMessageSend: fix unescaped player names

### DIFF
--- a/src/pages/Admin/AdminMessageSend.php
+++ b/src/pages/Admin/AdminMessageSend.php
@@ -45,7 +45,7 @@ class AdminMessageSend extends AccountPage {
 			foreach ($dbResult->records() as $dbRecord) {
 				$gamePlayers[] = [
 					'AccountID' => $dbRecord->getInt('account_id'),
-					'Name' => $dbRecord->getString('player_name') . ' (' . $dbRecord->getInt('player_id') . ')',
+					'Name' => htmlentities($dbRecord->getString('player_name')) . ' (' . $dbRecord->getInt('player_id') . ')',
 				];
 			}
 			$template->assign('GamePlayers', $gamePlayers);


### PR DESCRIPTION
Ideally we would be using the Player::getDisplayName method, but since we aren't using Player objects here, just escape the name manually.