### PR TITLE
Switch buy/sell perspective in port display

### DIFF
--- a/src/lib/Smr/Port.php
+++ b/src/lib/Smr/Port.php
@@ -289,7 +289,7 @@ class Port {
 	 *
 	 * @return array<int, TradeGood>
 	 */
-	public function getVisibleGoodsSold(?Player $player = null): array {
+	public function getVisibleGoodsPlayerSells(?Player $player = null): array {
 		return $this->getVisibleGoods($this->getSellGoodIDs(), $player);
 	}
 
@@ -298,7 +298,7 @@ class Port {
 	 *
 	 * @return array<int, TradeGood>
 	 */
-	public function getVisibleGoodsBought(?Player $player = null): array {
+	public function getVisibleGoodsPlayerBuys(?Player $player = null): array {
 		return $this->getVisibleGoods($this->getBuyGoodIDs(), $player);
 	}
 

--- a/src/pages/Player/AttackPortLootRenderer.php
+++ b/src/pages/Player/AttackPortLootRenderer.php
@@ -19,7 +19,7 @@ class AttackPortLootRenderer {
 				<th>Amount to Trade</th>
 				<th>Action</th>
 			</tr><?php
-			$BoughtGoodIDs = $ThisPort->getVisibleGoodsBought($ThisPlayer);
+			$BoughtGoodIDs = $ThisPort->getVisibleGoodsPlayerBuys($ThisPlayer);
 			foreach ($BoughtGoodIDs as $GoodID => $Good) {
 				$Amount = $ThisPort->getGoodAmount($GoodID); ?>
 				<form method="POST" action="<?php echo $ThisPort->getLootGoodHREF($GoodID); ?>">

--- a/src/pages/Player/ShopGoods.php
+++ b/src/pages/Player/ShopGoods.php
@@ -101,7 +101,7 @@ class ShopGoods extends PlayerPage {
 		$player->setLastPort($player->getSectorID());
 
 		$boughtGoods = [];
-		foreach ($port->getVisibleGoodsBought($player) as $goodID => $good) {
+		foreach ($port->getVisibleGoodsPlayerBuys($player) as $goodID => $good) {
 			$portAmount = $port->getGoodAmount($goodID);
 			$boughtGoods[$goodID] = [
 				'Page' => new ShopGoodsProcessor($goodID),
@@ -114,7 +114,7 @@ class ShopGoods extends PlayerPage {
 		}
 
 		$soldGoods = [];
-		foreach ($port->getVisibleGoodsSold($player) as $goodID => $good) {
+		foreach ($port->getVisibleGoodsPlayerSells($player) as $goodID => $good) {
 			$portAmount = $port->getGoodAmount($goodID);
 			$soldGoods[$goodID] = [
 				'Page' => new ShopGoodsProcessor($goodID),

--- a/src/pages/Shared/SectorMapRenderer.php
+++ b/src/pages/Shared/SectorMapRenderer.php
@@ -107,15 +107,15 @@ class SectorMapRenderer {
 											if ($isCurrentSector && !$GalaxyMap) {
 												?><a href="<?php echo Globals::getTradeHREF(); ?>"><?php
 											} ?>
-											<img src="images/port/sell.png" width="5" height="16" alt="Sell (<?php echo $Port->getRaceName(); ?>)"
-												title="Sell (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-											foreach ($Port->getVisibleGoodsBought($MapPlayer) as $Good) {
+											<img src="images/port/buy.png" width="5" height="16" alt="Buy (<?php echo $Port->getRaceName(); ?>)"
+												title="Buy (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
+											foreach ($Port->getVisibleGoodsPlayerBuys($MapPlayer) as $Good) {
 												echo $Good->getImageHTML();
 											} ?>
 											<br />
-											<img src="images/port/buy.png" width="5" height="16" alt="Buy (<?php echo $Port->getRaceName(); ?>)"
-												title="Buy (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-											foreach ($Port->getVisibleGoodsSold($MapPlayer) as $Good) {
+											<img src="images/port/sell.png" width="5" height="16" alt="Sell (<?php echo $Port->getRaceName(); ?>)"
+												title="Sell (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
+											foreach ($Port->getVisibleGoodsPlayerSells($MapPlayer) as $Good) {
 												echo $Good->getImageHTML();
 											}
 											if ($EditLinks !== null) { ?></div><?php }

--- a/src/pages/Shared/SectorPortRenderer.php
+++ b/src/pages/Shared/SectorPortRenderer.php
@@ -26,15 +26,15 @@ class SectorPortRenderer {
 						<td style="border-right:none">
 							<a href="<?php echo Globals::getTraderRelationsHREF(); ?>"><?php echo $ThisPlayer->getColouredRaceName($Port->getRaceID()); ?></a> Port <?php echo $Port->getSectorID(); ?> (Level <?php echo $Port->getLevel(); ?>)<br />
 								<div class="goods">
-									<img src="images/port/sell.png" width="5" height="16" alt="Sell (<?php echo $Port->getRaceName(); ?>)"
-										title="Sell (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-									foreach ($Port->getVisibleGoodsBought($ThisPlayer) as $Good) {
+									<img src="images/port/buy.png" width="5" height="16" alt="Buy (<?php echo $Port->getRaceName(); ?>)"
+										title="Buy (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
+									foreach ($Port->getVisibleGoodsPlayerBuys($ThisPlayer) as $Good) {
 										echo $Good->getImageHTML();
 									} ?>
 									<br />
-									<img src="images/port/buy.png" width="5" height="16" alt="Buy (<?php echo $Port->getRaceName(); ?>)"
-										title="Buy (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
-									foreach ($Port->getVisibleGoodsSold($ThisPlayer) as $Good) {
+									<img src="images/port/sell.png" width="5" height="16" alt="Sell (<?php echo $Port->getRaceName(); ?>)"
+										title="Sell (<?php echo $Port->getRaceName(); ?>)" class="port<?php echo $Port->getRaceID(); ?>"/><?php
+									foreach ($Port->getVisibleGoodsPlayerSells($ThisPlayer) as $Good) {
 										echo $Good->getImageHTML();
 									} ?>
 								</div>


### PR DESCRIPTION
In the SectorMap/SectorPort rendering, change the Buy/Sell text to refer to the action the player takes, rather than what the port takes.

This was requested by the community, and I admit the language was confusing (if it was the port action, it would be Buys/Sells instead of Buy/Sell).

Rename the Port methods to make it unambiguous who the action is with respect to.