### PR TITLE
Handle case where you lose more turns than you have

### DIFF
--- a/src/lib/Smr/Player.php
+++ b/src/lib/Smr/Player.php
@@ -2629,11 +2629,16 @@ class Player {
 		if ($take < 0 || $takeNewbie < 0) {
 			throw new Exception('Trying to take negative turns.');
 		}
-		$take = ICeil($take);
 		// Only take up to as many newbie turns as we have remaining
 		$takeNewbie = min($this->getNewbieTurns(), $takeNewbie);
 
-		$this->setTurns($this->getTurns() - $take);
+		// Turns can't go below 0, but we can delay the next turn update
+		$newTurns = $this->getTurns() - $take;
+		if ($newTurns < 0) {
+			$this->setLastTurnUpdateFromTurnsChange(-$newTurns);
+		}
+
+		$this->setTurns($newTurns);
 		$this->setNewbieTurns($this->getNewbieTurns() - $takeNewbie);
 		$this->increaseHOF($take, ['Movement', 'Turns Used', 'Since Last Death'], HOF_ALLIANCE);
 		$this->increaseHOF($take, ['Movement', 'Turns Used', 'Total'], HOF_ALLIANCE);
@@ -2671,7 +2676,13 @@ class Player {
 	public function getTimeUntilNextTurn(): int {
 		$secondsSinceUpdate = Epoch::time() - $this->getLastTurnUpdate();
 		$secondsPerTurn = 3600 / $this->getShip()->getRealSpeed();
-		return ICeil(fmod(abs($secondsSinceUpdate - $secondsPerTurn), $secondsPerTurn));
+		$secondsDiff = $secondsPerTurn - $secondsSinceUpdate;
+		// Handle the case where we're in turn debt
+		if ($secondsSinceUpdate <= 0) {
+			return ICeil($secondsDiff);
+		}
+		// Normal case, next turn comes within one $secondsPerTurn increment
+		return ICeil(fmod(abs($secondsDiff), $secondsPerTurn));
 	}
 
 	/**
@@ -2703,10 +2714,17 @@ class Player {
 		// do we have at least one turn to give?
 		if ($extraTurns > 0) {
 			// recalc the time to avoid rounding errors
-			$newLastTurnUpdate = $this->getLastTurnUpdate() + ICeil($extraTurns * 3600 / $this->getShip()->getRealSpeed());
-			$this->setLastTurnUpdate($newLastTurnUpdate);
+			$this->setLastTurnUpdateFromTurnsChange($extraTurns);
 			$this->giveTurns($extraTurns);
 		}
+	}
+
+	/**
+	 * Set the new lastTurnUpdate time corresponding to a given change in turns.
+	 */
+	protected function setLastTurnUpdateFromTurnsChange(int $turns): void {
+		$newLastTurnUpdate = $this->getLastTurnUpdate() + ICeil($turns * 3600 / $this->getShip()->getRealSpeed());
+		$this->setLastTurnUpdate($newLastTurnUpdate);
 	}
 
 	public function getLastTurnUpdate(): int {

--- a/test/SmrTest/Fakes/TurnPlayerFake.php
+++ b/test/SmrTest/Fakes/TurnPlayerFake.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\Fakes;
+
+use Override;
+use Smr\Account;
+use Smr\Ship;
+
+class TurnPlayerFake extends PlayerFake {
+
+	private const int MAX_TURNS = 100;
+
+	public function __construct(
+		private readonly Ship $ship,
+		private readonly Account $account,
+		int $turns,
+		int $lastTurnUpdate,
+	) {
+		parent::__construct(gameID: 1, accountID: 1);
+		$this->turns = $turns;
+		$this->newbieTurns = 0;
+		$this->lastTurnUpdate = $lastTurnUpdate;
+		$this->lastActive = 0;
+		$this->lastCPLAction = 0;
+	}
+
+	#[Override]
+	public function getAccount(): Account {
+		return $this->account;
+	}
+
+	#[Override]
+	public function getMaxTurns(): int {
+		return self::MAX_TURNS;
+	}
+
+	#[Override]
+	public function getShip(bool $forceUpdate = false): Ship {
+		return $this->ship;
+	}
+
+	#[Override]
+	public function increaseHOF(float $amount, array $typeList, string $visibility): void {
+	}
+
+}

--- a/test/SmrTest/lib/PlayerTest.php
+++ b/test/SmrTest/lib/PlayerTest.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Smr\Account;
+use Smr\Container\DiContainer;
+use Smr\Epoch;
+use Smr\Player;
+use Smr\Ship;
+use SmrTest\Fakes\TurnPlayerFake;
+
+#[CoversClass(Player::class)]
+class PlayerTest extends TestCase {
+
+	private const float TURN_SPEED = 10.0;
+	private const int TURN_INTERVAL = 360; // (3600 / TURN_SPEED)
+
+	protected function tearDown(): void {
+		DiContainer::initialize(false);
+	}
+
+	public function test_takeTurns_creates_turn_debt(): void {
+		// Start at 1 turn, take 3, go 2 turns into debt
+		$now = 10_000;
+		$turnsTaken = 3;
+		$this->setTime($now);
+		$player = $this->createPlayer(turns: 1, lastTurnUpdate: $now);
+
+		$player->takeTurns($turnsTaken);
+		$turnDebt = 2;
+
+		self::assertSame(0, $player->getTurns());
+		// Each turn takes 360 seconds at a speed of 10 turns per hour.
+		self::assertSame($now + $turnDebt * self::TURN_INTERVAL, $player->getLastTurnUpdate());
+		// The debt must be repaid before the next usable turn arrives.
+		self::assertSame(($turnDebt + 1) * self::TURN_INTERVAL, $player->getTimeUntilNextTurn());
+	}
+
+	public function test_takeTurns_accounts_for_pending_turns_when_creating_debt(): void {
+		// A stale lastTurnUpdate is effectively pending turns
+		$now = 10_000;
+		$pendingTurns = 2;
+		$turnsTaken = $pendingTurns + 1;
+		$this->setTime($now);
+		$player = $this->createPlayer(
+			turns: 0,
+			lastTurnUpdate: $now - $pendingTurns * self::TURN_INTERVAL,
+		);
+
+		$player->takeTurns($turnsTaken);
+
+		// Two pending turns offset two of the three turns taken, leaving one turn of debt.
+		self::assertSame($now + self::TURN_INTERVAL, $player->getLastTurnUpdate());
+
+		// Advance time and show we gain our turn at the proper time.
+		$this->setTime($now + self::TURN_INTERVAL);
+		$player->updateTurns();
+		self::assertSame(0, $player->getTurns());
+
+		$this->setTime($now + 2 * self::TURN_INTERVAL);
+		$player->updateTurns();
+		self::assertSame(1, $player->getTurns());
+	}
+
+	public function test_getTimeUntilNextTurn_handles_stale_turn_update(): void {
+		$now = 10_000;
+		$this->setTime($now);
+		// One full turn and half of the next have elapsed, so 180 seconds remain.
+		$player = $this->createPlayer(
+			turns: 0,
+			lastTurnUpdate: $now - self::TURN_INTERVAL - self::TURN_INTERVAL / 2,
+		);
+
+		self::assertSame(self::TURN_INTERVAL / 2, $player->getTimeUntilNextTurn());
+	}
+
+	private function setTime(int $time): void {
+		$epoch = $this->createStub(Epoch::class);
+		$epoch->method('getTime')->willReturn($time);
+		DiContainer::getContainer()->set(Epoch::class, $epoch);
+	}
+
+	private function createPlayer(int $turns, int $lastTurnUpdate): TurnPlayerFake {
+		$ship = $this->createStub(Ship::class);
+		$ship->method('getRealSpeed')->willReturn(self::TURN_SPEED);
+		$account = $this->createStub(Account::class);
+		$account->method('isValidated')->willReturn(true);
+
+		return new TurnPlayerFake(
+			ship: $ship,
+			account: $account,
+			turns: $turns,
+			lastTurnUpdate: $lastTurnUpdate,
+		);
+	}
+
+}


### PR DESCRIPTION
If you bump into mines without enough turns to pay the turn penalty, then you effectively circumvent the penalty. This was only a problem in the edge case where you are scouting a mined galaxy while protected and at 0 turns (thus you scout each sector for 1 turn instead of 3).

To avoid converting the turn count into a signed number, we can instead just delay the time until the next turn by setting the lastTurnUpdate into the future (as if you got the turns on advance).

The logic for displaying the time until next turn had to be adjusted for turn debt.

Thanks to StupidNewbie for reporting this issue.