### PR TITLE
UniGen: implement deterministic sector connectivity

### DIFF
--- a/src/lib/Smr/Galaxy.php
+++ b/src/lib/Smr/Galaxy.php
@@ -359,36 +359,39 @@ class Galaxy {
 		// Only set down/right, otherwise we double-hit every link
 		$linkDirs = ['Down', 'Right'];
 
-		$problem = true;
-		$problemTimes = 0;
-		while ($problem) {
-			$problem = false;
+		// Calculate the number of walls we need to add to achieve the desired connectivity.
+		$numWalls = IRound(count($linkDirs) * (1 - $connectivity / 100) * $this->getSize());
 
-			foreach ($this->getSectors() as $galSector) {
-				foreach ($linkDirs as $linkDir) {
-					if (flip_coin($connectivity)) {
-						$galSector->enableLink($linkDir);
-					} else {
-						$galSector->disableLink($linkDir);
-					}
+		// Make the initial condition fully connected.
+		$candidateLinks = [];
+		foreach ($this->getSectors() as $sector) {
+			foreach ($linkDirs as $linkDir) {
+				$sector->enableLink($linkDir);
+				if ($sector->hasLink($linkDir)) {
+					$candidateLinks[] = [$sector, $linkDir];
 				}
-			}
-
-			// Try again if any sector has 0 connections (except 1-sector gals)
-			if ($this->getSize() > 1) {
-				foreach ($this->getSectors() as $galSector) {
-					if ($galSector->getNumberOfConnections() === 0) {
-						$problem = true;
-						break;
-					}
-				}
-			}
-
-			if ($problem && $problemTimes++ > 350) {
-				$connectivity = 100;
 			}
 		}
-		return $problemTimes <= 350;
+
+		// Consider each link at most once so we terminate when no more walls
+		// can be added. The shuffled order keeps the resulting layout random.
+		shuffle($candidateLinks);
+		foreach ($candidateLinks as [$sector, $linkDir]) {
+			if ($numWalls === 0) {
+				break;
+			}
+			// Soft guard against spatially disconnected regions.
+			$linkSector = $sector->getLinkSector($linkDir);
+			if ($sector->getNumberOfLinks() <= 1 || $linkSector->getNumberOfLinks() <= 1) {
+				continue;
+			}
+			$sector->disableLink($linkDir);
+			$numWalls--;
+		}
+
+		// If we were not able to put in all the walls, then the target
+		// connectivity could not be reached.
+		return $numWalls === 0;
 	}
 
 	/**

--- a/src/pages/Admin/UniGen/EditGalaxyRenderer.php
+++ b/src/pages/Admin/UniGen/EditGalaxyRenderer.php
@@ -163,7 +163,7 @@ class EditGalaxyRenderer {
 						<span class="red bold">DANGEROUS OPTIONS</span>
 						<p><a href="<?php echo $ResetGalaxyHREF; ?>" class="submitStyle">Reset Current Galaxy</a></p>
 						<form method="POST" action="<?php echo $RedoConnectionsHREF; ?>">
-							<input required type="number" name="connect" placeholder="Connectivity %" class="center" style="width:140px" /><br />
+							<input required type="number" name="connect" placeholder="Connectivity %" min="0" max="100" class="center" style="width:140px" /><br />
 							<?php echo create_submit_display('Redo Connections'); ?>
 						</form><?php
 					} ?>

--- a/src/pages/Admin/UniGen/RedoConnectionsProcessor.php
+++ b/src/pages/Admin/UniGen/RedoConnectionsProcessor.php
@@ -20,7 +20,7 @@ class RedoConnectionsProcessor extends AccountPageProcessor {
 		$galaxy = Galaxy::getGalaxy($this->gameID, $this->galaxyID);
 		$connectivity = Request::getFloat('connect');
 		if (!$galaxy->setConnectivity($connectivity)) {
-			$message = '<span class="red">Error</span> : Regenerating connections failed.';
+			$message = '<span class="red">Error</span> : Failed to reach ' . $connectivity . '% connectivity target!';
 		} else {
 			$message = '<span class="green">Success</span> : Regenerated connectivity with ' . $connectivity . '% target.';
 		}

--- a/test/SmrTest/lib/GalaxyTest.php
+++ b/test/SmrTest/lib/GalaxyTest.php
@@ -12,12 +12,13 @@ use SmrTest\BaseIntegrationSpec;
 class GalaxyTest extends BaseIntegrationSpec {
 
 	protected function tablesToTruncate(): array {
-		return ['game_galaxy'];
+		return ['game_galaxy', 'sector'];
 	}
 
 	protected function setUp(): void {
 		// Start each test with an empty galaxy cache
 		Galaxy::clearCache();
+		Sector::clearCache();
 	}
 
 	public function test_getGalaxy_throws_if_galaxy_does_not_exist(): void {
@@ -46,6 +47,24 @@ class GalaxyTest extends BaseIntegrationSpec {
 		self::assertSame(3, $galaxy->getWidth());
 		self::assertSame(7, $galaxy->getHeight());
 		self::assertSame(21, $galaxy->getSize());
+	}
+
+	public function test_setConnectivity_matches_target_when_candidates_are_available(): void {
+		$galaxy = $this->createSmallGalaxy();
+
+		self::assertTrue($galaxy->setConnectivity(75));
+		self::assertSame(75.0, $galaxy->getConnectivity());
+	}
+
+	public function test_setConnectivity_returns_false_when_candidates_are_exhausted(): void {
+		$galaxy = $this->createSmallGalaxy();
+
+		// A 2-by-2 galaxy has eight links. Removing all eight would leave each
+		// sector isolated, so the local one-link guard must stop first.
+		self::assertFalse($galaxy->setConnectivity(0));
+		foreach ($galaxy->getSectors() as $sector) {
+			self::assertGreaterThanOrEqual(1, $sector->getNumberOfLinks());
+		}
 	}
 
 	public function test_get_galaxy_sector_range(): void {
@@ -90,6 +109,15 @@ class GalaxyTest extends BaseIntegrationSpec {
 		$sector2 = $this->createStub(Sector::class);
 		$sector2->method('getGalaxyID')->willReturn($galaxyID + 1);
 		self::assertFalse($galaxy->contains($sector2));
+	}
+
+	private function createSmallGalaxy(): Galaxy {
+		$galaxy = Galaxy::createGalaxy(1, 1);
+		$galaxy->setWidth(2);
+		$galaxy->setHeight(2);
+		$galaxy->generateSectors();
+
+		return $galaxy;
 	}
 
 }


### PR DESCRIPTION
The previous algorithm would only probabalistically hit the target sector connectivity due to the randomness on whether or not each link would be enabled or disabled. As such, this only converged as the galaxy size increased.

The new algorithm calculates the number of walls that are needed to match the target connectivity, and the randomness is only in selecting which sectors walls are added into. This is deterministic in matching the connectivity target, but you get a different layout each time.

We guard against making spatially disconnected sectors by checking if the target sector or the target sector's neighbor are already down to a single link, and if so we drop it from the target sector pool and pick another sector. This doesn't fully prevent disconnection, but checking that is a much more expensive operation.

Note that the algorithm will fail gracefully when it exhausts its pool of candidate walls, but will not time out. This happens around 30%.