### PR TITLE
AttackPlanet: fix serialized planet issue in render

### DIFF
--- a/src/pages/Player/AttackPlanet.php
+++ b/src/pages/Player/AttackPlanet.php
@@ -7,11 +7,12 @@ use Smr\Page\PlayerPage;
 use Smr\Planet;
 use Smr\Player;
 use Smr\Template;
+use Smr\Sector;
 
 class AttackPlanet extends PlayerPage {
 
 	public function __construct(
-		private readonly Planet $planet,
+		private readonly int $sectorID,
 		private readonly PlanetFullCombatResults $results,
 		bool $playerDied,
 	) {
@@ -20,11 +21,18 @@ class AttackPlanet extends PlayerPage {
 	}
 
 	public function build(Player $player, Template $template): void {
+		// Either player or planet may no longer be in sector
+		$sector = Sector::getSector($player->getGameID(), $this->sectorID);
+		if (!$sector->hasPlanet()) {
+			new CurrentSector(message: 'The planet no longer exists!')->go();
+		}
+		$planet = $sector->getPlanet();
+
 		$template->pageRenderer = fn() => AttackPlanetRenderer::render(
 			template: $template,
 			FullPlanetCombatResults: $this->results,
 			OverrideDeath: $player->isDead(),
-			Planet: $this->planet,
+			Planet: $planet,
 			ThisPlayer: $player,
 		);
 	}

--- a/src/pages/Player/AttackPlanet.php
+++ b/src/pages/Player/AttackPlanet.php
@@ -4,10 +4,9 @@ namespace Smr\Pages\Player;
 
 use Smr\Combat\Results\PlanetFullCombatResults;
 use Smr\Page\PlayerPage;
-use Smr\Planet;
 use Smr\Player;
-use Smr\Template;
 use Smr\Sector;
+use Smr\Template;
 
 class AttackPlanet extends PlayerPage {
 

--- a/src/pages/Player/AttackPlanetProcessor.php
+++ b/src/pages/Player/AttackPlanetProcessor.php
@@ -143,7 +143,7 @@ class AttackPlanetProcessor extends PlayerPageProcessor {
 		}
 
 		// If they died on the shot they get to see the results
-		$container = new AttackPlanet($planet, $results, $player->isDead());
+		$container = new AttackPlanet($planet->getSectorID(), $results, $player->isDead());
 		$container->go();
 	}
 


### PR DESCRIPTION
Fix planets always displaying "You have breached the defenses" after an ajax load of the planet result screen. This was broken because we were storing the Planet in the AttackPlanet page as a property, and when the session serialized it, it strips all the combat info (because it is only intended for combat logs and sector maps) and thus was showing as busted due to the uninitialized non-deserialized properties.

Note that we still need to pass in the sector ID, because if we try to get the sector ID from the attacking player sector ID, it will be buggy if the attacking player is podded (because they will no longer be in the same sector as the planet, and then the `skipRedirect` setting fails).

This was only a display bug.