### PR TITLE
Fix showing cloaked ship message on planets

### DIFF
--- a/src/pages/Player/AttackPortConfirm.php
+++ b/src/pages/Player/AttackPortConfirm.php
@@ -27,7 +27,7 @@ class AttackPortConfirm extends PlayerPage {
 		$template->pageRenderer = fn() => AttackPortConfirmRenderer::render(
 			PortAttackHREF: new AttackPortProcessor()->href(),
 			Port: $port,
-			VisiblePlayers: $eligibleAttackers,
+			EligibleAttackers: $eligibleAttackers,
 			SectorPlayersLabel: 'Attackers',
 			ThisShip: $player->getShip(),
 			ThisAccount: $player->getAccount(),

--- a/src/pages/Player/AttackPortConfirmRenderer.php
+++ b/src/pages/Player/AttackPortConfirmRenderer.php
@@ -14,12 +14,12 @@ use Smr\Ship;
 class AttackPortConfirmRenderer {
 
 	/**
-	 * @param array<int, Player> $VisiblePlayers
+	 * @param array<int, Player> $EligibleAttackers
 	 */
 	public static function render(
 		string $PortAttackHREF,
 		Port $Port,
-		array $VisiblePlayers,
+		array $EligibleAttackers,
 		string $SectorPlayersLabel,
 		Ship $ThisShip,
 		Account $ThisAccount,
@@ -69,8 +69,8 @@ class AttackPortConfirmRenderer {
 			ThisAccount: $ThisAccount,
 			ThisPlanet: $ThisPlanet,
 			ThisPlayer: $ThisPlayer,
-			VisiblePlayers: $VisiblePlayers,
-			CloakedPlayers: [],
+			VisiblePlayers: $EligibleAttackers,
+			DisplayCloakedShipMessage: false, // only showing allied ships
 			SectorPlayersLabel: $SectorPlayersLabel,
 		);
 		?>

--- a/src/pages/Player/CurrentSector.php
+++ b/src/pages/Player/CurrentSector.php
@@ -142,12 +142,13 @@ class CurrentSector extends PlayerPage {
 		// *******************************************
 		$otherPlayers = $sector->getOtherTraders($player);
 		$visiblePlayers = [];
-		$cloakedPlayers = [];
+		$displayCloakedShipMessage = false;
 		foreach ($otherPlayers as $accountID => $otherPlayer) {
 			if ($player->canSee($otherPlayer)) {
 				$visiblePlayers[$accountID] = $otherPlayer;
 			} else {
-				$cloakedPlayers[$accountID] = $otherPlayer;
+				// Display message if at least one unseen cloaked ship
+				$displayCloakedShipMessage = true;
 			}
 		}
 
@@ -164,7 +165,7 @@ class CurrentSector extends PlayerPage {
 			TradeMessage: $this->tradeMessage,
 			PortIsAtWar: $portIsAtWar,
 			VisiblePlayers: $visiblePlayers,
-			CloakedPlayers: $cloakedPlayers,
+			DisplayCloakedShipMessage: $displayCloakedShipMessage,
 			SectorPlayersLabel: 'Ships',
 			AttackResults: checkForAttackMessage($this->attackMessage, $player),
 			ThisAccount: $player->getAccount(),

--- a/src/pages/Player/CurrentSectorRenderer.php
+++ b/src/pages/Player/CurrentSectorRenderer.php
@@ -33,7 +33,6 @@ class CurrentSectorRenderer {
 	 * @param array<string, array{ID: int, Class: string}> $Sectors
 	 * @param array<int, ?string> $UnreadMissions
 	 * @param array<int, Player> $VisiblePlayers
-	 * @param array<int, Player> $CloakedPlayers
 	 * @param ?array{Results: \Smr\Combat\Results\Full\FullCombatResults, Link: string} $AttackResults
 	 * @param ?array<array{Time: string, Message: string}> $Ticker
 	 */
@@ -50,7 +49,7 @@ class CurrentSectorRenderer {
 		?string $TradeMessage,
 		?bool $PortIsAtWar,
 		array $VisiblePlayers,
-		array $CloakedPlayers,
+		bool $DisplayCloakedShipMessage,
 		string $SectorPlayersLabel,
 		?array $AttackResults,
 		Player $ThisPlayer,
@@ -154,7 +153,7 @@ class CurrentSectorRenderer {
 			ThisPlanet: $ThisPlanet,
 			ThisPlayer: $ThisPlayer,
 			VisiblePlayers: $VisiblePlayers,
-			CloakedPlayers: $CloakedPlayers,
+			DisplayCloakedShipMessage: $DisplayCloakedShipMessage,
 			SectorPlayersLabel: $SectorPlayersLabel,
 		);
 		SectorForcesRenderer::render(

--- a/src/pages/Player/ExaminePlanet.php
+++ b/src/pages/Player/ExaminePlanet.php
@@ -49,7 +49,7 @@ class ExaminePlanet extends PlayerPage {
 		$template->pageRenderer = fn() => ExaminePlanetRenderer::render(
 			ThisPlanet: $planet,
 			PlanetLand: $planetLand,
-			VisiblePlayers: $eligibleAttackers,
+			EligibleAttackers: $eligibleAttackers,
 			SectorPlayersLabel: 'Attackers',
 			ThisAccount: $player->getAccount(),
 			ThisPlayer: $player,

--- a/src/pages/Player/ExaminePlanetRenderer.php
+++ b/src/pages/Player/ExaminePlanetRenderer.php
@@ -10,12 +10,12 @@ use Smr\Player;
 class ExaminePlanetRenderer {
 
 	/**
-	 * @param array<int, Player> $VisiblePlayers
+	 * @param array<int, Player> $EligibleAttackers
 	 */
 	public static function render(
 		Planet $ThisPlanet,
 		bool $PlanetLand,
-		array $VisiblePlayers,
+		array $EligibleAttackers,
 		string $SectorPlayersLabel,
 		Account $ThisAccount,
 		Player $ThisPlayer,
@@ -90,8 +90,8 @@ class ExaminePlanetRenderer {
 			ThisAccount: $ThisAccount,
 			ThisPlanet: $ThisPlanet,
 			ThisPlayer: $ThisPlayer,
-			VisiblePlayers: $VisiblePlayers,
-			CloakedPlayers: [],
+			VisiblePlayers: $EligibleAttackers,
+			DisplayCloakedShipMessage: false, // only showing allied ships
 			SectorPlayersLabel: $SectorPlayersLabel,
 		);
 		?>

--- a/src/pages/Player/Planet/Main.php
+++ b/src/pages/Player/Planet/Main.php
@@ -26,7 +26,7 @@ class Main extends PlanetPage {
 			ErrorMsg: $this->errorMessage,
 			Msg: $this->message,
 			LaunchLink: new LaunchProcessor()->href(),
-			VisiblePlayers: $planet->getOtherTraders($player),
+			AllPlayers: $planet->getOtherTraders($player),
 			SectorPlayersLabel: 'Ships',
 			ThisPlanet: $player->getSectorPlanet(),
 			ThisAccount: $player->getAccount(),

--- a/src/pages/Player/Planet/MainRenderer.php
+++ b/src/pages/Player/Planet/MainRenderer.php
@@ -11,14 +11,14 @@ use Smr\Player;
 class MainRenderer {
 
 	/**
-	 * @param array<int, Player> $VisiblePlayers
+	 * @param array<int, Player> $AllPlayers
 	 * @param ?array<array{Time: string, Message: string}> $Ticker
 	 */
 	public static function render(
 		?string $ErrorMsg,
 		?string $Msg,
 		string $LaunchLink,
-		array $VisiblePlayers,
+		array $AllPlayers,
 		string $SectorPlayersLabel,
 		Planet $ThisPlanet,
 		Account $ThisAccount,
@@ -129,8 +129,8 @@ class MainRenderer {
 			ThisAccount: $ThisAccount,
 			ThisPlanet: $ThisPlanet,
 			ThisPlayer: $ThisPlayer,
-			VisiblePlayers: $VisiblePlayers,
-			CloakedPlayers: $VisiblePlayers,
+			VisiblePlayers: $AllPlayers,
+			DisplayCloakedShipMessage: false, // landed ships are always visible
 			SectorPlayersLabel: $SectorPlayersLabel,
 		);
 

--- a/src/pages/Shared/SectorPlayersRenderer.php
+++ b/src/pages/Shared/SectorPlayersRenderer.php
@@ -19,14 +19,13 @@ class SectorPlayersRenderer {
 
 	/**
 	 * @param array<\Smr\Player> $VisiblePlayers
-	 * @param array<\Smr\Player> $CloakedPlayers
 	 */
 	public static function render(
 		Account $ThisAccount,
 		?Planet $ThisPlanet,
 		Player $ThisPlayer,
 		array $VisiblePlayers,
-		array $CloakedPlayers,
+		bool $DisplayCloakedShipMessage,
 		string $SectorPlayersLabel,
 	): void {
 		?>
@@ -101,7 +100,7 @@ class SectorPlayersRenderer {
 					} ?>
 				</table><?php
 			}
-			if (count($CloakedPlayers) > 0) {
+			if ($DisplayCloakedShipMessage) {
 				?><p><span class="red bold">WARNING:</span> Sensors have detected the presence of cloaked vessels in this sector</p><?php
 			} ?>
 		</div><br />


### PR DESCRIPTION
Landed ships are always visible, so the Planet Main renderer should have all ships in VisiblePlayers and no ships in CloakedPlayers.

In the SectorPlayersRenderer, replace the array `$CloakedPlayers` with a bool for whether or not to show the cloaked ship message, since we were not using the list of cloaked players for anything else.

Also change the variable names for the list of visible players from the callers of SectorPlayersRenderer to be more accurately named and avoid confusion about what it's actually used for.