### PR TITLE
Fix bug in calculating port/planet downgrade chance

### DIFF
--- a/src/lib/Smr/Combat/NormalDamageTeamResultsResolver.php
+++ b/src/lib/Smr/Combat/NormalDamageTeamResultsResolver.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Combat;
+
+use Smr\Combat\Results\Damage\NormalDamageTeamTotals;
+
+/**
+ * Aggregates the normal damage dealt by a team in one round of combat.
+ */
+final class NormalDamageTeamResultsResolver {
+
+	/**
+	 * @param array<int, \Smr\Combat\Results\Combatant\CombatantResult<NormalCombatantInterface>> $combatantResults
+	 */
+	public static function resolve(array $combatantResults): NormalDamageTeamTotals {
+		$totalDamage = 0;
+		$shieldDamage = 0;
+		foreach ($combatantResults as $combatantResult) {
+			$totalDamage += $combatantResult->getTotalDamage();
+			$shieldDamage += $combatantResult->getTotalShieldDamage();
+		}
+		return new NormalDamageTeamTotals(
+			totalDamage: $totalDamage,
+			shieldDamage: $shieldDamage,
+		);
+	}
+
+}

--- a/src/lib/Smr/Combat/Results/Combatant/CombatantResult.php
+++ b/src/lib/Smr/Combat/Results/Combatant/CombatantResult.php
@@ -3,6 +3,7 @@
 namespace Smr\Combat\Results\Combatant;
 
 use Smr\Combat\CombatantInterface;
