### PR TITLE
CombatLogList: make query statically analyzable

### DIFF
--- a/phpstan-dba.neon
+++ b/phpstan-dba.neon
@@ -208,13 +208,6 @@ parameters:
             path: src/pages/Player/AllianceRoster.php
 
         -
-            # CombatLog queries are assembled dynamically by CombatLogType.
-            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: non\-falsy\-string\.$#'
-            identifier: dba.unresolvableQuery
-            count: 2
-            path: src/pages/Player/CombatLogList.php
-
-        -
             # MySQL returns this SUM() expression as a numeric string, which
             # DatabaseRecord::getInt() deliberately converts to an int.
             message: '#^Smr\\DatabaseRecord\:\:getInt returns type int, but field `total_unread` has type string$#'

--- a/src/pages/Player/CombatLogList.php
+++ b/src/pages/Player/CombatLogList.php
@@ -28,31 +28,50 @@ class CombatLogList extends PlayerPage {
 
 		$action = $this->action;
 
-		$query = match ($action) {
+		$actionClause = match ($action) {
 			CombatLogType::Personal, CombatLogType::Alliance => 'type=\'PLAYER\'',
 			CombatLogType::Port => 'type=\'PORT\'',
 			CombatLogType::Planet => 'type=\'PLANET\'',
 			CombatLogType::Saved => 'EXISTS(
 							SELECT 1
 							FROM player_saved_combat_logs
-							WHERE player_id = ' . $db->escapeNumber($player->getPlayerID()) . '
+							WHERE player_id = :player_id
 								AND log_id = c.log_id
 						)',
 			CombatLogType::Force => 'type=\'FORCE\'',
 		};
 
-		$query .= ' AND game_id=' . $db->escapeNumber($player->getGameID());
-		if ($action !== CombatLogType::Personal && $player->hasAlliance()) {
-			$query .= ' AND (attacker_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ' OR defender_alliance_id=' . $db->escapeNumber($player->getAllianceID()) . ') ';
-		} else {
-			$query .= ' AND (attacker_player_id=' . $db->escapeNumber($player->getPlayerID()) . ' OR defender_player_id=' . $db->escapeNumber($player->getPlayerID()) . ') ';
+		$params = [
+			'game_id' => $db->escapeNumber($player->getGameID()),
+		];
+		if ($action === CombatLogType::Saved) {
+			$params['player_id'] = $db->escapeNumber($player->getPlayerID());
 		}
+		if ($action !== CombatLogType::Personal && $player->hasAlliance()) {
+			$participantClause = ' AND (attacker_alliance_id = :alliance_id OR defender_alliance_id = :alliance_id)';
+			$params['alliance_id'] = $db->escapeNumber($player->getAllianceID());
+		} else {
+			$participantClause = ' AND (attacker_player_id = :player_id OR defender_player_id = :player_id)';
+			$params['player_id'] = $db->escapeNumber($player->getPlayerID());
+		}
+		$whereClause = $actionClause . ' AND game_id = :game_id' . $participantClause;
 
 		$page = $this->page;
-		$dbResult = $db->read('SELECT count(*) as count FROM combat_logs c WHERE ' . $query);
+		$dbResult = $db->read('SELECT count(*) as count FROM combat_logs c WHERE ' . $whereClause, $params);
 		$totalLogs = $dbResult->record()->getInt('count'); // count always returns a record
 
-		$dbResult = $db->read('SELECT attacker_player_id,defender_player_id,timestamp,sector_id,log_id FROM combat_logs c WHERE ' . $query . ' ORDER BY log_id DESC, sector_id LIMIT ' . ($page * COMBAT_LOGS_PER_PAGE) . ', ' . COMBAT_LOGS_PER_PAGE);
+		$dbResult = $db->read(
+			'SELECT attacker_player_id, defender_player_id, timestamp, sector_id, log_id
+				FROM combat_logs c
+				WHERE ' . $whereClause . '
+				ORDER BY log_id DESC, sector_id
+				LIMIT :offset, :limit',
+			[
+				...$params,
+				'offset' => $page * COMBAT_LOGS_PER_PAGE,
+				'limit' => COMBAT_LOGS_PER_PAGE,
+			],
+		);
 
 		$getParticipantName = function($playerID, $sectorID) use ($player): string {
 			if ($playerID === PLAYER_ID_PORT) {


### PR DESCRIPTION
The query was previously inserting parameter values directly into the query, making it dynamic. We can only analyze queries with phpstan-dba when they are constant strings with bound parameters for the dynamic values.

This particular query is complex due to the conditionals, but it can still be made a union of constant strings.