### PR TITLE
Sector: add getPlanetOrNull

### DIFF
--- a/src/lib/Smr/Sector.php
+++ b/src/lib/Smr/Sector.php
@@ -719,6 +719,11 @@ class Sector {
 		return Planet::getPlanet($this->getGameID(), $this->getSectorID());
 	}
 
+	public function getPlanetOrNull(): ?Planet {
+		$planet = $this->getPlanet();
+		return $planet->exists() ? $planet : null;
+	}
+
 	public function createPlanet(int $type = 1, ?int $inhabitableTime = null): Planet {
 		return Planet::createPlanet($this->getGameID(), $this->getSectorID(), $type, $inhabitableTime);
 	}

--- a/src/lib/Smr/SectorsFile.php
+++ b/src/lib/Smr/SectorsFile.php
@@ -147,9 +147,9 @@ class SectorsFile {
 						$file .= 'Sells=' . implode(',', $port->getBuyGoodIDs()) . EOL;
 					}
 				}
-				if ($sector->hasPlanet()) {
-					$planetType = $sector->getPlanet()->getTypeID();
-					$file .= 'Planet=' . $planetType . EOL;
+				$planet = $sector->getPlanetOrNull();
+				if ($planet !== null) {
+					$file .= 'Planet=' . $planet->getTypeID() . EOL;
 				}
 				if ($sector->hasLocation()) {
 					$locationsString = 'Locations=';

--- a/src/pages/Admin/UniGen/CreatePlanets.php
+++ b/src/pages/Admin/UniGen/CreatePlanets.php
@@ -37,8 +37,9 @@ class CreatePlanets extends AccountPage {
 		// Get the current number of each type of planet
 		$galaxy = Galaxy::getGalaxy($this->gameID, $this->galaxyID);
 		foreach ($galaxy->getSectors() as $galSector) {
-			if ($galSector->hasPlanet()) {
-				$numberOfPlanets[$galSector->getPlanet()->getTypeID()]++;
+			$planet = $galSector->getPlanetOrNull();
+			if ($planet !== null) {
+				$numberOfPlanets[$planet->getTypeID()]++;
 			}
 		}
 

--- a/src/pages/Admin/UniGen/EditSector.php
+++ b/src/pages/Admin/UniGen/EditSector.php
@@ -32,7 +32,7 @@ class EditSector extends AccountPage {
 		$editSector = Sector::getSector($this->gameID, $this->sectorID);
 		$template->pageTopic = 'Edit Sector #' . $editSector->getSectorID() . ' (' . $editSector->getGalaxy()->getDisplayName() . ')';
 
-		$planet = $editSector->hasPlanet() ? $editSector->getPlanet() : null;
+		$planet = $editSector->getPlanetOrNull();
 		$port = $editSector->getPortOrNull();
 
 		$sectorLocationIDs = array_pad(

--- a/src/pages/Admin/UniGen/EditSectorProcessor.php
+++ b/src/pages/Admin/UniGen/EditSectorProcessor.php
@@ -25,10 +25,13 @@ class EditSectorProcessor extends AccountPageProcessor {
 		$planetTypeID = Request::getInt('plan_type');
 		if ($planetTypeID === 0) {
 			$editSector->removePlanet();
-		} elseif (!$editSector->hasPlanet()) {
-			$editSector->createPlanet($planetTypeID);
 		} else {
-			$editSector->getPlanet()->setTypeID($planetTypeID);
+			$planet = $editSector->getPlanetOrNull();
+			if ($planet === null) {
+				$editSector->createPlanet($planetTypeID);
+			} else {
+				$planet->setTypeID($planetTypeID);
+			}
 		}
 
 		//update port

--- a/src/pages/Player/CurrentSector.php
+++ b/src/pages/Player/CurrentSector.php
@@ -168,7 +168,7 @@ class CurrentSector extends PlayerPage {
 			SectorPlayersLabel: 'Ships',
 			AttackResults: checkForAttackMessage($this->attackMessage, $player),
 			ThisAccount: $player->getAccount(),
-			ThisPlanet: $sector->hasPlanet() ? $sector->getPlanet() : null,
+			ThisPlanet: $sector->getPlanetOrNull(),
 			ThisPlayer: $player,
 			ThisSector: $sector,
 			ThisShip: $player->getShip(),

--- a/src/pages/Shared/SectorMapRenderer.php
+++ b/src/pages/Shared/SectorMapRenderer.php
@@ -58,7 +58,8 @@ class SectorMapRenderer {
 											} ?>
 										</div><?php
 									}
-									if ($Sector->hasLocation() || $Sector->hasPlanet()) { ?>
+									$planet = $Sector->getPlanetOrNull();
+									if ($Sector->hasLocation() || $planet !== null) { ?>
 										<div class="lmlocs"><?php
 											foreach ($Sector->getLocations() as $Location) {
 												if ($isCurrentSector && $Location->hasAction() && !$GalaxyMap) {
@@ -74,8 +75,7 @@ class SectorMapRenderer {
 												/><?php
 												if ($isCurrentSector && $Location->hasAction() && !$GalaxyMap) { ?></a><?php }
 											}
-											if ($Sector->hasPlanet()) {
-												$planet = $Sector->getPlanet();
+											if ($planet !== null) {
 												if ($isCurrentSector && !$GalaxyMap) {
 													?><a href="<?php echo $planet->getExamineHREF(); ?>"><?php
 												} ?>

--- a/src/pages/Shared/SectorPlanetRenderer.php
+++ b/src/pages/Shared/SectorPlanetRenderer.php
@@ -7,8 +7,8 @@ use Smr\Sector;
 class SectorPlanetRenderer {
 
 	public static function render(Sector $ThisSector): void {
-		if ($ThisSector->hasPlanet()) {
-			$Planet = $ThisSector->getPlanet(); ?>
+		$Planet = $ThisSector->getPlanetOrNull();
+		if ($Planet !== null) { ?>
 			<table class="standard csl">
 				<tr>
 					<th>Planet</th>

--- a/test/SmrTest/lib/SectorIntegrationTest.php
+++ b/test/SmrTest/lib/SectorIntegrationTest.php
@@ -4,6 +4,7 @@ namespace SmrTest\lib;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use Smr\Container\DiContainer;
+use Smr\Planet;
 use Smr\Player;
 use Smr\Port;
 use Smr\Sector;
@@ -14,10 +15,11 @@ use SmrTest\BaseIntegrationSpec;
 class SectorIntegrationTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {
-		return ['player_visited_port', 'port_info_cache'];
+		return ['planet', 'player_visited_port', 'port_info_cache'];
 	}
 
 	protected function tearDown(): void {
+		Planet::clearCache();
 		Port::clearCache();
 		Sector::clearCache();
 		DiContainer::initialize(false);
@@ -55,6 +57,18 @@ class SectorIntegrationTest extends BaseIntegrationSpec {
 		$cachedPort = $sector->getCachedPortOrNull($player);
 		self::assertNotNull($cachedPort);
 		self::assertSame([GOODS_ORE => TransactionType::Sell], $cachedPort->getGoodTransactions());
+	}
+
+	public function test_getPlanetOrNull(): void {
+		$sector = Sector::createSector(1, 1);
+
+		// Returns null when no planet in sector
+		self::assertNull($sector->getPlanetOrNull());
+
+		// Now create a planet
+		$planet = $sector->createPlanet(type: 1, inhabitableTime: 0);
+
+		self::assertSame($planet, $sector->getPlanetOrNull());
 	}
 
 }


### PR DESCRIPTION
Add Sector::getPlanetOrNull() for call sites where a sector may not contain a planet, and it is more useful to have null than an empty Planet object (i.e. where `->exists()` is false). This simplifies some expressions, allows using the nullsafe operator, and can avoid redundant retrieval (`hasPlanet()` -> `getPlanet()` both get the Planet object).

This provides some consistency with Ports from #2524.