### PR TITLE
Add git hash to page footer

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -14,6 +14,7 @@ const WWW = ROOT . 'src/htdocs/';
 const UPLOAD = WWW . 'upload/';
 const TOOLS = ROOT . 'src/tools/';
 const ASSET_MANIFEST = ROOT . 'assets/asset-manifest.json';
+const GIT_COMMIT = ROOT . 'git-commit';
 
 // Define server-specific constants
 require_once(ROOT . 'config/config.specific.php');

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -645,6 +645,7 @@ function getSkeletonData(Template $template): SkeletonData {
 	$minVoteWait = VoteLink::getMinTimeUntilFreeTurns($accountID, $session->getGameID());
 
 	// ------- VERSION --------
+	// Database version
 	$dbResult = $db->select('version', orderBy: ['went_live'], order: ['DESC'], limit: 1);
 	$version = '';
 	if ($dbResult->hasRecord()) {
@@ -652,6 +653,12 @@ function getSkeletonData(Template $template): SkeletonData {
 		$container = new ChangelogView();
 		$version = create_link($container, 'v' . $dbRecord->getInt('major_version') . '.' . $dbRecord->getInt('minor_version') . '.' . $dbRecord->getInt('patch_level'));
 	}
+	// Git commit version (truncate to 16 chars for display purposes)
+	$gitCommit = file_get_contents(GIT_COMMIT);
+	if ($gitCommit === false) {
+		throw new Exception('Missing file: ' . GIT_COMMIT);
+	}
+	$gitCommit = substr($gitCommit, 0, 16);
 
 	return new SkeletonData(
 		template: $template,
@@ -663,6 +670,7 @@ function getSkeletonData(Template $template): SkeletonData {
 		voteLinks: $voteLinks,
 		timeToNextVote: $minVoteWait,
 		version: $version,
+		gitCommit: $gitCommit,
 	);
 
 }

--- a/src/pages/Layout/CopyrightRenderer.php
+++ b/src/pages/Layout/CopyrightRenderer.php
@@ -6,15 +6,15 @@ use Smr\Epoch;
 
 class CopyrightRenderer {
 
-	public static function render(string $Version): void {
-			$CurrentYear = date('Y', Epoch::time());
+	public static function render(string $Version, string $GitCommit): void {
+		$CurrentYear = date('Y', Epoch::time());
 
 		?>
 		<div class="right">
-			SMR <?php echo $Version; ?>&copy;2007-<?php echo $CurrentYear; ?> Page and SMR<br />
-			Kindly Hosted by <a href="http://www.fem.tu-ilmenau.de/" target="fem">FeM</a><br />
+			SMR <?php echo $Version; ?> &copy;2007-<?php echo $CurrentYear; ?><br />
+			Build: <a href="https://github.com/smrealms/smr/commit/<?php echo $GitCommit; ?>"><?php echo $GitCommit; ?></a><br />
 			Script runtime: <span id="rt"><?php echo number_format(microtime(true) - $_SERVER['REQUEST_TIME_FLOAT'], 3); ?></span> seconds<br />
-			<a href="imprint.php">[Imprint]</a>
+			Kindly Hosted by <a href="http://www.fem.tu-ilmenau.de/" target="fem">FeM</a> <a href="imprint.php">[Imprint]</a>
 		</div>
 		<?php
 	}

--- a/src/pages/Layout/DefaultSkeletonRenderer.php
+++ b/src/pages/Layout/DefaultSkeletonRenderer.php
@@ -53,7 +53,7 @@ class DefaultSkeletonRenderer extends AbstractSkeletonRenderer {
 							<?php VoteLinksRenderer::render($data->voteLinks, $data->timeToNextVote); ?>
 						</td>
 						<td class="footer_right">
-							<?php CopyrightRenderer::render($data->version); ?>
+							<?php CopyrightRenderer::render($data->version, $data->gitCommit); ?>
 						</td>
 						<td></td>
 					</tr>

--- a/src/pages/Layout/Freon22SkeletonRenderer.php
+++ b/src/pages/Layout/Freon22SkeletonRenderer.php
@@ -118,7 +118,7 @@ class Freon22SkeletonRenderer extends AbstractSkeletonRenderer {
 									<?php VoteLinksRenderer::render($data->voteLinks, $data->timeToNextVote); ?>
 								</div>
 								<div class="footer_right">
-									<?php CopyrightRenderer::render($data->version); ?>
+									<?php CopyrightRenderer::render($data->version, $data->gitCommit); ?>
 								</div>
 							</td>
 

--- a/src/pages/Layout/SkeletonData.php
+++ b/src/pages/Layout/SkeletonData.php
@@ -21,6 +21,7 @@ readonly class SkeletonData {
 		public array $voteLinks,
 		public ?int $timeToNextVote,
 		public string $version,
+		public string $gitCommit,
 	) {}
 
 }


### PR DESCRIPTION
It is useful from an administration perspective to see the git hash of the built container in the displayed page. This provides a sanity check that (for the live server in particular) we're on the right version.

For builds that mount the src directory instead of using the version in the container, this may be somewhat misleading. Regardless, it'll still provide some information about when the container was last recreated. (Maybe we can make that caveat more apparent in the future, but it seems fine for now.)

Rearranged content in the footer to consolidate a bit.