### PR TITLE
.env.sample: default to source assets

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,5 +27,6 @@ SMR_BASE_IMG_SERVICE=smr-base-img-local
 SMR_BASE_SRC_SERVICE=smr-base-src-mount
 SMR_HOST_RULE=HostRegexp(`.+`)
 NO_DEV=0
+SMR_DEV_ASSETS=true
 DISABLE_PHPDI_COMPILATION=true
 #XDEBUG_MODE=profile


### PR DESCRIPTION
Restore the behavior of using source assets by default in the sample. This is commonly used for dev environments, and so should reflect the recommended dev settings. The SMR_DEV_ASSETS variable was accidentally omitted when we switched from grunt to esbuild.