### PR TITLE
Sector: tighten interface for port/visit methods

### DIFF
--- a/src/lib/Smr/Port.php
+++ b/src/lib/Smr/Port.php
@@ -1212,6 +1212,11 @@ class Port implements NormalCombatantInterface {
 				'limit' => count($accountIDs),
 			]);
 
+			// Unset the cache so the next getCachedPort fetches the new entry
+			foreach ($accountIDs as $accountID) {
+				unset(self::$CACHE_CACHED_PORTS[$this->getGameID()][$this->getSectorID()][$accountID]);
+			}
+
 			unset($cache);
 			return true;
 		}

--- a/src/lib/Smr/Sector.php
+++ b/src/lib/Smr/Sector.php
@@ -210,9 +210,7 @@ class Sector {
 	}
 
 	public function markVisited(Player $player): void {
-		if ($this->hasPort()) {
-			$this->getPort()->addCachePort($player->getAccountID());
-		}
+		$this->getPortOrNull()?->addCachePort($player->getAccountID());
 
 		//now delete the entry from visited
 		if (!$this->isVisited($player)) {
@@ -610,6 +608,11 @@ class Sector {
 		return Port::getPort($this->getGameID(), $this->getSectorID());
 	}
 
+	public function getPortOrNull(): ?Port {
+		$port = $this->getPort();
+		return $port->exists() ? $port : null;
+	}
+
 	public function createPort(): Port {
 		return Port::createPort($this->getGameID(), $this->getSectorID());
 	}
@@ -618,13 +621,7 @@ class Sector {
 		Port::removePort($this->getGameID(), $this->getSectorID());
 	}
 
-	/**
-	 * @phpstan-assert-if-true =Player $player
-	 */
-	public function hasCachedPort(?Player $player = null): bool {
-		if ($player === null) {
-			return false;
-		}
+	public function hasCachedPort(Player $player): bool {
 		try {
 			$this->getCachedPort($player);
 			return true;
@@ -635,6 +632,14 @@ class Sector {
 
 	public function getCachedPort(Player $player): Port {
 		return Port::getCachedPort($this->getGameID(), $this->getSectorID(), $player->getAccountID());
+	}
+
+	public function getCachedPortOrNull(Player $player): ?Port {
+		try {
+			return $this->getCachedPort($player);
+		} catch (CachedPortNotFound) {
+			return null;
+		}
 	}
 
 	public function hasAnyLocationsWithAction(): bool {
@@ -1002,10 +1007,7 @@ class Sector {
 		return $otherSector->getGameID() === $this->getGameID() && $this->isLinked($otherSector->getSectorID());
 	}
 
-	public function isVisited(?Player $player = null): bool {
-		if ($player === null) {
-			return true;
-		}
+	public function isVisited(Player $player): bool {
 		if (!isset($this->visited[$player->getAccountID()])) {
 			$db = Database::getInstance();
 			$dbResult = $db->select('player_visited_sector', [
@@ -1051,9 +1053,9 @@ class Sector {
 		}
 		if ($x instanceof TradeGoodTransaction) {
 			if ($player === null) {
-				return $this->hasPort() && $this->getPort()->hasGood($x->goodID, $x->transactionType);
+				return $this->getPortOrNull()?->hasGood($x->goodID, $x->transactionType) ?? false;
 			}
-			return $this->hasCachedPort($player) && $this->getCachedPort($player)->hasGood($x->goodID, $x->transactionType);
+			return $this->getCachedPortOrNull($player)?->hasGood($x->goodID, $x->transactionType) ?? false;
 		}
 
 		//Check if it's possible for location to have X, hacky but nice performance gains

--- a/src/lib/Smr/SectorsFile.php
+++ b/src/lib/Smr/SectorsFile.php
@@ -4,7 +4,10 @@ namespace Smr;
 
 class SectorsFile {
 
-	public static function create(int $gameID, ?Player $player, bool $adminCreate = false): never {
+	/**
+	 * Create a ".smr" sectors file. If player is null, create with admin vision.
+	 */
+	public static function create(int $gameID, ?Player $player): never {
 		// NOTE: If the format of this file is changed in an incompatible way,
 		// make sure to update the SMR_FILE_VERSION!
 
@@ -119,7 +122,7 @@ class SectorsFile {
 			foreach ($galaxy->getSectors() as $sector) {
 				$file .= '[Sector=' . $sector->getSectorID() . ']' . EOL;
 
-				if (!$sector->isVisited($player) && $adminCreate === false) {
+				if ($player !== null && !$sector->isVisited($player)) {
 					continue;
 				}
 
@@ -129,11 +132,10 @@ class SectorsFile {
 				if ($sector->hasWarp()) {
 					$file .= 'Warp=' . $sector->getWarp() . EOL;
 				}
-				$port = null;
-				if ($adminCreate && $sector->hasPort()) {
-					$port = $sector->getPort();
-				} elseif ($sector->hasCachedPort($player)) {
-					$port = $sector->getCachedPort($player);
+				if ($player === null) {
+					$port = $sector->getPortOrNull();
+				} else {
+					$port = $sector->getCachedPortOrNull($player);
 				}
 				if ($port !== null) {
 					$file .= 'Port Level=' . $port->getLevel() . EOL;

--- a/src/pages/Admin/UniGen/CreatePorts.php
+++ b/src/pages/Admin/UniGen/CreatePorts.php
@@ -31,9 +31,10 @@ class CreatePorts extends AccountPage {
 		$racePercents = $totalRaces;
 
 		foreach ($galaxy->getSectors() as $galSector) {
-			if ($galSector->hasPort()) {
-				$totalRaces[$galSector->getPort()->getRaceID()]++;
-				$totalPorts[$galSector->getPort()->getLevel()]++;
+			$port = $galSector->getPortOrNull();
+			if ($port !== null) {
+				$totalRaces[$port->getRaceID()]++;
+				$totalPorts[$port->getLevel()]++;
 			}
 		}
 		$total = array_sum($totalPorts);

--- a/src/pages/Admin/UniGen/EditSector.php
+++ b/src/pages/Admin/UniGen/EditSector.php
@@ -33,7 +33,7 @@ class EditSector extends AccountPage {
 		$template->pageTopic = 'Edit Sector #' . $editSector->getSectorID() . ' (' . $editSector->getGalaxy()->getDisplayName() . ')';
 
 		$planet = $editSector->hasPlanet() ? $editSector->getPlanet() : null;
-		$port = $editSector->hasPort() ? $editSector->getPort() : null;
+		$port = $editSector->getPortOrNull();
 
 		$sectorLocationIDs = array_pad(
 			array_keys($editSector->getLocations()),

--- a/src/pages/Admin/UniGen/EditSectorProcessor.php
+++ b/src/pages/Admin/UniGen/EditSectorProcessor.php
@@ -34,11 +34,7 @@ class EditSectorProcessor extends AccountPageProcessor {
 		//update port
 		$portLevel = Request::getInt('port_level');
 		if ($portLevel > 0) {
-			if (!$editSector->hasPort()) {
-				$port = $editSector->createPort();
-			} else {
-				$port = $editSector->getPort();
-			}
+			$port = $editSector->getPortOrNull() ?? $editSector->createPort();
 			$port->setRaceID(Request::getInt('port_race'));
 			if ($port->getLevel() !== $portLevel) {
 				$port->upgradeToLevel($portLevel);

--- a/src/pages/Admin/UniGen/SectorsFileDownloadProcessor.php
+++ b/src/pages/Admin/UniGen/SectorsFileDownloadProcessor.php
@@ -13,7 +13,7 @@ class SectorsFileDownloadProcessor extends AccountPageProcessor {
 	) {}
 
 	public function build(Account $account): never {
-		SectorsFile::create($this->gameID, player: null, adminCreate: true);
+		SectorsFile::create($this->gameID, player: null);
 	}
 
 }

--- a/src/pages/Player/AttackPort.php
+++ b/src/pages/Player/AttackPort.php
@@ -22,10 +22,10 @@ class AttackPort extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		// Either player or port may no longer be in sector
 		$sector = Sector::getSector($player->getGameID(), $this->sectorID);
-		if (!$sector->hasPort()) {
+		$port = $sector->getPortOrNull();
+		if ($port === null) {
 			new CurrentSector(message: 'The port no longer exists!')->go();
 		}
-		$port = $sector->getPort();
 
 		// Display port already destroyed page content if port is busted and we don't
 		// have existing combat results to display.

--- a/src/pages/Player/AttackPortConfirm.php
+++ b/src/pages/Player/AttackPortConfirm.php
@@ -11,10 +11,10 @@ class AttackPortConfirm extends PlayerPage {
 	public function build(Player $player, Template $template): void {
 		$sector = $player->getSector();
 
-		if (!$sector->hasPort()) {
+		$port = $sector->getPortOrNull();
+		if ($port === null) {
 			create_error('This sector does not have a port.');
 		}
-		$port = $sector->getPort();
 
 		if ($port->isBusted()) {
 			new AttackPort($sector->getSectorID())->go();

--- a/src/pages/Player/AttackPortProcessor.php
+++ b/src/pages/Player/AttackPortProcessor.php
@@ -37,9 +37,8 @@ class AttackPortProcessor extends PlayerPageProcessor {
 			create_error('You are not allowed to fight!');
 		}
 
-		$port = $sector->getPort();
-
-		if (!$port->exists()) {
+		$port = $sector->getPortOrNull();
+		if ($port === null) {
 			create_error('This port does not exist.');
 		}
 

--- a/src/pages/Player/CurrentSector.php
+++ b/src/pages/Player/CurrentSector.php
@@ -132,12 +132,8 @@ class CurrentSector extends PlayerPage {
 		// *
 		// *******************************************
 
-		if ($sector->hasPort()) {
-			$port = $sector->getPort();
-			$portIsAtWar = $player->getRelation($port->getRaceID()) < RELATIONS_WAR;
-		} else {
-			$portIsAtWar = null;
-		}
+		$port = $sector->getPortOrNull();
+		$portIsAtWar = $port === null ? null : $player->getRelation($port->getRaceID()) < RELATIONS_WAR;
 
 		// *******************************************
 		// *

--- a/src/pages/Player/ShopGoodsProcessor.php
+++ b/src/pages/Player/ShopGoodsProcessor.php
@@ -48,10 +48,10 @@ class ShopGoodsProcessor extends PlayerPageProcessor {
 		}
 
 		// get rid of those bugs when we die...there is no port at the home sector
-		if (!$sector->hasPort()) {
+		$port = $sector->getPortOrNull();
+		if ($port === null) {
 			create_error('I can\'t see a port in this sector. Can you?');
 		}
-		$port = $sector->getPort();
 
 		// check if the player has the right relations to trade at the current port
 		if ($player->getRelation($port->getRaceID()) < RELATIONS_WAR) {

--- a/src/pages/Shared/SectorMapRenderer.php
+++ b/src/pages/Shared/SectorMapRenderer.php
@@ -9,6 +9,8 @@ use Smr\Sector;
 class SectorMapRenderer {
 
 	/**
+	 * Render a grid of sectors. If ThisPlayer is null, render with admin vision.
+	 *
 	 * @param array<array<\Smr\Sector>> $MapSectors
 	 * @param ?array{ModifySector: string, ToggleLink: string, DragLocation: string, DragPlanet: string, DragPort: string, DragWarp: string} $EditLinks
 	 */
@@ -30,7 +32,7 @@ class SectorMapRenderer {
 						$isCurrentSector = $MapPlayer?->getSector()->equals($Sector) ?? false;
 						$isLinkedSector = $MapPlayer?->getSector()->isLinkedSector($Sector) ?? false;
 						$isSeedlistSector = $ShowSeedlistSectors && $MapPlayer?->getAlliance()->isInSeedlist($Sector) === true;
-						$isVisited = $Sector->isVisited($MapPlayer); ?>
+						$isVisited = $MapPlayer === null || $Sector->isVisited($MapPlayer); ?>
 						<td id="sector<?php echo $Sector->getSectorID(); ?>" class="ajax">
 							<div class="lm_sector galaxy<?php echo $Sector->getGalaxyID();
 								if ($isSeedlistSector) {
@@ -88,11 +90,10 @@ class SectorMapRenderer {
 											} ?>
 										</div><?php
 									}
-									$Port = null;
-									if (($MapPlayer === null || $isCurrentSector) && $Sector->hasPort()) {
-										$Port = $Sector->getPort();
-									} elseif ($Sector->hasCachedPort($MapPlayer)) {
-										$Port = $Sector->getCachedPort($MapPlayer);
+									if ($MapPlayer === null || $isCurrentSector) {
+										$Port = $Sector->getPortOrNull();
+									} else {
+										$Port = $Sector->getCachedPortOrNull($MapPlayer);
 									}
 									if ($Port !== null) { ?>
 										<div class="lmport <?php if ($Sector->getLinkLeft() !== 0) { ?>a<?php } else { ?>b<?php } ?>

--- a/src/pages/Shared/SectorPortRenderer.php
+++ b/src/pages/Shared/SectorPortRenderer.php
@@ -13,10 +13,10 @@ class SectorPortRenderer {
 		Sector $ThisSector,
 		?bool $PortIsAtWar,
 	): void {
+		$Port = $ThisSector->getPortOrNull();
 		?>
 		<div id="sector_port" class="ajax">
-			<?php if ($ThisSector->hasPort()) {
-				$Port = $ThisSector->getPort(); ?>
+			<?php if ($Port !== null) { ?>
 				<table class="standard csl">
 					<tr>
 						<th colspan="2">Port</th>

--- a/test/SmrTest/lib/SectorIntegrationTest.php
+++ b/test/SmrTest/lib/SectorIntegrationTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\lib;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Smr\Container\DiContainer;
+use Smr\Player;
+use Smr\Port;
+use Smr\Sector;
+use Smr\TransactionType;
+use SmrTest\BaseIntegrationSpec;
+
+#[CoversClass(Sector::class)]
+class SectorIntegrationTest extends BaseIntegrationSpec {
+
+	protected function tablesToTruncate(): array {
+		return ['player_visited_port', 'port_info_cache'];
+	}
+
+	protected function tearDown(): void {
+		Port::clearCache();
+		Sector::clearCache();
+		DiContainer::initialize(false);
+	}
+
+	public function test_getPortOrNull(): void {
+		$sector = Sector::createSector(1, 1);
+
+		// Returns null when no port in sector
+		self::assertNull($sector->getPortOrNull());
+
+		// Now create a port
+		$port = Port::createPort(1, 1);
+		$port->setLevel(1); // A new port does not exist until it has been changed.
+
+		self::assertSame($port, $sector->getPortOrNull());
+	}
+
+	public function test_getCachedPortOrNull(): void {
+		$sector = Sector::createSector(1, 1);
+		$player = $this->createStub(Player::class);
+		$player->method('getAccountID')->willReturn(1);
+
+		// Returns null when no port in sector
+		self::assertNull($sector->getCachedPortOrNull($player));
+
+		// Now create a port
+		$port = Port::createPort(1, 1);
+		$port->setLevel(1); // A new port does not exist until it has been changed.
+		$port->addPortGood(GOODS_ORE, TransactionType::Sell);
+		$port->addCachePort(1);
+		$player = $this->createStub(Player::class);
+		$player->method('getAccountID')->willReturn(1);
+
+		$cachedPort = $sector->getCachedPortOrNull($player);
+		self::assertNotNull($cachedPort);
+		self::assertSame([GOODS_ORE => TransactionType::Sell], $cachedPort->getGoodTransactions());
+	}
+
+}


### PR DESCRIPTION
Methods that took a nullable player that are meaningless without a player had their nullability removed. This was paired with new Port-or-null retrieval methods (for regular and cached ports) that help simplify logic due to the existence of the nullsafe operator.

We also reduce redunant Port existence checks from Sector methods by using these "construct or null" instead of "hasX + getX".

Also synchronize the SectorFileProcessor with the SectorMapRenderer in that they use the null player argument as a proxy for "admin vision".