### PR TITLE
Add phpstan-dba extension for database-aware checks

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -113,6 +113,9 @@ jobs:
           cache-from: type=gha
           load: true
 
+      - name: Setup test environment
+        run: composer start:test-services
+
       - name: Run static analysis
         run: composer phpstan
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM php:8.5.6-apache
 RUN apt-get --quiet=2 update \
 	&& apt-get --quiet=2 install zip unzip \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install pdo_mysql > /dev/null
+	&& docker-php-ext-install pdo_mysql calendar > /dev/null
 
 # Set the baseline php.ini version (default to production)
 ARG NO_DEV=1

--- a/abstract-services.yml
+++ b/abstract-services.yml
@@ -70,6 +70,7 @@ services:
             - ./config/config.specific.sample.php:/smr/config/config.specific.php:ro
             - ./phpunit.xml:/smr/phpunit.xml:ro
             - ./phpstan.neon.dist:/smr/phpstan.neon.dist:ro
+            - ./phpstan-dba.neon:/smr/phpstan-dba.neon:ro
             - ./phpcs.xml:/smr/phpcs.xml:ro
             # Mount the source code instead of copying it (read+write for rector)
             - ./rector.php:/smr/rector.php:rw

--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,8 @@
 		"phpstan/phpstan": "2.2.13",
 		"phpunit/phpunit": "13.3.1",
 		"rector/rector": "2.5.9",
-		"squizlabs/php_codesniffer": "4.0.4"
+		"sqlftw/sqlftw": "0.1.17",
+		"squizlabs/php_codesniffer": "4.0.4",
+		"staabm/phpstan-dba": "0.4.10"
 	}
 }

--- a/phpstan-dba.neon
+++ b/phpstan-dba.neon
@@ -1,0 +1,252 @@
+# PHPStan configuration for the phpstan-dba extension
+
+services:
+    -
+        class: staabm\PHPStanDba\Rules\SyntaxErrorInPreparedStatementMethodRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            classMethods:
+                - 'Smr\Database::read'
+                - 'Smr\Database::write'
+    -
+        class: staabm\PHPStanDba\Rules\DoctrineKeyValueStyleRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            classMethods:
+                - 'Smr\Database::count#1'
+                - 'Smr\Database::select#1'
+                - 'Smr\Database::insert#1'
+                - 'Smr\Database::replace#1'
+                - 'Smr\Database::delete#1'
+                - 'Smr\Database::update#1,2'
+    -
+        class: SmrTest\PHPStanExtensions\ArrayValuesAreColumnsRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            classMethods:
+                - 'Smr\Database::select#2,3'
+    -
+        class: SmrTest\PHPStanExtensions\DatabaseRecordRule
+        tags: [phpstan.rules.rule]
+    -
+        class: SmrTest\PHPStanExtensions\DatabaseReadDynamicReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+    -
+        class: SmrTest\PHPStanExtensions\DatabaseRecordDynamicReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+    -
+        class: SmrTest\PHPStanExtensions\DatabaseResultDynamicReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+    -
+        class: SmrTest\PHPStanExtensions\DatabaseSelectDynamicReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
+parameters:
+    ignoreErrors:
+        -
+            # History databases are not supported.
+            message: '#^Smr\\DatabaseRecord field name must be a constant string, got string$#'
+            identifier: smr.dba.databaseRecordFieldName
+            count: 1
+            path: src/lib/Smr/Account.php
+
+        -
+            # False positive due to incomplete LEFT JOIN support in phpstan-dba.
+            message: '#^Smr\\DatabaseRecord\:\:getNullableString returns type string\|null, but field `hof_name` has type int\<0, 65535\>$#'
+            identifier: smr.dba.databaseRecordType
+            count: 1
+            path: src/lib/Smr/Album.php
+
+        -
+            # Database is an intentionally dynamic wrapper around Doctrine DBAL methods.
+            message: '#^Argument \#0 expects a constant string, got string$#'
+            identifier: dba.ArrayValuesAreColumnsRule
+            count: 1
+            path: src/lib/Smr/Database.php
+
+        -
+            # Database is an intentionally dynamic wrapper around Doctrine DBAL methods.
+            message: '#^Argument \#0 expects a constant string, got string$#'
+            identifier: dba.keyValue
+            count: 3
+            path: src/lib/Smr/Database.php
+
+        -
+            # Database is an intentionally dynamic wrapper around Doctrine DBAL methods.
+            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: (non\-falsy\-string|string)\.$#'
+            identifier: dba.unresolvableQuery
+            count: 3
+            path: src/lib/Smr/Database.php
+
+        -
+            # Database is an intentionally dynamic wrapper around Doctrine DBAL methods.
+            message: '#^Unresolvable Query\: Cannot simulate parameter value for type\: mixed\.$#'
+            identifier: dba.unresolvableQuery
+            count: 1
+            path: src/lib/Smr/Database.php
+
+        -
+            # SUM() is technically nullable when information_schema.tables has no matching rows.
+            message: '#^Smr\\DatabaseRecord\:\:getInt returns type int, but field `db_bytes` has type numeric\-string\|null$#'
+            identifier: smr.dba.databaseRecordType
+            count: 1
+            path: src/lib/Smr/Database.php
+
+        -
+            # User-score ranking SQL is assembled from the single source of truth
+            # in Account::getUserScoreCaseStatement(). Duplicating it here would
+            # make the ranking and query implementations drift apart.
+            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: string\.$#'
+            identifier: dba.unresolvableQuery
+            count: 2
+            path: src/lib/Smr/HallOfFame.php
+
+        -
+            # This is a variable-length bulk INSERT assembled from player IDs.
+            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: non\-falsy\-string\.$#'
+            identifier: dba.unresolvableQuery
+            count: 1
+            path: src/lib/Smr/Port.php
+
+        -
+            # Rankings queries are assembled dynamically by stat.
+            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: non\-falsy\-string\.$#'
+            identifier: dba.unresolvableQuery
+            count: 2
+            path: src/lib/Smr/Rankings.php
+
+        -
+            # History databases are not supported.
+            message: '#^Smr\\DatabaseRecord does not contain field\: (end_date|speed|start_date|type)$#'
+            identifier: smr.dba.databaseRecordType
+            count: 4
+            path: src/pages/Account/GamePlay.php
+
+        -
+            # User-score ranking SQL is generated by Account::getUserScoreCaseStatement().
+            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: non\-falsy\-string\.$#'
+            identifier: dba.unresolvableQuery
+            count: 1
+            path: src/pages/Account/HallOfFameAll.php
+
+        -
+            # History databases are not supported.
+            message: '#^Query error\: Column "alliance\.leader_id" does not exist$#'
+            identifier: dba.ArrayValuesAreColumnsRule
+            count: 1
+            path: src/pages/Account/HistoryGames/AllianceDetail.php
+
+        -
+            # History databases are not supported.
+            message: '#^Smr\\DatabaseRecord does not contain field\: (bounty|race)$#'
+            identifier: smr.dba.databaseRecordType
+            count: 2
+            path: src/pages/Account/HistoryGames/AllianceDetail.php
+
+        -
+            # History databases are not supported.
+            message: '#^Query error\: Column "sector\.(kills|mines)" does not exist$#'
+            identifier: dba.ArrayValuesAreColumnsRule
+            count: 4
+            path: src/pages/Account/HistoryGames/ExtendedStatsDetail.php
+
+        -
+            # History databases are not supported.
+            message: '#^Query error\: SQLSTATE\[42S22\]\: Column not found\: 1054 Unknown column ''(deaths|kills)'' in ''field list'' \(42S22\)\.$#'
+            identifier: dba.syntaxError
+            count: 2
+            path: src/pages/Account/HistoryGames/ExtendedStatsDetail.php
+
+        -
+            # History databases are not supported.
+            message: '#^Smr\\DatabaseRecord does not contain field\: message$#'
+            identifier: smr.dba.databaseRecordType
+            count: 1
+            path: src/pages/Account/HistoryGames/GameNews.php
+
+        -
+            # History databases are not supported.
+            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: string\.$#'
+            identifier: dba.unresolvableQuery
+            count: 1
+            path: src/pages/Account/HistoryGames/HallOfFame.php
+
+        -
+            # History databases are not supported.
+            message: '#^Query error\: Column "alliance\.kills" does not exist$#'
+            identifier: dba.ArrayValuesAreColumnsRule
+            count: 2
+            path: src/pages/Account/HistoryGames/Summary.php
+
+        -
+            # History databases are not supported.
+            message: '#^Smr\\DatabaseRecord does not contain field\: (end_date|speed|start_date|type)$#'
+            identifier: smr.dba.databaseRecordType
+            count: 4
+            path: src/pages/Account/HistoryGames/Summary.php
+
+        -
+            # LEFT JOIN aggregation can possibly leave this value null.
+            message: '#^Smr\\DatabaseRecord\:\:getString returns type string, but field `common_ip` has type string\|null$#'
+            identifier: smr.dba.databaseRecordType
+            count: 1
+            path: src/pages/Admin/ComputerSharing.php
+
+        -
+            # False positive due to missing support for CTEs in phpstan-dba.
+            message: '#^Smr\\DatabaseRecord\:\:getInt returns type int, but field `(author_player_id|sendtime)` has type int\<\-2147483648, 2147483647\>\|null$#'
+            identifier: smr.dba.databaseRecordType
+            count: 3
+            path: src/pages/Player/AllianceMessageBoard.php
+
+        -
+            # The roster is rendered for an alliance with members, but phpstan-dba
+            # conservatively treats AVG() as nullable.
+            message: '#^Smr\\DatabaseRecord\:\:getInt returns type int, but field `alliance_avg` has type int\|null$#'
+            identifier: smr.dba.databaseRecordType
+            count: 1
+            path: src/pages/Player/AllianceRoster.php
+
+        -
+            # CombatLog queries are assembled dynamically by CombatLogType.
+            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: non\-falsy\-string\.$#'
+            identifier: dba.unresolvableQuery
+            count: 2
+            path: src/pages/Player/CombatLogList.php
+
+        -
+            # MySQL returns this SUM() expression as a numeric string, which
+            # DatabaseRecord::getInt() deliberately converts to an int.
+            message: '#^Smr\\DatabaseRecord\:\:getInt returns type int, but field `total_unread` has type string$#'
+            identifier: smr.dba.databaseRecordType
+            count: 1
+            path: src/pages/Player/MessageView.php
+
+        -
+            # The test2 table is created at runtime and thus is absent from the schema.
+            message: '#^Query error\: Table "test2" does not exist$#'
+            identifier: dba.ArrayValuesAreColumnsRule
+            count: 2
+            path: test/SmrTest/lib/DatabaseInsertTest.php
+
+        -
+            # The test2 table is created at runtime and thus is absent from the schema.
+            message: '#^Query error\: Table "test2" does not exist$#'
+            identifier: dba.keyValue
+            count: 2
+            path: test/SmrTest/lib/DatabaseInsertTest.php
+
+        -
+            # The test intentionally calls a dynamically selected escaping method
+            # with mixed values to exercise the runtime API.
+            message: '#^Unresolvable Query\: Cannot simulate parameter value for type\: mixed\.$#'
+            identifier: dba.unresolvableQuery
+            count: 1
+            path: test/SmrTest/lib/DatabaseIntegrationTest.php
+
+        -
+            # The test intentionally builds a variable-length UNION query.
+            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: non\-falsy\-string&uppercase\-string\.$#'
+            identifier: dba.unresolvableQuery
+            count: 1
+            path: test/SmrTest/lib/DatabaseResultTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,11 +1,20 @@
 # Distributed PHPStan config
