### PR TITLE
Planet: fix downgrade check on Sentinel Outpost

### DIFF
--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -1280,7 +1280,8 @@ class Planet implements NormalCombatantInterface {
 			if (flip_coin(self::CHANCE_TO_DOWNGRADE)) {
 				$chanceFactors = [];
 				foreach ($this->getStructureTypes() as $structureID => $structure) {
-					$chanceFactors[$structureID] = ($this->getBuilding($structureID) / $this->getMaxBuildings($structureID)) / $structure->baseTime();
+					// Gracefully handle structures with 0 build time (Sentinel Outpost)
+					$chanceFactors[$structureID] = ($this->getBuilding($structureID) / $this->getMaxBuildings($structureID)) / ($structure->baseTime() + 1);
 				}
 				$destroyID = getWeightedRandom($chanceFactors);
 				$this->destroyBuilding($destroyID, 1);


### PR DESCRIPTION
Because this planet type has 0 build times for structures, we were getting division by 0 errors in the downgrade check due to how we construct the probabilities for each structure to be targeted.

The simple fix is to just add 1 to the denomenator to make sure it is never 0. Because the build times for normal planets are much greater than 1, this has no practical impact on any real likelihoods.