### PR TITLE
Remove DOG vote site

### DIFF
--- a/src/lib/Smr/VoteSite.php
+++ b/src/lib/Smr/VoteSite.php
@@ -9,13 +9,14 @@ enum VoteSite: int {
 
 	// NOTE: site IDs should never be changed!
 	case TWG = 3;
-	case DOG = 4;
 	case PBBG = 5;
 
 	// MPOGD no longer exists
-	//1 => array('default_img' => 'mpogd.png', 'star_img' => 'mpogd_vote.png', 'base_url' => 'http://www.mpogd.com/games/game.asp?ID=1145'),
+	//    1 => http://www.mpogd.com/games/game.asp?ID=1145
 	// OMGN no longer do voting - the link actually just redirects to archive site.
-	//2 => array('default_img' => 'omgn.png', 'star_img' => 'omgn_vote.png', 'base_url' => 'http://www.omgn.com/topgames/vote.php?Game_ID=30'),
+	//    2 => http://www.omgn.com/topgames/vote.php?Game_ID=30
+	// DOG domain went up for sale
+	//    4 => https://www.directoryofgames.com/main.php?view=topgames&action=vote&v_tgame=2315
 
 	/**
 	 * @return array<string, mixed>
@@ -30,15 +31,6 @@ enum VoteSite: int {
 				'url_func' => function($baseUrl, $accountId, $gameId) {
 					$query = ['account' => $accountId, 'game' => $gameId, 'link' => $this->value, 'alwaysreward' => 1];
 					return $baseUrl . '&' . http_build_query($query);
-				},
-			],
-			self::DOG => [
-				'img_default' => 'dog.png',
-				'img_star' => 'dog_vote.png',
-				'url_base' => 'https://www.directoryofgames.com/main.php?view=topgames&action=vote&v_tgame=2315',
-				'url_func' => function($baseUrl, $accountId, $gameId) {
-					$params = implode(',', [$accountId, $gameId, $this->value]);
-					return $baseUrl . '&votedef=' . $params;
 				},
 			],
 			self::PBBG => [

--- a/test/SmrTest/lib/VoteSiteIntegrationTest.php
+++ b/test/SmrTest/lib/VoteSiteIntegrationTest.php
@@ -76,11 +76,6 @@ class VoteSiteIntegrationTest extends BaseIntegrationSpec {
 				'url' => 'https://topwebgames.com/in.aspx?ID=136&account=7&game=42&link=3&alwaysreward=1',
 				'sn' => LOADER_URI . '?sn=gbuyay',
 			],
-			VoteSite::DOG->value => [
-				'img' => 'dog_vote.png',
-				'url' => 'https://www.directoryofgames.com/main.php?view=topgames&action=vote&v_tgame=2315&votedef=7,42,4',
-				'sn' => LOADER_URI . '?sn=wnpclr',
-			],
 			VoteSite::PBBG->value => [
 				'img' => 'pbbg.png',
 				'url' => 'https://pbbg.com/games/space-merchant-realms',
@@ -101,11 +96,6 @@ class VoteSiteIntegrationTest extends BaseIntegrationSpec {
 			VoteSite::TWG->value => [
 				'img' => 'twg.png',
 				'url' => 'https://topwebgames.com/in.aspx?ID=136',
-				'sn' => false,
-			],
-			VoteSite::DOG->value => [
-				'img' => 'dog.png',
-				'url' => 'https://www.directoryofgames.com/main.php?view=topgames&action=vote&v_tgame=2315',
 				'sn' => false,
 			],
 			VoteSite::PBBG->value => [
@@ -131,19 +121,10 @@ class VoteSiteIntegrationTest extends BaseIntegrationSpec {
 		self::assertSame(0, VoteLink::getMinTimeUntilFreeTurns($accountID, $gameID));
 	}
 
-	public function test_getMinTimeUntilFreeTurns_some_links_clicked(): void {
-		// Test that min time is still zero if we claim turns on one site
-		$accountID = 9;
-		$gameID = 17;
-		$link = new VoteLink(VoteSite::DOG, $accountID, $gameID);
-		$link->setClicked();
-		$link->setFreeTurnsAwarded();
-		VoteLink::clearCache();
-		self::assertSame(0, VoteLink::getMinTimeUntilFreeTurns($accountID, $gameID));
-	}
-
 	public function test_getMinTimeUntilFreeTurns_all_links_clicked(): void {
 		// Test that the min time is positive if we claim turns on all sites
+		// (Note: we currently only have one free-turns-ready vote site, so we
+		// can't test this function with only some links clicked.)
 		$accountID = 9;
 		$gameID = 17;
 		foreach (VoteSite::cases() as $site) {


### PR DESCRIPTION
The URL now redirects to a GoDaddy for sale page. Remove it as a possible voting site to avoid confusion and in case the future owner puts something malicious there.

Note that we now only have 1 vote site for free turns, so we can no longer test the logic when only some of the sites have been used.