### PR TITLE
Update phpcs from 3.13.4 to 4.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,11 +83,11 @@
 		}
 	},
 	"require-dev": {
-		"fig-r/psr2r-sniffer": "2.3.0",
+		"fig-r/psr2r-sniffer": "2.9.0",
 		"overtrue/phplint": "9.7.2",
 		"phpstan/phpstan": "2.2.7",
 		"phpunit/phpunit": "13.2.6",
 		"rector/rector": "2.5.9",
-		"squizlabs/php_codesniffer": "3.13.4"
+		"squizlabs/php_codesniffer": "4.0.4"
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -31,11 +31,20 @@
         <!-- Personal preference for parentheses around require/echo. -->
         <exclude name="PSR2R.WhiteSpace.LanguageConstructSpacing" />
 
+        <!-- Erroneous sniff. Doesn't work with #[SensitiveParameter] attribute. -->
+        <exclude name="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing.IncorrectLinesCountBetweenAttributeAndTarget" />
+
+        <!-- Don't require spaces between const and member class attributes. -->
+        <exclude name="SlevomatCodingStandard.Classes.ClassMemberSpacing" />
+
         <!-- Allow more compact property doc comments. -->
         <exclude name="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment" />
 
         <!-- Jump statements on a single line can help keep code compact. -->
         <exclude name="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing" />
+
+        <!-- Allow parentheses with return, echo, etc. for readability. -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses.UsedWithParentheses" />
 
         <!-- Erroneous sniff. Disables a real language feature. -->
         <exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
@@ -43,14 +52,33 @@
         <!-- Don't be prescriptive about enum casing (e.g. HQ/UG) -->
         <exclude name="PhpCollective.Classes.EnumCaseCasing.WrongCasing" />
 
+        <!-- Incompatible with PHPStan-specific types in docblocks. -->
+        <exclude name="PhpCollective.Commenting.DocBlockParamTypeMismatch.Incompatible" />
+
         <!-- We do not demand that all constants have a docstring. -->
         <exclude name="PhpCollective.Commenting.DocBlockConst" />
 
         <!-- Docstring for return void is redundant with typehint. -->
         <exclude name="PhpCollective.Commenting.DocBlockReturnVoid" />
 
+        <!-- Allow compact empty control structures. -->
+        <exclude name="PhpCollective.ControlStructures.ControlStructureEmptyStatement" />
+
+        <!-- This is useful in for-loops, but we need count() in while loops. -->
+        <exclude name="Squiz.PHP.DisallowSizeFunctionsInLoops" />
+
         <!-- Prevents compact class declarations. -->
         <exclude name="Squiz.WhiteSpace.MemberVarSpacing" />
+
+        <!-- Prevents compact empty functions, e.g. {} on the same line. -->
+        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore" />
+
+        <!-- Property hooks are not supported yet!
+          See https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/734. -->
+        <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+        <exclude name="PSR2R.Classes.PropertyDeclaration.Multiple" />
+        <exclude name="PSR2R.Classes.PropertyDeclaration.ScopeMissing" />
+        <exclude name="Squiz.Scope.MemberVarScope.Missing" />
     </rule>
 
     <!-- Add sniffs not included by PSR2R. -->
@@ -100,6 +128,9 @@
     <rule ref="PhpCollective.ControlStructures.NoInlineAssignment">
         <exclude-pattern>src/templates/*</exclude-pattern>
     </rule>
+    <rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
+        <exclude-pattern>src/templates/*</exclude-pattern>
+    </rule>
 
     <!-- Ignore unknown docstring tags. -->
     <rule ref="PSR2R.Commenting.DocBlockTagTypes.Unknown">
@@ -108,13 +139,6 @@
 
     <!-- Ignore unknown docstring types. -->
     <rule ref="PhpCollective.Commenting.DocBlockParamAllowDefaultValue.Typehint">
-        <severity>0</severity>
-    </rule>
-
-    <!-- This suppression allows "assignment by reference" to be written so as
-      to clearly indicate that it is not "assignment of a reference", i.e. to
-      allow "$a =& $b" instead of "$a = &$b". -->
-    <rule ref="PSR2R.WhiteSpace.UnaryOperatorSpacing.WrongSpace">
         <severity>0</severity>
     </rule>
 
@@ -132,11 +156,6 @@
         <severity>0</severity>
     </rule>
 
-    <!-- Conflicts with PSR2R.Namespaces.NoInlineFullyQualifiedClassName.Signature -->
-    <rule ref="PhpCollective.Commenting.Attributes.ExpectedFQCN">
-        <severity>0</severity>
-    </rule>
-
     <!-- Allow assignment in else-if where it is really needed. -->
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition">
         <exclude-pattern>src/templates/Default/engine/Default/alliance_roster\.php</exclude-pattern>
@@ -148,4 +167,5 @@
         <exclude-pattern>src/tools/irc/irc\.php</exclude-pattern>
         <exclude-pattern>src/tools/npc/npc\.php</exclude-pattern>
     </rule>
+
 </ruleset>

--- a/src/lib/Default/course_plot.inc.php
+++ b/src/lib/Default/course_plot.inc.php
@@ -9,7 +9,6 @@ use Smr\Player;
  * This function is called by "Conventional" and "Plot To Nearest" pages.
  */
 function course_plot_forward(Player $player, Path $path): never {
-
 	if ($player->getSectorID() === $path->getStartSectorID()) {
 		$player->setPlottedCourse($path);
 

--- a/src/lib/Default/nha.inc.php
+++ b/src/lib/Default/nha.inc.php
@@ -9,7 +9,6 @@ use Smr\Player;
  * Create the Newbie Help Alliance and populate its Message Board
  */
 function createNHA(int $gameID): void {
-
 	$alliance = Alliance::createAlliance($gameID, NHA_ALLIANCE_NAME, true);
 	$alliance->createDefaultRoles();
 	$alliance->setAllianceDescription('Newbie Help Alliance');

--- a/src/lib/Default/sector_mines.inc.php
+++ b/src/lib/Default/sector_mines.inc.php
@@ -6,7 +6,6 @@ use Smr\Player;
 use Smr\ShipClass;
 
 function hit_sector_mines(Player $player): void {
-
 	// Get sector forces sorted by decreasing mines (largest mine stacks first)
 	$sectorForces = $player->getSector()->getForces();
 	uasort($sectorForces, fn($a, $b) => $b->getMines() <=> $a->getMines());

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -79,7 +79,7 @@ function linkCombatLog(int $logID): string {
  *
  * @param array<string, string> $tagParams
  */
-function smrBBCode(BBCode $bbParser, int $action, string $tagName, string $default, array $tagParams, string $tagContent): bool|string {
+function smrBBCode(BBCode $bbParser, int $action, string $tagName, string $default, array $tagParams, string $tagContent): string|bool {
 	global $overrideGameID, $disableBBLinks;
 	$session = Session::getInstance();
 	$linked = $disableBBLinks === false && $session->hasGame() && $overrideGameID === $session->getGameID();
@@ -383,7 +383,7 @@ function word_filter(string $string): string {
 }
 
 // choose correct pluralization based on amount
-function pluralise(int|float $amount, string $word, bool $includeAmount = true): string {
+function pluralise(float|int $amount, string $word, bool $includeAmount = true): string {
 	$result = $word;
 	if ((float)$amount !== 1.) {
 		$result .= 's';

--- a/src/lib/Smr/AbstractShip.php
+++ b/src/lib/Smr/AbstractShip.php
@@ -652,7 +652,7 @@ class AbstractShip {
 	/**
 	 * @return ($goodID is null ? array<int, int> : int)
 	 */
-	public function getCargo(?int $goodID = null): int|array {
+	public function getCargo(?int $goodID = null): array|int {
 		if ($goodID === null) {
 			return $this->cargo;
 		}

--- a/src/lib/Smr/CouncilVoting.php
+++ b/src/lib/Smr/CouncilVoting.php
@@ -10,7 +10,6 @@ use Exception;
 class CouncilVoting {
 
 	public static function modifyRelations(int $race_id_1, int $gameID): void {
-
 		// Process any votes that ended prior to the start of today
 		$endtime = strtotime(date('Y-m-d'));
 		if ($endtime === false) {
@@ -113,7 +112,6 @@ class CouncilVoting {
 	}
 
 	public static function checkPacts(int $race_id_1, int $gameID): void {
-
 		$db = Database::getInstance();
 
 		$dbResult = $db->read('SELECT * FROM race_has_voting

--- a/src/lib/Smr/Database.php
+++ b/src/lib/Smr/Database.php
@@ -315,7 +315,7 @@ class Database {
 	 * @param T $num
 	 * @return T
 	 */
-	public function escapeNumber(int|float $num): int|float {
+	public function escapeNumber(float|int $num): float|int {
 		return $num;
 	}
 

--- a/src/lib/Smr/Galaxy.php
+++ b/src/lib/Smr/Galaxy.php
@@ -409,7 +409,7 @@ class Galaxy {
 	/**
 	 * Check if the galaxy contains a specific sector.
 	 */
-	public function contains(int|Sector $sectorID): bool {
+	public function contains(Sector|int $sectorID): bool {
 		if ($sectorID instanceof Sector) {
 			return $sectorID->getGalaxyID() === $this->getGalaxyID();
 		}

--- a/src/lib/Smr/HallOfFame.php
+++ b/src/lib/Smr/HallOfFame.php
@@ -168,7 +168,7 @@ class HallOfFame {
 		return $rank;
 	}
 
-	public static function displayHOFRow(int $rank, int $accountID, ?int $gameID, float|string $amount): string {
+	public static function displayHOFRow(int $rank, int $accountID, ?int $gameID, string|float $amount): string {
 		$account = Session::getInstance()->getAccount();
 		if ($gameID !== null && Game::gameExists($gameID)) {
 			try {

--- a/src/lib/Smr/Lotto.php
+++ b/src/lib/Smr/Lotto.php
@@ -11,7 +11,6 @@ class Lotto {
 	public const float WIN_FRAC = 0.9; // fraction of ticket sales returned to winner
 
 	public static function checkForLottoWinner(int $gameID): void {
-
 		// No more lotto winners after the game has ended
 		if (Game::getGame($gameID)->hasEnded()) {
 			return;

--- a/src/lib/Smr/Menu.php
+++ b/src/lib/Smr/Menu.php
@@ -89,7 +89,7 @@ class Menu {
 		$menuItems[] = ['Link' => Globals::getPlanetListHREF($alliance_id), 'Text' => 'Defense'];
 		$menuItems[] = ['Link' => Globals::getPlanetListFinancialHREF($alliance_id), 'Text' => 'Financial'];
 		// make the selected index bold
-		$boldItem =& $menuItems[$selected_index]['Text'];
+		$boldItem = &$menuItems[$selected_index]['Text'];
 		$boldItem = '<span class="bold">' . $boldItem . '</span>';
 
 		$template = Template::getInstance();
@@ -228,7 +228,6 @@ class Menu {
 	 * $active_level1 - the id of the active menu on the second level
 	 */
 	public static function rankings(int $active_level1 = 0, int $active_level2 = 0): void {
-
 		$menu = [
 			// player rankings
 			[

--- a/src/lib/Smr/Messages.php
+++ b/src/lib/Smr/Messages.php
@@ -55,7 +55,7 @@ class Messages {
 		];
 	}
 
-	public static function getMessagePlayer(int $accountID, int $gameID, ?int $messageType = null): string|Player {
+	public static function getMessagePlayer(int $accountID, int $gameID, ?int $messageType = null): Player|string {
 		if ($accountID === ACCOUNT_ID_PORT) {
 			$return = '<span class="yellow">Port Defenses</span>';
 		} elseif ($accountID === ACCOUNT_ID_ADMIN) {

--- a/src/lib/Smr/Missions/DrunkGuy.php
+++ b/src/lib/Smr/Missions/DrunkGuy.php
@@ -57,7 +57,7 @@ readonly class DrunkGuy extends Mission {
 	/**
 	 * @param array<int> $excludeSectorIDs Sectors to exclude from picking.
 	 */
-	private function pickSector(int|string $loc, int $fromSectorID, ?array $excludeSectorIDs = null): int {
+	private function pickSector(string|int $loc, int $fromSectorID, ?array $excludeSectorIDs = null): int {
 		$toFind = Plotter::getX(PlotGroup::Locations, $loc, $this->gameID);
 		$fromSector = Sector::getSector($this->gameID, $fromSectorID);
 		try {

--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -582,7 +582,7 @@ class Planet {
 	/**
 	 * @return ($goodID is null ? array<int, int> : int)
 	 */
-	public function getStockpile(?int $goodID = null): int|array {
+	public function getStockpile(?int $goodID = null): array|int {
 		if (!isset($this->stockpile)) {
 			// initialize cargo array
 			$this->stockpile = [];
@@ -730,7 +730,7 @@ class Planet {
 	/**
 	 * @return ($buildingTypeID is null ? array<int, int> : int)
 	 */
-	public function getMaxBuildings(?int $buildingTypeID = null): int|array {
+	public function getMaxBuildings(?int $buildingTypeID = null): array|int {
 		if ($buildingTypeID === null) {
 			$maxBuildings = [];
 			foreach ($this->getStructureTypes() as $ID => $type) {

--- a/src/lib/Smr/Plotter.php
+++ b/src/lib/Smr/Plotter.php
@@ -7,7 +7,7 @@ use Smr\Exceptions\PathNotFound;
 
 class Plotter {
 
-	public static function getX(PlotGroup $xType, int|string $X, int $gameID, ?Player $player = null): mixed {
+	public static function getX(PlotGroup $xType, string|int $X, int $gameID, ?Player $player = null): mixed {
 		// Special case for Location categories (i.e. Bar, HQ, SafeFed)
 		if (!is_numeric($X)) {
 			if ($xType !== PlotGroup::Locations) {
@@ -115,7 +115,7 @@ class Plotter {
 		int $lowLimit = 0,
 		int $highLimit = 100000,
 		?array $excludeSectorIDs = null,
-	): array|Path {
+	): Path|array {
 		$warpAddIndex = TURNS_WARP_SECTOR_EQUIVALENCE - 1;
 
 		$checkSector = $sector;

--- a/src/lib/Smr/Race.php
+++ b/src/lib/Smr/Race.php
@@ -25,7 +25,7 @@ class Race {
 	 * @return array<int>
 	 */
 	public static function getAllIDs(): array {
-		return \array_keys(self::RACE_NAMES);
+		return array_keys(self::RACE_NAMES);
 	}
 
 	/**
@@ -47,7 +47,7 @@ class Race {
 	 * @return array<int>
 	 */
 	public static function getPlayableIDs(): array {
-		return \array_keys(self::getPlayableNames());
+		return array_keys(self::getPlayableNames());
 	}
 
 	/**

--- a/src/lib/Smr/Sector.php
+++ b/src/lib/Smr/Sector.php
@@ -558,8 +558,10 @@ class Sector {
 	 * a consistent 2-way warp.
 	 */
 	public function setWarp(Sector $warp): void {
-		if ($this->getWarp() === $warp->getSectorID() &&
-		    $warp->getWarp() === $this->getSectorID()) {
+		if (
+			$this->getWarp() === $warp->getSectorID() &&
+			$warp->getWarp() === $this->getSectorID()
+		) {
 			// Warps are already set correctly!
 			return;
 		}

--- a/src/pages/Account/FeatureRequestComments.php
+++ b/src/pages/Account/FeatureRequestComments.php
@@ -21,7 +21,6 @@ class FeatureRequestComments extends AccountPage {
 	) {}
 
 	public function build(Account $account, Template $template): void {
-
 		if (!Globals::isFeatureRequestOpen()) {
 			create_error('Feature requests are currently not being accepted.');
 		}

--- a/src/pages/Admin/UniGen/CreateGalaxiesAutoProcessor.php
+++ b/src/pages/Admin/UniGen/CreateGalaxiesAutoProcessor.php
@@ -19,7 +19,6 @@ class CreateGalaxiesAutoProcessor extends AccountPageProcessor {
 	) {}
 
 	public function build(Account $account): never {
-
 		// Prepare locations
 		//***********************************
 

--- a/src/pages/Player/Bar/BuyGalaxyMap.php
+++ b/src/pages/Player/Bar/BuyGalaxyMap.php
@@ -17,7 +17,6 @@ class BuyGalaxyMap extends PlayerPage {
 	) {}
 
 	public function build(Player $player, Template $template): void {
-
 		$timeUntilMaps = $player->getGame()->getStartTime() + TIME_MAP_BUY_WAIT - Epoch::time();
 		if ($timeUntilMaps > 0) {
 			create_error('You cannot buy maps for another ' . format_time($timeUntilMaps) . '!');

--- a/src/pages/Player/Rankings/SectorKills.php
+++ b/src/pages/Player/Rankings/SectorKills.php
@@ -17,7 +17,6 @@ class SectorKills extends PlayerPage {
 	public string $file = 'rankings_sector_kill.php';
 
 	public function build(Player $player, Template $template): void {
-
 		$template->pageTopic = 'Sector Death Rankings';
 
 		Menu::rankings(3, 0);

--- a/src/templates/Default/engine/Default/admin/location_edit.php
+++ b/src/templates/Default/engine/Default/admin/location_edit.php
@@ -58,7 +58,7 @@ if (isset($Locations)) {
 		</td>
 		<td>
 			<table><?php
-			foreach ($Location->getShipsSold() as $ShipTypeSold) { ?>
+				foreach ($Location->getShipsSold() as $ShipTypeSold) { ?>
 					<tr>
 						<td><?php echo $ShipTypeSold->getName(); ?></td>
 						<td><input type="checkbox" name="remove_ships[]" value="<?php echo $ShipTypeSold->getTypeID(); ?>" /></td>
@@ -79,7 +79,7 @@ if (isset($Locations)) {
 		</td>
 		<td>
 			<table><?php
-			foreach ($Location->getWeaponsSold() as $WeaponSold) { ?>
+				foreach ($Location->getWeaponsSold() as $WeaponSold) { ?>
 					<tr>
 						<td><?php echo $WeaponSold->getName(); ?></td>
 						<td><input type="checkbox" name="remove_weapons[]" value="<?php echo $WeaponSold->getWeaponTypeID(); ?>" /></td>

--- a/src/templates/Default/engine/Default/admin/unigen/universe_create_sector_details.php
+++ b/src/templates/Default/engine/Default/admin/unigen/universe_create_sector_details.php
@@ -39,8 +39,8 @@ use Smr\TransactionType;
 
 	<select name="port_race"><?php
 		foreach (Race::getAllNames() as $raceID => $raceName) { ?>
-		<option value="<?php echo $raceID; ?>" <?php echo ($raceID === $SelectedPortRaceID ? 'selected' : ''); ?>><?php echo $raceName; ?></option><?php
-	} ?>
+			<option value="<?php echo $raceID; ?>" <?php echo ($raceID === $SelectedPortRaceID ? 'selected' : ''); ?>><?php echo $raceName; ?></option><?php
+		} ?>
 	</select>
 	<br />
 

--- a/src/templates/Default/engine/Default/includes/SectorLocations.inc.php
+++ b/src/templates/Default/engine/Default/includes/SectorLocations.inc.php
@@ -24,6 +24,6 @@ if ($ThisSector->hasLocation()) { ?>
 					</td><?php
 				} ?>
 			</tr><?php
-			} ?>
+		} ?>
 	</table><br /><?php
 }

--- a/src/templates/Default/engine/Default/planet_defense.php
+++ b/src/templates/Default/engine/Default/planet_defense.php
@@ -89,7 +89,7 @@ if ($ThisPlanet->getMaxMountedWeapons() > 0) { ?>
 						}
 						if ($i !== $ThisPlanet->getMaxMountedWeapons() - 1) { ?>
 							<button type="submit" title="Move Down" style="padding:0px; height:20px; border:none;" name="move_down" value="<?php echo $i; ?>"><img src="images/down.gif" alt="" height="20" width="20" /></button><?php
-					} ?>
+						} ?>
 					</td><?php
 					if (isset($weapons[$i])) { ?>
 						<td class="left"><?php echo $weapons[$i]->getName(); ?></td>

--- a/src/tools/irc/channel.php
+++ b/src/tools/irc/channel.php
@@ -6,7 +6,6 @@ use Smr\Database;
  * @param resource $fp
  */
 function channel_join($fp, string $rdata): bool {
-
 	if (preg_match('/^:(.*)!(.*)@(.*)\sJOIN\s:(.*)\s$/i', $rdata, $msg) === 1) {
 
 		$nick = $msg[1];
@@ -74,7 +73,6 @@ function channel_join($fp, string $rdata): bool {
  * @param resource $fp
  */
 function channel_part($fp, string $rdata): bool {
-
 	// :Azool!Azool@coldfront-F706F7E1.co.hfc.comcastbusiness.net PART #smr-irc :
 	// :SomeGuy!mrspock@coldfront-DD847655.dip.t-dialin.net PART #smr-irc
 	if (preg_match('/^:(.*)!(.*)@(.*)\sPART\s(.*?)\s/i', $rdata, $msg) === 1) {

--- a/src/tools/irc/channel_action.php
+++ b/src/tools/irc/channel_action.php
@@ -6,7 +6,6 @@ use Smr\Irc\Message;
  * @param resource $fp
  */
 function channel_action_slap($fp, Message $msg): bool {
-
 	// :MrSpock!mrspock@coldfront-25B201B9.dip.t-dialin.net PRIVMSG #rod : ACTION slaps Caretaker around a bit with a large trout
 	if (preg_match('/^ACTION slaps ' . IRC_BOT_NICK . '/i', $msg->text) === 1) {
 

--- a/src/tools/irc/channel_msg.php
+++ b/src/tools/irc/channel_msg.php
@@ -162,7 +162,6 @@ function channel_msg_with_registration($fp, Message $msg): bool {
  * @param resource $fp
  */
 function channel_msg_seen($fp, Message $msg): bool {
-
 	// <Caretaker> MrSpock, Azool (Azool@smrealms.rulez) was last seen quitting #smr
 	// 2 days 10 hours 43 minutes ago (05.10. 05:04) stating 'Some people follow their dreams,
 	// others hunt them down and mercessly beat them into submission' after spending 1 hour 54 minutes there.
@@ -242,7 +241,6 @@ function channel_msg_seen($fp, Message $msg): bool {
  * @param resource $fp
  */
 function channel_msg_money($fp, Message $msg, Player $player): bool {
-
 	if ($msg->text === '!money') {
 
 		$nick = $msg->nick;
@@ -266,7 +264,6 @@ function channel_msg_money($fp, Message $msg, Player $player): bool {
  * @param resource $fp
  */
 function channel_msg_timer($fp, Message $msg): bool {
-
 	if (preg_match('/^!timer(\s\d+)?(\s.+)?$/i', $msg->text, $args) === 1) {
 
 		global $events;
@@ -357,7 +354,6 @@ function channel_msg_forces($fp, Message $msg, Player $player): bool {
  * @param resource $fp
  */
 function channel_msg_help($fp, Message $msg): bool {
-
 	// global help?
 	if ($msg->text === '!help') {
 

--- a/src/tools/irc/channel_msg_op.php
+++ b/src/tools/irc/channel_msg_op.php
@@ -9,7 +9,6 @@ use Smr\Player;
  * @param resource $fp
  */
 function channel_msg_op($fp, Message $msg): bool {
-
 	if (preg_match('/^!op(\s*help)?$/i', $msg->text) === 1) {
 
 		$nick = $msg->nick;
@@ -58,7 +57,6 @@ function channel_msg_op_info($fp, Message $msg, Player $player): bool {
  * @param resource $fp
  */
 function channel_msg_op_cancel($fp, Message $msg, Player $player): bool {
-
 	if ($msg->text === '!op cancel') {
 
 		$nick = $msg->nick;
@@ -97,7 +95,6 @@ function channel_msg_op_cancel($fp, Message $msg, Player $player): bool {
  * @param resource $fp
  */
 function channel_msg_op_set($fp, Message $msg, Player $player): bool {
-
 	if (preg_match('/^!op set (.*)$/i', $msg->text, $args) === 1) {
 
 		$nick = $msg->nick;
@@ -170,7 +167,6 @@ function channel_msg_op_turns($fp, Message $msg, Player $player): bool {
  * @param resource $fp
  */
 function channel_msg_op_response($fp, Message $msg, Player $player): bool {
-
 	if (preg_match('/^!op (yes|no|maybe)$/i', $msg->text, $args) === 1) {
 
 		$nick = $msg->nick;

--- a/src/tools/irc/channel_msg_sd.php
+++ b/src/tools/irc/channel_msg_sd.php
@@ -7,7 +7,6 @@ use Smr\Player;
  * @param resource $fp
  */
 function channel_msg_sd($fp, Message $msg): bool {
-
 	if (preg_match('/^!sd(\s*help)?$/i', $msg->text) === 1) {
 
 		$nick = $msg->nick;
@@ -31,7 +30,6 @@ function channel_msg_sd($fp, Message $msg): bool {
  * @param resource $fp
  */
 function channel_msg_sd_set($fp, Message $msg): bool {
-
 	if (preg_match('/^!sd set (\d+) (\d+)$/i', $msg->text, $args) === 1) {
 
 		global $sds;
@@ -71,7 +69,6 @@ function channel_msg_sd_set($fp, Message $msg): bool {
  * @param resource $fp
  */
 function channel_msg_sd_del($fp, Message $msg): bool {
-
 	if (preg_match('/^!sd del (\d+)$/i', $msg->text, $args) === 1) {
 
 		global $sds;
@@ -105,7 +102,6 @@ function channel_msg_sd_del($fp, Message $msg): bool {
  * @param resource $fp
  */
 function channel_msg_sd_list($fp, Message $msg, Player $player): bool {
-
 	if ($msg->text === '!sd list') {
 
 		global $sds;

--- a/src/tools/irc/ctcp.php
+++ b/src/tools/irc/ctcp.php
@@ -4,7 +4,6 @@
  * @param resource $fp
  */
 function ctcp_version($fp, string $rdata): bool {
-
 	// :(nick)!(user)@(host) PRIVMSG (botnick)
 	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:' . chr(1) . 'VERSION' . chr(1) . '\s$/i', $rdata, $msg) === 1) {
 
@@ -23,7 +22,6 @@ function ctcp_version($fp, string $rdata): bool {
  * @param resource $fp
  */
 function ctcp_finger($fp, string $rdata): bool {
-
 	// :(nick)!(user)@(host) PRIVMSG (botnick)
 	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:' . chr(1) . 'FINGER' . chr(1) . '\s$/i', $rdata, $msg) === 1) {
 
@@ -42,7 +40,6 @@ function ctcp_finger($fp, string $rdata): bool {
  * @param resource $fp
  */
 function ctcp_time($fp, string $rdata): bool {
-
 	// :(nick)!(user)@(host) PRIVMSG (botnick)
 	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:' . chr(1) . 'TIME' . chr(1) . '\s$/i', $rdata, $msg) === 1) {
 
@@ -61,7 +58,6 @@ function ctcp_time($fp, string $rdata): bool {
  * @param resource $fp
  */
 function ctcp_ping($fp, string $rdata): bool {
-
 	// :(nick)!(user)@(host) PRIVMSG (botnick)
 	if (preg_match('/^:(.*)!(.*)@(.*)\sPRIVMSG\s(.*)\s:' . chr(1) . 'PING\s(.*)' . chr(1) . '\s$/i', $rdata, $msg) === 1) {
 

--- a/src/tools/irc/invite.php
+++ b/src/tools/irc/invite.php
@@ -4,7 +4,6 @@
  * @param resource $fp
  */
 function invite($fp, string $rdata): bool {
-
 	// :MrSpock!mrspock@coldfront-425DB813.dip.t-dialin.net INVITE Caretaker :#fe
 	if (preg_match('/^:(.*)!(.*)@(.*) INVITE ' . IRC_BOT_NICK . ' :(.*)\s$/i', $rdata, $msg) === 1) {
 

--- a/src/tools/irc/notice.php
+++ b/src/tools/irc/notice.php
@@ -7,7 +7,6 @@ use Smr\Irc\CallbackEvent;
  * @param resource $fp
  */
 function notice_nickserv_registered_user($fp, string $rdata): bool {
-
 	// :NickServ!services@coldfront.net NOTICE Caretaker
 	if (preg_match('/^:NickServ!services@theairlock.net NOTICE ' . IRC_BOT_NICK . ' :([^ ]+) is ([^.]+)\s$/i', $rdata, $msg) === 1) {
 
@@ -49,7 +48,6 @@ function notice_nickserv_registered_user($fp, string $rdata): bool {
  * @param resource $fp
  */
 function notice_nickserv_unknown_user($fp, string $rdata): bool {
-
 	// :NickServ!services@coldfront.net NOTICE Caretaker :Nickname Slevin isn't registered.
 	if (preg_match('/^:NickServ!services@theairlock.net NOTICE ' . IRC_BOT_NICK . ' :Nickname .(.*). isn\'t registered\.\s$/i', $rdata, $msg) === 1) {
 

--- a/src/tools/irc/query.php
+++ b/src/tools/irc/query.php
@@ -4,7 +4,6 @@
  * @param resource $fp
  */
 function query_command($fp, string $rdata): bool {
-
 	// :MrSpock!mrspock@coldfront-120CBD34.dip.t-dialin.net PRIVMSG Caretaker :Test
 	if (preg_match('/^:(MrSpock!mrspock|Page!Page)@.*\sPRIVMSG\s' . IRC_BOT_NICK . '\s:(.*)\s$/i', $rdata, $msg) === 1) {
 

--- a/src/tools/irc/server.php
+++ b/src/tools/irc/server.php
@@ -37,7 +37,6 @@ function server_ping($fp, string $rdata): bool {
  * @param resource $fp
  */
 function server_msg_307($fp, string $rdata): bool {
-
 	// :alpha.theairlock.net 307 Caretaker MrSpock :is identified for this nick
 	if (preg_match('/^:(.*) 307 ' . IRC_BOT_NICK . ' (.*) :is identified for this nick\s/i', $rdata, $msg) === 1) {
 
@@ -70,7 +69,6 @@ function server_msg_307($fp, string $rdata): bool {
  * @param resource $fp
  */
 function server_msg_318($fp, string $rdata): bool {
-
 	// :ice.coldfront.net 318 Caretaker MrSpock :End of /WHOIS list.
 	if (preg_match('/^:(.*) 318 ' . IRC_BOT_NICK . ' (.*) :End of \/WHOIS list\.\s/i', $rdata, $msg) === 1) {
 
@@ -138,7 +136,6 @@ function server_msg_318($fp, string $rdata): bool {
  * @param resource $fp
  */
 function server_msg_352($fp, string $rdata): bool {
-
 	// :ice.coldfront.net 352 Caretaker #KMFDM caretaker coldfront-425DB813.dip.t-dialin.net ice.coldfront.net Caretaker Hr :0 Official SMR bot
 	if (preg_match('/^:(.*?) 352 ' . IRC_BOT_NICK . ' (.*?) (.*?) (.*?) (.*?) (.*?) (.*?) (.*?) (.*?)$/i', $rdata, $msg) === 1) {
 
@@ -192,7 +189,6 @@ function server_msg_352($fp, string $rdata): bool {
  * @param resource $fp
  */
 function server_msg_401($fp, string $rdata): bool {
-
 	// :ice.coldfront.net 401 Caretaker MrSpock :No such nick/channel
 	if (preg_match('/^:(.*) 401 ' . IRC_BOT_NICK . ' (.*) :No such nick\/channel\s/i', $rdata, $msg) === 1) {
 

--- a/src/tools/irc/user.php
+++ b/src/tools/irc/user.php
@@ -3,7 +3,6 @@
 use Smr\Database;
 
 function user_quit(string $rdata): bool {
-
 	// :Fubar!Mibbit@coldfront-77C78B7B.dyn.optonline.net QUIT :Quit: http://www.mibbit.com ajax IRC Client
 	if (preg_match('/^:(.*)!(.*)@(.*)\sQUIT\s:(.*)\s$/i', $rdata, $msg) === 1) {
 
@@ -44,7 +43,6 @@ function user_quit(string $rdata): bool {
  * Someone changed his nick
  */
 function user_nick(string $rdata): bool {
-
 	if (preg_match('/^:(.*)!(.*)@(.*)\sNICK\s:(.*)\s$/i', $rdata, $msg) === 1) {
 
 		$nick = $msg[1];

--- a/src/tools/npc/NpcActor.php
+++ b/src/tools/npc/NpcActor.php
@@ -132,7 +132,6 @@ class NpcActor {
 	}
 
 	public function getNextAction(): PlayerPageProcessor {
-
 		// Avoid infinite loops by restricting the number of actions
 		if ($this->actions >= NPC_MAX_ACTIONS) {
 			debug('Reached maximum number of actions: ' . NPC_MAX_ACTIONS);

--- a/src/tools/npc/chess.php
+++ b/src/tools/npc/chess.php
@@ -43,8 +43,8 @@ try {
 		1 => ['pipe', 'w'], // stdout is a pipe that the child will write to
 	];
 	proc_open(UCI_CHESS_ENGINE, $descriptorSpec, $pipes);
-	$toEngine =& $pipes[0];
-	$fromEngine =& $pipes[1];
+	$toEngine = &$pipes[0];
+	$fromEngine = &$pipes[1];
 
 	function readFromEngine(bool $block = true): void {
 		global $fromEngine;


### PR DESCRIPTION
This is a major version bump which brings in several new sniffs and updates many more. Some changes are accepted (e.g. improved spacing and type union ordering, but many sniffs are ignored either due to incomplete support of new PHP language features, or a preference for more compact code.

* `PhpCollective.Commenting.Attributes.ExpectedFQCN` no longer exists.

* Accept standard reference assignment syntax instead of using the uncommon `=&` notation. As such, no longer suppress `PSR2R.WhiteSpace.UnaryOperatorSpacing.WrongSpace`.