### PR TITLE
Rename "Piggy Bank" to "First Galactic Bank"

### DIFF
--- a/db/patches/V1_6_69_13__rename_piggy_bank.sql
+++ b/db/patches/V1_6_69_13__rename_piggy_bank.sql
@@ -1,0 +1,4 @@
+-- Update the bank's displayed name.
+UPDATE location_type
+	SET location_name = 'First Galactic Bank'
+	WHERE location_type_id = 703;

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -153,7 +153,7 @@ class DatabaseIntegrationTest extends TestCase {
 		// added that modify the base table size. If that becomes too onerous,
 		// we can do a fuzzier comparison. Until then, this is a useful check
 		// that the test database is properly reset between invocations.
-		self::assertSame($bytes, 775684);
+		self::assertSame($bytes, 775708);
 	}
 
 	public function test_escapeBoolean(): void {


### PR DESCRIPTION
I'm not sure where the name "Piggy Bank" came from. It certainly wasn't in original SM, because there were no bank variants then.

This name doesn't seem quite in theme (it's a little too cartoonish). As with many of our other locations, there's a bit of a subtle joke with "First Galactic Bank", since it competes directly with "Last Galactic Bank" (which is already an implied play on the typical First Bank idiom, this just makes it a bit more explicit in a humorous way, especially when seen together).