### PR TITLE
DatabaseRecordTypeResolver: support DatabaseRecord::getRow

### DIFF
--- a/src/pages/Admin/WordFilterRenderer.php
+++ b/src/pages/Admin/WordFilterRenderer.php
@@ -4,7 +4,7 @@ namespace Smr\Pages\Admin;
 
 class WordFilterRenderer {
 
-	/** @param array<array<string>> $FilteredWords */
+	/** @param list<array{word_id: int, word_value: string, word_replacement: string}> $FilteredWords */
 	public static function render(string $DelHREF, string $AddHREF, array $FilteredWords, ?string $Message): void {
 		?>
 		<h2>Filtered Words</h2><br />

--- a/src/pages/Player/MessageBlacklistRenderer.php
+++ b/src/pages/Player/MessageBlacklistRenderer.php
@@ -4,7 +4,7 @@ namespace Smr\Pages\Player;
 
 class MessageBlacklistRenderer {
 
-	/** @param array<array<string, string>> $Blacklist */
+	/** @param list<array{player_name: string, game_id: int, entry_id: int}> $Blacklist */
 	public static function render(?string $Message, array $Blacklist, string $BlacklistDeleteHREF, string $BlacklistAddHREF): void {
 		if ($Message !== null) {
 			echo $Message; ?><br /><br /><?php

--- a/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordDynamicReturnTypeExtension/types.php
+++ b/test/SmrTest/PHPStanExtensionTests/fixtures/DatabaseRecordDynamicReturnTypeExtension/types.php
@@ -8,7 +8,7 @@ use function PHPStan\Testing\assertType;
 function getters(Database $db): void {
 	$record = $db->select(
 		table: 'player',
-		returnColumns: ['player_id'],
+		returnColumns: ['player_id', 'account_id'],
 	)->record();
 
 	assertType('int<0, 4294967295>', $record->getInt('player_id'));
@@ -22,8 +22,11 @@ function getters(Database $db): void {
 	$allFieldsRecord = $db->select(table: 'player')->record();
 	assertType('int<0, 4294967295>', $allFieldsRecord->getInt('player_id'));
 
-	// Fallback to docstring return type because getRow is not supported
-	assertType('array<string, mixed>', $record->getRow());
+	// The entire result row is returned by getRow.
+	assertType(
+		'array{player_id: int<0, 4294967295>, account_id: int<0, 65535>}',
+		$record->getRow(),
+	);
 
 	// Fallback to docstring return type because DatabaseRecord RTE emits the
 	// error that the field doesn't have the type suggested by the getter.

--- a/test/SmrTest/PHPStanExtensions/DatabaseRecordDynamicReturnTypeExtension.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseRecordDynamicReturnTypeExtension.php
@@ -23,7 +23,7 @@ class DatabaseRecordDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 	}
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool {
-		return DatabaseRecordTypeResolver::isMethodSupported($methodReflection);
+		return true;
 	}
 
 	public function getTypeFromMethodCall(

--- a/test/SmrTest/PHPStanExtensions/DatabaseRecordRule.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseRecordRule.php
@@ -46,9 +46,6 @@ class DatabaseRecordRule implements Rule {
 			return [];
 		}
 
-		if (DatabaseRecordTypeResolver::isMethodSupported($methodReflection) === false) {
-			return [];
-		}
 		if (!($scope->getType($methodCall->var) instanceof DatabaseRecordObjectType)) {
 			return [];
 		}

--- a/test/SmrTest/PHPStanExtensions/DatabaseRecordTypeResolver.php
+++ b/test/SmrTest/PHPStanExtensions/DatabaseRecordTypeResolver.php
@@ -33,10 +33,6 @@ final class DatabaseRecordTypeResolver {
 		'getNullableInt',
 	];
 
-	public static function isMethodSupported(MethodReflection $methodReflection): bool {
-		return $methodReflection->getName() !== 'getRow';
-	}
-
 	/**
 	 * @throws DatabaseRecordTypeException
 	 */
@@ -51,6 +47,9 @@ final class DatabaseRecordTypeResolver {
 			// from a query, or the query was not resolvable. Therefore, we
 			// won't know its row type and cannot proceed.
 			return null;
+		}
+		if ($methodReflection->getName() === 'getRow') {
+			return $objectType->getRowType();
 		}
 
 		$resolvedArguments = CallArgumentResolver::resolve($methodReflection, $methodCall, $scope);


### PR DESCRIPTION
We can trivially get the entire row type from a DatabaseRecord, which makes the return type for DatabaseRecord::getRow equally trivial. As a result, we now fully support all DatabaseRecord methods.

This allows us to infer precise array shapes from `getRow`.