### PR TITLE
Migrate Template to HTML5 parser

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -66,8 +66,3 @@ parameters:
             message: '#Parameter \#1 \$token of method .*::getResourceOwner\(\) expects .*AccessToken, .*AccessTokenInterface given.#'
             path: src/lib/Smr/SocialLogin
             count: 2
-        -
-            # https://github.com/phpstan/phpstan/issues/8837
-            message: '#Cannot call method saveHTML() on DOMDocument|null.#'
-            path: src/lib/Smr/Template.php
-            count: 1

--- a/src/lib/Smr/Template.php
+++ b/src/lib/Smr/Template.php
@@ -3,9 +3,7 @@
 namespace Smr;
 
 use Closure;
-use DOMDocument;
-use DOMElement;
-use DOMXPath;
+use Dom\HTMLDocument;
 use Exception;
 use Smr\Combat\Results\Damage\ForceTakenDamage;
 use Smr\Combat\Results\Damage\NormalTakenDamage;
@@ -179,15 +177,6 @@ class Template {
 
 		$session = Session::getInstance();
 
-		$getInnerHTML = function(DOMElement $node): string {
-			$innerHTML = '';
-			$document = $node->ownerDocument;
-			foreach ($node->childNodes as $child) {
-				$innerHTML .= $document->saveHTML($child);
-			}
-			return $innerHTML;
-		};
-
 		// Helper function to canonicalize making an XML element,
 		// with its inner content properly escaped.
 		$xmlify = function(string $id, string $str): string {
@@ -195,11 +184,9 @@ class Template {
 		};
 
 		$xml = '';
-		$dom = new DOMDocument();
-
 		// Handle libxml errors ourselves to provide more detailed errors
 		$orig = libxml_use_internal_errors(true);
-		$dom->loadHTML($str);
+		$dom = HTMLDocument::createFromString($str);
 		$errors = libxml_get_errors();
 		libxml_use_internal_errors($orig);
 		foreach ($errors as $error) {
@@ -212,26 +199,12 @@ class Template {
 			}
 		}
 
-		$xpath = new DOMXPath($dom);
-
-		// Use relative xpath selectors so that they can be reused when we
-		// pass the middle panel as the xpath query's context node.
-		$ajaxSelectors = ['.//span[@id]', './/*[contains(@class,"ajax")]'];
-
-		foreach ($ajaxSelectors as $selector) {
-			$matchNodes = $xpath->query($selector);
-			if ($matchNodes === false) {
-				throw new Exception('XPath query failed for selector: ' . $selector);
-			}
-			foreach ($matchNodes as $node) {
-				if (!($node instanceof DOMElement)) {
-					throw new Exception('XPath query returned unexpected DOMNode type: ' . $node->nodeType);
-				}
-				$id = $node->getAttribute('id');
-				$inner = $getInnerHTML($node);
-				if (!$session->addAjaxReturns($id, $inner) && $returnXml) {
-					$xml .= $xmlify($id, $inner);
-				}
+		$ajaxSelector = 'span[id], .ajax';
+		foreach ($dom->querySelectorAll($ajaxSelector) as $node) {
+			$id = $node->getAttribute('id') ?? '';
+			$inner = $node->innerHTML;
+			if (!$session->addAjaxReturns($id, $inner) && $returnXml) {
+				$xml .= $xmlify($id, $inner);
 			}
 		}
 
@@ -239,21 +212,11 @@ class Template {
 		$mid = $dom->getElementById('middle_panel');
 		if ($mid !== null) {
 			// Skip if middle_panel has ajax-enabled children.
-			$doAjaxMiddle = true;
-			foreach ($ajaxSelectors as $selector) {
-				$matchNodes = $xpath->query($selector, $mid);
-				if ($matchNodes === false) {
-					throw new Exception('XPath query failed for selector: ' . $selector);
-				}
-				if (count($matchNodes) > 0) {
-					$doAjaxMiddle = false;
-					break;
-				}
-			}
+			$doAjaxMiddle = count($mid->querySelectorAll($ajaxSelector)) === 0;
 			if ($doAjaxMiddle) {
-				$inner = $getInnerHTML($mid);
+				$inner = $mid->innerHTML;
 				if (!$this->checkDisableAJAX($inner)) {
-					$id = $mid->getAttribute('id');
+					$id = $mid->getAttribute('id') ?? '';
 					if (!$session->addAjaxReturns($id, $inner) && $returnXml) {
 						$xml .= $xmlify($id, $inner);
 					}

--- a/test/SmrTest/lib/TemplateTest.php
+++ b/test/SmrTest/lib/TemplateTest.php
@@ -114,14 +114,18 @@ class TemplateTest extends TestCase {
 	}
 
 	#[DataProvider('convertHtmlToAjaxXml_provider')]
-	public function test_convertHtmlToAjaxXml(string $html, string $expected): void {
+	public function test_convertHtmlToAjaxXml(string $html, string $expected, bool $wrap = true): void {
 		$template = Template::getInstance();
 		$method = TestUtils::getPrivateMethod($template, 'convertHtmlToAjaxXml');
+		// Wrap the HTML excerpt in the full document tags, if specified
+		if ($wrap) {
+			$html = self::html($html);
+		}
 		self::assertSame($expected, $method->invoke($template, $html, true));
 	}
 
 	/**
-	 * @return array<array{string, string}>
+	 * @return array<array{string, string}|array{string, string, bool}>
 	 */
 	public static function convertHtmlToAjaxXml_provider(): array {
 		return [
@@ -129,6 +133,8 @@ class TemplateTest extends TestCase {
 			['<span id="foo">Test</span>', '<foo>Test</foo>'],
 			// Non-span with the ajax class
 			['<div id="bar" class="ajax">Hello</div>', '<bar>Hello</bar>'],
+			// The ajax class must be matched exactly (no partial string match)
+			['<div id="bar" class="notajax">Goodbye</div>', ''],
 			// Non-span *without* the ajax class
 			['<div id="bar">Goodbye</div>', ''],
 			// Middle panel with content that doesn't disable ajax
@@ -140,10 +146,16 @@ class TemplateTest extends TestCase {
 			['<div id="middle_panel"><span id="foo">Test</span></div>', '<foo>Test</foo>'],
 			// Middle panel with ajax disabled by the ajax class
 			['<div id="middle_panel"><div id="bar" class="ajax">Hello</div></div>', '<bar>Hello</bar>'],
-			// Empty string
+			// Empty body
 			['', ''],
+			// Empty string
+			['', '', false],
 			// Ajax-enabled elements both outside and inside middle panel
 			['<span id="foo">Test</span><div id="middle_panel">Foo</div>', '<foo>Test</foo><middle_panel>Foo</middle_panel>'],
+			// HTML void elements retain their HTML serialization
+			['<span id="tod">2021-04-24<br />01:39:51</span>', '<tod>2021-04-24&lt;br&gt;01:39:51</tod>'],
+			// HTML5 elements are accepted by the parser
+			['<details><summary>Locations</summary><span id="foo">Test</span></details>', '<foo>Test</foo>'],
 		];
 	}
 
@@ -157,7 +169,7 @@ class TemplateTest extends TestCase {
 
 		// This adds a special hook into convertHtmlToAjaxXml
 		$method = TestUtils::getPrivateMethod($template, 'convertHtmlToAjaxXml');
-		$result = $method->invoke($template, '<body></body>', true);
+		$result = $method->invoke($template, self::html(''), true);
 		self::assertSame('<JS><test>{"a":1,"b":2}</test></JS>', $result);
 	}
 
@@ -168,6 +180,13 @@ class TemplateTest extends TestCase {
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Trying to set javascript val twice: test');
 		$template->addJavascriptForAjax('test', '');
+	}
+
+	/**
+	 * Provide the full HTML document tokens required by HTMLDocument
+	 */
+	private static function html(string $body): string {
+		return '<!DOCTYPE html><html><head></head><body>' . $body . '</body></html>';
 	}
 
 }


### PR DESCRIPTION
Switch from the legacy libxml HTML4-based DOMDocument and DOMXPath to using Dom\HTMLDocument for collecting content to use with AJAX updates. This allows proper parsing of modern HTML5 elements, whereas previously they would cause an error for not being HTML4-compliant.

Use the HTMLDocument querySelectorAll API for finding content to update with AJAX (i.e. middle panel and spans with id), eliminating the need for legacy XPath selectors. CSS class matching now follows browser semantics, which makes the selectors more precise and fixes some edge cases (which we now test against explicitly).

Update the Template tests to use complete HTML documents, since the new parser will warn otherwise (which we promote to an error).

Closes #2197.