### PR TITLE
Convert simple isset checks to null comparisons

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -33,6 +33,8 @@ function logException(Throwable $err): void {
 
 		$var = $session->hasCurrentVar() ? $session->getCurrentVar() : null;
 		$message .= '$var: ' . print_r($var, true) . $delim;
+	} else {
+		$session = null;
 	}
 
 	// Don't display passwords input by users in the log message!
@@ -86,9 +88,9 @@ function logException(Throwable $err): void {
 	// Send error message to the in-game auto bugs mailbox
 	// (Truncate the message if necessary to avoid database errors)
 	$boxMessage = substr($message, 0, SQL_MAX_TEXT_LENGTH);
-	if (isset($session) && $session->hasGame()) {
+	if ($session?->hasGame()) {
 		$session->getPlayer()->sendMessageToBox(BOX_BUGS_AUTO, $boxMessage);
-	} elseif (isset($session) && $session->hasAccount()) {
+	} elseif ($session?->hasAccount()) {
 		// Will be logged without a game_id
 		$session->getAccount()->sendMessageToBox(BOX_BUGS_AUTO, $boxMessage);
 	} else {

--- a/src/htdocs/map_galaxy.php
+++ b/src/htdocs/map_galaxy.php
@@ -46,6 +46,8 @@ try {
 		} catch (GalaxyNotFound) {
 			create_error('Invalid galaxy ID');
 		}
+	} else {
+		$galaxy = null;
 	}
 
 	$player = $session->getPlayer();
@@ -79,7 +81,7 @@ try {
 	$galaxies = Galaxy::getGameGalaxies($session->getGameID());
 	$lastSector = $player->getGame()->getLastSectorID();
 
-	if (!isset($galaxy)) {
+	if ($galaxy === null) {
 		$galaxy = Galaxy::getGalaxyContaining($player->getGameID(), $player->getSectorID());
 		if ($account->isCenterGalaxyMapOnPlayer()) {
 			$sectorID = $player->getSectorID();
@@ -93,11 +95,7 @@ try {
 	$galaxy->getForces();
 	$galaxy->getPlayers();
 
-	if (isset($sectorID)) {
-		$mapSectors = $galaxy->getMapSectors($sectorID);
-	} else {
-		$mapSectors = $galaxy->getMapSectors();
-	}
+	$mapSectors = $galaxy->getMapSectors($sectorID);
 
 	$renderer = fn() => GalaxyMapRenderer::render(
 		ThisGalaxy: $galaxy,

--- a/src/lib/Default/help.inc.php
+++ b/src/lib/Default/help.inc.php
@@ -27,6 +27,8 @@ function echo_nav(int $topic_id): void {
 			'parent_topic_id' => $dbRecord->getInt('parent_topic_id'),
 			'order_id' => $dbRecord->getInt('order_id'),
 		];
+	} else {
+		$parent = null;
 	}
 
 	echo ('<table>');
@@ -46,11 +48,11 @@ function echo_nav(int $topic_id): void {
 			'id' => $dbRecord->getInt('topic_id'),
 			'topic' => stripslashes($dbRecord->getString('topic')),
 		];
-	} elseif (isset($parent)) {
+	} else {
 		$previous = $parent;
 	}
 
-	if (isset($previous)) {
+	if ($previous !== null) {
 		echo ('<a href="/manual.php?' . $previous['id'] . '"><img src="/images/help/previous.jpg" width="32" height="32" border="0"></a>');
 	} else {
 		echo ('<img src="/images/help/empty.jpg" width="32" height="32">');
@@ -61,10 +63,11 @@ function echo_nav(int $topic_id): void {
 	// **  UP
 	// **************************
 	echo ('<th width="32">');
-	if (isset($parent)) {
-		$up = $parent;
+	$up = $parent;
+	if ($up !== null) {
 		echo ('<a href="/manual.php?' . $up['id'] . '"><img src="/images/help/up.jpg" width="32" height="32" border="0"></a>');
 	} else {
+
 		echo ('<img src="/images/help/empty.jpg" width="32" height="32">');
 	}
 	echo ('</th>');
@@ -84,7 +87,7 @@ function echo_nav(int $topic_id): void {
 		]);
 	}
 
-	if (!$dbResult->hasRecord() && isset($parent)) {
+	if (!$dbResult->hasRecord() && $parent !== null) {
 		$dbResult = $db->select('manual', [
 			'parent_topic_id' => $parent['parent_topic_id'],
 			'order_id' => $parent['order_id'] + 1,
@@ -100,6 +103,7 @@ function echo_nav(int $topic_id): void {
 		];
 		echo ('<a href="/manual.php?' . $next['id'] . '"><img src="/images/help/next.jpg" width="32" height="32" border="0"></a>');
 	} else {
+		$next = null;
 		echo ('<img src="/images/help/empty.jpg" width="32" height="32">');
 	}
 	echo ('</th>');
@@ -111,13 +115,13 @@ function echo_nav(int $topic_id): void {
 
 	echo ('<tr>');
 	echo ('<td colspan="5">');
-	if (isset($previous) && $previous['id'] > 0) {
+	if ($previous !== null && $previous['id'] > 0) {
 		echo ('<b>Previous:</b> <a href="/manual.php?' . $previous['id'] . '">' . get_numbering($previous['id']) . $previous['topic'] . '</a>&nbsp;&nbsp;&nbsp;');
 	}
-	if (isset($up) && $up['id'] > 0) {
+	if ($up !== null && $up['id'] > 0) {
 		echo ('<b>Up:</b> <a href="/manual.php?' . $up['id'] . '">' . get_numbering($up['id']) . $up['topic'] . '</a>&nbsp;&nbsp;&nbsp;');
 	}
-	if (isset($next) && $next['id'] > 0) {
+	if ($next !== null && $next['id'] > 0) {
 		echo ('<b>Next:</b> <a href="/manual.php?' . $next['id'] . '">' . get_numbering($next['id']) . $next['topic'] . '</a>');
 	}
 	echo ('</tr>');

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -179,7 +179,7 @@ function inify(string $text): string {
 
 function bbify(string $message, ?int $gameID = null, bool $noLinks = false): string {
 	static $bbParser;
-	if (!isset($bbParser)) {
+	if ($bbParser === null) {
 		$bbParser = new BBCode();
 		$bbParser->setEnableSmileys(false);
 		$bbParser->removeRule('wiki');
@@ -466,7 +466,7 @@ function do_voodoo(): never {
 	$ajaxRefresh = $account->isUseAJAX();
 	if ($ajaxRefresh) {
 		// If we can refresh, specify the refresh interval in millisecs
-		if (isset($player) && $player->canFight()) {
+		if ($player !== null && $player->canFight()) {
 			$ajaxRefresh = AJAX_UNPROTECTED_REFRESH_TIME;
 		} else {
 			$ajaxRefresh = AJAX_DEFAULT_REFRESH_TIME;

--- a/src/lib/Smr/Discord/PlayerLink.php
+++ b/src/lib/Smr/Discord/PlayerLink.php
@@ -47,6 +47,7 @@ class PlayerLink {
 			if ($game_id === null) {
 				throw new UserError('Could not find any games!');
 			}
+			$alliance = null;
 		} else {
 			// Find the alliance associated with this public channel
 			// force update in case the ID has been changed in-game
@@ -67,7 +68,7 @@ class PlayerLink {
 		}
 
 		// Prevent players from leaking sensitive data in other alliance channels
-		if (isset($alliance) && $player->getAllianceID() !== $alliance->getAllianceID()) {
+		if ($alliance !== null && $player->getAllianceID() !== $alliance->getAllianceID()) {
 			throw new UserError('Player `' . $player->getPlayerName() . '` is not a member of alliance `' . $alliance->getAllianceName() . '`');
 		}
 

--- a/src/lib/Smr/HallOfFame.php
+++ b/src/lib/Smr/HallOfFame.php
@@ -94,7 +94,7 @@ class HallOfFame {
 			($vis === HOF_PRIVATE && $account->getAccountID() !== $accountID) ||
 			(
 				$vis === HOF_ALLIANCE &&
-				isset($gameID) &&
+				$gameID !== null &&
 				!Game::getGame($gameID)->hasEnded() &&
 				!Player::getPlayer($accountID, $gameID)->sameAlliance($session->getPlayer())
 			)
@@ -172,13 +172,13 @@ class HallOfFame {
 		$account = Session::getInstance()->getAccount();
 		if ($gameID !== null && Game::gameExists($gameID)) {
 			try {
-				$hofPlayer = Player::getPlayer($accountID, $gameID);
+				$hofName = htmlentities(Player::getPlayer($accountID, $gameID)->getPlayerName());
 			} catch (PlayerNotFound) {
-				$hofAccount = Account::getAccount($accountID);
+				// Must be in the global HoF, use account HoF name
 			}
-		} else {
-			$hofAccount = Account::getAccount($accountID);
 		}
+		$hofName ??= Account::getAccount($accountID)->getHofDisplayName();
+
 		$bold = '';
 		if ($accountID === $account->getAccountID()) {
 			$bold = 'class="bold"';
@@ -187,14 +187,7 @@ class HallOfFame {
 		$return .= ('<td ' . $bold . '>' . $rank . '</td>');
 
 		$container = new HallOfFamePersonal($accountID, $gameID);
-
-		if (isset($hofPlayer)) {
-			$return .= ('<td ' . $bold . '>' . create_link($container, htmlentities($hofPlayer->getPlayerName())) . '</td>');
-		} elseif (isset($hofAccount)) {
-			$return .= ('<td ' . $bold . '>' . create_link($container, $hofAccount->getHofDisplayName()) . '</td>');
-		} else {
-			$return .= ('<td ' . $bold . '>Unknown</td>');
-		}
+		$return .= ('<td ' . $bold . '>' . create_link($container, $hofName) . '</td>');
 		$return .= ('<td ' . $bold . '>' . $amount . '</td>');
 		$return .= ('</tr>');
 		return $return;

--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -540,15 +540,13 @@ class Planet {
 
 	private function swapMountedWeapons(int $orderID1, int $orderID2): void {
 		$this->getMountedWeapons(); // Make sure array is initialized
-		if (isset($this->mountedWeapons[$orderID1])) {
-			$saveWeapon = $this->mountedWeapons[$orderID1];
-		}
+		$saveWeapon = $this->mountedWeapons[$orderID1] ?? null;
 		if (isset($this->mountedWeapons[$orderID2])) {
 			$this->mountedWeapons[$orderID1] = $this->mountedWeapons[$orderID2];
 		} else {
 			unset($this->mountedWeapons[$orderID1]);
 		}
-		if (isset($saveWeapon)) {
+		if ($saveWeapon !== null) {
 			$this->mountedWeapons[$orderID2] = $saveWeapon;
 		} else {
 			unset($this->mountedWeapons[$orderID2]);

--- a/src/lib/Smr/PlanetList.php
+++ b/src/lib/Smr/PlanetList.php
@@ -25,10 +25,13 @@ class PlanetList {
 		}
 		if (!$playerOnly) {
 			$alliance = Alliance::getAlliance($allianceId, $player->getGameID());
+		} else {
+			$alliance = null;
 		}
 
 		// We might not assign the planet lists if the info is private.
 		$allPlanets = [];
+		$playerPlanet = null;
 		if ($getPlanets) {
 			// Get this player's planet if no alliance or viewing own alliance
 			if ($playerOnly || $player->getAllianceID() === $allianceId) {
@@ -36,16 +39,16 @@ class PlanetList {
 			}
 
 			// Get full list of planets
-			if (isset($alliance)) {
+			if ($alliance !== null) {
 				$allPlanets = $alliance->getPlanets();
-			} elseif (isset($playerPlanet)) {
+			} elseif ($playerPlanet !== null) {
 				$allPlanets[] = $playerPlanet;
 			}
 		}
 
 		return [
-			'Alliance' => $alliance ?? null,
-			'PlayerPlanet' => $playerPlanet ?? null,
+			'Alliance' => $alliance,
+			'PlayerPlanet' => $playerPlanet,
 			'AllPlanets' => $allPlanets,
 		];
 	}

--- a/src/lib/Smr/Plotter.php
+++ b/src/lib/Smr/Plotter.php
@@ -24,7 +24,7 @@ class Plotter {
 		// Helper function for plots to trade goods
 		$getGoodWithTransaction = function(int $goodID) use ($xType, $player) {
 			$good = TradeGood::get($goodID);
-			if (isset($player) && !$player->meetsAlignmentRestriction($good->alignRestriction)) {
+			if ($player !== null && !$player->meetsAlignmentRestriction($good->alignRestriction)) {
 				throw new Exception('Player trying to access alignment-restricted good!');
 			}
 			return new TradeGoodTransaction(

--- a/src/pages/Account/AlbumEditRenderer.php
+++ b/src/pages/Account/AlbumEditRenderer.php
@@ -72,7 +72,7 @@ class AlbumEditRenderer {
 				</tr>
 
 				<?php
-				if (isset($SuccessMsg)) { ?>
+				if ($SuccessMsg !== null) { ?>
 					<tr>
 						<td></td>
 						<td><p class="green"><?php echo $SuccessMsg; ?></p></td>

--- a/src/pages/Account/BuyMessageNotificationsRenderer.php
+++ b/src/pages/Account/BuyMessageNotificationsRenderer.php
@@ -6,7 +6,7 @@ class BuyMessageNotificationsRenderer {
 
 	/** @param array<array{Name: string, MessagesRemaining: int, MessagesPerCredit: int, BuyHref: string}> $MessageBoxes */
 	public static function render(?string $Message, array $MessageBoxes): void {
-		if (isset($Message)) {
+		if ($Message !== null) {
 			echo $Message; ?>
 			<br /><br /><?php
 		}

--- a/src/pages/Account/ChangelogViewRenderer.php
+++ b/src/pages/Account/ChangelogViewRenderer.php
@@ -8,7 +8,7 @@ class ChangelogViewRenderer {
 	 * @param array<array{version: string, went_live: ?string, changes: array<array{title: string, message: string}>}> $Versions
 	 */
 	public static function render(?string $ContinueHREF, array $Versions): void {
-		if (isset($ContinueHREF)) {
+		if ($ContinueHREF !== null) {
 			// Make the login changelog scroll if it is larger than 420px ?>
 			<style>div.login_scroll {height: 420px; overflow-y: auto;}</style>
 

--- a/src/pages/Account/ChatJoin.php
+++ b/src/pages/Account/ChatJoin.php
@@ -20,7 +20,7 @@ class ChatJoin extends AccountPage {
 
 		$autoChannels = '#SMR';
 		$nick = 'SMR-';
-		if (isset($player) && $player->hasAlliance()) {
+		if ($player !== null && $player->hasAlliance()) {
 			$allianceChan = $player->getAlliance()->getIrcChannel();
 			if ($allianceChan !== '') {
 				$autoChannels .= ',' . $allianceChan;

--- a/src/pages/Account/GameJoinRenderer.php
+++ b/src/pages/Account/GameJoinRenderer.php
@@ -68,7 +68,7 @@ class GameJoinRenderer {
 		</table><br />
 
 		<?php
-		if (!isset($JoinGameFormHref)) { ?>
+		if ($JoinGameFormHref === null) { ?>
 			<p class="bold big">
 				Time until you can join this game: <?php echo format_time($Game->getJoinTime() - Epoch::time()); ?>
 				<br /><br /><?php

--- a/src/pages/Account/GamePlayRenderer.php
+++ b/src/pages/Account/GamePlayRenderer.php
@@ -21,10 +21,10 @@ class GamePlayRenderer {
 		array $Voting,
 		string $OldAnnouncementsLink,
 	): void {
-		if (isset($ErrorMessage)) {
+		if ($ErrorMessage !== null) {
 			echo $ErrorMessage; ?><br /><br /><?php
 		}
-		if (isset($Message)) {
+		if ($Message !== null) {
 			echo $Message; ?><br /><br /><?php
 		} ?>
 

--- a/src/pages/Account/HallOfFameAll.php
+++ b/src/pages/Account/HallOfFameAll.php
@@ -41,7 +41,7 @@ class HallOfFameAll extends AccountPage {
 
 		$container = new HallOfFamePersonal($account->getAccountID(), $game_id);
 
-		$breadcrumb = HallOfFame::buildBreadcrumb($this, isset($game_id) ? 'Current HoF' : 'Global HoF');
+		$breadcrumb = HallOfFame::buildBreadcrumb($this, $game_id !== null ? 'Current HoF' : 'Global HoF');
 
 		$viewType = $this->viewType;
 		$hofVis = Player::getHOFVis();

--- a/src/pages/Account/HallOfFamePersonal.php
+++ b/src/pages/Account/HallOfFamePersonal.php
@@ -33,7 +33,7 @@ class HallOfFamePersonal extends AccountPage {
 		$account_id = $this->hofAccountID;
 		$game_id = $this->gameID;
 
-		if (isset($game_id)) {
+		if ($game_id !== null) {
 			try {
 				$player = Player::getPlayer($account->getAccountID(), $game_id);
 			} catch (PlayerNotFound) {

--- a/src/pages/Account/NewsReadAdvancedRenderer.php
+++ b/src/pages/Account/NewsReadAdvancedRenderer.php
@@ -76,7 +76,7 @@ class NewsReadAdvancedRenderer {
 				</tr>
 			</table>
 			<br /><br /><?php
-			if (isset($ResultsFor)) { ?>
+			if ($ResultsFor !== null) { ?>
 				Returning results for <?php echo htmlentities($ResultsFor); ?>.<br /><?php
 			} ?>
 		</div>

--- a/src/pages/Account/ValidateRenderer.php
+++ b/src/pages/Account/ValidateRenderer.php
@@ -43,7 +43,7 @@ class ValidateRenderer {
 		</form>
 
 		<?php
-		if (isset($Message)) { ?>
+		if ($Message !== null) { ?>
 			<p class="center"><?php echo $Message; ?></p><?php
 		}
 

--- a/src/pages/Admin/AccountEditRenderer.php
+++ b/src/pages/Admin/AccountEditRenderer.php
@@ -251,7 +251,7 @@ class AccountEditRenderer {
 				<tr>
 					<td valign="top" class="right bold">Exception:</td>
 					<td><?php
-						if (isset($Exception)) {
+						if ($Exception !== null) {
 							echo $Exception;
 						} else { ?>
 							This account is not listed.<br /><input type="text" name="exception_add" placeholder="Add An Exception"><?php

--- a/src/pages/Admin/AccountEditSearchRenderer.php
+++ b/src/pages/Admin/AccountEditSearchRenderer.php
@@ -63,10 +63,10 @@ class AccountEditSearchRenderer {
 			</table>
 		</form><?php
 
-		if (isset($ErrorMessage)) { ?>
+		if ($ErrorMessage !== null) { ?>
 			<div class="center red"><?php echo $ErrorMessage; ?></div><?php
 		}
-		if (isset($Message)) { ?>
+		if ($Message !== null) { ?>
 			<div class="center"><?php echo $Message; ?></div><?php
 		}
 

--- a/src/pages/Admin/AdminMessageSendRenderer.php
+++ b/src/pages/Admin/AdminMessageSendRenderer.php
@@ -16,7 +16,7 @@ class AdminMessageSendRenderer {
 		?string $Preview,
 		string $BackHREF,
 	): void {
-		if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbify($Preview, $MessageGameID); ?></td></tr></table><?php } ?>
+		if ($Preview !== null) { ?><table class="standard"><tr><td><?php echo bbify($Preview, $MessageGameID); ?></td></tr></table><?php } ?>
 		<form name="AdminMessageSendForm" method="POST" action="<?php echo $AdminMessageSendForm->href(); ?>">
 			<p>
 			<b>From: </b><span class="admin">Administrator</span><br />
@@ -31,7 +31,7 @@ class AdminMessageSendRenderer {
 					All Players (All Games)<?php
 				} ?>
 			</p>
-			<textarea required spellcheck="true" name="message"><?php if (isset($Preview)) { echo $Preview; } ?></textarea><br />
+			<textarea required spellcheck="true" name="message"><?php if ($Preview !== null) { echo $Preview; } ?></textarea><br />
 			Hours Till Expire: <input required type="number" step="0.01" name="expire" value="<?php echo $ExpireTime; ?>" min="0" size="2"> (0 = never expire)<br />
 			<br />
 			<?php echo $AdminMessageSendForm->actionSend->html('Send message'); ?>&nbsp;<?php echo $AdminMessageSendForm->actionPreview->html('Preview message'); ?>

--- a/src/pages/Admin/AdminToolsRenderer.php
+++ b/src/pages/Admin/AdminToolsRenderer.php
@@ -10,10 +10,10 @@ class AdminToolsRenderer {
 	 * @param array<int, list<array{Link: string|false, Name: string}>> $AdminPermissions
 	 */
 	public static function render(?string $ErrorMessage, ?string $Message, array $AdminPermissions): void {
-		if (isset($ErrorMessage)) {
+		if ($ErrorMessage !== null) {
 			echo $ErrorMessage; ?><br /><br /><?php
 		}
-		if (isset($Message)) {
+		if ($Message !== null) {
 			echo $Message; ?><br /><br /><?php
 		}
 		foreach ($AdminPermissions as $CategoryID => $Permissions) { ?>

--- a/src/pages/Admin/AnnouncementCreateRenderer.php
+++ b/src/pages/Admin/AnnouncementCreateRenderer.php
@@ -8,9 +8,9 @@ class AnnouncementCreateRenderer {
 		?>
 		Announcements are displayed to all users the next time they log in.<br />
 		You may use BBCode in your message, but not HTML.<br /><br />
-		<?php if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><br /><?php } ?>
+		<?php if ($Preview !== null) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><br /><?php } ?>
 		<form name="AnnouncementCreateForm" method="POST" action="<?php echo $AnnouncementCreateForm->href(); ?>">
-			<textarea required spellcheck="true" name="message"><?php if (isset($Preview)) { echo $Preview; } ?></textarea><br />
+			<textarea required spellcheck="true" name="message"><?php if ($Preview !== null) { echo $Preview; } ?></textarea><br />
 			<?php echo $AnnouncementCreateForm->actionCreate->html('Create announcement'); ?>&nbsp;
 			<?php echo $AnnouncementCreateForm->actionPreview->html('Preview announcement'); ?>
 		</form>

--- a/src/pages/Admin/AnonBankViewSelectRenderer.php
+++ b/src/pages/Admin/AnonBankViewSelectRenderer.php
@@ -5,7 +5,7 @@ namespace Smr\Pages\Admin;
 class AnonBankViewSelectRenderer {
 
 	public static function render(?string $Message, string $AnonViewHREF): void {
-		if (isset($Message)) { ?>
+		if ($Message !== null) { ?>
 			<p><span class="red"><?php echo $Message; ?></span></p><?php
 		} ?>
 		<p>What account would you like to view?</p>

--- a/src/pages/Admin/CombatSimulatorRenderer.php
+++ b/src/pages/Admin/CombatSimulatorRenderer.php
@@ -53,7 +53,7 @@ class CombatSimulatorRenderer {
 				</tr>
 			</table>
 		</form><?php
-		if (isset($TraderCombatResults)) {
+		if ($TraderCombatResults !== null) {
 			TraderFullCombatResultsRenderer::render(
 				template: $template,
 				MinimalDisplay: false,

--- a/src/pages/Admin/EnableGameRenderer.php
+++ b/src/pages/Admin/EnableGameRenderer.php
@@ -7,7 +7,7 @@ class EnableGameRenderer {
 	/** @param array<int, string> $DisabledGames */
 	public static function render(?string $ProcessingMsg, array $DisabledGames, string $EnableGameHREF): void {
 		// This var is passed by the processing file if we enabled a game
-		if (isset($ProcessingMsg)) {
+		if ($ProcessingMsg !== null) {
 			echo $ProcessingMsg;
 		}
 

--- a/src/pages/Admin/IpViewResultsRenderer.php
+++ b/src/pages/Admin/IpViewResultsRenderer.php
@@ -62,10 +62,10 @@ class IpViewResultsRenderer {
 		} elseif ($type === 'account_ips') { ?>
 			<center><?php
 				echo $Summary;
-				if (isset($Exception) && $Exception !== '') { ?>
+				if ($Exception !== null && $Exception !== '') { ?>
 					<br />This account has an exception: <?php echo $Exception;
 				}
-				if (isset($CloseReason) && $CloseReason !== '') { ?>
+				if ($CloseReason !== null && $CloseReason !== '') { ?>
 					<br />This account is closed: <?php echo $CloseReason;
 				} ?>
 				<br /><br />

--- a/src/pages/Admin/ManageDraftLeadersRenderer.php
+++ b/src/pages/Admin/ManageDraftLeadersRenderer.php
@@ -56,7 +56,7 @@ class ManageDraftLeadersRenderer {
 			<?php
 
 			// This var is passed by the processing file if there was an error
-			if (isset($ProcessingMsg)) {
+			if ($ProcessingMsg !== null) {
 				echo "<p>$ProcessingMsg</p>";
 			}
 

--- a/src/pages/Admin/ManagePostEditorsRenderer.php
+++ b/src/pages/Admin/ManagePostEditorsRenderer.php
@@ -45,7 +45,7 @@ class ManagePostEditorsRenderer {
 		<?php
 
 		// This var is passed by the processing file if we enabled a game
-		if (isset($ProcessingMsg)) {
+		if ($ProcessingMsg !== null) {
 			echo '<br />' . $ProcessingMsg;
 		} ?>
 		<br /><br />

--- a/src/pages/Admin/MessageBoxReplyRenderer.php
+++ b/src/pages/Admin/MessageBoxReplyRenderer.php
@@ -18,12 +18,12 @@ class MessageBoxReplyRenderer {
 	): void {
 		?>
 		<a href="<?php echo $BackHREF; ?>">&lt;&lt; Back</a><br /><br />
-		<?php if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><br /><?php } ?>
+		<?php if ($Preview !== null) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><br /><?php } ?>
 		<form name="BoxReplyForm" method="POST" action="<?php echo $BoxReplyFormPage->href(); ?>">
 			<b>From: </b><span class="admin">Administrator</span><br />
 			<b>To: </b><?php echo $Sender->getDisplayName(); ?> a.k.a <?php echo $SenderAccount->getLogin(); ?>
 			<br />
-			<textarea required spellcheck="true" name="message"><?php if (isset($Preview)) { echo $Preview; } ?></textarea><br /><br />
+			<textarea required spellcheck="true" name="message"><?php if ($Preview !== null) { echo $Preview; } ?></textarea><br /><br />
 			<input type="number" value="<?php echo $BanPoints; ?>" name="BanPoints" size="4" /> Add Ban Points<br /><br />
 			<input type="number" value="<?php echo $RewardCredits; ?>" name="RewardCredits" size="4" /> Add Reward Credits<br />
 			<p>Sending the message will add ban points or reward credits, if specified above.</p>

--- a/src/pages/Admin/ReportedMessageReplyRenderer.php
+++ b/src/pages/Admin/ReportedMessageReplyRenderer.php
@@ -17,17 +17,17 @@ class ReportedMessageReplyRenderer {
 		Leave a message box blank to not reply to that player.<br />
 		<br />
 		<form name="NotifyReplyForm" method="POST" action="<?php echo $NotifyReplyFormPage->href(); ?>">
-			<?php if (isset($PreviewOffender)) { ?><table class="standard"><tr><td><?php echo bbify($PreviewOffender); ?></td></tr></table><?php } ?>
+			<?php if ($PreviewOffender !== null) { ?><table class="standard"><tr><td><?php echo bbify($PreviewOffender); ?></td></tr></table><?php } ?>
 			<b>From: </b><span class="admin">Administrator</span><br />
 			<b>To Offender: </b><?php echo $Offender; ?><br />
-			<input type="number" value="<?php if (isset($OffenderBanPoints)) { echo $OffenderBanPoints; } else { ?>0<?php } ?>" name="offenderBanPoints" size="4" /> Points<br />
-			<textarea spellcheck="true" name="offenderReply"><?php if (isset($PreviewOffender)) { echo $PreviewOffender; } ?></textarea><br /><br />
+			<input type="number" value="<?php if ($OffenderBanPoints !== null) { echo $OffenderBanPoints; } else { ?>0<?php } ?>" name="offenderBanPoints" size="4" /> Points<br />
+			<textarea spellcheck="true" name="offenderReply"><?php if ($PreviewOffender !== null) { echo $PreviewOffender; } ?></textarea><br /><br />
 
-			<?php if (isset($PreviewOffended)) { ?><table class="standard"><tr><td><?php echo bbify($PreviewOffended); ?></td></tr></table><?php } ?>
+			<?php if ($PreviewOffended !== null) { ?><table class="standard"><tr><td><?php echo bbify($PreviewOffended); ?></td></tr></table><?php } ?>
 			<b>From: </b><span class="admin">Administrator</span><br />
 			<b>To Offended: </b><?php echo $Offended; ?><br />
-			<input type="number" value="<?php if (isset($OffendedBanPoints)) { echo $OffendedBanPoints; } else { ?>0<?php } ?>" name="offendedBanPoints" size="4" /> Points<br />
-			<textarea spellcheck="true" name="offendedReply"><?php if (isset($PreviewOffended)) { echo $PreviewOffended; } ?></textarea><br /><br />
+			<input type="number" value="<?php if ($OffendedBanPoints !== null) { echo $OffendedBanPoints; } else { ?>0<?php } ?>" name="offendedBanPoints" size="4" /> Points<br />
+			<textarea spellcheck="true" name="offendedReply"><?php if ($PreviewOffended !== null) { echo $PreviewOffended; } ?></textarea><br /><br />
 
 			<?php echo $NotifyReplyFormPage->actionSend->html(); ?>&nbsp;<?php echo $NotifyReplyFormPage->actionPreview->html(); ?>
 		</form>

--- a/src/pages/Admin/UniGen/CreateWarpsRenderer.php
+++ b/src/pages/Admin/UniGen/CreateWarpsRenderer.php
@@ -20,7 +20,7 @@ class CreateWarpsRenderer {
 		array $Galaxies,
 		array $Warps,
 	): void {
-		if (isset($Message)) {
+		if ($Message !== null) {
 			echo $Message; ?><br /><br /><?php
 		} ?>
 

--- a/src/pages/Admin/UniGen/EditGalaxyRenderer.php
+++ b/src/pages/Admin/UniGen/EditGalaxyRenderer.php
@@ -111,10 +111,10 @@ class EditGalaxyRenderer {
 							<tr><th>Modify Game</th></tr>
 							<tr><td><a href="<?php echo $EditGameDetailsHREF; ?>">Game Settings</a></td></tr>
 							<tr><td><a href="<?php echo $EditGalaxyDetailsHREF; ?>">Universe Layout</a></td></tr><?php
-							if (isset($AllEdit)) { ?>
+							if ($AllEdit !== null) { ?>
 								<tr><td><input type="checkbox" <?php if ($AllEdit) { ?>checked<?php } ?> name="all_edit" form="create_status" onchange="this.form.submit()" title="Check this box to let all map editors modify this game" /> Anyone edit?</td></tr><?php
 							}
-							if (isset($MapReady)) { ?>
+							if ($MapReady !== null) { ?>
 								<tr><td><input type="checkbox" <?php if ($MapReady) { ?>checked<?php } ?> name="map_ready" form="create_status" onchange="this.form.submit()" title="Check this box if the map is ready to be enabled" /> Map ready?</td></tr><?php
 							} ?>
 						</table><?php
@@ -172,7 +172,7 @@ class EditGalaxyRenderer {
 		</table>
 
 		<?php
-		if (isset($Message)) { ?>
+		if ($Message !== null) { ?>
 			<p class="center"><?php echo $Message; ?></p><?php
 		} ?>
 

--- a/src/pages/Admin/UniGen/EditSectorRenderer.php
+++ b/src/pages/Admin/UniGen/EditSectorRenderer.php
@@ -127,7 +127,7 @@ class EditSectorRenderer {
 		</form>
 
 		<?php
-		if (isset($Message)) {
+		if ($Message !== null) {
 			echo $Message;
 		}
 

--- a/src/pages/Admin/VoteCreateRenderer.php
+++ b/src/pages/Admin/VoteCreateRenderer.php
@@ -8,22 +8,22 @@ class VoteCreateRenderer {
 	 * @param array<int, array{ID: int, Question: string}> $CurrentVotes
 	 */
 	public static function render(VoteCreateProcessor $VoteFormPage, array $CurrentVotes, ?string $PreviewVote, ?int $Days, ?string $PreviewOption, ?int $VoteID): void {
-		if (isset($PreviewVote)) { ?><table class="standard"><tr><td><?php echo bbify(htmlentities($PreviewVote)); ?></td></tr></table><?php } ?>
+		if ($PreviewVote !== null) { ?><table class="standard"><tr><td><?php echo bbify(htmlentities($PreviewVote)); ?></td></tr></table><?php } ?>
 		<form name="VoteForm" method="POST" action="<?php echo $VoteFormPage->href(); ?>">
-			Question: <input type="text" name="question" required value="<?php if (isset($PreviewVote)) { echo bbify(htmlentities($PreviewVote)); } ?>" /><br />
-			Days to end: <input type="number" name="days" required value="<?php if (isset($Days)) { echo $Days; } ?>" /><br />
+			Question: <input type="text" name="question" required value="<?php if ($PreviewVote !== null) { echo bbify(htmlentities($PreviewVote)); } ?>" /><br />
+			Days to end: <input type="number" name="days" required value="<?php if ($Days !== null) { echo $Days; } ?>" /><br />
 			<?php echo $VoteFormPage->actionCreateVote->html(); ?>&nbsp;<?php echo $VoteFormPage->actionPreviewVote->html(); ?>
 		</form>
 		<br /><br />
 
-			<?php if (isset($PreviewOption)) { ?><table class="standard"><tr><td><?php echo bbify($PreviewOption); ?></td></tr></table><?php } ?>
+			<?php if ($PreviewOption !== null) { ?><table class="standard"><tr><td><?php echo bbify($PreviewOption); ?></td></tr></table><?php } ?>
 		<form name="VoteForm" method="POST" action="<?php echo $VoteFormPage->href(); ?>">
 			Vote: <select id="vote" name="vote"><?php
 				foreach ($CurrentVotes as $CurrentVote) {
-					?><option value="<?php echo $CurrentVote['ID']; ?>"<?php if (isset($VoteID) && $CurrentVote['ID'] === $VoteID) { ?>selected="selected"<?php } ?>><?php echo bbify(htmlentities($CurrentVote['Question'])); ?></option><?php
+					?><option value="<?php echo $CurrentVote['ID']; ?>"<?php if ($VoteID !== null && $CurrentVote['ID'] === $VoteID) { ?>selected="selected"<?php } ?>><?php echo bbify(htmlentities($CurrentVote['Question'])); ?></option><?php
 				} ?>
 			</select><br />
-			Option: <input type="text" name="option" required value="<?php if (isset($PreviewOption)) { echo htmlspecialchars($PreviewOption); } ?>" /><br />
+			Option: <input type="text" name="option" required value="<?php if ($PreviewOption !== null) { echo htmlspecialchars($PreviewOption); } ?>" /><br />
 			<?php echo $VoteFormPage->actionAddOption->html(); ?>&nbsp;<?php echo $VoteFormPage->actionPreviewOption->html(); ?>
 		</form>
 

--- a/src/pages/Admin/WordFilterRenderer.php
+++ b/src/pages/Admin/WordFilterRenderer.php
@@ -49,7 +49,7 @@ class WordFilterRenderer {
 		<br />
 
 		<?php
-		if (isset($Message)) {
+		if ($Message !== null) {
 			echo $Message;
 		}
 

--- a/src/pages/Album/EntryRenderer.php
+++ b/src/pages/Album/EntryRenderer.php
@@ -24,7 +24,7 @@ class EntryRenderer {
 						<table style="width: 100%">
 							<tr>
 								<td class="center" style="width: 30%" valign="middle"><?php
-									if (isset($PrevNick)) { ?>
+									if ($PrevNick !== null) { ?>
 										<a href="?nick=<?php echo urlencode($PrevNick); ?>">
 											<img src="/images/album/rew.jpg" alt="<?php echo htmlentities($PrevNick); ?>" border="0">
 										</a>&nbsp;&nbsp;&nbsp;<?php
@@ -36,7 +36,7 @@ class EntryRenderer {
 									<span style="font-size: 75%;">Views: <?php echo $Entry['PageViews']; ?></span>
 								</td>
 								<td class="center" style="width: 30%" valign="middle"><?php
-									if (isset($NextNick)) { ?>
+									if ($NextNick !== null) { ?>
 										&nbsp;&nbsp;&nbsp;
 										<a href="?nick=<?php echo urlencode($NextNick); ?>">
 											<img src="/images/album/fwd.jpg" alt="<?php echo htmlentities($NextNick); ?>" border="0">
@@ -87,7 +87,7 @@ class EntryRenderer {
 						<span style="font-size: 85%;">[<?php echo $Comment['date']; ?>] <b>&lt;<?php echo $Comment['commenter']; ?>&gt;</b> <?php echo $Comment['msg']; ?></span><br /><?php
 					}
 
-					if (isset($ViewerDisplayName)) { ?>
+					if ($ViewerDisplayName !== null) { ?>
 						<form action="album_comment_processing.php">
 							<input type="hidden" name="album_id" value="<?php echo $Entry['AccountID']; ?>" />
 							<input type="hidden" name="album_nick" value="<?php echo $Entry['Nick']; ?>" />

--- a/src/pages/Layout/HeadRenderer.php
+++ b/src/pages/Layout/HeadRenderer.php
@@ -13,13 +13,13 @@ class HeadRenderer {
 		$FontSize = $ThisAccount->getFontSize() - 20;
 		?>
 		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-		<title><?php echo PAGE_TITLE; ?><?php if (isset($GameName)) echo ": $GameName"; ?></title>
+		<title><?php echo PAGE_TITLE; ?><?php if ($GameName !== null) echo ": $GameName"; ?></title>
 		<meta http-equiv="pragma" content="no-cache" /><?php
 		if ($ThisAccount->isDefaultCSSEnabled()) { ?>
 			<link rel="stylesheet" type="text/css" href="<?php echo $CSSLink; ?>" />
 			<link rel="stylesheet" type="text/css" href="<?php echo $CSSColourLink; ?>" /><?php
 		}
-		if (isset($ExtraCSSLink) && $ExtraCSSLink !== '') {
+		if ($ExtraCSSLink !== null && $ExtraCSSLink !== '') {
 			?><link rel="stylesheet" type="text/css" href="<?php echo $ExtraCSSLink; ?>" /><?php
 		} ?>
 		<style>

--- a/src/pages/Layout/RightPanelShipRenderer.php
+++ b/src/pages/Layout/RightPanelShipRenderer.php
@@ -60,19 +60,19 @@ class RightPanelShipRenderer {
 			<br /><?php
 		} ?>
 		<a href="<?php echo $ForceDropLink; ?>"><span class="bold">Forces</span></a><br /><?php
-		if (isset($DropMineLink)) { ?>
+		if ($DropMineLink !== null) { ?>
 			<a href="<?php echo $DropMineLink; ?>">
 				<span class="bold">[X]</span>
 			</a><?php
 		} ?>Mines : <?php echo $ThisShip->getMines(); ?>/<?php echo $ThisShip->getMaxMines(); ?><br /><?php
 
-		if (isset($DropCDLink)) { ?>
+		if ($DropCDLink !== null) { ?>
 			<a href="<?php echo $DropCDLink; ?>">
 				<span class="bold">[X]</span>
 			</a><?php
 		} ?>Combat : <span id="cds"><?php echo get_colored_text_range($ThisShip->getCDs(), $ThisShip->getMaxCDs(), number_format($ThisShip->getCDs()) . '/' . number_format($ThisShip->getMaxCDs())); ?></span><br /><?php
 
-		if (isset($DropSDLink)) { ?>
+		if ($DropSDLink !== null) { ?>
 			<a href="<?php echo $DropSDLink; ?>">
 				<span class="bold">[X]</span>
 			</a><?php

--- a/src/pages/Login/LoginSocialCreateRenderer.php
+++ b/src/pages/Login/LoginSocialCreateRenderer.php
@@ -15,7 +15,7 @@ class LoginSocialCreateRenderer {
 				<table border="0" cellspacing="0" cellpadding="1">
 					<tr>
 						<td width="27%">User name:</td>
-						<td width="73%"><input required type="text" name="login" size="20" maxlength="32" class="InputFields" value="<?php if (isset($MatchingLogin)) { echo $MatchingLogin; } ?>"></td>
+						<td width="73%"><input required type="text" name="login" size="20" maxlength="32" class="InputFields" value="<?php if ($MatchingLogin !== null) { echo $MatchingLogin; } ?>"></td>
 					</tr>
 					<tr>
 						<td width="27%">Password:</td>
@@ -27,7 +27,7 @@ class LoginSocialCreateRenderer {
 			<br/>
 
 			<?php
-			if (!isset($MatchingLogin)) { ?>
+			if ($MatchingLogin === null) { ?>
 				<h1>Or Create New Login</h1>
 
 				<div class="register-note">

--- a/src/pages/Login/SkeletonRenderer.php
+++ b/src/pages/Login/SkeletonRenderer.php
@@ -63,7 +63,7 @@ class SkeletonRenderer {
 					</div>
 
 					<?php
-					if (isset($Message)) { ?>
+					if ($Message !== null) { ?>
 						<h4 style="margin-bottom: 0px;"><?php echo $Message ?></h4><?php
 					} ?>
 				</div>

--- a/src/pages/Player/AllianceListRenderer.php
+++ b/src/pages/Player/AllianceListRenderer.php
@@ -10,7 +10,7 @@ class AllianceListRenderer {
 	 * @param array<array{Name: string, TotalExperience: int, AverageExperience: int, Members: int, OpenRecruitment: bool}> $Alliances
 	 */
 	public static function render(Template $template, ?string $CreateAllianceHREF, array $Alliances): void {
-		if (isset($CreateAllianceHREF)) { ?>
+		if ($CreateAllianceHREF !== null) { ?>
 			<div class="center">
 				<div class="buttonA">
 					<a class="buttonA" href="<?php echo $CreateAllianceHREF; ?>">Create your own alliance!</a>

--- a/src/pages/Player/AllianceMessageBoardRenderer.php
+++ b/src/pages/Player/AllianceMessageBoardRenderer.php
@@ -56,19 +56,19 @@ class AllianceMessageBoardRenderer {
 			$template->listjsInclude = 'alliance_message';
 		}
 
-		if (isset($CreateNewThreadFormPage)) { ?>
+		if ($CreateNewThreadFormPage !== null) { ?>
 			<h2>Create Thread</h2><br /><?php
-			if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><?php } ?>
+			if ($Preview !== null) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><?php } ?>
 			<form class="standard" id="CreateNewThreadForm" method="POST" action="<?php echo $CreateNewThreadFormPage->href(); ?>">
 			<table class="standardnobord nohpad">
 				<tr>
 					<td class="top">Topic:&nbsp;</td>
-					<td class="mb"><input type="text" name="topic" required size="30" value="<?php if (isset($Topic)) { echo htmlspecialchars($Topic); } ?>"></td>
-					<td>For Alliance Eyes Only:<input name="allEyesOnly" type="checkbox"<?php if (isset($AllianceEyesOnly) && $AllianceEyesOnly) { ?>checked="checked" <?php } ?>></td>
+					<td class="mb"><input type="text" name="topic" required size="30" value="<?php if ($Topic !== null) { echo htmlspecialchars($Topic); } ?>"></td>
+					<td>For Alliance Eyes Only:<input name="allEyesOnly" type="checkbox"<?php if ($AllianceEyesOnly !== null && $AllianceEyesOnly) { ?>checked="checked" <?php } ?>></td>
 				</tr>
 				<tr>
 					<td class="top">Body:&nbsp;</td>
-					<td colspan="2"><textarea spellcheck="true" name="body" required><?php if (isset($Preview)) { echo $Preview; } ?></textarea></td>
+					<td colspan="2"><textarea spellcheck="true" name="body" required><?php if ($Preview !== null) { echo $Preview; } ?></textarea></td>
 				</tr>
 			</table><br />
 			<?php echo $CreateNewThreadFormPage->actionCreate->html('New Thread'); ?>&nbsp;<?php echo $CreateNewThreadFormPage->actionPreview->html('Preview Thread'); ?>

--- a/src/pages/Player/AllianceMessageBoardViewRenderer.php
+++ b/src/pages/Player/AllianceMessageBoardViewRenderer.php
@@ -12,11 +12,11 @@ class AllianceMessageBoardViewRenderer {
 	 * @param array{AllianceEyesOnly: bool, CanDelete: bool, Replies: array<int, array{Sender: string, Message: string, SendTime: int, DeleteHref?: string}>, CreateThreadReplyFormPage?: \Smr\Pages\Player\AllianceMessageBoardAddProcessor} $Thread
 	 */
 	public static function render(?array $PrevThread, ?array $NextThread, array $Thread, ?string $Preview, Account $ThisAccount): void {
-		if (isset($PrevThread) || isset($NextThread)) { ?>
+		if ($PrevThread !== null || $NextThread !== null) { ?>
 			<h2>Switch Topic</h2><br />
 			<table class="nobord fullwidth">
 				<tr><?php
-				if (isset($PrevThread)) { ?>
+				if ($PrevThread !== null) { ?>
 					<td>
 						<a href="<?php echo $PrevThread['Href']; ?>"><img src="images/album/rew.jpg" alt="Previous" title="Previous"></a>
 						&nbsp;&nbsp;<?php echo htmlentities($PrevThread['Topic']); ?>
@@ -24,7 +24,7 @@ class AllianceMessageBoardViewRenderer {
 				} else {
 					?><td>&nbsp;</td><?php
 				}
-				if (isset($NextThread)) { ?>
+				if ($NextThread !== null) { ?>
 					<td class="right">
 					<?php echo htmlentities($NextThread['Topic']); ?>&nbsp;&nbsp;
 					<a href="<?php echo $NextThread['Href']; ?>"><img src="images/album/fwd.jpg" alt="Next" title="Next"></a>
@@ -63,12 +63,12 @@ class AllianceMessageBoardViewRenderer {
 		</div><?php
 		if (isset($Thread['CreateThreadReplyFormPage'])) { ?>
 			<br /><h2>Create Reply</h2><br /><?php
-			if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><?php } ?>
+			if ($Preview !== null) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><?php } ?>
 			<form class="standard" id="CreateThreadReplyForm" method="POST" action="<?php echo $Thread['CreateThreadReplyFormPage']->href(); ?>">
 				<table class="nobord nohpad">
 					<tr>
 						<td class="top">Body:&nbsp;</td>
-						<td><textarea spellcheck="true" name="body" required><?php if (isset($Preview)) { echo $Preview; } ?></textarea></td>
+						<td><textarea spellcheck="true" name="body" required><?php if ($Preview !== null) { echo $Preview; } ?></textarea></td>
 					</tr>
 				</table><br />
 				<?php echo $Thread['CreateThreadReplyFormPage']->actionCreate->html('Create Reply'); ?>&nbsp;<?php echo $Thread['CreateThreadReplyFormPage']->actionPreview->html('Preview Reply'); ?>

--- a/src/pages/Player/AllianceMotdRenderer.php
+++ b/src/pages/Player/AllianceMotdRenderer.php
@@ -24,7 +24,7 @@ class AllianceMotdRenderer {
 		<div class="center">
 
 		<?php
-		if (isset($OpTime)) { ?>
+		if ($OpTime !== null) { ?>
 			<table class="center nobord opResponse">
 				<tr><th>ENCRYPTED ALLIANCE TELEGRAM</th></tr>
 				<tr><td>Your leader has scheduled an important alliance operation for <?php echo date($ThisAccount->getDateTimeFormat(), $OpTime); ?></td></tr>
@@ -51,13 +51,13 @@ class AllianceMotdRenderer {
 		<p><?php echo bbify($Alliance->getMotD()); ?></p>
 
 		<?php
-		if (isset($EditHREF)) { ?>
+		if ($EditHREF !== null) { ?>
 			<div class="buttonA">
 				<a class="buttonA" href="<?php echo $EditHREF; ?>">Edit</a>
 			</div><?php
 		}
 
-		if (isset($DiscordServer)) { ?>
+		if ($DiscordServer !== null) { ?>
 			<br /><br />
 			<iframe src="https://discordapp.com/widget?id=<?php echo $DiscordServer; ?>&amp;theme=dark" width="350" height="375" allowtransparency="true" frameborder="0"></iframe>
 			<?php

--- a/src/pages/Player/AllianceRosterRenderer.php
+++ b/src/pages/Player/AllianceRosterRenderer.php
@@ -36,7 +36,7 @@ class AllianceRosterRenderer {
 			<div id="alliance-desc" class="ajax"><?php
 				echo bbify($Alliance->getDescription()); ?>
 			</div><?php
-			if (isset($EditAllianceDescriptionHREF)) { ?>
+			if ($EditAllianceDescriptionHREF !== null) { ?>
 				<br />
 				<div class="buttonA"><a class="buttonA" href="<?php echo $EditAllianceDescriptionHREF; ?>">Edit</a></div>
 				<br /><?php
@@ -69,10 +69,10 @@ class AllianceRosterRenderer {
 						<th class="sort" data-sort="sort_name">Trader Name</th>
 						<th class="sort" data-sort="sort_race">Race</th>
 						<th class="sort" data-sort="sort_experience">Experience</th><?php
-						if (isset($Roles)) { ?>
+						if ($Roles !== null) { ?>
 							<th class="sort shrink" data-sort="sort_role">Role</th><?php
 						}
-						if (isset($ActiveIDs)) { ?>
+						if ($ActiveIDs !== null) { ?>
 							<th class="sort shrink" data-sort="sort_status">Status</th><?php
 						} ?>
 					</tr>
@@ -102,7 +102,7 @@ class AllianceRosterRenderer {
 							<td class="sort_experience"><?php
 								echo number_format($AlliancePlayer->getExperience()); ?>
 							</td><?php
-							if (isset($Roles)) { ?>
+							if ($Roles !== null) { ?>
 								<td class="sort_role"><?php
 									$PlayerRole = $AlliancePlayer->getAllianceRole();
 									if ($CanChangeRoles && !$AlliancePlayer->isAllianceLeader()) { ?>
@@ -121,7 +121,7 @@ class AllianceRosterRenderer {
 									} ?>
 								</td><?php
 							}
-							if (isset($ActiveIDs)) { ?>
+							if ($ActiveIDs !== null) { ?>
 								<td class="sort_status center"><?php
 									if (in_array($AlliancePlayer->getAccountID(), $ActiveIDs, true)) { ?>
 										<span class="green">Online</span><?php
@@ -144,10 +144,10 @@ class AllianceRosterRenderer {
 			<br /><h2>Options</h2><br />
 			<div class="buttonA">
 				<a class="buttonA" href="<?php echo $ToggleRolesHREF; ?>"><?php
-					if (isset($Roles)) { ?>Hide Alliance Roles<?php } else { ?>Show Alliance Roles<?php } ?>
+					if ($Roles !== null) { ?>Hide Alliance Roles<?php } else { ?>Show Alliance Roles<?php } ?>
 				</a>
 			</div><?php
-			if (isset($Roles) && $CanChangeRoles) { ?>
+			if ($Roles !== null && $CanChangeRoles) { ?>
 				&nbsp;&nbsp;
 				<form id="roles" style="display: inline;" method="POST" action="<?php echo $SaveAllianceRolesHREF; ?>">
 					<?php echo create_submit_display('Save Alliance Roles'); ?>

--- a/src/pages/Player/AllianceSetOpRenderer.php
+++ b/src/pages/Player/AllianceSetOpRenderer.php
@@ -19,10 +19,10 @@ class AllianceSetOpRenderer {
 		?>
 		<h2>Alliance Operation Schedule</h2>
 		<?php
-		if (isset($Message)) {
+		if ($Message !== null) {
 			echo "<p>$Message</p>";
 		}
-		if (isset($OpDate)) { ?>
+		if ($OpDate !== null) { ?>
 			<p>The next alliance operation is scheduled for:</p>
 			<table class="nobord">
 				<tr>

--- a/src/pages/Player/AllianceTreatiesRenderer.php
+++ b/src/pages/Player/AllianceTreatiesRenderer.php
@@ -14,7 +14,7 @@ class AllianceTreatiesRenderer {
 		?>
 		<div class="center">
 			<?php
-			if (isset($Message)) {
+			if ($Message !== null) {
 				echo $Message . '<br /><br />';
 			} ?>
 

--- a/src/pages/Player/AttackForcesRenderer.php
+++ b/src/pages/Player/AttackForcesRenderer.php
@@ -18,7 +18,7 @@ class AttackForcesRenderer {
 		); ?><br />
 		<br />
 		<div class="center"><?php
-			if (isset($Target)) { ?>
+			if ($Target !== null) { ?>
 				<div class="buttonA">
 					<a href="<?php echo $Target->getAttackForcesHREF() ?>" class="buttonA">Continue Attack (<?php echo $Target->getAttackTurnCost($ThisShip); ?>)</a>
 				</div><?php

--- a/src/pages/Player/AttackPlayerRenderer.php
+++ b/src/pages/Player/AttackPlayerRenderer.php
@@ -20,7 +20,7 @@ class AttackPlayerRenderer {
 		); ?><br />
 		<br />
 		<div class="center"><?php
-			if (isset($Target)) { ?>
+			if ($Target !== null) { ?>
 				<div class="buttonA">
 					<a href="<?php echo $Target->getAttackTraderHREF(); ?>" class="buttonA">Continue Attack</a>
 				</div><?php

--- a/src/pages/Player/Bank/AllianceBankRenderer.php
+++ b/src/pages/Player/Bank/AllianceBankRenderer.php
@@ -44,9 +44,9 @@ class AllianceBankRenderer {
 		Hello <?php echo $ThisPlayer->getDisplayName(); ?>,<br /><?php
 		if ($UnlimitedWithdrawal) {
 			?>You can withdraw an unlimited amount from this account.<?php
-		} elseif (isset($PositiveWithdrawal)) {
+		} elseif ($PositiveWithdrawal !== null) {
 			?>You can only withdraw <?php echo number_format($PositiveWithdrawal); ?> more credits based on your deposits.<?php
-		} elseif (isset($TotalWithdrawn) && isset($RemainingWithdrawal)) { ?>
+		} elseif ($TotalWithdrawn !== null && $RemainingWithdrawal !== null) { ?>
 			You can withdraw up to <?php echo number_format($WithdrawalPerDay); ?> credits per 24 hours.<br />
 			So far you have withdrawn <?php echo number_format($TotalWithdrawn); ?> credits in the past 24 hours. You can withdraw <?php echo number_format($RemainingWithdrawal); ?> more credits.<?php
 		} ?>

--- a/src/pages/Player/Bank/AllianceBankReportRenderer.php
+++ b/src/pages/Player/Bank/AllianceBankReportRenderer.php
@@ -7,7 +7,7 @@ class AllianceBankReportRenderer {
 	public static function render(string $BankReport, ?string $SendReportHREF): void {
 		?>
 		<div class="center"><?php
-			if (isset($SendReportHREF)) { ?>
+			if ($SendReportHREF !== null) { ?>
 				<div class="buttonA">
 					<a class="buttonA" href="<?php echo $SendReportHREF; ?>">Send Report to Alliance</a>
 				</div><?php

--- a/src/pages/Player/Bar/BuyDrinkProcessor.php
+++ b/src/pages/Player/Bar/BuyDrinkProcessor.php
@@ -80,25 +80,25 @@ class BuyDrinkProcessor extends PlayerPageProcessor {
 			$num_drinks = $db->count('player_has_drinks', $player->SQLID);
 			//display woozy message
 			$message .= '<br />You feel a little W' . str_repeat('oO', $num_drinks) . 'zy<br />';
+
+			//see if the player blacksout or not
+			if ($num_drinks > 15) {
+				$percent = rand(1, 25);
+				$lostCredits = IRound($player->getCredits() * $percent / 100);
+
+				$message .= '<span class="red">You decide you need to go to the restroom.  So you stand up and try to start walking but immediately collapse!<br />About 10 minutes later you wake up and find yourself missing ' . number_format($lostCredits) . ' credits</span><br />';
+
+				$player->decreaseCredits($lostCredits);
+				$player->increaseHOF(1, ['Bar', 'Robbed', 'Number Of Times'], HOF_PUBLIC);
+				$player->increaseHOF($lostCredits, ['Bar', 'Robbed', 'Money Lost'], HOF_PUBLIC);
+
+				$db->delete('player_has_drinks', $player->SQLID);
+			}
 		}
 
 		$action = new BuyDrink(sectorID: $player->getSectorID(), drink: $drinkName);
 		$player->actionTaken($action);
 
-		//see if the player blacksout or not
-		if (isset($num_drinks) && $num_drinks > 15) {
-			$percent = rand(1, 25);
-			$lostCredits = IRound($player->getCredits() * $percent / 100);
-
-			$message .= '<span class="red">You decide you need to go to the restroom.  So you stand up and try to start walking but immediately collapse!<br />About 10 minutes later you wake up and find yourself missing ' . number_format($lostCredits) . ' credits</span><br />';
-
-			$player->decreaseCredits($lostCredits);
-			$player->increaseHOF(1, ['Bar', 'Robbed', 'Number Of Times'], HOF_PUBLIC);
-			$player->increaseHOF($lostCredits, ['Bar', 'Robbed', 'Money Lost'], HOF_PUBLIC);
-
-			$db->delete('player_has_drinks', $player->SQLID);
-
-		}
 		$player->increaseHOF(1, ['Bar', 'Drinks', 'Total'], HOF_PUBLIC);
 		$message .= '</div>';
 

--- a/src/pages/Player/Bar/PlayBlackjackRenderer.php
+++ b/src/pages/Player/Bar/PlayBlackjackRenderer.php
@@ -27,7 +27,7 @@ class PlayBlackjackRenderer {
 			<?php echo $PlayerHand; ?>
 			<div><?php echo $PlayerStatus; ?></div><br />
 			<?php echo $Winnings; ?>
-			<?php if (isset($BetHREF)) { ?>
+			<?php if ($BetHREF !== null) { ?>
 				<p><a class="submitStyle" href="<?php echo $BetHREF; ?>">Play Some More ($<?php echo $Bet; ?>)</a></p><?php
 			} else { ?>
 				<a class="submitStyle" href="<?php echo $HitHREF; ?>">HIT</a>

--- a/src/pages/Player/ChatSharingRenderer.php
+++ b/src/pages/Player/ChatSharingRenderer.php
@@ -9,7 +9,7 @@ class ChatSharingRenderer {
 	 * @param array<int, array{"Player ID": string|int, "Player Name": string, "All Games": string, "Game ID": int}> $ShareTo
 	 */
 	public static function render(?string $Message, array $ShareFrom, array $ShareTo, string $ProcessingHREF): void {
-		if (isset($Message)) { ?>
+		if ($Message !== null) { ?>
 			<?php echo $Message; ?><?php
 		} ?>
 

--- a/src/pages/Player/Chess/MatchListRenderer.php
+++ b/src/pages/Player/Chess/MatchListRenderer.php
@@ -57,7 +57,7 @@ class MatchListRenderer {
 			<p>You have challenged every player.</p><?php
 		}
 
-		if (isset($NPCList)) {
+		if ($NPCList !== null) {
 			if (count($NPCList) > 0) { ?>
 				<form action="<?php echo Globals::getChessCreateHREF(); ?>" method="POST">
 					<label for="player_id">Challenge NPC: </label>

--- a/src/pages/Player/Chess/MatchPlayRenderer.php
+++ b/src/pages/Player/Chess/MatchPlayRenderer.php
@@ -31,7 +31,7 @@ class MatchPlayRenderer {
 		<p><span id="chess_status">
 			<?php if ($Ended) { ?>
 				The game has ended.<?php
-				if (isset($Winner)) { ?>
+				if ($Winner !== null) { ?>
 					<?php echo $Winner; ?> has won!<?php
 				}
 			} else { ?>

--- a/src/pages/Player/CombatLogListRenderer.php
+++ b/src/pages/Player/CombatLogListRenderer.php
@@ -23,7 +23,7 @@ class CombatLogListRenderer {
 		array $Logs,
 		Account $ThisAccount,
 	): void {
-		if (isset($Message)) {?>
+		if ($Message !== null) {?>
 			<div class="center"><?php echo $Message; ?></div><br /><?php
 		} ?>
 
@@ -36,7 +36,7 @@ class CombatLogListRenderer {
 					<table class="fullwidth center">
 						<tr>
 							<td id="prev" class="ajax" style="width: 30%" valign="middle"><?php
-								if (isset($PreviousPage)) { ?>
+								if ($PreviousPage !== null) { ?>
 									<a href="<?php echo $PreviousPage; ?>"><img src="images/album/rew.jpg" width="25" height="25" alt="Previous Page" border="0"></a><?php
 								} ?>
 							</td>
@@ -50,7 +50,7 @@ class CombatLogListRenderer {
 								} ?>
 							</td>
 							<td id="next" class="ajax" style="width: 30%" valign="middle"><?php
-								if (isset($NextPage)) { ?>
+								if ($NextPage !== null) { ?>
 									<a href="<?php echo $NextPage; ?>"><img src="images/album/fwd.jpg" width="25" height="25" alt="Next Page" border="0"></a><?php
 								} ?>
 							</td>

--- a/src/pages/Player/CombatLogViewerRenderer.php
+++ b/src/pages/Player/CombatLogViewerRenderer.php
@@ -26,12 +26,12 @@ class CombatLogViewerRenderer {
 		?string $NextLogHREF,
 		Player $ThisPlayer,
 	): void {
-		if (isset($PreviousLogHREF) || isset($NextLogHREF)) { ?>
+		if ($PreviousLogHREF !== null || $NextLogHREF !== null) { ?>
 			<div class="center"><?php
-			if (isset($PreviousLogHREF)) {
+			if ($PreviousLogHREF !== null) {
 				?><a href="<?php echo $PreviousLogHREF ?>"><img title="Previous" alt="Previous" src="images/album/rew.jpg" /></a><?php
 			}
-			if (isset($NextLogHREF)) {
+			if ($NextLogHREF !== null) {
 				?><a href="<?php echo $NextLogHREF ?>"><img title="Next" alt="Next" src="images/album/fwd.jpg" /></a><?php
 			} ?>
 			</div><?php

--- a/src/pages/Player/CurrentSectorRenderer.php
+++ b/src/pages/Player/CurrentSectorRenderer.php
@@ -84,22 +84,22 @@ class CurrentSectorRenderer {
 						MissionMessage: $MissionMessage,
 					); ?>
 					<span id="secmess"><?php
-						if (isset($ErrorMessage)) {
+						if ($ErrorMessage !== null) {
 							echo $ErrorMessage; ?><br /><?php
 						}
-						if (isset($ProtectionMessage)) {
+						if ($ProtectionMessage !== null) {
 							echo $ProtectionMessage; ?><br /><?php
 						}
-						if (isset($TurnsMessage)) {
+						if ($TurnsMessage !== null) {
 							echo $TurnsMessage; ?><br /><?php
 						}
-						if (isset($TradeMessage)) {
+						if ($TradeMessage !== null) {
 							echo $TradeMessage; ?><br /><?php
 						}
-						if (isset($ForceRefreshMessage)) {
+						if ($ForceRefreshMessage !== null) {
 							echo $ForceRefreshMessage; ?><br /><?php
 						}
-						if (isset($AttackResults)) {
+						if ($AttackResults !== null) {
 							$results = $AttackResults['Results'];
 							if ($results instanceof TraderFullCombatResults) {
 								TraderFullCombatResultsRenderer::render(
@@ -135,7 +135,7 @@ class CurrentSectorRenderer {
 								throw new Exception('Unknown combat result type');
 							} ?><br /><?php
 						}
-						if (isset($VarMessage)) {
+						if ($VarMessage !== null) {
 							echo bbify($VarMessage); ?><br /><?php
 						} ?>
 					</span>

--- a/src/pages/Player/GalacticPost/ArticleViewRenderer.php
+++ b/src/pages/Player/GalacticPost/ArticleViewRenderer.php
@@ -23,7 +23,7 @@ class ArticleViewRenderer {
 		} ?>
 
 		<br /><br /><?php
-		if (isset($SelectedArticle)) { ?>
+		if ($SelectedArticle !== null) { ?>
 			<h2><?php echo $SelectedArticle['title']; ?></h2>
 			<p><?php echo $SelectedArticle['text']; ?></p>
 			<a href="<?php echo $SelectedArticle['editHREF']; ?>"><b>Edit this article</b></a>

--- a/src/pages/Player/GalacticPost/ArticleWriteRenderer.php
+++ b/src/pages/Player/GalacticPost/ArticleWriteRenderer.php
@@ -5,7 +5,7 @@ namespace Smr\Pages\Player\GalacticPost;
 class ArticleWriteRenderer {
 
 	public static function render(?string $PreviewTitle, ?string $Preview, ArticleWriteProcessor $SubmitArticlePage): void {
-		if (isset($PreviewTitle) && isset($Preview)) { ?>
+		if ($PreviewTitle !== null && $Preview !== null) { ?>
 			<table class="standard">
 				<tr>
 					<td>Title:</td>
@@ -19,9 +19,9 @@ class ArticleWriteRenderer {
 		} ?>
 		What is the title?<br />
 		<form name="GPArticleForm" method="POST" action="<?php echo $SubmitArticlePage->href(); ?>">
-			<input type="text" name="title" class="center" style="width:525;" value="<?php if (isset($PreviewTitle)) { echo htmlspecialchars($PreviewTitle); } ?>" required><br /><br />
+			<input type="text" name="title" class="center" style="width:525;" value="<?php if ($PreviewTitle !== null) { echo htmlspecialchars($PreviewTitle); } ?>" required><br /><br />
 			<br />Write what you want to write here!<br />
-			<textarea spellcheck="true" name="message" required><?php if (isset($Preview)) { echo $Preview; } ?></textarea><br /><br />
+			<textarea spellcheck="true" name="message" required><?php if ($Preview !== null) { echo $Preview; } ?></textarea><br /><br />
 			<?php echo $SubmitArticlePage->actionSubmit->html(); ?>&nbsp;<?php echo $SubmitArticlePage->actionPreview->html(); ?>
 		</form>
 

--- a/src/pages/Player/GalacticPost/EditionReadRenderer.php
+++ b/src/pages/Player/GalacticPost/EditionReadRenderer.php
@@ -8,11 +8,11 @@ class EditionReadRenderer {
 	 * @param ?array<int, array<int, array{title: string, text: string}>> $ArticleLayout
 	 */
 	public static function render(?int $PaperGameID, ?string $BackHREF, ?array $ArticleLayout): void {
-		if (isset($BackHREF)) { ?>
+		if ($BackHREF !== null) { ?>
 			<a href="<?php echo $BackHREF; ?>"><b>&lt;&lt;Back</b></a><?php
 		}
 
-		if (!isset($ArticleLayout)) { ?>
+		if ($ArticleLayout === null) { ?>
 			There is no current edition of the Galactic Post for this game.<?php
 		} else { ?>
 			<table class="center" spacepadding="20" cellspacing="20"><?php

--- a/src/pages/Player/HardwareConfigureRenderer.php
+++ b/src/pages/Player/HardwareConfigureRenderer.php
@@ -28,7 +28,7 @@ class HardwareConfigureRenderer {
 				<?php
 			}
 
-			if (isset($IllusionShips)) { ?>
+			if ($IllusionShips !== null) { ?>
 				<form id="SetIllusionForm" method="POST" action="<?php echo $SetIllusionFormHREF; ?>">
 					<b>Illusion Generator:</b><br /><br />
 					<table class="nobord">

--- a/src/pages/Player/Headquarters/GovernmentRenderer.php
+++ b/src/pages/Player/Headquarters/GovernmentRenderer.php
@@ -32,7 +32,7 @@ class GovernmentRenderer {
 				BountyListRenderer::render(Bounties: $MyBounties);
 			}
 
-			if (isset($JoinHREF)) { ?>
+			if ($JoinHREF !== null) { ?>
 				<p><a href="<?php echo $JoinHREF; ?>" class="submitStyle">Become a deputy</a></p><?php
 			} ?>
 		</div>

--- a/src/pages/Player/Headquarters/UndergroundRenderer.php
+++ b/src/pages/Player/Headquarters/UndergroundRenderer.php
@@ -26,7 +26,7 @@ class UndergroundRenderer {
 			BountyListRenderer::render(Bounties: $MyBounties);
 		}
 
-		if (isset($JoinHREF)) { ?>
+		if ($JoinHREF !== null) { ?>
 			<p class="center">
 				<a href="<?php echo $JoinHREF; ?>" class="submitStyle">Become a smuggler</a>
 			</p><?php

--- a/src/pages/Player/MessageBlacklistRenderer.php
+++ b/src/pages/Player/MessageBlacklistRenderer.php
@@ -6,7 +6,7 @@ class MessageBlacklistRenderer {
 
 	/** @param array<array<string, string>> $Blacklist */
 	public static function render(?string $Message, array $Blacklist, string $BlacklistDeleteHREF, string $BlacklistAddHREF): void {
-		if (isset($Message)) {
+		if ($Message !== null) {
 			echo $Message; ?><br /><br /><?php
 		} ?>
 

--- a/src/pages/Player/MessageViewRenderer.php
+++ b/src/pages/Player/MessageViewRenderer.php
@@ -48,7 +48,7 @@ class MessageViewRenderer {
 			<table class="fullwidth center">
 				<tr>
 					<td style="width: 30%" valign="middle"><?php
-						if (isset($PreviousPageHREF)) {
+						if ($PreviousPageHREF !== null) {
 							?><a href="<?php echo $PreviousPageHREF; ?>"><img src="images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
 						} ?>
 					</td>
@@ -60,7 +60,7 @@ class MessageViewRenderer {
 						<p>You have <span class="yellow"><?php echo $MessageBox['TotalMessages']; ?></span> <?php echo pluralise($MessageBox['TotalMessages'], 'message', false); if ($MessageBox['TotalMessages'] !== $MessageBox['NumberMessages']) { ?> (<?php echo $MessageBox['NumberMessages']; ?> displayed)<?php } ?>.</p>
 					</td>
 					<td style="width: 30%" valign="middle"><?php
-						if (isset($NextPageHREF)) {
+						if ($NextPageHREF !== null) {
 							?><a href="<?php echo $NextPageHREF; ?>"><img src="images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
 						} ?>
 					</td>
@@ -137,14 +137,14 @@ class MessageViewRenderer {
 		<table class="fullwidth center">
 			<tr>
 				<td style="width: 30%" valign="middle"><?php
-					if (isset($PreviousPageHREF)) {
+					if ($PreviousPageHREF !== null) {
 						?><a href="<?php echo $PreviousPageHREF; ?>"><img src="images/album/rew.jpg" alt="Previous Page" border="0"></a><?php
 					} ?>
 				</td>
 				<td>
 				</td>
 				<td style="width: 30%" valign="middle"><?php
-					if (isset($NextPageHREF)) {
+					if ($NextPageHREF !== null) {
 						?><a href="<?php echo $NextPageHREF; ?>"><img src="images/album/fwd.jpg" alt="Next Page" border="0"></a><?php
 					} ?>
 				</td>

--- a/src/pages/Player/Planet/MainRenderer.php
+++ b/src/pages/Player/Planet/MainRenderer.php
@@ -25,10 +25,10 @@ class MainRenderer {
 		Player $ThisPlayer,
 		?array $Ticker,
 	): void {
-		if (isset($ErrorMsg)) {
+		if ($ErrorMsg !== null) {
 			echo $ErrorMsg; ?><br /><?php
 		}
-		if (isset($Msg)) {
+		if ($Msg !== null) {
 			echo bbify($Msg); ?><br /><?php
 		}
 		?>
@@ -116,7 +116,7 @@ class MainRenderer {
 						</table>
 					<?php } ?>
 				</td><?php
-				if (isset($Ticker)) { ?>
+				if ($Ticker !== null) { ?>
 					<td><?php
 						TickerRenderer::render($Ticker); ?>
 					</td><?php

--- a/src/pages/Player/Planet/OwnershipRenderer.php
+++ b/src/pages/Player/Planet/OwnershipRenderer.php
@@ -12,7 +12,7 @@ class OwnershipRenderer {
 		if (!$Planet->hasOwner()) { ?>
 			<p>
 				This planet is unclaimed.<?php
-				if (isset($PlayerPlanet)) { ?>
+				if ($PlayerPlanet !== null) { ?>
 					<br />If you claim it, you will lose ownership of the planet in Sector #<?php echo $PlayerPlanet; ?>!<?php
 				} ?>
 			</p>
@@ -25,7 +25,7 @@ class OwnershipRenderer {
 				<p><?php echo Player::getPlayer($Planet->getOwnerID(), $Planet->getGameID())->getLinkedDisplayName(false); ?> owns this planet.</p>
 				<p>
 					You can claim the planet when you enter the correct password.<?php
-					if (isset($PlayerPlanet)) { ?>
+					if ($PlayerPlanet !== null) { ?>
 						<br />If you do, you will lose ownership of the planet in Sector #<?php echo $PlayerPlanet; ?>!<?php
 					} ?>
 				</p>

--- a/src/pages/Player/SearchForTraderResult.php
+++ b/src/pages/Player/SearchForTraderResult.php
@@ -38,12 +38,14 @@ class SearchForTraderResult extends PlayerPage {
 				$resultPlayer = Player::getPlayerByPlayerID($player_id, $player->getGameID());
 			} catch (PlayerNotFound) {
 				// No player found, we'll return an empty result
+				$resultPlayer = null;
 			}
 		} else {
 			try {
 				$resultPlayer = Player::getPlayerByPlayerName($player_name, $player->getGameID());
 			} catch (PlayerNotFound) {
 				// No exact match, but that's okay
+				$resultPlayer = null;
 			}
 
 			$db = Database::getInstance();
@@ -96,12 +98,12 @@ class SearchForTraderResult extends PlayerPage {
 			return $result;
 		};
 
-		if (!isset($resultPlayer) && count($similarPlayers) === 0) {
+		if ($resultPlayer === null && count($similarPlayers) === 0) {
 			$container = new SearchForTrader(emptyResult: true);
 			$container->go();
 		}
 
-		if (isset($resultPlayer)) {
+		if ($resultPlayer !== null) {
 			$resultPlayerLinks = $playerLinks($resultPlayer);
 		} else {
 			$resultPlayerLinks = null;

--- a/src/pages/Player/SearchForTraderResultRenderer.php
+++ b/src/pages/Player/SearchForTraderResultRenderer.php
@@ -84,11 +84,11 @@ class SearchForTraderResultRenderer {
 	 * @param ?list<array{Player: Player, SearchHREF: string, RaceHREF: string, MessageHREF: string, BountyHREF: string, HofHREF: string, NewsHREF: string, JumpHREF?: string}> $SimilarPlayersLinks
 	 */
 	public static function render(?array $ResultPlayerLinks, ?array $SimilarPlayersLinks, Player $ThisPlayer): void {
-		if (isset($ResultPlayerLinks)) {
+		if ($ResultPlayerLinks !== null) {
 			DisplayResult([$ResultPlayerLinks], $ThisPlayer);
 			echo '<br /><br />';
 		}
-		if (isset($SimilarPlayersLinks)) {
+		if ($SimilarPlayersLinks !== null) {
 			DisplayResult($SimilarPlayersLinks, $ThisPlayer);
 		}
 

--- a/src/pages/Player/ShopGoodsNegotiateRenderer.php
+++ b/src/pages/Player/ShopGoodsNegotiateRenderer.php
@@ -31,7 +31,7 @@ class ShopGoodsNegotiateRenderer {
 			$ThisPlayer->getRelation($Port->getRaceID()),
 		];
 
-		if (isset($OfferToo)) { ?>
+		if ($OfferToo !== null) { ?>
 			<p class="red">I can't accept your offer. It's too <?php echo $OfferToo; ?>.</p><?php
 		} ?>
 

--- a/src/pages/Player/ShopGoodsRenderer.php
+++ b/src/pages/Player/ShopGoodsRenderer.php
@@ -29,13 +29,13 @@ class ShopGoodsRenderer {
 		Your relations with them are <?php echo get_colored_text($ThisPlayer->getRelation($Port->getRaceID())); ?>.</p>
 
 		<?php
-		if (isset($TradeMsg)) { ?>
+		if ($TradeMsg !== null) { ?>
 			<p><?php echo $TradeMsg; ?></p><?php
 		}
 
 		if ($SearchedByFeds) { ?>
 			<p><?php
-				if (isset($TotalFine)) { ?>
+				if ($TotalFine !== null) { ?>
 					<span class="red">
 						The Federation searched your ship and illegal goods were found!<br />
 						All illegal goods have been removed from your ship and you have been fined <?php echo number_format($TotalFine); ?> credits.

--- a/src/pages/Player/ShopShipRenderer.php
+++ b/src/pages/Player/ShopShipRenderer.php
@@ -64,7 +64,7 @@ class ShopShipRenderer {
 			?>We've got nothing for you here! Get outta here!<br /><?php
 		}
 		?><br /><?php
-		if (isset($CompareShip) && isset($ShipDiffs) && isset($TradeInValue) && isset($TotalCost)) { ?>
+		if ($CompareShip !== null && $ShipDiffs !== null && $TradeInValue !== null && $TotalCost !== null) { ?>
 			<h2>Details</h2>
 			<table class="standard">
 				<tr>

--- a/src/pages/Shared/AllianceRankingsRenderer.php
+++ b/src/pages/Shared/AllianceRankingsRenderer.php
@@ -21,7 +21,7 @@ class AllianceRankingsRenderer {
 		?>
 		<div class="center">
 			<p>Here are the rankings of alliances by their <?php echo $RankingStat; ?>.</p><?php
-			if (isset($OurRank)) { ?>
+			if ($OurRank !== null) { ?>
 				<p>Your alliance is ranked <?php echo number_format($OurRank); ?> out of <?php echo number_format($TotalRanks); ?> alliances.</p><?php
 			}
 			AllianceRankingsListRenderer::render(RankingStat: $RankingStat, Rankings: $Rankings); ?>

--- a/src/pages/Shared/CommonMessageSendRenderer.php
+++ b/src/pages/Shared/CommonMessageSendRenderer.php
@@ -13,13 +13,13 @@ class CommonMessageSendRenderer {
 		MessageSendProcessor $MessageSendPage,
 		?string $Preview,
 	): void {
-		if (isset($Preview)) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><?php } ?>
+		if ($Preview !== null) { ?><table class="standard"><tr><td><?php echo bbify($Preview); ?></td></tr></table><?php } ?>
 		<form name="MessageSendForm" method="POST" action="<?php echo $MessageSendPage->href(); ?>">
 			<p>
 				<b>From: </b><?php echo $ThisPlayer->getDisplayName(); ?><br />
 				<b>To: </b><?php echo $Receiver; ?>
 			</p>
-			<textarea spellcheck="true" name="message" required><?php if (isset($Preview)) { echo $Preview; } ?></textarea><br />
+			<textarea spellcheck="true" name="message" required><?php if ($Preview !== null) { echo $Preview; } ?></textarea><br />
 			<br />
 			<?php echo $MessageSendPage->actionSend->html('Send message'); ?>&nbsp;<?php echo $MessageSendPage->actionPreview->html('Preview message'); ?>
 		</form>

--- a/src/pages/Shared/CommonNewsRenderer.php
+++ b/src/pages/Shared/CommonNewsRenderer.php
@@ -15,7 +15,7 @@ class CommonNewsRenderer {
 		?array $BreakingNews,
 		?array $LottoNews,
 	): void {
-		if (isset($BreakingNews)) {
+		if ($BreakingNews !== null) {
 			?><b>MAJOR NEWS! - <?php echo date($ThisAccount->getDateTimeFormat(), $BreakingNews['Time']); ?></b><br />
 			<table class="standard">
 				<tr>
@@ -30,7 +30,7 @@ class CommonNewsRenderer {
 			<br /><br /><?php
 		}
 
-		if (isset($LottoNews)) { ?>
+		if ($LottoNews !== null) { ?>
 			<b>Lotto News</b><br />
 			<table class="standard">
 				<tr>

--- a/src/pages/Shared/HallOfFameRenderer.php
+++ b/src/pages/Shared/HallOfFameRenderer.php
@@ -22,7 +22,7 @@ class HallOfFameRenderer {
 			Welcome to the Hall of Fame, <?php echo $ThisAccount->getHofDisplayName(); ?>!<br />
 			The Hall of Fame is a comprehensive list of player accomplishments.
 			Here you can view how players rank in many different aspects of the game.<?php
-			if (isset($PersonalHofHREF)) { ?>
+			if ($PersonalHofHREF !== null) { ?>
 				<a href="<?php echo $PersonalHofHREF; ?>">You can also view your Personal Hall of Fame here.</a><?php
 			} ?>
 			<br /><br />
@@ -30,7 +30,7 @@ class HallOfFameRenderer {
 		</div>
 
 		<?php
-		if (isset($Categories)) { ?>
+		if ($Categories !== null) { ?>
 			<table class="standard center" width="75%">
 				<tr>
 					<th>Category</th>
@@ -43,7 +43,7 @@ class HallOfFameRenderer {
 					</tr><?php
 				} ?>
 			</table><?php
-		} elseif (isset($Rows)) { ?>
+		} elseif ($Rows !== null) { ?>
 			<table class="standard center">
 				<tr>
 					<th>Rank</th>

--- a/src/pages/Shared/MissionsRenderer.php
+++ b/src/pages/Shared/MissionsRenderer.php
@@ -18,7 +18,7 @@ class MissionsRenderer {
 		array $UnreadMissions,
 		?string $MissionMessage,
 	): void {
-		if (isset($MissionMessage)) { ?>
+		if ($MissionMessage !== null) { ?>
 			<span class="green">Mission Complete: </span><?php
 			echo $MissionMessage;
 		}

--- a/src/pages/Shared/PlanetListRenderer.php
+++ b/src/pages/Shared/PlanetListRenderer.php
@@ -23,7 +23,7 @@ class PlanetListRenderer {
 		?>
 		<div class="center">
 			<?php
-			if (isset($PlayerPlanet)) { ?>
+			if ($PlayerPlanet !== null) { ?>
 				You own the planet in sector <a href="#planet-<?php echo $PlayerPlanet->getSectorID(); ?>" target="_self">#<?php echo $PlayerPlanet->getSectorID(); ?></a>.<br /><?php
 			}
 

--- a/src/pages/Shared/SectorMapOptionsRenderer.php
+++ b/src/pages/Shared/SectorMapOptionsRenderer.php
@@ -9,7 +9,7 @@ class SectorMapOptionsRenderer {
 		?bool $ShowSeedlistSectors,
 		?string $CheckboxFormHREF,
 	): void {
-		if (isset($CheckboxFormHREF)) { ?>
+		if ($CheckboxFormHREF !== null) { ?>
 			<form method="POST" action="<?php echo $CheckboxFormHREF; ?>">
 				<table>
 					<tr>

--- a/src/pages/Shared/TickerRenderer.php
+++ b/src/pages/Shared/TickerRenderer.php
@@ -8,7 +8,7 @@ class TickerRenderer {
 	 * @param ?array<array{Time: string, Message: string}> $Ticker
 	 */
 	public static function render(?array $Ticker): void {
-		if (isset($Ticker)) { ?>
+		if ($Ticker !== null) { ?>
 			<div id="ticker" class="ajax left" style="overflow:auto;height:8em;border:2px solid #0b8d45;"><?php
 				if (count($Ticker) > 0) {
 					foreach ($Ticker as $Tick) {

--- a/src/pages/Shared/TraderCombatKillMessageRenderer.php
+++ b/src/pages/Shared/TraderCombatKillMessageRenderer.php
@@ -15,7 +15,7 @@ class TraderCombatKillMessageRenderer {
 		array $KillResults,
 	): void {
 		echo $TargetPlayer->getDisplayName(); ?> has been <span class="red">DESTROYED</span>, losing <span class="exp"><?php echo number_format($KillResults['DeadExp'])?></span> experience.<br /><?php
-		if (isset($ShootingPlayer)) {
+		if ($ShootingPlayer !== null) {
 			// Killed by another player
 			echo $ShootingPlayer->getDisplayName(); ?> salvages <span class="creds"><?php echo number_format($KillResults['KillerCredits']); ?></span> credits from the wreckage and gains <span class="exp"><?php echo number_format($KillResults['KillerExp']); ?></span> experience.<br /><?php
 		} else {

--- a/src/pages/Standalone/GalaxyMapRenderer.php
+++ b/src/pages/Standalone/GalaxyMapRenderer.php
@@ -30,7 +30,7 @@ class GalaxyMapRenderer {
 		<html>
 			<head><?php
 				HeadRenderer::render($ThisPlayer->getAccount(), $ThisPlayer->getGame()->getName());
-				if (isset($FocusSector)) { ?>
+				if ($FocusSector !== null) { ?>
 					<script>
 						$(function() {
 							var focusSector = $('#sector<?php echo $FocusSector; ?>'),


### PR DESCRIPTION
These are safer because setting a null value is often a more intentional and explicit choice than letting a variable be undefined.

In many places, we already had a null variable (largely due to the Renderer refactor), so checking against null is strictly better than checking `isset()`.