### PR TITLE
Fix changing feature request statuses

### DIFF
--- a/src/pages/Account/FeatureRequestVoteProcessor.php
+++ b/src/pages/Account/FeatureRequestVoteProcessor.php
@@ -53,6 +53,11 @@ class FeatureRequestVoteProcessor extends AccountPageProcessor {
 			$setStatusIDs = Request::getIntArray('set_status_ids');
 
 			foreach ($setStatusIDs as $featureID) {
+				$db->update(
+					'feature_request',
+					['status' => $status],
+					['feature_request_id' => $featureID],
+				);
 				$db->insert('feature_request_comments', [
 					'feature_request_id' => $featureID,
 					'poster_id' => $account->getAccountID(),


### PR DESCRIPTION
In 8540a6555, updating the status of the feature request was accidentally removed along with the static yes/no/fav tracking.