### PR TITLE
Database: add InnoDB transaction locking API

### DIFF
--- a/src/lib/Smr/Database.php
+++ b/src/lib/Smr/Database.php
@@ -98,6 +98,34 @@ class Database {
 	}
 
 	/**
+	 * Start a transaction for InnoDB operations.
+	 */
+	public function beginTransaction(): void {
+		$this->dbConn->beginTransaction();
+	}
+
+	/**
+	 * Commit the active InnoDB transaction.
+	 */
+	public function commit(): void {
+		$this->dbConn->commit();
+	}
+
+	/**
+	 * Roll back the active InnoDB transaction.
+	 */
+	public function rollBack(): void {
+		$this->dbConn->rollBack();
+	}
+
+	/**
+	 * Return whether this connection has an active InnoDB transaction.
+	 */
+	public function isTransactionActive(): bool {
+		return $this->dbConn->isTransactionActive();
+	}
+
+	/**
 	 * Perform a write-only query on the database.
 	 * Used for UPDATE, DELETE, REPLACE and INSERT queries, for example.
 	 *
@@ -156,6 +184,7 @@ class Database {
 	 * @param list<string> $returnColumns
 	 * @param list<string> $orderBy Columns to order the result by
 	 * @param list<'ASC'|'DESC'> $order Direction to order the $orderBy columns
+	 * @param ?RowLockMode $lock InnoDB row lock to hold until the transaction ends
 	 */
 	public function select(
 		string $table,
@@ -164,7 +193,11 @@ class Database {
 		array $orderBy = [],
 		array $order = [],
 		?int $limit = null,
+		?RowLockMode $lock = null,
 	): DatabaseResult {
+		if ($lock !== null && !$this->isTransactionActive()) {
+			throw new Exception('Row locks require an active transaction');
+		}
 		$query = 'SELECT ' . implode(',', $returnColumns) . ' FROM ' . $table;
 		if (count($criteria) > 0) {
 			// Create named placeholder SQL using the name of each column in the criteria
@@ -187,6 +220,9 @@ class Database {
 		}
 		if ($limit !== null) {
 			$query .= ' LIMIT ' . $limit;
+		}
+		if ($lock !== null) {
+			$query .= ' ' . $lock->value;
 		}
 		return $this->read($query, $criteria);
 	}

--- a/src/lib/Smr/RowLockMode.php
+++ b/src/lib/Smr/RowLockMode.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Smr;
+
+/**
+ * InnoDB row-locking modes for SELECT statements in an active transaction.
+ */
+enum RowLockMode: string {
+
+	case Share = 'FOR SHARE';
+	case Update = 'FOR UPDATE';
+
+}

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Smr\Container\DiContainer;
 use Smr\Database;
 use Smr\DatabaseProperties;
+use Smr\RowLockMode;
 
 /**
  * This is an integration test, but does not need to extend BaseIntegrationTest since we are not writing any data.
@@ -136,6 +137,38 @@ class DatabaseIntegrationTest extends TestCase {
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('order and orderBy must be the same length');
 		$db->select('level', orderBy: ['level_id', 'level_name'], order: ['DESC']);
+	}
+
+	public function test_select_lock_requires_active_transaction(): void {
+		$db = Database::getInstance();
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Row locks require an active transaction');
+		$db->select('player', limit: 1, lock: RowLockMode::Update);
+	}
+
+	public function test_beginTransaction_and_rollBack_change_transaction_state(): void {
+		$db = Database::getInstance();
+		self::assertFalse($db->isTransactionActive());
+
+		$db->beginTransaction();
+		try {
+			self::assertTrue($db->isTransactionActive());
+			$db->select('player', limit: 1, lock: RowLockMode::Update);
+		} finally {
+			$db->rollBack();
+		}
+
+		self::assertFalse($db->isTransactionActive());
+	}
+
+	public function test_commit_deactivates_transaction(): void {
+		$db = Database::getInstance();
+		$db->beginTransaction();
+		self::assertTrue($db->isTransactionActive());
+
+		$db->commit();
+
+		self::assertFalse($db->isTransactionActive());
 	}
 
 	public function test_count(): void {


### PR DESCRIPTION
Expose Doctrine DBAL transaction lifecycle methods with simple wrappers, and an explicit InnoDB row-lock mode for select queries. Locked reads now require an active transaction, preventing accidental locks whose lifetime is unclear.