+includes:
+    - phpstan-dba.neon
+
 parameters:
     level: 8
     paths:
         - src
         - test
+    excludePaths:
+        analyse:
+            # These PHPStan fixture files intentionally contain invalid code.
+            # PHPUnit's PHPStan test harness analyzes them with expected errors.
+            - test/SmrTest/PHPStanExtensionTests/fixtures
     bootstrapFiles:
         - src/config.php
+        - test/phpstan-dba-bootstrap.php
 
     # Stricter analysis
     polluteScopeWithLoopInitialAssignments: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
 	</testsuites>
 	<php>
 		<env name="DISABLE_PHPDI_COMPILATION" value="true" force="true" />
+		<ini name="memory_limit" value="512M" />
 	</php>
 	<coverage>
 		<report>
@@ -32,6 +33,7 @@
 	<source>
 		<include>
 			<directory suffix=".php">src/lib</directory>
+			<directory suffix=".php">test/SmrTest/PHPStanExtensions</directory>
 		</include>
 	</source>
 </phpunit>

--- a/test/SmrTest/PHPStanExtensionTests/ArrayValuesAreColumnsRuleTest.php
+++ b/test/SmrTest/PHPStanExtensionTests/ArrayValuesAreColumnsRuleTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests;
+
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SmrTest\PHPStanExtensions\ArrayValuesAreColumnsRule;
+use SmrTest\PHPStanExtensions\CallArgumentResolver;
+
+/**
+ * @extends RuleTestCase<ArrayValuesAreColumnsRule>
+ */
+#[CoversClass(ArrayValuesAreColumnsRule::class)]
+#[CoversClass(CallArgumentResolver::class)]
+class ArrayValuesAreColumnsRuleTest extends RuleTestCase {
+
+	protected function getRule(): Rule {
+		return self::getContainer()->getByType(ArrayValuesAreColumnsRule::class);
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	#[Override]
+	public static function getAdditionalConfigFiles(): array {
+		return [__DIR__ . '/config/phpstan.neon'];
+	}
+
+	public function test_select_validates_table_and_array_arguments(): void {
+		$this->analyse([__DIR__ . '/fixtures/ArrayValuesAreColumnsRule/validation-errors.php'], [
+			[
+				'Query error: Table "unknown_table" does not exist',
+				8,
+			],
+			[
+				'Query error: Column "player.unknown_column" does not exist',
+				12,
+			],
+			[
+				'Query error: Column "player.unknown_column" does not exist',
+				16,
+			],
+			[
+				'Argument #0 expects a constant string, got string',
+				20,
+			],
+			[
+				'Query error: Argument #2 is not a constant array, got array',
+				24,
+			],
+			[
+				'Query error: Argument #3 is not a constant array, got array',
+				28,
+			],
+			[
+				'Query error: Element #1 of argument #2 must have a string value, got 42',
+				32,
+			],
+			[
+				'Query error: Element #0 of argument #3 must have a string value, got 42',
+				36,
+			],
+		]);
+	}
+
+	public function test_select_valid_calls(): void {
+		$this->analyse([__DIR__ . '/fixtures/ArrayValuesAreColumnsRule/valid-calls.php'], []);
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensionTests/DatabaseReadDynamicReturnTypeExtensionTest.php
+++ b/test/SmrTest/PHPStanExtensionTests/DatabaseReadDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SmrTest\PHPStanExtensions\DatabaseReadDynamicReturnTypeExtension;
+use SmrTest\PHPStanExtensions\DatabaseResultObjectType;
+
+#[CoversClass(DatabaseReadDynamicReturnTypeExtension::class)]
+#[CoversClass(DatabaseResultObjectType::class)]
+class DatabaseReadDynamicReturnTypeExtensionTest extends TypeInferenceTestCase {
+
+	public function test_read_infers_resolvable_and_unresolvable_query_results(): void {
+		foreach ($this->gatherAssertTypes(__DIR__ . '/fixtures/DatabaseReadDynamicReturnTypeExtension/types.php') as $assert) {
+			$this->assertFileAsserts(...$assert);
+		}
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	#[Override]
+	public static function getAdditionalConfigFiles(): array {
+		return [__DIR__ . '/config/phpstan.neon'];
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensionTests/DatabaseReadRuleTest.php
+++ b/test/SmrTest/PHPStanExtensionTests/DatabaseReadRuleTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests;
+
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SmrTest\PHPStanExtensions\DatabaseReadDynamicReturnTypeExtension;
+use staabm\PHPStanDba\Rules\SyntaxErrorInPreparedStatementMethodRule;
+
+/**
+ * The return type extension falls back to DatabaseResult for a dynamic query.
+ * Packagist phpstan-dba leaves such whole-query strings to wrapper layers in
+ * normal mode; phpstan-dba's own suite covers its debug-mode reporting.
+ *
+ * @extends RuleTestCase<SyntaxErrorInPreparedStatementMethodRule>
+ */
+#[CoversClass(DatabaseReadDynamicReturnTypeExtension::class)]
+class DatabaseReadRuleTest extends RuleTestCase {
+
+	protected function getRule(): Rule {
+		return self::getContainer()->getByType(SyntaxErrorInPreparedStatementMethodRule::class);
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	#[Override]
+	public static function getAdditionalConfigFiles(): array {
+		return [__DIR__ . '/config/phpstan.neon'];
+	}
+
+	public function test_read_allows_dynamic_query_in_normal_mode(): void {
+		// NOTE: It would be helpful if phpstan-dba would emit an unresolvable
+		// query error in debug mode in the case of a non-constant query string.
+		$this->analyse([__DIR__ . '/fixtures/DatabaseReadRule/dynamic-query.php'], []);
+	}
+
+	public function test_read_accepts_value_from_invalid_record_getter(): void {
+		$this->analyse([__DIR__ . '/fixtures/DatabaseReadRule/invalid-record-getter-value.php'], []);
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensionTests/DatabaseRecordDynamicReturnTypeExtensionTest.php
+++ b/test/SmrTest/PHPStanExtensionTests/DatabaseRecordDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SmrTest\PHPStanExtensions\DatabaseRecordDynamicReturnTypeExtension;
+use SmrTest\PHPStanExtensions\DatabaseRecordTypeResolver;
+
+#[CoversClass(DatabaseRecordDynamicReturnTypeExtension::class)]
+#[CoversClass(DatabaseRecordTypeResolver::class)]
+class DatabaseRecordDynamicReturnTypeExtensionTest extends TypeInferenceTestCase {
+
+	public function test_database_record_getters_infer_row_field_types(): void {
+		foreach ($this->gatherAssertTypes(__DIR__ . '/fixtures/DatabaseRecordDynamicReturnTypeExtension/types.php') as $assert) {
+			$this->assertFileAsserts(...$assert);
+		}
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	#[Override]
+	public static function getAdditionalConfigFiles(): array {
+		return [__DIR__ . '/config/phpstan.neon'];
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensionTests/DatabaseRecordRuleTest.php
+++ b/test/SmrTest/PHPStanExtensionTests/DatabaseRecordRuleTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests;
+
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SmrTest\PHPStanExtensions\DatabaseRecordRule;
+use SmrTest\PHPStanExtensions\DatabaseRecordTypeResolver;
+
+/**
+ * @extends RuleTestCase<DatabaseRecordRule>
+ */
+#[CoversClass(DatabaseRecordRule::class)]
+#[CoversClass(DatabaseRecordTypeResolver::class)]
+class DatabaseRecordRuleTest extends RuleTestCase {
+
+	protected function getRule(): Rule {
+		return self::getContainer()->getByType(DatabaseRecordRule::class);
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	#[Override]
+	public static function getAdditionalConfigFiles(): array {
+		return [__DIR__ . '/config/phpstan.neon'];
+	}
+
+	public function test_getInt_reports_missing_field(): void {
+		$this->analyse([__DIR__ . '/fixtures/DatabaseRecordRule/missing-field.php'], [
+			[
+				'Smr\\DatabaseRecord does not contain field: player_name',
+				12,
+			],
+		]);
+	}
+
+	public function test_getInt_reports_incompatible_field_type(): void {
+		$this->analyse([__DIR__ . '/fixtures/DatabaseRecordRule/incompatible-field-type.php'], [
+			[
+				'Smr\\DatabaseRecord::getInt returns type int, but field `player_name` has type string',
+				12,
+			],
+		]);
+	}
+
+	public function test_getInt_reports_dynamic_field_name(): void {
+		$this->analyse([__DIR__ . '/fixtures/DatabaseRecordRule/dynamic-field.php'], [
+			[
+				'Smr\\DatabaseRecord field name must be a constant string, got string',
+				12,
+			],
+		]);
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensionTests/DatabaseResultDynamicReturnTypeExtensionTest.php
+++ b/test/SmrTest/PHPStanExtensionTests/DatabaseResultDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SmrTest\PHPStanExtensions\DatabaseRecordObjectType;
+use SmrTest\PHPStanExtensions\DatabaseResultDynamicReturnTypeExtension;
+
+#[CoversClass(DatabaseRecordObjectType::class)]
+#[CoversClass(DatabaseResultDynamicReturnTypeExtension::class)]
+class DatabaseResultDynamicReturnTypeExtensionTest extends TypeInferenceTestCase {
+
+	public function test_record_and_records_propagate_query_row_types(): void {
+		foreach ($this->gatherAssertTypes(__DIR__ . '/fixtures/DatabaseResultDynamicReturnTypeExtension/types.php') as $assert) {
+			$this->assertFileAsserts(...$assert);
+		}
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	#[Override]
+	public static function getAdditionalConfigFiles(): array {
+		return [__DIR__ . '/config/phpstan.neon'];
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensionTests/DatabaseSelectDynamicReturnTypeExtensionTest.php
+++ b/test/SmrTest/PHPStanExtensionTests/DatabaseSelectDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SmrTest\PHPStanExtensions\CallArgumentResolver;
+use SmrTest\PHPStanExtensions\DatabaseSelectDynamicReturnTypeExtension;
+
+#[CoversClass(CallArgumentResolver::class)]
+#[CoversClass(DatabaseSelectDynamicReturnTypeExtension::class)]
+class DatabaseSelectDynamicReturnTypeExtensionTest extends TypeInferenceTestCase {
+
+	public function test_select_with_dynamic_return_columns_falls_back_to_declared_type(): void {
+		// A dynamic column list has no static row shape, but is valid at runtime.
+		$asserts = self::gatherAssertTypes(
+			__DIR__ . '/fixtures/DatabaseSelectDynamicReturnTypeExtension/dynamic-return-columns.php',
+		);
+		foreach ($asserts as $assert) {
+			$this->assertFileAsserts(...$assert);
+		}
+	}
+
+	public function test_select_with_reordered_named_arguments_infers_result_type(): void {
+		// PHP permits named arguments in source order unrelated to parameter order.
+		$asserts = self::gatherAssertTypes(
+			__DIR__ . '/fixtures/DatabaseSelectDynamicReturnTypeExtension/reordered-named-arguments.php',
+		);
+		foreach ($asserts as $assert) {
+			$this->assertFileAsserts(...$assert);
+		}
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	#[Override]
+	public static function getAdditionalConfigFiles(): array {
+		return [__DIR__ . '/config/phpstan.neon'];
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensionTests/config/phpstan.neon
+++ b/test/SmrTest/PHPStanExtensionTests/config/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+  - ../../../../phpstan-dba.neon
+
+parameters:
+    # Fixtures exercise the same configured rules and introspected schema as SMR.
+    bootstrapFiles:
+        - ../../../phpstan-dba-bootstrap.php

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/ArrayValuesAreColumnsRule/valid-calls.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/ArrayValuesAreColumnsRule/valid-calls.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests\Fixtures\ArrayValuesAreColumnsRule;
+
+use Smr\Database;
+
+function positionalArguments(Database $db): void {
+	$db->select('player', [], ['player_id']);
+}
+
+function reorderedNamedArguments(Database $db): void {
+	$db->select(
+		returnColumns: ['player_id'],
+		table: 'player',
+	);
+}
+
+function escapedTableAndColumnNames(Database $db): void {
+	$db->select(
+		table: '`player`',
+		returnColumns: ['`player_id`'],
+		orderBy: ['`player_name`'],
+	);
+}
+
+function criteriaValuesAreNotColumnNames(Database $db): void {
+	$db->select(
+		table: 'player',
+		criteria: ['player_id' => 42],
+		returnColumns: ['player_id'],
+	);
+}
+
+function allReturnColumns(Database $db): void {
+	$db->select(
+		table: 'player',
+		returnColumns: ['*'],
+	);
+}
+
+function omittedReturnColumns(Database $db): void {
+	// orderBy is after returnColumns in select()'s signature. PHPStan fills the
+	// omitted returnColumns slot with its ['*'] default while normalizing this.
+	$db->select('player', orderBy: ['player_id']);
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/ArrayValuesAreColumnsRule/validation-errors.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/ArrayValuesAreColumnsRule/validation-errors.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests\Fixtures\ArrayValuesAreColumnsRule;
+
+use Smr\Database;
+
+function unknownTable(Database $db): void {
+	$db->select('unknown_table');
+}
+
+function unknownReturnColumns(Database $db): void {
+	$db->select('player', [], ['unknown_column']);
+}
+
+function unknownOrderBy(Database $db): void {
+	$db->select('player', orderBy: ['unknown_column']);
+}
+
+function dynamicTable(Database $db, string $table): void {
+	$db->select($table);
+}
+
+function dynamicReturnColumns(Database $db, array $returnColumns): void {
+	$db->select('player', [], $returnColumns);
+}
+
+function dynamicOrderBy(Database $db, array $orderBy): void {
+	$db->select('player', [], ['player_id'], $orderBy);
+}
+
+function nonStringReturnColumn(Database $db): void {
+	$db->select('player', [], ['player_id', 42]);
+}
+
+function nonStringOrderBy(Database $db): void {
+	$db->select('player', [], ['player_id'], [42]);
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseReadDynamicReturnTypeExtension/types.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseReadDynamicReturnTypeExtension/types.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionFixtures\DatabaseReadDynamicReturnTypeExtension;
+
+use Smr\Database;
+use function PHPStan\Testing\assertType;
+
+function resolvableRead(Database $db): void {
+	$result = $db->read('SELECT player_id FROM player');
+	assertType('Smr\\DatabaseResult<Doctrine\\DBAL\\Result>', $result);
+	assertType('int<0, 4294967295>', $result->record()->getInt('player_id'));
+}
+
+function unresolvableRead(Database $db, string $query): void {
+	$result = $db->read($query);
+	assertType('Smr\\DatabaseResult', $result);
+	assertType('Smr\\DatabaseRecord', $result->record());
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseReadRule/dynamic-query.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseReadRule/dynamic-query.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests\Fixtures\DatabaseReadRule;
+
+use Smr\Database;
+
+function dynamicQuery(Database $db, string $query): void {
+	$db->read($query);
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseReadRule/invalid-record-getter-value.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseReadRule/invalid-record-getter-value.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionFixtures\DatabaseReadRule;
+
+use Smr\Database;
+
+function invalidRecordGetterValue(Database $db): void {
+	$record = $db->select(
+		table: 'player',
+		returnColumns: ['player_name'],
+	)->record();
+
+	// DatabaseRecordRule reports the incompatible getter. Its declared int
+	// fallback must remain usable as a prepared-statement parameter.
+	$db->read('SELECT player_id FROM player WHERE player_id = :player_id', [
+		'player_id' => $record->getInt('player_name'),
+	]);
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordDynamicReturnTypeExtension/types.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordDynamicReturnTypeExtension/types.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionFixtures\DatabaseRecordDynamicReturnTypeExtension;
+
+use Smr\Database;
+use function PHPStan\Testing\assertType;
+
+function getters(Database $db): void {
+	$record = $db->select(
+		table: 'player',
+		returnColumns: ['player_id'],
+	)->record();
+
+	assertType('int<0, 4294967295>', $record->getInt('player_id'));
+	assertType('int<0, 4294967295>', $record->getInt(name: 'player_id'));
+
+	// Fallback to docstring return type because DatabaseRecord RTE emits the
+	// error that the field is not present in the record.
+	assertType('int', $record->getInt('player_name'));
+
+	// Check that we get all fields when none are specified (default '*')
+	$allFieldsRecord = $db->select(table: 'player')->record();
+	assertType('int<0, 4294967295>', $allFieldsRecord->getInt('player_id'));
+
+	// Fallback to docstring return type because getRow is not supported
+	assertType('array<string, mixed>', $record->getRow());
+
+	// Fallback to docstring return type because DatabaseRecord RTE emits the
+	// error that the field doesn't have the type suggested by the getter.
+	$stringRecord = $db->select(
+		table: 'player',
+		returnColumns: ['player_name'],
+	)->record();
+	assertType('int', $stringRecord->getInt('player_name'));
+	assertType('bool', $stringRecord->getBoolean('player_name'));
+
+	// PDO returns aggregate counts as numeric strings; getInt() converts them.
+	$numericStringRecord = $db
+		->read('SELECT COUNT(*) AS player_count FROM player')
+		->record();
+	assertType('int<0, max>', $numericStringRecord->getInt('player_count'));
+}
+
+function dynamicField(Database $db, string $field): void {
+	// DatabaseRecordRule reports that the field cannot be checked against the row shape.
+	$record = $db->select(
+		table: 'player',
+		returnColumns: ['player_id'],
+	)->record();
+	assertType('int', $record->getInt($field));
+}
+
+function unionOfConstantFieldNames(Database $db, bool $usePlayerId): void {
+	$record = $db->select(
+		table: 'player',
+		returnColumns: ['player_id', 'account_id'],
+	)->record();
+	$field = $usePlayerId ? 'player_id' : 'account_id';
+	assertType('int<0, 4294967295>', $record->getInt($field));
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordRule/dynamic-field.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordRule/dynamic-field.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests\Fixtures\DatabaseRecordRule;
+
+use Smr\Database;
+
+function dynamicField(Database $db, string $field): void {
+	$record = $db->select(
+		table: 'player',
+		returnColumns: ['player_id'],
+	)->record();
+	$record->getInt($field);
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordRule/incompatible-field-type.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordRule/incompatible-field-type.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionFixtures\DatabaseRecordRule;
+
+use Smr\Database;
+
+function incompatibleFieldType(Database $db): void {
+	$record = $db->select(
+		table: 'player',
+		returnColumns: ['player_name'],
+	)->record();
+	$record->getInt('player_name');
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordRule/missing-field.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordRule/missing-field.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionFixtures\DatabaseRecordRule;
+
+use Smr\Database;
+
+function missingField(Database $db): void {
+	$record = $db->select(
+		table: 'player',
+		returnColumns: ['player_id'],
+	)->record();
+	$record->getInt('player_name');
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseResultDynamicReturnTypeExtension/types.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseResultDynamicReturnTypeExtension/types.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionFixtures\DatabaseResultDynamicReturnTypeExtension;
+
+use Smr\Database;
+use function PHPStan\Testing\assertType;
+
+function record(Database $db): void {
+	$record = $db->read('SELECT player_id FROM player')->record();
+	assertType('Smr\DatabaseRecord<array{player_id: int<0, 4294967295>}>', $record);
+}
+
+function records(Database $db): void {
+	$records = $db->read('SELECT player_id FROM player')->records();
+	assertType('Generator<int, Smr\DatabaseRecord<array{player_id: int<0, 4294967295>}>>', $records);
+	foreach ($records as $record) {
+		assertType('Smr\DatabaseRecord<array{player_id: int<0, 4294967295>}>', $record);
+	}
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseSelectDynamicReturnTypeExtension/dynamic-return-columns.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseSelectDynamicReturnTypeExtension/dynamic-return-columns.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests\Fixtures\DatabaseSelectDynamicReturnTypeExtension;
+
+use Smr\Database;
+use function PHPStan\Testing\assertType;
+
+function dynamicReturnColumns(Database $db, array $returnColumns): void {
+	$result = $db->select(
+		table: 'player',
+		returnColumns: $returnColumns,
+	);
+	assertType('Smr\\DatabaseResult', $result);
+}

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseSelectDynamicReturnTypeExtension/reordered-named-arguments.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseSelectDynamicReturnTypeExtension/reordered-named-arguments.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensionTests\Fixtures\DatabaseSelectDynamicReturnTypeExtension;
+
+use Smr\Database;
+use function PHPStan\Testing\assertType;
+
+function reorderedNamedArguments(Database $db): void {
+	$record = $db->select(
+		returnColumns: ['player_id'],
+		table: 'player',
+	)->record();
+	assertType('int<0, 4294967295>', $record->getInt('player_id'));
+}

--- a/test/SmrTest/PHPStanExtensions/ArrayValuesAreColumnsRule.php
+++ b/test/SmrTest/PHPStanExtensions/ArrayValuesAreColumnsRule.php
@@ -1,0 +1,209 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\VerbosityLevel;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
+use function array_key_exists;
+use function count;
+use function is_string;
+
+/**
+	* Validates configured Database API calls whose array values name columns.
+	*
+	* phpstan-dba's DoctrineKeyValueStyleRule validates arrays keyed by column
+	* name. SMR's select() API instead supplies column names as array values.
+	* This rule resolves the configured table against phpstan-dba's schema and
+	* reports dynamic or invalid table, array, and column values.
+	*
+	* @implements Rule<CallLike>
+ */
+final class ArrayValuesAreColumnsRule implements Rule {
+
+	/**
+	 * @var array<array{string, string, list<int>}>
+	 */
+	public array $classMethods;
+
+	private ?QueryReflection $queryReflection = null;
+
+	/**
+	 * @param list<string> $classMethods
+	 */
+	public function __construct(
+		array $classMethods,
+		private readonly ReflectionProvider $reflectionProvider,
+	) {
+		$this->classMethods = [];
+		foreach ($classMethods as $classMethod) {
+			sscanf($classMethod, '%[^::]::%[^#]#%[0-9,]', $className, $methodName, $arrayArgPositions);
+			if (!is_string($className) || !is_string($methodName)) {
+				throw new ShouldNotHappenException('Invalid classMethod definition');
+			}
+			if ($arrayArgPositions !== null) {
+				$arrayArgPositions = array_map(
+					fn($pos) => (int)$pos,
+					explode(',', (string)$arrayArgPositions),
+				);
+			} else {
+				$arrayArgPositions = [];
+			}
+			$this->classMethods[] = [$className, $methodName, $arrayArgPositions];
+		}
+	}
+
+	public function getNodeType(): string {
+		return CallLike::class;
+	}
+
+	/**
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode(Node $callLike, Scope $scope): array {
+		if ($callLike instanceof MethodCall) {
+			if (!$callLike->name instanceof Identifier) {
+				return [];
+			}
+
+			$methodReflection = $scope->getMethodReflection($scope->getType($callLike->var), $callLike->name->toString());
+		} elseif ($callLike instanceof New_) {
+			if (!$callLike->class instanceof FullyQualified) {
+				return [];
+			}
+			$methodReflection = $scope->getMethodReflection(new ObjectType($callLike->class->toCodeString()), '__construct');
+		} else {
+			return [];
+		}
+
+		if ($methodReflection === null) {
+			return [];
+		}
+
+		$unsupportedMethod = true;
+		$arrayArgPositions = [];
+		foreach ($this->classMethods as [$className, $methodName, $arrayArgPositionsConfig]) {
+			if ($methodName === $methodReflection->getName() &&
+				(
+					$methodReflection->getDeclaringClass()->getName() === $className
+					|| ($this->reflectionProvider->hasClass($className) && $methodReflection->getDeclaringClass()->isSubclassOfClass($this->reflectionProvider->getClass($className)))
+				)
+			) {
+				$arrayArgPositions = $arrayArgPositionsConfig;
+				$unsupportedMethod = false;
+				break;
+			}
+		}
+
+		if ($unsupportedMethod) {
+			return [];
+		}
+
+		if (count($callLike->getArgs()) < 1) {
+			return [];
+		}
+
+		$resolvedArguments = CallArgumentResolver::resolve($methodReflection, $callLike, $scope);
+		$paramIndexToArg = $resolvedArguments->getArguments();
+		if ($paramIndexToArg === null) {
+			return [];
+		}
+
+		if (!array_key_exists(0, $paramIndexToArg)) {
+			return [];
+		}
+		$parameters = $resolvedArguments->getParametersAcceptor()->getParameters();
+
+		$tableExpr = $paramIndexToArg[0]->value;
+		$tableType = $scope->getType($tableExpr);
+		$tableNames = $tableType->getConstantStrings();
+		if (count($tableNames) === 0) {
+			return [
+				RuleErrorBuilder::message('Argument #0 expects a constant string, got ' . $tableType->describe(VerbosityLevel::precise()))->identifier('dba.ArrayValuesAreColumnsRule')->line($callLike->getStartLine())->build(),
+			];
+		}
+
+		if ($this->queryReflection === null) {
+			$this->queryReflection = new QueryReflection();
+		}
+		$schemaReflection = $this->queryReflection->getSchemaReflection();
+
+		$errors = [];
+		foreach ($tableNames as $tableName) {
+			// Table name may be escaped with backticks
+			$tableName = trim($tableName->getValue(), '`');
+			$table = $schemaReflection->getTable($tableName);
+			if ($table === null) {
+				$errors[] = 'Table "' . $tableName . '" does not exist';
+				continue;
+			}
+
+			// All array arguments should have table columns as VALUES
+			// (whereas DoctrineKeyValueStyleRule has table columns as KEYS)
+			foreach ($arrayArgPositions as $arrayArgPosition) {
+				// If the argument doesn't exist, just skip it since we don't want
+				// to error in case it has a default value
+				if (!array_key_exists($arrayArgPosition, $paramIndexToArg)) {
+					continue;
+				}
+				$isReturnColumnsArgument = isset($parameters[$arrayArgPosition])
+					&& $parameters[$arrayArgPosition]->getName() === 'returnColumns';
+
+				$argType = $scope->getType($paramIndexToArg[$arrayArgPosition]->value);
+				$argArrays = $argType->getConstantArrays();
+				if (count($argArrays) === 0) {
+					$errors[] = 'Argument #' . $arrayArgPosition . ' is not a constant array, got ' . $argType->describe(VerbosityLevel::precise());
+					continue;
+				}
+
+				foreach ($argArrays as $argArray) {
+					foreach ($argArray->getValueTypes() as $valueIndex => $valueType) {
+						$valueNames = $valueType->getConstantStrings();
+						if (count($valueNames) === 0) {
+							$errors[] = 'Element #' . $valueIndex . ' of argument #' . $arrayArgPosition . ' must have a string value, got ' . $valueType->describe(VerbosityLevel::precise());
+							continue;
+						}
+
+						foreach ($valueNames as $valueName) {
+							// Column name may be escaped with backticks
+							$argColumnName = trim($valueName->getValue(), '`');
+							if ($isReturnColumnsArgument && $argColumnName === '*') {
+								// select() accepts '*' to request every table column.
+								continue;
+							}
+
+							$argColumn = null;
+							foreach ($table->getColumns() as $column) {
+								if ($argColumnName === $column->getName()) {
+									$argColumn = $column;
+								}
+							}
+							if ($argColumn === null) {
+								$errors[] = 'Column "' . $table->getName() . '.' . $argColumnName . '" does not exist';
+								continue;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		$ruleErrors = [];
+		foreach ($errors as $error) {
+			$ruleErrors[] = RuleErrorBuilder::message('Query error: ' . $error)->identifier('dba.ArrayValuesAreColumnsRule')->line($callLike->getStartLine())->build();
+		}
+		return $ruleErrors;
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensions/CallArgumentResolver.php
+++ b/test/SmrTest/PHPStanExtensions/CallArgumentResolver.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PHPStan\Analyser\ArgumentsNormalizer;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+
+/**
+	* Provides PHPStan-normalized call arguments together with their signature.
+	*
+	* PHPStan's normalizer can reorder named arguments only after selecting the
+	* applicable method variant. Extended reflections additionally provide
+	* named-argument variants; other reflections use their regular variants.
+ */
+final readonly class CallArgumentResolver {
+
+	private function __construct(
+		private ParametersAcceptor $parametersAcceptor,
+		private ?CallLike $reorderedCall,
+	) {}
+
+	public static function resolve(
+		MethodReflection $methodReflection,
+		CallLike $callLike,
+		Scope $scope,
+	): self {
+		$namedArgumentsVariants = $methodReflection instanceof ExtendedMethodReflection
+			? $methodReflection->getNamedArgumentsVariants()
+			: null;
+		$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$callLike->getArgs(),
+			$methodReflection->getVariants(),
+			$namedArgumentsVariants,
+		);
+		$reorderedCall = match (true) {
+			$callLike instanceof MethodCall => ArgumentsNormalizer::reorderMethodArguments($parametersAcceptor, $callLike),
+			$callLike instanceof New_ => ArgumentsNormalizer::reorderNewArguments($parametersAcceptor, $callLike),
+			default => null,
+		};
+		return new self(
+			parametersAcceptor: $parametersAcceptor,
+			reorderedCall: $reorderedCall,
+		);
+	}
+
+	/**
+	 * @return ?array<int, \PhpParser\Node\Arg>
+	 */
+	public function getArguments(): ?array {
+		return $this->reorderedCall?->getArgs();
+	}
+
+	public function getParametersAcceptor(): ParametersAcceptor {
+		return $this->parametersAcceptor;
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensions/DatabaseReadDynamicReturnTypeExtension.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseReadDynamicReturnTypeExtension.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use Smr\Database;
+use staabm\PHPStanDba\Extensions\DoctrineConnectionExecuteQueryDynamicReturnTypeExtension;
+
+/**
+ * Adapts phpstan-dba's Doctrine query inference for Database::read().
+ *
+ * The proxy infers the underlying Doctrine result type. This extension wraps
+ * that type in DatabaseResultObjectType so later SMR-specific extensions can
+ * infer record() and records() field shapes.
+ */
+class DatabaseReadDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension {
+
+	public function getClass(): string {
+		return Database::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool {
+		return $methodReflection->getName() === 'read';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope,
+	): ?Type {
+		$proxy = new DoctrineConnectionExecuteQueryDynamicReturnTypeExtension();
+		$type = $proxy->getTypeFromMethodCall($methodReflection, $methodCall, $scope);
+		if ($type === null) {
+			// The query is not resolvable, so we cannot reason further about
+			// the result of the query.
+			return null;
+		}
+		return new DatabaseResultObjectType($type);
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensions/DatabaseRecordDynamicReturnTypeExtension.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseRecordDynamicReturnTypeExtension.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use Smr\DatabaseRecord;
+
+/**
+ * Narrows DatabaseRecord getter return types from an inferred row shape.
+ *
+ * DatabaseRecordTypeResolver contains the shared validation and inference.
+ * When inference finds an invalid field access, this adapter falls back to the
+ * declared getter type. DatabaseRecordRule reports the precise diagnostic.
+ */
+class DatabaseRecordDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension {
+
+	public function getClass(): string {
+		return DatabaseRecord::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool {
+		return DatabaseRecordTypeResolver::isMethodSupported($methodReflection);
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope,
+	): ?Type {
+		try {
+			return DatabaseRecordTypeResolver::resolve($methodReflection, $methodCall, $scope);
+		} catch (DatabaseRecordTypeException) {
+			return CallArgumentResolver::resolve(
+				$methodReflection,
+				$methodCall,
+				$scope,
+			)->getParametersAcceptor()->getReturnType();
+		}
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensions/DatabaseRecordObjectType.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseRecordObjectType.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Type;
+use Smr\DatabaseRecord;
+
+/**
+ * Represents a DatabaseRecord carrying the constant-array type of its row.
+ *
+ * The generic argument is internal type metadata used by the record getter
+ * extension and rule; runtime DatabaseRecord objects remain unchanged.
+ */
+class DatabaseRecordObjectType extends GenericObjectType {
+
+	public function __construct(Type $rowType) {
+		parent::__construct(DatabaseRecord::class, [$rowType]);
+	}
+
+	public function getRowType(): Type {
+		return $this->getTypes()[0];
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensions/DatabaseRecordRule.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseRecordRule.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\VerbosityLevel;
+use Smr\DatabaseRecord;
+
+/**
+	* Reports DatabaseRecord accesses that cannot safely retain a precise type.
+	*
+	* The return-type extension must fall back to declared types when a field is
+	* dynamic or incompatible with the inferred row. This Rule makes that loss
+	* of precision visible, using DatabaseRecordTypeResolver for consistency.
+	*
+	* @implements Rule<MethodCall>
+ */
+class DatabaseRecordRule implements Rule {
+
+	public function getNodeType(): string {
+		return MethodCall::class;
+	}
+
+	/**
+	 * @return list<\PHPStan\Rules\IdentifierRuleError> List of error messages from this node
+	 */
+	public function processNode(Node $methodCall, Scope $scope): array {
+		if (!($methodCall->name instanceof Identifier)) {
+			// PHPStan mostly ignores methods that are variables, favoring
+			// instead first-class callables. We could grab the constant
+			// strings from the type of the method name, but probably better
+			// to stay in line with PHPStan convention here.
+			return [];
+		}
+
+		$methodReflection = $scope->getMethodReflection(
+			$scope->getType($methodCall->var),
+			$methodCall->name->toString(),
+		);
+		if ($methodReflection?->getDeclaringClass()->getName() !== DatabaseRecord::class) {
+			return [];
+		}
+
+		if (DatabaseRecordTypeResolver::isMethodSupported($methodReflection) === false) {
+			return [];
+		}
+		if (!($scope->getType($methodCall->var) instanceof DatabaseRecordObjectType)) {
+			return [];
+		}
+
+		$resolvedArguments = CallArgumentResolver::resolve($methodReflection, $methodCall, $scope);
+		$arguments = $resolvedArguments->getArguments();
+		if ($arguments === null) {
+			return [];
+		}
+		if (!isset($arguments[0])) {
+			return [];
+		}
+		$fieldType = $scope->getType($arguments[0]->value);
+		if (count($fieldType->getConstantStrings()) === 0) {
+			return [
+				RuleErrorBuilder::message(
+					'Smr\\DatabaseRecord field name must be a constant string, got '
+					. $fieldType->describe(VerbosityLevel::precise()),
+				)->identifier('smr.dba.databaseRecordFieldName')->build(),
+			];
+		}
+
+		try {
+			DatabaseRecordTypeResolver::resolve(
+				$methodReflection,
+				$methodCall,
+				$scope,
+			);
+		} catch (DatabaseRecordTypeException $err) {
+			return [
+				RuleErrorBuilder::message($err->getMessage())
+					->identifier('smr.dba.databaseRecordType')
+					->build(),
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensions/DatabaseRecordTypeException.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseRecordTypeException.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use Exception;
+
+/**
+ * Signals a field absent from an inferred row or incompatible with a getter.
+ *
+ * The shared resolver throws this instead of deciding how PHPStan surfaces
+ * the issue: its RTE caller falls back to the declared getter type and its
+ * Rule caller emits an identifier-bearing diagnostic.
+ */
+class DatabaseRecordTypeException extends Exception {
+}

--- a/test/SmrTest/PHPStanExtensions/DatabaseRecordTypeResolver.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseRecordTypeResolver.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * Resolves DatabaseRecord getter types against the row shape from a query.
+ *
+ * This is deliberately independent of PHPStan extension interfaces so the
+ * RTE and Rule share exactly the same field checks, numeric-string handling,
+ * and fallback decisions.
+ */
+final class DatabaseRecordTypeResolver {
+
+	private const array SKIP_TYPE_METHODS = [
+		'getBoolean', // bools are stored in database as (enum) strings
+		'getClass', // uses getObject
+		'getNullableObject', // uses getObject
+		'getObject', // objects are stored in the database as (serialized class) strings
+		'getStringEnum', // string enums are stored in the database as strings
+	];
+
+	private const array INT_TYPE_METHODS = [
+		'getInt',
+		'getNullableInt',
+	];
+
+	public static function isMethodSupported(MethodReflection $methodReflection): bool {
+		return $methodReflection->getName() !== 'getRow';
+	}
+
+	/**
+	 * @throws DatabaseRecordTypeException
+	 */
+	public static function resolve(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope,
+	): ?Type {
+		$objectType = $scope->getType($methodCall->var);
+		if (!($objectType instanceof DatabaseRecordObjectType)) {
+			// We have a DatabaseRecord, but it either did not come directly
+			// from a query, or the query was not resolvable. Therefore, we
+			// won't know its row type and cannot proceed.
+			return null;
+		}
+
+		$resolvedArguments = CallArgumentResolver::resolve($methodReflection, $methodCall, $scope);
+		$returnType = $resolvedArguments->getParametersAcceptor()->getReturnType();
+		$arguments = $resolvedArguments->getArguments();
+		if ($arguments === null) {
+			return $returnType;
+		}
+		if (!isset($arguments[0])) {
+			return $returnType;
+		}
+
+		// We should always have a constant array inside the DatabaseRecord.
+		$constantArrays = $objectType->getRowType()->getConstantArrays();
+		if (count($constantArrays) !== 1) {
+			throw new ShouldNotHappenException();
+		}
+		$rowType = $constantArrays[0];
+
+		$dbFieldNames = [];
+		foreach ($rowType->getKeyTypes() as $keyType) {
+			$dbFieldNames[] = $keyType->getConstantStrings()[0]->getValue();
+		}
+
+		$fieldType = $scope->getType($arguments[0]->value);
+		$fieldNames = array_map(
+			fn(ConstantStringType $type) => $type->getValue(),
+			$fieldType->getConstantStrings(),
+		);
+		if (count($fieldNames) === 0) {
+			// No constant strings means the field cannot be checked against the
+			// database record. The accompanying Rule reports this fallback.
+			return $returnType;
+		}
+
+		$returnTypes = [];
+		foreach ($fieldNames as $fieldName) {
+			$matchingIndex = array_search($fieldName, $dbFieldNames, true);
+			if ($matchingIndex === false) {
+				throw new DatabaseRecordTypeException(
+					$methodReflection->getDeclaringClass()->getName() . ' does not contain field: ' . $fieldName,
+				);
+			}
+
+			$methodName = $methodReflection->getName();
+			if (in_array($methodName, self::SKIP_TYPE_METHODS, true)) {
+				continue;
+			}
+
+			$databaseType = $rowType->getValueTypes()[$matchingIndex];
+			if (in_array($methodName, self::INT_TYPE_METHODS, true) && $databaseType->isNumericString()->yes()) {
+				// getInt() and getNullableInt() convert numeric strings to ints.
+				$returnTypes[] = $databaseType->toInteger();
+				continue;
+			}
+			if (!$returnType->isSuperTypeOf($databaseType)->yes()) {
+				$verbosity = VerbosityLevel::precise();
+				throw new DatabaseRecordTypeException(
+					$methodReflection->getDeclaringClass()->getName() . '::' . $methodName
+					. ' returns type ' . $returnType->describe($verbosity) . ', but field `' . $fieldName . '`'
+					. ' has type ' . $databaseType->describe($verbosity),
+				);
+			}
+			$returnTypes[] = $databaseType;
+		}
+
+		return $returnTypes === [] ? $returnType : TypeCombinator::union(...$returnTypes);
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensions/DatabaseResultDynamicReturnTypeExtension.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseResultDynamicReturnTypeExtension.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use Generator;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+use Smr\DatabaseResult;
+use staabm\PHPStanDba\DoctrineReflection\DoctrineReflection;
+
+/**
+ * Propagates an inferred query row shape through DatabaseResult accessors.
+ *
+ * It converts Doctrine's fetch result into DatabaseRecordObjectType for
+ * record(), and a Generator of that type for records(). Unresolvable query
+ * results deliberately retain their declared DatabaseResult type instead.
+ */
+class DatabaseResultDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension {
+
+	public function getClass(): string {
+		return DatabaseResult::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool {
+		return in_array($methodReflection->getName(), ['record', 'records'], true);
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope,
+	): ?Type {
+		$objectType = $scope->getType($methodCall->var);
+		if (!($objectType instanceof DatabaseResultObjectType)) {
+			// We have a DatabaseResult, but it either did not come directly
+			// from a query, or the query was not resolvable. Therefore, we
+			// won't know it's row type and cannot proceed.
+			return null;
+		}
+		$innerType = $objectType->getRowType();
+
+		// DatabaseResult internally calls Doctrine methods
+		$proxyMethodReflection = $scope->getMethodReflection($innerType, 'fetchAssociative');
+		if ($proxyMethodReflection === null) {
+			throw new ShouldNotHappenException();
+		}
+		$doctrineReflection = new DoctrineReflection();
+		$innerResultType = $doctrineReflection->reduceResultType($proxyMethodReflection, $innerType);
+		if ($innerResultType === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		// Doctrine can return false on no rows, but we throw, so remove false
+		$innerResultType = $innerResultType->tryRemove(new ConstantBooleanType(false));
+		if ($innerResultType === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		$resultType = new DatabaseRecordObjectType($innerResultType);
+		return match ($methodReflection->getName()) {
+			'record' => $resultType,
+			'records' => new GenericObjectType(Generator::class, [new IntegerType(), $resultType]),
+			default => throw new ShouldNotHappenException(),
+		};
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensions/DatabaseResultObjectType.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseResultObjectType.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Type;
+use Smr\DatabaseResult;
+
+/**
+ * Represents a DatabaseResult carrying the inferred Doctrine row type.
+ *
+ * DatabaseResultDynamicReturnTypeExtension consumes this generic argument to
+ * pass row-shape information on to DatabaseRecordObjectType.
+ */
+class DatabaseResultObjectType extends GenericObjectType {
+
+	public function __construct(Type $rowType) {
+		parent::__construct(DatabaseResult::class, [$rowType]);
+	}
+
+	public function getRowType(): Type {
+		return $this->getTypes()[0];
+	}
+
+}

--- a/test/SmrTest/PHPStanExtensions/DatabaseSelectDynamicReturnTypeExtension.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseSelectDynamicReturnTypeExtension.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types=1);
+
+namespace SmrTest\PHPStanExtensions;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use Smr\Database;
+use staabm\PHPStanDba\DoctrineReflection\DoctrineResultObjectType;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
+use staabm\PHPStanDba\QueryReflection\QueryReflector;
+
+/**
+ * Infers Database::select() result rows from a constant table and columns.
+ *
+ * select() is a table-oriented wrapper rather than raw SQL. This extension
+ * builds an equivalent SELECT for phpstan-dba, then wraps the inferred row in
+ * DatabaseResultObjectType. Dynamic inputs fall back to the declared type.
+ */
+class DatabaseSelectDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension {
+
+	public function getClass(): string {
+		return Database::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool {
+		return $methodReflection->getName() === 'select';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope,
+	): ?Type {
+		// Get the table and result columns from this call.
+		$resolvedArguments = CallArgumentResolver::resolve($methodReflection, $methodCall, $scope);
+		$paramIndexToArg = $resolvedArguments->getArguments();
+		if ($paramIndexToArg === null) {
+			return null;
+		}
+		$params = $resolvedArguments->getParametersAcceptor()->getParameters();
+
+		if (!isset($paramIndexToArg[0])) {
+			return null;
+		}
+
+		$table = $this->resolveString($scope->getType($paramIndexToArg[0]->value));
+		if ($table === null) {
+			return null; // table is not a constant string
+		}
+		if (isset($paramIndexToArg[2])) {
+			$resultColsType = $scope->getType($paramIndexToArg[2]->value);
+		} else {
+			// If argument not specified, get the type of the default value
+			// (which should be ['*']).
+			$resultColsType = $params[2]->getDefaultValue();
+		}
+		if ($resultColsType === null) {
+			// Result columns should always have a type
+			throw new ShouldNotHappenException();
+		}
+		$resultCols = $this->resolveStringArrayValues($resultColsType);
+		if ($resultCols === null) {
+			// Dynamic result columns cannot produce a static result shape.
+			return null;
+		}
+
+		// Generate a proxy query with the same return type as the actual query
+		// executed at runtime. We only need the table and result columns.
+		$query = 'SELECT ' . implode(',', $resultCols) . ' FROM ' . $table;
+
+		// Simulate the query and package it in the relevant result wrapper types
+		// Note: Rather than simulating a query, we could have looked up the SQL
+		// types for these columns and then converted them to PHP types, but it
+		// wasn't obvious how to do that.
+		$queryReflection = new QueryReflection();
+		$resultType = $queryReflection->getResultType($query, QueryReflector::FETCH_TYPE_BOTH);
+		if ($resultType === null) {
+			return null; // failed to simulate query, hopefully will be caught by Rules
+		}
+		$doctrineResultType = DoctrineResultObjectType::newWithRowType($resultType);
+		return new DatabaseResultObjectType($doctrineResultType);
+	}
+
+	/**
+	 * @return ?non-empty-list<string>
+	 */
+	private function resolveStringArrayValues(Type $type): ?array {
+		// iterate over all constant array possibilities (union-safe)
+		$strings = [];
+		foreach ($type->getConstantArrays() as $array) {
+			foreach ($array->getValueTypes() as $valueType) {
+				// each valueType might be a constant string
+				foreach ($valueType->getConstantStrings() as $constString) {
+					$strings[] = $constString->getValue();
+				}
+			}
+		}
+		return $strings ?: null;
+	}
+
+	private function resolveString(Type $type): ?string {
+		// get all constant strings for this type (union-safe)
+		$constantStrings = $type->getConstantStrings();
+
+		if (count($constantStrings) !== 1) {
+			return null; // not a single constant string, fallback
+		}
+
+		return $constantStrings[0]->getValue();
+	}
+
+}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -34,6 +34,11 @@ services:
             file: ../abstract-services.yml
             service: smr-test
         entrypoint: vendor/bin/phpstan --memory-limit=4G --ansi analyse -v
+        networks:
+            - backend
+        depends_on:
+            mysql:
+                condition: service_healthy
 
     phpcs:
         extends:

--- a/test/phpstan-dba-bootstrap.php
+++ b/test/phpstan-dba-bootstrap.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+use Doctrine\DBAL\Connection;
+use Smr\Container\DiContainer;
+use staabm\PHPStanDba\DbSchema\SchemaHasherMysql;
+use staabm\PHPStanDba\QueryReflection\PdoMysqlQueryReflector;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
+use staabm\PHPStanDba\QueryReflection\ReflectionCache;
+use staabm\PHPStanDba\QueryReflection\ReplayAndRecordingQueryReflector;
+use staabm\PHPStanDba\QueryReflection\RuntimeConfiguration;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$config = new RuntimeConfiguration();
+$config->debugMode(true);
+$config->utilizeSqlAst(true);
+
+DiContainer::initialize(false);
+$conn = DiContainer::getClass(Connection::class)->getNativeConnection();
+if (!($conn instanceof PDO)) {
+	throw new Exception('Connection is type ' . gettype($conn) . ', expected PDO');
+}
+
+$cacheFile = __DIR__ . '/../.phpstan-dba.cache';
+$reflector = new ReplayAndRecordingQueryReflector(
+	ReflectionCache::create($cacheFile),
+	new PdoMysqlQueryReflector($conn),
+	new SchemaHasherMysql($conn),
+);
+
+$reflector = new PdoMysqlQueryReflector($conn);
+
+QueryReflection::setupReflector($reflector, $config);


### PR DESCRIPTION
This allows us to validate most database queries (generic read/write as well as Doctrine-like wrappers insert/update/delete/etc.), checking for invalid table names, column names, input parameter types, and output result types.

The implementation has two main components:

1) Rules - these emit PHPStan errors when a database interaction is
   definitively known to be invalid. This could be either due to the
   construction of the query itself (e.g. missing table/column) or due
   to a type mismatch between PHP and the database layer (e.g. if you
   pass a string where the query expects an int, or if you call `getInt`
   on a result column that is a string).

2) RTEs (Return Type Extensions) - these provide the type resolution so
   that we can get more precise types from DatabaseRecord getters. If we
   cannot resolve a query, then we fallback to the declared getter
   return type.

There are still some notable limitations. Not all queries are resolved properly (e.g. incomplete query AST support), and not all query errors are emitted as PHPStan errors. Some of these omissions are intentional by the author to limit noise and ease onboarding friction. Hopefully strict options can be added in the future to prevent false negatives.

The `phpstan-dba.neon` file contains the extension configuration, as well as the extension-specific error suppressions (some are unavoidable, some can be fixed with reworking SMR queries, and others will require development work upstream in phpstan-dba).

Add comprehensive testing of the custom Rule and RTE classes added to support phpstan-dba in SMR.