### PR TITLE
Add weapon damage modifier tests

### DIFF
--- a/src/lib/Smr/Combat/Weapon/Mines.php
+++ b/src/lib/Smr/Combat/Weapon/Mines.php
@@ -8,7 +8,6 @@ use Smr\Force;
 use Smr\Planet;
 use Smr\Player;
 use Smr\Port;
-use Smr\Sector;
 
 class Mines extends AbstractWeapon {
 
@@ -39,7 +38,7 @@ class Mines extends AbstractWeapon {
 		$modifiedAccuracy = $this->getModifiedAccuracy();
 		$modifiedAccuracy -= $targetPlayer->getLevelID() + $random;
 		if ($minesAreAttacker) {
-			$modifiedAccuracy /= pow(Sector::getSector($forces->getGameID(), $forces->getSectorID())->getNumberOfConnections(), 0.6);
+			$modifiedAccuracy /= pow($forces->getSector()->getNumberOfConnections(), 0.6);
 		}
 
 		if (self::TOTAL_ENEMY_MINES_MODIFIER > 0) {

--- a/test/SmrTest/lib/Combat/Weapon/CombatDronesTest.php
+++ b/test/SmrTest/lib/Combat/Weapon/CombatDronesTest.php
@@ -3,8 +3,14 @@
 namespace SmrTest\lib\Combat\Weapon;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Smr\AbstractShip;
 use Smr\Combat\Weapon\CombatDrones;
+use Smr\Force;
+use Smr\Planet;
+use Smr\Player;
+use Smr\Port;
 
 #[CoversClass(CombatDrones::class)]
 class CombatDronesTest extends TestCase {
@@ -30,6 +36,207 @@ class CombatDronesTest extends TestCase {
 		// port/planet drones
 		$drones = new CombatDrones(100, true);
 		self::assertSame(1, $drones->getArmourDamage());
+	}
+
+	// Test Accuracy methods --------------------------------------------------
+
+	public function test_getBaseAccuracy(): void {
+		$result = $this->createDrones()->getBaseAccuracy();
+		self::assertSame(3, $result);
+	}
+
+	public function test_getModifiedAccuracyAgainstForces_adds_random_accuracy(): void {
+		$drones = $this->createDrones();
+		$player = $this->createStub(Player::class);
+		$forces = $this->createStub(Force::class);
+		srand(1);
+
+		$result = $drones->getModifiedAccuracyAgainstForces($player, $forces);
+		self::assertSame(51.0, $result);
+	}
+
+	public function test_getModifiedAccuracyAgainstPort_adds_random_accuracy(): void {
+		$drones = $this->createDrones();
+		$player = $this->createStub(Player::class);
+		$port = $this->createStub(Port::class);
+		srand(1);
+
+		$result = $drones->getModifiedAccuracyAgainstPort($player, $port);
+		self::assertSame(51.0, $result);
+	}
+
+	public function test_getModifiedAccuracyAgainstPlanet_adds_random_accuracy(): void {
+		$drones = $this->createDrones();
+		$player = $this->createStub(Player::class);
+		$planet = $this->createStub(Planet::class);
+		srand(1);
+
+		$result = $drones->getModifiedAccuracyAgainstPlanet($player, $planet);
+		self::assertSame(51.0, $result);
+	}
+
+	#[TestWith([0, 32.7477777778])]
+	#[TestWith([10, 41.6366666667])]
+	public function test_getModifiedAccuracyAgainstPlayer_applies_level_and_mr_modifiers(
+		int $level,
+		float $expected,
+	): void {
+		$drones = $this->createDrones();
+		$weaponPlayer = $this->createWeaponPlayer($level);
+		$targetPlayer = $this->createTargetPlayer(hasDcs: false, mr: 15);
+		srand(1);
+
+		$result = $drones->getModifiedAccuracyAgainstPlayer($weaponPlayer, $targetPlayer);
+		self::assertEqualsWithDelta($expected, $result, 0.0001);
+	}
+
+	public function test_getModifiedForceAccuracyAgainstPlayer_adds_random_accuracy(): void {
+		$drones = $this->createDrones();
+		$forces = $this->createStub(Force::class);
+		$targetPlayer = $this->createStub(Player::class);
+		srand(1);
+
+		$result = $drones->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer);
+		self::assertSame(51.0, $result);
+	}
+
+	// Test Damage methods ----------------------------------------------------
+
+	#[TestWith([true, 66, 3])]
+	#[TestWith([false, 12, 0])]
+	public function test_getModifiedDamageAgainstForces_applies_kamikaze_setting(
+		bool $kamikazeOnMines,
+		int $damage,
+		int $kamikaze,
+	): void {
+		$drones = $this->createDrones();
+		$player = $this->createStub(Player::class);
+		$player->method('isCombatDronesKamikazeOnMines')->willReturn($kamikazeOnMines);
+		$forces = $this->createStub(Force::class);
+		$forces->method('getMines')->willReturn(3);
+		srand(1);
+
+		$expected = ['Shield' => $damage, 'Armour' => $damage, 'Rollover' => true, 'Launched' => 6, 'Kamikaze' => $kamikaze];
+		$result = $drones->getModifiedDamageAgainstForces($player, $forces);
+		self::assertSame($expected, $result);
+	}
+
+	public function test_getModifiedDamageAgainstPort_applies_launched_drone_damage(): void {
+		$drones = $this->createDrones();
+		$player = $this->createStub(Player::class);
+		$port = $this->createStub(Port::class);
+		srand(1);
+
+		$expected = ['Shield' => 12, 'Armour' => 12, 'Rollover' => true, 'Launched' => 6];
+		$result = $drones->getModifiedDamageAgainstPort($player, $port);
+		self::assertSame($expected, $result);
+	}
+
+	public function test_getModifiedDamageAgainstPlanet_reduces_damage_for_planet(): void {
+		$drones = $this->createDrones();
+		$player = $this->createStub(Player::class);
+		$planet = $this->createStub(Planet::class);
+		srand(1);
+
+		$expected = ['Shield' => 3, 'Armour' => 3, 'Rollover' => true, 'Launched' => 6];
+		$result = $drones->getModifiedDamageAgainstPlanet($player, $planet);
+		self::assertSame($expected, $result);
+	}
+
+	#[TestWith([true, 7])]
+	#[TestWith([false, 10])]
+	public function test_getModifiedDamageAgainstPlayer_applies_dcs_modifier(bool $hasDcs, int $damage): void {
+		$drones = $this->createDrones();
+		$weaponPlayer = $this->createWeaponPlayer();
+		$targetPlayer = $this->createTargetPlayer(hasDcs: $hasDcs);
+		srand(1);
+
+		$expected = ['Shield' => $damage, 'Armour' => $damage, 'Rollover' => true, 'Launched' => 5];
+		$result = $drones->getModifiedDamageAgainstPlayer($weaponPlayer, $targetPlayer);
+		self::assertSame($expected, $result);
+	}
+
+	#[TestWith([true, 9])]
+	#[TestWith([false, 12])]
+	public function test_getModifiedForceDamageAgainstPlayer_applies_dcs_modifier(bool $hasDcs, int $damage): void {
+		$drones = $this->createDrones();
+		$forces = $this->createStub(Force::class);
+		$targetPlayer = $this->createTargetPlayer(hasDcs: $hasDcs);
+		srand(1);
+
+		$expected = ['Shield' => $damage, 'Armour' => $damage, 'Rollover' => true, 'Launched' => 6];
+		$result = $drones->getModifiedForceDamageAgainstPlayer($forces, $targetPlayer);
+		self::assertSame($expected, $result);
+	}
+
+	#[TestWith([true, 15])]
+	#[TestWith([false, 20])]
+	public function test_getModifiedPortDamageAgainstPlayer_applies_dcs_modifier(bool $hasDcs, int $damage): void {
+		$drones = $this->createDrones();
+		$port = $this->createStub(Port::class);
+		$targetPlayer = $this->createTargetPlayer(hasDcs: $hasDcs);
+
+		$expected = ['Shield' => $damage, 'Armour' => $damage, 'Rollover' => true, 'Launched' => 10];
+		$result = $drones->getModifiedPortDamageAgainstPlayer($port, $targetPlayer);
+		self::assertSame($expected, $result);
+	}
+
+	#[TestWith([true, 15])]
+	#[TestWith([false, 20])]
+	public function test_getModifiedPlanetDamageAgainstPlayer_applies_dcs_modifier(bool $hasDcs, int $damage): void {
+		$drones = $this->createDrones();
+		$planet = $this->createStub(Planet::class);
+		$targetPlayer = $this->createTargetPlayer(hasDcs: $hasDcs);
+
+		$expected = ['Shield' => $damage, 'Armour' => $damage, 'Rollover' => true, 'Launched' => 10];
+		$result = $drones->getModifiedPlanetDamageAgainstPlayer($planet, $targetPlayer);
+		self::assertSame($expected, $result);
+	}
+
+	// Test shoot methods -----------------------------------------------------
+
+	public function test_shootForces_always_reports_hit_and_consumes_kamikaze_drones(): void {
+		$drones = $this->createDrones();
+		$player = $this->createStub(Player::class);
+		$player->method('isCombatDronesKamikazeOnMines')->willReturn(true);
+		$ship = $this->createMock(AbstractShip::class);
+		// With kamikaze on mines, CD amount on ship will be decreased by kamikaze amount
+		$ship->expects($this->once())->method('decreaseCDs')->with(3)->seal();
+		$player->method('getShip')->willReturn($ship);
+		$forces = $this->createStub(Force::class);
+		$forces->method('getMines')->willReturn(3);
+		$forces->method('takeDamage')->willReturn(['KillingShot' => false]);
+		srand(1);
+
+		$result = $drones->shootForces($player, $forces);
+
+		self::assertTrue($result['Hit']);
+		self::assertSame(['Shield' => 66, 'Armour' => 66, 'Rollover' => true, 'Launched' => 6, 'Kamikaze' => 3], $result['WeaponDamage']);
+	}
+
+	// Private helper functions -----------------------------------------------
+
+	private function createDrones(): CombatDrones {
+		return new CombatDrones(10);
+	}
+
+	private function createWeaponPlayer(int $level = 10): Player {
+		$ship = $this->createStub(AbstractShip::class);
+		$ship->method('getMR')->willReturn(0);
+		$player = $this->createStub(Player::class);
+		$player->method('getLevelID')->willReturn($level);
+		$player->method('getShip')->willReturn($ship);
+		return $player;
+	}
+
+	private function createTargetPlayer(bool $hasDcs, int $mr = 0): Player {
+		$ship = $this->createStub(AbstractShip::class);
+		$ship->method('hasDCS')->willReturn($hasDcs);
+		$ship->method('getMR')->willReturn($mr);
+		$player = $this->createStub(Player::class);
+		$player->method('getLevelID')->willReturn(10);
+		$player->method('getShip')->willReturn($ship);
+		return $player;
 	}
 
 }

--- a/test/SmrTest/lib/Combat/Weapon/MinesTest.php
+++ b/test/SmrTest/lib/Combat/Weapon/MinesTest.php
@@ -3,8 +3,13 @@
 namespace SmrTest\lib\Combat\Weapon;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Smr\AbstractShip;
 use Smr\Combat\Weapon\Mines;
+use Smr\Force;
+use Smr\Player;
+use Smr\Sector;
 
 #[CoversClass(Mines::class)]
 class MinesTest extends TestCase {
@@ -22,6 +27,104 @@ class MinesTest extends TestCase {
 	public function test_getArmourDamage(): void {
 		$mines = new Mines(100); // doesn't matter how many
 		self::assertSame(20, $mines->getShieldDamage());
+	}
+
+	public function test_getBaseAccuracy(): void {
+		$mines = new Mines(100);
+		self::assertSame(100, $mines->getBaseAccuracy());
+	}
+
+	#[TestWith([0, 0, false, 96.0])]
+	#[TestWith([0, 10, false, 86.0])]
+	#[TestWith([25, 10, false, 87.0])]
+	#[TestWith([0, 10, true, 37.433674221733])]
+	public function test_getModifiedForceAccuracyAgainstPlayer_reduces_accuracy_for_player_level_and_randomness(
+		int $numberOfMines,
+		int $level,
+		bool $minesAreAttacker,
+		float $expected,
+	): void {
+		$mines = new Mines(10);
+		$sector = $this->createStub(Sector::class);
+		$enemyForces = [];
+		if ($numberOfMines > 0) {
+			$enemyForce = $this->createStub(Force::class);
+			$enemyForce->method('getMines')->willReturn($numberOfMines);
+			$enemyForces[] = $enemyForce;
+		}
+		$sector->method('getEnemyForces')->willReturn($enemyForces);
+		$sector->method('getNumberOfConnections')->willReturn(4);
+		$forces = $this->createStub(Force::class);
+		$forces->method('getSector')->willReturn($sector);
+		$targetPlayer = $this->createStub(Player::class);
+		$targetPlayer->method('getLevelID')->willReturn($level);
+		srand(1);
+
+		$result = $mines->getModifiedForceAccuracyAgainstPlayer($forces, $targetPlayer, $minesAreAttacker);
+		self::assertEqualsWithDelta($expected, $result, 0.0001);
+	}
+
+	#[TestWith([false, false, 100])]
+	#[TestWith([false, true, 75])]
+	#[TestWith([true, false, 50])]
+	#[TestWith([true, true, 40])]
+	public function test_getModifiedForceDamageAgainstPlayer_applies_federal_and_dcs_modifiers(
+		bool $isFederal,
+		bool $hasDcs,
+		int $damage,
+	): void {
+		$mines = $this->createMines(accuracy: 50);
+		$force = $this->createStub(Force::class);
+		$targetPlayer = $this->createTargetPlayer(isFederal: $isFederal, hasDcs: $hasDcs);
+
+		$expected = ['Shield' => $damage, 'Armour' => $damage, 'Rollover' => false, 'Launched' => 5];
+		$result = $mines->getModifiedForceDamageAgainstPlayer($force, $targetPlayer);
+		self::assertSame($expected, $result);
+	}
+
+	public function test_shootPlayerAsForce_consumes_only_mines_needed_for_damage(): void {
+		$mines = $this->createMines(accuracy: 50);
+		$forces = $this->createStub(Force::class);
+		$ship = $this->createStub(AbstractShip::class);
+		// Five launched mines deal 100 shield damage; only 40 damage was taken.
+		$ship->method('takeDamageFromMines')->willReturn(['TotalDamage' => 40, 'KillingShot' => false]);
+		$targetPlayer = $this->createStub(Player::class);
+		$targetPlayer->method('getShip')->willReturn($ship);
+
+		$result = $mines->shootPlayerAsForce($forces, $targetPlayer);
+
+		self::assertTrue($result['Hit']);
+		assert(isset($result['WeaponDamage']['Launched'])); // needed for PHPStan
+		self::assertSame(2, $result['WeaponDamage']['Launched']);
+		// The two adjusted launches are subtracted from the original ten mines.
+		self::assertSame(8, $mines->getAmount());
+	}
+
+	private function createMines(int $accuracy): Mines {
+		return new class ($accuracy) extends Mines {
+
+			public function __construct(private readonly int $fixedAccuracy) {
+				parent::__construct(10);
+			}
+
+			public function getModifiedForceAccuracyAgainstPlayer(
+				Force $forces,
+				Player $targetPlayer,
+				bool $minesAreAttacker,
+			): float {
+				return $this->fixedAccuracy;
+			}
+
+		};
+	}
+
+	private function createTargetPlayer(bool $isFederal, bool $hasDcs): Player {
+		$ship = $this->createStub(AbstractShip::class);
+		$ship->method('isFederal')->willReturn($isFederal);
+		$ship->method('hasDCS')->willReturn($hasDcs);
+		$player = $this->createStub(Player::class);
+		$player->method('getShip')->willReturn($ship);
+		return $player;
 	}
 
 }

--- a/test/SmrTest/lib/Combat/Weapon/ScoutDronesTest.php
+++ b/test/SmrTest/lib/Combat/Weapon/ScoutDronesTest.php
@@ -3,8 +3,12 @@
 namespace SmrTest\lib\Combat\Weapon;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Smr\AbstractShip;
 use Smr\Combat\Weapon\ScoutDrones;
+use Smr\Force;
+use Smr\Player;
 
 #[CoversClass(ScoutDrones::class)]
 class ScoutDronesTest extends TestCase {
@@ -22,6 +26,61 @@ class ScoutDronesTest extends TestCase {
 	public function test_getArmourDamage(): void {
 		$sds = new ScoutDrones(100); // doesn't matter how many
 		self::assertSame(20, $sds->getShieldDamage());
+	}
+
+	public function test_getBaseAccuracy(): void {
+		$sds = new ScoutDrones(100);
+		self::assertSame(100, $sds->getBaseAccuracy());
+	}
+
+	#[TestWith([0, 96.0])]
+	#[TestWith([10, 86.0])]
+	public function test_getModifiedForceAccuracyAgainstPlayer_reduces_accuracy_for_player_level_and_randomness(
+		int $level,
+		float $expected,
+	): void {
+		$drones = $this->createDrones();
+		$force = $this->createStub(Force::class);
+		$targetPlayer = $this->createStub(Player::class);
+		$targetPlayer->method('getLevelID')->willReturn($level);
+		srand(1);
+
+		$result = $drones->getModifiedForceAccuracyAgainstPlayer($force, $targetPlayer);
+		self::assertSame($expected, $result);
+	}
+
+	public function test_getModifiedForceDamageAgainstPlayer_applies_launched_drone_damage(): void {
+		$drones = $this->createDrones();
+		$targetPlayer = $this->createStub(Player::class);
+		$targetPlayer->method('getLevelID')->willReturn(0);
+		$forces = $this->createStub(Force::class);
+		srand(1);
+
+		$expected = ['Shield' => 200, 'Armour' => 200, 'Rollover' => false, 'Launched' => 10];
+		$result = $drones->getModifiedForceDamageAgainstPlayer($forces, $targetPlayer);
+
+		self::assertSame($expected, $result);
+	}
+
+	public function test_shootPlayerAsForce_applies_damage_and_consumes_launched_drones(): void {
+		$drones = $this->createDrones();
+		$forces = $this->createStub(Force::class);
+		$ship = $this->createStub(AbstractShip::class);
+		$ship->method('takeDamage')
+			->willReturn(['TotalDamage' => 200, 'KillingShot' => false]);
+		$targetPlayer = $this->createStub(Player::class);
+		$targetPlayer->method('getLevelID')->willReturn(0);
+		$targetPlayer->method('getShip')->willReturn($ship);
+		srand(1);
+
+		$result = $drones->shootPlayerAsForce($forces, $targetPlayer);
+
+		self::assertTrue($result['Hit']);
+		self::assertSame(0, $drones->getAmount());
+	}
+
+	private function createDrones(): ScoutDrones {
+		return new ScoutDrones(10);
 	}
 
 }

--- a/test/SmrTest/lib/Combat/Weapon/WeaponTest.php
+++ b/test/SmrTest/lib/Combat/Weapon/WeaponTest.php
@@ -1,0 +1,223 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\Combat\Weapon;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Smr\AbstractShip;
+use Smr\Combat\Weapon\Weapon;
+use Smr\Force;
+use Smr\Planet;
+use Smr\Player;
+use Smr\Port;
+
+#[CoversClass(Weapon::class)]
+class WeaponTest extends TestCase {
+
+	// Test Damage methods ----------------------------------------------------
+
+	public function test_getModifiedDamageAgainstForces_returns_base_damage(): void {
+		$weapon = $this->createWeapon();
+		$expected = $this->baseDamage();
+		$result = $weapon->getModifiedDamageAgainstForces(
+			$this->createStub(Player::class),
+			$this->createStub(Force::class),
+		);
+
+		self::assertSame($expected, $result);
+	}
+
+	public function test_getModifiedDamageAgainstPort_returns_base_damage(): void {
+		$weapon = $this->createWeapon();
+		$expected = $this->baseDamage();
+		$result = $weapon->getModifiedDamageAgainstPort(
+			$this->createStub(Player::class),
+			$this->createStub(Port::class),
+		);
+
+		self::assertSame($expected, $result);
+	}
+
+	public function test_getModifiedDamageAgainstPlanet_reduces_base_damage(): void {
+		$weapon = $this->createWeapon();
+		$expected = ['Shield' => 3, 'Armour' => 2, 'Rollover' => false];
+		$result = $weapon->getModifiedDamageAgainstPlanet(
+			$this->createStub(Player::class),
+			$this->createStub(Planet::class),
+		);
+
+		self::assertSame($expected, $result);
+	}
+
+	public function test_getModifiedDamageAgainstPlayer_returns_base_damage(): void {
+		$weapon = $this->createWeapon();
+		$expected = $this->baseDamage();
+		$result = $weapon->getModifiedDamageAgainstPlayer(
+			$this->createStub(Player::class),
+			$this->createStub(Player::class),
+		);
+
+		self::assertSame($expected, $result);
+	}
+
+	public function test_getModifiedPortDamageAgainstPlayer_returns_base_damage(): void {
+		$weapon = $this->createWeapon();
+		$expected = $this->baseDamage();
+		$result = $weapon->getModifiedPortDamageAgainstPlayer(
+			$this->createStub(Port::class),
+			$this->createStub(Player::class),
+		);
+
+		self::assertSame($expected, $result);
+	}
+
+	public function test_getModifiedPlanetDamageAgainstPlayer_returns_base_damage(): void {
+		$weapon = $this->createWeapon();
+		$expected = $this->baseDamage();
+		$result = $weapon->getModifiedPlanetDamageAgainstPlayer(
+			$this->createStub(Planet::class),
+			$this->createStub(Player::class),
+		);
+
+		self::assertSame($expected, $result);
+	}
+
+	// Test Accuracy methods --------------------------------------------------
+
+	#[TestWith([0, 61.2])]
+	#[TestWith([10, 65.2])]
+	public function test_getModifiedAccuracyAgainstForces_applies_player_level_modifier(int $level, float $expected): void {
+		$weaponPlayer = $this->createPlayer($level);
+		$force = $this->createStub(Force::class);
+
+		$result = $this->createWeapon()->getModifiedAccuracyAgainstForces($weaponPlayer, $force);
+		self::assertEqualsWithDelta($expected, $result, 0.0001);
+	}
+
+	#[TestWith([0, 0, 61.2])]
+	#[TestWith([0, 10, 49.2])]
+	#[TestWith([10, 0, 65.2])]
+	#[TestWith([10, 10, 53.2])]
+	public function test_getModifiedAccuracyAgainstPort_reduces_accuracy_for_port_level(
+		int $weaponLevel,
+		int $portLevel,
+		float $expected,
+	): void {
+		$port = $this->createStub(Port::class);
+		$port->method('getLevel')->willReturn($portLevel);
+		$weaponPlayer = $this->createPlayer($weaponLevel);
+
+		$result = $this->createWeapon()->getModifiedAccuracyAgainstPort($weaponPlayer, $port);
+		self::assertEqualsWithDelta($expected, $result, 0.0001);
+	}
+
+	#[TestWith([0, 0.0, 61.2])]
+	#[TestWith([0, 35.0, 55.2])]
+	#[TestWith([10, 0.0, 65.2])]
+	#[TestWith([10, 35.0, 59.2])]
+	public function test_getModifiedAccuracyAgainstPlanet_reduces_accuracy_for_planet_level(
+		int $weaponLevel,
+		float $planetLevel,
+		float $expected,
+	): void {
+		$planet = $this->createStub(Planet::class);
+		$planet->method('getLevel')->willReturn($planetLevel);
+		$weaponPlayer = $this->createPlayer($weaponLevel);
+
+		$result = $this->createWeapon()->getModifiedAccuracyAgainstPlanet($weaponPlayer, $planet);
+		self::assertEqualsWithDelta($expected, $result, 0.0001);
+	}
+
+	#[TestWith([0, 0, 60.0])]
+	#[TestWith([0, 20, 55.0])]
+	#[TestWith([10, 0, 64.0])]
+	#[TestWith([10, 20, 59.0])]
+	public function test_getModifiedAccuracyAgainstPlayer_reduces_accuracy_for_level_and_mr(
+		int $weaponLevel,
+		int $targetLevel,
+		float $expected,
+	): void {
+		$weaponPlayer = $this->createPlayer(level: $weaponLevel, mr: 0);
+		$targetPlayer = $this->createPlayer(level: $targetLevel, mr: 15);
+
+		$result = $this->createWeapon()->getModifiedAccuracyAgainstPlayer($weaponPlayer, $targetPlayer);
+		self::assertEqualsWithDelta($expected, $result, 0.0001);
+	}
+
+	#[TestWith([0, 58.8])]
+	#[TestWith([20, 48.8])]
+	public function test_getModifiedPortAccuracyAgainstPlayer_reduces_accuracy_for_player_level(
+		int $targetLevel,
+		float $expected,
+	): void {
+		$port = $this->createStub(Port::class);
+		$targetPlayer = $this->createPlayer($targetLevel);
+
+		$result = $this->createWeapon()->getModifiedPortAccuracyAgainstPlayer($port, $targetPlayer);
+		self::assertEqualsWithDelta($expected, $result, 0.0001);
+	}
+
+	#[TestWith([false, 0, 0.0, 4, 62.8])]
+	#[TestWith([false, 0, 10.0, 4, 62.8])] // planet level does not change mounted weapon accuracy
+	#[TestWith([false, 0, 10.0, 10, 68.8])] // accuracy bonus does change mounted weapon accuracy
+	#[TestWith([false, 20, 10.0, 10, 58.8])] // target player level changes mounted weapon accuracy
+	#[TestWith([true, 0, 0.0, 4, 58.8])]
+	#[TestWith([true, 0, 10.0, 4, 63.8])] // planet level does change turret accuracy
+	#[TestWith([true, 0, 10.0, 10, 63.8])] // accuracy bonus does not turret accuracy
+	#[TestWith([true, 20, 10.0, 10, 53.8])] // target player level changes turret accuracy
+	public function test_getModifiedPlanetAccuracyAgainstPlayer_reduces_modified_accuracy_for_player_level(
+		bool $isTurret,
+		int $playerLevel,
+		float $planetLevel,
+		int $accuracyBonus,
+		float $expected,
+	): void {
+		$planet = $this->createStub(Planet::class);
+		$planet->method('getLevel')->willReturn($planetLevel);
+		$planet->method('getAccuracyBonus')->willReturn($accuracyBonus);
+		$targetPlayer = $this->createPlayer($playerLevel);
+
+		$result = $this->createWeapon(isTurret: $isTurret)
+			->getModifiedPlanetAccuracyAgainstPlayer($planet, $targetPlayer);
+		self::assertEqualsWithDelta($expected, $result, 0.0001);
+	}
+
+	// Private helper functions -----------------------------------------------
+
+	private function createWeapon(bool $isTurret = false): Weapon {
+		return new class ($isTurret) extends Weapon {
+
+			public function __construct(private readonly bool $isTurret) {}
+
+			public function getBaseAccuracy(): int {
+				return 60;
+			}
+
+			public function getWeaponTypeID(): int {
+				return $this->isTurret ? WEAPON_PLANET_TURRET : 0;
+			}
+
+			/** @return array{Shield: int, Armour: int, Rollover: bool} */
+			public function getDamage(): array {
+				return ['Shield' => 11, 'Armour' => 9, 'Rollover' => false];
+			}
+
+		};
+	}
+
+	/** @return array{Shield: int, Armour: int, Rollover: bool} */
+	private function baseDamage(): array {
+		return ['Shield' => 11, 'Armour' => 9, 'Rollover' => false];
+	}
+
+	private function createPlayer(int $level, int $mr = 0): Player {
+		$ship = $this->createStub(AbstractShip::class);
+		$ship->method('getMR')->willReturn($mr);
+		$player = $this->createStub(Player::class);
+		$player->method('getLevelID')->willReturn($level);
+		$player->method('getShip')->willReturn($ship);
+		return $player;
+	}
+
+}


### PR DESCRIPTION
Cover the non-throwing modified damage and accuracy methods for every concrete AbstractWeapon type. Use stubs to avoid Database interaction. Minimal coverage of highest-level `shoot*` methods, except for a few special cases.

These tests are useful to help avoid regressions in an upcoming Combat refactor.