### PR TITLE
Remove unread message cache

### DIFF
--- a/db/patches/V1_6_70_02__remove_unread_message_cache.sql
+++ b/db/patches/V1_6_70_02__remove_unread_message_cache.sql
@@ -1,0 +1,6 @@
+-- The message sidebar reads unread counts from message directly. This index
+-- covers its player, visibility, unread-state, and message-type lookup.
+ALTER TABLE message
+	ADD KEY unread_by_player (player_id, receiver_delete, msg_read, message_type_id);
+
+DROP TABLE player_has_unread_messages;

--- a/src/htdocs/login_processing.php
+++ b/src/htdocs/login_processing.php
@@ -167,21 +167,6 @@ try {
 	$db->write('UPDATE message SET receiver_delete = \'TRUE\', sender_delete = \'TRUE\', expire_time = 0 WHERE expire_time < :now AND expire_time != 0', [
 		'now' => $db->escapeNumber(Epoch::time()),
 	]);
-	//update unread message status (in case changed by expired messages)
-	$db->write('DELETE player_has_unread_messages FROM player_has_unread_messages
-		JOIN player USING (player_id)
-		WHERE player.account_id = :account_id', [
-		'account_id' => $db->escapeNumber($account->getAccountID()),
-	]);
-	$db->write('
-		INSERT INTO player_has_unread_messages (player_id, game_id, message_type_id)
-		SELECT message.player_id, message.game_id, message.message_type_id
-		FROM message JOIN player USING (player_id)
-		WHERE player.account_id = :account_id AND msg_read = :msg_read AND receiver_delete = :receiver_delete', [
-		'account_id' => $db->escapeNumber($account->getAccountID()),
-		'msg_read' => $db->escapeBoolean(false),
-		'receiver_delete' => $db->escapeBoolean(false),
-	]);
 
 	header('Location: ' . $href);
 	exit;

--- a/src/lib/Default/smr.inc.php
+++ b/src/lib/Default/smr.inc.php
@@ -594,13 +594,25 @@ function getSkeletonData(Template $template): SkeletonData {
 		$gameName = Game::getGame($session->getGameID())->getName();
 
 		$unreadMessages = [];
-		$dbResult = $db->read('SELECT message_type_id,COUNT(*) FROM player_has_unread_messages WHERE ' . Player::SQL . ' GROUP BY message_type_id', $player->SQLID);
+		$dbResult = $db->read(
+			'SELECT message_type_id, COUNT(*) AS unread_count
+			FROM message
+			WHERE ' . Player::SQL . '
+				AND receiver_delete = :receiver_delete
+				AND msg_read = :msg_read
+			GROUP BY message_type_id',
+			[
+				...$player->SQLID,
+				'receiver_delete' => $db->escapeBoolean(false),
+				'msg_read' => $db->escapeBoolean(false),
+			],
+		);
 		foreach ($dbResult->records() as $dbRecord) {
 			$messageTypeID = $dbRecord->getInt('message_type_id');
 			$container = new MessageView($messageTypeID);
 			$unreadMessages[] = [
 				'href' => $container->href(),
-				'num' => $dbRecord->getInt('COUNT(*)'),
+				'num' => $dbRecord->getInt('unread_count'),
 				'alt' => Messages::getMessageTypeNames($messageTypeID),
 				'img' => Messages::getMessageTypeImage($messageTypeID),
 			];

--- a/src/lib/Smr/Player.php
+++ b/src/lib/Smr/Player.php
@@ -849,15 +849,6 @@ class Player {
 			'sender_delete' => $db->escapeBoolean($senderDelete),
 		]);
 
-		if ($unread === true) {
-			// give him the message icon
-			$db->replace('player_has_unread_messages', [
-				'player_id' => $receiverPlayerID,
-				'game_id' => $gameID,
-				'message_type_id' => $messageTypeID,
-			]);
-		}
-
 		switch ($messageTypeID) {
 			case MSG_PLAYER:
 				$receiverAccount = $receiverPlayer->getAccount();
@@ -1131,10 +1122,6 @@ class Player {
 
 	public function setMessagesRead(int $messageTypeID): void {
 		$db = Database::getInstance();
-		$db->delete('player_has_unread_messages', [
-			'message_type_id' => $messageTypeID,
-			...$this->SQLID,
-		]);
 		$db->update(
 			'message',
 			['msg_read' => $db->escapeBoolean(true)],

--- a/src/pages/Admin/AccountEditProcessor.php
+++ b/src/pages/Admin/AccountEditProcessor.php
@@ -225,7 +225,6 @@ class AccountEditProcessor extends AccountPageProcessor {
 				$db->delete('player_has_notes', $editPlayer->SQLID);
 				$db->delete('player_has_ticker', $editPlayer->SQLID);
 				$db->delete('player_has_ticket', $editPlayer->SQLID);
-				$db->delete('player_has_unread_messages', $editPlayer->SQLID);
 				$db->delete('player_plotted_course', $editPlayer->SQLID);
 				$db->delete('player_read_thread', $editPlayer->SQLID);
 				$db->delete('player_stored_sector', $editPlayer->SQLID);

--- a/src/pages/Admin/DatabaseCleanupProcessor.php
+++ b/src/pages/Admin/DatabaseCleanupProcessor.php
@@ -34,7 +34,6 @@ class DatabaseCleanupProcessor extends AccountPageProcessor {
 			'player_visited_port',
 			'player_visited_sector',
 			'port_info_cache',
-			'player_has_unread_messages',
 			'player_read_thread',
 			'route_cache',
 			'weighted_random',

--- a/src/pages/Player/AllianceSetOpProcessor.php
+++ b/src/pages/Player/AllianceSetOpProcessor.php
@@ -30,8 +30,6 @@ class AllianceSetOpProcessor extends PlayerPageProcessor {
 				'player_ids' => $db->escapeArray($memberPlayerIDs),
 			]);
 
-			// NOTE: for simplicity we don't touch `player_has_unread_messages` here,
-			// so they may get an errant alliance message icon if logged in.
 		} else {
 			// schedule an op
 			$date = Request::get('date');

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -186,7 +186,7 @@ class DatabaseIntegrationTest extends TestCase {
 		// added that modify the base table size. If that becomes too onerous,
 		// we can do a fuzzier comparison. Until then, this is a useful check
 		// that the test database is properly reset between invocations.
-		self::assertSame($bytes, 1590421);
+		self::assertSame($bytes, 1557653);
 	}
 
 	public function test_escapeBoolean(): void {


### PR DESCRIPTION
Use the `messages` table directly to determine unread message counts, rather than using the `player_has_unread_messages` cache table, which required constant (and inefficient) rebuilding, and was prone to stale entries. A proper index on the `messages` table is therefore more efficient and straightforward for this purpose.