### PR TITLE
Remove deprecated curl_close call

### DIFF
--- a/src/pages/Account/AlbumEditProcessor.php
+++ b/src/pages/Account/AlbumEditProcessor.php
@@ -25,7 +25,6 @@ function isUrlReachable(string $url): bool {
 	]);
 	curl_exec($ch);
 	$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	curl_close($ch);
 
 	$statusClass = IFloor($statusCode / 100);
 	return $statusClass === 2 || $statusClass === 3;


### PR DESCRIPTION
This function does nothing as of PHP 8.0. The handle is now cleaned up automatically.