### PR TITLE
Rankings: make queries statically analyzable

### DIFF
--- a/phpstan-dba.neon
+++ b/phpstan-dba.neon
@@ -109,13 +109,6 @@ parameters:
             path: src/lib/Smr/Port.php
 
         -
-            # Rankings queries are assembled dynamically by stat.
-            message: '#^Unresolvable Query\: Cannot resolve query with variable type\: non\-falsy\-string\.$#'
-            identifier: dba.unresolvableQuery
-            count: 2
-            path: src/lib/Smr/Rankings.php
-
-        -
             # History databases are not supported.
             message: '#^Smr\\DatabaseRecord does not contain field\: (end_date|speed|start_date|type)$#'
             identifier: smr.dba.databaseRecordType

--- a/src/lib/Smr/Rankings.php
+++ b/src/lib/Smr/Rankings.php
@@ -154,12 +154,12 @@ class Rankings {
 		$db = Database::getInstance();
 		$playerStats = [];
 		$query = 'SELECT player.*, ' . $stat . ' AS amount FROM player WHERE game_id = :game_id ORDER BY amount DESC, player_name';
+		$params = ['game_id' => $db->escapeNumber($gameID)];
 		if ($limit !== null) {
-			$query .= ' LIMIT ' . $limit;
+			$query .= ' LIMIT :limit';
+			$params['limit'] = $db->escapeNumber($limit);
 		}
-		$dbResult = $db->read($query, [
-			'game_id' => $db->escapeNumber($gameID),
-		]);
+		$dbResult = $db->read($query, $params);
 		foreach ($dbResult->records() as $dbRecord) {
 			$playerStats[$dbRecord->getInt('player_id')] = $dbRecord;
 		}
@@ -213,6 +213,7 @@ class Rankings {
 	/**
 	 * Get stats from the alliance table sorted by $stat (high to low).
 	 *
+	 * @param 'experience'|'kills'|'deaths' $stat
 	 * @return array<int, \Smr\DatabaseRecord>
 	 */
 	public static function allianceStats(string $stat, int $gameID, ?int $limit = null): array {
@@ -229,10 +230,12 @@ class Rankings {
 			$query = 'SELECT alliance.*, alliance_' . $stat . ' AS amount
 				FROM alliance WHERE game_id = :game_id ORDER BY amount DESC, alliance_name';
 		}
+		$params = ['game_id' => $db->escapeNumber($gameID)];
 		if ($limit !== null) {
-			$query .= ' LIMIT ' . $limit;
+			$query .= ' LIMIT :limit';
+			$params['limit'] = $db->escapeNumber($limit);
 		}
-		$dbResult = $db->read($query, ['game_id' => $db->escapeNumber($gameID)]);
+		$dbResult = $db->read($query, $params);
 		foreach ($dbResult->records() as $dbRecord) {
 			$allianceStats[$dbRecord->getInt('alliance_id')] = $dbRecord;
 		}

--- a/src/pages/Account/GameStats.php
+++ b/src/pages/Account/GameStats.php
@@ -2,6 +2,7 @@
 
 namespace Smr\Pages\Account;
 
+use Closure;
 use Smr\Account;
 use Smr\Alliance;
 use Smr\Database;
@@ -60,15 +61,6 @@ class GameStats extends AccountPage {
 		$playerKillRecords = Rankings::playerStats('kills', $gameID, 10);
 		$playerKillRanks = Rankings::collectRankings($playerKillRecords, $player);
 
-		$allianceTopTen = function(string $stat) use ($getAllianceLink, $gameID, $player): array {
-			$allianceRecords = Rankings::allianceStats($stat, $gameID, 10);
-			$allianceRanks = Rankings::collectAllianceRankings($allianceRecords, $player);
-			foreach ($allianceRanks as $rank => $info) {
-				$allianceRanks[$rank]['AllianceName'] = $getAllianceLink($info['Alliance']);
-			}
-			return $allianceRanks;
-		};
-
 		if ($player !== null) {
 			$playerInfo = [
 				'Name' => $player->getLevelName() . ' ' . $player->getDisplayName(),
@@ -104,12 +96,25 @@ class GameStats extends AccountPage {
 			TotalAlliances: $db->count('alliance', ['game_id' => $gameID]),
 			ExperienceRankings: $playerExpRanks,
 			KillRankings: $playerKillRanks,
-			AllianceExpRankings: $allianceTopTen('experience'),
-			AllianceKillRankings: $allianceTopTen('kills'),
+			AllianceExpRankings: $this->allianceTopTen('experience', $getAllianceLink, $player),
+			AllianceKillRankings: $this->allianceTopTen('kills', $getAllianceLink, $player),
 			PlayerInfo: $playerInfo,
 			BackHref: new GamePlay()->href(),
 			ThisAccount: $account,
 		);
+	}
+
+	/**
+	 * @param 'experience'|'kills' $stat
+	 * @return array<int, array{Alliance: Alliance, Class: string, Value: int, AllianceName: string}>
+	 */
+	private function allianceTopTen(string $stat, Closure $getAllianceLink, ?Player $player): array {
+		$allianceRecords = Rankings::allianceStats($stat, $this->gameID, 10);
+		$allianceRanks = Rankings::collectAllianceRankings($allianceRecords, $player);
+		foreach ($allianceRanks as $rank => $info) {
+			$allianceRanks[$rank]['AllianceName'] = $getAllianceLink($info['Alliance']);
+		}
+		return $allianceRanks;
 	}
 
 }


### PR DESCRIPTION
Directly appending the dynamic `$limit` value to the query string was causing these queries to resolve as "non-falsy-string" instead of constant strings. By binding them as query parameters, we can recover the constant query string.

Minor refactoring needed in GameStats to narrow the `$stat` type to a union of literals in the closure. Convert the closure to a function to avoid the permissive type-coercion of `@var` (compared to `@param`).