### PR TITLE
UniGen: fix galaxyID not propagating in returnTo data

### DIFF
--- a/src/pages/Admin/UniGen/CreateLocations.php
+++ b/src/pages/Admin/UniGen/CreateLocations.php
@@ -16,12 +16,13 @@ class CreateLocations extends AccountPage {
 	use ReusableTrait;
 	public function __construct(
 		private readonly int $gameID,
-		private readonly EditGalaxy $returnTo,
+		private EditGalaxy $returnTo,
 		private ?int $galaxyID = null,
 	) {}
 
 	public function build(Account $account, Template $template): void {
 		$this->galaxyID ??= Request::getInt('gal_on');
+		$this->returnTo->galaxyID = $this->galaxyID;
 
 		$locations = Location::getAllLocations($this->gameID);
 

--- a/src/pages/Admin/UniGen/CreatePlanets.php
+++ b/src/pages/Admin/UniGen/CreatePlanets.php
@@ -15,12 +15,13 @@ class CreatePlanets extends AccountPage {
 	use ReusableTrait;
 	public function __construct(
 		private readonly int $gameID,
-		private readonly EditGalaxy $returnTo,
+		private EditGalaxy $returnTo,
 		private ?int $galaxyID = null,
 	) {}
 
 	public function build(Account $account, Template $template): void {
 		$this->galaxyID ??= Request::getInt('gal_on');
+		$this->returnTo->galaxyID = $this->galaxyID;
 
 		// Get a list of all available planet types
 		$allowedTypes = [];

--- a/src/pages/Admin/UniGen/CreatePorts.php
+++ b/src/pages/Admin/UniGen/CreatePorts.php
@@ -16,12 +16,13 @@ class CreatePorts extends AccountPage {
 	use ReusableTrait;
 	public function __construct(
 		private readonly int $gameID,
-		private readonly EditGalaxy $returnTo,
+		private EditGalaxy $returnTo,
 		private ?int $galaxyID = null,
 	) {}
 
 	public function build(Account $account, Template $template): void {
 		$this->galaxyID ??= Request::getInt('gal_on');
+		$this->returnTo->galaxyID = $this->galaxyID;
 
 		$galaxy = Galaxy::getGalaxy($this->gameID, $this->galaxyID);
 


### PR DESCRIPTION
On the `Create{Locations,Planets,Ports}` pages, we can switch the galaxyID, but then when we return to the EditGalaxy page, we revert to the galaxyID from before we switched. This was because the `returnTo` page wasn't being updated when the galaxyID changed.