### PR TITLE
AccountEditSearch: display games in reverse order

### DIFF
--- a/src/pages/Admin/AccountEditSearch.php
+++ b/src/pages/Admin/AccountEditSearch.php
@@ -21,7 +21,13 @@ class AccountEditSearch extends AccountPage {
 
 		$games = [];
 		$db = Database::getInstance();
-		$dbResult = $db->select('game', ['enabled' => $db->escapeBoolean(true)], ['game_id', 'game_name']);
+		$dbResult = $db->select(
+			'game',
+			['enabled' => $db->escapeBoolean(true)],
+			['game_id', 'game_name'],
+			['game_id'],
+			['DESC'],
+		);
 		foreach ($dbResult->records() as $dbRecord) {
 			$gameID = $dbRecord->getInt('game_id');
 			$games[$gameID] = $dbRecord->getString('game_name') . ' (' . $gameID . ')';


### PR DESCRIPTION
Largest game ID should be first, since it's more likely to select players from the current game than the first game.

Note that without sorting, the games were listed in an arbitrary order. (PHP does not automatically sort by array key.)