### PR TITLE
NPC galaxy: fix giving weapon to alliance leader

### DIFF
--- a/src/pages/Admin/NpcManageSetupGalaxyProcessor.php
+++ b/src/pages/Admin/NpcManageSetupGalaxyProcessor.php
@@ -78,6 +78,7 @@ class NpcManageSetupGalaxyProcessor extends AccountPageProcessor {
 			$leader = $alliance->getLeader();
 			$ship = $leader->getShip();
 			$ship->setTypeID(SHIP_TYPE_SLAYER);
+			$ship->removeAllWeapons();
 			$ship->addWeapon(Weapon::getWeapon(WEAPON_TYPE_HELL_BLASTER));
 
 			// Lock ship so we don't switch back to a starter ship


### PR DESCRIPTION
Since the NPC alliance leader will likely have its starting Laser, we need to remove that before we can add the Hell Blaster. (Adding a weapon when there are no open slots just returns false, and the Slayer only has one hardpoint.)