### PR TITLE
AttackPort: fix displaying loot options after bust

### DIFF
--- a/src/pages/Player/AttackPort.php
+++ b/src/pages/Player/AttackPort.php
@@ -24,13 +24,15 @@ class AttackPort extends PlayerPage {
 		}
 		$port = $sector->getPort();
 
-		if ($this->results !== null) {
-			$alreadyDestroyed = false;
-			$creditedAttacker = false;
-		} else {
-			$alreadyDestroyed = true;
-			$creditedAttacker = $port->isCreditedAttacker($player);
-		}
+		// Display port already destroyed page content if port is busted and we don't
+		// have existing combat results to display.
+		$hasResults = $this->results !== null;
+		$alreadyDestroyed = $port->isBusted() && !$hasResults;
+
+		// If port is busted and we do have combat results, it means the player has
+		// attacked the port, and we can skip the credited check as an optimization.
+		// (Note: credited attackers may not have been present for kill)
+		$creditedAttacker = $port->isBusted() && ($hasResults || $port->isCreditedAttacker($player));
 
 		$template->pageRenderer = fn() => AttackPortRenderer::render(
 			template: $template,


### PR DESCRIPTION
For the attacking player, once the port is busted, they should be considered a credited attacker (that is, having a combat result should not preclude crediting).

This error was introduced in b2bfa2e83 during the Renderer refactor, but the new logic is even more robust because it first considers whether or not the port is actually busted before setting post-bust variables.