### PR TITLE
dependabot.yml: fix formatting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
   rebase-strategy: disabled
 
 - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: "weekly"
+  directory: "/"
+  schedule:
+    interval: "weekly"
   rebase-strategy: disabled


### PR DESCRIPTION
In #2504, we added dependabot updating of npm, but this entry was not formatted correctly due to unexpected indentation.