+use Smr\Combat\Results\Damage\NormalTakenDamage;
 use Smr\Combat\Results\Weapon\HitWeaponResult;
 
 /**
@@ -48,20 +49,42 @@ class CombatantResult {
 	 */
 	public function getTotalDamagePerTarget(): array {
 		$totals = [];
-		$allResults = $this->weaponResults;
-		if ($this->dronesResult !== null) {
-			$allResults[] = $this->dronesResult;
-		}
-		foreach ($allResults as $result) {
-			if ($result instanceof HitWeaponResult) {
-				$targetID = $result->target->getCombatID();
-				if (!array_key_exists($targetID, $totals)) {
-					$totals[$targetID] = 0;
-				}
-				$totals[$targetID] += $result->actualDamage->totalDamage;
+		foreach ($this->getHitWeaponResults() as $result) {
+			$targetID = $result->target->getCombatID();
+			if (!array_key_exists($targetID, $totals)) {
+				$totals[$targetID] = 0;
 			}
+			$totals[$targetID] += $result->actualDamage->totalDamage;
 		}
 		return $totals;
+	}
+
+	/**
+	 * Returns the total actual damage to shields by this combatant in this round of combat.
+	 * Includes shield damage from both weapon and CD NormalDamage hits.
+	 */
+	public function getTotalShieldDamage(): int {
+		$shieldDamage = 0;
+		foreach ($this->getHitWeaponResults() as $result) {
+			if ($result->actualDamage instanceof NormalTakenDamage) {
+				$shieldDamage += $result->actualDamage->shieldDamage;
+			}
+		}
+		return $shieldDamage;
+	}
+
+	/**
+	 * @return iterable<HitWeaponResult<TTarget>>
+	 */
+	private function getHitWeaponResults(): iterable {
+		foreach ($this->weaponResults as $result) {
+			if ($result instanceof HitWeaponResult) {
+				yield $result;
+			}
+		}
+		if ($this->dronesResult !== null) {
+			yield $this->dronesResult;
+		}
 	}
 
 }

--- a/src/lib/Smr/Combat/Results/Damage/NormalDamageTeamTotals.php
+++ b/src/lib/Smr/Combat/Results/Damage/NormalDamageTeamTotals.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Smr\Combat\Results\Damage;
+
+/**
+ * Stores normal damage dealt by one team of combatants.
+ */
+final readonly class NormalDamageTeamTotals {
+
+	public function __construct(
+		public int $totalDamage,
+		public int $shieldDamage,
+	) {}
+
+	/**
+	 * Damage that can contribute to port or planet downgrades.
+	 */
+	public function getNonShieldDamage(): int {
+		return $this->totalDamage - $this->shieldDamage;
+	}
+
+}

--- a/src/pages/Admin/CombatSimulatorProcessor.php
+++ b/src/pages/Admin/CombatSimulatorProcessor.php
@@ -3,6 +3,7 @@
 namespace Smr\Pages\Admin;
 
 use Smr\Account;
+use Smr\Combat\NormalDamageTeamResultsResolver;
 use Smr\Combat\Results\Combatant\TeamCombatResults;
 use Smr\Combat\Results\Full\TraderFullCombatResults;
 use Smr\DummyShip;
@@ -16,22 +17,20 @@ use Smr\Request;
  */
 function runAnAttack(array $realAttackers, array $realDefenders): TraderFullCombatResults {
 	$attackerResults = [];
-	$attackerTotalDamage = 0;
 	$defenderResults = [];
-	$defenderTotalDamage = 0;
 	foreach ($realAttackers as $teamPlayer) {
 		$playerResults = $teamPlayer->getShip()->shootPlayers($realDefenders);
 		$attackerResults[] = $playerResults;
-		$attackerTotalDamage += $playerResults->getTotalDamage();
 	}
 	foreach ($realDefenders as $teamPlayer) {
 		$playerResults = $teamPlayer->getShip()->shootPlayers($realAttackers);
 		$defenderResults[] = $playerResults;
-		$defenderTotalDamage += $playerResults->getTotalDamage();
 	}
+	$attackerTotals = NormalDamageTeamResultsResolver::resolve($attackerResults);
+	$defenderTotals = NormalDamageTeamResultsResolver::resolve($defenderResults);
 	return new TraderFullCombatResults(
-		attackers: new TeamCombatResults($attackerTotalDamage, $attackerResults),
-		defenders: new TeamCombatResults($defenderTotalDamage, $defenderResults),
+		attackers: new TeamCombatResults($attackerTotals->totalDamage, $attackerResults),
+		defenders: new TeamCombatResults($defenderTotals->totalDamage, $defenderResults),
 	);
 }
 

--- a/src/pages/Player/AttackPlanetProcessor.php
+++ b/src/pages/Player/AttackPlanetProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Smr\Pages\Player;
 
+use Smr\Combat\NormalDamageTeamResultsResolver;
 use Smr\Combat\Results\Combatant\PlanetAttackerCombatResults;
 use Smr\Combat\Results\Full\PlanetFullCombatResults;
 use Smr\Database;
@@ -61,7 +62,6 @@ class AttackPlanetProcessor extends PlayerPageProcessor {
 		// ********************************
 
 		$attackerResults = [];
-		$totalDamage = 0;
 
 		// take the turns
 		$player->takeTurns(TURNS_TO_SHOOT_PLANET);
@@ -73,21 +73,18 @@ class AttackPlanetProcessor extends PlayerPageProcessor {
 			$attacker->getShip()->decloak();
 		}
 
-		$totalShieldDamage = 0;
 		foreach ($attackers as $attacker) {
 			$playerResults = $attacker->getShip()->shootPlanet($planet);
 			$attackerResults[$attacker->getAccountID()] = $playerResults;
-			$totalDamage += $playerResults->getTotalDamage();
-			foreach ($playerResults->weaponResults as $weapon) {
-				if (isset($weapon->actualDamage)) { // Only set if the weapon hits
-					$totalShieldDamage += $weapon->actualDamage->shieldDamage;
-				}
-			}
 		}
 
 		// Planet downgrades only occur on non-shield damage
-		$downgradeDamage = $totalDamage - $totalShieldDamage;
-		$attackerResults = new PlanetAttackerCombatResults($totalDamage, $attackerResults, $planet->checkForDowngrade($downgradeDamage));
+		$damageTotals = NormalDamageTeamResultsResolver::resolve($attackerResults);
+		$attackerResults = new PlanetAttackerCombatResults(
+			totalDamage: $damageTotals->totalDamage,
+			traders: $attackerResults,
+			downgrades: $planet->checkForDowngrade($damageTotals->getNonShieldDamage()),
+		);
 
 		$results = new PlanetFullCombatResults(
 			attackers: $attackerResults,

--- a/src/pages/Player/AttackPlayerProcessor.php
+++ b/src/pages/Player/AttackPlayerProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Smr\Pages\Player;
 
+use Smr\Combat\NormalDamageTeamResultsResolver;
 use Smr\Combat\Results\Combatant\TeamCombatResults;
 use Smr\Combat\Results\Full\TraderFullCombatResults;
 use Smr\Database;
@@ -71,11 +72,9 @@ class AttackPlayerProcessor extends PlayerPageProcessor {
 
 		$teamAttack = function(string $attack, string $defend) use ($fightingPlayers): TeamCombatResults {
 			$traders = [];
-			$totalDamage = 0;
 			foreach ($fightingPlayers[$attack] as $teamPlayer) {
 				$playerResults = $teamPlayer->getShip()->shootPlayers($fightingPlayers[$defend]);
 				$traders[$teamPlayer->getAccountID()] = $playerResults;
-				$totalDamage += $playerResults->getTotalDamage();
 
 				// Award assists (if there are multiple attackers)
 				if (count($fightingPlayers[$attack]) > 1) {
@@ -90,7 +89,8 @@ class AttackPlayerProcessor extends PlayerPageProcessor {
 					}
 				}
 			}
-			return new TeamCombatResults($totalDamage, $traders);
+			$totals = NormalDamageTeamResultsResolver::resolve($traders);
+			return new TeamCombatResults($totals->totalDamage, $traders);
 		};
 
 		$results = new TraderFullCombatResults(

--- a/src/pages/Player/AttackPortProcessor.php
+++ b/src/pages/Player/AttackPortProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Smr\Pages\Player;
 
+use Smr\Combat\NormalDamageTeamResultsResolver;
 use Smr\Combat\Results\Combatant\PortAttackerCombatResults;
 use Smr\Combat\Results\Full\PortFullCombatResults;
 use Smr\Database;
@@ -58,7 +59,6 @@ class AttackPortProcessor extends PlayerPageProcessor {
 		// ********************************
 
 		$attackerResults = [];
-		$totalDamage = 0;
 
 		$port->attackedBy($player, $attackers);
 
@@ -68,21 +68,18 @@ class AttackPortProcessor extends PlayerPageProcessor {
 			$attacker->getShip()->decloak();
 		}
 
-		$totalShieldDamage = 0;
 		foreach ($attackers as $attacker) {
 			$playerResults = $attacker->getShip()->shootPort($port);
 			$attackerResults[$attacker->getAccountID()] = $playerResults;
-			$totalDamage += $playerResults->getTotalDamage();
-			foreach ($playerResults->weaponResults as $weapon) {
-				if (isset($weapon->actualDamage)) { // Only set if the weapon hits
-					$totalShieldDamage += $weapon->actualDamage->shieldDamage;
-				}
-			}
 		}
 
 		// Port downgrades only occur on non-shield damage
-		$downgradeDamage = $totalDamage - $totalShieldDamage;
-		$attackerResults = new PortAttackerCombatResults($totalDamage, $attackerResults, $port->checkForDowngrade($downgradeDamage));
+		$damageTotals = NormalDamageTeamResultsResolver::resolve($attackerResults);
+		$attackerResults = new PortAttackerCombatResults(
+			totalDamage: $damageTotals->totalDamage,
+			traders: $attackerResults,
+			downgrades: $port->checkForDowngrade($damageTotals->getNonShieldDamage()),
+		);
 
 		$results = new PortFullCombatResults(
 			attackers: $attackerResults,

--- a/test/SmrTest/lib/Combat/NormalDamageTeamResultsResolverTest.php
+++ b/test/SmrTest/lib/Combat/NormalDamageTeamResultsResolverTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib\Combat;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Smr\AbstractShip;
+use Smr\Combat\NormalDamageTeamResultsResolver;
+use Smr\Combat\Results\Combatant\CombatantResult;
+use Smr\Combat\Results\Damage\NormalDamageTeamTotals;
+use Smr\Combat\Results\Damage\NormalTakenDamage;
+use Smr\Combat\Results\Damage\WeaponDamage;
+use Smr\Combat\Results\Weapon\HitWeaponResult;
+use Smr\Combat\Results\Weapon\MissedWeaponResult;
+use Smr\Combat\Weapon\CombatDrones;
+
+#[CoversClass(NormalDamageTeamResultsResolver::class)]
+#[CoversClass(NormalDamageTeamTotals::class)]
+class NormalDamageTeamResultsResolverTest extends TestCase {
+
+	public function test_resolve_includes_weapon_and_drone_shield_damage(): void {
+		$attacker = $this->createShip();
+		$target = $this->createShip();
+		$results = [
+			CombatantResult::create(
+				combatant: $attacker,
+				weaponResults: [
+					$this->createHit($target, shieldDamage: 2, armourDamage: 3),
+					new MissedWeaponResult(new CombatDrones(1), $target),
+				],
+				dronesResult: $this->createHit($target, shieldDamage: 4, armourDamage: 5),
+			),
+		];
+
+		$totals = NormalDamageTeamResultsResolver::resolve($results);
+
+		self::assertSame(14, $totals->totalDamage);
+		self::assertSame(6, $totals->shieldDamage);
+		self::assertSame(8, $totals->getNonShieldDamage());
+	}
+
+	private function createShip(): AbstractShip {
+		return $this->createStub(AbstractShip::class);
+	}
+
+	/**
+	 * @return HitWeaponResult<AbstractShip>
+	 */
+	private function createHit(
+		AbstractShip $target,
+		int $shieldDamage,
+		int $armourDamage,
+	): HitWeaponResult {
+		return new HitWeaponResult(
+			weapon: new CombatDrones(1),
+			target: $target,
+			weaponDamage: new WeaponDamage(
+				shieldDamage: $shieldDamage,
+				armourDamage: $armourDamage,
+				damageRollover: false,
+			),
+			actualDamage: new NormalTakenDamage(
+				killingShot: false,
+				targetAlreadyDead: false,
+				shieldDamage: $shieldDamage,
+				combatDroneDamage: 0,
+				numCombatDrones: 0,
+				hasCombatDrones: false,
+				armourDamage: $armourDamage,
+				totalDamage: $shieldDamage + $armourDamage,
+			),
+			killResult: null,
+		);
+	}
+
+}

--- a/test/SmrTest/lib/Combat/Results/Combatant/CombatantResultTest.php
+++ b/test/SmrTest/lib/Combat/Results/Combatant/CombatantResultTest.php
@@ -34,6 +34,7 @@ class CombatantResultTest extends TestCase {
 		);
 
 		self::assertSame([2 => 7, 3 => 5], $result->getTotalDamagePerTarget());
+		self::assertSame(12, $result->getTotalShieldDamage());
 	}
 
 	public function test_getTotalDamage_sums_damage_across_targets(): void {


### PR DESCRIPTION
Previously, we were unintentionally including drone shield damage in the total damage used to compute port/planet downgrade chance. Given enough attackers with drones, this could result in unexpected downgrades while the shields were still up. (Nominally, while shields are up, you only get the non-shield damage from armour-only weapon piercing, which is usually not enough to trigger downgrades.)

The fix only requires adding drone shield damage to shield damage total calculations. However, we centralize this logic, along with the total damage calculation, into a NormalDamageTeamResultsResolver. This ensures consistency between Port/PlanetAttackProcessor, and leaves them focused on executing attacks while the resolver focuses on the shared totals.