### PR TITLE
Add newlines after mission claim reward text

### DIFF
--- a/src/pages/Shared/MissionsRenderer.php
+++ b/src/pages/Shared/MissionsRenderer.php
@@ -20,7 +20,7 @@ class MissionsRenderer {
 	): void {
 		if ($MissionMessage !== null) { ?>
 			<span class="green">Mission Complete: </span><?php
-			echo $MissionMessage;
+			echo $MissionMessage; ?><br /><br /><?php
 		}
 
 		foreach ($ThisPlayer->getAvailableMissions() as $Mission) { ?>


### PR DESCRIPTION
The lack of newlines here resulted in any other sector message being displayed on the same line as the mission claim reward text (e.g. newbie protection). This change spaces it out for readability.

This is probably better done with some kind of block display with margins or padding, but this will suffice until we can modernize the HTML layout.

<img width="531" height="204" alt="image" src="https://github.com/user-attachments/assets/bdaf6138-3254-498c-a754-10715276dafc" />
