### PR TITLE
Make Database::getDbBytes test less sensitive

### DIFF
--- a/src/lib/Smr/Database.php
+++ b/src/lib/Smr/Database.php
@@ -90,10 +90,13 @@ class Database {
 	}
 
 	/**
-	 * Returns the size of the current database in bytes.
+	 * Returns the size of the current database's game tables in bytes.
+	 *
+	 * The Flyway schema history table is migration bookkeeping rather than game
+	 * data, so it is excluded from this total.
 	 */
 	public function getDbBytes(): int {
-		$query = 'SELECT SUM(data_length + index_length) as db_bytes FROM information_schema.tables WHERE table_schema=(SELECT database())';
+		$query = 'SELECT SUM(data_length + index_length) as db_bytes FROM information_schema.tables WHERE table_schema=(SELECT database()) AND table_name <> \'flyway_schema_history\'';
 		return $this->read($query)->record()->getInt('db_bytes');
 	}
 

--- a/test/SmrTest/lib/DatabaseIntegrationTest.php
+++ b/test/SmrTest/lib/DatabaseIntegrationTest.php
@@ -181,12 +181,12 @@ class DatabaseIntegrationTest extends TestCase {
 
 	public function test_getDbBytes(): void {
 		$db = Database::getInstance();
+		// Test that the database size is within some reasonable range (1-3 MB).
+		// Using a range prevents the test from failing after every Flyway patch
+		// that changes the schema.
 		$bytes = $db->getDbBytes();
-		// This value will need to change whenever database migrations are
-		// added that modify the base table size. If that becomes too onerous,
-		// we can do a fuzzier comparison. Until then, this is a useful check
-		// that the test database is properly reset between invocations.
-		self::assertSame($bytes, 1574037);
+		$bytesToMB = 1024 * 1024;
+		self::assertEqualsWithDelta(2 * $bytesToMB, $bytes, 1 * $bytesToMB);
 	}
 
 	public function test_escapeBoolean(): void {


### PR DESCRIPTION
Verify getDbBytes within a reasonable range (1-3 MB) instead of expecting an exact value. This prevents the test from failing after every Flyway migration.

We also exclude the Flyway history table from the getDbBytes result since that will grow without bound as more migrations are added, which will allow the range test to be valid for much longer.

This test previously mentioned that it was a useful sanity check for idempotence of the test database, but that concern is handled by the checksums in the BaseIntegrationSpec.