### PR TITLE
Add missing "Under Attack" warning to Freon22 template

### DIFF
--- a/src/htdocs/css/Freon22-layout.css
+++ b/src/htdocs/css/Freon22-layout.css
@@ -142,7 +142,12 @@ div#LeftNavTwo {
  *****************************************************/
 div.rightInfoMail {
 	padding: 0px 10px;
-	margin: 0px 10px;
+	margin: 0px 50px 0px 10px;
+}
+#attack_area:not(:empty) {
+	/* align with the rightInfoShip panel */
+	display: block;
+	margin: 0px 50px 10px 10px;
 }
 div.rightInfoShip {
 	font-weight: bold;

--- a/src/pages/Layout/Freon22SkeletonRenderer.php
+++ b/src/pages/Layout/Freon22SkeletonRenderer.php
@@ -87,6 +87,12 @@ class Freon22SkeletonRenderer extends AbstractSkeletonRenderer {
 							</td>
 							<td class="rightCell bottom"><?php
 								if ($data->rightPanelData !== null) { ?>
+									<span id="attack_area"><?php
+										if ($data->rightPanelData->underAttack) { ?>
+											<p class="attack_warning">You Are Under Attack!</p>
+											<script>triggerAttackBlink('3B1111');</script><?php
+										} ?>
+									</span>
 									<div class="rightInfoMail noWrap"><?php
 										UnreadMessagesRenderer::render($data->rightPanelData->unreadMessages); ?>
 									</div><?php


### PR DESCRIPTION
Users with the Freon22 template will now get the blinking warning when they are under attack.

Adjusted the CSS so that it lines up with the right ship panel.