### PR TITLE
Remove redundant player drink identifier

### DIFF
--- a/db/patches/V1_6_70_03__remove_player_drink_id.sql
+++ b/db/patches/V1_6_70_03__remove_player_drink_id.sql
@@ -1,0 +1,6 @@
+-- Drinks are represented by their rows. player_id indexes the per-player
+-- counts used by the bar without requiring a sequential drink identifier.
+ALTER TABLE player_has_drinks
+	DROP PRIMARY KEY,
+	DROP COLUMN drink_id,
+	ADD KEY (player_id);

--- a/src/pages/Player/Bar/BuyDrinkProcessor.php
+++ b/src/pages/Player/Bar/BuyDrinkProcessor.php
@@ -34,16 +34,12 @@ class BuyDrinkProcessor extends PlayerPageProcessor {
 			'expire_time' => $db->escapeNumber(Epoch::time() - 1800),
 		]);
 
-		$dbResult = $db->read('SELECT IFNULL(MAX(drink_id), 0) AS max_drink_id FROM player_has_drinks WHERE game_id = :game_id', [
-			'game_id' => $db->escapeNumber($player->getGameID()),
-		]);
-		$curr_drink_id = $dbResult->record()->getInt('max_drink_id');
-
 		if ($this->action !== 'drink') {
 			$drinkName = 'water';
 			$message .= 'You ask the bartender for some water and you quickly down it.<br />';
 			// have they been drinking recently?
-			if ($curr_drink_id > 0) {
+			$num_drinks = $db->count('player_has_drinks', $player->SQLID);
+			if ($num_drinks > 0) {
 				$message .= 'You don\'t feel quite so intoxicated anymore.<br />';
 				$db->write('DELETE FROM player_has_drinks WHERE ' . Player::SQL . ' LIMIT 1', $player->SQLID);
 			}
@@ -58,11 +54,9 @@ class BuyDrinkProcessor extends PlayerPageProcessor {
 			}
 			$drinkName = array_rand_value($drinkList);
 
-			$curr_drink_id++;
 			$db->insert('player_has_drinks', [
 				'player_id' => $player->getPlayerID(),
 				'game_id' => $player->getGameID(),
-				'drink_id' => $curr_drink_id,
 				'time' => Epoch::time(),
 			]);
 

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -186,7 +186,7 @@ class DatabaseIntegrationTest extends TestCase {
 		// added that modify the base table size. If that becomes too onerous,
 		// we can do a fuzzier comparison. Until then, this is a useful check
 		// that the test database is properly reset between invocations.
-		self::assertSame($bytes, 1557653);
+		self::assertSame($bytes, 1574037);
 	}
 
 	public function test_escapeBoolean(): void {


### PR DESCRIPTION
Use per-player counts after removing the redundant drink counter.

This also fixes a subtle display issue where the current intoxication level was determined by game_id instead of player_id.