### PR TITLE
Fix hidden JS functions due to esbuild bundling

### DIFF
--- a/src/htdocs/js/course_plot.js
+++ b/src/htdocs/js/course_plot.js
@@ -1,15 +1,15 @@
-function processCourse(sectorID) {
+window.processCourse = function(sectorID) {
 	var plotCourseForm = document.getElementById('plotCourseForm');
 	plotCourseForm.to.value = sectorID;
 	plotCourseForm.submit();
-}
+};
 
-function processRemove(sectorID) {
+window.processRemove = function(sectorID) {
 	var manageDestination = document.getElementById('manageDestination');
 	manageDestination.sectorId.value = sectorID;
 	manageDestination.type.value = 'delete';
 	manageDestination.submit();
-}
+};
 
 $(function() {
 	$('.draggableObject').draggable({ containment: 'parent' });

--- a/src/htdocs/js/filter_list.js
+++ b/src/htdocs/js/filter_list.js
@@ -3,22 +3,22 @@
 var filter = [];
 
 //reset all check boxes
-function resetBoxes() {
+window.resetBoxes = function() {
 	var toggle = document.getElementById("raceform");
 	for (var i = 0; i < toggle.races.length; i++) {
 		toggle.races[i].checked = true;
 	}
-}
+};
 
-function filterSelect(element) {
+window.filterSelect = function(element) {
 	var selected = element.options[element.selectedIndex].value;
 	var columnId = element.parentElement.cellIndex;
 
 	filter[columnId] = [selected];
 	applyFilter('data-list');
-}
+};
 
-function raceToggle() {
+window.raceToggle = function() {
 	var toggle = document.getElementById("raceform");
 	// 1 is the index of the "Race" column
 	filter[1] = [];
@@ -28,7 +28,7 @@ function raceToggle() {
 		}
 	}
 	applyFilter('data-list');
-}
+};
 
 function applyFilter(tableId) {
 	var table = document.getElementById(tableId);

--- a/src/htdocs/js/smr15.js
+++ b/src/htdocs/js/smr15.js
@@ -91,31 +91,31 @@
 })();
 
 // Used by shop_hardware.php
-function recalcOnKeyUp(transaction, hardwareTypeID, cost) {
+window.recalcOnKeyUp = function(transaction, hardwareTypeID, cost) {
 	var form = document.getElementById(transaction + hardwareTypeID);
 	form.total.value = form.amount.value * cost;
-}
+};
 
 // Used by planet_defense.php
-function showWeaponInfo(select) {
+window.showWeaponInfo = function(select) {
 	var target = $(select).data('target');
 	var show = $("option:selected", select).data('show');
 	$(target).children().addClass('hide');
 	$(show).removeClass('hide');
-}
+};
 
 // Used by game_join.php
-function showRaceInfo(select) {
+window.showRaceInfo = function(select) {
 	var race_id = $("option:selected", select).val();
 	document.getElementById('race_image').src = "images/race/race" + race_id + ".jpg";
 	var desc = document.getElementById('race_descr');
 	$(desc).children().addClass('hide');
 	$(".race_descr" + race_id, desc).removeClass('hide');
-	createRaceRadarChart(race_id);
-}
+	window.createRaceRadarChart(race_id);
+};
 
 // Used by game_join.php
-function createRaceRadarChart(race_id) {
+window.createRaceRadarChart = function(race_id) {
 
 	// Each array key is the race ID
 	var races = {
@@ -163,10 +163,10 @@ function createRaceRadarChart(race_id) {
 	};
 
 	Plotly.newPlot('graphframe', data, layout, {staticPlot: true});
-}
+};
 
 // Used by alliance_create.php and alliance_stat.php
-function togglePassword(select) {
+window.togglePassword = function(select) {
 	var showPassword = $(select).val() === "password";
 	// We need to both toggle the element display (for the user) and toggle the
 	// disabled property (for the form submission).
@@ -176,9 +176,9 @@ function togglePassword(select) {
 		$("#password-display").hide();
 	}
 	$("#password-input").prop("disabled", !showPassword);
-}
+};
 
 // Used by message_view.php
-function toggleScoutGroup(senderID) {
+window.toggleScoutGroup = function(senderID) {
 	$('#group'+senderID).toggle();
-}
+};

--- a/src/htdocs/js/weapon_reorder.js
+++ b/src/htdocs/js/weapon_reorder.js
@@ -147,7 +147,7 @@ var table = document.getElementById('weapon_reorder');
 var tableDnD = new TableDnD();
 tableDnD.init(table);
 
-function moveRow(cell, move) {
+window.moveRow = function(cell, move) {
 	var currentRow = cell.parentNode;
 	var currentRowID = false;
 	var rows = currentRow.parentNode.rows;


### PR DESCRIPTION
The esbuild `bundle: true` option wraps each entry point in an IIFE, which hides functions that are not exported onto the window (to avoid leaking names globally). Therefore, all public functions (those called in the PHP) need to be attached to window (by prefixing with `window.`) to preserve the legacy JS function calls.