### PR TITLE
PlanetListDefenseRenderer: report complete builds

### DIFF
--- a/src/lib/Smr/Planet.php
+++ b/src/lib/Smr/Planet.php
@@ -994,6 +994,10 @@ class Planet implements NormalCombatantInterface {
 		return array_sum($this->getMaxBuildings()) / 3;
 	}
 
+	public function atMaxLevel(): bool {
+		return $this->getLevel() === $this->getMaxLevel();
+	}
+
 	/**
 	 * Returns the modified accuracy of turrets on this planet.
 	 * Only used for display purposes.

--- a/src/pages/Shared/PlanetListDefenseRenderer.php
+++ b/src/pages/Shared/PlanetListDefenseRenderer.php
@@ -80,6 +80,8 @@ class PlanetListDefenseRenderer {
 										echo $Planet->getStructureTypes($Building['ConstructionID'])->name(); ?><br /><?php
 										echo format_time($Building['TimeRemaining'], true);
 									}
+								} elseif ($Planet->atMaxLevel()) {
+									?>Complete<?php
 								} else {
 									?>Nothing<?php
 								} ?>

--- a/test/SmrTest/lib/PlanetIntegrationTest.php
+++ b/test/SmrTest/lib/PlanetIntegrationTest.php
@@ -429,8 +429,10 @@ class PlanetIntegrationTest extends BaseIntegrationSpec {
 	public function test_setBuildingsToMax(): void {
 		$planet = Planet::createPlanet(1, 1, 1, 1);
 		self::assertSame(0., $planet->getLevel());
+		self::assertFalse($planet->atMaxLevel());
 		$planet->setBuildingsToMax();
 		self::assertSame($planet->getMaxLevel(), $planet->getLevel());
+		self::assertTrue($planet->atMaxLevel());
 		self::assertSame($planet->getMaxBuildings(), $planet->getBuildings());
 	}
 


### PR DESCRIPTION
If the planet is at max level, put "Complete" in the Build column of the table instead of "Nothing". This helps to visually disambiguate planets that need a build from planets that are done building.

Add and test a Planet::atMaxLevel method.