### PR TITLE
Fix missing cache-busted URLs for some CSS files

### DIFF
--- a/src/htdocs/imprint.php
+++ b/src/htdocs/imprint.php
@@ -19,8 +19,8 @@ $lastUpdated = date(DateTimeInterface::RFC7231, strtotime($data->lastUpdate));
 
 <html>
 	<head>
-		<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS; ?>">
-		<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS_COLOUR; ?>">
+		<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS); ?>">
+		<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS_COLOUR); ?>">
 		<title>Imprint</title>
 		<meta http-equiv='pragma' content='no-cache'>
 	</head>

--- a/src/htdocs/level_requirements.php
+++ b/src/htdocs/level_requirements.php
@@ -8,8 +8,8 @@ try {
 <!DOCTYPE html>
 <html>
 	<head>
-		<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS; ?>">
-		<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS_COLOUR; ?>">
+		<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS); ?>">
+		<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS_COLOUR); ?>">
 		<title>Level Requirements</title>
 		<meta http-equiv="pragma" content="no-cache">
 	</head>

--- a/src/htdocs/manual.php
+++ b/src/htdocs/manual.php
@@ -13,8 +13,8 @@ try {
 
 <html>
 	<head>
-		<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS; ?>">
-		<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS_COLOUR; ?>">
+		<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS); ?>">
+		<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS_COLOUR); ?>">
 		<title>Space Merchant Realms - Manual</title>
 		<meta http-equiv="pragma" content="no-cache">
 	</head>

--- a/src/htdocs/manual_toc.php
+++ b/src/htdocs/manual_toc.php
@@ -8,8 +8,8 @@ try {
 
 <html>
 	<head>
-	<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS; ?>">
-	<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS_COLOUR; ?>">
+	<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS); ?>">
+	<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS_COLOUR); ?>">
 		<title>Space Merchant Realms - Manual</title>
 		<meta http-equiv="pragma" content="no-cache">
 	</head>

--- a/src/pages/Album/SkeletonRenderer.php
+++ b/src/pages/Album/SkeletonRenderer.php
@@ -15,8 +15,8 @@ class SkeletonRenderer {
 		<!DOCTYPE html>
 		<html>
 			<head>
-				<link rel="stylesheet" type="text/css" href="/<?php echo DEFAULT_CSS; ?>">
-				<link rel="stylesheet" type="text/css" href="/<?php echo DEFAULT_CSS_COLOUR; ?>">
+				<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS); ?>">
+				<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS_COLOUR); ?>">
 				<title>Space Merchant Realms - Photo Album</title>
 				<meta http-equiv="pragma" content="no-cache">
 			</head>

--- a/src/pages/Standalone/ShipListRenderer.php
+++ b/src/pages/Standalone/ShipListRenderer.php
@@ -25,8 +25,8 @@ class ShipListRenderer {
 		<!DOCTYPE html>
 		<html>
 			<head>
-				<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS; ?>">
-				<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS_COLOUR; ?>">
+				<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS); ?>">
+				<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS_COLOUR); ?>">
 				<title>Space Merchant Realms - Ship List</title>
 				<meta http-equiv="pragma" content="no-cache">
 				<style>

--- a/src/pages/Standalone/WeaponListRenderer.php
+++ b/src/pages/Standalone/WeaponListRenderer.php
@@ -16,8 +16,8 @@ class WeaponListRenderer {
 		<!DOCTYPE html>
 		<html>
 			<head>
-				<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS; ?>">
-				<link rel="stylesheet" type="text/css" href="<?php echo DEFAULT_CSS_COLOUR; ?>">
+				<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS); ?>">
+				<link rel="stylesheet" type="text/css" href="<?php echo asset_url(DEFAULT_CSS_COLOUR); ?>">
 				<title>Weapon List</title>
 				<meta http-equiv="pragma" content="no-cache">
 				<style>


### PR DESCRIPTION
Complete the `asset_url()` migration introduced by d8a536e64 for standalone pages that reference the default CSS constants directly.

These omitted pages otherwise bypass the asset manifest in production and serve unhashed stylesheet paths. The album renderer now also avoids prepending a second slash to the canonical URL.