### PR TITLE
AttackPort: fix diplay when attacking player dies

### DIFF
--- a/src/pages/Player/AttackPort.php
+++ b/src/pages/Player/AttackPort.php
@@ -5,11 +5,13 @@ namespace Smr\Pages\Player;
 use Smr\Combat\Results\Full\PortFullCombatResults;
 use Smr\Page\PlayerPage;
 use Smr\Player;
+use Smr\Sector;
 use Smr\Template;
 
 class AttackPort extends PlayerPage {
 
 	public function __construct(
+		private readonly int $sectorID,
 		private readonly ?PortFullCombatResults $results = null,
 		bool $playerDied = false,
 	) {
@@ -18,7 +20,8 @@ class AttackPort extends PlayerPage {
 	}
 
 	public function build(Player $player, Template $template): void {
-		$sector = $player->getSector();
+		// Either player or port may no longer be in sector
+		$sector = Sector::getSector($player->getGameID(), $this->sectorID);
 		if (!$sector->hasPort()) {
 			new CurrentSector(message: 'The port no longer exists!')->go();
 		}

--- a/src/pages/Player/AttackPortConfirm.php
+++ b/src/pages/Player/AttackPortConfirm.php
@@ -17,7 +17,7 @@ class AttackPortConfirm extends PlayerPage {
 		$port = $sector->getPort();
 
 		if ($port->isBusted()) {
-			new AttackPort()->go();
+			new AttackPort($sector->getSectorID())->go();
 		}
 
 		$template->pageTopic = 'Port Raid: Sector #' . $port->getSectorID();

--- a/src/pages/Player/AttackPortProcessor.php
+++ b/src/pages/Player/AttackPortProcessor.php
@@ -44,7 +44,7 @@ class AttackPortProcessor extends PlayerPageProcessor {
 		}
 
 		if ($port->isBusted()) {
-			new AttackPort()->go();
+			new AttackPort($sector->getSectorID())->go();
 		}
 
 		$attackers = $sector->getFightingTradersAgainstPort($player, $port);
@@ -122,7 +122,7 @@ class AttackPortProcessor extends PlayerPageProcessor {
 		}
 
 		// If they died on the shot they get to see the results
-		$container = new AttackPort($results, $player->isDead());
+		$container = new AttackPort($sector->getSectorID(), $results, $player->isDead());
 		$container->go();
 	}
 


### PR DESCRIPTION
If the attacking player is podded, they will no longer be in the same sector as the port, and so we lose the `skipRedirect` setting, due to the "port not in sector" error.

The fix is to get the sectorID independent of the player sector, as we did for AttackPlanet in #2509.