### PR TITLE
Scale combat drone damage by level against Port/Planet

### DIFF
--- a/src/lib/Smr/Combat/Weapon/CombatDrones.php
+++ b/src/lib/Smr/Combat/Weapon/CombatDrones.php
@@ -2,6 +2,7 @@
 
 namespace Smr\Combat\Weapon;
 
+use LogicException;
 use Smr\Combat\CombatantInterface;
 use Smr\Combat\Results\Damage\WeaponDamage;
 use Smr\Combat\Results\Weapon\HitWeaponResult;
@@ -41,9 +42,13 @@ class CombatDrones extends AbstractWeapon {
 		$modifiedAccuracy = $this->getBaseAccuracy();
 		$random = rand(self::MIN_CDS_RAND, self::MAX_CDS_RAND);
 
-		if (($shooter instanceof Force) || !($target instanceof Ship)) {
+		if ($target instanceof Force || $shooter instanceof Force) {
 			$modifiedAccuracy += $random;
-		} else {
+		} elseif ($target instanceof Port) {
+			$modifiedAccuracy += $random + 0.4 * $shooter->getLevel() - 6 - $target->getLevel() / 2;
+		} elseif ($target instanceof Planet) {
+			$modifiedAccuracy += $random + 0.4 * $shooter->getLevel() - 6 - $target->getLevel() / 10;
+		} elseif ($target instanceof Ship) {
 			// Player vs. Player
 			assert($shooter instanceof Ship);
 			$levelRand = rand(IFloor($shooter->getLevel() / 2), $shooter->getLevel());
@@ -53,6 +58,8 @@ class CombatDrones extends AbstractWeapon {
 			if ($mrDiff > 0) {
 				$modifiedAccuracy -= $this->getBaseAccuracy() * ($mrDiff / MR_FACTOR) / 100;
 			}
+		} else {
+			throw new LogicException('Should not happen: unhandled combatant types');
 		}
 
 		return max(0, min(100, $modifiedAccuracy));

--- a/test/SmrTest/lib/Combat/Weapon/CombatDronesTest.php
+++ b/test/SmrTest/lib/Combat/Weapon/CombatDronesTest.php
@@ -61,24 +61,42 @@ class CombatDronesTest extends TestCase {
 		self::assertSame(51.0, $result);
 	}
 
-	public function test_getModifiedAccuracyAgainstPort_adds_random_accuracy(): void {
+	#[TestWith([1, 1, 44.9])]
+	#[TestWith([1, 9, 40.9])]
+	#[TestWith([50, 1, 64.5])]
+	#[TestWith([50, 9, 60.5])]
+	public function test_getModifiedAccuracyAgainstPort_applies_level_modifiers(
+		int $playerLevel,
+		int $portLevel,
+		float $expected,
+	): void {
 		$drones = $this->createDrones();
-		$ship = $this->createShip();
+		$ship = $this->createShip(level: $playerLevel);
 		$port = $this->createStub(Port::class);
+		$port->method('getLevel')->willReturn($portLevel);
 		srand(1);
 
 		$result = $drones->getModifiedAccuracyAgainstTarget($ship, $port);
-		self::assertSame(51.0, $result);
+		self::assertSame($expected, $result);
 	}
 
-	public function test_getModifiedAccuracyAgainstPlanet_adds_random_accuracy(): void {
+	#[TestWith([1, 5.0, 44.9])]
+	#[TestWith([1, 45.0, 40.9])]
+	#[TestWith([50, 5.0, 64.5])]
+	#[TestWith([50, 45.0, 60.5])]
+	public function test_getModifiedAccuracyAgainstPlanet_applies_level_modifiers(
+		int $playerLevel,
+		float $planetLevel,
+		float $expected,
+	): void {
 		$drones = $this->createDrones();
-		$ship = $this->createShip();
+		$ship = $this->createShip(level: $playerLevel);
 		$planet = $this->createStub(Planet::class);
+		$planet->method('getLevel')->willReturn($planetLevel);
 		srand(1);
 
 		$result = $drones->getModifiedAccuracyAgainstTarget($ship, $planet);
-		self::assertSame(51.0, $result);
+		self::assertSame($expected, $result);
 	}
 
 	#[TestWith([0, 32.7477777778])]
@@ -104,6 +122,24 @@ class CombatDronesTest extends TestCase {
 
 		$result = $drones->getModifiedAccuracyAgainstTarget($forces, $targetShip);
 		self::assertSame(51.0, $result);
+	}
+
+	public function test_getModifiedPlanetAccuracyAgainstPlayer(): void {
+		$drones = $this->createDrones();
+		$planet = $this->createStub(Planet::class);
+		$targetShip = $this->createShip();
+
+		$result = $drones->getModifiedAccuracyAgainstTarget($planet, $targetShip);
+		self::assertSame(100.0, $result);
+	}
+
+	public function test_getModifiedPortAccuracyAgainstPlayer(): void {
+		$drones = $this->createDrones();
+		$port = $this->createStub(Port::class);
+		$targetShip = $this->createShip();
+
+		$result = $drones->getModifiedAccuracyAgainstTarget($port, $targetShip);
+		self::assertSame(100.0, $result);
 	}
 
 	// Test Damage methods ----------------------------------------------------
@@ -141,7 +177,7 @@ class CombatDronesTest extends TestCase {
 		$port = $this->createStub(Port::class);
 		srand(1);
 
-		$expected = $this->damage(amount: 12, launched: 6);
+		$expected = $this->damage(amount: 10, launched: 5);
 		$result = $drones->getModifiedDamageAgainstTarget($ship, $port);
 		self::assertEquals($expected, $result);
 	}
@@ -152,7 +188,7 @@ class CombatDronesTest extends TestCase {
 		$planet = $this->createStub(Planet::class);
 		srand(1);
 
-		$expected = $this->damage(amount: 3, launched: 6);
+		$expected = $this->damage(amount: 2, launched: 5);
 		$result = $drones->getModifiedDamageAgainstTarget($ship, $planet);
 		self::assertEquals($expected, $result);
 	}


### PR DESCRIPTION
There was no apparent reason why CD damage was not influenced by level for PvE combat. My guess is it was an oversight. As a result, ITMS was almost always near the bottom of the rankings for PvE damage. Adding some level scaling provides an incentive to gain levels and gives CD ships a small boost.

Here are the changes:

* Accuracy now scales linearly with player and port/planet levels.

* For a min level port or planet, CDs will do more damage above level 15 (up to a maximum of +14% accuracy at level 50) and less damage below (down to a minimum of -6% accuracy at level 1).

* For a max level port or (Terran) planet, CDs will do more damage above level 25 (up to a maximum of +10% accuracy at level 50) and less damage below (down to a minimum of -10% accuracy at level 1).

In testing, this makes an ITMS with a PPL comparable to (but slightly below) a Dev with all lasers across most PvE combat scenarios.