### PR TITLE
Template: add pageTopic property hook

### DIFF
--- a/src/lib/Smr/PlanetList.php
+++ b/src/lib/Smr/PlanetList.php
@@ -25,11 +25,11 @@ class PlanetList {
 		$template->assign('PlayerOnly', $playerOnly);
 
 		if ($playerOnly) {
-			$template->assign('PageTopic', 'Planet');
+			$template->pageTopic = 'Planet';
 		} else {
 			$alliance = Alliance::getAlliance($allianceId, $player->getGameID());
 			$template->assign('Alliance', $alliance);
-			$template->assign('PageTopic', 'Planets : ' . $alliance->getAllianceDisplayName());
+			$template->pageTopic = 'Planets : ' . $alliance->getAllianceDisplayName();
 		}
 
 		// We might not assign the planet lists if the info is private.

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -51,6 +51,15 @@ class Template {
 		unset($this->data[$var]);
 	}
 
+	public ?string $pageTopic = null {
+		set {
+			if ($this->pageTopic !== null) {
+				throw new Exception('Cannot re-assign pageTopic: ' . $this->pageTopic);
+			}
+			$this->pageTopic = $value;
+		}
+	}
+
 	/**
 	 * Displays the template HTML. Stores any ajax-enabled elements for future
 	 * comparison, and outputs modified elements in XML for ajax if requested.

--- a/src/pages/Account/AlbumDeleteConfirm.php
+++ b/src/pages/Account/AlbumDeleteConfirm.php
@@ -11,7 +11,7 @@ class AlbumDeleteConfirm extends AccountPage {
 	public string $file = 'album_delete_confirmation.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Delete Album Entry - Confirmation');
+		$template->pageTopic = 'Delete Album Entry - Confirmation';
 		$template->assign('CancelHref', (new AlbumEdit())->href());
 		$template->assign('ConfirmHref', (new AlbumDeleteProcessor())->href());
 	}

--- a/src/pages/Account/AlbumEdit.php
+++ b/src/pages/Account/AlbumEdit.php
@@ -21,7 +21,7 @@ class AlbumEdit extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Edit Photo');
+		$template->pageTopic = 'Edit Photo';
 
 		try {
 			$album = new Album($account->getAccountID());

--- a/src/pages/Account/BugReport.php
+++ b/src/pages/Account/BugReport.php
@@ -14,7 +14,7 @@ class BugReport extends AccountPage {
 	public string $file = 'bug_report.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Report a Bug');
+		$template->pageTopic = 'Report a Bug';
 	}
 
 }

--- a/src/pages/Account/BuyMessageNotifications.php
+++ b/src/pages/Account/BuyMessageNotifications.php
@@ -18,7 +18,7 @@ class BuyMessageNotifications extends AccountPage {
 	public function build(Account $account, Template $template): void {
 		$template->assign('Message', $this->message);
 
-		$template->assign('PageTopic', 'Message Notifications');
+		$template->pageTopic = 'Message Notifications';
 
 		// Presently only player messages are eligible for notifications
 		$notifyTypeIDs = [MSG_PLAYER];

--- a/src/pages/Account/ChangelogView.php
+++ b/src/pages/Account/ChangelogView.php
@@ -19,7 +19,7 @@ class ChangelogView extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Change Log');
+		$template->pageTopic = 'Change Log';
 
 		if ($this->lastLogin !== null) {
 			$container = new LoginProcessor();

--- a/src/pages/Account/ChatJoin.php
+++ b/src/pages/Account/ChatJoin.php
@@ -18,7 +18,7 @@ class ChatJoin extends AccountPage {
 		$session = Session::getInstance();
 		$player = $session->hasGame() ? $session->getPlayer() : null;
 
-		$template->assign('PageTopic', 'Space Merchant Realms Chat');
+		$template->pageTopic = 'Space Merchant Realms Chat';
 
 		$autoChannels = '#SMR';
 		$nick = 'SMR-';

--- a/src/pages/Account/ContactForm.php
+++ b/src/pages/Account/ContactForm.php
@@ -14,7 +14,7 @@ class ContactForm extends AccountPage {
 	public string $file = 'contact.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Contact Form');
+		$template->pageTopic = 'Contact Form';
 
 		$container = new ContactFormProcessor();
 		$template->assign('ProcessingHREF', $container->href());

--- a/src/pages/Account/Donation.php
+++ b/src/pages/Account/Donation.php
@@ -16,7 +16,7 @@ class Donation extends AccountPage {
 	public string $file = 'donation.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Donations');
+		$template->pageTopic = 'Donations';
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT IFNULL(SUM(amount), 0) as total_donation FROM account_donated WHERE time > :hide_donation_time', [
 			'hide_donation_time' => $db->escapeNumber(Epoch::time() - (86400 * 90)), // 90 days

--- a/src/pages/Account/ErrorDisplay.php
+++ b/src/pages/Account/ErrorDisplay.php
@@ -15,7 +15,7 @@ class ErrorDisplay extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Error');
+		$template->pageTopic = 'Error';
 		$template->assign('Message', $this->message);
 	}
 

--- a/src/pages/Account/FeatureRequest.php
+++ b/src/pages/Account/FeatureRequest.php
@@ -33,7 +33,7 @@ class FeatureRequest extends AccountPage {
 
 		$thisStatus = self::statusFromCategory($this->category);
 
-		$template->assign('PageTopic', 'Feature Requests - ' . $this->category);
+		$template->pageTopic = 'Feature Requests - ' . $this->category;
 
 		$requestCategories = [
 			self::CATEGORY_NEW => 'Open requests active within the past ' . self::NEW_REQUEST_DAYS . ' days',

--- a/src/pages/Account/FeatureRequestComments.php
+++ b/src/pages/Account/FeatureRequestComments.php
@@ -26,7 +26,7 @@ class FeatureRequestComments extends AccountPage {
 			create_error('Feature requests are currently not being accepted.');
 		}
 
-		$template->assign('PageTopic', 'Feature Request Comments');
+		$template->pageTopic = 'Feature Request Comments';
 
 		$template->assign('BackHref', $this->previousPage->href());
 

--- a/src/pages/Account/GameJoin.php
+++ b/src/pages/Account/GameJoin.php
@@ -65,7 +65,7 @@ class GameJoin extends AccountPage {
 			create_error('This game has no races assigned yet!');
 		}
 
-		$template->assign('PageTopic', 'Join Game: ' . $game->getDisplayName());
+		$template->pageTopic = 'Join Game: ' . $game->getDisplayName();
 		$template->assign('Game', $game);
 
 		if (Epoch::time() >= $game->getJoinTime()) {

--- a/src/pages/Account/GamePlay.php
+++ b/src/pages/Account/GamePlay.php
@@ -25,7 +25,7 @@ class GamePlay extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Play Game');
+		$template->pageTopic = 'Play Game';
 
 		$template->assign('ErrorMessage', $this->errorMessage);
 		$template->assign('Message', $this->message);

--- a/src/pages/Account/GameStats.php
+++ b/src/pages/Account/GameStats.php
@@ -28,7 +28,7 @@ class GameStats extends AccountPage {
 		$statsGame = Game::getGame($gameID);
 		$template->assign('StatsGame', $statsGame);
 
-		$template->assign('PageTopic', 'Game Stats: ' . $statsGame->getName() . ' (' . $gameID . ')');
+		$template->pageTopic = 'Game Stats: ' . $statsGame->getName() . ' (' . $gameID . ')';
 
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT count(*) total_players, IFNULL(MAX(experience),0) max_exp, IFNULL(MAX(alignment),0) max_align, IFNULL(MIN(alignment),0) min_align, IFNULL(MAX(kills),0) max_kills FROM player WHERE game_id = :game_id', [

--- a/src/pages/Account/HallOfFameAll.php
+++ b/src/pages/Account/HallOfFameAll.php
@@ -39,7 +39,7 @@ class HallOfFameAll extends AccountPage {
 		} else {
 			$topic = 'Hall of Fame: ' . Game::getGame($game_id)->getDisplayName();
 		}
-		$template->assign('PageTopic', $topic);
+		$template->pageTopic = $topic;
 
 		$container = new HallOfFamePersonal($account->getAccountID(), $game_id);
 		$template->assign('PersonalHofHREF', $container->href());

--- a/src/pages/Account/HallOfFamePersonal.php
+++ b/src/pages/Account/HallOfFamePersonal.php
@@ -47,10 +47,10 @@ class HallOfFamePersonal extends AccountPage {
 			} catch (PlayerNotFound) {
 				create_error('That player has not yet joined this game.');
 			}
-			$template->assign('PageTopic', htmlentities($hofPlayer->getPlayerName()) . '\'s Personal Hall of Fame: ' . Game::getGame($game_id)->getDisplayName());
+			$template->pageTopic = htmlentities($hofPlayer->getPlayerName()) . '\'s Personal Hall of Fame: ' . Game::getGame($game_id)->getDisplayName();
 		} else {
 			$hofName = Account::getAccount($account_id)->getHofDisplayName();
-			$template->assign('PageTopic', $hofName . '\'s All Time Personal Hall of Fame');
+			$template->pageTopic = $hofName . '\'s All Time Personal Hall of Fame';
 		}
 
 		$breadcrumb = HallOfFame::buildBreadcrumb($this, 'Personal HoF');

--- a/src/pages/Account/HistoryGames/AllianceDetail.php
+++ b/src/pages/Account/HistoryGames/AllianceDetail.php
@@ -36,7 +36,7 @@ class AllianceDetail extends HistoryPage {
 		);
 		$dbRecord = $dbResult->record();
 		$leaderID = $dbRecord->getInt('leader_id');
-		$template->assign('PageTopic', 'Alliance Roster: ' . htmlentities($dbRecord->getString('alliance_name')));
+		$template->pageTopic = 'Alliance Roster: ' . htmlentities($dbRecord->getString('alliance_name'));
 
 		//get alliance members
 		$oldAccountID = $account->getOldAccountID($this->historyDatabase);

--- a/src/pages/Account/HistoryGames/ExtendedStats.php
+++ b/src/pages/Account/HistoryGames/ExtendedStats.php
@@ -16,7 +16,7 @@ class ExtendedStats extends HistoryPage {
 	) {}
 
 	protected function buildHistory(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Extended Stats : ' . $this->historyGameName);
+		$template->pageTopic = 'Extended Stats : ' . $this->historyGameName;
 		$this->addMenu($template);
 
 		$categories = [

--- a/src/pages/Account/HistoryGames/ExtendedStatsDetail.php
+++ b/src/pages/Account/HistoryGames/ExtendedStatsDetail.php
@@ -20,7 +20,7 @@ class ExtendedStatsDetail extends HistoryPage {
 
 	protected function buildHistory(Account $account, Template $template): void {
 		$game_id = $this->historyGameID;
-		$template->assign('PageTopic', 'Extended Stats : ' . $this->historyGameName);
+		$template->pageTopic = 'Extended Stats : ' . $this->historyGameName;
 		$this->addMenu($template, ExtendedStats::class);
 
 		$oldAccountID = $account->getOldAccountID($this->historyDatabase);

--- a/src/pages/Account/HistoryGames/GameNews.php
+++ b/src/pages/Account/HistoryGames/GameNews.php
@@ -12,7 +12,7 @@ class GameNews extends HistoryPage {
 	public string $file = 'history_games_news.php';
 
 	protected function buildHistory(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Game News : ' . $this->historyGameName);
+		$template->pageTopic = 'Game News : ' . $this->historyGameName;
 		$this->addMenu($template);
 
 		$min = Request::getInt('min', 1);

--- a/src/pages/Account/HistoryGames/HallOfFame.php
+++ b/src/pages/Account/HistoryGames/HallOfFame.php
@@ -18,7 +18,7 @@ class HallOfFame extends HistoryPage {
 	) {}
 
 	protected function buildHistory(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Hall of Fame : ' . $this->historyGameName);
+		$template->pageTopic = 'Hall of Fame : ' . $this->historyGameName;
 		$this->addMenu($template);
 
 		$db = Database::getInstance();

--- a/src/pages/Account/HistoryGames/Summary.php
+++ b/src/pages/Account/HistoryGames/Summary.php
@@ -14,7 +14,7 @@ class Summary extends HistoryPage {
 		//topic
 		$game_name = $this->historyGameName;
 		$game_id = $this->historyGameID;
-		$template->assign('PageTopic', 'Old SMR Game : ' . $game_name);
+		$template->pageTopic = 'Old SMR Game : ' . $game_name;
 		$this->addMenu($template);
 
 		$db = Database::getInstance();

--- a/src/pages/Account/InvalidEmail.php
+++ b/src/pages/Account/InvalidEmail.php
@@ -12,7 +12,7 @@ class InvalidEmail extends AccountPage {
 	public string $file = 'invalid_email.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Invalid E-mail Address');
+		$template->pageTopic = 'Invalid E-mail Address';
 
 		// This page should only be accessed by players whose accounts
 		// have been closed due to an invalid e-mail.

--- a/src/pages/Account/LoginAnnouncements.php
+++ b/src/pages/Account/LoginAnnouncements.php
@@ -18,7 +18,7 @@ class LoginAnnouncements extends AccountPage {
 	public function build(Account $account, Template $template): void {
 		$db = Database::getInstance();
 
-		$template->assign('PageTopic', 'Announcements');
+		$template->pageTopic = 'Announcements';
 
 		if (!$this->viewAll) {
 			$dbResult = $db->read('SELECT time, msg

--- a/src/pages/Account/NewsReadAdvanced.php
+++ b/src/pages/Account/NewsReadAdvanced.php
@@ -98,7 +98,7 @@ class NewsReadAdvanced extends AccountPage {
 
 		$template->assign('NewsItems', News::getNewsItems($dbResult));
 
-		$template->assign('PageTopic', 'Advanced News');
+		$template->pageTopic = 'Advanced News';
 		Menu::news($gameID);
 	}
 

--- a/src/pages/Account/NewsReadArchives.php
+++ b/src/pages/Account/NewsReadArchives.php
@@ -32,7 +32,7 @@ class NewsReadArchives extends AccountPage {
 		$template->assign('MinNews', $min_news);
 		$template->assign('MaxNews', $max_news);
 
-		$template->assign('PageTopic', 'Reading The News');
+		$template->pageTopic = 'Reading The News';
 
 		Menu::news($gameID);
 

--- a/src/pages/Account/Preferences.php
+++ b/src/pages/Account/Preferences.php
@@ -17,7 +17,7 @@ class Preferences extends AccountPage {
 	public string $file = 'preferences.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Preferences');
+		$template->pageTopic = 'Preferences';
 
 		$session = Session::getInstance();
 		if ($session->hasGame()) {

--- a/src/pages/Account/PreferencesTransferConfirm.php
+++ b/src/pages/Account/PreferencesTransferConfirm.php
@@ -33,7 +33,7 @@ class PreferencesTransferConfirm extends AccountPage {
 			create_error('You cannot send SMR credits to unvalidated accounts.');
 		}
 
-		$template->assign('PageTopic', 'Confirmation');
+		$template->pageTopic = 'Confirmation';
 		$template->assign('Amount', $amount);
 		$template->assign('ToAccountID', $account_id);
 		$template->assign('HofName', $toAccount->getHofDisplayName());

--- a/src/pages/Account/PreviousGameAllianceDetail.php
+++ b/src/pages/Account/PreviousGameAllianceDetail.php
@@ -24,7 +24,7 @@ class PreviousGameAllianceDetail extends AccountPage {
 		$alliance = Alliance::getAlliance($allianceID, $gameID);
 		$template->assign('Alliance', $alliance);
 
-		$template->assign('PageTopic', 'Alliance Roster: ' . $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = 'Alliance Roster: ' . $alliance->getAllianceDisplayName(false, true);
 
 		// Offer a back button
 		$container = new GameStats($gameID);

--- a/src/pages/Account/ReopenAccount.php
+++ b/src/pages/Account/ReopenAccount.php
@@ -22,7 +22,7 @@ class ReopenAccount extends AccountPage {
 			create_error('You are not allowed to re-open your account!');
 		}
 
-		$template->assign('PageTopic', 'Re-Open Account?');
+		$template->pageTopic = 'Re-Open Account?';
 
 		$container = new ReopenAccountProcessor();
 		$template->assign('ReopenLink', $container->href());

--- a/src/pages/Account/UserRankingView.php
+++ b/src/pages/Account/UserRankingView.php
@@ -14,7 +14,7 @@ class UserRankingView extends AccountPage {
 	public string $file = 'rankings_view.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Extended User Rankings');
+		$template->pageTopic = 'Extended User Rankings';
 	}
 
 }

--- a/src/pages/Account/Validate.php
+++ b/src/pages/Account/Validate.php
@@ -16,7 +16,7 @@ class Validate extends AccountPage {
 
 	public function build(Account $account, Template $template): void {
 		$template->assign('Message', $this->message);
-		$template->assign('PageTopic', 'Validation Reminder');
+		$template->pageTopic = 'Validation Reminder';
 		$template->assign('ValidateFormHref', (new ValidateProcessor())->href());
 	}
 

--- a/src/pages/Account/Vote.php
+++ b/src/pages/Account/Vote.php
@@ -13,7 +13,7 @@ class Vote extends AccountPage {
 	public string $file = 'vote.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Voting');
+		$template->pageTopic = 'Voting';
 
 		$db = Database::getInstance();
 		$dbResult = $db->select('voting', orderBy: ['end'], order: ['DESC']);

--- a/src/pages/Admin/AccountEdit.php
+++ b/src/pages/Admin/AccountEdit.php
@@ -22,7 +22,7 @@ class AccountEdit extends AccountPage {
 	public function build(Account $account, Template $template): void {
 		$db = Database::getInstance();
 
-		$template->assign('PageTopic', 'Edit Account');
+		$template->pageTopic = 'Edit Account';
 
 		$account_id = $this->editAccountID;
 		$curr_account = Account::getAccount($account_id);

--- a/src/pages/Admin/AccountEditSearch.php
+++ b/src/pages/Admin/AccountEditSearch.php
@@ -17,7 +17,7 @@ class AccountEditSearch extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Edit Account');
+		$template->pageTopic = 'Edit Account';
 
 		$games = [];
 		$db = Database::getInstance();

--- a/src/pages/Admin/AdminMessageSend.php
+++ b/src/pages/Admin/AdminMessageSend.php
@@ -23,7 +23,7 @@ class AdminMessageSend extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Send Admin Message');
+		$template->pageTopic = 'Send Admin Message';
 
 		$this->sendGameID ??= Request::getInt('SendGameID');
 		$gameID = $this->sendGameID;

--- a/src/pages/Admin/AdminMessageSendSelect.php
+++ b/src/pages/Admin/AdminMessageSendSelect.php
@@ -14,7 +14,7 @@ class AdminMessageSendSelect extends AccountPage {
 	public string $file = 'admin/admin_message_send_select.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Send Admin Message');
+		$template->pageTopic = 'Send Admin Message';
 
 		$template->assign('AdminMessageChooseGameFormHref', (new AdminMessageSend())->href());
 

--- a/src/pages/Admin/AdminPermissionManage.php
+++ b/src/pages/Admin/AdminPermissionManage.php
@@ -22,7 +22,7 @@ class AdminPermissionManage extends AccountPage {
 	public function build(Account $account, Template $template): void {
 		$admin_id = $this->adminAccountID;
 
-		$template->assign('PageTopic', 'Manage Admin Permissions');
+		$template->pageTopic = 'Manage Admin Permissions';
 
 		$adminLinks = [];
 		$db = Database::getInstance();

--- a/src/pages/Admin/AdminTools.php
+++ b/src/pages/Admin/AdminTools.php
@@ -17,7 +17,7 @@ class AdminTools extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Admin Tools');
+		$template->pageTopic = 'Admin Tools';
 		$template->assign('ErrorMessage', $this->errorMessage);
 		$template->assign('Message', $this->message);
 

--- a/src/pages/Admin/AlbumApprove.php
+++ b/src/pages/Admin/AlbumApprove.php
@@ -14,7 +14,7 @@ class AlbumApprove extends AccountPage {
 	public string $file = 'admin/album_approve.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Approve Album Entries');
+		$template->pageTopic = 'Approve Album Entries';
 
 		try {
 			$album = Album::getNextUnapproved();

--- a/src/pages/Admin/AlbumModerate.php
+++ b/src/pages/Admin/AlbumModerate.php
@@ -19,7 +19,7 @@ class AlbumModerate extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Moderate Photo Album');
+		$template->pageTopic = 'Moderate Photo Album';
 
 		$account_id = $this->albumAccountID;
 

--- a/src/pages/Admin/AlbumModerateSelect.php
+++ b/src/pages/Admin/AlbumModerateSelect.php
@@ -12,7 +12,7 @@ class AlbumModerateSelect extends AccountPage {
 	public string $file = 'admin/album_moderate_select.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Moderate Photo Album');
+		$template->pageTopic = 'Moderate Photo Album';
 
 		$moderateHREF = (new AlbumModerateSelectProcessor())->href();
 		$template->assign('ModerateHREF', $moderateHREF);

--- a/src/pages/Admin/AnnouncementCreate.php
+++ b/src/pages/Admin/AnnouncementCreate.php
@@ -15,7 +15,7 @@ class AnnouncementCreate extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Create Announcement');
+		$template->pageTopic = 'Create Announcement';
 		$template->assign('AnnouncementCreateForm', new AnnouncementCreateProcessor());
 		if ($this->preview !== null) {
 			$template->assign('Preview', htmlentities($this->preview));

--- a/src/pages/Admin/AnonBankView.php
+++ b/src/pages/Admin/AnonBankView.php
@@ -16,7 +16,7 @@ class AnonBankView extends AccountPage {
 		$session = Session::getInstance();
 
 		//view anon acct activity.
-		$template->assign('PageTopic', 'View Anonymous Account Info');
+		$template->pageTopic = 'View Anonymous Account Info';
 
 		$container = new AnonBankViewSelect();
 		$template->assign('BackHREF', $container->href());

--- a/src/pages/Admin/AnonBankViewSelect.php
+++ b/src/pages/Admin/AnonBankViewSelect.php
@@ -16,7 +16,7 @@ class AnonBankViewSelect extends AccountPage {
 
 	public function build(Account $account, Template $template): void {
 		//view anon acct activity.
-		$template->assign('PageTopic', 'View Anonymous Account Info');
+		$template->pageTopic = 'View Anonymous Account Info';
 
 		$container = new AnonBankView();
 		$template->assign('AnonViewHREF', $container->href());

--- a/src/pages/Admin/ChangelogAdd.php
+++ b/src/pages/Admin/ChangelogAdd.php
@@ -21,7 +21,7 @@ class ChangelogAdd extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Change Log');
+		$template->pageTopic = 'Change Log';
 
 		$template->assign('ChangeTitle', $this->changeTitle);
 		$template->assign('ChangeMessage', $this->changeMessage);

--- a/src/pages/Admin/CheatingShipCheck.php
+++ b/src/pages/Admin/CheatingShipCheck.php
@@ -12,7 +12,7 @@ class CheatingShipCheck extends AccountPage {
 	public string $file = 'admin/ship_check.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Ship Integrity Check');
+		$template->pageTopic = 'Ship Integrity Check';
 
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT * FROM ship_type_support_hardware, player, ship_has_hardware, hardware_type '

--- a/src/pages/Admin/CombatSimulator.php
+++ b/src/pages/Admin/CombatSimulator.php
@@ -23,7 +23,7 @@ class CombatSimulator extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Combat Simulator');
+		$template->pageTopic = 'Combat Simulator';
 
 		$template->assign('EditDummysLink', (new EditDummies())->href());
 		$template->assign('DummyNames', DummyShip::getDummyNames());

--- a/src/pages/Admin/ComputerSharing.php
+++ b/src/pages/Admin/ComputerSharing.php
@@ -16,7 +16,7 @@ class ComputerSharing extends AccountPage {
 	public string $file = 'admin/comp_share.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Computer Sharing');
+		$template->pageTopic = 'Computer Sharing';
 
 		$unusedAfter = 86400 * 365; // 1 year
 

--- a/src/pages/Admin/DatabaseCleanup.php
+++ b/src/pages/Admin/DatabaseCleanup.php
@@ -19,7 +19,7 @@ class DatabaseCleanup extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Database Cleanup');
+		$template->pageTopic = 'Database Cleanup';
 
 		$bytesToMB = function(int $bytes): string {
 			return round($bytes / (1024 * 1024), 1) . ' MB';

--- a/src/pages/Admin/EditDummies.php
+++ b/src/pages/Admin/EditDummies.php
@@ -16,7 +16,7 @@ class EditDummies extends AccountPage {
 	public string $file = 'admin/edit_dummys.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Edit Dummys');
+		$template->pageTopic = 'Edit Dummys';
 
 		$template->assign('CombatSimLink', (new CombatSimulator())->href());
 		$template->assign('ShipTypes', ShipType::getAll());

--- a/src/pages/Admin/EnableGame.php
+++ b/src/pages/Admin/EnableGame.php
@@ -16,7 +16,7 @@ class EnableGame extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Enable New Games');
+		$template->pageTopic = 'Enable New Games';
 
 		// If we have just forwarded from the processing file, pass its message.
 		$template->assign('ProcessingMsg', $this->processingMessage);

--- a/src/pages/Admin/FormOpen.php
+++ b/src/pages/Admin/FormOpen.php
@@ -15,7 +15,7 @@ class FormOpen extends AccountPage {
 	public string $file = 'admin/form_open.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Open/Close Forms');
+		$template->pageTopic = 'Open/Close Forms';
 
 		$container = new FormOpenProcessor(
 			isOpen: Globals::isFeatureRequestOpen(),

--- a/src/pages/Admin/GameDelete.php
+++ b/src/pages/Admin/GameDelete.php
@@ -12,7 +12,7 @@ class GameDelete extends AccountPage {
 	public string $file = 'admin/game_delete.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Deleting A Game');
+		$template->pageTopic = 'Deleting A Game';
 
 		$container = new GameDeleteConfirm();
 		$template->assign('ConfirmHREF', $container->href());

--- a/src/pages/Admin/GameDeleteConfirm.php
+++ b/src/pages/Admin/GameDeleteConfirm.php
@@ -17,7 +17,7 @@ class GameDeleteConfirm extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Delete Game - Confirmation');
+		$template->pageTopic = 'Delete Game - Confirmation';
 
 		$this->deleteGameID ??= Request::getInt('delete_game_id');
 		$template->assign('Game', Game::getGame($this->deleteGameID));

--- a/src/pages/Admin/IpView.php
+++ b/src/pages/Admin/IpView.php
@@ -14,7 +14,7 @@ class IpView extends AccountPage {
 	public string $file = 'admin/ip_view.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'IP Search');
+		$template->pageTopic = 'IP Search';
 
 		$template->assign('IpFormHref', (new IpViewResults())->href());
 	}

--- a/src/pages/Admin/IpViewResults.php
+++ b/src/pages/Admin/IpViewResults.php
@@ -274,7 +274,7 @@ class IpViewResults extends AccountPage {
 
 		}
 
-		$template->assign('PageTopic', 'IP Search Results');
+		$template->pageTopic = 'IP Search Results';
 	}
 
 }

--- a/src/pages/Admin/LogConsole.php
+++ b/src/pages/Admin/LogConsole.php
@@ -19,7 +19,7 @@ class LogConsole extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Log Console');
+		$template->pageTopic = 'Log Console';
 
 		$loggedAccounts = [];
 

--- a/src/pages/Admin/LogConsoleAnonBank.php
+++ b/src/pages/Admin/LogConsoleAnonBank.php
@@ -12,7 +12,7 @@ class LogConsoleAnonBank extends AccountPage {
 	public string $file = 'admin/log_anonymous_account.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Anonymous Account Access');
+		$template->pageTopic = 'Anonymous Account Access';
 
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT account_id FROM account_has_logs GROUP BY account_id');

--- a/src/pages/Admin/LogConsoleDetail.php
+++ b/src/pages/Admin/LogConsoleDetail.php
@@ -23,7 +23,7 @@ class LogConsoleDetail extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Log Console - Detail');
+		$template->pageTopic = 'Log Console - Detail';
 
 		// get the account_ids from last form
 		$account_ids = $this->accountIDs;

--- a/src/pages/Admin/ManageDraftLeaders.php
+++ b/src/pages/Admin/ManageDraftLeaders.php
@@ -20,7 +20,7 @@ class ManageDraftLeaders extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Manage Draft Leaders');
+		$template->pageTopic = 'Manage Draft Leaders';
 
 		$container = new ManageDraftLeadersSelectProcessor();
 		$template->assign('SelectGameHREF', $container->href());

--- a/src/pages/Admin/ManagePostEditors.php
+++ b/src/pages/Admin/ManagePostEditors.php
@@ -20,7 +20,7 @@ class ManagePostEditors extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Manage Galactic Post Editors');
+		$template->pageTopic = 'Manage Galactic Post Editors';
 
 		$container = new ManagePostEditorsSelectProcessor();
 		$template->assign('SelectGameHREF', $container->href());

--- a/src/pages/Admin/MessageBoxReply.php
+++ b/src/pages/Admin/MessageBoxReply.php
@@ -23,7 +23,7 @@ class MessageBoxReply extends AccountPage {
 
 	public function build(Account $account, Template $template): void {
 		$boxName = Messages::getAdminBoxNames()[$this->boxTypeID];
-		$template->assign('PageTopic', 'Reply To ' . $boxName);
+		$template->pageTopic = 'Reply To ' . $boxName;
 
 		$container = new MessageBoxReplyProcessor(
 			senderAccountID: $this->senderAccountID,

--- a/src/pages/Admin/MessageBoxView.php
+++ b/src/pages/Admin/MessageBoxView.php
@@ -25,7 +25,7 @@ class MessageBoxView extends AccountPage {
 		$db = Database::getInstance();
 
 		if ($this->boxTypeID === null) {
-			$template->assign('PageTopic', 'Viewing Message Boxes');
+			$template->pageTopic = 'Viewing Message Boxes';
 
 			$boxes = [];
 			foreach (Messages::getAdminBoxNames() as $boxTypeID => $boxName) {
@@ -45,7 +45,7 @@ class MessageBoxView extends AccountPage {
 			$template->assign('Boxes', $boxes);
 		} else {
 			$boxName = Messages::getAdminBoxNames()[$this->boxTypeID];
-			$template->assign('PageTopic', 'Viewing ' . $boxName);
+			$template->pageTopic = 'Viewing ' . $boxName;
 
 			$template->assign('BackHREF', (new self())->href());
 			$dbResult = $db->select(

--- a/src/pages/Admin/NewsletterSend.php
+++ b/src/pages/Admin/NewsletterSend.php
@@ -12,7 +12,7 @@ class NewsletterSend extends AccountPage {
 	public string $file = 'admin/newsletter_send.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Newsletter');
+		$template->pageTopic = 'Newsletter';
 
 		$template->assign('CurrentEmail', $account->getEmail());
 

--- a/src/pages/Admin/NpcManage.php
+++ b/src/pages/Admin/NpcManage.php
@@ -20,7 +20,7 @@ class NpcManage extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Manage NPCs');
+		$template->pageTopic = 'Manage NPCs';
 
 		$selectedGameID = $this->selectedGameID;
 

--- a/src/pages/Admin/ReportedMessageReply.php
+++ b/src/pages/Admin/ReportedMessageReply.php
@@ -22,7 +22,7 @@ class ReportedMessageReply extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Reply To Reported Messages');
+		$template->pageTopic = 'Reply To Reported Messages';
 
 		$container = new ReportedMessageReplyProcessor(
 			gameID: $this->gameID,

--- a/src/pages/Admin/ReportedMessageView.php
+++ b/src/pages/Admin/ReportedMessageView.php
@@ -15,7 +15,7 @@ class ReportedMessageView extends AccountPage {
 	public string $file = 'admin/notify_view.php';
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Viewing Reported Messages');
+		$template->pageTopic = 'Viewing Reported Messages';
 
 		$container = new ReportedMessageDeleteProcessor();
 		$template->assign('DeleteHREF', $container->href());

--- a/src/pages/Admin/ServerStatus.php
+++ b/src/pages/Admin/ServerStatus.php
@@ -17,10 +17,10 @@ class ServerStatus extends AccountPage {
 		$db = Database::getInstance();
 		$dbResult = $db->select('game_disable');
 		if (!$dbResult->hasRecord()) {
-			$template->assign('PageTopic', 'Close Server');
+			$template->pageTopic = 'Close Server';
 			$template->assign('ServerIsOpen', true);
 		} else {
-			$template->assign('PageTopic', 'Open Server');
+			$template->pageTopic = 'Open Server';
 			$template->assign('ServerIsOpen', false);
 		}
 	}

--- a/src/pages/Admin/UniGen/CheckMap.php
+++ b/src/pages/Admin/UniGen/CheckMap.php
@@ -28,7 +28,7 @@ class CheckMap extends AccountPage {
 
 	public function build(Account $account, Template $template): void {
 		$game = Game::getGame($this->gameID);
-		$template->assign('PageTopic', 'Check Map : ' . $game->getDisplayName());
+		$template->pageTopic = 'Check Map : ' . $game->getDisplayName();
 
 		$template->assign('BackHREF', $this->returnTo->href());
 

--- a/src/pages/Admin/UniGen/CreateGalaxies.php
+++ b/src/pages/Admin/UniGen/CreateGalaxies.php
@@ -23,7 +23,7 @@ class CreateGalaxies extends AccountPage {
 		$numGals = $session->getRequestVarInt('num_gals', 12);
 
 		$game = Game::getGame($this->gameID);
-		$template->assign('PageTopic', 'Create Galaxies : ' . $game->getDisplayName());
+		$template->pageTopic = 'Create Galaxies : ' . $game->getDisplayName();
 		$template->assign('GameEnabled', $game->isEnabled());
 
 		// Link for updating the number of galaxies

--- a/src/pages/Admin/UniGen/CreateWarps.php
+++ b/src/pages/Admin/UniGen/CreateWarps.php
@@ -31,7 +31,7 @@ class CreateWarps extends AccountPage {
 		$galaxies = Galaxy::getGameGalaxies($this->gameID);
 		$galaxy = Galaxy::getGalaxy($this->gameID, $this->galaxyID);
 
-		$template->assign('PageTopic', 'Warps for Galaxy : ' . $galaxy->getDisplayName() . ' (' . $galaxy->getGalaxyID() . ')');
+		$template->pageTopic = 'Warps for Galaxy : ' . $galaxy->getDisplayName() . ' (' . $galaxy->getGalaxyID() . ')';
 
 		// Initialize warps array
 		$warps = [];

--- a/src/pages/Admin/UniGen/EditGalaxies.php
+++ b/src/pages/Admin/UniGen/EditGalaxies.php
@@ -18,7 +18,7 @@ class EditGalaxies extends AccountPage {
 
 	public function build(Account $account, Template $template): void {
 		$game = Game::getGame($this->gameID);
-		$template->assign('PageTopic', 'Edit Galaxies : ' . $game->getDisplayName());
+		$template->pageTopic = 'Edit Galaxies : ' . $game->getDisplayName();
 		$template->assign('GameEnabled', $game->isEnabled());
 
 		$container = new EditGalaxiesProcessor($this->gameID, $this->returnTo);

--- a/src/pages/Admin/UniGen/EditGame.php
+++ b/src/pages/Admin/UniGen/EditGame.php
@@ -18,7 +18,7 @@ class EditGame extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Edit Game Details');
+		$template->pageTopic = 'Edit Game Details';
 
 		$gameID = $this->gameID;
 

--- a/src/pages/Admin/UniGen/EditSector.php
+++ b/src/pages/Admin/UniGen/EditSector.php
@@ -33,7 +33,7 @@ class EditSector extends AccountPage {
 	public function build(Account $account, Template $template): void {
 		$this->sectorID ??= Request::getInt('sector_edit');
 		$editSector = Sector::getSector($this->gameID, $this->sectorID);
-		$template->assign('PageTopic', 'Edit Sector #' . $editSector->getSectorID() . ' (' . $editSector->getGalaxy()->getDisplayName() . ')');
+		$template->pageTopic = 'Edit Sector #' . $editSector->getSectorID() . ' (' . $editSector->getGalaxy()->getDisplayName() . ')';
 		$template->assign('EditSector', $editSector);
 
 		$template->assign('LastSector', Game::getGame($this->gameID)->getLastSectorID());

--- a/src/pages/Admin/VoteCreate.php
+++ b/src/pages/Admin/VoteCreate.php
@@ -20,7 +20,7 @@ class VoteCreate extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Create Vote');
+		$template->pageTopic = 'Create Vote';
 
 		$template->assign('VoteFormPage', new VoteCreateProcessor());
 

--- a/src/pages/Admin/WordFilter.php
+++ b/src/pages/Admin/WordFilter.php
@@ -19,7 +19,7 @@ class WordFilter extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-		$template->assign('PageTopic', 'Word Filter');
+		$template->pageTopic = 'Word Filter';
 
 		$template->assign('Message', $this->message);
 

--- a/src/pages/Player/AllianceBroadcast.php
+++ b/src/pages/Player/AllianceBroadcast.php
@@ -22,7 +22,7 @@ class AllianceBroadcast extends PlayerPage {
 
 	public function build(Player $player, Template $template): void {
 		$alliance = Alliance::getAlliance($this->allianceID, $player->getGameID());
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		$container = new MessageSendProcessor(allianceID: $this->allianceID);

--- a/src/pages/Player/AllianceCreate.php
+++ b/src/pages/Player/AllianceCreate.php
@@ -11,7 +11,7 @@ class AllianceCreate extends PlayerPage {
 	public string $file = 'alliance_create.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Create Alliance');
+		$template->pageTopic = 'Create Alliance';
 
 		$container = new AllianceCreateProcessor();
 		$template->assign('CreateHREF', $container->href());

--- a/src/pages/Player/AllianceDraftMember.php
+++ b/src/pages/Player/AllianceDraftMember.php
@@ -27,7 +27,7 @@ class AllianceDraftMember extends PlayerPage {
 		$db = Database::getInstance();
 		$alliance = $player->getAlliance();
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		// Get the current teams

--- a/src/pages/Player/AllianceExemptAuthorize.php
+++ b/src/pages/Player/AllianceExemptAuthorize.php
@@ -16,7 +16,7 @@ class AllianceExemptAuthorize extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$alliance = $player->getAlliance();
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		//get rid of already approved entries

--- a/src/pages/Player/AllianceForces.php
+++ b/src/pages/Player/AllianceForces.php
@@ -27,7 +27,7 @@ class AllianceForces extends PlayerPage {
 		$allianceID = $this->allianceID;
 
 		$alliance = Alliance::getAlliance($allianceID, $player->getGameID());
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		$db = Database::getInstance();

--- a/src/pages/Player/AllianceGovernance.php
+++ b/src/pages/Player/AllianceGovernance.php
@@ -22,7 +22,7 @@ class AllianceGovernance extends PlayerPage {
 
 		$alliance = Alliance::getAlliance($alliance_id, $player->getGameID());
 		$account = $player->getAccount();
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance_id);
 
 		$role_id = $player->getAllianceRole($alliance->getAllianceID());

--- a/src/pages/Player/AllianceInvitePlayer.php
+++ b/src/pages/Player/AllianceInvitePlayer.php
@@ -18,7 +18,7 @@ class AllianceInvitePlayer extends PlayerPage {
 		$alliance = $player->getAlliance();
 		$game = $player->getGame();
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		// Get list of pending invitations

--- a/src/pages/Player/AllianceLeadership.php
+++ b/src/pages/Player/AllianceLeadership.php
@@ -14,7 +14,7 @@ class AllianceLeadership extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$alliance = $player->getAlliance();
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($player->getAllianceID());
 
 		$container = new AllianceLeadershipProcessor();

--- a/src/pages/Player/AllianceLeaveConfirm.php
+++ b/src/pages/Player/AllianceLeaveConfirm.php
@@ -14,7 +14,7 @@ class AllianceLeaveConfirm extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$alliance = $player->getAlliance();
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		$container = new AllianceLeaveProcessor();

--- a/src/pages/Player/AllianceList.php
+++ b/src/pages/Player/AllianceList.php
@@ -17,7 +17,7 @@ class AllianceList extends PlayerPage {
 	public string $file = 'alliance_list.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'List Of Alliances');
+		$template->pageTopic = 'List Of Alliances';
 
 		$allowCreate = !$player->hasAlliance() && (!$player->getGame()->isGameType(Game::GAME_TYPE_DRAFT) || $player->isDraftLeader());
 		if ($allowCreate) {

--- a/src/pages/Player/AllianceManageNpcs.php
+++ b/src/pages/Player/AllianceManageNpcs.php
@@ -14,7 +14,7 @@ class AllianceManageNpcs extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$alliance = $player->getAlliance();
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		$npcs = [];

--- a/src/pages/Player/AllianceMessageBoard.php
+++ b/src/pages/Player/AllianceMessageBoard.php
@@ -30,7 +30,7 @@ class AllianceMessageBoard extends PlayerPage {
 		$allianceID = $this->allianceID;
 
 		$alliance = Alliance::getAlliance($allianceID, $player->getGameID());
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		$mbWrite = true;

--- a/src/pages/Player/AllianceMessageBoardView.php
+++ b/src/pages/Player/AllianceMessageBoardView.php
@@ -38,7 +38,7 @@ class AllianceMessageBoardView extends PlayerPage {
 		$thread_index = $this->threadIndex;
 		$thread_id = $this->threadIDs[$thread_index];
 
-		$template->assign('PageTopic', htmlentities($this->threadTopics[$thread_index]));
+		$template->pageTopic = htmlentities($this->threadTopics[$thread_index]);
 		Menu::alliance($alliance->getAllianceID());
 
 		$db = Database::getInstance();

--- a/src/pages/Player/AllianceMotd.php
+++ b/src/pages/Player/AllianceMotd.php
@@ -28,7 +28,7 @@ class AllianceMotd extends PlayerPage {
 
 		Globals::canAccessPage('AllianceMOTD', $player, ['AllianceID' => $alliance->getAllianceID()]);
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		// Check to see if an alliance op is scheduled

--- a/src/pages/Player/AllianceOptions.php
+++ b/src/pages/Player/AllianceOptions.php
@@ -18,7 +18,7 @@ class AllianceOptions extends PlayerPage {
 
 	public function build(Player $player, Template $template): void {
 		$alliance = $player->getAlliance();
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		// Create an array of links with descriptions

--- a/src/pages/Player/AllianceRemoveMember.php
+++ b/src/pages/Player/AllianceRemoveMember.php
@@ -19,7 +19,7 @@ class AllianceRemoveMember extends PlayerPage {
 		$account = $player->getAccount();
 		$alliance = $player->getAlliance();
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		$container = new AllianceRemoveMemberProcessor();

--- a/src/pages/Player/AllianceRoles.php
+++ b/src/pages/Player/AllianceRoles.php
@@ -18,7 +18,7 @@ class AllianceRoles extends PlayerPage {
 
 	public function build(Player $player, Template $template): void {
 		$alliance = $player->getAlliance();
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		$db = Database::getInstance();

--- a/src/pages/Player/AllianceRoster.php
+++ b/src/pages/Player/AllianceRoster.php
@@ -30,7 +30,7 @@ class AllianceRoster extends PlayerPage {
 		$alliance = Alliance::getAlliance($allianceID, $player->getGameID());
 		$template->assign('Alliance', $alliance);
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		if ($this->showRoles) {

--- a/src/pages/Player/AllianceSetOp.php
+++ b/src/pages/Player/AllianceSetOp.php
@@ -21,7 +21,7 @@ class AllianceSetOp extends PlayerPage {
 		$account = $player->getAccount();
 		$alliance = $player->getAlliance();
 
-		$template->assign('PageTopic', $alliance->getAllianceDisplayName(false, true));
+		$template->pageTopic = $alliance->getAllianceDisplayName(false, true);
 		Menu::alliance($alliance->getAllianceID());
 
 		// Print any error messages that may have been created

--- a/src/pages/Player/AllianceTreaties.php
+++ b/src/pages/Player/AllianceTreaties.php
@@ -21,7 +21,7 @@ class AllianceTreaties extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$alliance = $player->getAlliance();
 
-		$template->assign('PageTopic', 'Alliance Treaties');
+		$template->pageTopic = 'Alliance Treaties';
 		Menu::alliance($alliance->getAllianceID());
 
 		$alliances = [];

--- a/src/pages/Player/AllianceTreatiesConfirm.php
+++ b/src/pages/Player/AllianceTreatiesConfirm.php
@@ -35,7 +35,7 @@ class AllianceTreatiesConfirm extends PlayerPage {
 		$alliance2 = Alliance::getAlliance($alliance_id_2, $player->getGameID());
 		$template->assign('AllianceName', $alliance2->getAllianceDisplayName());
 
-		$template->assign('PageTopic', 'Alliance Treaty Confirmation');
+		$template->pageTopic = 'Alliance Treaty Confirmation';
 		Menu::alliance($alliance1->getAllianceID());
 
 		// Get the terms selected for this offer

--- a/src/pages/Player/AttackPortConfirm.php
+++ b/src/pages/Player/AttackPortConfirm.php
@@ -22,7 +22,7 @@ class AttackPortConfirm extends PlayerPage {
 			(new AttackPort())->go();
 		}
 
-		$template->assign('PageTopic', 'Port Raid: Sector #' . $port->getSectorID());
+		$template->pageTopic = 'Port Raid: Sector #' . $port->getSectorID();
 
 		$template->assign('PortAttackHREF', (new AttackPortProcessor())->href());
 		$template->assign('Port', $port);

--- a/src/pages/Player/AttackPortLoot.php
+++ b/src/pages/Player/AttackPortLoot.php
@@ -11,7 +11,7 @@ class AttackPortLoot extends PlayerPage {
 	public string $file = 'port_loot.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Looting The Port');
+		$template->pageTopic = 'Looting The Port';
 		$template->assign('ThisPort', $player->getSectorPort());
 	}
 

--- a/src/pages/Player/Bank/AllianceBank.php
+++ b/src/pages/Player/Bank/AllianceBank.php
@@ -30,7 +30,7 @@ class AllianceBank extends PlayerPage {
 		$allianceID = $this->allianceID;
 
 		$alliance = Alliance::getAlliance($allianceID, $player->getGameID());
-		$template->assign('PageTopic', 'Bank');
+		$template->pageTopic = 'Bank';
 
 		Menu::bank();
 

--- a/src/pages/Player/Bank/AllianceBankReport.php
+++ b/src/pages/Player/Bank/AllianceBankReport.php
@@ -87,7 +87,7 @@ class AllianceBankReport extends PlayerPage {
 			$template->assign('SendReportHREF', $container->href());
 		}
 
-		$template->assign('PageTopic', 'Alliance Bank Report');
+		$template->pageTopic = 'Alliance Bank Report';
 		Menu::bank();
 	}
 

--- a/src/pages/Player/Bank/AnonBank.php
+++ b/src/pages/Player/Bank/AnonBank.php
@@ -24,7 +24,7 @@ class AnonBank extends PlayerPage {
 			create_error('You are not validated so you cannot use banks.');
 		}
 
-		$template->assign('PageTopic', 'Anonymous Account');
+		$template->pageTopic = 'Anonymous Account';
 		Menu::bank();
 
 		$container = new AnonBankProcessor();

--- a/src/pages/Player/Bank/AnonBankCreate.php
+++ b/src/pages/Player/Bank/AnonBankCreate.php
@@ -12,7 +12,7 @@ class AnonBankCreate extends PlayerPage {
 	public string $file = 'bank_anon_create.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Create Anonymous Account');
+		$template->pageTopic = 'Create Anonymous Account';
 		Menu::bank();
 
 		$container = new AnonBankCreateProcessor();

--- a/src/pages/Player/Bank/AnonBankDetail.php
+++ b/src/pages/Player/Bank/AnonBankDetail.php
@@ -98,7 +98,7 @@ class AnonBankDetail extends PlayerPage {
 		$container = new AnonBankDetailProcessor($account_num);
 		$template->assign('TransactionPage', $container);
 
-		$template->assign('PageTopic', 'Anonymous Account #' . $account_num);
+		$template->pageTopic = 'Anonymous Account #' . $account_num;
 		Menu::bank();
 	}
 

--- a/src/pages/Player/Bank/PersonalBank.php
+++ b/src/pages/Player/Bank/PersonalBank.php
@@ -17,7 +17,7 @@ class PersonalBank extends PlayerPage {
 			create_error('You are not validated so you cannot use banks.');
 		}
 
-		$template->assign('PageTopic', 'Bank');
+		$template->pageTopic = 'Bank';
 
 		Menu::bank();
 

--- a/src/pages/Player/Bar/BarMain.php
+++ b/src/pages/Player/Bar/BarMain.php
@@ -21,7 +21,7 @@ class BarMain extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		//get bar name
 		$location = Location::getLocation($player->getGameID(), $this->locationID);
-		$template->assign('PageTopic', 'Welcome to ' . $location->getName());
+		$template->pageTopic = 'Welcome to ' . $location->getName();
 		Menu::bar($this->locationID);
 
 		if ($this->message !== null) {

--- a/src/pages/Player/Bar/BuyGalaxyMap.php
+++ b/src/pages/Player/Bar/BuyGalaxyMap.php
@@ -23,7 +23,7 @@ class BuyGalaxyMap extends PlayerPage {
 			create_error('You cannot buy maps for another ' . format_time($timeUntilMaps) . '!');
 		}
 
-		$template->assign('PageTopic', 'Buy Galaxy Maps');
+		$template->pageTopic = 'Buy Galaxy Maps';
 		Menu::bar($this->locationID);
 
 		//find what gal they want

--- a/src/pages/Player/Bar/BuyTicker.php
+++ b/src/pages/Player/Bar/BuyTicker.php
@@ -17,7 +17,7 @@ class BuyTicker extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Buy System');
+		$template->pageTopic = 'Buy System';
 		Menu::bar($this->locationID);
 
 		//they can buy the ticker...first we need to find out what they want

--- a/src/pages/Player/Bar/LottoBuyTicket.php
+++ b/src/pages/Player/Bar/LottoBuyTicket.php
@@ -17,7 +17,7 @@ class LottoBuyTicket extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Galactic Lotto');
+		$template->pageTopic = 'Galactic Lotto';
 		Menu::bar($this->locationID);
 
 		Lotto::checkForLottoWinner($player->getGameID());

--- a/src/pages/Player/Bar/PlayBlackjack.php
+++ b/src/pages/Player/Bar/PlayBlackjack.php
@@ -64,7 +64,7 @@ class PlayBlackjack extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'BlackJack');
+		$template->pageTopic = 'BlackJack';
 		Menu::bar($this->locationID);
 
 		$table = $this->table;

--- a/src/pages/Player/Bar/PlayBlackjackBet.php
+++ b/src/pages/Player/Bar/PlayBlackjackBet.php
@@ -16,7 +16,7 @@ class PlayBlackjackBet extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'BlackJack');
+		$template->pageTopic = 'BlackJack';
 		Menu::bar($this->locationID);
 
 		if ($player->hasNewbieTurns()) {

--- a/src/pages/Player/Bar/TalkToBartender.php
+++ b/src/pages/Player/Bar/TalkToBartender.php
@@ -18,7 +18,7 @@ class TalkToBartender extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Talk to Bartender');
+		$template->pageTopic = 'Talk to Bartender';
 		Menu::bar($this->locationID);
 
 		// We save the displayed message in session since it is randomized

--- a/src/pages/Player/BetaFunctions/BetaFunctions.php
+++ b/src/pages/Player/BetaFunctions/BetaFunctions.php
@@ -23,7 +23,7 @@ class BetaFunctions extends PlayerPage {
 
 		$sector = $player->getSector();
 
-		$template->assign('PageTopic', 'Beta Functions');
+		$template->pageTopic = 'Beta Functions';
 
 		// let them map all
 		$container = new RevealMapProcessor();

--- a/src/pages/Player/BountyView.php
+++ b/src/pages/Player/BountyView.php
@@ -16,7 +16,7 @@ class BountyView extends PlayerPage {
 
 	public function build(Player $player, Template $template): void {
 		$bountyPlayer = Player::getPlayer($this->otherAccountID, $player->getGameID());
-		$template->assign('PageTopic', 'Viewing Bounties');
+		$template->pageTopic = 'Viewing Bounties';
 		$template->assign('BountyPlayer', $bountyPlayer);
 	}
 

--- a/src/pages/Player/BuyShipName.php
+++ b/src/pages/Player/BuyShipName.php
@@ -14,7 +14,7 @@ class BuyShipName extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$costs = Globals::getBuyShipNameCosts();
 
-		$template->assign('PageTopic', 'Naming Your Ship');
+		$template->pageTopic = 'Naming Your Ship';
 		$template->assign('Costs', $costs);
 		$template->assign('ProcessorPage', new BuyShipNameProcessor());
 	}

--- a/src/pages/Player/BuyShipNamePreview.php
+++ b/src/pages/Player/BuyShipNamePreview.php
@@ -16,7 +16,7 @@ class BuyShipNamePreview extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Naming Your Ship');
+		$template->pageTopic = 'Naming Your Ship';
 
 		$container = new BuyShipNamePreviewProcessor($this->shipName, $this->cost);
 		$template->assign('ContinueHREF', $container->href());

--- a/src/pages/Player/CargoDump.php
+++ b/src/pages/Player/CargoDump.php
@@ -17,7 +17,7 @@ class CargoDump extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$ship = $player->getShip();
 
-		$template->assign('PageTopic', 'Dump Cargo');
+		$template->pageTopic = 'Dump Cargo';
 
 		$goods = [];
 		foreach ($ship->getCargo() as $goodID => $amount) {

--- a/src/pages/Player/ChatSharing.php
+++ b/src/pages/Player/ChatSharing.php
@@ -18,7 +18,7 @@ class ChatSharing extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Chat Sharing Settings');
+		$template->pageTopic = 'Chat Sharing Settings';
 
 		$template->assign('Message', $this->message);
 

--- a/src/pages/Player/Chess/MatchList.php
+++ b/src/pages/Player/Chess/MatchList.php
@@ -18,7 +18,7 @@ class MatchList extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$chessGames = ChessGame::getOngoingPlayerGames($player);
 		$template->assign('ChessGames', $chessGames);
-		$template->assign('PageTopic', 'Casino');
+		$template->pageTopic = 'Casino';
 
 		$playersChallenged = [$player->getAccountID() => true];
 		foreach ($chessGames as $chessGame) {

--- a/src/pages/Player/Chess/MatchPlay.php
+++ b/src/pages/Player/Chess/MatchPlay.php
@@ -21,7 +21,7 @@ class MatchPlay extends PlayerPage {
 		$template->assign('ChessGame', $chessGame);
 
 		$topic = $chessGame->getWhitePlayer()->getPlayerName() . ' vs. ' . $chessGame->getBlackPlayer()->getPlayerName();
-		$template->assign('PageTopic', htmlentities($topic));
+		$template->pageTopic = htmlentities($topic);
 
 		// Board orientation depends on the player's color.
 		$playerIsWhite = $chessGame->getWhiteID() === $player->getAccountID();

--- a/src/pages/Player/CombatLogList.php
+++ b/src/pages/Player/CombatLogList.php
@@ -26,7 +26,7 @@ class CombatLogList extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$db = Database::getInstance();
 
-		$template->assign('PageTopic', 'Combat Logs');
+		$template->pageTopic = 'Combat Logs';
 		Menu::combatLog();
 
 		// Do we have a message from the processing page?

--- a/src/pages/Player/CombatLogViewer.php
+++ b/src/pages/Player/CombatLogViewer.php
@@ -52,7 +52,7 @@ class CombatLogViewer extends PlayerPage {
 			$template->assign('NextLogHREF', $container->href());
 		}
 
-		$template->assign('PageTopic', 'Combat Logs');
+		$template->pageTopic = 'Combat Logs';
 		Menu::combatLog();
 	}
 

--- a/src/pages/Player/Council/Embassy.php
+++ b/src/pages/Player/Council/Embassy.php
@@ -23,7 +23,7 @@ class Embassy extends PlayerPage {
 			create_error('Only the president can view the embassy.');
 		}
 
-		$template->assign('PageTopic', 'Ruling Council Of ' . $player->getRaceName());
+		$template->pageTopic = 'Ruling Council Of ' . $player->getRaceName();
 
 		Menu::council($player->getRaceID());
 

--- a/src/pages/Player/Council/MessageCouncil.php
+++ b/src/pages/Player/Council/MessageCouncil.php
@@ -23,7 +23,7 @@ class MessageCouncil extends PlayerPage {
 		$raceName = Race::getName($this->raceID);
 		$template->assign('RaceName', $raceName);
 
-		$template->assign('PageTopic', 'Send message to Ruling Council of the ' . $raceName);
+		$template->pageTopic = 'Send message to Ruling Council of the ' . $raceName;
 
 		Menu::messages();
 

--- a/src/pages/Player/Council/PoliticalStatus.php
+++ b/src/pages/Player/Council/PoliticalStatus.php
@@ -23,7 +23,7 @@ class PoliticalStatus extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$raceID = $this->raceID;
 
-		$template->assign('PageTopic', 'Ruling Council Of ' . Race::getName($raceID));
+		$template->pageTopic = 'Ruling Council Of ' . Race::getName($raceID);
 
 		// echo menu
 		Menu::council($raceID);

--- a/src/pages/Player/Council/ViewCouncil.php
+++ b/src/pages/Player/Council/ViewCouncil.php
@@ -23,7 +23,7 @@ class ViewCouncil extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$raceID = $this->raceID;
 
-		$template->assign('PageTopic', 'Ruling Council Of ' . Race::getName($raceID));
+		$template->pageTopic = 'Ruling Council Of ' . Race::getName($raceID);
 		$template->assign('RaceID', $raceID);
 
 		Menu::council($raceID);

--- a/src/pages/Player/Council/VotingCenter.php
+++ b/src/pages/Player/Council/VotingCenter.php
@@ -24,7 +24,7 @@ class VotingCenter extends PlayerPage {
 			create_error('You have to be on the council in order to vote.');
 		}
 
-		$template->assign('PageTopic', 'Ruling Council Of ' . $player->getRaceName());
+		$template->pageTopic = 'Ruling Council Of ' . $player->getRaceName();
 		Menu::council($player->getRaceID());
 
 		// determine for what we voted

--- a/src/pages/Player/CurrentPlayers.php
+++ b/src/pages/Player/CurrentPlayers.php
@@ -18,7 +18,7 @@ class CurrentPlayers extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$inactiveTime = Epoch::time() - TIME_BEFORE_INACTIVE;
 
-		$template->assign('PageTopic', 'Current Players');
+		$template->pageTopic = 'Current Players';
 		$db = Database::getInstance();
 		$db->write('DELETE FROM cpl_tag WHERE expires > 0 AND expires < :now', [
 			'now' => $db->escapeNumber(Epoch::time()),

--- a/src/pages/Player/CurrentSector.php
+++ b/src/pages/Player/CurrentSector.php
@@ -39,7 +39,7 @@ class CurrentSector extends PlayerPage {
 
 		$template->assign('SpaceView', true);
 
-		$template->assign('PageTopic', 'Current Sector: ' . $player->getSectorID() . ' (' . $sector->getGalaxy()->getDisplayName() . ')');
+		$template->pageTopic = 'Current Sector: ' . $player->getSectorID() . ' (' . $sector->getGalaxy()->getDisplayName() . ')';
 
 		Menu::navigation($player);
 

--- a/src/pages/Player/Death.php
+++ b/src/pages/Player/Death.php
@@ -11,7 +11,7 @@ class Death extends PlayerPage {
 	public string $file = 'death.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Death');
+		$template->pageTopic = 'Death';
 	}
 
 }

--- a/src/pages/Player/ExaminePlanet.php
+++ b/src/pages/Player/ExaminePlanet.php
@@ -15,7 +15,7 @@ class ExaminePlanet extends PlayerPage {
 		$planet = $player->getSectorPlanet();
 		$template->assign('ThisPlanet', $planet);
 
-		$template->assign('PageTopic', 'Examine Planet: Sector #' . $planet->getSectorID());
+		$template->pageTopic = 'Examine Planet: Sector #' . $planet->getSectorID();
 
 		$planetLand =
 			!$planet->hasOwner()

--- a/src/pages/Player/ExamineTrader.php
+++ b/src/pages/Player/ExamineTrader.php
@@ -24,7 +24,7 @@ class ExamineTrader extends PlayerPage {
 			$container->go();
 		}
 
-		$template->assign('PageTopic', 'Examine Ship');
+		$template->pageTopic = 'Examine Ship';
 		$template->assign('TargetPlayer', $targetPlayer);
 		$template->assign('NewbieKill', $targetPlayer->isNewbieCombatant($player));
 	}

--- a/src/pages/Player/ForcesDrop.php
+++ b/src/pages/Player/ForcesDrop.php
@@ -18,10 +18,10 @@ class ForcesDrop extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		if ($this->ownerAccountID !== null) {
 			$owner = Player::getPlayer($this->ownerAccountID, $player->getGameID());
-			$template->assign('PageTopic', 'Change ' . htmlentities($owner->getPlayerName()) . '\'s Forces');
+			$template->pageTopic = 'Change ' . htmlentities($owner->getPlayerName()) . '\'s Forces';
 			$owner_id = $this->ownerAccountID;
 		} else {
-			$template->assign('PageTopic', 'Drop Forces');
+			$template->pageTopic = 'Drop Forces';
 			$owner_id = $player->getAccountID();
 		}
 

--- a/src/pages/Player/ForcesList.php
+++ b/src/pages/Player/ForcesList.php
@@ -17,7 +17,7 @@ class ForcesList extends PlayerPage {
 	public string $file = 'forces_list.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'View Forces');
+		$template->pageTopic = 'View Forces';
 
 		$db = Database::getInstance();
 		$dbResult = $db->read('SELECT *

--- a/src/pages/Player/GalacticPost/ArticleDeleteConfirm.php
+++ b/src/pages/Player/GalacticPost/ArticleDeleteConfirm.php
@@ -18,7 +18,7 @@ class ArticleDeleteConfirm extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$db = Database::getInstance();
 
-		$template->assign('PageTopic', 'Delete Article - Confirm');
+		$template->pageTopic = 'Delete Article - Confirm';
 		$dbResult = $db->select(
 			'galactic_post_article',
 			['article_id' => $this->articleID, 'game_id' => $player->getGameID()],

--- a/src/pages/Player/GalacticPost/ArticleView.php
+++ b/src/pages/Player/GalacticPost/ArticleView.php
@@ -20,7 +20,7 @@ class ArticleView extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$db = Database::getInstance();
 
-		$template->assign('PageTopic', 'Viewing Articles');
+		$template->pageTopic = 'Viewing Articles';
 		Menu::galacticPost();
 
 		// Get the articles that are not already in a paper

--- a/src/pages/Player/GalacticPost/ArticleWrite.php
+++ b/src/pages/Player/GalacticPost/ArticleWrite.php
@@ -25,7 +25,7 @@ class ArticleWrite extends PlayerPage {
 		$text = $this->previewText;
 
 		if ($this->articleID !== null) {
-			$template->assign('PageTopic', 'Editing An Article');
+			$template->pageTopic = 'Editing An Article';
 			if ($this->previewText === null) {
 				$db = Database::getInstance();
 				$dbResult = $db->select(
@@ -43,7 +43,7 @@ class ArticleWrite extends PlayerPage {
 				}
 			}
 		} else {
-			$template->assign('PageTopic', 'Writing An Article');
+			$template->pageTopic = 'Writing An Article';
 		}
 
 		$template->assign('PreviewTitle', $title);

--- a/src/pages/Player/GalacticPost/EditionRead.php
+++ b/src/pages/Player/GalacticPost/EditionRead.php
@@ -37,7 +37,7 @@ class EditionRead extends PlayerPage {
 				['title'],
 			);
 			$paper_name = bbify($dbResult->record()->getString('title'), $this->gameID);
-			$template->assign('PageTopic', 'Reading <i>Galactic Post</i> Edition : ' . $paper_name);
+			$template->pageTopic = 'Reading <i>Galactic Post</i> Edition : ' . $paper_name;
 
 			//now get the articles in this paper.
 			$dbResult = $db->read('SELECT * FROM galactic_post_paper_content JOIN galactic_post_article USING(game_id, article_id) WHERE paper_id = :paper_id AND game_id = :game_id', [
@@ -66,7 +66,7 @@ class EditionRead extends PlayerPage {
 			}
 			$template->assign('ArticleLayout', $articleLayout);
 		} else {
-			$template->assign('PageTopic', 'Galactic Post');
+			$template->pageTopic = 'Galactic Post';
 		}
 	}
 

--- a/src/pages/Player/GalacticPost/EditorOptions.php
+++ b/src/pages/Player/GalacticPost/EditorOptions.php
@@ -18,7 +18,7 @@ class EditorOptions extends PlayerPage {
 			throw new Exception('Only the GP Editor is allowed to view this page!');
 		}
 
-		$template->assign('PageTopic', 'Galactic Post');
+		$template->pageTopic = 'Galactic Post';
 		Menu::galacticPost();
 
 		$db = Database::getInstance();

--- a/src/pages/Player/GalacticPost/PaperDeleteConfirm.php
+++ b/src/pages/Player/GalacticPost/PaperDeleteConfirm.php
@@ -18,7 +18,7 @@ class PaperDeleteConfirm extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$db = Database::getInstance();
 
-		$template->assign('PageTopic', 'Delete Paper - Confirm');
+		$template->pageTopic = 'Delete Paper - Confirm';
 		$dbResult = $db->select(
 			'galactic_post_paper',
 			[

--- a/src/pages/Player/GalacticPost/PaperEdit.php
+++ b/src/pages/Player/GalacticPost/PaperEdit.php
@@ -17,7 +17,7 @@ class PaperEdit extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Edit Paper');
+		$template->pageTopic = 'Edit Paper';
 		Menu::galacticPost();
 
 		$db = Database::getInstance();

--- a/src/pages/Player/GalacticPost/PaperMake.php
+++ b/src/pages/Player/GalacticPost/PaperMake.php
@@ -12,7 +12,7 @@ class PaperMake extends PlayerPage {
 	public string $file = 'galactic_post_make_paper.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Making A Paper');
+		$template->pageTopic = 'Making A Paper';
 		Menu::galacticPost();
 
 		$container = new PaperMakeProcessor();

--- a/src/pages/Player/GalacticPost/PastEditionSelect.php
+++ b/src/pages/Player/GalacticPost/PastEditionSelect.php
@@ -17,7 +17,7 @@ class PastEditionSelect extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Past <i>Galactic Post</i> Editions');
+		$template->pageTopic = 'Past <i>Galactic Post</i> Editions';
 		Menu::galacticPost();
 
 		$container = new PastEditionSelectProcessor();

--- a/src/pages/Player/HardwareConfigure.php
+++ b/src/pages/Player/HardwareConfigure.php
@@ -17,7 +17,7 @@ class HardwareConfigure extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$ship = $player->getShip();
 
-		$template->assign('PageTopic', 'Configure Hardware');
+		$template->pageTopic = 'Configure Hardware';
 
 		if ($ship->hasCloak()) {
 			$container = new HardwareConfigureCloakProcessor(disable: $ship->isCloaked());

--- a/src/pages/Player/Headquarters/BountyClaim.php
+++ b/src/pages/Player/Headquarters/BountyClaim.php
@@ -17,7 +17,7 @@ class BountyClaim extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Bounty Payout');
+		$template->pageTopic = 'Bounty Payout';
 
 		Menu::headquarters($this->locationID);
 

--- a/src/pages/Player/Headquarters/BountyPlace.php
+++ b/src/pages/Player/Headquarters/BountyPlace.php
@@ -17,7 +17,7 @@ class BountyPlace extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Place Bounty');
+		$template->pageTopic = 'Place Bounty';
 
 		Menu::headquarters($this->locationID);
 

--- a/src/pages/Player/Headquarters/BountyPlaceConfirm.php
+++ b/src/pages/Player/Headquarters/BountyPlaceConfirm.php
@@ -19,7 +19,7 @@ class BountyPlaceConfirm extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Place Bounty');
+		$template->pageTopic = 'Place Bounty';
 
 		Menu::headquarters($this->locationID);
 

--- a/src/pages/Player/Headquarters/Government.php
+++ b/src/pages/Player/Headquarters/Government.php
@@ -39,7 +39,7 @@ class Government extends PlayerPage {
 			create_error('We are at WAR with your race! Get outta here before I call the guards!');
 		}
 
-		$template->assign('PageTopic', $location->getName());
+		$template->pageTopic = $location->getName();
 
 		// header menu
 		Menu::headquarters($this->locationID);

--- a/src/pages/Player/Headquarters/HireTrader.php
+++ b/src/pages/Player/Headquarters/HireTrader.php
@@ -22,7 +22,7 @@ class HireTrader extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Hire Trader');
+		$template->pageTopic = 'Hire Trader';
 
 		Menu::headquarters($this->locationID);
 

--- a/src/pages/Player/Headquarters/MilitaryPaymentClaim.php
+++ b/src/pages/Player/Headquarters/MilitaryPaymentClaim.php
@@ -17,7 +17,7 @@ class MilitaryPaymentClaim extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Military Payment Center');
+		$template->pageTopic = 'Military Payment Center';
 
 		Menu::headquarters($this->locationID);
 

--- a/src/pages/Player/Headquarters/Underground.php
+++ b/src/pages/Player/Headquarters/Underground.php
@@ -31,7 +31,7 @@ class Underground extends PlayerPage {
 			create_error('There is no underground here.');
 		}
 
-		$template->assign('PageTopic', $location->getName());
+		$template->pageTopic = $location->getName();
 
 		Menu::headquarters($this->locationID);
 

--- a/src/pages/Player/MessageBlacklist.php
+++ b/src/pages/Player/MessageBlacklist.php
@@ -17,7 +17,7 @@ class MessageBlacklist extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Player Blacklist');
+		$template->pageTopic = 'Player Blacklist';
 
 		Menu::messages();
 

--- a/src/pages/Player/MessageBox.php
+++ b/src/pages/Player/MessageBox.php
@@ -21,7 +21,7 @@ class MessageBox extends PlayerPage {
 
 		Menu::messages();
 
-		$template->assign('PageTopic', 'View Messages');
+		$template->pageTopic = 'View Messages';
 
 		$messageBoxes = [];
 		foreach (Messages::getMessageTypeNames() as $message_type_id => $message_type_name) {

--- a/src/pages/Player/MessageReportConfirm.php
+++ b/src/pages/Player/MessageReportConfirm.php
@@ -33,7 +33,7 @@ class MessageReportConfirm extends PlayerPage {
 		$container = new MessageView($this->folderID);
 		$template->assign('CancelHREF', $container->href());
 
-		$template->assign('PageTopic', 'Report a Message');
+		$template->pageTopic = 'Report a Message';
 		Menu::messages();
 	}
 

--- a/src/pages/Player/MessageSend.php
+++ b/src/pages/Player/MessageSend.php
@@ -20,7 +20,7 @@ class MessageSend extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Send Message');
+		$template->pageTopic = 'Send Message';
 
 		Menu::messages();
 

--- a/src/pages/Player/MessageView.php
+++ b/src/pages/Player/MessageView.php
@@ -76,7 +76,7 @@ class MessageView extends PlayerPage {
 		}
 
 		$messageBox['Name'] = Messages::getMessageTypeNames($folderID);
-		$template->assign('PageTopic', 'Viewing ' . $messageBox['Name']);
+		$template->pageTopic = 'Viewing ' . $messageBox['Name'];
 
 		if ($messageBox['Type'] === MSG_GLOBAL) {
 			$container = new MessagePreferenceIgnoreGlobalsProcessor($folderID);

--- a/src/pages/Player/NewbieLeave.php
+++ b/src/pages/Player/NewbieLeave.php
@@ -21,7 +21,7 @@ class NewbieLeave extends PlayerPage {
 		$template->assign('CancelHREF', new CurrentSector()->href());
 		$template->assign('ConfirmHREF', $player->getLeaveNewbieProtectionHREF());
 
-		$template->assign('PageTopic', 'Leave Newbie Protection');
+		$template->pageTopic = 'Leave Newbie Protection';
 	}
 
 }

--- a/src/pages/Player/NewbieWarning.php
+++ b/src/pages/Player/NewbieWarning.php
@@ -11,7 +11,7 @@ class NewbieWarning extends PlayerPage {
 	public string $file = 'newbie_warning.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Warning!');
+		$template->pageTopic = 'Warning!';
 	}
 
 }

--- a/src/pages/Player/NewsReadCurrent.php
+++ b/src/pages/Player/NewsReadCurrent.php
@@ -23,7 +23,7 @@ class NewsReadCurrent extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$gameID = $player->getGameID();
 
-		$template->assign('PageTopic', 'Current News');
+		$template->pageTopic = 'Current News';
 		Menu::news($gameID);
 
 		News::doBreakingNewsAssign($gameID);

--- a/src/pages/Player/Planet/PlanetPage.php
+++ b/src/pages/Player/Planet/PlanetPage.php
@@ -23,7 +23,7 @@ abstract class PlanetPage extends PlayerPage {
 
 		$planet = $player->getSectorPlanet();
 		$template->assign('ThisPlanet', $planet);
-		$template->assign('PageTopic', 'Planet : ' . $planet->getDisplayName() . ' [Sector #' . $player->getSectorID() . ']');
+		$template->pageTopic = 'Planet : ' . $planet->getDisplayName() . ' [Sector #' . $player->getSectorID() . ']';
 
 		$this->addMenu($template, $planet);
 

--- a/src/pages/Player/PlotCourse.php
+++ b/src/pages/Player/PlotCourse.php
@@ -23,7 +23,7 @@ class PlotCourse extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$session = Session::getInstance();
 
-		$template->assign('PageTopic', 'Plot A Course');
+		$template->pageTopic = 'Plot A Course';
 
 		Menu::navigation($player);
 

--- a/src/pages/Player/PlotCourseResult.php
+++ b/src/pages/Player/PlotCourseResult.php
@@ -20,7 +20,7 @@ class PlotCourseResult extends PlayerPage {
 		$path = $this->path;
 		$fullPath = implode(' - ', $path->getPath());
 
-		$template->assign('PageTopic', 'Plot A Course');
+		$template->pageTopic = 'Plot A Course';
 		Menu::navigation($player);
 
 		$template->assign('Path', $path);

--- a/src/pages/Player/Rankings/AllianceDeaths.php
+++ b/src/pages/Player/Rankings/AllianceDeaths.php
@@ -16,7 +16,7 @@ class AllianceDeaths extends PlayerPage {
 	public string $file = 'rankings_alliance_death.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Alliance Death Rankings');
+		$template->pageTopic = 'Alliance Death Rankings';
 		Menu::rankings(1, 3);
 
 		$rankedStats = Rankings::allianceStats('deaths', $player->getGameID());

--- a/src/pages/Player/Rankings/AllianceExperience.php
+++ b/src/pages/Player/Rankings/AllianceExperience.php
@@ -16,7 +16,7 @@ class AllianceExperience extends PlayerPage {
 	public string $file = 'rankings_alliance_experience.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Alliance Experience Rankings');
+		$template->pageTopic = 'Alliance Experience Rankings';
 		Menu::rankings(1, 0);
 
 		$rankedStats = Rankings::allianceStats('experience', $player->getGameID());

--- a/src/pages/Player/Rankings/AllianceKills.php
+++ b/src/pages/Player/Rankings/AllianceKills.php
@@ -16,7 +16,7 @@ class AllianceKills extends PlayerPage {
 	public string $file = 'rankings_alliance_kills.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Alliance Kill Rankings');
+		$template->pageTopic = 'Alliance Kill Rankings';
 		Menu::rankings(1, 2);
 
 		$rankedStats = Rankings::allianceStats('kills', $player->getGameID());

--- a/src/pages/Player/Rankings/AllianceProfit.php
+++ b/src/pages/Player/Rankings/AllianceProfit.php
@@ -13,7 +13,7 @@ class AllianceProfit extends PlayerPage {
 	public string $file = 'rankings_alliance_profit.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Alliance Profit Rankings');
+		$template->pageTopic = 'Alliance Profit Rankings';
 		Menu::rankings(1, 1);
 
 		$hofCategory = ['Trade', 'Money', 'Profit'];

--- a/src/pages/Player/Rankings/AllianceVsAlliance.php
+++ b/src/pages/Player/Rankings/AllianceVsAlliance.php
@@ -27,7 +27,7 @@ class AllianceVsAlliance extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Alliance VS Alliance Rankings');
+		$template->pageTopic = 'Alliance VS Alliance Rankings';
 
 		Menu::rankings(1, 4);
 		$db = Database::getInstance();

--- a/src/pages/Player/Rankings/PlayerAssists.php
+++ b/src/pages/Player/Rankings/PlayerAssists.php
@@ -13,7 +13,7 @@ class PlayerAssists extends PlayerPage {
 	public string $file = 'rankings_player_assists.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Assist Rankings');
+		$template->pageTopic = 'Assist Rankings';
 
 		Menu::rankings(0, 4);
 

--- a/src/pages/Player/Rankings/PlayerDeaths.php
+++ b/src/pages/Player/Rankings/PlayerDeaths.php
@@ -16,7 +16,7 @@ class PlayerDeaths extends PlayerPage {
 	public string $file = 'rankings_player_death.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Death Rankings');
+		$template->pageTopic = 'Death Rankings';
 
 		Menu::rankings(0, 3);
 

--- a/src/pages/Player/Rankings/PlayerExperience.php
+++ b/src/pages/Player/Rankings/PlayerExperience.php
@@ -16,7 +16,7 @@ class PlayerExperience extends PlayerPage {
 	public string $file = 'rankings_player_experience.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Experience Rankings');
+		$template->pageTopic = 'Experience Rankings';
 
 		Menu::rankings(0, 0);
 

--- a/src/pages/Player/Rankings/PlayerKills.php
+++ b/src/pages/Player/Rankings/PlayerKills.php
@@ -16,7 +16,7 @@ class PlayerKills extends PlayerPage {
 	public string $file = 'rankings_player_kills.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Kill Rankings');
+		$template->pageTopic = 'Kill Rankings';
 
 		Menu::rankings(0, 2);
 

--- a/src/pages/Player/Rankings/PlayerNpcKills.php
+++ b/src/pages/Player/Rankings/PlayerNpcKills.php
@@ -13,7 +13,7 @@ class PlayerNpcKills extends PlayerPage {
 	public string $file = 'rankings_player_npc_kills.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'NPC Kill Rankings');
+		$template->pageTopic = 'NPC Kill Rankings';
 
 		Menu::rankings(0, 5);
 

--- a/src/pages/Player/Rankings/PlayerProfit.php
+++ b/src/pages/Player/Rankings/PlayerProfit.php
@@ -16,7 +16,7 @@ class PlayerProfit extends PlayerPage {
 	public string $file = 'rankings_player_profit.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Profit Rankings');
+		$template->pageTopic = 'Profit Rankings';
 
 		Menu::rankings(0, 1);
 

--- a/src/pages/Player/Rankings/RaceDeaths.php
+++ b/src/pages/Player/Rankings/RaceDeaths.php
@@ -16,7 +16,7 @@ class RaceDeaths extends PlayerPage {
 	public string $file = 'rankings_race_death.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Racial Standings');
+		$template->pageTopic = 'Racial Standings';
 
 		Menu::rankings(2, 2);
 

--- a/src/pages/Player/Rankings/RaceExperience.php
+++ b/src/pages/Player/Rankings/RaceExperience.php
@@ -16,7 +16,7 @@ class RaceExperience extends PlayerPage {
 	public string $file = 'rankings_race.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Racial Standings');
+		$template->pageTopic = 'Racial Standings';
 
 		Menu::rankings(2, 0);
 

--- a/src/pages/Player/Rankings/RaceKills.php
+++ b/src/pages/Player/Rankings/RaceKills.php
@@ -16,7 +16,7 @@ class RaceKills extends PlayerPage {
 	public string $file = 'rankings_race_kills.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Racial Standings');
+		$template->pageTopic = 'Racial Standings';
 
 		Menu::rankings(2, 1);
 

--- a/src/pages/Player/Rankings/SectorKills.php
+++ b/src/pages/Player/Rankings/SectorKills.php
@@ -18,7 +18,7 @@ class SectorKills extends PlayerPage {
 
 	public function build(Player $player, Template $template): void {
 
-		$template->assign('PageTopic', 'Sector Death Rankings');
+		$template->pageTopic = 'Sector Death Rankings';
 
 		Menu::rankings(3, 0);
 

--- a/src/pages/Player/SearchForTrader.php
+++ b/src/pages/Player/SearchForTrader.php
@@ -18,7 +18,7 @@ class SearchForTrader extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Search For Trader');
+		$template->pageTopic = 'Search For Trader';
 		$template->assign('TraderSearchHREF', (new SearchForTraderResult())->href());
 
 		$template->assign('EmptyResult', $this->emptyResult);

--- a/src/pages/Player/SearchForTraderResult.php
+++ b/src/pages/Player/SearchForTraderResult.php
@@ -117,7 +117,7 @@ class SearchForTraderResult extends PlayerPage {
 			$template->assign('SimilarPlayersLinks', $similarPlayersLinks);
 		}
 
-		$template->assign('PageTopic', 'Search For Trader Results');
+		$template->pageTopic = 'Search For Trader Results';
 	}
 
 }

--- a/src/pages/Player/SectorJumpCalculate.php
+++ b/src/pages/Player/SectorJumpCalculate.php
@@ -18,7 +18,7 @@ class SectorJumpCalculate extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Jump Drive');
+		$template->pageTopic = 'Jump Drive';
 		Menu::navigation($player);
 
 		$targetSector = Sector::getSector($player->getGameID(), $this->targetSectorID);

--- a/src/pages/Player/SectorScan.php
+++ b/src/pages/Player/SectorScan.php
@@ -26,7 +26,7 @@ class SectorScan extends PlayerPage {
 		// initialize vars
 		$scanSector = Sector::getSector($player->getGameID(), $this->targetSectorID);
 
-		$template->assign('PageTopic', 'Sector Scan of #' . $scanSector->getSectorID() . ' (' . $scanSector->getGalaxy()->getDisplayName() . ')');
+		$template->pageTopic = 'Sector Scan of #' . $scanSector->getSectorID() . ' (' . $scanSector->getGalaxy()->getDisplayName() . ')';
 		Menu::navigation($player);
 
 		$friendly_forces = 0;

--- a/src/pages/Player/ShopGoods.php
+++ b/src/pages/Player/ShopGoods.php
@@ -27,7 +27,7 @@ class ShopGoods extends PlayerPage {
 		}
 
 		// topic
-		$template->assign('PageTopic', 'Port In Sector #' . $player->getSectorID());
+		$template->pageTopic = 'Port In Sector #' . $player->getSectorID();
 		$template->assign('Port', $port);
 
 		$player->log(LOG_TYPE_TRADING, 'Player examines port');

--- a/src/pages/Player/ShopGoodsNegotiate.php
+++ b/src/pages/Player/ShopGoodsNegotiate.php
@@ -22,7 +22,7 @@ class ShopGoodsNegotiate extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Negotiate Price');
+		$template->pageTopic = 'Negotiate Price';
 
 		// creates needed objects
 		$port = $player->getSectorPort();

--- a/src/pages/Player/ShopHardware.php
+++ b/src/pages/Player/ShopHardware.php
@@ -21,7 +21,7 @@ class ShopHardware extends PlayerPage {
 		}
 
 		$location = Location::getLocation($player->getGameID(), $this->locationID);
-		$template->assign('PageTopic', $location->getName());
+		$template->pageTopic = $location->getName();
 
 		if ($location->isHardwareSold()) {
 			$hardwareSold = [];

--- a/src/pages/Player/ShopShip.php
+++ b/src/pages/Player/ShopShip.php
@@ -21,7 +21,7 @@ class ShopShip extends PlayerPage {
 
 	public function build(Player $player, Template $template): void {
 		$location = Location::getLocation($player->getGameID(), $this->locationID);
-		$template->assign('PageTopic', $location->getName());
+		$template->pageTopic = $location->getName();
 
 		$shipsSold = $location->getShipsSold();
 

--- a/src/pages/Player/ShopWeapon.php
+++ b/src/pages/Player/ShopWeapon.php
@@ -18,7 +18,7 @@ class ShopWeapon extends PlayerPage {
 
 	public function build(Player $player, Template $template): void {
 		$location = Location::getLocation($player->getGameID(), $this->locationID);
-		$template->assign('PageTopic', $location->getName());
+		$template->pageTopic = $location->getName();
 		$template->assign('ThisLocation', $location);
 
 		$weaponsSold = $location->getWeaponsSold();

--- a/src/pages/Player/TraderBounties.php
+++ b/src/pages/Player/TraderBounties.php
@@ -16,7 +16,7 @@ class TraderBounties extends PlayerPage {
 	public string $file = 'trader_bounties.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Bounties');
+		$template->pageTopic = 'Bounties';
 
 		Menu::trader();
 

--- a/src/pages/Player/TraderRelations.php
+++ b/src/pages/Player/TraderRelations.php
@@ -17,7 +17,7 @@ class TraderRelations extends PlayerPage {
 	public string $file = 'trader_relations.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Trader Relations');
+		$template->pageTopic = 'Trader Relations';
 
 		Menu::trader();
 

--- a/src/pages/Player/TraderSavings.php
+++ b/src/pages/Player/TraderSavings.php
@@ -17,7 +17,7 @@ class TraderSavings extends PlayerPage {
 	public string $file = 'trader_savings.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Savings');
+		$template->pageTopic = 'Savings';
 
 		Menu::trader();
 

--- a/src/pages/Player/TraderStatus.php
+++ b/src/pages/Player/TraderStatus.php
@@ -17,7 +17,7 @@ class TraderStatus extends PlayerPage {
 	public string $file = 'trader_status.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Trader Status');
+		$template->pageTopic = 'Trader Status';
 
 		Menu::trader();
 

--- a/src/pages/Player/UserRankingView.php
+++ b/src/pages/Player/UserRankingView.php
@@ -15,7 +15,7 @@ class UserRankingView extends PlayerPage {
 	public string $file = 'rankings_view.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Extended User Rankings');
+		$template->pageTopic = 'Extended User Rankings';
 		Menu::trader();
 	}
 

--- a/src/pages/Player/WeaponReorder.php
+++ b/src/pages/Player/WeaponReorder.php
@@ -14,7 +14,7 @@ class WeaponReorder extends PlayerPage {
 	public string $file = 'weapon_reorder.php';
 
 	public function build(Player $player, Template $template): void {
-		$template->assign('PageTopic', 'Weapon Reorder');
+		$template->pageTopic = 'Weapon Reorder';
 	}
 
 }

--- a/src/templates/Default/engine/Default/includes/menu.inc.php
+++ b/src/templates/Default/engine/Default/includes/menu.inc.php
@@ -1,7 +1,11 @@
 <?php declare(strict_types=1);
 
+/**
+ * @var Smr\Template $this
+ */
+
 // If there are no menu items, we still want a blank menu bar if there is a page topic
-if (isset($MenuItems) || isset($SubMenuBar) || isset($PageTopic)) { ?>
+if (isset($MenuItems) || isset($SubMenuBar) || $this->pageTopic !== null) { ?>
 	<div class="bar1">
 		<div><?php
 			if (isset($MenuItems)) { ?>

--- a/src/templates/Default/engine/Default/skeleton.php
+++ b/src/templates/Default/engine/Default/skeleton.php
@@ -21,8 +21,8 @@
 				</td>
 				<td class="m0" colspan="2">
 					<div id="middle_panel"><?php
-						if (isset($PageTopic)) {
-							?><h1><?php echo $PageTopic; ?></h1><br /><?php
+						if ($this->pageTopic !== null) {
+							?><h1><?php echo $this->pageTopic; ?></h1><br /><?php
 						}
 						$this->includeTemplate('includes/menu.inc.php');
 						$this->includeTemplate($TemplateBody); ?>

--- a/src/templates/Freon22/engine/Default/skeleton.php
+++ b/src/templates/Freon22/engine/Default/skeleton.php
@@ -97,8 +97,8 @@ use Smr\Globals;
 
 					<td class="centerContent">
 						<div id="middle_panel" class="MainContentArea<?php if (isset($SpaceView) && $SpaceView) { ?> stars<?php } ?>"><?php
-							if (isset($PageTopic)) {
-								?><h1><?php echo $PageTopic; ?></h1><br /><?php
+							if ($this->pageTopic !== null) {
+								?><h1><?php echo $this->pageTopic; ?></h1><br /><?php
 							}
 							$this->includeTemplate('includes/menu.inc.php');
 							$this->includeTemplate($TemplateBody); ?>

--- a/test/SmrTest/lib/TemplateTest.php
+++ b/test/SmrTest/lib/TemplateTest.php
@@ -41,6 +41,20 @@ class TemplateTest extends TestCase {
 		}
 	}
 
+	public function test_pageTopic(): void {
+		$template = Template::getInstance();
+		$template->pageTopic = 'foo';
+		self::assertSame($template->pageTopic, 'foo');
+	}
+
+	public function test_pageTopic_set_twice_throws(): void {
+		$template = Template::getInstance();
+		$template->pageTopic = 'foo';
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Cannot re-assign pageTopic: foo');
+		$template->pageTopic = 'bar';
+	}
+
 	public function test_doAn(): void {
 		$template = Template::getInstance();
 		$method = TestUtils::getPrivateMethod($template, 'doAn');


### PR DESCRIPTION
Since the "PageTopic" template variable is used in almost every page, promote it to a separate attribute of the Template class. This allows for more robust static analysis of Template-related code.

Use PHP 8.4 property hooks for the most succinct setter/getter while retaining the ability to forbid overriding the value once set.