### PR TITLE
UniGen: add summary in CreateLocations

### DIFF
--- a/src/pages/Admin/UniGen/CreateLocations.php
+++ b/src/pages/Admin/UniGen/CreateLocations.php
@@ -28,8 +28,10 @@ class CreateLocations extends AccountPage {
 
 		// Initialize all location counts to zero
 		$totalLocs = [];
+		$locNames = [];
 		foreach ($locations as $location) {
 			$totalLocs[$location->getTypeID()] = 0;
+			$locNames[$location->getTypeID()] = $location->getName();
 		}
 
 		$galaxy = Galaxy::getGalaxy($this->gameID, $this->galaxyID);
@@ -93,11 +95,61 @@ class CreateLocations extends AccountPage {
 			$locText[$location->getTypeID()] = $location->getName() . $extra;
 		}
 
+		// Build summary rows for locations that can be configured directly.
+		$locationSummary = [
+			'Total' => array_sum($totalLocs),
+			'Categories' => [],
+		];
+		$shownLocationIDs = [];
+		foreach ($categories->locTypes as $category => $locIDs) {
+			$summaryLocations = [];
+			$categoryLocationCount = 0;
+			foreach ($locIDs as $locID) {
+				$shownLocationIDs[] = $locID;
+				$count = $totalLocs[$locID];
+				if ($count > 0) {
+					$categoryLocationCount += $count;
+					$summaryLocations[] = [
+						'Name' => $locNames[$locID],
+						'Count' => $count,
+					];
+				}
+			}
+			if (count($summaryLocations) > 0) {
+				$locationSummary['Categories'][] = [
+					'Name' => $category,
+					'Count' => $categoryLocationCount,
+					'Locations' => $summaryLocations,
+				];
+			}
+		}
+
+		// Append locations that are created automatically with another location.
+		$linkedLocations = [];
+		$linkedLocationCount = 0;
+		foreach ($totalLocs as $locID => $count) {
+			if ($count > 0 && !in_array($locID, $shownLocationIDs, true)) {
+				$linkedLocationCount += $count;
+				$linkedLocations[] = [
+					'Name' => $locNames[$locID],
+					'Count' => $count,
+				];
+			}
+		}
+		if (count($linkedLocations) > 0) {
+			$locationSummary['Categories'][] = [
+				'Name' => 'Automatically linked',
+				'Count' => $linkedLocationCount,
+				'Locations' => $linkedLocations,
+			];
+		}
+
 		$template->pageRenderer = fn() => CreateLocationsRenderer::render(
 			Galaxies: Galaxy::getGameGalaxies($this->gameID),
 			JumpGalaxyHREF: new self($this->gameID, $this->returnTo)->href(),
 			Galaxy: $galaxy,
 			TotalLocs: $totalLocs,
+			LocationSummary: $locationSummary,
 			LocText: $locText,
 			LocTypes: $categories->locTypes,
 			CreateLocationsFormHREF: new CreateLocationsProcessor(

--- a/src/pages/Admin/UniGen/CreateLocationsRenderer.php
+++ b/src/pages/Admin/UniGen/CreateLocationsRenderer.php
@@ -9,6 +9,7 @@ class CreateLocationsRenderer {
 	/**
 	 * @param array<int, Galaxy> $Galaxies
 	 * @param array<int, int> $TotalLocs
+	 * @param array{Total: int, Categories: list<array{Name: string, Count: int, Locations: list<array{Name: string, Count: int}>}>} $LocationSummary
 	 * @param array<int, string> $LocText
 	 * @param array<string, array<int>> $LocTypes
 	 */
@@ -17,6 +18,7 @@ class CreateLocationsRenderer {
 		string $JumpGalaxyHREF,
 		Galaxy $Galaxy,
 		array $TotalLocs,
+		array $LocationSummary,
 		array $LocText,
 		array $LocTypes,
 		string $CreateLocationsFormHREF,
@@ -33,6 +35,38 @@ class CreateLocationsRenderer {
 				} ?>
 			</select>
 		</form>
+		<br />
+
+		<style>
+			.location-summary-count {
+				display: inline-block;
+				margin-right: 0.75em;
+				text-align: right;
+				width: 2ch;
+			}
+		</style>
+
+		<table class="standard">
+			<tr>
+				<th colspan="2">Existing locations (<?php echo $LocationSummary['Total']; ?>)</th>
+			</tr>
+			<tr>
+				<th>Category</th>
+				<th>Locations</th>
+			</tr><?php
+			foreach ($LocationSummary['Categories'] as $summaryCategory) { ?>
+				<tr>
+					<td class="right"><?php echo $summaryCategory['Name']; ?> (<?php echo $summaryCategory['Count']; ?>)</td>
+					<td><?php
+					foreach ($summaryCategory['Locations'] as $summaryLocation) { ?>
+						<div>
+							<span class="location-summary-count yellow bold"><?php echo $summaryLocation['Count']; ?></span><?php echo $summaryLocation['Name']; ?>
+						</div><?php
+					} ?>
+					</td>
+				</tr><?php
+			} ?>
+		</table>
 		<br />
 
 		<?php


### PR DESCRIPTION
The form for adding locations on this page is so unwieldy that it is hard to see at a glance which locations already exist in the galaxy.

We add a summary table at the top of the page, counting the number of each location, each location group, and total locations. This will be especially useful for finding broken symmetries between galaxies.

<img width="339" height="333" alt="image" src="https://github.com/user-attachments/assets/fb62459d-a059-47b8-9054-b9f00263a67a" />
