### PR TITLE
AttackPlanet: fix combat result display on planet deletion

### DIFF
--- a/src/pages/Player/AttackPlanet.php
+++ b/src/pages/Player/AttackPlanet.php
@@ -4,8 +4,8 @@ namespace Smr\Pages\Player;
 
 use Smr\Combat\Results\Full\PlanetFullCombatResults;
 use Smr\Page\PlayerPage;
+use Smr\Planet;
 use Smr\Player;
-use Smr\Sector;
 use Smr\Template;
 
 class AttackPlanet extends PlayerPage {
@@ -20,18 +20,15 @@ class AttackPlanet extends PlayerPage {
 	}
 
 	public function build(Player $player, Template $template): void {
-		// Either player or planet may no longer be in sector
-		$sector = Sector::getSector($player->getGameID(), $this->sectorID);
-		if (!$sector->hasPlanet()) {
-			new CurrentSector(message: 'The planet no longer exists!')->go();
-		}
-		$planet = $sector->getPlanet();
-
+		// Note that either player (due to death) or planet (due to being deleted,
+		// e.g. Sentinel Outpost) may no longer be in sector. In the case of a
+		// deleted planet, Planet::getPlanet returns an empty Planet object, which
+		// will allow the final combat result to be displayed.
 		$template->pageRenderer = fn() => AttackPlanetRenderer::render(
 			template: $template,
 			FullPlanetCombatResults: $this->results,
 			OverrideDeath: $player->isDead(),
-			Planet: $planet,
+			Planet: Planet::getPlanet($player->getGameID(), $this->sectorID),
 			ThisPlayer: $player,
 		);
 	}


### PR DESCRIPTION
On the shot where the Sentinel Outpost is destroyed, the planet will no longer exist in sector. Therefore, remove the Current Sector redirect in this case so that we can display the final combat result.

Revert to the logic that was used prior to 2eb79ad85. This works correctly both for the page serialization (fixed a different way in PR #2509) and for displaying the final combat result for the Sentinel Outpost planet type (due to deletion on destruction).